### PR TITLE
Various CS fix for consistency

### DIFF
--- a/src/Symfony/Bridge/Twig/NodeVisitor/TranslationDefaultDomainNodeVisitor.php
+++ b/src/Symfony/Bridge/Twig/NodeVisitor/TranslationDefaultDomainNodeVisitor.php
@@ -59,9 +59,9 @@ final class TranslationDefaultDomainNodeVisitor implements NodeVisitorInterface
 
             if (class_exists(Nodes::class)) {
                 return new SetNode(false, new Nodes([$name]), new Nodes([$node->getNode('expr')]), $node->getTemplateLine());
-            } else {
-                return new SetNode(false, new Node([$name]), new Node([$node->getNode('expr')]), $node->getTemplateLine());
-            }
+            }  
+
+            return new SetNode(false, new Node([$name]), new Node([$node->getNode('expr')]), $node->getTemplateLine());
         }
 
         if (!$this->scope->has('domain')) {

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_signalable.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_signalable.php
@@ -12,7 +12,7 @@ while (!file_exists($vendor.'/vendor')) {
 }
 require $vendor.'/vendor/autoload.php';
 
-(new class() extends SingleCommandApplication implements SignalableCommandInterface {
+(new class extends SingleCommandApplication implements SignalableCommandInterface {
     public function getSubscribedSignals(): array
     {
         return [SIGINT];

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/closure.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/closure.php
@@ -2,7 +2,7 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-return new class() {
+return new class {
     public function __invoke(ContainerConfigurator $c)
     {
         $c->services()

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/from_callable.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/from_callable.php
@@ -2,7 +2,7 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-return new class() {
+return new class {
     public function __invoke(ContainerConfigurator $c)
     {
         $c->services()

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/object.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/object.php
@@ -4,7 +4,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use App\BarService;
 
-return new class() {
+return new class {
     public function __invoke(ContainerConfigurator $c)
     {
         $s = $c->services()->defaults()->public();

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Fixtures/long_receiver.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Fixtures/long_receiver.php
@@ -34,7 +34,7 @@ $receiver = new AmqpReceiver($connection, $serializer);
 $eventDispatcher = new EventDispatcher();
 $eventDispatcher->addSubscriber(new DispatchPcntlSignalListener());
 
-$worker = new Worker(['the_receiver' => $receiver], new class() implements MessageBusInterface {
+$worker = new Worker(['the_receiver' => $receiver], new class implements MessageBusInterface {
     public function dispatch($envelope, array $stamps = []): Envelope
     {
         echo 'Get envelope with message: '.$envelope->getMessage()::class."\n";

--- a/src/Symfony/Component/Routing/Tests/Fixtures/php_object_dsl.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/php_object_dsl.php
@@ -2,7 +2,7 @@
 
 namespace Symfony\Component\Routing\Loader\Configurator;
 
-return new class() {
+return new class {
     public function __invoke(RoutingConfigurator $routes)
     {
         $routes

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -1230,7 +1230,7 @@ class AbstractObjectNormalizerTest extends TestCase
 
     public function testDenormalizeArrayObject()
     {
-        $normalizer = new class() extends AbstractObjectNormalizerDummy {
+        $normalizer = new class extends AbstractObjectNormalizerDummy {
             public function __construct()
             {
                 parent::__construct(null, null, new PhpDocExtractor());

--- a/src/Symfony/Component/Translation/Dumper/PoFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/PoFileDumper.php
@@ -100,9 +100,9 @@ EOF;
             if (preg_match($intervalRegexp, $part)) {
                 // Explicit rule is not a standard rule.
                 return [];
-            } else {
-                $standardRules[] = $part;
-            }
+            }  
+
+            $standardRules[] = $part;
         }
 
         return $standardRules;

--- a/src/Symfony/Contracts/Tests/Service/LegacyTestService.php
+++ b/src/Symfony/Contracts/Tests/Service/LegacyTestService.php
@@ -54,7 +54,7 @@ class LegacyTestService extends LegacyParentTestService implements ServiceSubscr
 
 class LegacyChildTestService extends LegacyTestService
 {
-    #[SubscribedService()]
+    #[SubscribedService]
     public function aChildService(): LegacyService3
     {
         return $this->container->get(__METHOD__);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

A few fixes to match the rest of the codebase:

- Remove useless `else` branches (as done in https://github.com/symfony/symfony/pull/57897)
- Instantiating anonymous classes should not be followed by parentheses
- An attribute without args should not be followed by parentheses