### PR TITLE
[ExpressionLanguage] Add support for logical `xor` operator

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/CHANGELOG.md
+++ b/src/Symfony/Component/ExpressionLanguage/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add support for comments using `/*` & `*/`
  * Allow passing any iterable as `$providers` list to `ExpressionLanguage` constructor
  * Add support for `<<`, `>>`, and `~` bitwise operators
+ * Add support for logical `xor` operator
 
 7.1
 ---

--- a/src/Symfony/Component/ExpressionLanguage/Lexer.php
+++ b/src/Symfony/Component/ExpressionLanguage/Lexer.php
@@ -72,7 +72,7 @@ class Lexer
             } elseif (preg_match('{/\*.*?\*/}A', $expression, $match, 0, $cursor)) {
                 // comments
                 $cursor += \strlen($match[0]);
-            } elseif (preg_match('/(?<=^|[\s(])starts with(?=[\s(])|(?<=^|[\s(])ends with(?=[\s(])|(?<=^|[\s(])contains(?=[\s(])|(?<=^|[\s(])matches(?=[\s(])|(?<=^|[\s(])not in(?=[\s(])|(?<=^|[\s(])not(?=[\s(])|(?<=^|[\s(])and(?=[\s(])|\=\=\=|\!\=\=|(?<=^|[\s(])or(?=[\s(])|\|\||&&|\=\=|\!\=|\>\=|\<\=|(?<=^|[\s(])in(?=[\s(])|\.\.|\*\*|\<\<|\>\>|\!|\||\^|&|\<|\>|\+|\-|~|\*|\/|%/A', $expression, $match, 0, $cursor)) {
+            } elseif (preg_match('/(?<=^|[\s(])starts with(?=[\s(])|(?<=^|[\s(])ends with(?=[\s(])|(?<=^|[\s(])contains(?=[\s(])|(?<=^|[\s(])matches(?=[\s(])|(?<=^|[\s(])not in(?=[\s(])|(?<=^|[\s(])not(?=[\s(])|(?<=^|[\s(])xor(?=[\s(])|(?<=^|[\s(])and(?=[\s(])|\=\=\=|\!\=\=|(?<=^|[\s(])or(?=[\s(])|\|\||&&|\=\=|\!\=|\>\=|\<\=|(?<=^|[\s(])in(?=[\s(])|\.\.|\*\*|\<\<|\>\>|\!|\||\^|&|\<|\>|\+|\-|~|\*|\/|%/A', $expression, $match, 0, $cursor)) {
                 // operators
                 $tokens[] = new Token(Token::OPERATOR_TYPE, $match[0], $cursor + 1);
                 $cursor += \strlen($match[0]);

--- a/src/Symfony/Component/ExpressionLanguage/Node/BinaryNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/BinaryNode.php
@@ -116,6 +116,8 @@ class BinaryNode extends Node
             case 'or':
             case '||':
                 return $left || $this->nodes['right']->evaluate($functions, $values);
+            case 'xor':
+                return $left xor $this->nodes['right']->evaluate($functions, $values);
             case 'and':
             case '&&':
                 return $left && $this->nodes['right']->evaluate($functions, $values);

--- a/src/Symfony/Component/ExpressionLanguage/Parser.php
+++ b/src/Symfony/Component/ExpressionLanguage/Parser.php
@@ -48,6 +48,7 @@ class Parser
         $this->binaryOperators = [
             'or' => ['precedence' => 10, 'associativity' => self::OPERATOR_LEFT],
             '||' => ['precedence' => 10, 'associativity' => self::OPERATOR_LEFT],
+            'xor' => ['precedence' => 12, 'associativity' => self::OPERATOR_LEFT],
             'and' => ['precedence' => 15, 'associativity' => self::OPERATOR_LEFT],
             '&&' => ['precedence' => 15, 'associativity' => self::OPERATOR_LEFT],
             '|' => ['precedence' => 16, 'associativity' => self::OPERATOR_LEFT],

--- a/src/Symfony/Component/ExpressionLanguage/Resources/bin/generate_operator_regex.php
+++ b/src/Symfony/Component/ExpressionLanguage/Resources/bin/generate_operator_regex.php
@@ -13,7 +13,7 @@ if ('cli' !== \PHP_SAPI) {
     throw new Exception('This script must be run from the command line.');
 }
 
-$operators = ['not', '!', 'or', '||', '&&', 'and', '|', '^', '&', '==', '===', '!=', '!==', '<', '>', '>=', '<=', 'not in', 'in', '..', '+', '-', '~', '*', '/', '%', 'contains', 'starts with', 'ends with', 'matches', '**', '<<', '>>'];
+$operators = ['not', '!', 'or', '||', 'xor', '&&', 'and', '|', '^', '&', '==', '===', '!=', '!==', '<', '>', '>=', '<=', 'not in', 'in', '..', '+', '-', '~', '*', '/', '%', 'contains', 'starts with', 'ends with', 'matches', '**', '<<', '>>'];
 $operators = array_combine($operators, array_map('strlen', $operators));
 arsort($operators);
 

--- a/src/Symfony/Component/ExpressionLanguage/Tests/LexerTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/LexerTest.php
@@ -182,6 +182,14 @@ class LexerTest extends TestCase
                 ],
                 '"/* this is not a comment */"',
             ],
