### PR TITLE
[Notifier][GatewayAPI] Add support for label parameter

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/GatewayApi/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/GatewayApi/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+ * Add label option to `GatewayApiOptions` class
+
 6.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/GatewayApi/GatewayApiOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/GatewayApi/GatewayApiOptions.php
@@ -58,6 +58,16 @@ final class GatewayApiOptions implements MessageOptionsInterface
         return $this;
     }
 
+    /**
+     * @return $this
+     */
+    public function label(string $label): static
+    {
+        $this->options['label'] = $label;
+
+        return $this;
+    }
+
     public function toArray(): array
     {
         return $this->options;

--- a/src/Symfony/Component/Notifier/Bridge/GatewayApi/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/GatewayApi/README.md
@@ -32,6 +32,7 @@ $options = (new GatewayApiOptions())
     ->class('standard')
     ->callbackUrl('https://my-callback-url')
     ->userRef('user_ref')
+    ->label('label')
     // ...
     ;
 

--- a/src/Symfony/Component/Notifier/Bridge/GatewayApi/Tests/GatewayApiOptionsTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/GatewayApi/Tests/GatewayApiOptionsTest.php
@@ -21,12 +21,14 @@ class GatewayApiOptionsTest extends TestCase
         $gatewayApiOptions = (new GatewayApiOptions())
             ->class('test_class')
             ->callbackUrl('test_callback_url')
-            ->userRef('test_user_ref');
+            ->userRef('test_user_ref')
+            ->label('test_label');
 
         self::assertSame([
             'class' => 'test_class',
             'callback_url' => 'test_callback_url',
             'userref' => 'test_user_ref',
+            'label' => 'test_label',
         ], $gatewayApiOptions->toArray());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT

Add `label` parameter for GatewayAPI.

From the documentation:
```
label (string) - A label added to each sent message, which can be used to uniquely identify a customer or company that you have sent the message on behalf of. Can e.g. be used when invoicing your customers. If specified it must be the same for all messages in the request.
```