### PR TITLE
[Mailer] Remove useless `sprintf()` call

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Postal/Transport/PostalApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postal/Transport/PostalApiTransport.php
@@ -44,9 +44,7 @@ final class PostalApiTransport extends AbstractApiTransport
 
     protected function doSendApi(SentMessage $sentMessage, Email $email, Envelope $envelope): ResponseInterface
     {
-        $path = \sprintf('/api/v1/send/message');
-
-        $response = $this->client->request('POST', 'https://'.$this->getEndpoint().$path, [
+        $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/api/v1/send/message', [
             'json' => $this->getPayload($email, $envelope),
             'headers' => [
                 'X-Server-API-Key' => $this->apiToken,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT
