### PR TITLE
Remove calls to `getExpectedException()`

### DIFF
--- a/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
@@ -396,7 +396,7 @@ class UrlMatcherTest extends TestCase
 
     public function testExtraTrailingSlash()
     {
-        $this->getExpectedException() ?: $this->expectException(ResourceNotFoundException::class);
+        $this->expectException(ResourceNotFoundException::class);
         $coll = new RouteCollection();
         $coll->add('foo', new Route('/foo'));
 
@@ -406,7 +406,7 @@ class UrlMatcherTest extends TestCase
 
     public function testMissingTrailingSlashForNonSafeMethod()
     {
-        $this->getExpectedException() ?: $this->expectException(ResourceNotFoundException::class);
+        $this->expectException(ResourceNotFoundException::class);
         $coll = new RouteCollection();
         $coll->add('foo', new Route('/foo/'));
 
@@ -418,7 +418,7 @@ class UrlMatcherTest extends TestCase
 
     public function testExtraTrailingSlashForNonSafeMethod()
     {
-        $this->getExpectedException() ?: $this->expectException(ResourceNotFoundException::class);
+        $this->expectException(ResourceNotFoundException::class);
         $coll = new RouteCollection();
         $coll->add('foo', new Route('/foo'));
 
@@ -430,7 +430,7 @@ class UrlMatcherTest extends TestCase
 
     public function testSchemeRequirement()
     {
-        $this->getExpectedException() ?: $this->expectException(ResourceNotFoundException::class);
+        $this->expectException(ResourceNotFoundException::class);
         $coll = new RouteCollection();
         $coll->add('foo', new Route('/foo', [], [], [], '', ['https']));
         $matcher = $this->getUrlMatcher($coll);
@@ -439,7 +439,7 @@ class UrlMatcherTest extends TestCase
 
     public function testSchemeRequirementForNonSafeMethod()
     {
-        $this->getExpectedException() ?: $this->expectException(ResourceNotFoundException::class);
+        $this->expectException(ResourceNotFoundException::class);
         $coll = new RouteCollection();
         $coll->add('foo', new Route('/foo', [], [], [], '', ['https']));
 

--- a/src/Symfony/Contracts/Service/Test/ServiceLocatorTestCase.php
+++ b/src/Symfony/Contracts/Service/Test/ServiceLocatorTestCase.php
@@ -75,10 +75,8 @@ abstract class ServiceLocatorTestCase extends TestCase
             'foo' => function () use (&$locator) { return $locator->get('bar'); },
         ]);
 
-        if (!$this->getExpectedException()) {
-            $this->expectException(NotFoundExceptionInterface::class);
-            $this->expectExceptionMessage('The service "foo" has a dependency on a non-existent service "bar". This locator only knows about the "foo" service.');
-        }
+        $this->expectException(NotFoundExceptionInterface::class);
+        $this->expectExceptionMessage('The service "foo" has a dependency on a non-existent service "bar". This locator only knows about the "foo" service.');
 
         $locator->get('foo');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

PHPUnit 11 does not allow us to query anymore whether we already expect an exception. We call the now-removed method `getExpectedException()` several times, but I could not really figure out why we do that. The simplest fix would be to remove the calls. As far as I can tell, our tests pass without them.