### PR TITLE
[Notifier][JoliNotif] Allow `jolicode/jolinotif` 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -135,7 +135,7 @@
         "dragonmantank/cron-expression": "^3.1",
         "egulias/email-validator": "^2.1.10|^3.1|^4",
         "guzzlehttp/promises": "^1.4|^2.0",
-        "jolicode/jolinotif": "^2.7.2",
+        "jolicode/jolinotif": "^2.7.2|^3.0",
         "league/html-to-markdown": "^5.0",
         "league/uri": "^6.5|^7.0",
         "masterminds/html5": "^2.7.2",

--- a/src/Symfony/Component/Notifier/Bridge/JoliNotif/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/JoliNotif/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": ">=8.2",
-        "jolicode/jolinotif": "^2.7.2",
+        "jolicode/jolinotif": "^2.7.2|^3.0",
         "symfony/http-client": "^7.2",
         "symfony/notifier": "^7.2"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | none
| License       | MIT

Allow newly version of Jolinotif to be used with the Notifier. The current bridge already used the new architecture, so nothing to change here.
