### PR TITLE
Fix named arguments in data providers

### DIFF
--- a/src/Symfony/Component/HtmlSanitizer/Tests/TextSanitizer/UrlSanitizerTest.php
+++ b/src/Symfony/Component/HtmlSanitizer/Tests/TextSanitizer/UrlSanitizerTest.php
@@ -24,7 +24,7 @@ class UrlSanitizerTest extends TestCase
         $this->assertSame($expected, UrlSanitizer::sanitize($input, $allowedSchemes, $forceHttps, $allowedHosts, $allowRelative));
     }
 
-    public static function provideSanitize()
+    public static function provideSanitize(): iterable
     {
         // Simple accepted cases
         yield [
@@ -33,7 +33,7 @@ class UrlSanitizerTest extends TestCase
             'allowedHosts' => null,
             'forceHttps' => false,
             'allowRelative' => false,
-            'output' => null,
+            'expected' => null,
         ];
 
         yield [
@@ -42,7 +42,7 @@ class UrlSanitizerTest extends TestCase
             'allowedHosts' => null,
             'forceHttps' => false,
             'allowRelative' => false,
-            'output' => null,
+            'expected' => null,
         ];
 
         yield [
@@ -51,7 +51,7 @@ class UrlSanitizerTest extends TestCase
             'allowedHosts' => null,
             'forceHttps' => false,
             'allowRelative' => false,
-            'output' => 'http://trusted.com/link.php',
+            'expected' => 'http://trusted.com/link.php',
         ];
 
         yield [
@@ -60,7 +60,7 @@ class UrlSanitizerTest extends TestCase
             'allowedHosts' => null,
             'forceHttps' => false,
             'allowRelative' => false,
-            'output' => 'https://trusted.com/link.php',
+            'expected' => 'https://trusted.com/link.php',
         ];
 
         yield [
@@ -69,7 +69,7 @@ class UrlSanitizerTest extends TestCase
             'allowedHosts' => null,
             'forceHttps' => false,
             'allowRelative' => false,
-            'output' => 'data:text/plain;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
+            'expected' => 'data:text/plain;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
         ];
 
         yield [
@@ -78,7 +78,7 @@ class UrlSanitizerTest extends TestCase
             'allowedHosts' => null,
             'forceHttps' => false,
             'allowRelative' => false,
-            'output' => 'https://trusted.com/link.php',
+            'expected' => 'https://trusted.com/link.php',
         ];
 
         yield [
@@ -87,7 +87,7 @@ class UrlSanitizerTest extends TestCase
             'allowedHosts' => ['trusted.com'],
             'forceHttps' => false,
             'allowRelative' => false,
-            'output' => 'https://trusted.com/link.php',
+            'expected' => 'https://trusted.com/link.php',
         ];
 
         yield [
@@ -96,7 +96,7 @@ class UrlSanitizerTest extends TestCase
             'allowedHosts' => ['trusted.com'],
             'forceHttps' => false,
             'allowRelative' => false,
-            'output' => 'http://trusted.com/link.php',
+            'expected' => 'http://trusted.com/link.php',
         ];
 
         yield [
@@ -105,7 +105,7 @@ class UrlSanitizerTest extends TestCase
             'allowedHosts' => null,
             'forceHttps' => false,
             'allowRelative' => false,
-            'output' => 'data:text/plain;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
+            'expected' => 'data:text/plain;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
         ];
 
         // Simple filtered cases
@@ -115,7 +115,7 @@ class UrlSanitizerTest extends TestCase
             'allowedHosts' => null,
             'forceHttps' => false,
             'allowRelative' => false,
-            'output' => null,
+            'expected' => null,
         ];
 
         yield [
@@ -124,7 +124,7 @@ class UrlSanitizerTest extends TestCase
             'allowedHosts' => null,
             'forceHttps' => false,
             'allowRelative' => false,
-            'output' => null,
+            'expected' => null,
         ];
 
         yield [
@@ -133,7 +133,7 @@ class UrlSanitizerTest extends TestCase
             'allowedHosts' => null,
             'forceHttps' => false,
             'allowRelative' => true,
-            'output' => 'http:link.php',
+            'expected' => 'http:link.php',
         ];
 
         yield [
@@ -142,7 +142,7 @@ class UrlSanitizerTest extends TestCase
             'allowedHosts' => ['trusted.com'],
             'forceHttps' => false,
             'allowRelative' => false,
-            'output' => null,
+            'expected' => null,
         ];
 
         yield [
@@ -151,7 +151,7 @@ class UrlSanitizerTest extends TestCase
             'allowedHosts' => null,
             'forceHttps' => false,
             'allowRelative' => false,
-            'output' => null,
+            'expected' => null,
         ];
 
         yield [
@@ -160,7 +160,7 @@ class UrlSanitizerTest extends TestCase
             'allowedHosts' => ['trusted.com'],
             'forceHttps' => false,
             'allowRelative' => false,
-            'output' => null,
+            'expected' => null,
         ];
 
         yield [
@@ -169,7 +169,7 @@ class UrlSanitizerTest extends TestCase
             'allowedHosts' => ['trusted.com'],
             'forceHttps' => false,
             'allowRelative' => false,
-            'output' => null,
+            'expected' => null,
         ];
 
         yield [
@@ -178,7 +178,7 @@ class UrlSanitizerTest extends TestCase
             'allowedHosts' => null,
             'forceHttps' => false,
             'allowRelative' => false,
-            'output' => null,
+            'expected' => null,
         ];
 
         yield [
@@ -187,7 +187,7 @@ class UrlSanitizerTest extends TestCase
             'allowedHosts' => ['trusted.com'],
             'forceHttps' => false,
             'allowRelative' => false,
-            'output' => null,
+            'expected' => null,
         ];
 
         // Allow null host (data scheme for instance)
