### PR TITLE
[TwigBridge] Fixed a parameterized choice label translation

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/FormExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/FormExtension.php
@@ -19,6 +19,7 @@ use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\Form\FormView;
+use Symfony\Contracts\Translation\TranslatableInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
@@ -149,23 +150,26 @@ final class FormExtension extends AbstractExtension
     private function createFieldChoicesList(iterable $choices, string|false|null $translationDomain): iterable
     {
         foreach ($choices as $choice) {
-            $translatableLabel = $this->createFieldTranslation($choice->label, [], $translationDomain);
-
             if ($choice instanceof ChoiceGroupView) {
+                $translatableLabel = $this->createFieldTranslation($choice->label, [], $translationDomain);
                 yield $translatableLabel => $this->createFieldChoicesList($choice, $translationDomain);
 
                 continue;
             }
 
             /* @var ChoiceView $choice */
+            $translatableLabel = $this->createFieldTranslation($choice->label, $choice->labelTranslationParameters, $translationDomain);
             yield $translatableLabel => $choice->value;
         }
     }
 
-    private function createFieldTranslation(?string $value, array $parameters, string|false|null $domain): ?string
+    private function createFieldTranslation(TranslatableInterface|string|null $value, array $parameters, string|false|null $domain): ?string
     {
         if (!$this->translator || !$value || false === $domain) {
-            return $value;
+            return null !== $value ? (string) $value : null;
+        }
+        if ($value instanceof TranslatableInterface) {
+            return $value->trans($this->translator);
         }
 
         return $this->translator->trans($value, $parameters, $domain);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT

Currently, choice translation does not use the parameters assigned to them.

This pull request adds the use of parameters when translating choices.