### PR TITLE
[Finder] do not use `assertCount()` with generators

### DIFF
--- a/src/Symfony/Component/Finder/Tests/Iterator/LazyIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/LazyIteratorTest.php
@@ -31,7 +31,7 @@ class LazyIteratorTest extends TestCase
             return new Iterator(['foo', 'bar']);
         });
 
-        $this->assertCount(2, $iterator);
+        $this->assertCount(2, iterator_to_array($iterator));
     }
 
     public function testInnerDestructedAtTheEnd()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Generators are no longer supported in PHPUnit 10+.