### PR TITLE
[FrameworkBundle] Add the `clock.default_timezone` option

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -17,6 +17,7 @@ CHANGELOG
  * Add the ability to use an existing service as a lock/semaphore resource
  * Add support for configuring multiple serializer instances via the configuration
  * Add support for `SYMFONY_TRUSTED_PROXIES`, `SYMFONY_TRUSTED_HEADERS`, `SYMFONY_TRUST_X_SENDFILE_TYPE_HEADER` and `SYMFONY_TRUSTED_HOSTS` env vars
+ * Add `clock.default_timezone` option to configure the default timezone for the `clock` service
 
 7.1
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/clock.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/clock.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Psr\Clock\ClockInterface as PsrClockInterface;
+use Symfony\Component\Clock\Clock;
+use Symfony\Component\Clock\ClockInterface;
+
+return static function (ContainerConfigurator $container) {
+    $container->services()
+        ->set('clock', Clock::class)
+        ->alias(ClockInterface::class, 'clock')
+        ->alias(PsrClockInterface::class, 'clock');
+};

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -46,6 +46,7 @@
             <xsd:element name="enabled-locale" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="webhook" type="webhook" minOccurs="0" maxOccurs="1" />
             <xsd:element name="remote-event" type="remote-event" minOccurs="0" maxOccurs="1" />
+            <xsd:element name="clock" type="clock" minOccurs="0" maxOccurs="1" />
         </xsd:choice>
 
         <xsd:attribute name="http-method-override" type="xsd:boolean" />
@@ -978,5 +979,9 @@
 
     <xsd:complexType name="remote-event">
         <xsd:attribute name="enabled" type="xsd:boolean" />
+    </xsd:complexType>
+
+    <xsd:complexType name="clock">
+        <xsd:attribute name="default-timezone" type="xsd:string" />
     </xsd:complexType>
 </xsd:schema>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
@@ -11,12 +11,9 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-use Psr\Clock\ClockInterface as PsrClockInterface;
 use Psr\EventDispatcher\EventDispatcherInterface as PsrEventDispatcherInterface;
 use Symfony\Bundle\FrameworkBundle\CacheWarmer\ConfigBuilderCacheWarmer;
 use Symfony\Bundle\FrameworkBundle\HttpCache\HttpCache;
-use Symfony\Component\Clock\Clock;
-use Symfony\Component\Clock\ClockInterface;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Resource\SelfCheckingResourceChecker;
 use Symfony\Component\Config\ResourceCheckerConfigCacheFactory;
@@ -229,10 +226,6 @@ return static function (ContainerConfigurator $container) {
         ->set('config_builder.warmer', ConfigBuilderCacheWarmer::class)
             ->args([service(KernelInterface::class), service('logger')->nullOnInvalid()])
             ->tag('kernel.cache_warmer')
-
-        ->set('clock', Clock::class)
-        ->alias(ClockInterface::class, 'clock')
-        ->alias(PsrClockInterface::class, 'clock')
 
         // register as abstract and excluded, aka not-autowirable types
         ->set(LoaderInterface::class)->abstract()->tag('container.excluded')

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -954,6 +954,9 @@ class ConfigurationTest extends TestCase
             'remote-event' => [
                 'enabled' => !class_exists(FullStack::class) && class_exists(RemoteEvent::class),
             ],
+            'clock' => [
+                'default_timezone' => null,
+            ],
         ];
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/clock_invalid_timezone.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/clock_invalid_timezone.php
@@ -1,0 +1,7 @@
+<?php
+
+$container->loadFromExtension('framework', [
+    'clock' => [
+        'default_timezone' => 'invalid',
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/clock_timezone.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/clock_timezone.php
@@ -1,0 +1,7 @@
+<?php
+
+$container->loadFromExtension('framework', [
+    'clock' => [
+        'default_timezone' => 'Europe/Paris',
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/clock_invalid_timezone.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/clock_invalid_timezone.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:framework="http://symfony.com/schema/dic/symfony"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <services>
+        <service id="my_service" class="\Redis" />
+    </services>
+
+    <framework:config http-method-override="false" handle-all-throwables="true">
+        <framework:clock default-timezone="invalid" />
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/clock_timezone.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/clock_timezone.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:framework="http://symfony.com/schema/dic/symfony"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <services>
+        <service id="my_service" class="\Redis" />
+    </services>
+
+    <framework:config http-method-override="false" handle-all-throwables="true">
+        <framework:clock default-timezone="Europe/Paris" />
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/clock_invalid_timezone.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/clock_invalid_timezone.yml
@@ -1,0 +1,3 @@
+framework:
+    clock:
+        default_timezone: invalid

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/clock_timezone.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/clock_timezone.yml
@@ -1,0 +1,3 @@
+framework:
+    clock:
+        default_timezone: Europe/Paris

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -2498,6 +2498,21 @@ abstract class FrameworkExtensionTestCase extends TestCase
         self::assertEquals(new Reference('my_service'), $storeDef->getArgument(0));
     }
 
+    public function testClockWithTimezone()
+    {
+        $container = $this->createContainerFromFile('clock_timezone');
+
+        $this->assertEquals(new \DateTimeZone('Europe/Paris'), $container->getDefinition('clock')->getArgument('$timezone'));
+    }
+
+    public function testClockWithInvalidTimeZone()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The "default_timezone" option must be a valid timezone.');
+
+        $this->createContainerFromFile('clock_invalid_timezone');
+    }
+
     protected function createContainer(array $data = [])
     {
         return new ContainerBuilder(new EnvPlaceholderParameterBag(array_merge([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

We are introducing the clock component in a project. Because of legacy reasons, dates are stored using the `Europe/Paris` timezone instead of using UTC. Because we'd like to use the `clock` service and the `ClockAwareTrait`, it would be nice to configure the timezone to use right in the framework configuration, under a new option called `clock.default_timezone`:

```yaml
framework:
    clock:
        default_timezone: Europe/Paris
```

This adds more flexibility to developers to configure the default timezone to use. Even if the clock gets a default timezone using `date_default_timezone_get()`, having the possibility to set this option would remove some magic. More than that, it makes the clock service consistent across different PHP installation that may have any value in their `php.ini`.