+            [
+                [
+                    new Token('name', 'foo', 1),
+                    new Token('operator', 'xor', 5),
+                    new Token('name', 'bar', 9),
+                ],
+                'foo xor bar',
+            ],
         ];
     }
 

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/BinaryNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/BinaryNodeTest.php
@@ -29,6 +29,7 @@ class BinaryNodeTest extends AbstractNodeTestCase
         return [
             [true, new BinaryNode('or', new ConstantNode(true), new ConstantNode(false))],
             [true, new BinaryNode('||', new ConstantNode(true), new ConstantNode(false))],
+            [false, new BinaryNode('xor', new ConstantNode(true), new ConstantNode(true))],
             [false, new BinaryNode('and', new ConstantNode(true), new ConstantNode(false))],
             [false, new BinaryNode('&&', new ConstantNode(true), new ConstantNode(false))],
 
@@ -86,6 +87,7 @@ class BinaryNodeTest extends AbstractNodeTestCase
         return [
             ['(true || false)', new BinaryNode('or', new ConstantNode(true), new ConstantNode(false))],
             ['(true || false)', new BinaryNode('||', new ConstantNode(true), new ConstantNode(false))],
+            ['(true xor true)', new BinaryNode('xor', new ConstantNode(true), new ConstantNode(true))],
             ['(true && false)', new BinaryNode('and', new ConstantNode(true), new ConstantNode(false))],
             ['(true && false)', new BinaryNode('&&', new ConstantNode(true), new ConstantNode(false))],
 
@@ -140,6 +142,7 @@ class BinaryNodeTest extends AbstractNodeTestCase
         return [
             ['(true or false)', new BinaryNode('or', new ConstantNode(true), new ConstantNode(false))],
             ['(true || false)', new BinaryNode('||', new ConstantNode(true), new ConstantNode(false))],
+            ['(true xor true)', new BinaryNode('xor', new ConstantNode(true), new ConstantNode(true))],
             ['(true and false)', new BinaryNode('and', new ConstantNode(true), new ConstantNode(false))],
             ['(true && false)', new BinaryNode('&&', new ConstantNode(true), new ConstantNode(false))],
 

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
@@ -245,6 +245,15 @@ class ParserTest extends TestCase
                 ['foo'],
             ],
             [
+                new Node\BinaryNode(
+                    'xor',
+                    new Node\NameNode('foo'),
+                    new Node\NameNode('bar'),
+                ),
+                'foo xor bar',
+                ['foo', 'bar'],
+            ],
+            [
                 new Node\BinaryNode('..', new Node\ConstantNode(0), new Node\ConstantNode(3)),
                 '0..3',
             ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Contains #58342

Adds support for the logical `xor` operator.