@@ -197,7 +197,7 @@ class UrlSanitizerTest extends TestCase
             'allowedHosts' => ['trusted.com', null],
             'forceHttps' => false,
             'allowRelative' => false,
-            'output' => 'data:text/plain;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
+            'expected' => 'data:text/plain;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
         ];
 
         // Force HTTPS
@@ -207,7 +207,7 @@ class UrlSanitizerTest extends TestCase
             'allowedHosts' => ['trusted.com'],
             'forceHttps' => true,
             'allowRelative' => false,
-            'output' => 'https://trusted.com/link.php',
+            'expected' => 'https://trusted.com/link.php',
         ];
 
         yield [
@@ -216,7 +216,7 @@ class UrlSanitizerTest extends TestCase
             'allowedHosts' => ['trusted.com'],
             'forceHttps' => true,
             'allowRelative' => false,
-            'output' => 'https://trusted.com/link.php',
+            'expected' => 'https://trusted.com/link.php',
         ];
 
         yield [
@@ -225,7 +225,7 @@ class UrlSanitizerTest extends TestCase
             'allowedHosts' => null,
             'forceHttps' => true,
             'allowRelative' => false,
-            'output' => 'data:text/plain;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
+            'expected' => 'data:text/plain;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
         ];
 
         yield [
@@ -234,7 +234,7 @@ class UrlSanitizerTest extends TestCase
             'allowedHosts' => ['trusted.com', null],
             'forceHttps' => true,
             'allowRelative' => false,
-            'output' => 'data:text/plain;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
+            'expected' => 'data:text/plain;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
         ];
 
         // Domain matching
@@ -244,7 +244,7 @@ class UrlSanitizerTest extends TestCase
             'allowedHosts' => ['trusted.com'],
             'forceHttps' => false,
             'allowRelative' => false,
-            'output' => 'https://subdomain.trusted.com/link.php',
+            'expected' => 'https://subdomain.trusted.com/link.php',
         ];
 
         yield [
@@ -253,7 +253,7 @@ class UrlSanitizerTest extends TestCase
             'allowedHosts' => ['trusted.com'],
             'forceHttps' => false,
             'allowRelative' => false,
-            'output' => null,
+            'expected' => null,
         ];
 
         yield [
@@ -262,7 +262,7 @@ class UrlSanitizerTest extends TestCase
             'allowedHosts' => ['trusted.com'],
             'forceHttps' => false,
             'allowRelative' => false,
-            'output' => 'https://deep.subdomain.trusted.com/link.php',
+            'expected' => 'https://deep.subdomain.trusted.com/link.php',
         ];
 
         yield [
@@ -271,7 +271,7 @@ class UrlSanitizerTest extends TestCase
             'allowedHosts' => ['trusted.com'],
             'forceHttps' => false,
             'allowRelative' => false,
-            'output' => null,
+            'expected' => null,
         ];
 
         // Allow relative
@@ -281,7 +281,7 @@ class UrlSanitizerTest extends TestCase
             'allowedHosts' => ['trusted.com'],
             'forceHttps' => true,
             'allowRelative' => true,
-            'output' => '/link.php',
+            'expected' => '/link.php',
         ];
 
         yield [
@@ -290,7 +290,7 @@ class UrlSanitizerTest extends TestCase
             'allowedHosts' => ['trusted.com'],
             'forceHttps' => true,
             'allowRelative' => false,
-            'output' => null,
+            'expected' => null,
         ];
     }
 

--- a/src/Symfony/Component/HttpClient/Tests/ScopingHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/ScopingHttpClientTest.php
@@ -49,16 +49,16 @@ class ScopingHttpClientTest extends TestCase
         $this->assertSame($options[$regexp]['case'], $requestedOptions['case']);
     }
 
