### PR TITLE
[Security] Fix serialized object representation in tests

### DIFF
--- a/src/Symfony/Component/Security/Core/Tests/Role/LegacyRoleTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Role/LegacyRoleTest.php
@@ -18,7 +18,7 @@ class LegacyRoleTest extends TestCase
 {
     public function testPayloadFromV4CanBeUnserialized()
     {
-        $serialized = 'C:74:"Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken":236:{a:3:{i:0;N;i:1;s:4:"main";i:2;a:5:{i:0;s:2:"sf";i:1;b:1;i:2;a:1:{i:0;O:41:"Symfony\Component\Security\Core\Role\Role":1:{s:47:"Symfony\Component\Security\Core\Role\Role'."\0".'role'."\0".'";s:9:"ROLE_USER";}}i:3;a:0:{}i:4;a:1:{i:0;s:9:"ROLE_USER";}}}}';
+        $serialized = 'C:74:"Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken":236:{a:3:{i:0;N;i:1;s:4:"main";i:2;a:5:{i:0;s:2:"sf";i:1;b:1;i:2;a:1:{i:0;O:41:"Symfony\Component\Security\Core\Role\Role":1:{s:47:"'."\0".'Symfony\Component\Security\Core\Role\Role'."\0".'role";s:9:"ROLE_USER";}}i:3;a:0:{}i:4;a:1:{i:0;s:9:"ROLE_USER";}}}}';
 
         $token = unserialize($serialized);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`LegacyRoleTest` triggers the following error:

```
Legacy deprecation triggered by Symfony\Component\Security\Core\Tests\Role\LegacyRoleTest::testPayloadFromV4CanBeUnserialized:
Creation of dynamic property Symfony\Component\Security\Core\Role\Role::$Symfony\Component\Security\Core\Role\Role is deprecated
```