### PR TITLE
[ExpressionLanguage] Use script to generate regex

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Lexer.php
+++ b/src/Symfony/Component/ExpressionLanguage/Lexer.php
@@ -72,7 +72,7 @@ class Lexer
             } elseif (preg_match('{/\*.*?\*/}A', $expression, $match, 0, $cursor)) {
                 // comments
                 $cursor += \strlen($match[0]);
-            } elseif (preg_match('/(?<=^|[\s(])starts with(?=[\s(])|(?<=^|[\s(])ends with(?=[\s(])|(?<=^|[\s(])contains(?=[\s(])|(?<=^|[\s(])matches(?=[\s(])|(?<=^|[\s(])not in(?=[\s(])|(?<=^|[\s(])not(?=[\s(])|(?<=^|[\s(])and(?=[\s(])|\=\=\=|\!\=\=|(?<=^|[\s(])or(?=[\s(])|\|\||&&|\=\=|\!\=|\>\=|\<\=|(?<=^|[\s(])in(?=[\s(])|\.\.|\*\*|\!|\||\^|&|<<|>>|\<|\>|\+|\-|~|\*|\/|%/A', $expression, $match, 0, $cursor)) {
+            } elseif (preg_match('/(?<=^|[\s(])starts with(?=[\s(])|(?<=^|[\s(])ends with(?=[\s(])|(?<=^|[\s(])contains(?=[\s(])|(?<=^|[\s(])matches(?=[\s(])|(?<=^|[\s(])not in(?=[\s(])|(?<=^|[\s(])not(?=[\s(])|(?<=^|[\s(])and(?=[\s(])|\=\=\=|\!\=\=|(?<=^|[\s(])or(?=[\s(])|\|\||&&|\=\=|\!\=|\>\=|\<\=|(?<=^|[\s(])in(?=[\s(])|\.\.|\*\*|\<\<|\>\>|\!|\||\^|&|\<|\>|\+|\-|~|\*|\/|%/A', $expression, $match, 0, $cursor)) {
                 // operators
                 $tokens[] = new Token(Token::OPERATOR_TYPE, $match[0], $cursor + 1);
                 $cursor += \strlen($match[0]);

--- a/src/Symfony/Component/ExpressionLanguage/Resources/bin/generate_operator_regex.php
+++ b/src/Symfony/Component/ExpressionLanguage/Resources/bin/generate_operator_regex.php
@@ -13,7 +13,7 @@ if ('cli' !== \PHP_SAPI) {
     throw new Exception('This script must be run from the command line.');
 }
 
-$operators = ['not', '!', 'or', '||', '&&', 'and', '|', '^', '&', '==', '===', '!=', '!==', '<', '>', '>=', '<=', 'not in', 'in', '..', '+', '-', '~', '*', '/', '%', 'contains', 'starts with', 'ends with', 'matches', '**'];
+$operators = ['not', '!', 'or', '||', '&&', 'and', '|', '^', '&', '==', '===', '!=', '!==', '<', '>', '>=', '<=', 'not in', 'in', '..', '+', '-', '~', '*', '/', '%', 'contains', 'starts with', 'ends with', 'matches', '**', '<<', '>>'];
 $operators = array_combine($operators, array_map('strlen', $operators));
 arsort($operators);
 

--- a/src/Symfony/Component/ExpressionLanguage/Tests/LexerTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/LexerTest.php
@@ -184,4 +184,20 @@ class LexerTest extends TestCase
             ],
         ];
     }
+
+    public function testOperatorRegexWasGeneratedWithScript()
+    {
+        ob_start();
+        try {
+            require $script = \dirname(__DIR__).'/Resources/bin/generate_operator_regex.php';
+        } finally {
+            $output = ob_get_clean();
+        }
+
+        self::assertStringContainsString(
+            $output,
+            file_get_contents((new \ReflectionClass(Lexer::class))->getFileName()),
+            \sprintf('You need to run "%s" to generate the operator regex.', $script),
+        );
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | maybe?
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Fixes/uses the `generate_operator_regex.php` script for the regex added in #58052