### PR TITLE
[Routing] Add the `Requirement::UID_RFC9562` constant

### DIFF
--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+ * Add the `Requirement::UID_RFC9562` constant to validate UUIDs in the RFC 9562 format
+
 7.1
 ---
 

--- a/src/Symfony/Component/Routing/Requirement/Requirement.php
+++ b/src/Symfony/Component/Routing/Requirement/Requirement.php
@@ -24,6 +24,7 @@ enum Requirement
     public const UID_BASE32 = '[0-9A-HJKMNP-TV-Z]{26}';
     public const UID_BASE58 = '[1-9A-HJ-NP-Za-km-z]{22}';
     public const UID_RFC4122 = '[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}';
+    public const UID_RFC9562 = self::UID_RFC4122;
     public const ULID = '[0-7][0-9A-HJKMNP-TV-Z]{25}';
     public const UUID = '[0-9a-f]{8}-[0-9a-f]{4}-[13-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}';
     public const UUID_V1 = '[0-9a-f]{8}-[0-9a-f]{4}-1[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}';

--- a/src/Symfony/Component/Routing/Tests/Requirement/RequirementTest.php
+++ b/src/Symfony/Component/Routing/Tests/Requirement/RequirementTest.php
@@ -224,10 +224,7 @@ class RequirementTest extends TestCase
     }
 
     /**
-     * @testWith    ["00000000-0000-0000-0000-000000000000"]
-     *              ["ffffffff-ffff-ffff-ffff-ffffffffffff"]
-     *              ["01802c4e-c409-9f07-863c-f025ca7766a0"]
-     *              ["056654ca-0699-4e16-9895-e60afca090d7"]
+     * @dataProvider provideUidRfc4122
      */
     public function testUidRfc4122OK(string $uid)
     {
@@ -238,11 +235,7 @@ class RequirementTest extends TestCase
     }
 
     /**
-     * @testWith    [""]
-     *              ["foo"]
-     *              ["01802c4e-c409-9f07-863c-f025ca7766a"]
-     *              ["01802c4e-c409-9f07-863c-f025ca7766ag"]
-     *              ["01802c4ec4099f07863cf025ca7766a0"]
+     * @dataProvider provideUidRfc4122KO
      */
     public function testUidRfc4122KO(string $uid)
     {
@@ -250,6 +243,45 @@ class RequirementTest extends TestCase
             (new Route('/{uid}', [], ['uid' => Requirement::UID_RFC4122]))->compile()->getRegex(),
             '/'.$uid,
         );
+    }
+
+    /**
+     * @dataProvider provideUidRfc4122
+     */
+    public function testUidRfc9562OK(string $uid)
+    {
+        $this->assertMatchesRegularExpression(
+            (new Route('/{uid}', [], ['uid' => Requirement::UID_RFC9562]))->compile()->getRegex(),
+            '/'.$uid,
+        );
+    }
+
+    /**
+     * @dataProvider provideUidRfc4122KO
+     */
+    public function testUidRfc9562KO(string $uid)
+    {
+        $this->assertDoesNotMatchRegularExpression(
+            (new Route('/{uid}', [], ['uid' => Requirement::UID_RFC9562]))->compile()->getRegex(),
+            '/'.$uid,
+        );
+    }
+
+    public static function provideUidRfc4122(): iterable
+    {
+        yield ['00000000-0000-0000-0000-000000000000'];
+        yield ['ffffffff-ffff-ffff-ffff-ffffffffffff'];
+        yield ['01802c4e-c409-9f07-863c-f025ca7766a0'];
+        yield ['056654ca-0699-4e16-9895-e60afca090d7'];
+    }
+
+    public static function provideUidRfc4122KO(): iterable
+    {
+        yield [''];
+        yield ['foo'];
+        yield ['01802c4e-c409-9f07-863c-f025ca7766a'];
+        yield ['01802c4e-c409-9f07-863c-f025ca7766ag'];
+        yield ['01802c4ec4099f07863cf025ca7766a0'];
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Following https://github.com/symfony/symfony/pull/58329/files#r1768217660