### PR TITLE
Make `@var` occurrences consistent

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/TestBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/TestBundle.php
@@ -24,7 +24,7 @@ class TestBundle extends Bundle
     {
         parent::build($container);
 
-        /** @var $extension DependencyInjection\TestExtension */
+        /** @var DependencyInjection\TestExtension $extension */
         $extension = $container->getExtension('test');
 
         if (!$container->getParameterBag() instanceof FrozenParameterBag) {

--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
@@ -40,7 +40,7 @@ class ValidatorExtension extends AbstractExtension
         // the DIC, where the XML file is loaded automatically. Thus the following
         // code must be kept synchronized with validation.xml
 
-        /* @var $metadata ClassMetadata */
+        /* @var ClassMetadata $metadata */
         $metadata->addConstraint(new Form());
         $metadata->addConstraint(new Traverse(false));
     }

--- a/src/Symfony/Component/Form/FormBuilder.php
+++ b/src/Symfony/Component/Form/FormBuilder.php
@@ -142,7 +142,7 @@ class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormB
 
     public function getFormConfig(): FormConfigInterface
     {
-        /** @var $config self */
+        /** @var self $config */
         $config = parent::getFormConfig();
 
         $config->children = [];

--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -80,7 +80,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
 
     public function getShortDescription(string $class, string $property, array $context = []): ?string
     {
-        /** @var $docBlock DocBlock */
+        /** @var DocBlock $docBlock */
         [$docBlock] = $this->findDocBlock($class, $property);
         if (!$docBlock) {
             return null;
@@ -107,7 +107,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
 
     public function getLongDescription(string $class, string $property, array $context = []): ?string
     {
-        /** @var $docBlock DocBlock */
+        /** @var DocBlock $docBlock */
         [$docBlock] = $this->findDocBlock($class, $property);
         if (!$docBlock) {
             return null;
@@ -120,7 +120,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
 
     public function getTypes(string $class, string $property, array $context = []): ?array
     {
-        /** @var $docBlock DocBlock */
+        /** @var DocBlock $docBlock */
         [$docBlock, $source, $prefix] = $this->findDocBlock($class, $property);
         if (!$docBlock) {
             return null;
@@ -199,7 +199,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
      */
     public function getType(string $class, string $property, array $context = []): ?Type
     {
-        /** @var $docBlock DocBlock */
+        /** @var DocBlock $docBlock */
         [$docBlock, $source, $prefix] = $this->findDocBlock($class, $property);
         if (!$docBlock) {
             return null;

--- a/src/Symfony/Component/Routing/Tests/Fixtures/validresource.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/validresource.php
@@ -1,6 +1,6 @@
 <?php
 
-/** @var $loader \Symfony\Component\Routing\Loader\PhpFileLoader */
+/** @var \Symfony\Component\Routing\Loader\PhpFileLoader $loader */
 /** @var \Symfony\Component\Routing\RouteCollection $collection */
 $collection = $loader->import('validpattern.php');
 $collection->addDefaults([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Both notation are indeed valid but given the number of occurrences, I suggest making the few "inverted" ones consistent with the rest of the whole codebase.