### PR TITLE
[Serializer] Fix test expectation

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/PropertyInfoLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/PropertyInfoLoaderTest.php
@@ -126,6 +126,7 @@ class PropertyInfoLoaderTest extends TestCase
                 true,
                 true,
                 false,
+                true,
                 true
             )
         ;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Stumbled across the following error while running tests on recent PHPUnit version:

```
Only 12 return values have been configured for Symfony\Component\PropertyInfo\PropertyAccessExtractorInterface::isWritable()
```