### PR TITLE
Add PR template and auto-close PR on subtree split repositories

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,5 @@
 /src/Symfony/Component/Runtime export-ignore
 /src/Symfony/Component/Translation/Bridge export-ignore
 /src/Symfony/Component/Intl/Resources/data/*/* linguist-generated=true
+/src/Symfony/**/.github/workflows/close-pull-request.yml linguist-generated=true
+/src/Symfony/**/.github/PULL_REQUEST_TEMPLATE.md linguist-generated=true

--- a/.github/sync-packages.php
+++ b/.github/sync-packages.php
@@ -1,0 +1,57 @@
+<?php
+
+if ('cli' !== PHP_SAPI) {
+    echo "This script can only be run from the command line.\n";
+    exit(1);
+}
+
+$mainRepo = 'https://github.com/symfony/symfony';
+exec('find src -name composer.json', $packages);
+
+foreach ($packages as $package) {
+    $package = dirname($package);
+    $c = file_get_contents($package.'/.gitattributes');
+    $c = preg_replace('{^/\.git.*+\n}m', '', $c);
+    $c .= "/.git* export-ignore\n";
+    file_put_contents($package.'/.gitattributes', $c);
+
+    @mkdir($package.'/.github');
+    file_put_contents($package.'/.github/PULL_REQUEST_TEMPLATE.md', <<<EOTXT
+        Please do not submit any Pull Requests here. They will be closed.
+        ---
+
+        Please submit your PR here instead:
+        {$mainRepo}
+
+        This repository is what we call a "subtree split": a read-only subset of that main repository.
+        We're looking forward to your PR there!
+
+        EOTXT
+    );
+
+    @mkdir($package.'/.github/workflows');
+    file_put_contents($package.'/.github/workflows/close-pull-request.yml', <<<EOTXT
+        name: Close Pull Request
+
+        on:
+          pull_request_target:
+            types: [opened]
+
+        jobs:
+          run:
+            runs-on: ubuntu-latest
+            steps:
+            - uses: superbrothers/close-pull-request@v3
+              with:
+                comment: |
+                  Thanks for your Pull Request! We love contributions.
+
+                  However, you should instead open your PR on the main repository:
+                  {$mainRepo}
+
+                  This repository is what we call a "subtree split": a read-only subset of that main repository.
+                  We're looking forward to your PR there!
+
+        EOTXT
+    );
+}

