### PR TITLE
[PropertyInfo] Fix bigint extraction with type info

### DIFF
--- a/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
+++ b/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
@@ -133,7 +133,7 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
 
         // DBAL 4 has a special fallback strategy for BINGINT (int -> string)
         if (Types::BIGINT === $typeOfField && !method_exists(BigIntType::class, 'getName')) {
-            return Type::collection(Type::int(), Type::string());
+            return $nullable ? Type::nullable(Type::union(Type::int(), Type::string())) : Type::union(Type::int(), Type::string());
         }
 
         $enumType = null;

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
@@ -286,7 +286,7 @@ class DoctrineExtractorTest extends TestCase
     {
         // DBAL 4 has a special fallback strategy for BINGINT (int -> string)
         if (!method_exists(BigIntType::class, 'getName')) {
-            $expectedBigIntType = Type::collection(Type::int(), Type::string());
+            $expectedBigIntType = Type::union(Type::int(), Type::string());
         } else {
             $expectedBigIntType = Type::string();
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

During an upmerge, an issue has been made, indeed:
```php
return [
    new Type(Type::BUILTIN_TYPE_INT, $nullable),
    new Type(Type::BUILTIN_TYPE_STRING, $nullable),
];
```
must be considered as an union and not a collection (ie: `Type::union` instead of `Type::collection`)
