### PR TITLE
[Mailer][Mime] Support unicode email addresses

### DIFF
--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -5,7 +5,7 @@ CHANGELOG
 ---
 
  * Make `TransportFactoryTestCase` compatible with PHPUnit 10+
- * Support unicode email addresses such as "dømi@dømi.fo", no client changes needed
+ * Support unicode email addresses such as "dømi@dømi.fo"
 
 7.1
 ---

--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Make `TransportFactoryTestCase` compatible with PHPUnit 10+
+ * Support unicode email addresses such as "dømi@dømi.fo", no client changes needed
 
 7.1
 ---

--- a/src/Symfony/Component/Mailer/Envelope.php
+++ b/src/Symfony/Component/Mailer/Envelope.php
@@ -83,7 +83,6 @@ class Envelope
     }
 
     /**
-
       * Returns true if any address' localpart contains at least one
       * non-ASCII character, and false if all addresses have all-ASCII
       * localparts.
@@ -97,8 +96,6 @@ class Envelope
       * then it is possible to to send the message using IDN encoding
       * instead of SMTPUTF8. The most common software will display the
       * message as intended.
-      *
-      * @return bool
       */
     public function anyAddressHasUnicodeLocalpart(): bool
     {

--- a/src/Symfony/Component/Mailer/Envelope.php
+++ b/src/Symfony/Component/Mailer/Envelope.php
@@ -83,27 +83,31 @@ class Envelope
     }
 
     /**
-      * Returns true if any address' localpart contains at least one
-      * non-ASCII character, and false if all addresses have all-ASCII
-      * localparts.
-      *
-      * This helps to decide whether to the SMTPUTF8 extensions (RFC
-      * 6530 and following) for any given message.
-      *
-      * The SMTPUTF8 extension is strictly required if any address
-      * contains a non-ASCII character in its localpart. If non-ASCII
-      * is only used in domains (e.g. horst@freiherr-von-mühlhausen.de)
-      * then it is possible to to send the message using IDN encoding
-      * instead of SMTPUTF8. The most common software will display the
-      * message as intended.
-      */
+     * Returns true if any address' localpart contains at least one
+     * non-ASCII character, and false if all addresses have all-ASCII
+     * localparts.
+     *
+     * This helps to decide whether to the SMTPUTF8 extensions (RFC
+     * 6530 and following) for any given message.
+     *
+     * The SMTPUTF8 extension is strictly required if any address
+     * contains a non-ASCII character in its localpart. If non-ASCII
+     * is only used in domains (e.g. horst@freiherr-von-mühlhausen.de)
+     * then it is possible to to send the message using IDN encoding
+     * instead of SMTPUTF8. The most common software will display the
+     * message as intended.
+     */
     public function anyAddressHasUnicodeLocalpart(): bool
     {
-        if($this->getSender()->hasUnicodeLocalpart())
+        if ($this->getSender()->hasUnicodeLocalpart()) {
             return true;
-        foreach($this->getRecipients() as $r)
-            if($r->hasUnicodeLocalpart())
+        }
+        foreach ($this->getRecipients() as $r) {
+            if ($r->hasUnicodeLocalpart()) {
                 return true;
+            }
+        }
+
         return false;
     }
 }

--- a/src/Symfony/Component/Mailer/Envelope.php
+++ b/src/Symfony/Component/Mailer/Envelope.php
@@ -44,6 +44,10 @@ class Envelope
 
     public function setSender(Address $sender): void
     {
+        // to ensure deliverability of bounce emails independent of UTF-8 capabilities of SMTP servers
+        if (!preg_match('/^[^@\x80-\xFF]++@/', $sender->getAddress())) {
+            throw new InvalidArgumentException(\sprintf('Invalid sender "%s": non-ASCII characters not supported in local-part of email.', $sender->getAddress()));
+        }
         $this->sender = $sender;
     }
 

--- a/src/Symfony/Component/Mailer/Envelope.php
+++ b/src/Symfony/Component/Mailer/Envelope.php
@@ -85,4 +85,17 @@ class Envelope
     {
         return $this->recipients;
     }
+
+    /**
+      * @return bool
+      */
+    public function anyAddressHasUnicodeLocalpart(): bool
+    {
+        if($this->sender->hasUnicodeLocalpart())
+            return true;
+        foreach($this->recipients as $r)
+            if($r->hasUnicodeLocalpart())
+                return true;
+        return false;
+    }
 }