--- a/src/Symfony/Bridge/Doctrine/.gitattributes
+++ b/src/Symfony/Bridge/Doctrine/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Bridge/Doctrine/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Bridge/Doctrine/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Bridge/Doctrine/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Bridge/Doctrine/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Bridge/Monolog/.gitattributes
+++ b/src/Symfony/Bridge/Monolog/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Bridge/Monolog/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Bridge/Monolog/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Bridge/Monolog/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Bridge/Monolog/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Bridge/PhpUnit/.gitattributes
+++ b/src/Symfony/Bridge/PhpUnit/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Bridge/PhpUnit/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Bridge/PhpUnit/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Bridge/PhpUnit/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Bridge/PhpUnit/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Bridge/ProxyManager/.gitattributes
+++ b/src/Symfony/Bridge/ProxyManager/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Bridge/ProxyManager/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Bridge/ProxyManager/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Bridge/ProxyManager/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Bridge/ProxyManager/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Bridge/Twig/.gitattributes
+++ b/src/Symfony/Bridge/Twig/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Bridge/Twig/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Bridge/Twig/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Bridge/Twig/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Bridge/Twig/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Bundle/DebugBundle/.gitattributes
+++ b/src/Symfony/Bundle/DebugBundle/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Bundle/DebugBundle/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Bundle/DebugBundle/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Bundle/DebugBundle/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Bundle/DebugBundle/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Bundle/FrameworkBundle/.gitattributes
+++ b/src/Symfony/Bundle/FrameworkBundle/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Bundle/FrameworkBundle/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Bundle/FrameworkBundle/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Bundle/FrameworkBundle/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Bundle/SecurityBundle/.gitattributes
+++ b/src/Symfony/Bundle/SecurityBundle/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Bundle/SecurityBundle/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Bundle/SecurityBundle/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Bundle/SecurityBundle/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Bundle/SecurityBundle/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Bundle/TwigBundle/.gitattributes
+++ b/src/Symfony/Bundle/TwigBundle/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Bundle/TwigBundle/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Bundle/TwigBundle/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Bundle/TwigBundle/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Bundle/TwigBundle/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Bundle/WebProfilerBundle/.gitattributes
+++ b/src/Symfony/Bundle/WebProfilerBundle/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Bundle/WebProfilerBundle/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Bundle/WebProfilerBundle/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Bundle/WebProfilerBundle/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Bundle/WebProfilerBundle/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Asset/.gitattributes
+++ b/src/Symfony/Component/Asset/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Asset/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Asset/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Asset/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Asset/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/BrowserKit/.gitattributes
+++ b/src/Symfony/Component/BrowserKit/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/BrowserKit/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/BrowserKit/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/BrowserKit/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/BrowserKit/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Cache/.gitattributes
+++ b/src/Symfony/Component/Cache/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Cache/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Cache/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Cache/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Cache/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Config/.gitattributes
+++ b/src/Symfony/Component/Config/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Config/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Config/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Config/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Config/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Console/.gitattributes
+++ b/src/Symfony/Component/Console/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Console/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Console/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Console/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Console/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/CssSelector/.gitattributes
+++ b/src/Symfony/Component/CssSelector/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/CssSelector/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/CssSelector/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/CssSelector/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/CssSelector/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/DependencyInjection/.gitattributes
+++ b/src/Symfony/Component/DependencyInjection/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/DependencyInjection/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/DependencyInjection/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/DependencyInjection/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/DependencyInjection/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/DomCrawler/.gitattributes
+++ b/src/Symfony/Component/DomCrawler/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/DomCrawler/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/DomCrawler/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/DomCrawler/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/DomCrawler/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Dotenv/.gitattributes
+++ b/src/Symfony/Component/Dotenv/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Dotenv/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Dotenv/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Dotenv/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Dotenv/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/ErrorHandler/.gitattributes
+++ b/src/Symfony/Component/ErrorHandler/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/ErrorHandler/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/ErrorHandler/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/ErrorHandler/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/ErrorHandler/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/EventDispatcher/.gitattributes
+++ b/src/Symfony/Component/EventDispatcher/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/EventDispatcher/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/EventDispatcher/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/EventDispatcher/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/EventDispatcher/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/ExpressionLanguage/.gitattributes
+++ b/src/Symfony/Component/ExpressionLanguage/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/ExpressionLanguage/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/ExpressionLanguage/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/ExpressionLanguage/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/ExpressionLanguage/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Filesystem/.gitattributes
+++ b/src/Symfony/Component/Filesystem/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Filesystem/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Filesystem/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Filesystem/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Filesystem/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Finder/.gitattributes
+++ b/src/Symfony/Component/Finder/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Finder/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Finder/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Finder/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Finder/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Form/.gitattributes
+++ b/src/Symfony/Component/Form/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Form/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Form/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Form/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Form/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/HttpClient/.gitattributes
+++ b/src/Symfony/Component/HttpClient/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/HttpClient/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/HttpClient/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/HttpClient/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/HttpClient/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/HttpFoundation/.gitattributes
+++ b/src/Symfony/Component/HttpFoundation/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/HttpFoundation/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/HttpFoundation/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/HttpFoundation/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/HttpFoundation/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/HttpKernel/.gitattributes
+++ b/src/Symfony/Component/HttpKernel/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/HttpKernel/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/HttpKernel/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/HttpKernel/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/HttpKernel/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Inflector/.gitattributes
+++ b/src/Symfony/Component/Inflector/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Inflector/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Inflector/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Inflector/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Inflector/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Intl/.gitattributes
+++ b/src/Symfony/Component/Intl/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Intl/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Intl/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Intl/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Intl/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Ldap/.gitattributes
+++ b/src/Symfony/Component/Ldap/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Ldap/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Ldap/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Ldap/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Ldap/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Lock/.gitattributes
+++ b/src/Symfony/Component/Lock/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Lock/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Lock/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Lock/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Lock/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Mailer/.gitattributes
+++ b/src/Symfony/Component/Mailer/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Mailer/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Mailer/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Mailer/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Mailer/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/.gitattributes
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Mailer/Bridge/Google/.gitattributes
+++ b/src/Symfony/Component/Mailer/Bridge/Google/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Mailer/Bridge/Google/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Mailer/Bridge/Google/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Mailer/Bridge/Google/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Mailer/Bridge/Google/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/.gitattributes
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/.gitattributes
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/.gitattributes
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Mailer/Bridge/OhMySmtp/.gitattributes
+++ b/src/Symfony/Component/Mailer/Bridge/OhMySmtp/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Mailer/Bridge/OhMySmtp/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Mailer/Bridge/OhMySmtp/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Mailer/Bridge/OhMySmtp/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Mailer/Bridge/OhMySmtp/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/.gitattributes
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/.gitattributes
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Mailer/Bridge/Sendinblue/.gitattributes
+++ b/src/Symfony/Component/Mailer/Bridge/Sendinblue/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Mailer/Bridge/Sendinblue/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Mailer/Bridge/Sendinblue/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Mailer/Bridge/Sendinblue/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Mailer/Bridge/Sendinblue/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Messenger/.gitattributes
+++ b/src/Symfony/Component/Messenger/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Messenger/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Messenger/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Messenger/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Messenger/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/.gitattributes
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/.gitattributes
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Messenger/Bridge/Beanstalkd/.gitattributes
+++ b/src/Symfony/Component/Messenger/Bridge/Beanstalkd/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Messenger/Bridge/Beanstalkd/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Messenger/Bridge/Beanstalkd/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Messenger/Bridge/Beanstalkd/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Messenger/Bridge/Beanstalkd/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/.gitattributes
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Messenger/Bridge/Redis/.gitattributes
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Messenger/Bridge/Redis/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Messenger/Bridge/Redis/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Mime/.gitattributes
+++ b/src/Symfony/Component/Mime/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Mime/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Mime/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Mime/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Mime/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/.gitattributes
+++ b/src/Symfony/Component/Notifier/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/AllMySms/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/AllMySms/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/AllMySms/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/AllMySms/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/AllMySms/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/AllMySms/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/AmazonSns/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/AmazonSns/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/AmazonSns/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/AmazonSns/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/AmazonSns/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/AmazonSns/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Clickatell/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Clickatell/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Clickatell/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/Clickatell/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Clickatell/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/Clickatell/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Discord/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Discord/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Discord/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Esendex/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Esendex/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Esendex/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/Esendex/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Esendex/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/Esendex/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Expo/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Expo/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Expo/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/Expo/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Expo/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/Expo/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/FakeChat/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/FakeChat/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/FakeChat/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/FakeChat/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/FakeChat/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/FakeChat/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/FakeSms/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/FakeSms/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/FakeSms/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/FakeSms/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/FakeSms/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/FakeSms/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/FreeMobile/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/FreeMobile/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/FreeMobile/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/FreeMobile/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/FreeMobile/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/FreeMobile/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/GatewayApi/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/GatewayApi/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/GatewayApi/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/GatewayApi/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/GatewayApi/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/GatewayApi/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Gitter/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Gitter/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Gitter/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/Gitter/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Gitter/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/Gitter/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Infobip/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Infobip/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Infobip/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/Infobip/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Infobip/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/Infobip/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Iqsms/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Iqsms/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Iqsms/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/Iqsms/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Iqsms/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/Iqsms/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/LightSms/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/LightSms/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/LightSms/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/LightSms/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/LightSms/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/LightSms/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/LinkedIn/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/LinkedIn/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/LinkedIn/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/LinkedIn/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/LinkedIn/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/LinkedIn/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Mailjet/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Mailjet/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Mailjet/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/Mailjet/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Mailjet/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/Mailjet/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Mattermost/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Mattermost/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Mattermost/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/Mattermost/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Mattermost/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/Mattermost/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Mercure/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Mercure/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Mercure/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/Mercure/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Mercure/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/Mercure/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/MessageBird/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/MessageBird/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/MessageBird/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/MessageBird/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/MessageBird/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/MessageBird/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/MessageMedia/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/MessageMedia/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/MessageMedia/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/MessageMedia/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/MessageMedia/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/MessageMedia/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Nexmo/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Nexmo/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Nexmo/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/Nexmo/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Nexmo/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/Nexmo/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Octopush/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Octopush/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Octopush/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/Octopush/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Octopush/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/Octopush/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/OneSignal/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/OneSignal/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/OneSignal/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/OneSignal/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/OneSignal/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/OneSignal/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Sendinblue/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Sendinblue/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Sendinblue/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/Sendinblue/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Sendinblue/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/Sendinblue/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Sinch/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Sinch/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Sinch/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/Sinch/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Sinch/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/Sinch/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Slack/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Slack/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Slack/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Sms77/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Sms77/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Sms77/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/Sms77/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Sms77/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/Sms77/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/SmsBiuras/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/SmsBiuras/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/SmsBiuras/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/SmsBiuras/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/SmsBiuras/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/SmsBiuras/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Smsc/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Smsc/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Smsc/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/Smsc/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Smsc/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/Smsc/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/SpotHit/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/SpotHit/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/SpotHit/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/SpotHit/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/SpotHit/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/SpotHit/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Telnyx/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Telnyx/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Telnyx/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/Telnyx/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Telnyx/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/Telnyx/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/TurboSms/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/TurboSms/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/TurboSms/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/TurboSms/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/TurboSms/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/TurboSms/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Vonage/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Vonage/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Vonage/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/Vonage/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Vonage/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/Vonage/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Yunpian/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Yunpian/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Yunpian/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/Yunpian/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Yunpian/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/Yunpian/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Zulip/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Zulip/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Zulip/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/Zulip/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Zulip/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/Zulip/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/OptionsResolver/.gitattributes
+++ b/src/Symfony/Component/OptionsResolver/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/OptionsResolver/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/OptionsResolver/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/OptionsResolver/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/OptionsResolver/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/PasswordHasher/.gitattributes
+++ b/src/Symfony/Component/PasswordHasher/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/PasswordHasher/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/PasswordHasher/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/PasswordHasher/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/PasswordHasher/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Process/.gitattributes
+++ b/src/Symfony/Component/Process/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Process/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Process/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Process/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Process/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/PropertyAccess/.gitattributes
+++ b/src/Symfony/Component/PropertyAccess/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/PropertyAccess/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/PropertyAccess/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/PropertyAccess/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/PropertyAccess/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/PropertyInfo/.gitattributes
+++ b/src/Symfony/Component/PropertyInfo/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/PropertyInfo/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/PropertyInfo/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/PropertyInfo/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/PropertyInfo/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/RateLimiter/.gitattributes
+++ b/src/Symfony/Component/RateLimiter/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/RateLimiter/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/RateLimiter/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/RateLimiter/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/RateLimiter/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Routing/.gitattributes
+++ b/src/Symfony/Component/Routing/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Routing/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Routing/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Routing/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Routing/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Runtime/.gitattributes
+++ b/src/Symfony/Component/Runtime/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Runtime/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Runtime/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Runtime/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Runtime/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Security/Core/.gitattributes
+++ b/src/Symfony/Component/Security/Core/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Security/Core/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Security/Core/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Security/Core/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Security/Core/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Security/Csrf/.gitattributes
+++ b/src/Symfony/Component/Security/Csrf/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Security/Csrf/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Security/Csrf/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Security/Csrf/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Security/Csrf/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Security/Guard/.gitattributes
+++ b/src/Symfony/Component/Security/Guard/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Security/Guard/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Security/Guard/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Security/Guard/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Security/Guard/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Security/Http/.gitattributes
+++ b/src/Symfony/Component/Security/Http/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Security/Http/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Security/Http/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Security/Http/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Security/Http/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Semaphore/.gitattributes
+++ b/src/Symfony/Component/Semaphore/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Semaphore/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Semaphore/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Semaphore/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Semaphore/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Serializer/.gitattributes
+++ b/src/Symfony/Component/Serializer/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Serializer/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Serializer/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Serializer/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Serializer/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Stopwatch/.gitattributes
+++ b/src/Symfony/Component/Stopwatch/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Stopwatch/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Stopwatch/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Stopwatch/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Stopwatch/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/String/.gitattributes
+++ b/src/Symfony/Component/String/.gitattributes
@@ -2,5 +2,4 @@
 /Resources/WcswidthDataGenerator.php export-ignore
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/String/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/String/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/String/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/String/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Templating/.gitattributes
+++ b/src/Symfony/Component/Templating/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Templating/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Templating/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Templating/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Templating/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Translation/.gitattributes
+++ b/src/Symfony/Component/Translation/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Translation/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Translation/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Translation/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Translation/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/.gitattributes
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Translation/Bridge/Loco/.gitattributes
+++ b/src/Symfony/Component/Translation/Bridge/Loco/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Translation/Bridge/Loco/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Translation/Bridge/Loco/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Translation/Bridge/Loco/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Translation/Bridge/Loco/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Translation/Bridge/Lokalise/.gitattributes
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Translation/Bridge/Lokalise/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Translation/Bridge/Lokalise/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Uid/.gitattributes
+++ b/src/Symfony/Component/Uid/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Uid/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Uid/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Uid/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Uid/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Validator/.gitattributes
+++ b/src/Symfony/Component/Validator/.gitattributes
@@ -1,5 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
 /Resources/bin/sync-iban-formats.php export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Validator/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Validator/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Validator/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Validator/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/VarDumper/.gitattributes
