### PR TITLE
[Notifier] allow the Novu bridge to be used with symfony/notifier 7.x

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Novu/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Novu/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/http-client": "^5.4|^6.0|^7.0",
-        "symfony/notifier": "^6.4"
+        "symfony/notifier": "^6.4|^7.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Novu\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT