### PR TITLE
Mutate remaining data providers to static ones

### DIFF
--- a/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
+++ b/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
@@ -200,7 +200,7 @@ class OutputFormatterTest extends TestCase
         ];
     }
 
-    public function provideInlineStyleTagsWithUnknownOptions()
+    public static function provideInlineStyleTagsWithUnknownOptions()
     {
         return [
             ['<options=abc;>', 'abc'],

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Factory/CachingFactoryDecoratorTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Factory/CachingFactoryDecoratorTest.php
@@ -586,7 +586,7 @@ class CachingFactoryDecoratorTest extends TestCase
         ];
     }
 
-    public function provideSameKeyChoices()
+    public static function provideSameKeyChoices()
     {
         // Only test types here that can be used as array keys
         return [
@@ -597,7 +597,7 @@ class CachingFactoryDecoratorTest extends TestCase
         ];
     }
 
-    public function provideDistinguishedKeyChoices()
+    public static function provideDistinguishedKeyChoices()
     {
         // Only test types here that can be used as array keys
         return [

--- a/src/Symfony/Component/Intl/Tests/LocalesTest.php
+++ b/src/Symfony/Component/Intl/Tests/LocalesTest.php
@@ -21,12 +21,12 @@ class LocalesTest extends ResourceBundleTestCase
 {
     public function testGetLocales()
     {
-        $this->assertSame($this->getLocales(), Locales::getLocales());
+        $this->assertSame(static::getLocales(), Locales::getLocales());
     }
 
     public function testGetAliases()
     {
-        $this->assertSame($this->getLocaleAliases(), Locales::getAliases());
+        $this->assertSame(static::getLocaleAliases(), Locales::getAliases());
     }
 
     /**
@@ -41,7 +41,7 @@ class LocalesTest extends ResourceBundleTestCase
         // We can't assert on exact list of locale, as there's too many variations.
         // The best we can do is to make sure getNames() returns a subset of what getLocales() returns.
         $this->assertNotEmpty($locales);
-        $this->assertEmpty(array_diff($locales, $this->getLocales()));
+        $this->assertEmpty(array_diff($locales, static::getLocales()));
     }
 
     public function testGetNamesDefaultLocale()

--- a/src/Symfony/Component/Intl/Tests/ResourceBundleTestCase.php
+++ b/src/Symfony/Component/Intl/Tests/ResourceBundleTestCase.php
@@ -758,45 +758,37 @@ abstract class ResourceBundleTestCase extends TestCase
         \Locale::setDefault($this->defaultLocale);
     }
 
-    public function provideLocales()
+    public static function provideLocales()
     {
         return array_map(
             function ($locale) { return [$locale]; },
-            $this->getLocales()
+            static::getLocales()
         );
     }
 
-    public function provideLocaleAliases()
+    public static function provideLocaleAliases()
     {
         return array_map(
             function ($alias, $ofLocale) { return [$alias, $ofLocale]; },
-            array_keys($this->getLocaleAliases()),
-            $this->getLocaleAliases()
+            array_keys(static::getLocaleAliases()),
+            static::getLocaleAliases()
         );
     }
 
-    public function provideRootLocales()
-    {
-        return array_map(
-            function ($locale) { return [$locale]; },
-            $this->getRootLocales()
-        );
-    }
-
-    protected function getLocales()
+    protected static function getLocales()
     {
         return self::LOCALES;
     }
 
-    protected function getLocaleAliases()
+    protected static function getLocaleAliases()
     {
         return self::LOCALE_ALIASES;
     }
 
-    protected function getRootLocales()
+    protected static function getRootLocales()
     {
         if (null === self::$rootLocales) {
-            self::$rootLocales = array_filter($this->getLocales(), function ($locale) {
+            self::$rootLocales = array_filter(static::getLocales(), function ($locale) {
                 // no locales for which fallback is possible (e.g "en_GB")
                 return !str_contains($locale, '_');
             });

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/ConnectionTest.php
@@ -500,7 +500,7 @@ class ConnectionTest extends TestCase
         $connection->findAll(50);
     }
 
-    public function provideFindAllSqlGeneratedByPlatform(): iterable
+    public static function provideFindAllSqlGeneratedByPlatform(): iterable
     {
         yield 'MySQL' => [
             class_exists(MySQLPlatform::class) ? new MySQLPlatform() : new MySQL57Platform(),

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -701,7 +701,7 @@ class AbstractObjectNormalizerTest extends TestCase
         $normalizer->denormalize($data, $type);
     }
 
-    public function provideBooleanTypesData()
+    public static function provideBooleanTypesData()
     {
         return [
             [['foo' => true], FalsePropertyDummy::class],

--- a/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
@@ -52,7 +52,7 @@ END'],
         $this->assertSame('Dieser Wert sollte grOEsser oder gleich', (string) $s->ascii([$rule]));
     }
 
-    public function provideCreateFromCodePoint(): array
+    public static function provideCreateFromCodePoint(): array
     {
         return [
             ['', []],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Non-static data providers are deprecated.