### PR TITLE
[Messenger] Avoid skipping batch handlers on flush

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/WorkerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/WorkerTest.php
@@ -44,6 +44,7 @@ use Symfony\Component\Messenger\Stamp\ReceivedStamp;
 use Symfony\Component\Messenger\Stamp\SentStamp;
 use Symfony\Component\Messenger\Stamp\StampInterface;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessageInterface;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyReceiver;
 use Symfony\Component\Messenger\Tests\Fixtures\ResettableDummyReceiver;
 use Symfony\Component\Messenger\Transport\Receiver\QueueReceiverInterface;
@@ -574,6 +575,52 @@ class WorkerTest extends TestCase
         $this->assertSame($expectedMessages, $handler->processedMessages);
     }
 
+    public function testFlushMultipleBatchOnStop()
+    {
+        $expectedMessages = [
+            new DummyMessage('Hey'),
+        ];
+
+        $secondHandlerExpectedMessages = [
+            new SecondHandlerDummyMessage('Ho'),
+        ];
+
+        $receiver = new DummyReceiver([
+            [new Envelope($expectedMessages[0])],
+        ]);
+
+        $secondHandlerReceiver = new DummyReceiver([
+            [new Envelope($secondHandlerExpectedMessages[0])],
+        ]);
+
+        $handler = new DummyBatchHandler();
+        $secondHandler = new SecondDummyBatchHandler();
+
+        $middleware = new HandleMessageMiddleware(new HandlersLocator([
+            DummyMessage::class => [new HandlerDescriptor($handler)],
+            SecondHandlerDummyMessage::class => [new HandlerDescriptor($secondHandler)],
+        ]));
+
+        $bus = new MessageBus([$middleware]);
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(WorkerRunningEvent::class, function (WorkerRunningEvent $event) use ($receiver, $secondHandlerReceiver) {
+            static $i = 0;
+            if (1 < ++$i) {
+                $event->getWorker()->stop();
+            }
+
+            $this->assertSame(0, $receiver->getAcknowledgeCount());
+            $this->assertSame(0, $secondHandlerReceiver->getAcknowledgeCount());
+        });
+
+        $worker = new Worker(['first' => $receiver, 'second' => $secondHandlerReceiver], $bus, $dispatcher, clock: new MockClock());
+        $worker->run();
+
+        $this->assertSame($expectedMessages, $handler->processedMessages);
+        $this->assertSame($secondHandlerExpectedMessages, $secondHandler->processedMessages);
+    }
+
     public function testFlushRemovesNoAutoAckStampOnException()
     {
         $envelope = new Envelope(new DummyMessage('Test'));
@@ -649,5 +696,46 @@ class DummyBatchHandler implements BatchHandlerInterface
         foreach ($jobs as [$job, $ack]) {
             $ack->ack($job);
         }
+    }
+}
+
+class SecondDummyBatchHandler implements BatchHandlerInterface
+{
+    use BatchHandlerTrait;
+
+    public array $processedMessages;
+
+    public function __invoke(SecondHandlerDummyMessage $message, ?Acknowledger $ack = null)
+    {
+        return $this->handle($message, $ack);
+    }
+
+    private function shouldFlush(): bool
+    {
+        return 5 <= \count($this->jobs);
+    }
+
+    private function process(array $jobs): void
+    {
+        $this->processedMessages = array_column($jobs, 0);
+
+        foreach ($jobs as [$job, $ack]) {
+            $ack->ack($job);
+        }
+    }
+}
+
+class SecondHandlerDummyMessage implements DummyMessageInterface
+{
+    private string $message;
+
+    public function __construct(string $message)
+    {
+        $this->message = $message;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
     }
 }

--- a/src/Symfony/Component/Messenger/Worker.php
+++ b/src/Symfony/Component/Messenger/Worker.php
@@ -258,7 +258,6 @@ class Worker
             try {
                 $e = null;
                 $this->bus->dispatch($envelope->with(new FlushBatchHandlersStamp($force)));
-                unset($unacks[$batchHandler], $batchHandler);
             } catch (\Throwable $e) {
                 $envelope = $envelope->withoutAll(NoAutoAckStamp::class);
                 $this->acks[] = [$transportName, $envelope, $e];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59958
| License       | MIT

When using multiple Batch handlers, the situation can occur that there are multiple batch handlers that have messages that aren't processed and therefor not acked yet. The issue is caused by a optimalization that unsets the current batch handler in a foreach loop.

"The acknowledger was not called by the ... batch handler." is thrown when a worker is stopped and the batch isn't handled. 

The issue is reproducable and testable with the attached unit test.