### PR TITLE
[Validator][CidrValidator] Fix error message for `OutOfRangeNetmask` validation

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/CidrValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CidrValidator.php
@@ -81,7 +81,7 @@ class CidrValidator extends ConstraintValidator
             $this->context
                 ->buildViolation($constraint->netmaskRangeViolationMessage)
                 ->setParameter('{{ min }}', $constraint->netmaskMin)
-                ->setParameter('{{ max }}', $constraint->netmaskMax)
+                ->setParameter('{{ max }}', $netmaskMax)
                 ->setCode(Cidr::OUT_OF_RANGE_ERROR)
                 ->addViolation();
         }

--- a/src/Symfony/Component/Validator/Tests/Constraints/CidrValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CidrValidatorTest.php
@@ -106,7 +106,7 @@ class CidrValidatorTest extends ConstraintValidatorTestCase
     /**
      * @dataProvider getOutOfRangeNetmask
      */
-    public function testOutOfRangeNetmask(string $cidr, ?string $version = null, ?int $min = null, ?int $max = null)
+    public function testOutOfRangeNetmask(string $cidr, int $maxExpected, ?string $version = null, ?int $min = null, ?int $max = null)
     {
         $cidrConstraint = new Cidr([
             'version' => $version,
@@ -118,7 +118,7 @@ class CidrValidatorTest extends ConstraintValidatorTestCase
         $this
             ->buildViolation('The value of the netmask should be between {{ min }} and {{ max }}.')
             ->setParameter('{{ min }}', $cidrConstraint->netmaskMin)
-            ->setParameter('{{ max }}', $cidrConstraint->netmaskMax)
+            ->setParameter('{{ max }}', $maxExpected)
             ->setCode(Cidr::OUT_OF_RANGE_ERROR)
             ->assertRaised();
     }
@@ -240,9 +240,9 @@ class CidrValidatorTest extends ConstraintValidatorTestCase
     public static function getOutOfRangeNetmask(): array
     {
         return [
-            ['10.0.0.0/24', Ip::V4, 10, 20],
-            ['10.0.0.0/128'],
-            ['2001:0DB8:85A3:0000:0000:8A2E:0370:7334/24', Ip::V6, 10, 20],
+            ['10.0.0.0/24', 20, Ip::V4, 10, 20],
+            ['10.0.0.0/128', 32],
+            ['2001:0DB8:85A3:0000:0000:8A2E:0370:7334/24', 20, Ip::V6, 10, 20],
         ];
     }
 


### PR DESCRIPTION
<table>
<tr>
<th>Q</th>
<th>A</th>
</tr>
<tr>
<td>Branch?</td>
<td>7.1</td>
</tr>
<tr>
<td>Bug fix?</td>
<td>yes</td>
</tr>
<tr>
<td>New feature?</td>
<td>no</td>
</tr>
<tr>
<td>Deprecations?</td>
<td>no</td>
</tr>
<tr>
<td>License</td>
<td>MIT</td>
</tr>
</table>

**Description**

This pull request addresses an issue with the error message generated for the OutOfRangeNetmask validation in the CidrValidator. The previous implementation allowed a maximum netmask of 128, which is incorrect for IPv4 addresses. The maximum should be set to 32 instead.

**Changes Made:**

- Updated the error message parameters in the CidrValidator to reflect the correct maximum netmask for IPv4.
- Modified the corresponding test to ensure that it accurately verifies the expected behavior.

**Benefits:**

This fix ensures that users receive accurate feedback when providing invalid CIDR notations, which enhances the overall reliability of the validation process.

**Testing:**

All existing tests have been run, and the new behavior has been verified. The tests confirm that the error message now correctly states the maximum allowed netmask for IPv4 addresses.

Feel free to adjust any part of it to better fit your style or add any additional information you think is relevant!