--- a/src/Symfony/Component/Mailer/Tests/EnvelopeTest.php
+++ b/src/Symfony/Component/Mailer/Tests/EnvelopeTest.php
@@ -83,7 +83,7 @@ class EnvelopeTest extends TestCase
         $this->assertEquals($from, $e->getSender());
     }
 
-    public function testSenderFromHeadersWithMulitpleHeaders()
+    public function testSenderFromHeadersWithMultipleHeaders()
     {
         $headers = new Headers();
         $headers->addMailboxListHeader('From', [new Address('from@symfony.com', 'from'), 'some@symfony.com']);

--- a/src/Symfony/Component/Mailer/Tests/EnvelopeTest.php
+++ b/src/Symfony/Component/Mailer/Tests/EnvelopeTest.php
@@ -127,6 +127,19 @@ class EnvelopeTest extends TestCase
         $this->assertEquals([new Address('to@symfony.com'), new Address('cc@symfony.com'), new Address('bcc@symfony.com')], $e->getRecipients());
     }
 
+    public function testUnicodeLocalparts()
+    {
+        /* dømi means example and is reserved by the .fo registry */
+        $i = new Address('info@dømi.fo');
+        $d = new Address('dømi@dømi.fo');
+        $e = new Envelope($i, [$i]);
+        $this->assertFalse($e->anyAddressHasUnicodeLocalpart());
+        $e = new Envelope($i, [$d]);
+        $this->assertTrue($e->anyAddressHasUnicodeLocalpart());
+        $e = new Envelope($i, [$i, $d]);
+        $this->assertTrue($e->anyAddressHasUnicodeLocalpart());
+    }
+
     public function testRecipientsFromHeadersWithNames()
     {
         $headers = new Headers();

--- a/src/Symfony/Component/Mailer/Tests/EnvelopeTest.php
+++ b/src/Symfony/Component/Mailer/Tests/EnvelopeTest.php
@@ -13,11 +13,9 @@ namespace Symfony\Component\Mailer\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mailer\Envelope;
-use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Mailer\Exception\LogicException;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Header\Headers;
-use Symfony\Component\Mime\Header\PathHeader;
 use Symfony\Component\Mime\Message;
 use Symfony\Component\Mime\RawMessage;
 

--- a/src/Symfony/Component/Mailer/Tests/EnvelopeTest.php
+++ b/src/Symfony/Component/Mailer/Tests/EnvelopeTest.php
@@ -29,13 +29,6 @@ class EnvelopeTest extends TestCase
         $this->assertEquals(new Address('fabien@symfony.com'), $e->getSender());
     }
 
-    public function testConstructorWithAddressSenderAndNonAsciiCharactersInLocalPartOfAddress()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid sender "fabièn@symfony.com": non-ASCII characters not supported in local-part of email.');
-        new Envelope(new Address('fabièn@symfony.com'), [new Address('thomas@symfony.com')]);
-    }
-
     public function testConstructorWithNamedAddressSender()
     {
         $e = new Envelope($sender = new Address('fabien@symfony.com', 'Fabien'), [new Address('thomas@symfony.com')]);
@@ -79,14 +72,6 @@ class EnvelopeTest extends TestCase
         $headers->addMailboxListHeader('To', ['to@symfony.com']);
         $e = Envelope::create(new Message($headers));
         $this->assertEquals($from, $e->getSender());
-    }
-
-    public function testSenderFromHeadersFailsWithNonAsciiCharactersInLocalPart()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid sender "fabièn@symfony.com": non-ASCII characters not supported in local-part of email.');
-        $message = new Message(new Headers(new PathHeader('Return-Path', new Address('fabièn@symfony.com'))));
-        Envelope::create($message)->getSender();
     }
 
     public function testSenderFromHeadersWithoutFrom()

--- a/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransport.php
@@ -195,7 +195,7 @@ class EsmtpTransport extends SmtpTransport
         return $capabilities;
     }
 
-    protected function serverSupportsSmtputf8(): bool
+    protected function serverSupportsSmtpUtf8(): bool
     {
         return \array_key_exists('SMTPUTF8', $this->capabilities);
     }

--- a/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransport.php
@@ -195,6 +195,11 @@ class EsmtpTransport extends SmtpTransport
         return $capabilities;
     }
 
