### PR TITLE
[Translation] Fix extracting of message from ->trans() method with named params

### DIFF
--- a/src/Symfony/Component/Translation/Extractor/Visitor/TransMethodVisitor.php
+++ b/src/Symfony/Component/Translation/Extractor/Visitor/TransMethodVisitor.php
@@ -44,7 +44,7 @@ final class TransMethodVisitor extends AbstractVisitor implements NodeVisitor
         if ('trans' === $name || 't' === $name) {
             $firstNamedArgumentIndex = $this->nodeFirstNamedArgumentIndex($node);
 
-            if (!$messages = $this->getStringArguments($node, 0 < $firstNamedArgumentIndex ? 0 : 'message')) {
+            if (!$messages = $this->getStringArguments($node, 0 < $firstNamedArgumentIndex ? 0 : 'id')) {
                 return null;
             }
 

--- a/src/Symfony/Component/Translation/Tests/Fixtures/extractor-ast/translation.html.php
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/extractor-ast/translation.html.php
@@ -46,14 +46,14 @@ EOF
 
 <?php echo $view['translator']->trans('default domain', [], null); ?>
 
-<?php echo $view['translator']->trans(message: 'ordered-named-arguments-in-trans-method', parameters: [], domain: 'not_messages'); ?>
-<?php echo $view['translator']->trans(domain: 'not_messages', message: 'disordered-named-arguments-in-trans-method', parameters: []); ?>
+<?php echo $view['translator']->trans(id: 'ordered-named-arguments-in-trans-method', parameters: [], domain: 'not_messages'); ?>
+<?php echo $view['translator']->trans(domain: 'not_messages', id: 'disordered-named-arguments-in-trans-method', parameters: []); ?>
 
 <?php echo $view['translator']->trans($key = 'variable-assignation-inlined-in-trans-method-call1', $parameters = [], $domain = 'not_messages'); ?>
 <?php echo $view['translator']->trans('variable-assignation-inlined-in-trans-method-call2', $parameters = [], $domain = 'not_messages'); ?>
 <?php echo $view['translator']->trans('variable-assignation-inlined-in-trans-method-call3', [], $domain = 'not_messages'); ?>
 
-<?php echo $view['translator']->trans(domain: $domain = 'not_messages', message: $key = 'variable-assignation-inlined-with-named-arguments-in-trans-method', parameters: $parameters = []); ?>
+<?php echo $view['translator']->trans(domain: $domain = 'not_messages', id: $key = 'variable-assignation-inlined-with-named-arguments-in-trans-method', parameters: $parameters = []); ?>
 
 <?php echo $view['translator']->trans('mix-named-arguments', parameters: ['foo' => 'bar']); ?>
 <?php echo $view['translator']->trans('mix-named-arguments-locale', parameters: ['foo' => 'bar'], locale: 'de'); ?>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | No
| Deprecations? | No
| Issues        | Will be explained in this PR
| License       | MIT

Hi, this PR fixes a problem of an extracting translations from ```\Symfony\Contracts\Translation\TranslatorInterface::trans()``` method
As you can see the first argument is named as `id`, but not `message`, as expected in Visitor
