### PR TITLE
[Config] Add `StringNode`

### DIFF
--- a/src/Symfony/Component/Config/CHANGELOG.md
+++ b/src/Symfony/Component/Config/CHANGELOG.md
@@ -8,6 +8,9 @@ CHANGELOG
  * Generate a meta file in JSON format for resource tracking
  * Add `SkippingResourceChecker`
  * Add support for `defaultNull()` on `BooleanNode`
+ * Add `StringNode` and `StringNodeDefinition`
+ * Add `ArrayNodeDefinition::stringPrototype()` method
+ * Add `NodeBuilder::stringNode()` method
 
 7.1
 ---

--- a/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
@@ -73,6 +73,11 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
         return $this->prototype('scalar');
     }
 
+    public function stringPrototype(): StringNodeDefinition
+    {
+        return $this->prototype('string');
+    }
+
     public function booleanPrototype(): BooleanNodeDefinition
     {
         return $this->prototype('boolean');

--- a/src/Symfony/Component/Config/Definition/Builder/NodeBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NodeBuilder.php
@@ -31,6 +31,7 @@ class NodeBuilder implements NodeParentInterface
             'float' => FloatNodeDefinition::class,
             'array' => ArrayNodeDefinition::class,
             'enum' => EnumNodeDefinition::class,
+            'string' => StringNodeDefinition::class,
         ];
     }
 
@@ -100,6 +101,14 @@ class NodeBuilder implements NodeParentInterface
     public function variableNode(string $name): VariableNodeDefinition
     {
         return $this->node($name, 'variable');
+    }
+
+    /**
+     * Creates a child string node.
+     */
+    public function stringNode(string $name): StringNodeDefinition
+    {
+        return $this->node($name, 'string');
     }
 
     /**

--- a/src/Symfony/Component/Config/Definition/Builder/StringNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/StringNodeDefinition.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Definition\Builder;
+
+use Symfony\Component\Config\Definition\StringNode;
+
+/**
+ * This class provides a fluent interface for defining a node.
+ *
+ * @author Raffaele Carelle <raffaele.carelle@gmail.com>
+ */
+class StringNodeDefinition extends ScalarNodeDefinition
+{
+    public function __construct(?string $name, ?NodeParentInterface $parent = null)
+    {
+        parent::__construct($name, $parent);
+
+        $this->nullEquivalent = '';
+    }
+
+    protected function instantiateNode(): StringNode
+    {
+        return new StringNode($this->name, $this->parent, $this->pathSeparator);
+    }
+}

--- a/src/Symfony/Component/Config/Definition/StringNode.php
+++ b/src/Symfony/Component/Config/Definition/StringNode.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Definition;
+
+use Symfony\Component\Config\Definition\Exception\InvalidTypeException;
+
+/**
+ * This node represents a String value in the config tree.
+ *
+ * @author Raffaele Carelle <raffaele.carelle@gmail.com>
+ */
+class StringNode extends ScalarNode
+{
+    protected function validateType(mixed $value): void
+    {
+        if (!\is_string($value)) {
+            $ex = new InvalidTypeException(\sprintf('Invalid type for path "%s". Expected "string", but got "%s".', $this->getPath(), get_debug_type($value)));
+            if ($hint = $this->getInfo()) {
+                $ex->addHint($hint);
+            }
+            $ex->setPath($this->getPath());
+
+            throw $ex;
+        }
+    }
+
+    protected function getValidPlaceholderTypes(): array
+    {
+        return ['string'];
+    }
+}

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/ArrayNodeDefinitionTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/ArrayNodeDefinitionTest.php
@@ -267,6 +267,12 @@ class ArrayNodeDefinitionTest extends TestCase
         $this->assertEquals($node->prototype('boolean'), $node->booleanPrototype());
     }
 
+    public function testPrototypeString()
+    {
+        $node = new ArrayNodeDefinition('root');
+        $this->assertEquals($node->prototype('string'), $node->stringPrototype());
+    }
+
     public function testPrototypeInteger()
     {
         $node = new ArrayNodeDefinition('root');

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/NodeBuilderTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/NodeBuilderTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Builder\FloatNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\IntegerNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder as BaseNodeBuilder;
+use Symfony\Component\Config\Definition\Builder\StringNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\VariableNodeDefinition as BaseVariableNodeDefinition;
 
 class NodeBuilderTest extends TestCase
@@ -85,6 +86,14 @@ class NodeBuilderTest extends TestCase
 
         $node = $builder->floatNode('bar')->min(3.0)->max(5.0);
         $this->assertInstanceOf(FloatNodeDefinition::class, $node);
+    }
+
+    public function testStringNodeCreation()
+    {
+        $builder = new BaseNodeBuilder();
+
+        $node = $builder->stringNode('foo bar');
+        $this->assertInstanceOf(StringNodeDefinition::class, $node);
     }
 }
 

--- a/src/Symfony/Component/Config/Tests/Definition/StringNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/StringNodeTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Tests\Definition;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Exception\InvalidTypeException;
+use Symfony\Component\Config\Definition\StringNode;
+
+class StringNodeTest extends TestCase
+{
+    /**
+     * @testWith [""]
+     *           ["valid string"]
+     */
+    public function testNormalize(string $value)
+    {
+        $node = new StringNode('test');
+        $this->assertSame($value, $node->normalize($value));
+    }
+
+    /**
+     * @testWith [null]
+     *           [false]
+     *           [true]
+     *           [0]
+     *           [1]
+     *           [0.0]
+     *           [0.1]
+     *           [{}]
+     *           [{"foo": "bar"}]
+     */
+    public function testNormalizeThrowsExceptionOnInvalidValues($value)
+    {
+        $node = new StringNode('test');
+
+        $this->expectException(InvalidTypeException::class);
+
+        $node->normalize($value);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #57660
| License       | MIT

Introduce the `StringNode` class to handle string values within the configuration tree. Added validation for incorrect types and complemented it with unit tests to verify both valid and invalid scenarios.

Introduce the `StringNode` class to handle string values within the configuration tree.