+    protected function serverSupportsSmtputf8(): bool
+    {
+        return \array_key_exists('SMTPUTF8', $this->capabilities);
+    }
+
     private function handleAuth(array $modes): void
     {
         if (!$this->username) {

--- a/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Mailer\Transport\Smtp;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Mailer\Exception\LogicException;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
@@ -211,7 +212,7 @@ class SmtpTransport extends AbstractTransport
 
         try {
             $envelope = $message->getEnvelope();
-            $this->doMailFromCommand($envelope->getSender()->getEncodedAddress());
+            $this->doMailFromCommand($envelope->getSender()->getEncodedAddress(), $envelope->anyAddressHasUnicodeLocalpart());
             foreach ($envelope->getRecipients() as $recipient) {
                 $this->doRcptToCommand($recipient->getEncodedAddress());
             }
@@ -244,14 +245,22 @@ class SmtpTransport extends AbstractTransport
         }
     }
 
+    protected function serverSupportsSmtputf8(): bool
+    {
+        return false;
+    }
+
     private function doHeloCommand(): void
     {
         $this->executeCommand(\sprintf("HELO %s\r\n", $this->domain), [250]);
     }
 
-    private function doMailFromCommand(string $address): void
+    private function doMailFromCommand(string $address, bool $smtputf8): void
     {
-        $this->executeCommand(\sprintf("MAIL FROM:<%s>\r\n", $address), [250]);
+        if($smtputf8 && !$this->serverSupportsSmtputf8()) {
+            throw new InvalidArgumentException('Invalid addresses: non-ASCII characters not supported in local-part of email.');
+        }
+        $this->executeCommand(sprintf("MAIL FROM:<%s>%s\r\n", $address, ($smtputf8 ? " SMTPUTF8" : "")), [250]);
     }
 
     private function doRcptToCommand(string $address): void

--- a/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
@@ -245,7 +245,7 @@ class SmtpTransport extends AbstractTransport
         }
     }
 
-    protected function serverSupportsSmtputf8(): bool
+    protected function serverSupportsSmtpUtf8(): bool
     {
         return false;
     }
@@ -257,7 +257,7 @@ class SmtpTransport extends AbstractTransport
 
     private function doMailFromCommand(string $address, bool $smtputf8): void
     {
-        if($smtputf8 && !$this->serverSupportsSmtputf8()) {
+        if($smtputf8 && !$this->serverSupportsSmtpUtf8()) {
             throw new InvalidArgumentException('Invalid addresses: non-ASCII characters not supported in local-part of email.');
         }
         $this->executeCommand(sprintf("MAIL FROM:<%s>%s\r\n", $address, ($smtputf8 ? " SMTPUTF8" : "")), [250]);

--- a/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
@@ -257,10 +257,10 @@ class SmtpTransport extends AbstractTransport
 
     private function doMailFromCommand(string $address, bool $smtputf8): void
     {
-        if($smtputf8 && !$this->serverSupportsSmtpUtf8()) {
+        if ($smtputf8 && !$this->serverSupportsSmtpUtf8()) {
             throw new InvalidArgumentException('Invalid addresses: non-ASCII characters not supported in local-part of email.');
         }
-        $this->executeCommand(sprintf("MAIL FROM:<%s>%s\r\n", $address, ($smtputf8 ? " SMTPUTF8" : "")), [250]);
+        $this->executeCommand(\sprintf("MAIL FROM:<%s>%s\r\n", $address, $smtputf8 ? ' SMTPUTF8' : ''), [250]);
     }
 
     private function doRcptToCommand(string $address): void

--- a/src/Symfony/Component/Mailer/composer.json
+++ b/src/Symfony/Component/Mailer/composer.json
@@ -21,7 +21,7 @@
         "psr/event-dispatcher": "^1",
         "psr/log": "^1|^2|^3",
         "symfony/event-dispatcher": "^6.4|^7.0",
-        "symfony/mime": "^6.4|^7.0",
+        "symfony/mime": "^7.2",
         "symfony/service-contracts": "^2.5|^3"
     },
     "require-dev": {

--- a/src/Symfony/Component/Mime/Address.php
+++ b/src/Symfony/Component/Mime/Address.php
@@ -117,4 +117,27 @@ final class Address
 
         return $addrs;
     }
+
+    /**
+
+      * Returns true if this address' localpart contains at least one
+      * non-ASCII character, and false if it is only ASCII (or empty).
+      *
+      * This is a helper for Envelope, which has to decide whether to
+      * the SMTPUTF8 extensions (RFC 6530 and following) for any given
+      * message.
+      *
+      * The SMTPUTF8 extension is strictly required if any address
+      * contains a non-ASCII character in its localpart. If non-ASCII
+      * is only used in domains (e.g. horst@freiherr-von-mühlhausen.de)
+      * then it is possible to to send the message using IDN encoding
+      * instead of SMTPUTF8. The most common software will display the
+      * message as intended.
+      *
+      * @return bool
+      */
+    public function hasUnicodeLocalpart(): bool
+    {
+        return (bool) preg_match( '/[\x80-\xFF].*@/', $this->address);
+    }
 }

--- a/src/Symfony/Component/Mime/Address.php
+++ b/src/Symfony/Component/Mime/Address.php
@@ -119,22 +119,22 @@ final class Address
     }
 
     /**
-      * Returns true if this address' localpart contains at least one
-      * non-ASCII character, and false if it is only ASCII (or empty).
-      *
-      * This is a helper for Envelope, which has to decide whether to
-      * the SMTPUTF8 extensions (RFC 6530 and following) for any given
-      * message.
-      *
-      * The SMTPUTF8 extension is strictly required if any address
-      * contains a non-ASCII character in its localpart. If non-ASCII
-      * is only used in domains (e.g. horst@freiherr-von-mühlhausen.de)
-      * then it is possible to to send the message using IDN encoding
-      * instead of SMTPUTF8. The most common software will display the
-      * message as intended.
-      */
+     * Returns true if this address' localpart contains at least one
+     * non-ASCII character, and false if it is only ASCII (or empty).
+     *
+     * This is a helper for Envelope, which has to decide whether to
+     * the SMTPUTF8 extensions (RFC 6530 and following) for any given
+     * message.
+     *
+     * The SMTPUTF8 extension is strictly required if any address
+     * contains a non-ASCII character in its localpart. If non-ASCII
+     * is only used in domains (e.g. horst@freiherr-von-mühlhausen.de)
+     * then it is possible to to send the message using IDN encoding
+     * instead of SMTPUTF8. The most common software will display the
+     * message as intended.
+     */
     public function hasUnicodeLocalpart(): bool
     {
-        return (bool) preg_match( '/[\x80-\xFF].*@/', $this->address);
+        return (bool) preg_match('/[\x80-\xFF].*@/', $this->address);
     }
 }

