### PR TITLE
[String] Add the `AbstractString::kebab()` method

### DIFF
--- a/src/Symfony/Component/String/AbstractString.php
+++ b/src/Symfony/Component/String/AbstractString.php
@@ -433,6 +433,11 @@ abstract class AbstractString implements \Stringable, \JsonSerializable
 
     abstract public function snake(): static;
 
+    public function kebab(): static
+    {
+        return $this->snake()->replace('_', '-');
+    }
+
     abstract public function splice(string $replacement, int $start = 0, ?int $length = null): static;
 
     /**

--- a/src/Symfony/Component/String/CHANGELOG.md
+++ b/src/Symfony/Component/String/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `TruncateMode` enum to handle more truncate methods
+ * Add the `AbstractString::kebab()` method
 
 7.1
 ---

--- a/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
@@ -1090,6 +1090,35 @@ abstract class AbstractAsciiTestCase extends TestCase
     }
 
     /**
+     * @dataProvider provideKebab
+     */
+    public function testKebab(string $expectedString, string $origin)
+    {
+        $instance = static::createFromString($origin)->kebab();
+
+        $this->assertEquals(static::createFromString($expectedString), $instance);
+        $this->assertNotSame($origin, $instance, 'Strings should be immutable');
+    }
+
+    public static function provideKebab(): array
+    {
+        return [
+            ['', ''],
+            ['x-y', 'x_y'],
+            ['x-y', 'X_Y'],
+            ['xu-yo', 'xu_yo'],
+            ['symfony-is-great', 'symfonyIsGreat'],
+            ['symfony123-is-great', 'symfony123IsGreat'],
+            ['symfony123is-great', 'symfony123isGreat'],
+            ['symfony-is-great', 'Symfony is great'],
+            ['symfony-is-a-great-framework', 'symfonyIsAGreatFramework'],
+            ['symfony-is-great', 'symfonyIsGREAT'],
+            ['symfony-is-really-great', 'symfonyIsREALLYGreat'],
+            ['symfony', 'SYMFONY'],
+        ];
+    }
+
+    /**
      * @dataProvider provideStartsWith
      */
     public function testStartsWith(bool $expected, string $origin, $prefix, ?int $form = null)

--- a/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
@@ -665,6 +665,15 @@ END'],
         );
     }
 
+    public static function provideKebab(): array
+    {
+        return [
+            ...parent::provideKebab(),
+            ['symfony-ist-äußerst-cool', 'symfonyIstÄußerstCool'],
+            ['symfony-with-emojis', 'Symfony with 😃 emojis'],
+        ];
+    }
+
     public static function provideEqualsTo()
     {
         return array_merge(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #48780
| License       | MIT

Supersedes #48781. It seems there's quite a demand for this feature. I think it is a nice DX improvement which also helps readability over calling `snake()->replace('_', '-')`.