### PR TITLE
[Cache][Routing] do not use `TestCase::getName()` when possible

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/ApcuAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ApcuAdapterTest.php
@@ -30,7 +30,7 @@ class ApcuAdapterTest extends AdapterTestCase
             $this->markTestSkipped('APCu extension is required.');
         }
         if ('cli' === \PHP_SAPI && !filter_var(\ini_get('apc.enable_cli'), \FILTER_VALIDATE_BOOLEAN)) {
-            if ('testWithCliSapi' !== $this->getName()) {
+            if ('testWithCliSapi' !== (method_exists($this, 'name') ? $this->name() : $this->getName())) {
                 $this->markTestSkipped('apc.enable_cli=1 is required.');
             }
         }

--- a/src/Symfony/Component/Routing/Tests/Generator/Dumper/CompiledUrlGeneratorDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/Dumper/CompiledUrlGeneratorDumperTest.php
@@ -52,8 +52,8 @@ class CompiledUrlGeneratorDumperTest extends TestCase
 
         $this->routeCollection = new RouteCollection();
         $this->generatorDumper = new CompiledUrlGeneratorDumper($this->routeCollection);
-        $this->testTmpFilepath = sys_get_temp_dir().'/php_generator.'.$this->getName().'.php';
-        $this->largeTestTmpFilepath = sys_get_temp_dir().'/php_generator.'.$this->getName().'.large.php';
+        $this->testTmpFilepath = sys_get_temp_dir().'/php_generator.php';
+        $this->largeTestTmpFilepath = sys_get_temp_dir().'/php_generator.large.php';
         @unlink($this->testTmpFilepath);
         @unlink($this->largeTestTmpFilepath);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

The method has been removed in PHPUnit 10.
