### PR TITLE
relax mock class name matching

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Middleware/SendMessageMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/SendMessageMiddlewareTest.php
@@ -44,7 +44,7 @@ class SendMessageMiddlewareTest extends MiddlewareTestCase
         /* @var SentStamp $stamp */
         $this->assertInstanceOf(SentStamp::class, $stamp = $envelope->last(SentStamp::class), 'it adds a sent stamp');
         $this->assertSame('my_sender', $stamp->getSenderAlias());
-        $this->assertStringMatchesFormat('Mock_SenderInterface_%s', $stamp->getSenderClass());
+        $this->assertStringMatchesFormat($sender::class, $stamp->getSenderClass());
     }
 
     public function testItSendsTheMessageToMultipleSenders()

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCollectionTestCase.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCollectionTestCase.php
@@ -165,7 +165,7 @@ abstract class PropertyAccessorCollectionTestCase extends PropertyAccessorArrayA
             ->willReturn($axesBefore);
 
         $this->expectException(NoSuchPropertyException::class);
-        $this->expectExceptionMessageMatches('/Could not determine access type for property "axes" in class "Mock_PropertyAccessorCollectionTestCase_CarNoAdderAndRemover_[^"]*"./');
+        $this->expectExceptionMessageMatches(\sprintf('/Could not determine access type for property "axes" in class "%s"./', $car::class));
 
         $this->propertyAccessor->setValue($car, 'axes', $axesAfter);
     }

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/AuthenticatorManagerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/AuthenticatorManagerTest.php
@@ -368,7 +368,7 @@ class AuthenticatorManagerTest extends TestCase
         $manager = $this->createManager([$authenticator], 'main', true, [], $logger);
         $response = $manager->authenticateRequest($this->request);
         $this->assertSame($this->response, $response);
-        $this->assertStringContainsString('Mock_TestInteractiveAuthenticator', $logger->logContexts[0]['authenticator']);
+        $this->assertStringContainsString($authenticator::class, $logger->logContexts[0]['authenticator']);
     }
 
     private function createAuthenticator(?bool $supports = true)

--- a/src/Symfony/Component/Security/Http/Tests/Controller/UserValueResolverTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Controller/UserValueResolverTest.php
@@ -120,7 +120,7 @@ class UserValueResolverTest extends TestCase
         $metadata = new ArgumentMetadata('foo', InMemoryUser::class, false, false, null, false, [new CurrentUser()]);
 
         $this->expectException(AccessDeniedException::class);
-        $this->expectExceptionMessageMatches('/^The logged-in user is an instance of "Mock_UserInterface[^"]+" but a user of type "Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\InMemoryUser" is expected.$/');
+        $this->expectExceptionMessageMatches(\sprintf('/^The logged-in user is an instance of "%s" but a user of type "Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\InMemoryUser" is expected.$/', $user::class));
         $resolver->resolve(Request::create('/'), $metadata);
     }
 

--- a/src/Symfony/Component/VarDumper/Tests/Caster/DoctrineCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/DoctrineCasterTest.php
@@ -29,7 +29,9 @@ class DoctrineCasterTest extends TestCase
     {
         $classMetadata = new ClassMetadata(__CLASS__);
 
-        $collection = new PersistentCollection($this->createMock(EntityManagerInterface::class), $classMetadata, new ArrayCollection(['test']));
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManagerClass = $entityManager::class;
+        $collection = new PersistentCollection($entityManager, $classMetadata, new ArrayCollection(['test']));
 
         if (property_exists(PersistentCollection::class, 'isDirty')) {
             // Collections >= 2
@@ -38,7 +40,7 @@ class DoctrineCasterTest extends TestCase
                 %A
                   -backRefFieldName: null
                   -isDirty: false
-                  -em: Mock_EntityManagerInterface_%s { …3}
+                  -em: $entityManagerClass { …3}
                   -typeClass: Doctrine\ORM\Mapping\ClassMetadata { …}
                 %A
                 EODUMP;
@@ -47,7 +49,7 @@ class DoctrineCasterTest extends TestCase
             $expected = <<<EODUMP
                 Doctrine\ORM\PersistentCollection {
                 %A
-                  -em: Mock_EntityManagerInterface_%s { …3}
+                  -em: $entityManagerClass { …3}
                   -backRefFieldName: null
                   -typeClass: Doctrine\ORM\Mapping\ClassMetadata { …}
                 %A


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Instead of performing some fuzzy matching on the automatically generated mock name (the pattern varies between different PHPUnit versions) we can simply use the actual exact class name.