### PR TITLE
[FrameworkBundle] rewrite `WebTestCaseTest` to not rely on PHPUnit implementation details

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Test/Fixtures/Kernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Test/Fixtures/Kernel.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Test\Fixtures;
+
+use Psr\Log\NullLogger;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\HttpKernel\Kernel as BaseKernel;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+class Kernel extends BaseKernel
+{
+    use MicroKernelTrait;
+
+    public function registerBundles(): iterable
+    {
+        return [
+            new FrameworkBundle(),
+        ];
+    }
+
+    private function configureContainer(ContainerConfigurator $container, LoaderInterface $loader, ContainerBuilder $builder): void
+    {
+        $container->extension('framework', [
+            'router' => [
+                'utf8' => true,
+            ],
+            'test' => true,
+        ]);
+        $container->services()->set('logger', NullLogger::class);
+    }
+
+    private function configureRoutes(RoutingConfigurator $routes): void
+    {
+        $routes->add('ok', '/200')->controller([WebTestCaseController::class, 'ok']);
+        $routes->add('not_found', '/404')->controller([WebTestCaseController::class, 'notFound']);
+        $routes->add('moved_permanently', '/301')->controller([WebTestCaseController::class, 'movedPermanently']);
+        $routes->add('found', '/302')->controller([WebTestCaseController::class, 'found']);
+        $routes->add('internal_server_error', '/500')->controller([WebTestCaseController::class, 'internalServerError']);
+        $routes->add('custom_format', '/custom-format')->controller([WebTestCaseController::class, 'customFormat']);
+        $routes->add('jsonld_format', '/jsonld-format')->controller([WebTestCaseController::class, 'jsonldFormat']);
+        $routes->add('no_format', '/no-format')->controller([WebTestCaseController::class, 'noFormat']);
+        $routes->add('crawler', '/crawler/{content}')->controller([WebTestCaseController::class, 'crawler']);
+        $routes->add('request_attribute', '/request-attribute')->controller([WebTestCaseController::class, 'requestAttribute']);
+        $routes->add('homepage', '/homepage/{foo}')->controller([WebTestCaseController::class, 'homepage']);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Test/Fixtures/WebTestCaseController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Test/Fixtures/WebTestCaseController.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Test\Fixtures;
+
+use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class WebTestCaseController
+{
+    public function ok(): Response
+    {
+        $response = new Response('', 200, [
+            'Cache-Control' => 'no-cache, private',
+        ]);
+        $response->setDate(new \DateTimeImmutable());
+        $response->headers->setCookie(new Cookie('foo', 'bar'));
+
+        return $response;
+    }
+
+    public function customFormat(): Response
+    {
+        return new Response('', 200, [
+            'Content-Type' => 'application/vnd.myformat',
+        ]);
+    }
+
+    public function jsonldFormat(): Response
+    {
+        return new Response('', 200, [
+            'Content-Type' => 'application/ld+json',
+        ]);
+    }
+
+    public function noFormat(): Response
+    {
+        return new Response('', 200, [
+            'Content-Type' => '',
+        ]);
+    }
+
+    public function notFound(): Response
+    {
+        return new Response('', 404);
+    }
+
+    public function movedPermanently(): Response
+    {
+        return new RedirectResponse('https://example.com/', 301);
+    }
+
+    public function found(): Response
+    {
+        return new RedirectResponse('https://example.com/', 302);
+    }
+
+    public function internalServerError(): Response
+    {
+        return new Response('', 500, [
+            'X-Debug-Exception' => 'An exception has occurred',
+            'X-Debug-Exception-File' => '%2Fsrv%2Ftest.php:12',
+        ]);
+    }
+
+    public function crawler(string $content): Response
+    {
+        return new Response(urldecode($content));
+    }
+
+    public function requestAttribute(Request $request): Response
+    {
+        $request->attributes->set('foo', 'bar');
+
+        return new Response();
+    }
+
+    public function homepage(): Response
+    {
+        return new Response();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT
