### PR TITLE
[Translation] Allow sort when extracting translation files

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 7.2
 ---
 
+ * Add support for `--sort` option when extracting translations with `translation:extract` command and `--force` option
  * Add support for setting `headers` with `Symfony\Bundle\FrameworkBundle\Controller\TemplateController`
  * Add `--resolve-env-vars` option to `lint:container` command
  * Derivate `kernel.secret` from the decryption secret when its env var is not defined


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no
| Issues        | Fix #49250 #37918
| License       | MIT

This will keep current sorting when no `--sort` is specified.
- when dumping messages will sort `asc` by default
- when writing files will apply no sorting