--- a/src/Symfony/Component/Mime/Address.php
+++ b/src/Symfony/Component/Mime/Address.php
@@ -119,7 +119,6 @@ final class Address
     }
 
     /**
-
       * Returns true if this address' localpart contains at least one
       * non-ASCII character, and false if it is only ASCII (or empty).
       *
@@ -133,8 +132,6 @@ final class Address
       * then it is possible to to send the message using IDN encoding
       * instead of SMTPUTF8. The most common software will display the
       * message as intended.
-      *
-      * @return bool
       */
     public function hasUnicodeLocalpart(): bool
     {

--- a/src/Symfony/Component/Mime/Tests/AddressTest.php
+++ b/src/Symfony/Component/Mime/Tests/AddressTest.php
@@ -81,6 +81,13 @@ class AddressTest extends TestCase
         $this->assertEquals([$fabien], Address::createArray(['fabien@symfony.com']));
     }
 
+    public function testUnicodeLocalpart()
+    {
+        /* dømi means example and is reserved by the .fo registry */
+        $this->assertFalse((new Address('info@dømi.fo'))->hasUnicodeLocalpart());
+        $this->assertTrue((new Address('info@dømi.fo'))->hasUnicodeLocalpart());
+    }
+
     public function testCreateArrayWrongArg()
     {
         $this->expectException(\TypeError::class);

--- a/src/Symfony/Component/Mime/Tests/AddressTest.php
+++ b/src/Symfony/Component/Mime/Tests/AddressTest.php
@@ -85,7 +85,7 @@ class AddressTest extends TestCase
     {
         /* dømi means example and is reserved by the .fo registry */
         $this->assertFalse((new Address('info@dømi.fo'))->hasUnicodeLocalpart());
-        $this->assertTrue((new Address('info@dømi.fo'))->hasUnicodeLocalpart());
+        $this->assertTrue((new Address('dømi@dømi.fo'))->hasUnicodeLocalpart());
     }
 
     public function testCreateArrayWrongArg()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

This allows applications to send mail to all-Chinese email addresses, or like my test address grå@grå.org. Code that uses Symfony needs no change and should experience no difference, although if the upstream MTA doesn't support it (most do by now) then an exception is thrown slightly later than before this change.