### PR TITLE
[FrameworkBundle] Do not access the container when the kernel is shut down

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -157,13 +157,14 @@ abstract class KernelTestCase extends TestCase
         if (null !== static::$kernel) {
             static::$kernel->boot();
             $container = static::$kernel->getContainer();
-            static::$kernel->shutdown();
-            static::$booted = false;
 
             if ($container->has('services_resetter')) {
                 // Instantiate the service because Container::reset() only resets services that have been used
                 $container->get('services_resetter');
             }
+
+            static::$kernel->shutdown();
+            static::$booted = false;
 
             if ($container instanceof ResetInterface) {
                 $container->reset();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

#58240 play with the container after the kernel was shut down. 
This is an issue when the kernel performs a cleanup operation. For instance, the @Nyholm TestBundle [deletes cache files](https://github.com/SymfonyTest/symfony-bundle-test/blob/241bf0e2f00f28f7327113570ab20e24a5828829/src/TestKernel.php#L184-L199) as a result, the service is not accessible anymore and triggers errors.


This PR move the call to `container->get` before `kernel::shutdown`