### PR TITLE
[FrameworkBundle] Never hash the empty decryption key to compute `kernel.secret`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Secrets/SodiumVault.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Secrets/SodiumVault.php
@@ -114,7 +114,7 @@ class SodiumVault extends AbstractVault implements EnvVarLoaderInterface
 
         $this->loadKeys();
 
-        if ('' === $this->decryptionKey) {
+        if ('' === $this->decryptionKey = (string) $this->decryptionKey) {
             $this->lastMessage = \sprintf('Secret "%s" cannot be revealed as no decryption key was found in "%s".', $name, $this->getPrettyPath(\dirname($this->pathPrefix).\DIRECTORY_SEPARATOR));
 
             return null;
@@ -181,8 +181,8 @@ class SodiumVault extends AbstractVault implements EnvVarLoaderInterface
         }
 
         if ($this->derivedSecretEnvVar && !\array_key_exists($this->derivedSecretEnvVar, $envs)) {
-            $decryptionKey = $this->decryptionKey;
-            $envs[$this->derivedSecretEnvVar] = LazyString::fromCallable(static fn () => base64_encode(hash('sha256', $decryptionKey, true)));
+            $k = $this->decryptionKey;
+            $envs[$this->derivedSecretEnvVar] = LazyString::fromCallable(static fn () => '' !== ($k = (string) $k) ? base64_encode(hash('sha256', $k, true)) : '');
         }
 
         return $envs;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Secrets/SodiumVaultTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Secrets/SodiumVaultTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Secrets;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\Secrets\SodiumVault;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\String\LazyString;
 
 /**
  * @requires extension sodium
@@ -83,5 +84,18 @@ class SodiumVaultTest extends TestCase
         $vault->seal('FOO', 'bar');
 
         $this->assertSame(['FOO', 'MY_SECRET'], array_keys($vault->loadEnvVars()));
+    }
+
+    public function testEmptySecretEnvVar()
+    {
+        $vault = new SodiumVault($this->secretsDir, '', 'MY_SECRET');
+        $envVars = $vault->loadEnvVars();
+        $envVars['MY_SECRET'] = (string) $envVars['MY_SECRET'];
+        $this->assertSame(['MY_SECRET' => ''], $envVars);
+
+        $vault = new SodiumVault($this->secretsDir, LazyString::fromCallable(fn () => ''), 'MY_SECRET');
+        $envVars = $vault->loadEnvVars();
+        $envVars['MY_SECRET'] = (string) $envVars['MY_SECRET'];
+        $this->assertSame(['MY_SECRET' => ''], $envVars);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

As spotted by @javiereguiluz in https://github.com/symfony/demo/pull/1529#issuecomment-2383116682