+++ b/src/Symfony/Component/VarDumper/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/VarDumper/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/VarDumper/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/VarDumper/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/VarDumper/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/VarExporter/.gitattributes
+++ b/src/Symfony/Component/VarExporter/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/VarExporter/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/VarExporter/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/VarExporter/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/VarExporter/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/WebLink/.gitattributes
+++ b/src/Symfony/Component/WebLink/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/WebLink/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/WebLink/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/WebLink/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/WebLink/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Workflow/.gitattributes
+++ b/src/Symfony/Component/Workflow/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Workflow/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Workflow/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Workflow/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Workflow/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Yaml/.gitattributes
+++ b/src/Symfony/Component/Yaml/.gitattributes
@@ -1,4 +1,3 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Yaml/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Yaml/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Yaml/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Yaml/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Contracts/.gitattributes
+++ b/src/Symfony/Contracts/.gitattributes
@@ -1,0 +1,1 @@
+/.git* export-ignore

--- a/src/Symfony/Contracts/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Contracts/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Contracts/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Contracts/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Contracts/Cache/.gitattributes
+++ b/src/Symfony/Contracts/Cache/.gitattributes
@@ -1,0 +1,1 @@
+/.git* export-ignore

--- a/src/Symfony/Contracts/Cache/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Contracts/Cache/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Contracts/Cache/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Contracts/Cache/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Contracts/Deprecation/.gitattributes
+++ b/src/Symfony/Contracts/Deprecation/.gitattributes
@@ -1,0 +1,1 @@
+/.git* export-ignore

