### PR TITLE
[Console] Fix failing test when TTY is not supported

### DIFF
--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -2035,6 +2035,10 @@ class ApplicationTest extends TestCase
      */
     public function testSignalableRestoresStty()
     {
+        if (!Process::isTtySupported()) {
+            $this->markTestSkipped('tty is not supported');
+        }
+
         if (!Terminal::hasSttyAvailable()) {
             $this->markTestSkipped('stty not available');
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

On macOS, when running the test suite in parallel with `./phpunit src/Symfony/Component/`, I encounter every time the following error:

<img width="751" alt="Capture d’écran 2024-09-30 à 21 48 39" src="https://github.com/user-attachments/assets/7b69e83f-c2ed-4f2f-9d6e-608b34d85c85">

I propose to add a check at the beginning of the test to check for TTY support to avoid a false-negative, as it's done for STTY support.