### PR TITLE
[DependencyInjection] Rename non-empty parameter methods

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -309,7 +309,7 @@ class FrameworkExtension extends Extension
         if (isset($config['secret'])) {
             $container->setParameter('kernel.secret', $config['secret']);
         }
-        $container->nonEmptyParameter('kernel.secret', 'A non-empty value for the parameter "kernel.secret" is required. Did you forget to configure the "framework.secret" option?');
+        $container->parameterCannotBeEmpty('kernel.secret', 'A non-empty value for the parameter "kernel.secret" is required. Did you forget to configure the "framework.secret" option?');
 
         $container->setParameter('kernel.http_method_override', $config['http_method_override']);
         $container->setParameter('kernel.trust_x_sendfile_type_header', $config['trust_x_sendfile_type_header']);

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -7,7 +7,7 @@ CHANGELOG
  * Deprecate `!tagged` tag, use `!tagged_iterator` instead
  * Add a `ContainerBuilder::registerChild()` shortcut method for registering child definitions
  * Add support for `key-type` in `XmlFileLoader`
- * Enable non-empty parameters with `ParameterBag::nonEmpty()` and `ContainerBuilder::nonEmptyParameter()` methods
+ * Enable non-empty parameters with `ParameterBag::cannotBeEmpty()` and `ContainerBuilder::parameterCannotBeEmpty()` methods
 
 7.1
 ---

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -673,7 +673,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
             }
 
             foreach ($otherBag->allNonEmpty() as $name => $message) {
-                $parameterBag->nonEmpty($name, $message);
+                $parameterBag->cannotBeEmpty($name, $message);
             }
         }
 
@@ -768,13 +768,13 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
         $this->parameterBag->deprecate($name, $package, $version, $message);
     }
 
-    public function nonEmptyParameter(string $name, string $message): void
+    public function parameterCannotBeEmpty(string $name, string $message): void
     {
         if (!$this->parameterBag instanceof ParameterBag) {
             throw new BadMethodCallException(\sprintf('The parameter bag must be an instance of "%s" to call "%s()".', ParameterBag::class, __METHOD__));
         }
 
-        $this->parameterBag->nonEmpty($name, $message);
+        $this->parameterBag->cannotBeEmpty($name, $message);
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/FrozenParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/FrozenParameterBag.php
@@ -55,9 +55,9 @@ class FrozenParameterBag extends ParameterBag
         throw new LogicException('Impossible to call deprecate() on a frozen ParameterBag.');
     }
 
-    public function nonEmpty(string $name, string $message = 'A non-empty parameter "%s" is required.'): never
+    public function cannotBeEmpty(string $name, string $message = 'A non-empty parameter "%s" is required.'): never
     {
-        throw new LogicException('Impossible to call nonEmpty() on a frozen ParameterBag.');
+        throw new LogicException('Impossible to call cannotBeEmpty() on a frozen ParameterBag.');
     }
 
     public function remove(string $name): never

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
@@ -133,7 +133,7 @@ class ParameterBag implements ParameterBagInterface
         $this->deprecatedParameters[$name] = [$package, $version, $message, $name];
     }
 
-    public function nonEmpty(string $name, string $message): void
+    public function cannotBeEmpty(string $name, string $message): void
     {
         $this->nonEmptyParameters[$name] = $message;
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container_nonempty_parameters.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container_nonempty_parameters.php
@@ -4,7 +4,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Parameter;
 
 $container = new ContainerBuilder();
-$container->nonEmptyParameter('bar', 'Did you forget to configure the "foo.bar" option?');
+$container->parameterCannotBeEmpty('bar', 'Did you forget to configure the "foo.bar" option?');
 $container->register('foo', 'stdClass')
     ->setArguments([new Parameter('bar')])
     ->setPublic(true)

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/ParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/ParameterBagTest.php
@@ -13,8 +13,8 @@ namespace Symfony\Component\DependencyInjection\Tests\ParameterBag;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\ExpectUserDeprecationMessageTrait;
-use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\EmptyParameterValueException;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\ParameterCircularReferenceException;
 use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
@@ -201,7 +201,7 @@ class ParameterBagTest extends TestCase
     {
         $bag = new ParameterBag();
 
-        $bag->nonEmpty('bar', 'Did you forget to configure the "foo.bar" option?');
+        $bag->cannotBeEmpty('bar', 'Did you forget to configure the "foo.bar" option?');
 
         $this->expectException(ParameterNotFoundException::class);
         $this->expectExceptionMessage('You have requested a non-existent parameter "bar". Did you forget to configure the "foo.bar" option?');
@@ -213,7 +213,7 @@ class ParameterBagTest extends TestCase
     {
         $bag = new ParameterBag();
         $bag->set('bar', null);
-        $bag->nonEmpty('bar', 'Did you forget to configure the "foo.bar" option?');
+        $bag->cannotBeEmpty('bar', 'Did you forget to configure the "foo.bar" option?');
 
         $this->expectException(EmptyParameterValueException::class);
         $this->expectExceptionMessage('Did you forget to configure the "foo.bar" option?');
@@ -225,7 +225,19 @@ class ParameterBagTest extends TestCase
     {
         $bag = new ParameterBag();
         $bag->set('bar', '');
-        $bag->nonEmpty('bar', 'Did you forget to configure the "foo.bar" option?');
+        $bag->cannotBeEmpty('bar', 'Did you forget to configure the "foo.bar" option?');
+
+        $this->expectException(EmptyParameterValueException::class);
+        $this->expectExceptionMessage('Did you forget to configure the "foo.bar" option?');
+
+        $bag->get('bar');
+    }
+
+    public function testGetNonEmptyParameterThrowsWhenEmptyArrayValue()
+    {
+        $bag = new ParameterBag();
+        $bag->set('bar', []);
+        $bag->cannotBeEmpty('bar', 'Did you forget to configure the "foo.bar" option?');
 
         $this->expectException(EmptyParameterValueException::class);
         $this->expectExceptionMessage('Did you forget to configure the "foo.bar" option?');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        |  -
| License       | MIT

After an internal discussion we are proposing to rename the main methods of this feature to make them clearer.

New names:
```php
$parameterBag->cannotBeEmpty(...);
$containerBuilder->parameterCannotBeEmpty(...);
```