### PR TITLE
Add missing Albanian translations for Security and Validator components

### DIFF
--- a/src/Symfony/Component/Security/Core/Resources/translations/security.sq.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.sq.xlf
@@ -20,7 +20,7 @@
             </trans-unit>
             <trans-unit id="5">
                 <source>Cookie has already been used by someone else.</source>
-                <target>Cookie është përdorur tashmë nga dikush tjetër.</target>
+                <target>“Cookie” është përdorur tashmë nga dikush tjetër.</target>
             </trans-unit>
             <trans-unit id="6">
                 <source>Not privileged to request the resource.</source>
@@ -76,7 +76,7 @@
             </trans-unit>
             <trans-unit id="20">
                 <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target state="needs-review-translation">Shumë përpjekje të pasuksesshme për t'u identifikuar, ju lutemi provoni përsëri pas %minutes% minutash.</target>
+                <target>Shumë përpjekje të dështuara për identifikim, ju lutemi provoni përsëri pas %minutes% minutash.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.sq.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sq.xlf
@@ -453,27 +453,27 @@
             </trans-unit>
             <trans-unit id="114">
                 <source>This value is too short. It should contain at least one word.|This value is too short. It should contain at least {{ min }} words.</source>
-                <target state="needs-translation">This value is too short. It should contain at least one word.|This value is too short. It should contain at least {{ min }} words.</target>
+                <target>Kjo vlerë është shumë e shkurtër. Duhet të përmbajë të paktën një fjalë.|Kjo vlerë është shumë e shkurtër. Duhet të përmbajë të paktën {{ min }} fjalë.</target>
             </trans-unit>
             <trans-unit id="115">
                 <source>This value is too long. It should contain one word.|This value is too long. It should contain {{ max }} words or less.</source>
-                <target state="needs-translation">This value is too long. It should contain one word.|This value is too long. It should contain {{ max }} words or less.</target>
+                <target>Kjo vlerë është shumë e gjatë. Duhet të përmbajë një fjalë.|Kjo vlerë është shumë e gjatë. Duhet të përmbajë {{ max }} fjalë ose më pak.</target>
             </trans-unit>
             <trans-unit id="116">
                 <source>This value does not represent a valid week in the ISO 8601 format.</source>
-                <target state="needs-translation">This value does not represent a valid week in the ISO 8601 format.</target>
+                <target>Kjo vlerë nuk përfaqëson një javë të vlefshme në formatin ISO 8601.</target>
             </trans-unit>
             <trans-unit id="117">
                 <source>This value is not a valid week.</source>
-                <target state="needs-translation">This value is not a valid week.</target>
+                <target>Kjo vlerë nuk është një javë e vlefshme.</target>
             </trans-unit>
             <trans-unit id="118">
                 <source>This value should not be before week "{{ min }}".</source>
-                <target state="needs-translation">This value should not be before week "{{ min }}".</target>
+                <target>Kjo vlerë nuk duhet të jetë para javës "{{ min }}".</target>
             </trans-unit>
             <trans-unit id="119">
                 <source>This value should not be after week "{{ max }}".</source>
-                <target state="needs-translation">This value should not be after week "{{ max }}".</target>
+                <target>Kjo vlerë nuk duhet të jetë pas javës "{{ max }}".</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54548 
| License       | MIT

Added missing Albanian translations, in
src/Symfony/Component/Security/Core/Resources/translations/security.sq.xlf and src/Symfony/Component/Validator/Resources/translations/validators.sq.xlf
files respectively.