-    public static function provideMatchingUrls()
+    public static function provideMatchingUrls(): iterable
     {
         $defaultOptions = [
             '.*/foo-bar' => ['case' => 1],
             '.*' => ['case' => 2],
         ];
 
-        yield ['regexp' => '.*/foo-bar', 'url' => 'http://example.com/foo-bar', 'default_options' => $defaultOptions];
-        yield ['regexp' => '.*', 'url' => 'http://example.com/bar-foo', 'default_options' => $defaultOptions];
-        yield ['regexp' => '.*', 'url' => 'http://example.com/foobar', 'default_options' => $defaultOptions];
+        yield ['regexp' => '.*/foo-bar', 'url' => 'http://example.com/foo-bar', 'options' => $defaultOptions];
+        yield ['regexp' => '.*', 'url' => 'http://example.com/bar-foo', 'options' => $defaultOptions];
+        yield ['regexp' => '.*', 'url' => 'http://example.com/foobar', 'options' => $defaultOptions];
     }
 
     public function testMatchingUrlsAndOptions()

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportTest.php
@@ -623,7 +623,7 @@ final class TelegramTransportTest extends TransportTestCase
     }
 
     /**
-     * @return array<array<string, array{messageOptions: TelegramOptions, endpoint: string, fileOption: string, expectedBody: array<mixed>, responseContent: array<mixed>}>>
+     * @return array<array<string, array{messageOptions: TelegramOptions, endpoint: string, fileOption: string, expectedParameters: array<mixed>, responseContent: array<mixed>}>>
      */
     public static function sendFileByUploadProvider(): array
     {
@@ -632,7 +632,7 @@ final class TelegramTransportTest extends TransportTestCase
                 'messageOptions' => (new TelegramOptions())->uploadPhoto(self::FIXTURE_FILE)->hasSpoiler(true),
                 'endpoint' => 'sendPhoto',
                 'fileOption' => 'photo',
-                'expectedBody' => [
+                'expectedParameters' => [
                     'has_spoiler' => true,
                     'chat_id' => 'testChannel',
                     'parse_mode' => 'MarkdownV2',
@@ -654,7 +654,7 @@ final class TelegramTransportTest extends TransportTestCase
                 'messageOptions' => (new TelegramOptions())->uploadVideo(self::FIXTURE_FILE),
                 'endpoint' => 'sendVideo',
                 'fileOption' => 'video',
-                'expectedBody' => [
+                'expectedParameters' => [
                     'chat_id' => 'testChannel',
                     'parse_mode' => 'MarkdownV2',
                     'video' => self::FIXTURE_FILE,
@@ -673,7 +673,7 @@ final class TelegramTransportTest extends TransportTestCase
                 'messageOptions' => (new TelegramOptions())->uploadAnimation(self::FIXTURE_FILE),
                 'endpoint' => 'sendAnimation',
                 'fileOption' => 'animation',
-                'expectedBody' => [
+                'expectedParameters' => [
                     'chat_id' => 'testChannel',
                     'parse_mode' => 'MarkdownV2',
                     'animation' => self::FIXTURE_FILE,
@@ -692,7 +692,7 @@ final class TelegramTransportTest extends TransportTestCase
                 'messageOptions' => (new TelegramOptions())->uploadAudio(self::FIXTURE_FILE),
                 'endpoint' => 'sendAudio',
                 'fileOption' => 'audio',
-                'expectedBody' => [
+                'expectedParameters' => [
                     'chat_id' => 'testChannel',
                     'parse_mode' => 'MarkdownV2',
                     'audio' => self::FIXTURE_FILE,
@@ -711,7 +711,7 @@ final class TelegramTransportTest extends TransportTestCase
                 'messageOptions' => (new TelegramOptions())->uploadDocument(self::FIXTURE_FILE),
                 'endpoint' => 'sendDocument',
                 'fileOption' => 'document',
-                'expectedBody' => [
+                'expectedParameters' => [
                     'chat_id' => 'testChannel',
                     'parse_mode' => 'MarkdownV2',
                     'document' => self::FIXTURE_FILE,
@@ -732,7 +732,7 @@ final class TelegramTransportTest extends TransportTestCase
                 'messageOptions' => (new TelegramOptions())->uploadSticker(self::FIXTURE_FILE, '🤖'),
                 'endpoint' => 'sendSticker',
                 'fileOption' => 'sticker',
-                'expectedBody' => [
+                'expectedParameters' => [
                     'emoji' => '🤖',
                     'chat_id' => 'testChannel',
                     'parse_mode' => 'MarkdownV2',
@@ -757,7 +757,7 @@ final class TelegramTransportTest extends TransportTestCase
                 'messageOptions' => (new TelegramOptions())->uploadSticker(self::FIXTURE_FILE),
                 'endpoint' => 'sendSticker',
                 'fileOption' => 'sticker',
-                'expectedBody' => [
+                'expectedParameters' => [
                     'chat_id' => 'testChannel',
                     'parse_mode' => 'MarkdownV2',
                     'sticker' => self::FIXTURE_FILE,

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/TraceableAccessDecisionManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/TraceableAccessDecisionManagerTest.php
@@ -116,7 +116,7 @@ class TraceableAccessDecisionManagerTest extends TestCase
                 'result' => true,
                 'voterDetails' => [],
             ]],
-            'attributes' => [12],
+            [12],
             12345,
             [],
             true,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

If a data provider returns data sets with strings keys, PHPUnit 9 would simply discard those keys. PHPUnit 11 however supports named arguments, so the keys are actually matches to parameter names.

This PR fixes data providers where the keys of the data sets were not consistent with the names of the parameters of the test cases those providers were applied to.