### PR TITLE
[TwigBridge] Remove `VersionAwareTest` from `AbstractLayoutTestCase`

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTestCase.php
@@ -2869,8 +2869,6 @@ abstract class AbstractBootstrap3LayoutTestCase extends AbstractLayoutTestCase
 
     public function testWeekSingleText()
     {
-        $this->requiresFeatureSet(404);
-
         $form = $this->factory->createNamed('holidays', 'Symfony\Component\Form\Extension\Core\Type\WeekType', '1970-W01', [
             'input' => 'string',
             'widget' => 'single_text',
@@ -2889,8 +2887,6 @@ abstract class AbstractBootstrap3LayoutTestCase extends AbstractLayoutTestCase
 
     public function testWeekSingleTextNoHtml5()
     {
-        $this->requiresFeatureSet(404);
-
         $form = $this->factory->createNamed('holidays', 'Symfony\Component\Form\Extension\Core\Type\WeekType', '1970-W01', [
             'input' => 'string',
             'widget' => 'single_text',
@@ -2910,8 +2906,6 @@ abstract class AbstractBootstrap3LayoutTestCase extends AbstractLayoutTestCase
 
     public function testWeekChoices()
     {
-        $this->requiresFeatureSet(404);
-
         $data = ['year' => (int) date('Y'), 'week' => 1];
 
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\WeekType', $data, [
@@ -2938,8 +2932,6 @@ abstract class AbstractBootstrap3LayoutTestCase extends AbstractLayoutTestCase
 
     public function testWeekText()
     {
-        $this->requiresFeatureSet(404);
-
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\WeekType', '2000-W01', [
             'input' => 'string',
             'widget' => 'text',

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap5LayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap5LayoutTestCase.php
@@ -1842,8 +1842,6 @@ abstract class AbstractBootstrap5LayoutTestCase extends AbstractBootstrap4Layout
 
     public function testWeekChoices()
     {
-        $this->requiresFeatureSet(404);
-
         $data = ['year' => (int) date('Y'), 'week' => 1];
 
         $form = $this->factory->createNamed('name', WeekType::class, $data, [

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractLayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractLayoutTestCase.php
@@ -18,7 +18,6 @@ use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Csrf\CsrfExtension;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormView;
-use Symfony\Component\Form\Tests\VersionAwareTest;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\Translation\TranslatableMessage;
 use Symfony\Contracts\Translation\TranslatableInterface;
@@ -26,8 +25,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 abstract class AbstractLayoutTestCase extends FormLayoutTestCase
 {
-    use VersionAwareTest;
-
     protected MockObject&CsrfTokenManagerInterface $csrfTokenManager;
     protected array $testableFeatures = [];
 
@@ -672,8 +669,6 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
 
     public function testSingleChoiceWithPreferred()
     {
-        $this->requiresFeatureSet(404);
-
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', [
             'choices' => ['Choice&A' => '&a', 'Choice&B' => '&b'],
             'preferred_choices' => ['&b'],
@@ -698,8 +693,6 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
 
     public function testSingleChoiceWithPreferredAndNoSeparator()
     {
-        $this->requiresFeatureSet(404);
-
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', [
             'choices' => ['Choice&A' => '&a', 'Choice&B' => '&b'],
             'preferred_choices' => ['&b'],
@@ -723,8 +716,6 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
 
     public function testSingleChoiceWithPreferredAndBlankSeparator()
     {
-        $this->requiresFeatureSet(404);
-
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', [
             'choices' => ['Choice&A' => '&a', 'Choice&B' => '&b'],
             'preferred_choices' => ['&b'],
@@ -749,8 +740,6 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
 
     public function testChoiceWithOnlyPreferred()
     {
-        $this->requiresFeatureSet(404);
-
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', [
             'choices' => ['Choice&A' => '&a', 'Choice&B' => '&b'],
             'preferred_choices' => ['&a', '&b'],
@@ -1814,8 +1803,6 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
 
     public function testRenderNumberWithHtml5NumberType()
     {
-        $this->requiresFeatureSet(403);
-
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\NumberType', 1234.56, [
             'html5' => true,
         ]);
@@ -1832,8 +1819,6 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
 
     public function testRenderNumberWithHtml5NumberTypeAndStepAttribute()
     {
-        $this->requiresFeatureSet(403);
-
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\NumberType', 1234.56, [
             'html5' => true,
             'attr' => ['step' => '0.1'],
@@ -1908,8 +1893,6 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
 
     public function testPercentNoSymbol()
     {
-        $this->requiresFeatureSet(403);
-
         $form = $this->factory->createNamed('name', PercentType::class, 0.1, ['symbol' => false, 'rounding_mode' => \NumberFormatter::ROUND_CEILING]);
         $this->assertWidgetMatchesXpath($form->createView(), [],
             '/input
@@ -1923,8 +1906,6 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
 
     public function testPercentCustomSymbol()
     {
-        $this->requiresFeatureSet(403);
-
         $form = $this->factory->createNamed('name', PercentType::class, 0.1, ['symbol' => '‱', 'rounding_mode' => \NumberFormatter::ROUND_CEILING]);
         $this->assertWidgetMatchesXpath($form->createView(), [],
             '/input
@@ -2602,8 +2583,6 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
 
     public function testLabelWithTranslationParameters()
     {
-        $this->requiresFeatureSet(403);
-
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
         $html = $this->renderLabel($form->createView(), 'Address is %address%', [
             'label_translation_parameters' => [
@@ -2621,8 +2600,6 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
 
     public function testHelpWithTranslationParameters()
     {
-        $this->requiresFeatureSet(403);
-
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
             'help' => 'for company %company%',
             'help_translation_parameters' => [
@@ -2693,8 +2670,6 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
 
     public function testAttributesWithTranslationParameters()
     {
-        $this->requiresFeatureSet(403);
-
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
             'attr' => [
                 'title' => 'Message to %company%',
@@ -2716,8 +2691,6 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
 
     public function testButtonWithTranslationParameters()
     {
-        $this->requiresFeatureSet(403);
-
         $form = $this->factory->createNamedBuilder('myform')
             ->add('mybutton', 'Symfony\Component\Form\Extension\Core\Type\ButtonType', [
                 'label' => 'Submit to %company%',
@@ -2741,8 +2714,6 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
      */
     public function testSubmitFormNoValidate(bool $validate)
     {
-        $this->requiresFeatureSet(404);
-
         $form = $this->factory->create(SubmitType::class, null, [
             'validate' => $validate,
         ]);
@@ -2772,8 +2743,6 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
 
     public function testWeekSingleText()
     {
-        $this->requiresFeatureSet(404);
-
         $form = $this->factory->createNamed('holidays', 'Symfony\Component\Form\Extension\Core\Type\WeekType', '1970-W01', [
             'input' => 'string',
             'widget' => 'single_text',
@@ -2791,8 +2760,6 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
 
     public function testWeekSingleTextNoHtml5()
     {
-        $this->requiresFeatureSet(404);
-
         $form = $this->factory->createNamed('holidays', 'Symfony\Component\Form\Extension\Core\Type\WeekType', '1970-W01', [
             'input' => 'string',
             'widget' => 'single_text',
@@ -2811,8 +2778,6 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
 
     public function testWeekChoices()
     {
-        $this->requiresFeatureSet(404);
-
         $data = ['year' => (int) date('Y'), 'week' => 1];
 
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\WeekType', $data, [
@@ -2837,8 +2802,6 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
 
     public function testWeekText()
     {
-        $this->requiresFeatureSet(404);
-
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\WeekType', '2000-W01', [
             'input' => 'string',
             'widget' => 'text',

--- a/src/Symfony/Component/Form/Test/FormPerformanceTestCase.php
+++ b/src/Symfony/Component/Form/Test/FormPerformanceTestCase.php
@@ -25,7 +25,6 @@ use Symfony\Component\Form\Tests\VersionAwareTest;
 abstract class FormPerformanceTestCase extends FormIntegrationTestCase
 {
     use RunTestTrait;
-    use VersionAwareTest;
 
     /**
      * @var int

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTestCase.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTestCase.php
@@ -19,8 +19,6 @@ use Symfony\Component\Form\Tests\VersionAwareTest;
  */
 abstract class BaseTypeTestCase extends TypeTestCase
 {
-    use VersionAwareTest;
-
     public const TESTED_TYPE = '';
 
     public function testPassDisabledAsOption()
@@ -114,8 +112,6 @@ abstract class BaseTypeTestCase extends TypeTestCase
 
     public function testPassLabelTranslationParametersToView()
     {
-        $this->requiresFeatureSet(403);
-
         $view = $this->factory->create($this->getTestedType(), null, array_merge($this->getTestOptions(), [
             'label_translation_parameters' => ['%param%' => 'value'],
         ]))
@@ -126,8 +122,6 @@ abstract class BaseTypeTestCase extends TypeTestCase
 
     public function testPassAttrTranslationParametersToView()
     {
-        $this->requiresFeatureSet(403);
-
         $view = $this->factory->create($this->getTestedType(), null, array_merge($this->getTestOptions(), [
             'attr_translation_parameters' => ['%param%' => 'value'],
         ]))
@@ -138,8 +132,6 @@ abstract class BaseTypeTestCase extends TypeTestCase
 
     public function testInheritLabelTranslationParametersFromParent()
     {
-        $this->requiresFeatureSet(403);
-
         $view = $this->factory
             ->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE, null, [
                 'label_translation_parameters' => ['%param%' => 'value'],
@@ -153,8 +145,6 @@ abstract class BaseTypeTestCase extends TypeTestCase
 
     public function testInheritAttrTranslationParametersFromParent()
     {
-        $this->requiresFeatureSet(403);
-
         $view = $this->factory
             ->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE, null, [
                 'attr_translation_parameters' => ['%param%' => 'value'],
@@ -168,8 +158,6 @@ abstract class BaseTypeTestCase extends TypeTestCase
 
     public function testPreferOwnLabelTranslationParameters()
     {
-        $this->requiresFeatureSet(403);
-
         $view = $this->factory
             ->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE, null, [
                 'label_translation_parameters' => ['%parent_param%' => 'parent_value', '%override_param%' => 'parent_override_value'],
@@ -185,8 +173,6 @@ abstract class BaseTypeTestCase extends TypeTestCase
 
     public function testPreferOwnAttrTranslationParameters()
     {
-        $this->requiresFeatureSet(403);
-
         $view = $this->factory
             ->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE, null, [
                 'attr_translation_parameters' => ['%parent_param%' => 'parent_value', '%override_param%' => 'parent_override_value'],
@@ -202,8 +188,6 @@ abstract class BaseTypeTestCase extends TypeTestCase
 
     public function testDefaultLabelTranslationParameters()
     {
-        $this->requiresFeatureSet(403);
-
         $view = $this->factory->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE)
             ->add('child', $this->getTestedType(), $this->getTestOptions())
             ->getForm()
@@ -214,8 +198,6 @@ abstract class BaseTypeTestCase extends TypeTestCase
 
     public function testDefaultAttrTranslationParameters()
     {
-        $this->requiresFeatureSet(403);
-
         $view = $this->factory->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE)
             ->add('child', $this->getTestedType(), $this->getTestOptions())
             ->getForm()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

I propose to backport what was done in #57839 (cc @derrabus) because the test suite currently fails on 6.4 high deps: https://github.com/symfony/symfony/actions/runs/11082470673/job/30795519671#step:8:9163
