### PR TITLE
Make more data providers static

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Attribute/AutowireTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Attribute/AutowireTest.php
@@ -74,7 +74,7 @@ class AutowireTest extends TestCase
     /**
      * @see testCanOnlySetOneParameter
      */
-    private static function provideMultipleParameters(): iterable
+    public static function provideMultipleParameters(): iterable
     {
         yield [['service' => 'id', 'expression' => 'expr']];
 

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
@@ -98,7 +98,7 @@ class MongoDbSessionHandlerTest extends TestCase
         new MongoDbSessionHandler($this->manager, $options);
     }
 
-    public function provideInvalidOptions()
+    public static function provideInvalidOptions(): iterable
     {
         yield 'empty' => [[]];
         yield 'collection missing' => [['database' => 'foo']];

--- a/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseHeaderLocationSameTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseHeaderLocationSameTest.php
@@ -36,7 +36,7 @@ class ResponseHeaderLocationSameTest extends TestCase
         self::assertTrue($constraint->evaluate($response, '', true));
     }
 
-    public function provideSuccessCases(): iterable
+    public static function provideSuccessCases(): iterable
     {
         yield ['http://example.com', 'http://example.com', 'http://example.com'];
         yield ['http://example.com', 'http://example.com', '//example.com'];
@@ -112,7 +112,7 @@ class ResponseHeaderLocationSameTest extends TestCase
         $constraint->evaluate($response);
     }
 
-    public function provideFailureCases(): iterable
+    public static function provideFailureCases(): iterable
     {
         yield ['http://example.com', null, 'http://example.com'];
         yield ['http://example.com', null, '//example.com'];

--- a/src/Symfony/Component/Mime/Tests/MessageTest.php
+++ b/src/Symfony/Component/Mime/Tests/MessageTest.php
@@ -306,7 +306,7 @@ EOF;
         $m->ensureValidity();
     }
 
