### PR TITLE
[WebProfilerBundle] Update the contents of the Config panel

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
@@ -72,6 +72,14 @@
     {% endset %}
 
     {% set text %}
+        {% if symfony_version_status %}
+            <div class="sf-toolbar-info-group">
+                <div class="sf-toolbar-info-piece">
+                    <span>{{ symfony_version_status }}</span>
+                </div>
+            </div>
+        {% endif %}
+
         <div class="sf-toolbar-info-group">
             <div class="sf-toolbar-info-piece">
                 <b>Profiler token</b>
@@ -149,7 +157,7 @@
         </div>
     {% endset %}
 
-    {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: true, name: 'config', status: block_status, additional_classes: 'sf-toolbar-block-right', block_attrs: 'title="' ~ symfony_version_status ~ '"' }) }}
+    {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: true, name: 'config', status: block_status, additional_classes: 'sf-toolbar-block-right' }) }}
 {% endblock %}
 
 {% block menu %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -lain below instead -->
| License       | MIT

Similar to #58366 and #58380, this fixes an accessibility issue of the Web Debug Toolbar:

```
The "title" attribute can't be used in non-interactive elements
```

It now looks like this:

![image](https://github.com/user-attachments/assets/dff8d754-9661-40a7-81f9-5734f0ab36aa)