--- a/src/Symfony/Contracts/Deprecation/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Contracts/Deprecation/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Contracts/Deprecation/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Contracts/Deprecation/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Contracts/EventDispatcher/.gitattributes
+++ b/src/Symfony/Contracts/EventDispatcher/.gitattributes
@@ -1,0 +1,1 @@
+/.git* export-ignore

--- a/src/Symfony/Contracts/EventDispatcher/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Contracts/EventDispatcher/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Contracts/EventDispatcher/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Contracts/EventDispatcher/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Contracts/HttpClient/.gitattributes
+++ b/src/Symfony/Contracts/HttpClient/.gitattributes
@@ -1,0 +1,1 @@
+/.git* export-ignore

--- a/src/Symfony/Contracts/HttpClient/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Contracts/HttpClient/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Contracts/HttpClient/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Contracts/HttpClient/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Contracts/Service/.gitattributes
+++ b/src/Symfony/Contracts/Service/.gitattributes
@@ -1,0 +1,1 @@
+/.git* export-ignore

--- a/src/Symfony/Contracts/Service/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Contracts/Service/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Contracts/Service/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Contracts/Service/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Contracts/Translation/.gitattributes
+++ b/src/Symfony/Contracts/Translation/.gitattributes
@@ -1,0 +1,1 @@
+/.git* export-ignore

--- a/src/Symfony/Contracts/Translation/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Contracts/Translation/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Contracts/Translation/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Contracts/Translation/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #57267
| License       | MIT

Extract the Pull Request Template from #54653.

~The GitHub action did not work as said by @nicolas-grekas https://github.com/symfony/symfony/pull/57267#issuecomment-2142429561.~ Replaced by https://github.com/superbrothers/close-pull-request.