### PR TITLE
get rid of `getInvocationCount()` calls in tests

### DIFF
--- a/src/Symfony/Component/Mailer/Tests/Transport/FailoverTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/FailoverTransportTest.php
@@ -86,11 +86,12 @@ class FailoverTransportTest extends TestCase
     {
         $t1 = $this->createMock(TransportInterface::class);
 
-        $t1Matcher = $this->any();
-        $t1->expects($t1Matcher)
+        $t1->expects($this->any())
             ->method('send')
-            ->willReturnCallback(function () use ($t1Matcher) {
-                if (1 === $t1Matcher->getInvocationCount()) {
+            ->willReturnCallback(function () {
+                static $call = 0;
+
+                if (1 === ++$call) {
                     throw new TransportException();
                 }
 
@@ -98,11 +99,12 @@ class FailoverTransportTest extends TestCase
             });
 
         $t2 = $this->createMock(TransportInterface::class);
-        $t2Matcher = $this->exactly(4);
-        $t2->expects($t2Matcher)
+        $t2->expects($this->exactly(4))
             ->method('send')
-            ->willReturnCallback(function () use ($t2Matcher) {
-                if (4 === $t2Matcher->getInvocationCount()) {
+            ->willReturnCallback(function () {
+                static $call = 0;
+
+                if (4 === ++$call) {
                     throw new TransportException();
                 }
 
@@ -132,11 +134,12 @@ class FailoverTransportTest extends TestCase
         $t1->method('send')->willThrowException(new TransportException());
         $t1->expects($this->once())->method('send');
         $t2 = $this->createMock(TransportInterface::class);
-        $matcher = $this->exactly(3);
-        $t2->expects($matcher)
+        $t2->expects($this->exactly(3))
             ->method('send')
-            ->willReturnCallback(function () use ($matcher) {
-                if (3 === $matcher->getInvocationCount()) {
+            ->willReturnCallback(function () {
+                static $call = 0;
+
+                if (3 === ++$call) {
                     throw new TransportException();
                 }
 
@@ -154,10 +157,11 @@ class FailoverTransportTest extends TestCase
 
     public function testSendOneDeadButRecover()
     {
-        $t1Matcher = $this->any();
         $t1 = $this->createMock(TransportInterface::class);
-        $t1->expects($t1Matcher)->method('send')->willReturnCallback(function () use ($t1Matcher) {
-            if (1 === $t1Matcher->getInvocationCount()) {
+        $t1->expects($this->any())->method('send')->willReturnCallback(function () {
+            static $call = 0;
+
+            if (1 === ++$call) {
                 throw new TransportException();
             }
 
@@ -165,11 +169,12 @@ class FailoverTransportTest extends TestCase
         });
 
         $t2 = $this->createMock(TransportInterface::class);
-        $matcher = $this->exactly(3);
-        $t2->expects($matcher)
+        $t2->expects($this->exactly(3))
             ->method('send')
-            ->willReturnCallback(function () use ($matcher) {
-                if (3 === $matcher->getInvocationCount()) {
+            ->willReturnCallback(function () {
+                static $call = 0;
+
+                if (3 === ++$call) {
                     throw new TransportException();
                 }
 

--- a/src/Symfony/Component/Mailer/Tests/Transport/RoundRobinTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/RoundRobinTransportTest.php
@@ -118,12 +118,13 @@ class RoundRobinTransportTest extends TestCase
         $t1 = $this->createMock(TransportInterface::class);
         $t1->expects($this->exactly(3))->method('send');
 
-        $matcher = $this->exactly(2);
         $t2 = $this->createMock(TransportInterface::class);
-        $t2->expects($matcher)
+        $t2->expects($this->exactly(2))
             ->method('send')
-            ->willReturnCallback(function () use ($matcher) {
-                if (1 === $matcher->getInvocationCount()) {
+            ->willReturnCallback(function () {
+                static $call = 0;
+
+                if (1 === ++$call) {
                     throw new TransportException();
                 }
 

--- a/src/Symfony/Component/Messenger/Tests/Middleware/DispatchAfterCurrentBusMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/DispatchAfterCurrentBusMiddlewareTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Messenger\Tests\Middleware;
 
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Constraint\Callback;
-use PHPUnit\Framework\MockObject\Stub\ReturnCallback;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\DelayedMessageHandlingException;
@@ -106,14 +105,15 @@ class DispatchAfterCurrentBusMiddlewareTest extends TestCase
             $secondEvent,
         ];
 
-        $matcher = $this->exactly(3);
-        $handlingMiddleware->expects($matcher)
+        $handlingMiddleware->expects($this->exactly(3))
             ->method('handle')
             ->with($this->callback(function (Envelope $envelope) use (&$series) {
                 return $envelope->getMessage() === array_shift($series);
             }))
-            ->willReturnCallback(function ($envelope, StackInterface $stack) use ($matcher) {
-                if (2 === $matcher->getInvocationCount()) {
+            ->willReturnCallback(function ($envelope, StackInterface $stack) {
+                static $call = 0;
+
+                if (2 === ++$call) {
                     throw new \RuntimeException('Some exception while handling first event');
                 }
 
@@ -175,14 +175,15 @@ class DispatchAfterCurrentBusMiddlewareTest extends TestCase
             // Note: $eventL3a should not be handled.
         ];
 
-        $matcher = $this->exactly(7);
-        $handlingMiddleware->expects($matcher)
+        $handlingMiddleware->expects($this->exactly(7))
             ->method('handle')
             ->with($this->callback(function (Envelope $envelope) use (&$series) {
                 return $envelope->getMessage() === array_shift($series);
             }))
-            ->willReturnCallback(function ($envelope, StackInterface $stack) use ($eventBus, $eventL2a, $eventL2b, $eventL3a, $eventL3b, $matcher) {
-                switch ($matcher->getInvocationCount()) {
+            ->willReturnCallback(function ($envelope, StackInterface $stack) use ($eventBus, $eventL2a, $eventL2b, $eventL3a, $eventL3b) {
+                static $call = 0;
+
+                switch (++$call) {
                     case 1:
                     case 2:
                     case 4:

--- a/src/Symfony/Component/Notifier/Tests/Transport/FailoverTransportTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Transport/FailoverTransportTest.php
@@ -122,11 +122,12 @@ class FailoverTransportTest extends TestCase
         $t2 = $this->createMock(TransportInterface::class);
         $t2->method('supports')->with($message)->willReturn(true);
 
-        $matcher = $this->exactly(3);
-        $t2->expects($matcher)
+        $t2->expects($this->exactly(3))
             ->method('send')
-            ->willReturnCallback(function () use ($matcher, $message) {
-                if (3 === $matcher->getInvocationCount()) {
+            ->willReturnCallback(function () use ($message) {
+                static $call = 0;
+
+                if (3 === ++$call) {
                     throw $this->createMock(TransportExceptionInterface::class);
                 }
 
@@ -151,10 +152,11 @@ class FailoverTransportTest extends TestCase
         $t1 = $this->createMock(TransportInterface::class);
         $t1->method('supports')->with($message)->willReturn(true);
 
-        $t1Matcher = $this->exactly(2);
-        $t1->expects($t1Matcher)->method('send')
-            ->willReturnCallback(function () use ($t1Matcher, $message) {
-                if (1 === $t1Matcher->getInvocationCount()) {
+        $t1->expects($this->exactly(2))->method('send')
+            ->willReturnCallback(function () use ($message) {
+                static $call = 0;
+
+                if (1 === ++$call) {
                     throw $this->createMock(TransportExceptionInterface::class);
                 }
 
@@ -163,9 +165,10 @@ class FailoverTransportTest extends TestCase
         $t2 = $this->createMock(TransportInterface::class);
         $t2->method('supports')->with($message)->willReturn(true);
 
-        $t2Matcher = $this->exactly(2);
-        $t2->expects($t2Matcher)->method('send')->willReturnCallback(function () use ($t2Matcher, $message) {
-            if (1 === $t2Matcher->getInvocationCount()) {
+        $t2->expects($this->exactly(2))->method('send')->willReturnCallback(function () use ($message) {
+            static $call = 0;
+
+            if (1 === ++$call) {
                 return new SentMessage($message, 't1');
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT
