### PR TITLE
[Form] Support `intl.use_exceptions/error_level` in `NumberToLocalizedStringTransformer`

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php
@@ -152,10 +152,14 @@ class NumberToLocalizedStringTransformer implements DataTransformerInterface
                 : \NumberFormatter::TYPE_INT32;
         }
 
-        $result = $formatter->parse($value, $type, $position);
+        try {
+            $result = @$formatter->parse($value, $type, $position);
+        } catch (\IntlException $e) {
+            throw new TransformationFailedException($e->getMessage(), $e->getCode(), $e);
+        }
 
         if (intl_is_failure($formatter->getErrorCode())) {
-            throw new TransformationFailedException($formatter->getErrorMessage());
+            throw new TransformationFailedException($formatter->getErrorMessage(), $formatter->getErrorCode());
         }
 
         if ($result >= \PHP_INT_MAX || $result <= -\PHP_INT_MAX) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/PercentToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/PercentToLocalizedStringTransformer.php
@@ -139,11 +139,15 @@ class PercentToLocalizedStringTransformer implements DataTransformerInterface
             $type = \PHP_INT_SIZE === 8 ? \NumberFormatter::TYPE_INT64 : \NumberFormatter::TYPE_INT32;
         }
 
-        // replace normal spaces so that the formatter can read them
-        $result = $formatter->parse(str_replace(' ', "\xc2\xa0", $value), $type, $position);
+        try {
+            // replace normal spaces so that the formatter can read them
+            $result = @$formatter->parse(str_replace(' ', "\xc2\xa0", $value), $type, $position);
+        } catch (\IntlException $e) {
+            throw new TransformationFailedException($e->getMessage(), 0, $e);
+        }
 
         if (intl_is_failure($formatter->getErrorCode())) {
-            throw new TransformationFailedException($formatter->getErrorMessage());
+            throw new TransformationFailedException($formatter->getErrorMessage(), $formatter->getErrorCode());
         }
 
         if (self::FRACTIONAL == $this->type) {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
@@ -56,7 +56,7 @@ class DateTimeToLocalizedStringTransformerTest extends BaseDateTimeTransformerTe
 
         if (\extension_loaded('intl')) {
             ini_set('intl.use_exceptions', $this->initialTestCaseUseException);
-            ini_set('intl.error_level', $this->initialTestCaseUseException);
+            ini_set('intl.error_level', $this->initialTestCaseErrorLevel);
         }
     }
 
@@ -341,12 +341,11 @@ class DateTimeToLocalizedStringTransformerTest extends BaseDateTimeTransformerTe
         $transformer->reverseTransform('20107-03-21 12:34:56');
     }
 
+    /**
+     * @requires extension intl
+     */
     public function testReverseTransformWrapsIntlErrorsWithErrorLevel()
     {
-        if (!\extension_loaded('intl')) {
-            $this->markTestSkipped('intl extension is not loaded');
-        }
-
         $errorLevel = ini_set('intl.error_level', \E_WARNING);
 
         try {
@@ -358,12 +357,11 @@ class DateTimeToLocalizedStringTransformerTest extends BaseDateTimeTransformerTe
         }
     }
 
+    /**
+     * @requires extension intl
+     */
     public function testReverseTransformWrapsIntlErrorsWithExceptions()
     {
-        if (!\extension_loaded('intl')) {
-            $this->markTestSkipped('intl extension is not loaded');
-        }
-
         $initialUseExceptions = ini_set('intl.use_exceptions', 1);
 
         try {
@@ -375,12 +373,11 @@ class DateTimeToLocalizedStringTransformerTest extends BaseDateTimeTransformerTe
         }
     }
 
