### PR TITLE
[HttpFoundation] ensure session storages are opened in tests before destroying them

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/AbstractRedisSessionHandlerTestCase.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/AbstractRedisSessionHandlerTestCase.php
@@ -106,6 +106,7 @@ abstract class AbstractRedisSessionHandlerTestCase extends TestCase
 
     public function testDestroySession()
     {
+        $this->storage->open('', '');
         $this->redisClient->set(self::PREFIX.'id', 'foo');
 
         $this->assertTrue((bool) $this->redisClient->exists(self::PREFIX.'id'));

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MemcachedSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MemcachedSessionHandlerTest.php
@@ -119,6 +119,7 @@ class MemcachedSessionHandlerTest extends TestCase
 
     public function testDestroySession()
     {
+        $this->storage->open('', '');
         $this->memcached
             ->expects($this->once())
             ->method('delete')

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MigratingSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MigratingSessionHandlerTest.php
@@ -51,6 +51,8 @@ class MigratingSessionHandlerTest extends TestCase
 
     public function testDestroy()
     {
+        $this->dualHandler->open('/path/to/save/location', 'xyz');
+
         $sessionId = 'xyz';
 
         $this->currentHandler->expects($this->once())

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
@@ -174,6 +174,8 @@ class MongoDbSessionHandlerTest extends TestCase
             ->method('deleteOne')
             ->with([$this->options['id_field'] => 'foo']);
 
+        $this->storage->open('test', 'test');
+
         $this->assertTrue($this->storage->destroy('foo'));
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
@@ -225,6 +225,7 @@ class PdoSessionHandlerTest extends TestCase
     {
         // wrong method sequence that should no happen, but still works
         $storage = new PdoSessionHandler($this->getMemorySqlitePdo());
+        $storage->open('', 'sid');
         $storage->write('id', 'data');
         $storage->write('other_id', 'other_data');
         $storage->destroy('inexistent');

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/StrictSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/StrictSessionHandlerTest.php
@@ -130,6 +130,7 @@ class StrictSessionHandlerTest extends TestCase
         $handler->expects($this->never())->method('write');
         $handler->expects($this->once())->method('destroy')->willReturn(true);
         $proxy = new StrictSessionHandler($handler);
+        $proxy->open('path', 'name');
 
         $this->assertFalse($proxy->validateId('id'));
         $this->assertSame('', $proxy->read('id'));
@@ -144,6 +145,7 @@ class StrictSessionHandlerTest extends TestCase
         $handler->expects($this->never())->method('write');
         $handler->expects($this->once())->method('destroy')->willReturn(true);
         $proxy = new StrictSessionHandler($handler);
+        $proxy->open('path', 'name');
 
         $this->assertSame('data', $proxy->read('id'));
         $this->assertTrue($proxy->write('id', ''));
@@ -155,6 +157,7 @@ class StrictSessionHandlerTest extends TestCase
         $handler->expects($this->once())->method('destroy')
             ->with('id')->willReturn(true);
         $proxy = new StrictSessionHandler($handler);
+        $proxy->open('path', 'name');
 
         $this->assertTrue($proxy->destroy('id'));
     }
@@ -166,6 +169,7 @@ class StrictSessionHandlerTest extends TestCase
             ->with('id')->willReturn('');
         $handler->expects($this->once())->method('destroy')->willReturn(true);
         $proxy = new StrictSessionHandler($handler);
+        $proxy->open('path', 'name');
 
         $this->assertSame('', $proxy->read('id'));
         $this->assertTrue($proxy->destroy('id'));
@@ -181,6 +185,7 @@ class StrictSessionHandlerTest extends TestCase
         $handler->expects($this->once())->method('destroy')
             ->with('id')->willReturn(true);
         $proxy = new StrictSessionHandler($handler);
+        $proxy->open('path', 'name');
 
         $this->assertSame('', $proxy->read('id'));
         $this->assertTrue($proxy->write('id', 'data'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

The tests currently only pass by luck as the condition in https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/AbstractSessionHandler.php#L129 does not evaluate to `true` (because headers are already sent).