### PR TITLE
[Validator] do not skip tests from data providers

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Constraints/CompareWithNullValueAtPropertyAtTestTrait.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CompareWithNullValueAtPropertyAtTestTrait.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Tests\Constraints\Fixtures\TypedDummy;
+
+trait CompareWithNullValueAtPropertyAtTestTrait
+{
+    public function testCompareWithNullValueAtPropertyAt()
+    {
+        $constraint = $this->createConstraint(['propertyPath' => 'value']);
+        $constraint->message = 'Constraint Message';
+
+        $object = new ComparisonTest_Class(null);
+        $this->setObject($object);
+
+        $this->validator->validate(5, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function testCompareWithUninitializedPropertyAtPropertyPath()
+    {
+        $this->setObject(new TypedDummy());
+
+        $this->validator->validate(5, $this->createConstraint([
+            'message' => 'Constraint Message',
+            'propertyPath' => 'value',
+        ]));
+
+        $this->assertNoViolation();
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/DivisibleByValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DivisibleByValidatorTest.php
@@ -21,6 +21,10 @@ use Symfony\Component\Validator\Exception\UnexpectedValueException;
  */
 class DivisibleByValidatorTest extends AbstractComparisonValidatorTestCase
 {
+    use InvalidComparisonToValueTestTrait;
+    use ThrowsOnInvalidStringDatesTestTrait;
+    use ValidComparisonToValueTrait;
+
     protected function createValidator(): DivisibleByValidator
     {
         return new DivisibleByValidator();
@@ -101,10 +105,5 @@ class DivisibleByValidatorTest extends AbstractComparisonValidatorTestCase
             [\stdClass::class, 2, new \stdClass()],
             [\ArrayIterator::class, new \ArrayIterator(), 12],
         ];
-    }
-
-    public static function provideComparisonsToNullValueAtPropertyPath()
-    {
-        self::markTestSkipped('DivisibleByValidator rejects null values.');
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/EqualToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EqualToValidatorTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\EqualTo;
 use Symfony\Component\Validator\Constraints\EqualToValidator;
+use Symfony\Component\Validator\Tests\Constraints\Fixtures\TypedDummy;
 use Symfony\Component\Validator\Tests\IcuCompatibilityTrait;
 
 /**
@@ -22,6 +23,9 @@ use Symfony\Component\Validator\Tests\IcuCompatibilityTrait;
 class EqualToValidatorTest extends AbstractComparisonValidatorTestCase
 {
     use IcuCompatibilityTrait;
+    use InvalidComparisonToValueTestTrait;
+    use ThrowsOnInvalidStringDatesTestTrait;
+    use ValidComparisonToValueTrait;
 
     protected function createValidator(): EqualToValidator
     {
@@ -71,10 +75,40 @@ class EqualToValidatorTest extends AbstractComparisonValidatorTestCase
         ];
     }
 
-    public static function provideComparisonsToNullValueAtPropertyPath(): array
+    public function testCompareWithNullValueAtPropertyAt()
     {
-        return [
-            [5, '5', false],
-        ];
+        $constraint = $this->createConstraint(['propertyPath' => 'value']);
+        $constraint->message = 'Constraint Message';
+
+        $object = new ComparisonTest_Class(null);
+        $this->setObject($object);
+
+        $this->validator->validate(5, $constraint);
+
+        $this->buildViolation('Constraint Message')
+            ->setParameter('{{ value }}', '5')
+            ->setParameter('{{ compared_value }}', 'null')
+            ->setParameter('{{ compared_value_type }}', 'null')
+            ->setParameter('{{ compared_value_path }}', 'value')
+            ->setCode($this->getErrorCode())
+            ->assertRaised();
+    }
+
+    public function testCompareWithUninitializedPropertyAtPropertyPath()
+    {
+        $this->setObject(new TypedDummy());
+
+        $this->validator->validate(5, $this->createConstraint([
+            'message' => 'Constraint Message',
+            'propertyPath' => 'value',
+        ]));
+
+        $this->buildViolation('Constraint Message')
+            ->setParameter('{{ value }}', '5')
+            ->setParameter('{{ compared_value }}', 'null')
+            ->setParameter('{{ compared_value_type }}', 'null')
+            ->setParameter('{{ compared_value_path }}', 'value')
+            ->setCode($this->getErrorCode())
+            ->assertRaised();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorTest.php
@@ -21,7 +21,11 @@ use Symfony\Component\Validator\Tests\IcuCompatibilityTrait;
  */
 class GreaterThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCase
 {
+    use CompareWithNullValueAtPropertyAtTestTrait;
     use IcuCompatibilityTrait;
+    use InvalidComparisonToValueTestTrait;
+    use ThrowsOnInvalidStringDatesTestTrait;
+    use ValidComparisonToValueTrait;
 
     protected function createValidator(): GreaterThanOrEqualValidator
     {
@@ -71,13 +75,6 @@ class GreaterThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCas
             [new \DateTime('2000/01/01'), self::normalizeIcuSpaces("Jan 1, 2000, 12:00\u{202F}AM"), '2005/01/01', self::normalizeIcuSpaces("Jan 1, 2005, 12:00\u{202F}AM"), 'DateTime'],
             [new \DateTime('2000/01/01 UTC'), self::normalizeIcuSpaces("Jan 1, 2000, 12:00\u{202F}AM"), '2005/01/01 UTC', self::normalizeIcuSpaces("Jan 1, 2005, 12:00\u{202F}AM"), 'DateTime'],
             ['b', '"b"', 'c', '"c"', 'string'],
-        ];
-    }
-
-    public static function provideComparisonsToNullValueAtPropertyPath(): array
-    {
-        return [
-            [5, '5', true],
         ];
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest.php
@@ -12,15 +12,20 @@
 namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraint;
-use Symfony\Component\Validator\Constraints\AbstractComparison;
+use Symfony\Component\Validator\Constraints\GreaterThanOrEqualValidator;
 use Symfony\Component\Validator\Constraints\PositiveOrZero;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 
 /**
  * @author Jan Schädlich <jan.schaedlich@sensiolabs.de>
  */
-class GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest extends GreaterThanOrEqualValidatorTest
+class GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest extends AbstractComparisonValidatorTestCase
 {
+    protected function createValidator(): GreaterThanOrEqualValidator
+    {
+        return new GreaterThanOrEqualValidator();
+    }
+
     protected static function createConstraint(?array $options = null): Constraint
     {
         return new PositiveOrZero($options);
@@ -36,6 +41,14 @@ class GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest extends Greate
             ['0', '0'],
             ['333', '0'],
             [null, 0],
+        ];
+    }
+
+    public static function provideValidComparisonsToPropertyPath(): array
+    {
+        return [
+            [5],
+            [6],
         ];
     }
 
@@ -82,11 +95,6 @@ class GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest extends Greate
         $this->markTestSkipped('PropertyPath option is not used in PositiveOrZero constraint');
     }
 
-    public static function provideAllValidComparisons(): array
-    {
-        self::markTestSkipped('The "value" option cannot be used in the PositiveOrZero constraint');
-    }
-
     /**
      * @dataProvider provideValidComparisonsToPropertyPath
      */
@@ -100,31 +108,8 @@ class GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest extends Greate
         $this->markTestSkipped('PropertyPath option is not used in PositiveOrZero constraint');
     }
 
-    /**
-     * @dataProvider throwsOnInvalidStringDatesProvider
-     */
-    public function testThrowsOnInvalidStringDates(AbstractComparison $constraint, $expectedMessage, $value)
-    {
-        $this->markTestSkipped('The compared value cannot be an invalid string date because it is hardcoded to 0.');
-    }
-
     public function testInvalidComparisonToPropertyPathAddsPathAsParameter()
     {
         $this->markTestSkipped('PropertyPath option is not used in PositiveOrZero constraint');
-    }
-
-    public static function throwsOnInvalidStringDatesProvider(): array
-    {
-        self::markTestSkipped('The "value" option cannot be used in the PositiveOrZero constraint');
-    }
-
-    public static function provideAllInvalidComparisons(): array
-    {
-        self::markTestSkipped('The "value" option cannot be used in the Negative constraint');
-    }
-
-    public static function provideComparisonsToNullValueAtPropertyPath(): array
-    {
-        self::markTestSkipped('PropertyPath option is not used in PositiveOrZero constraint');
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorTest.php
@@ -21,7 +21,11 @@ use Symfony\Component\Validator\Tests\IcuCompatibilityTrait;
  */
 class GreaterThanValidatorTest extends AbstractComparisonValidatorTestCase
 {
+    use CompareWithNullValueAtPropertyAtTestTrait;
     use IcuCompatibilityTrait;
+    use InvalidComparisonToValueTestTrait;
+    use ThrowsOnInvalidStringDatesTestTrait;
+    use ValidComparisonToValueTrait;
 
     protected function createValidator(): GreaterThanValidator
     {
@@ -73,13 +77,6 @@ class GreaterThanValidatorTest extends AbstractComparisonValidatorTestCase
             [new ComparisonTest_Class(5), '5', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'],
             ['22', '"22"', '333', '"333"', 'string'],
             ['22', '"22"', '22', '"22"', 'string'],
-        ];
-    }
-
-    public static function provideComparisonsToNullValueAtPropertyPath(): array
-    {
-        return [
-            [5, '5', true],
         ];
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorWithPositiveConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorWithPositiveConstraintTest.php
@@ -12,15 +12,20 @@
 namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraint;
-use Symfony\Component\Validator\Constraints\AbstractComparison;
+use Symfony\Component\Validator\Constraints\GreaterThanValidator;
 use Symfony\Component\Validator\Constraints\Positive;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 
 /**
  * @author Jan Schädlich <jan.schaedlich@sensiolabs.de>
  */
-class GreaterThanValidatorWithPositiveConstraintTest extends GreaterThanValidatorTest
+class GreaterThanValidatorWithPositiveConstraintTest extends AbstractComparisonValidatorTestCase
 {
+    protected function createValidator(): GreaterThanValidator
+    {
+        return new GreaterThanValidator();
+    }
+
     protected static function createConstraint(?array $options = null): Constraint
     {
         return new Positive($options);
@@ -33,6 +38,13 @@ class GreaterThanValidatorWithPositiveConstraintTest extends GreaterThanValidato
             [2.5, 0],
             ['333', '0'],
             [null, 0],
+        ];
+    }
+
+    public static function provideValidComparisonsToPropertyPath(): array
+    {
+        return [
+            [6],
         ];
     }
 
@@ -85,11 +97,6 @@ class GreaterThanValidatorWithPositiveConstraintTest extends GreaterThanValidato
         $this->markTestSkipped('PropertyPath option is not used in Positive constraint');
     }
 
-    public static function provideAllValidComparisons(): array
-    {
-        self::markTestSkipped('The "value" option cannot be used in the Positive constraint');
-    }
-
     /**
      * @dataProvider provideValidComparisonsToPropertyPath
      */
@@ -98,31 +105,8 @@ class GreaterThanValidatorWithPositiveConstraintTest extends GreaterThanValidato
         $this->markTestSkipped('PropertyPath option is not used in Positive constraint');
     }
 
-    /**
-     * @dataProvider throwsOnInvalidStringDatesProvider
-     */
-    public function testThrowsOnInvalidStringDates(AbstractComparison $constraint, $expectedMessage, $value)
-    {
-        $this->markTestSkipped('The compared value cannot be an invalid string date because it is hardcoded to 0.');
-    }
-
     public function testInvalidComparisonToPropertyPathAddsPathAsParameter()
     {
         $this->markTestSkipped('PropertyPath option is not used in Positive constraint');
-    }
-
-    public static function throwsOnInvalidStringDatesProvider(): array
-    {
-        self::markTestSkipped('The "value" option cannot be used in the Positive constraint');
-    }
-
-    public static function provideAllInvalidComparisons(): array
-    {
-        self::markTestSkipped('The "value" option cannot be used in the Positive constraint');
-    }
-
-    public static function provideComparisonsToNullValueAtPropertyPath(): array
-    {
-        self::markTestSkipped('PropertyPath option is not used in PositiveOrZero constraint');
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/InvalidComparisonToValueTestTrait.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/InvalidComparisonToValueTestTrait.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Intl\Util\IntlTestHelper;
+
+trait InvalidComparisonToValueTestTrait
+{
+    /**
+     * @dataProvider provideAllInvalidComparisons
+     */
+    public function testInvalidComparisonToValue($dirtyValue, $dirtyValueAsString, $comparedValue, $comparedValueString, $comparedValueType)
+    {
+        // Conversion of dates to string differs between ICU versions
+        // Make sure we have the correct version loaded
+        if ($dirtyValue instanceof \DateTimeInterface) {
+            IntlTestHelper::requireIntl($this, '57.1');
+        }
+
+        $constraint = $this->createConstraint(['value' => $comparedValue]);
+        $constraint->message = 'Constraint Message';
+
+        $this->validator->validate($dirtyValue, $constraint);
+
+        $this->buildViolation('Constraint Message')
+            ->setParameter('{{ value }}', $dirtyValueAsString)
+            ->setParameter('{{ compared_value }}', $comparedValueString)
+            ->setParameter('{{ compared_value_type }}', $comparedValueType)
+            ->setCode($this->getErrorCode())
+            ->assertRaised();
+    }
+
+    public function testInvalidComparisonToPropertyPathAddsPathAsParameter()
+    {
+        [$dirtyValue, $dirtyValueAsString, $comparedValue, $comparedValueString, $comparedValueType] = current($this->provideAllInvalidComparisons());
+
+        $constraint = $this->createConstraint(['propertyPath' => 'value']);
+        $constraint->message = 'Constraint Message';
+
+        $object = new ComparisonTest_Class($comparedValue);
+
+        $this->setObject($object);
+
+        $this->validator->validate($dirtyValue, $constraint);
+
+        $this->buildViolation('Constraint Message')
+            ->setParameter('{{ value }}', $dirtyValueAsString)
+            ->setParameter('{{ compared_value }}', $comparedValueString)
+            ->setParameter('{{ compared_value_path }}', 'value')
+            ->setParameter('{{ compared_value_type }}', $comparedValueType)
+            ->setCode($this->getErrorCode())
+            ->assertRaised();
+    }
+
+    public static function provideAllInvalidComparisons(): array
+    {
+        // The provider runs before setUp(), so we need to manually fix
+        // the default timezone
+        $timezone = date_default_timezone_get();
+        date_default_timezone_set('UTC');
+
+        $comparisons = self::addPhp5Dot5Comparisons(static::provideInvalidComparisons());
+
+        date_default_timezone_set($timezone);
+
+        return $comparisons;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorTest.php
@@ -21,7 +21,11 @@ use Symfony\Component\Validator\Tests\IcuCompatibilityTrait;
  */
 class LessThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCase
 {
+    use CompareWithNullValueAtPropertyAtTestTrait;
     use IcuCompatibilityTrait;
+    use InvalidComparisonToValueTestTrait;
+    use ThrowsOnInvalidStringDatesTestTrait;
+    use ValidComparisonToValueTrait;
 
     protected function createValidator(): LessThanOrEqualValidator
     {
@@ -74,13 +78,6 @@ class LessThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCase
             [new \DateTime('2010-01-01 UTC'), self::normalizeIcuSpaces("Jan 1, 2010, 12:00\u{202F}AM"), '2000-01-01 UTC', self::normalizeIcuSpaces("Jan 1, 2000, 12:00\u{202F}AM"), 'DateTime'],
             [new ComparisonTest_Class(5), '5', new ComparisonTest_Class(4), '4', __NAMESPACE__.'\ComparisonTest_Class'],
             ['c', '"c"', 'b', '"b"', 'string'],
-        ];
-    }
-
-    public static function provideComparisonsToNullValueAtPropertyPath(): array
-    {
-        return [
-            [5, '5', true],
         ];
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest.php
@@ -12,14 +12,20 @@
 namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\LessThanOrEqualValidator;
 use Symfony\Component\Validator\Constraints\NegativeOrZero;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 
 /**
  * @author Jan Schädlich <jan.schaedlich@sensiolabs.de>
  */
-class LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest extends LessThanOrEqualValidatorTest
+class LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest extends AbstractComparisonValidatorTestCase
 {
+    protected function createValidator(): LessThanOrEqualValidator
+    {
+        return new LessThanOrEqualValidator();
+    }
+
     protected static function createConstraint(?array $options = null): Constraint
     {
         return new NegativeOrZero($options);
@@ -33,6 +39,14 @@ class LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest extends LessThanO
             [-2, 0],
             [-2.5, 0],
             [null, 0],
+        ];
+    }
+
+    public static function provideValidComparisonsToPropertyPath(): array
+    {
+        return [
+            [4],
+            [5],
         ];
     }
 
@@ -84,11 +98,6 @@ class LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest extends LessThanO
         $this->markTestSkipped('PropertyPath option is not used in NegativeOrZero constraint');
     }
 
-    public static function provideAllValidComparisons(): array
-    {
-        self::markTestSkipped('The "value" option cannot be used in the NegativeOrZero constraint');
-    }
-
     /**
      * @dataProvider provideValidComparisonsToPropertyPath
      */
@@ -100,31 +109,5 @@ class LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest extends LessThanO
     public function testInvalidComparisonToPropertyPathAddsPathAsParameter()
     {
         $this->markTestSkipped('PropertyPath option is not used in NegativeOrZero constraint');
-    }
-
-    /**
-     * @dataProvider provideComparisonsToNullValueAtPropertyPath
-     */
-    public function testCompareWithNullValueAtPropertyAt($dirtyValue, $dirtyValueAsString, $isValid)
-    {
-        $this->markTestSkipped('PropertyPath option is not used in NegativeOrZero constraint');
-    }
-
-    /**
-     * @dataProvider provideComparisonsToNullValueAtPropertyPath
-     */
-    public function testCompareWithUninitializedPropertyAtPropertyPath($dirtyValue, $dirtyValueAsString, $isValid)
-    {
-        $this->markTestSkipped('PropertyPath option is not used in NegativeOrZero constraint');
-    }
-
-    public static function throwsOnInvalidStringDatesProvider(): array
-    {
-        self::markTestSkipped('The "value" option cannot be used in the NegativeOrZero constraint');
-    }
-
-    public static function provideAllInvalidComparisons(): array
-    {
-        self::markTestSkipped('The "value" option cannot be used in the NegativeOrZero constraint');
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorTest.php
@@ -21,7 +21,11 @@ use Symfony\Component\Validator\Tests\IcuCompatibilityTrait;
  */
 class LessThanValidatorTest extends AbstractComparisonValidatorTestCase
 {
+    use CompareWithNullValueAtPropertyAtTestTrait;
     use IcuCompatibilityTrait;
+    use InvalidComparisonToValueTestTrait;
+    use ThrowsOnInvalidStringDatesTestTrait;
+    use ValidComparisonToValueTrait;
 
     protected function createValidator(): LessThanValidator
     {
@@ -72,13 +76,6 @@ class LessThanValidatorTest extends AbstractComparisonValidatorTestCase
             [new ComparisonTest_Class(5), '5', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'],
             [new ComparisonTest_Class(6), '6', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'],
             ['333', '"333"', '22', '"22"', 'string'],
-        ];
-    }
-
-    public static function provideComparisonsToNullValueAtPropertyPath(): array
-    {
-        return [
-            [5, '5', true],
         ];
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorWithNegativeConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorWithNegativeConstraintTest.php
@@ -12,14 +12,20 @@
 namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\LessThanValidator;
 use Symfony\Component\Validator\Constraints\Negative;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 
 /**
  * @author Jan Schädlich <jan.schaedlich@sensiolabs.de>
  */
-class LessThanValidatorWithNegativeConstraintTest extends LessThanValidatorTest
+class LessThanValidatorWithNegativeConstraintTest extends AbstractComparisonValidatorTestCase
 {
+    protected function createValidator(): LessThanValidator
+    {
+        return new LessThanValidator();
+    }
+
     protected static function createConstraint(?array $options = null): Constraint
     {
         return new Negative($options);
@@ -32,6 +38,13 @@ class LessThanValidatorWithNegativeConstraintTest extends LessThanValidatorTest
             [-2, 0],
             [-2.5, 0],
             [null, 0],
+        ];
+    }
+
+    public static function provideValidComparisonsToPropertyPath(): array
+    {
+        return [
+            [4],
         ];
     }
 
@@ -84,11 +97,6 @@ class LessThanValidatorWithNegativeConstraintTest extends LessThanValidatorTest
         $this->markTestSkipped('PropertyPath option is not used in Negative constraint');
     }
 
-    public static function provideAllValidComparisons(): array
-    {
-        self::markTestSkipped('The "value" option cannot be used in the Negative constraint');
-    }
-
     /**
      * @dataProvider provideValidComparisonsToPropertyPath
      */
@@ -97,34 +105,8 @@ class LessThanValidatorWithNegativeConstraintTest extends LessThanValidatorTest
         $this->markTestSkipped('PropertyPath option is not used in Negative constraint');
     }
 
-    public static function throwsOnInvalidStringDatesProvider(): array
-    {
-        self::markTestSkipped('The "value" option cannot be used in the Negative constraint');
-    }
-
-    /**
-     * @dataProvider provideComparisonsToNullValueAtPropertyPath
-     */
-    public function testCompareWithNullValueAtPropertyAt($dirtyValue, $dirtyValueAsString, $isValid)
-    {
-        $this->markTestSkipped('PropertyPath option is not used in Negative constraint');
-    }
-
-    /**
-     * @dataProvider provideComparisonsToNullValueAtPropertyPath
-     */
-    public function testCompareWithUninitializedPropertyAtPropertyPath($dirtyValue, $dirtyValueAsString, $isValid)
-    {
-        $this->markTestSkipped('PropertyPath option is not used in Negative constraint');
-    }
-
     public function testInvalidComparisonToPropertyPathAddsPathAsParameter()
     {
         $this->markTestSkipped('PropertyPath option is not used in Negative constraint');
-    }
-
-    public static function provideAllInvalidComparisons(): array
-    {
-        self::markTestSkipped('The "value" option cannot be used in the Negative constraint');
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotEqualToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotEqualToValidatorTest.php
@@ -21,7 +21,11 @@ use Symfony\Component\Validator\Tests\IcuCompatibilityTrait;
  */
 class NotEqualToValidatorTest extends AbstractComparisonValidatorTestCase
 {
+    use CompareWithNullValueAtPropertyAtTestTrait;
     use IcuCompatibilityTrait;
+    use InvalidComparisonToValueTestTrait;
+    use ThrowsOnInvalidStringDatesTestTrait;
+    use ValidComparisonToValueTrait;
 
     protected function createValidator(): NotEqualToValidator
     {
@@ -68,13 +72,6 @@ class NotEqualToValidatorTest extends AbstractComparisonValidatorTestCase
             [new \DateTime('2000-01-01'), self::normalizeIcuSpaces("Jan 1, 2000, 12:00\u{202F}AM"), '2000-01-01', self::normalizeIcuSpaces("Jan 1, 2000, 12:00\u{202F}AM"), 'DateTime'],
             [new \DateTime('2000-01-01 UTC'), self::normalizeIcuSpaces("Jan 1, 2000, 12:00\u{202F}AM"), '2000-01-01 UTC', self::normalizeIcuSpaces("Jan 1, 2000, 12:00\u{202F}AM"), 'DateTime'],
             [new ComparisonTest_Class(5), '5', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'],
-        ];
-    }
-
-    public static function provideComparisonsToNullValueAtPropertyPath(): array
-    {
-        return [
-            [5, '5', true],
         ];
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotIdenticalToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotIdenticalToValidatorTest.php
@@ -21,7 +21,11 @@ use Symfony\Component\Validator\Tests\IcuCompatibilityTrait;
  */
 class NotIdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
 {
+    use CompareWithNullValueAtPropertyAtTestTrait;
     use IcuCompatibilityTrait;
+    use InvalidComparisonToValueTestTrait;
+    use ThrowsOnInvalidStringDatesTestTrait;
+    use ValidComparisonToValueTrait;
 
     protected function createValidator(): NotIdenticalToValidator
     {
@@ -85,13 +89,6 @@ class NotIdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
             ['a', '"a"', 'a', '"a"', 'string'],
             [$date, self::normalizeIcuSpaces("Jan 1, 2000, 12:00\u{202F}AM"), $date, self::normalizeIcuSpaces("Jan 1, 2000, 12:00\u{202F}AM"), 'DateTime'],
             [$object, '2', $object, '2', __NAMESPACE__.'\ComparisonTest_Class'],
-        ];
-    }
-
-    public static function provideComparisonsToNullValueAtPropertyPath(): array
-    {
-        return [
-            [5, '5', true],
         ];
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/ThrowsOnInvalidStringDatesTestTrait.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ThrowsOnInvalidStringDatesTestTrait.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\AbstractComparison;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+
+trait ThrowsOnInvalidStringDatesTestTrait
+{
+    /**
+     * @dataProvider throwsOnInvalidStringDatesProvider
+     */
+    public function testThrowsOnInvalidStringDates(AbstractComparison $constraint, $expectedMessage, $value)
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        $this->validator->validate($value, $constraint);
+    }
+
+    public static function throwsOnInvalidStringDatesProvider(): array
+    {
+        $constraint = static::createConstraint([
+            'value' => 'foo',
+        ]);
+
+        return [
+            [$constraint, \sprintf('The compared value "foo" could not be converted to a "DateTimeImmutable" instance in the "%s" constraint.', $constraint::class), new \DateTimeImmutable()],
+            [$constraint, \sprintf('The compared value "foo" could not be converted to a "DateTime" instance in the "%s" constraint.', $constraint::class), new \DateTime()],
+        ];
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/ValidComparisonToValueTrait.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ValidComparisonToValueTrait.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+trait ValidComparisonToValueTrait
+{
+    /**
+     * @dataProvider provideAllValidComparisons
+     */
+    public function testValidComparisonToValue($dirtyValue, $comparisonValue)
+    {
+        $constraint = $this->createConstraint(['value' => $comparisonValue]);
+
+        $this->validator->validate($dirtyValue, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public static function provideAllValidComparisons(): array
+    {
+        // The provider runs before setUp(), so we need to manually fix
+        // the default timezone
+        $timezone = date_default_timezone_get();
+        date_default_timezone_set('UTC');
+
+        $comparisons = self::addPhp5Dot5Comparisons(static::provideValidComparisons());
+
+        date_default_timezone_set($timezone);
+
+        return $comparisons;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

While this used to work in the past PHPUnit 11 will report and error when a data provider does not return a valid set of data to run tests for.