+    /**
+     * @requires extension intl
+     */
     public function testReverseTransformWrapsIntlErrorsWithExceptionsAndErrorLevel()
     {
-        if (!\extension_loaded('intl')) {
-            $this->markTestSkipped('intl extension is not loaded');
-        }
-
         $initialUseExceptions = ini_set('intl.use_exceptions', 1);
         $initialErrorLevel = ini_set('intl.error_level', \E_WARNING);
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
@@ -20,8 +20,17 @@ class NumberToLocalizedStringTransformerTest extends TestCase
 {
     private $defaultLocale;
 
+    private $initialTestCaseUseException;
+    private $initialTestCaseErrorLevel;
+
     protected function setUp(): void
     {
+        // Normalize intl. configuration settings.
+        if (\extension_loaded('intl')) {
+            $this->initialTestCaseUseException = ini_set('intl.use_exceptions', 0);
+            $this->initialTestCaseErrorLevel = ini_set('intl.error_level', 0);
+        }
+
         $this->defaultLocale = \Locale::getDefault();
         \Locale::setDefault('en');
     }
@@ -29,6 +38,11 @@ class NumberToLocalizedStringTransformerTest extends TestCase
     protected function tearDown(): void
     {
         \Locale::setDefault($this->defaultLocale);
+
+        if (\extension_loaded('intl')) {
+            ini_set('intl.use_exceptions', $this->initialTestCaseUseException);
+            ini_set('intl.error_level', $this->initialTestCaseErrorLevel);
+        }
     }
 
     public static function provideTransformations()
@@ -645,6 +659,56 @@ class NumberToLocalizedStringTransformerTest extends TestCase
         $transformer = new NumberToLocalizedStringTransformer();
 
         $this->assertSame($output, $transformer->reverseTransform($input));
+    }
+
+    /**
+     * @requires extension intl
+     */
+    public function testReverseTransformWrapsIntlErrorsWithErrorLevel()
+    {
+        $errorLevel = ini_set('intl.error_level', \E_WARNING);
+
+        try {
+            $this->expectException(TransformationFailedException::class);
+            $transformer = new NumberToLocalizedStringTransformer();
+            $transformer->reverseTransform('invalid_number');
+        } finally {
+            ini_set('intl.error_level', $errorLevel);
+        }
+    }
+
+    /**
+     * @requires extension intl
+     */
+    public function testReverseTransformWrapsIntlErrorsWithExceptions()
+    {
+        $initialUseExceptions = ini_set('intl.use_exceptions', 1);
+
+        try {
+            $this->expectException(TransformationFailedException::class);
+            $transformer = new NumberToLocalizedStringTransformer();
+            $transformer->reverseTransform('invalid_number');
+        } finally {
+            ini_set('intl.use_exceptions', $initialUseExceptions);
+        }
+    }
+
+    /**
+     * @requires extension intl
+     */
+    public function testReverseTransformWrapsIntlErrorsWithExceptionsAndErrorLevel()
+    {
+        $initialUseExceptions = ini_set('intl.use_exceptions', 1);
+        $initialErrorLevel = ini_set('intl.error_level', \E_WARNING);
+
+        try {
+            $this->expectException(TransformationFailedException::class);
+            $transformer = new NumberToLocalizedStringTransformer();
+            $transformer->reverseTransform('invalid_number');
+        } finally {
+            ini_set('intl.use_exceptions', $initialUseExceptions);
+            ini_set('intl.error_level', $initialErrorLevel);
+        }
     }
 
     public static function eNotationProvider(): array

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/PercentToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/PercentToLocalizedStringTransformerTest.php
@@ -23,8 +23,17 @@ class PercentToLocalizedStringTransformerTest extends TestCase
 
     private $defaultLocale;
 
+    private $initialTestCaseUseException;
+    private $initialTestCaseErrorLevel;
+
     protected function setUp(): void
     {
+        // Normalize intl. configuration settings.
+        if (\extension_loaded('intl')) {
+            $this->initialTestCaseUseException = ini_set('intl.use_exceptions', 0);
+            $this->initialTestCaseErrorLevel = ini_set('intl.error_level', 0);
+        }
+
         $this->defaultLocale = \Locale::getDefault();
         \Locale::setDefault('en');
     }
@@ -32,6 +41,11 @@ class PercentToLocalizedStringTransformerTest extends TestCase
     protected function tearDown(): void
     {
         \Locale::setDefault($this->defaultLocale);
+
+        if (\extension_loaded('intl')) {
+            ini_set('intl.use_exceptions', $this->initialTestCaseUseException);
+            ini_set('intl.error_level', $this->initialTestCaseErrorLevel);
+        }
     }
 
     public function testTransform()
@@ -482,6 +496,56 @@ class PercentToLocalizedStringTransformerTest extends TestCase
         $transformer = new PercentToLocalizedStringTransformer(2, null, \NumberFormatter::ROUND_HALFUP, true);
 
         $this->assertEquals(0.1234, $transformer->reverseTransform('12.34'));
+    }
+
+    /**
+     * @requires extension intl
+     */
+    public function testReverseTransformWrapsIntlErrorsWithErrorLevel()
+    {
+        $errorLevel = ini_set('intl.error_level', \E_WARNING);
+
+        try {
+            $this->expectException(TransformationFailedException::class);
+            $transformer = new PercentToLocalizedStringTransformer(null, null, \NumberFormatter::ROUND_HALFUP);
+            $transformer->reverseTransform('invalid_number');
+        } finally {
+            ini_set('intl.error_level', $errorLevel);
+        }
+    }
+
+    /**
+     * @requires extension intl
+     */
+    public function testReverseTransformWrapsIntlErrorsWithExceptions()
+    {
+        $initialUseExceptions = ini_set('intl.use_exceptions', 1);
+
+        try {
+            $this->expectException(TransformationFailedException::class);
+            $transformer = new PercentToLocalizedStringTransformer(null, null, \NumberFormatter::ROUND_HALFUP);
+            $transformer->reverseTransform('invalid_number');
+        } finally {
+            ini_set('intl.use_exceptions', $initialUseExceptions);
+        }
+    }
+
+    /**
+     * @requires extension intl
+     */
+    public function testReverseTransformWrapsIntlErrorsWithExceptionsAndErrorLevel()
+    {
+        $initialUseExceptions = ini_set('intl.use_exceptions', 1);
+        $initialErrorLevel = ini_set('intl.error_level', \E_WARNING);
+
+        try {
+            $this->expectException(TransformationFailedException::class);
+            $transformer = new PercentToLocalizedStringTransformer(null, null, \NumberFormatter::ROUND_HALFUP);
+            $transformer->reverseTransform('invalid_number');
+        } finally {
+            ini_set('intl.use_exceptions', $initialUseExceptions);
+            ini_set('intl.error_level', $initialErrorLevel);
+        }
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Same as #36149, support the ini settings `intl.error_level` and `intl.use_exceptions`, by catching the exception and rethrowing as `TransformationFailedException`.