### PR TITLE
Tweak error/exception handler registration

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -60,6 +60,7 @@ use Symfony\Component\Messenger\DependencyInjection\MessengerPass;
 use Symfony\Component\Mime\DependencyInjection\AddMimeTypeGuesserPass;
 use Symfony\Component\PropertyInfo\DependencyInjection\PropertyInfoPass;
 use Symfony\Component\Routing\DependencyInjection\RoutingResolverPass;
+use Symfony\Component\Runtime\SymfonyRuntime;
 use Symfony\Component\Serializer\DependencyInjection\SerializerPass;
 use Symfony\Component\Translation\DependencyInjection\TranslationDumperPass;
 use Symfony\Component\Translation\DependencyInjection\TranslationExtractorPass;
@@ -91,7 +92,16 @@ class FrameworkBundle extends Bundle
 {
     public function boot()
     {
-        ErrorHandler::register(null, false)->throwAt($this->container->getParameter('debug.error_handler.throw_at'), true);
+        if (class_exists(SymfonyRuntime::class)) {
+            $handler = set_error_handler('var_dump');
+            restore_error_handler();
+        } else {
+            $handler = [ErrorHandler::register(null, false)];
+        }
+
+        if (\is_array($handler) && $handler[0] instanceof ErrorHandler) {
+            $handler[0]->throwAt($this->container->getParameter('debug.error_handler.throw_at'), true);
+        }
 
         if ($this->container->getParameter('kernel.http_method_override')) {
             Request::enableHttpMethodParameterOverride();

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -86,6 +86,7 @@
         "symfony/mime": "<4.4",
         "symfony/property-info": "<4.4",
         "symfony/property-access": "<5.3",
+        "symfony/runtime": "<5.4.45|>=6.0,<6.4.13|>=7.0,<7.1.6",
         "symfony/serializer": "<5.2",
         "symfony/service-contracts": ">=3.0",
         "symfony/security-csrf": "<5.3",

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -165,9 +165,9 @@ class Application implements ResetInterface
             }
         }
 
-        $this->configureIO($input, $output);
-
         try {
+            $this->configureIO($input, $output);
+
             $exitCode = $this->doRun($input, $output);
         } catch (\Exception $e) {
             if (!$this->catchExceptions) {

--- a/src/Symfony/Component/HttpKernel/EventListener/DebugHandlersListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/DebugHandlersListener.php
@@ -57,7 +57,7 @@ class DebugHandlersListener implements EventSubscriberInterface
             $deprecationLogger = $fileLinkFormat;
         }
 
-        $handler = set_exception_handler('is_int');
+        $handler = set_exception_handler('var_dump');
         $this->earlyHandler = \is_array($handler) ? $handler[0] : null;
         restore_exception_handler();
 
@@ -84,7 +84,7 @@ class DebugHandlersListener implements EventSubscriberInterface
         $this->firstCall = $this->hasTerminatedWithException = false;
         $hasRun = null;
 
-        $handler = set_exception_handler('is_int');
+        $handler = set_exception_handler('var_dump');
         $handler = \is_array($handler) ? $handler[0] : null;
         restore_exception_handler();
 

--- a/src/Symfony/Component/Runtime/GenericRuntime.php
+++ b/src/Symfony/Component/Runtime/GenericRuntime.php
@@ -71,13 +71,13 @@ class GenericRuntime implements RuntimeInterface
         if ($debug) {
             umask(0000);
             $_SERVER[$debugKey] = $_ENV[$debugKey] = '1';
-
-            if (false !== $errorHandler = ($options['error_handler'] ?? BasicErrorHandler::class)) {
-                $errorHandler::register($debug);
-                $options['error_handler'] = false;
-            }
         } else {
             $_SERVER[$debugKey] = $_ENV[$debugKey] = '0';
+        }
+
+        if (false !== $errorHandler = ($options['error_handler'] ?? BasicErrorHandler::class)) {
+            $errorHandler::register($debug);
+            $options['error_handler'] = false;
         }
 
         $this->options = $options;

--- a/src/Symfony/Component/Runtime/Internal/BasicErrorHandler.php
+++ b/src/Symfony/Component/Runtime/Internal/BasicErrorHandler.php
@@ -30,10 +30,10 @@ class BasicErrorHandler
         }
 
         if (0 <= \ini_get('zend.assertions')) {
-            ini_set('zend.assertions', 1);
-            ini_set('assert.active', $debug);
-            ini_set('assert.exception', 1);
+            ini_set('zend.assertions', (int) $debug);
         }
+        ini_set('assert.active', 1);
+        ini_set('assert.exception', 1);
 
         set_error_handler(new self());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53812, Fix #46692
| License       | MIT

This should allow removing the custom bootstrap file from #58370 /cc @xabbuh 

The change on FrameworkBundle leads to a tweaked behavior: we don't override the previous error handler in case it's not the Symfony one. This shouldn't change anything in practice since the error handler is already registered by the runtime component.

The rest is closer to bug fixes.