### PR TITLE
[FrameworkBundle][Lock] Fix certain DSNs identified as service IDs

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2008,7 +2008,7 @@ class FrameworkExtension extends Extension
             $storeDefinitions = [];
             foreach ($resourceStores as $resourceStore) {
                 $storeDsn = $container->resolveEnvPlaceholders($resourceStore, null, $usedEnvs);
-                if (!$usedEnvs && !str_contains($resourceStore, '://')) {
+                if (!$usedEnvs && !str_contains($resourceStore, ':') && !\in_array($resourceStore, ['flock', 'semaphore', 'in-memory'], true)) {
                     $resourceStore = new Reference($resourceStore);
                 }
                 $storeDefinition = new Definition(PersistingStoreInterface::class);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/lock_named.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/lock_named.php
@@ -12,5 +12,7 @@ $container->loadFromExtension('framework', [
         'bar' => 'flock',
         'baz' => ['semaphore', 'flock'],
         'qux' => '%env(REDIS_DSN)%',
+        'corge' => 'in-memory',
+        'grault' => 'mysql:host=localhost;dbname=test',
     ],
 ]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/lock_named.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/lock_named.xml
@@ -18,6 +18,8 @@
             <framework:resource name="baz">semaphore</framework:resource>
             <framework:resource name="baz">flock</framework:resource>
             <framework:resource name="qux">%env(REDIS_DSN)%</framework:resource>
+            <framework:resource name="corge">in-memory</framework:resource>
+            <framework:resource name="grault">mysql:host=localhost;dbname=test</framework:resource>
         </framework:lock>
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/lock_named.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/lock_named.yml
@@ -12,3 +12,5 @@ framework:
         bar: flock
         baz: [semaphore, flock]
         qux: "%env(REDIS_DSN)%"
+        corge: in-memory
+        grault: mysql:host=localhost;dbname=test

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -2423,9 +2423,9 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $storeDef = $container->getDefinition($container->getDefinition('lock.default.factory')->getArgument(0));
 
         if (class_exists(SemaphoreStore::class) && SemaphoreStore::isSupported()) {
-            self::assertEquals(new Reference('semaphore'), $storeDef->getArgument(0));
+            self::assertSame('semaphore', $storeDef->getArgument(0));
         } else {
-            self::assertEquals(new Reference('flock'), $storeDef->getArgument(0));
+            self::assertSame('flock', $storeDef->getArgument(0));
         }
     }
 
@@ -2435,23 +2435,31 @@ abstract class FrameworkExtensionTestCase extends TestCase
 
         self::assertTrue($container->hasDefinition('lock.foo.factory'));
         $storeDef = $container->getDefinition($container->getDefinition('lock.foo.factory')->getArgument(0));
-        self::assertEquals(new Reference('semaphore'), $storeDef->getArgument(0));
+        self::assertSame('semaphore', $storeDef->getArgument(0));
 
         self::assertTrue($container->hasDefinition('lock.bar.factory'));
         $storeDef = $container->getDefinition($container->getDefinition('lock.bar.factory')->getArgument(0));
-        self::assertEquals(new Reference('flock'), $storeDef->getArgument(0));
+        self::assertSame('flock', $storeDef->getArgument(0));
 
         self::assertTrue($container->hasDefinition('lock.baz.factory'));
         $storeDef = $container->getDefinition($container->getDefinition('lock.baz.factory')->getArgument(0));
         self::assertIsArray($storeDefArg = $storeDef->getArgument(0));
         $storeDef1 = $container->getDefinition($storeDefArg[0]);
         $storeDef2 = $container->getDefinition($storeDefArg[1]);
-        self::assertEquals(new Reference('semaphore'), $storeDef1->getArgument(0));
-        self::assertEquals(new Reference('flock'), $storeDef2->getArgument(0));
+        self::assertSame('semaphore', $storeDef1->getArgument(0));
+        self::assertSame('flock', $storeDef2->getArgument(0));
 
         self::assertTrue($container->hasDefinition('lock.qux.factory'));
         $storeDef = $container->getDefinition($container->getDefinition('lock.qux.factory')->getArgument(0));
         self::assertStringContainsString('REDIS_DSN', $storeDef->getArgument(0));
+
+        self::assertTrue($container->hasDefinition('lock.corge.factory'));
+        $storeDef = $container->getDefinition($container->getDefinition('lock.corge.factory')->getArgument(0));
+        self::assertSame('in-memory', $storeDef->getArgument(0));
+
+        self::assertTrue($container->hasDefinition('lock.grault.factory'));
+        $storeDef = $container->getDefinition($container->getDefinition('lock.grault.factory')->getArgument(0));
+        self::assertSame('mysql:host=localhost;dbname=test', $storeDef->getArgument(0));
     }
 
     public function testLockWithService()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony/pull/58249#discussion_r1770062425
| License       | MIT

Follow up to #58249

The first PR introduced a BC break, as lock DSNs can also be in the following formats:

```yaml
framework:
    lock: 'flock'
    lock: 'semaphore'
    lock: 'in-memory'

    lock: 'mysql:host=127.0.0.1;dbname=app'
    lock: 'pgsql:host=127.0.0.1;dbname=app'
    lock: 'pgsql+advisory:host=127.0.0.1;dbname=app'
    lock: 'sqlsrv:server=127.0.0.1;Database=app'
    lock: 'oci:host=127.0.0.1;dbname=app'
```

This PR introduces two changes:
1. The framework bundle now treats any string containing a `:` as a DSN, instead of only those with `://`
2. `flock`, `semaphore`, and `in-memory` are now treated as special cases