-    public function ensureValidityProvider()
+    public static function ensureValidityProvider(): array
     {
         return [
             'Valid address fields' => [

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/AccessTokenAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/AccessTokenAuthenticatorTest.php
@@ -177,7 +177,7 @@ class AccessTokenAuthenticatorTest extends TestCase
         $this->assertEquals($expectedToken, $token);
     }
 
-    public function provideAccessTokenHeaderRegex(): array
+    public static function provideAccessTokenHeaderRegex(): array
     {
         return [
             ['Bearer token', 'token'],

--- a/src/Symfony/Component/Translation/Bridge/Phrase/Tests/PhraseProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Phrase/Tests/PhraseProviderTest.php
@@ -51,8 +51,10 @@ class PhraseProviderTest extends TestCase
     /**
      * @dataProvider toStringProvider
      */
-    public function testToString(ProviderInterface $provider, string $expected)
+    public function testToString(?string $endpoint, string $expected)
     {
+        $provider = $this->createProvider(endpoint: $endpoint);
+
         self::assertSame($expected, (string) $provider);
     }
 
@@ -332,7 +334,7 @@ class PhraseProviderTest extends TestCase
         $provider->read(['messages'], ['en_GB']);
     }
 
-    public function cacheItemProvider(): \Generator
+    public static function cacheItemProvider(): \Generator
     {
         yield 'null value' => [
             'cached_value' => null,
@@ -347,7 +349,7 @@ class PhraseProviderTest extends TestCase
         ];
     }
 
-    public function cacheKeyProvider(): \Generator
+    public static function cacheKeyProvider(): \Generator
     {
         yield 'sortorder one' => [
             'options' => [
@@ -787,7 +789,7 @@ class PhraseProviderTest extends TestCase
         $provider->write($bag);
     }
 
-    public function writeProvider(): \Generator
+    public static function writeProvider(): \Generator
     {
         $expectedEnglishXliff = <<<'XLIFF'
 <?xml version="1.0" encoding="utf-8"?>
@@ -869,84 +871,66 @@ XLIFF;
         ];
     }
 
-    public function toStringProvider(): \Generator
+    public static function toStringProvider(): \Generator
     {
         yield 'default endpoint' => [
-            'provider' => $this->createProvider(httpClient: $this->getHttpClient()->withOptions([
-                'base_uri' => 'https://api.phrase.com/api/v2/projects/PROJECT_ID/',
-                'headers' => [
-                    'Authorization' => 'token API_TOKEN',
-                    'User-Agent' => 'myProject',
-                ],
-            ])),
+            'endpoint' => null,
             'expected' => 'phrase://api.phrase.com',
         ];
 
         yield 'custom endpoint' => [
-            'provider' => $this->createProvider(httpClient: $this->getHttpClient()->withOptions([
-                'base_uri' => 'https://api.us.app.phrase.com/api/v2/projects/PROJECT_ID/',
-                'headers' => [
-                    'Authorization' => 'token API_TOKEN',
-                    'User-Agent' => 'myProject',
-                ],
-            ]), endpoint: 'api.us.app.phrase.com'),
+            'endpoint' => 'api.us.app.phrase.com',
             'expected' => 'phrase://api.us.app.phrase.com',
         ];
 
         yield 'custom endpoint with port' => [
-            'provider' => $this->createProvider(httpClient: $this->getHttpClient()->withOptions([
-                'base_uri' => 'https://api.us.app.phrase.com:8080/api/v2/projects/PROJECT_ID/',
-                'headers' => [
-                    'Authorization' => 'token API_TOKEN',
-                    'User-Agent' => 'myProject',
-                ],
-            ]), endpoint: 'api.us.app.phrase.com:8080'),
+            'endpoint' => 'api.us.app.phrase.com:8080',
             'expected' => 'phrase://api.us.app.phrase.com:8080',
         ];
     }
 
-    public function deleteExceptionsProvider(): array
+    public static function deleteExceptionsProvider(): array
     {
-        return $this->getExceptionResponses(
+        return self::getExceptionResponses(
             exceptionMessage: 'Unable to delete key in phrase.',
             loggerMessage: 'Unable to delete key "key.to.delete" in phrase: "provider error".',
             statusCode: 500
         );
     }
 
-    public function writeExceptionsProvider(): array
+    public static function writeExceptionsProvider(): array
     {
-        return $this->getExceptionResponses(
+        return self::getExceptionResponses(
             exceptionMessage: 'Unable to upload translations to phrase.',
             loggerMessage: 'Unable to upload translations for domain "messages" to phrase: "provider error".'
         );
     }
 
-    public function createLocalesExceptionsProvider(): array
+    public static function createLocalesExceptionsProvider(): array
     {
-        return $this->getExceptionResponses(
+        return self::getExceptionResponses(
             exceptionMessage: 'Unable to create locale phrase.',
             loggerMessage: 'Unable to create locale "nl-NL" in phrase: "provider error".'
         );
     }
 
-    public function initLocalesExceptionsProvider(): array
+    public static function initLocalesExceptionsProvider(): array
     {
-        return $this->getExceptionResponses(
+        return self::getExceptionResponses(
             exceptionMessage: 'Unable to get locales from phrase.',
             loggerMessage: 'Unable to get locales from phrase: "provider error".'
         );
     }
 
-    public function readProviderExceptionsProvider(): array
+    public static function readProviderExceptionsProvider(): array
     {
-        return $this->getExceptionResponses(
+        return self::getExceptionResponses(
             exceptionMessage: 'Unable to get translations from phrase.',
             loggerMessage: 'Unable to get translations for locale "en_GB" from phrase: "provider error".'
         );
     }
 
-    public function readProvider(): \Generator
+    public static function readProvider(): \Generator
     {
         $bag = new TranslatorBag();
         $catalogue = new MessageCatalogue('en_GB', [
@@ -1045,7 +1029,7 @@ XLIFF,
         ];
     }
 
-    private function getExceptionResponses(string $exceptionMessage, string $loggerMessage, int $statusCode = 400): array
+    private static function getExceptionResponses(string $exceptionMessage, string $loggerMessage, int $statusCode = 400): array
     {
         return [
             'bad request' => [

--- a/src/Symfony/Component/Validator/Tests/Constraints/CssColorValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CssColorValidatorTest.php
@@ -426,7 +426,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
-    public function getInvalidHSLA(): array
+    public static function getInvalidHSLA(): array
     {
         return [['hsla(1000, 1000%, 20000%, 999)'], ['hsla(-100, -10%, -2%, 999)'], ['hsla(a, b, c, d)'], ['hsla(a, b%, c%, d)'], ['hsla( 9 99% , 99 9% , 9 %']];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Data providers must be public and static in PHPUnit 11.