### PR TITLE
[Dotenv] Default value can be empty

### DIFF
--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -495,7 +495,7 @@ final class Dotenv
             (?!\()                             # no opening parenthesis
             (?P<opening_brace>\{)?             # optional brace
             (?P<name>'.self::VARNAME_REGEX.')? # var name
-            (?P<default_value>:[-=][^\}]++)?   # optional default value
+            (?P<default_value>:[-=][^\}]*+)?   # optional default value
             (?P<closing_brace>\})?             # optional closing brace
         /x';
 

--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -175,6 +175,14 @@ class DotenvTest extends TestCase
             ["FOO=BAR\nBAR=\${NOTDEFINED:=TEST}", ['FOO' => 'BAR', 'NOTDEFINED' => 'TEST', 'BAR' => 'TEST']],
             ["FOO=\nBAR=\${FOO:=TEST}", ['FOO' => 'TEST', 'BAR' => 'TEST']],
             ["FOO=\nBAR=\$FOO:=TEST}", ['FOO' => 'TEST', 'BAR' => 'TEST}']],
+            ["FOO=BAR\nBAR=\${FOO:-}", ['FOO' => 'BAR', 'BAR' => 'BAR']],
+            ["FOO=BAR\nBAR=\${NOTDEFINED:-}", ['FOO' => 'BAR', 'BAR' => '']],
+            ["FOO=\nBAR=\${FOO:-}", ['FOO' => '', 'BAR' => '']],
+            ["FOO=\nBAR=\$FOO:-}", ['FOO' => '', 'BAR' => '}']],
+            ["FOO=BAR\nBAR=\${FOO:=}", ['FOO' => 'BAR', 'BAR' => 'BAR']],
+            ["FOO=BAR\nBAR=\${NOTDEFINED:=}", ['FOO' => 'BAR', 'NOTDEFINED' => '', 'BAR' => '']],
+            ["FOO=\nBAR=\${FOO:=}", ['FOO' => '', 'BAR' => '']],
+            ["FOO=\nBAR=\$FOO:=}", ['FOO' => '', 'BAR' => '}']],
             ["FOO=foo\nFOOBAR=\${FOO}\${BAR}", ['FOO' => 'foo', 'FOOBAR' => 'foo']],
 
             // underscores


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

According to the [spec](https://pubs.opengroup.org/onlinepubs/9799919799/utilities/V3_chap02.html#tag_19_06_02) the default value for parameter expansion can be an empty string as well, eg:

```
MY_VAR=${OTHER_VAR:-}
```