### PR TITLE
Remove useless parent method calls in tests

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -28,8 +28,6 @@ class DoctrineExtensionTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->extension = $this
             ->getMockBuilder(AbstractDoctrineExtension::class)
             ->onlyMethods([

--- a/src/Symfony/Bridge/Doctrine/Tests/Middleware/Debug/MiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Middleware/Debug/MiddlewareTest.php
@@ -38,8 +38,6 @@ class MiddlewareTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         if (!interface_exists(MiddlewareInterface::class)) {
             $this->markTestSkipped(\sprintf('%s needed to run this test', MiddlewareInterface::class));
         }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractLayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractLayoutTestCase.php
@@ -58,8 +58,6 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
     protected function tearDown(): void
     {
         \Locale::setDefault($this->defaultLocale);
-
-        parent::tearDown();
     }
 
     protected function assertWidgetMatchesXpath(FormView $view, array $vars, $xpath)

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/UidTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/UidTest.php
@@ -20,8 +20,6 @@ class UidTest extends AbstractWebTestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         self::deleteTmpDir();
     }
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/WebProfilerExtensionTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/WebProfilerExtensionTest.php
@@ -54,8 +54,6 @@ class WebProfilerExtensionTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->kernel = $this->createMock(KernelInterface::class);
 
         $profiler = $this->createMock(Profiler::class);
@@ -88,8 +86,6 @@ class WebProfilerExtensionTest extends TestCase
 
     protected function tearDown(): void
     {
-        parent::tearDown();
-
         $this->container = null;
     }
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Profiler/TemplateManagerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Profiler/TemplateManagerTest.php
@@ -30,8 +30,6 @@ class TemplateManagerTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->profiler = $this->createMock(Profiler::class);
         $twigEnvironment = $this->mockTwigEnvironment();
         $templates = [

--- a/src/Symfony/Component/Cache/Tests/Adapter/AdapterTestCase.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/AdapterTestCase.php
@@ -23,8 +23,6 @@ abstract class AdapterTestCase extends CachePoolTest
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         if (!\array_key_exists('testPrune', $this->skippedTests) && !$this->createCachePool() instanceof PruneableInterface) {
             $this->skippedTests['testPrune'] = 'Not a pruneable cache pool.';
         }

--- a/src/Symfony/Component/Cache/Tests/Psr16CacheProxyTest.php
+++ b/src/Symfony/Component/Cache/Tests/Psr16CacheProxyTest.php
@@ -21,8 +21,6 @@ class Psr16CacheProxyTest extends SimpleCacheTest
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         try {
             \assert(false === true, new \Exception());
             $this->skippedTests['testGetInvalidKeys'] =

--- a/src/Symfony/Component/Cache/Tests/Psr16CacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Psr16CacheTest.php
@@ -24,8 +24,6 @@ class Psr16CacheTest extends SimpleCacheTest
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         if (\array_key_exists('testPrune', $this->skippedTests)) {
             return;
         }

--- a/src/Symfony/Component/Cache/Tests/Psr16CacheWithExternalAdapter.php
+++ b/src/Symfony/Component/Cache/Tests/Psr16CacheWithExternalAdapter.php
@@ -23,8 +23,6 @@ class Psr16CacheWithExternalAdapter extends SimpleCacheTest
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->skippedTests['testSetTtl'] =
         $this->skippedTests['testSetMultipleTtl'] = 'The ExternalAdapter test class does not support TTLs.';
     }

--- a/src/Symfony/Component/Config/Tests/Builder/GeneratedConfigTest.php
+++ b/src/Symfony/Component/Config/Tests/Builder/GeneratedConfigTest.php
@@ -40,8 +40,6 @@ class GeneratedConfigTest extends TestCase
 
     protected function setup(): void
     {
-        parent::setup();
-
         $this->tempDir = [];
     }
 
@@ -49,8 +47,6 @@ class GeneratedConfigTest extends TestCase
     {
         (new Filesystem())->remove($this->tempDir);
         $this->tempDir = [];
-
-        parent::tearDown();
     }
 
     public static function fixtureNames()

--- a/src/Symfony/Component/Console/Tests/Question/QuestionTest.php
+++ b/src/Symfony/Component/Console/Tests/Question/QuestionTest.php
@@ -20,7 +20,6 @@ class QuestionTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
         $this->question = new Question('Test question');
     }
 

--- a/src/Symfony/Component/Form/Tests/ChoiceList/AbstractChoiceListTestCase.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/AbstractChoiceListTestCase.php
@@ -39,8 +39,6 @@ abstract class AbstractChoiceListTestCase extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->list = $this->createChoiceList();
 
         $choices = $this->getChoices();

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
@@ -31,8 +31,6 @@ class DateTimeToLocalizedStringTransformerTest extends BaseDateTimeTransformerTe
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         // Normalize intl. configuration settings.
         if (\extension_loaded('intl')) {
             $this->initialTestCaseUseException = ini_set('intl.use_exceptions', 0);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToRfc3339TransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToRfc3339TransformerTest.php
@@ -25,8 +25,6 @@ class DateTimeToRfc3339TransformerTest extends BaseDateTimeTransformerTestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->dateTime = new \DateTime('2010-02-03 04:05:06 UTC');
         $this->dateTimeWithoutSeconds = new \DateTime('2010-02-03 04:05:00 UTC');
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
@@ -33,8 +33,6 @@ class MoneyTypeTest extends BaseTypeTestCase
 
     protected function tearDown(): void
     {
-        parent::tearDown();
-
         \Locale::setDefault($this->defaultLocale);
     }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/NumberTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/NumberTypeTest.php
@@ -35,8 +35,6 @@ class NumberTypeTest extends BaseTypeTestCase
 
     protected function tearDown(): void
     {
-        parent::tearDown();
-
         \Locale::setDefault($this->defaultLocale);
     }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/PercentTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/PercentTypeTest.php
@@ -34,8 +34,6 @@ class PercentTypeTest extends TypeTestCase
 
     protected function tearDown(): void
     {
-        parent::tearDown();
-
         \Locale::setDefault($this->defaultLocale);
     }
 

--- a/src/Symfony/Component/Form/Tests/NativeRequestHandlerTest.php
+++ b/src/Symfony/Component/Form/Tests/NativeRequestHandlerTest.php
@@ -41,8 +41,6 @@ class NativeRequestHandlerTest extends AbstractRequestHandlerTestCase
 
     protected function tearDown(): void
     {
-        parent::tearDown();
-
         $_GET = [];
         $_POST = [];
         $_FILES = [];

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Flash/AutoExpireFlashBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Flash/AutoExpireFlashBagTest.php
@@ -27,7 +27,6 @@ class AutoExpireFlashBagTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
         $this->bag = new FlashBag();
         $this->array = ['new' => ['notice' => ['A previous flash message']]];
         $this->bag->initialize($this->array);
@@ -36,7 +35,6 @@ class AutoExpireFlashBagTest extends TestCase
     protected function tearDown(): void
     {
         unset($this->bag);
-        parent::tearDown();
     }
 
     public function testInitialize()

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Flash/FlashBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Flash/FlashBagTest.php
@@ -27,7 +27,6 @@ class FlashBagTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
         $this->bag = new FlashBag();
         $this->array = ['notice' => ['A previous flash message']];
         $this->bag->initialize($this->array);
@@ -36,7 +35,6 @@ class FlashBagTest extends TestCase
     protected function tearDown(): void
     {
         unset($this->bag);
-        parent::tearDown();
     }
 
     public function testInitialize()

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/AbstractRedisSessionHandlerTestCase.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/AbstractRedisSessionHandlerTestCase.php
@@ -31,8 +31,6 @@ abstract class AbstractRedisSessionHandlerTestCase extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         if (!\extension_loaded('redis')) {
             self::markTestSkipped('Extension redis required.');
         }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MemcachedSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MemcachedSessionHandlerTest.php
@@ -30,8 +30,6 @@ class MemcachedSessionHandlerTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         if (version_compare(phpversion('memcached'), '2.2.0', '>=') && version_compare(phpversion('memcached'), '3.0.0b1', '<')) {
             $this->markTestSkipped('Tests can only be run with memcached extension 2.1.0 or lower, or 3.0.0b1 or higher');
         }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
@@ -44,8 +44,6 @@ class MongoDbSessionHandlerTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->manager = new Manager('mongodb://'.getenv('MONGODB_HOST'));
 
         try {

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
@@ -30,7 +30,6 @@ class PdoSessionHandlerTest extends TestCase
         if ($this->dbFile) {
             @unlink($this->dbFile);
         }
-        parent::tearDown();
     }
 
     protected function getPersistentSqliteDsn()

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MetadataBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MetadataBagTest.php
@@ -26,7 +26,6 @@ class MetadataBagTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
         $this->bag = new MetadataBag();
         $this->array = [MetadataBag::CREATED => 1234567, MetadataBag::UPDATED => 12345678, MetadataBag::LIFETIME => 0];
         $this->bag->initialize($this->array);

--- a/src/Symfony/Component/Intl/Tests/IntlTest.php
+++ b/src/Symfony/Component/Intl/Tests/IntlTest.php
@@ -20,15 +20,11 @@ class IntlTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->defaultLocale = \Locale::getDefault();
     }
 
     protected function tearDown(): void
     {
-        parent::tearDown();
-
         \Locale::setDefault($this->defaultLocale);
     }
 

--- a/src/Symfony/Component/Mailer/Tests/Transport/NativeTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/NativeTransportFactoryTest.php
@@ -26,8 +26,6 @@ final class NativeTransportFactoryTest extends TestCase
 
     public static function setUpBeforeClass(): void
     {
-        parent::setUpBeforeClass();
-
         $namespace = str_replace('\\Tests\\', '\\', __NAMESPACE__);
 
         $current = static::class;

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpExtIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpExtIntegrationTest.php
@@ -40,8 +40,6 @@ class AmqpExtIntegrationTest extends TestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         if (!getenv('MESSENGER_AMQP_DSN')) {
             $this->markTestSkipped('The "MESSENGER_AMQP_DSN" environment variable is required.');
         }

--- a/src/Symfony/Component/Routing/Tests/Generator/Dumper/CompiledUrlGeneratorDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/Dumper/CompiledUrlGeneratorDumperTest.php
@@ -33,8 +33,6 @@ class CompiledUrlGeneratorDumperTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->routeCollection = new RouteCollection();
         $this->generatorDumper = new CompiledUrlGeneratorDumper($this->routeCollection);
         $this->testTmpFilepath = sys_get_temp_dir().'/php_generator.'.$this->getName().'.php';
@@ -45,8 +43,6 @@ class CompiledUrlGeneratorDumperTest extends TestCase
 
     protected function tearDown(): void
     {
-        parent::tearDown();
-
         @unlink($this->testTmpFilepath);
         @unlink($this->largeTestTmpFilepath);
     }

--- a/src/Symfony/Component/Routing/Tests/Loader/AttributeClassLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AttributeClassLoaderTest.php
@@ -50,8 +50,6 @@ class AttributeClassLoaderTest extends TestCase
 
     protected function setUp(?string $env = null): void
     {
-        parent::setUp();
-
         $this->loader = new TraceableAttributeClassLoader($env);
     }
 

--- a/src/Symfony/Component/Routing/Tests/Loader/AttributeDirectoryLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AttributeDirectoryLoaderTest.php
@@ -27,8 +27,6 @@ class AttributeDirectoryLoaderTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->classLoader = new TraceableAttributeClassLoader();
         $this->loader = new AttributeDirectoryLoader(new FileLocator(), $this->classLoader);
     }

--- a/src/Symfony/Component/Routing/Tests/Loader/AttributeFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AttributeFileLoaderTest.php
@@ -33,8 +33,6 @@ class AttributeFileLoaderTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->classLoader = new TraceableAttributeClassLoader();
         $this->loader = new AttributeFileLoader(new FileLocator(), $this->classLoader);
     }

--- a/src/Symfony/Component/Routing/Tests/Loader/DirectoryLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/DirectoryLoaderTest.php
@@ -26,8 +26,6 @@ class DirectoryLoaderTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $locator = new FileLocator();
         $this->loader = new DirectoryLoader($locator);
         $resolver = new LoaderResolver([

--- a/src/Symfony/Component/Routing/Tests/Matcher/Dumper/CompiledUrlMatcherDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/Dumper/CompiledUrlMatcherDumperTest.php
@@ -28,15 +28,11 @@ class CompiledUrlMatcherDumperTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->dumpPath = tempnam(sys_get_temp_dir(), 'sf_matcher_');
     }
 
     protected function tearDown(): void
     {
-        parent::tearDown();
-
         @unlink($this->dumpPath);
     }
 

--- a/src/Symfony/Component/Security/Csrf/Tests/CsrfTokenManagerTest.php
+++ b/src/Symfony/Component/Security/Csrf/Tests/CsrfTokenManagerTest.php
@@ -546,8 +546,6 @@ class CsrfTokenManagerTest extends TestCase
 
     protected function tearDown(): void
     {
-        parent::tearDown();
-
         unset($_SERVER['HTTPS']);
     }
 }

--- a/src/Symfony/Component/Translation/Tests/Command/TranslationProviderTestCase.php
+++ b/src/Symfony/Component/Translation/Tests/Command/TranslationProviderTestCase.php
@@ -29,7 +29,6 @@ abstract class TranslationProviderTestCase extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
         $this->defaultLocale = \Locale::getDefault();
         \Locale::setDefault('en');
         $this->fs = new Filesystem();
@@ -42,7 +41,6 @@ abstract class TranslationProviderTestCase extends TestCase
     {
         \Locale::setDefault($this->defaultLocale);
         $this->fs->remove($this->translationAppDir);
-        parent::tearDown();
     }
 
     protected function getProviderCollection(ProviderInterface $provider, array $providerNames = ['loco'], array $locales = ['en'], array $domains = ['messages']): TranslationProviderCollection

--- a/src/Symfony/Component/Translation/Tests/LocaleSwitcherTest.php
+++ b/src/Symfony/Component/Translation/Tests/LocaleSwitcherTest.php
@@ -25,15 +25,11 @@ class LocaleSwitcherTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->intlLocale = \Locale::getDefault();
     }
 
     protected function tearDown(): void
     {
-        parent::tearDown();
-
         \Locale::setDefault($this->intlLocale);
     }
 

--- a/src/Symfony/Component/VarDumper/Tests/Caster/DateCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/DateCasterTest.php
@@ -29,15 +29,11 @@ class DateCasterTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->previousTimezone = date_default_timezone_get();
     }
 
     protected function tearDown(): void
     {
-        parent::tearDown();
-
         date_default_timezone_set($this->previousTimezone);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The vast majority of tests don't call these parent methods, because they are no op. There are a few places where they are called, let's remove them?