### PR TITLE
[Console] Use `assertSame` for input tests

### DIFF
--- a/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
@@ -26,17 +26,17 @@ class ArgvInputTest extends TestCase
         $r = new \ReflectionObject($input);
         $p = $r->getProperty('tokens');
 
-        $this->assertEquals(['foo'], $p->getValue($input), '__construct() automatically get its input from the argv server variable');
+        $this->assertSame(['foo'], $p->getValue($input), '__construct() automatically get its input from the argv server variable');
     }
 
     public function testParseArguments()
     {
         $input = new ArgvInput(['cli.php', 'foo']);
         $input->bind(new InputDefinition([new InputArgument('name')]));
-        $this->assertEquals(['name' => 'foo'], $input->getArguments(), '->parse() parses required arguments');
+        $this->assertSame(['name' => 'foo'], $input->getArguments(), '->parse() parses required arguments');
 
         $input->bind(new InputDefinition([new InputArgument('name')]));
-        $this->assertEquals(['name' => 'foo'], $input->getArguments(), '->parse() is stateless');
+        $this->assertSame(['name' => 'foo'], $input->getArguments(), '->parse() is stateless');
     }
 
     /**
@@ -57,7 +57,7 @@ class ArgvInputTest extends TestCase
     {
         $input = new ArgvInput($input);
         $input->bind(new InputDefinition($options));
-        $this->assertEquals($expectedOptions, $input->getOptions(), $message);
+        $this->assertSame($expectedOptions, $input->getOptions(), $message);
     }
 
     public static function provideOptions()
@@ -363,7 +363,7 @@ class ArgvInputTest extends TestCase
         $input = new ArgvInput(['cli.php', 'foo', 'bar', 'baz', 'bat']);
         $input->bind(new InputDefinition([new InputArgument('name', InputArgument::IS_ARRAY)]));
 
-        $this->assertEquals(['name' => ['foo', 'bar', 'baz', 'bat']], $input->getArguments(), '->parse() parses array arguments');
+        $this->assertSame(['name' => ['foo', 'bar', 'baz', 'bat']], $input->getArguments(), '->parse() parses array arguments');
     }
 
     public function testParseArrayOption()
@@ -371,11 +371,11 @@ class ArgvInputTest extends TestCase
         $input = new ArgvInput(['cli.php', '--name=foo', '--name=bar', '--name=baz']);
         $input->bind(new InputDefinition([new InputOption('name', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY)]));
 
-        $this->assertEquals(['name' => ['foo', 'bar', 'baz']], $input->getOptions(), '->parse() parses array options ("--option=value" syntax)');
+        $this->assertSame(['name' => ['foo', 'bar', 'baz']], $input->getOptions(), '->parse() parses array options ("--option=value" syntax)');
 
         $input = new ArgvInput(['cli.php', '--name', 'foo', '--name', 'bar', '--name', 'baz']);
         $input->bind(new InputDefinition([new InputOption('name', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY)]));
-        $this->assertEquals(['name' => ['foo', 'bar', 'baz']], $input->getOptions(), '->parse() parses array options ("--option value" syntax)');
+        $this->assertSame(['name' => ['foo', 'bar', 'baz']], $input->getOptions(), '->parse() parses array options ("--option value" syntax)');
 
         $input = new ArgvInput(['cli.php', '--name=foo', '--name=bar', '--name=']);
         $input->bind(new InputDefinition([new InputOption('name', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY)]));
@@ -393,12 +393,12 @@ class ArgvInputTest extends TestCase
     {
         $input = new ArgvInput(['cli.php', '--', '-1']);
         $input->bind(new InputDefinition([new InputArgument('number')]));
-        $this->assertEquals(['number' => '-1'], $input->getArguments(), '->parse() parses arguments with leading dashes as arguments after having encountered a double-dash sequence');
+        $this->assertSame(['number' => '-1'], $input->getArguments(), '->parse() parses arguments with leading dashes as arguments after having encountered a double-dash sequence');
 
         $input = new ArgvInput(['cli.php', '-f', 'bar', '--', '-1']);
         $input->bind(new InputDefinition([new InputArgument('number'), new InputOption('foo', 'f', InputOption::VALUE_OPTIONAL)]));
-        $this->assertEquals(['foo' => 'bar'], $input->getOptions(), '->parse() parses arguments with leading dashes as options before having encountered a double-dash sequence');
-        $this->assertEquals(['number' => '-1'], $input->getArguments(), '->parse() parses arguments with leading dashes as arguments after having encountered a double-dash sequence');
+        $this->assertSame(['foo' => 'bar'], $input->getOptions(), '->parse() parses arguments with leading dashes as options before having encountered a double-dash sequence');
+        $this->assertSame(['number' => '-1'], $input->getArguments(), '->parse() parses arguments with leading dashes as arguments after having encountered a double-dash sequence');
     }
 
     public function testParseEmptyStringArgument()
@@ -406,7 +406,7 @@ class ArgvInputTest extends TestCase
         $input = new ArgvInput(['cli.php', '-f', 'bar', '']);
         $input->bind(new InputDefinition([new InputArgument('empty'), new InputOption('foo', 'f', InputOption::VALUE_OPTIONAL)]));
 
-        $this->assertEquals(['empty' => ''], $input->getArguments(), '->parse() parses empty string arguments');
+        $this->assertSame(['empty' => ''], $input->getArguments(), '->parse() parses empty string arguments');
     }
 
     public function testGetFirstArgument()
@@ -415,7 +415,7 @@ class ArgvInputTest extends TestCase
         $this->assertNull($input->getFirstArgument(), '->getFirstArgument() returns null when there is no arguments');
 
         $input = new ArgvInput(['cli.php', '-fbbar', 'foo']);
-        $this->assertEquals('foo', $input->getFirstArgument(), '->getFirstArgument() returns the first argument from the raw input');
+        $this->assertSame('foo', $input->getFirstArgument(), '->getFirstArgument() returns the first argument from the raw input');
 
         $input = new ArgvInput(['cli.php', '--foo', 'fooval', 'bar']);
         $input->bind(new InputDefinition([new InputOption('foo', 'f', InputOption::VALUE_OPTIONAL), new InputArgument('arg')]));
@@ -495,7 +495,7 @@ class ArgvInputTest extends TestCase
         // No warning thrown
         $this->assertFalse($input->hasParameterOption(['-m', '']));
 
-        $this->assertEquals('dev', $input->getParameterOption(['-e', '']));
+        $this->assertSame('dev', $input->getParameterOption(['-e', '']));
         // No warning thrown
         $this->assertFalse($input->getParameterOption(['-m', '']));
     }
@@ -503,10 +503,10 @@ class ArgvInputTest extends TestCase
     public function testToString()
     {
         $input = new ArgvInput(['cli.php', '-f', 'foo']);
-        $this->assertEquals('-f foo', (string) $input);
+        $this->assertSame('-f foo', (string) $input);
 
         $input = new ArgvInput(['cli.php', '-f', '--bar=foo', 'a b c d', "A\nB'C"]);
-        $this->assertEquals('-f --bar=foo '.escapeshellarg('a b c d').' '.escapeshellarg("A\nB'C"), (string) $input);
+        $this->assertSame('-f --bar=foo '.escapeshellarg('a b c d').' '.escapeshellarg("A\nB'C"), (string) $input);
     }
 
     /**
@@ -515,7 +515,7 @@ class ArgvInputTest extends TestCase
     public function testGetParameterOptionEqualSign($argv, $key, $default, $onlyParams, $expected)
     {
         $input = new ArgvInput($argv);
-        $this->assertEquals($expected, $input->getParameterOption($key, $default, $onlyParams), '->getParameterOption() returns the expected value');
+        $this->assertSame($expected, $input->getParameterOption($key, $default, $onlyParams), '->getParameterOption() returns the expected value');
     }
 
     public static function provideGetParameterOptionValues()
@@ -539,33 +539,33 @@ class ArgvInputTest extends TestCase
     {
         $input = new ArgvInput(['cli.php', '-']);
         $input->bind(new InputDefinition([new InputArgument('file')]));
-        $this->assertEquals(['file' => '-'], $input->getArguments(), '->parse() parses single dash as an argument');
+        $this->assertSame(['file' => '-'], $input->getArguments(), '->parse() parses single dash as an argument');
     }
 
     public function testParseOptionWithValueOptionalGivenEmptyAndRequiredArgument()
     {
         $input = new ArgvInput(['cli.php', '--foo=', 'bar']);
         $input->bind(new InputDefinition([new InputOption('foo', 'f', InputOption::VALUE_OPTIONAL), new InputArgument('name', InputArgument::REQUIRED)]));
-        $this->assertEquals(['foo' => null], $input->getOptions(), '->parse() parses optional options with empty value as null');
-        $this->assertEquals(['name' => 'bar'], $input->getArguments(), '->parse() parses required arguments');
+        $this->assertSame(['foo' => ''], $input->getOptions(), '->parse() parses optional options with empty value as null');
+        $this->assertSame(['name' => 'bar'], $input->getArguments(), '->parse() parses required arguments');
 
         $input = new ArgvInput(['cli.php', '--foo=0', 'bar']);
         $input->bind(new InputDefinition([new InputOption('foo', 'f', InputOption::VALUE_OPTIONAL), new InputArgument('name', InputArgument::REQUIRED)]));
-        $this->assertEquals(['foo' => '0'], $input->getOptions(), '->parse() parses optional options with empty value as null');
-        $this->assertEquals(['name' => 'bar'], $input->getArguments(), '->parse() parses required arguments');
+        $this->assertSame(['foo' => '0'], $input->getOptions(), '->parse() parses optional options with empty value as null');
+        $this->assertSame(['name' => 'bar'], $input->getArguments(), '->parse() parses required arguments');
     }
 
     public function testParseOptionWithValueOptionalGivenEmptyAndOptionalArgument()
     {
         $input = new ArgvInput(['cli.php', '--foo=', 'bar']);
         $input->bind(new InputDefinition([new InputOption('foo', 'f', InputOption::VALUE_OPTIONAL), new InputArgument('name', InputArgument::OPTIONAL)]));
-        $this->assertEquals(['foo' => null], $input->getOptions(), '->parse() parses optional options with empty value as null');
-        $this->assertEquals(['name' => 'bar'], $input->getArguments(), '->parse() parses optional arguments');
+        $this->assertSame(['foo' => ''], $input->getOptions(), '->parse() parses optional options with empty value as null');
+        $this->assertSame(['name' => 'bar'], $input->getArguments(), '->parse() parses optional arguments');
 
         $input = new ArgvInput(['cli.php', '--foo=0', 'bar']);
         $input->bind(new InputDefinition([new InputOption('foo', 'f', InputOption::VALUE_OPTIONAL), new InputArgument('name', InputArgument::OPTIONAL)]));
-        $this->assertEquals(['foo' => '0'], $input->getOptions(), '->parse() parses optional options with empty value as null');
-        $this->assertEquals(['name' => 'bar'], $input->getArguments(), '->parse() parses optional arguments');
+        $this->assertSame(['foo' => '0'], $input->getOptions(), '->parse() parses optional options with empty value as null');
+        $this->assertSame(['name' => 'bar'], $input->getArguments(), '->parse() parses optional arguments');
     }
 
     public function testGetRawTokensFalse()

--- a/src/Symfony/Component/Console/Tests/Input/ArrayInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArrayInputTest.php
@@ -24,9 +24,9 @@ class ArrayInputTest extends TestCase
         $input = new ArrayInput([]);
         $this->assertNull($input->getFirstArgument(), '->getFirstArgument() returns null if no argument were passed');
         $input = new ArrayInput(['name' => 'Fabien']);
-        $this->assertEquals('Fabien', $input->getFirstArgument(), '->getFirstArgument() returns the first passed argument');
+        $this->assertSame('Fabien', $input->getFirstArgument(), '->getFirstArgument() returns the first passed argument');
         $input = new ArrayInput(['--foo' => 'bar', 'name' => 'Fabien']);
-        $this->assertEquals('Fabien', $input->getFirstArgument(), '->getFirstArgument() returns the first passed argument');
+        $this->assertSame('Fabien', $input->getFirstArgument(), '->getFirstArgument() returns the first passed argument');
     }
 
     public function testHasParameterOption()
@@ -46,22 +46,22 @@ class ArrayInputTest extends TestCase
     public function testGetParameterOption()
     {
         $input = new ArrayInput(['name' => 'Fabien', '--foo' => 'bar']);
-        $this->assertEquals('bar', $input->getParameterOption('--foo'), '->getParameterOption() returns the option of specified name');
-        $this->assertEquals('default', $input->getParameterOption('--bar', 'default'), '->getParameterOption() returns the default value if an option is not present in the passed parameters');
+        $this->assertSame('bar', $input->getParameterOption('--foo'), '->getParameterOption() returns the option of specified name');
+        $this->assertSame('default', $input->getParameterOption('--bar', 'default'), '->getParameterOption() returns the default value if an option is not present in the passed parameters');
 
         $input = new ArrayInput(['Fabien', '--foo' => 'bar']);
-        $this->assertEquals('bar', $input->getParameterOption('--foo'), '->getParameterOption() returns the option of specified name');
+        $this->assertSame('bar', $input->getParameterOption('--foo'), '->getParameterOption() returns the option of specified name');
 
         $input = new ArrayInput(['--foo', '--', '--bar' => 'woop']);
-        $this->assertEquals('woop', $input->getParameterOption('--bar'), '->getParameterOption() returns the correct value if an option is present in the passed parameters');
-        $this->assertEquals('default', $input->getParameterOption('--bar', 'default', true), '->getParameterOption() returns the default value if an option is present in the passed parameters after an end of options signal');
+        $this->assertSame('woop', $input->getParameterOption('--bar'), '->getParameterOption() returns the correct value if an option is present in the passed parameters');
+        $this->assertSame('default', $input->getParameterOption('--bar', 'default', true), '->getParameterOption() returns the default value if an option is present in the passed parameters after an end of options signal');
     }
 
     public function testParseArguments()
     {
         $input = new ArrayInput(['name' => 'foo'], new InputDefinition([new InputArgument('name')]));
 
-        $this->assertEquals(['name' => 'foo'], $input->getArguments(), '->parse() parses required arguments');
+        $this->assertSame(['name' => 'foo'], $input->getArguments(), '->parse() parses required arguments');
     }
 
     /**
@@ -71,7 +71,7 @@ class ArrayInputTest extends TestCase
     {
         $input = new ArrayInput($input, new InputDefinition($options));
 
-        $this->assertEquals($expectedOptions, $input->getOptions(), $message);
+        $this->assertSame($expectedOptions, $input->getOptions(), $message);
     }
 
     public static function provideOptions(): array
@@ -162,7 +162,7 @@ class ArrayInputTest extends TestCase
     public function testToString()
     {
         $input = new ArrayInput(['-f' => null, '-b' => 'bar', '--foo' => 'b a z', '--lala' => null, 'test' => 'Foo', 'test2' => "A\nB'C"]);
-        $this->assertEquals('-f -b bar --foo='.escapeshellarg('b a z').' --lala Foo '.escapeshellarg("A\nB'C"), (string) $input);
+        $this->assertSame('-f -b bar --foo='.escapeshellarg('b a z').' --lala Foo '.escapeshellarg("A\nB'C"), (string) $input);
 
         $input = new ArrayInput(['-b' => ['bval_1', 'bval_2'], '--f' => ['fval_1', 'fval_2']]);
         $this->assertSame('-b bval_1 -b bval_2 --f=fval_1 --f=fval_2', (string) $input);

--- a/src/Symfony/Component/Console/Tests/Input/InputArgumentTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputArgumentTest.php
@@ -23,7 +23,7 @@ class InputArgumentTest extends TestCase
     public function testConstructor()
     {
         $argument = new InputArgument('foo');
-        $this->assertEquals('foo', $argument->getName(), '__construct() takes a name as its first argument');
+        $this->assertSame('foo', $argument->getName(), '__construct() takes a name as its first argument');
     }
 
     public function testModes()
@@ -62,13 +62,13 @@ class InputArgumentTest extends TestCase
     public function testGetDescription()
     {
         $argument = new InputArgument('foo', null, 'Some description');
-        $this->assertEquals('Some description', $argument->getDescription(), '->getDescription() return the message description');
+        $this->assertSame('Some description', $argument->getDescription(), '->getDescription() return the message description');
     }
 
     public function testGetDefault()
     {
         $argument = new InputArgument('foo', InputArgument::OPTIONAL, '', 'default');
-        $this->assertEquals('default', $argument->getDefault(), '->getDefault() return the default value');
+        $this->assertSame('default', $argument->getDefault(), '->getDefault() return the default value');
     }
 
     public function testSetDefault()
@@ -77,11 +77,11 @@ class InputArgumentTest extends TestCase
         $argument->setDefault(null);
         $this->assertNull($argument->getDefault(), '->setDefault() can reset the default value by passing null');
         $argument->setDefault('another');
-        $this->assertEquals('another', $argument->getDefault(), '->setDefault() changes the default value');
+        $this->assertSame('another', $argument->getDefault(), '->setDefault() changes the default value');
 
         $argument = new InputArgument('foo', InputArgument::OPTIONAL | InputArgument::IS_ARRAY);
         $argument->setDefault([1, 2]);
-        $this->assertEquals([1, 2], $argument->getDefault(), '->setDefault() changes the default value');
+        $this->assertSame([1, 2], $argument->getDefault(), '->setDefault() changes the default value');
     }
 
     public function testSetDefaultWithRequiredArgument()

--- a/src/Symfony/Component/Console/Tests/Input/InputDefinitionTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputDefinitionTest.php
@@ -36,10 +36,10 @@ class InputDefinitionTest extends TestCase
         $this->initializeArguments();
 
         $definition = new InputDefinition();
-        $this->assertEquals([], $definition->getArguments(), '__construct() creates a new InputDefinition object');
+        $this->assertSame([], $definition->getArguments(), '__construct() creates a new InputDefinition object');
 
         $definition = new InputDefinition([$this->foo, $this->bar]);
-        $this->assertEquals(['foo' => $this->foo, 'bar' => $this->bar], $definition->getArguments(), '__construct() takes an array of InputArgument objects as its first argument');
+        $this->assertSame(['foo' => $this->foo, 'bar' => $this->bar], $definition->getArguments(), '__construct() takes an array of InputArgument objects as its first argument');
     }
 
     public function testConstructorOptions()
@@ -47,10 +47,10 @@ class InputDefinitionTest extends TestCase
         $this->initializeOptions();
 
         $definition = new InputDefinition();
-        $this->assertEquals([], $definition->getOptions(), '__construct() creates a new InputDefinition object');
+        $this->assertSame([], $definition->getOptions(), '__construct() creates a new InputDefinition object');
 
         $definition = new InputDefinition([$this->foo, $this->bar]);
-        $this->assertEquals(['foo' => $this->foo, 'bar' => $this->bar], $definition->getOptions(), '__construct() takes an array of InputOption objects as its first argument');
+        $this->assertSame(['foo' => $this->foo, 'bar' => $this->bar], $definition->getOptions(), '__construct() takes an array of InputOption objects as its first argument');
     }
 
     public function testSetArguments()
@@ -59,10 +59,10 @@ class InputDefinitionTest extends TestCase
 
         $definition = new InputDefinition();
         $definition->setArguments([$this->foo]);
-        $this->assertEquals(['foo' => $this->foo], $definition->getArguments(), '->setArguments() sets the array of InputArgument objects');
+        $this->assertSame(['foo' => $this->foo], $definition->getArguments(), '->setArguments() sets the array of InputArgument objects');
         $definition->setArguments([$this->bar]);
 
-        $this->assertEquals(['bar' => $this->bar], $definition->getArguments(), '->setArguments() clears all InputArgument objects');
+        $this->assertSame(['bar' => $this->bar], $definition->getArguments(), '->setArguments() clears all InputArgument objects');
     }
 
     public function testAddArguments()
@@ -71,9 +71,9 @@ class InputDefinitionTest extends TestCase
 
         $definition = new InputDefinition();
         $definition->addArguments([$this->foo]);
-        $this->assertEquals(['foo' => $this->foo], $definition->getArguments(), '->addArguments() adds an array of InputArgument objects');
+        $this->assertSame(['foo' => $this->foo], $definition->getArguments(), '->addArguments() adds an array of InputArgument objects');
         $definition->addArguments([$this->bar]);
-        $this->assertEquals(['foo' => $this->foo, 'bar' => $this->bar], $definition->getArguments(), '->addArguments() does not clear existing InputArgument objects');
+        $this->assertSame(['foo' => $this->foo, 'bar' => $this->bar], $definition->getArguments(), '->addArguments() does not clear existing InputArgument objects');
     }
 
     public function testAddArgument()
@@ -82,9 +82,9 @@ class InputDefinitionTest extends TestCase
 
         $definition = new InputDefinition();
         $definition->addArgument($this->foo);
-        $this->assertEquals(['foo' => $this->foo], $definition->getArguments(), '->addArgument() adds a InputArgument object');
+        $this->assertSame(['foo' => $this->foo], $definition->getArguments(), '->addArgument() adds a InputArgument object');
         $definition->addArgument($this->bar);
-        $this->assertEquals(['foo' => $this->foo, 'bar' => $this->bar], $definition->getArguments(), '->addArgument() adds a InputArgument object');
+        $this->assertSame(['foo' => $this->foo, 'bar' => $this->bar], $definition->getArguments(), '->addArgument() adds a InputArgument object');
     }
 
     public function testArgumentsMustHaveDifferentNames()
@@ -126,7 +126,7 @@ class InputDefinitionTest extends TestCase
 
         $definition = new InputDefinition();
         $definition->addArguments([$this->foo]);
-        $this->assertEquals($this->foo, $definition->getArgument('foo'), '->getArgument() returns a InputArgument by its name');
+        $this->assertSame($this->foo, $definition->getArgument('foo'), '->getArgument() returns a InputArgument by its name');
     }
 
     public function testGetInvalidArgument()
@@ -157,9 +157,9 @@ class InputDefinitionTest extends TestCase
 
         $definition = new InputDefinition();
         $definition->addArgument($this->foo2);
-        $this->assertEquals(1, $definition->getArgumentRequiredCount(), '->getArgumentRequiredCount() returns the number of required arguments');
+        $this->assertSame(1, $definition->getArgumentRequiredCount(), '->getArgumentRequiredCount() returns the number of required arguments');
         $definition->addArgument($this->foo);
-        $this->assertEquals(1, $definition->getArgumentRequiredCount(), '->getArgumentRequiredCount() returns the number of required arguments');
+        $this->assertSame(1, $definition->getArgumentRequiredCount(), '->getArgumentRequiredCount() returns the number of required arguments');
     }
 
     public function testGetArgumentCount()
@@ -168,9 +168,9 @@ class InputDefinitionTest extends TestCase
 
         $definition = new InputDefinition();
         $definition->addArgument($this->foo2);
-        $this->assertEquals(1, $definition->getArgumentCount(), '->getArgumentCount() returns the number of arguments');
+        $this->assertSame(1, $definition->getArgumentCount(), '->getArgumentCount() returns the number of arguments');
         $definition->addArgument($this->foo);
-        $this->assertEquals(2, $definition->getArgumentCount(), '->getArgumentCount() returns the number of arguments');
+        $this->assertSame(2, $definition->getArgumentCount(), '->getArgumentCount() returns the number of arguments');
     }
 
     public function testGetArgumentDefaults()
@@ -181,12 +181,12 @@ class InputDefinitionTest extends TestCase
             new InputArgument('foo3', InputArgument::OPTIONAL | InputArgument::IS_ARRAY),
             //  new InputArgument('foo4', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, '', [1, 2]),
         ]);
-        $this->assertEquals(['foo1' => null, 'foo2' => 'default', 'foo3' => []], $definition->getArgumentDefaults(), '->getArgumentDefaults() return the default values for each argument');
+        $this->assertSame(['foo1' => null, 'foo2' => 'default', 'foo3' => []], $definition->getArgumentDefaults(), '->getArgumentDefaults() return the default values for each argument');
 
         $definition = new InputDefinition([
             new InputArgument('foo4', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, '', [1, 2]),
         ]);
-        $this->assertEquals(['foo4' => [1, 2]], $definition->getArgumentDefaults(), '->getArgumentDefaults() return the default values for each argument');
+        $this->assertSame(['foo4' => [1, 2]], $definition->getArgumentDefaults(), '->getArgumentDefaults() return the default values for each argument');
     }
 
     public function testSetOptions()
@@ -194,9 +194,9 @@ class InputDefinitionTest extends TestCase
         $this->initializeOptions();
 
         $definition = new InputDefinition([$this->foo]);
-        $this->assertEquals(['foo' => $this->foo], $definition->getOptions(), '->setOptions() sets the array of InputOption objects');
+        $this->assertSame(['foo' => $this->foo], $definition->getOptions(), '->setOptions() sets the array of InputOption objects');
         $definition->setOptions([$this->bar]);
-        $this->assertEquals(['bar' => $this->bar], $definition->getOptions(), '->setOptions() clears all InputOption objects');
+        $this->assertSame(['bar' => $this->bar], $definition->getOptions(), '->setOptions() clears all InputOption objects');
     }
 
     public function testSetOptionsClearsOptions()
@@ -215,9 +215,9 @@ class InputDefinitionTest extends TestCase
         $this->initializeOptions();
 
         $definition = new InputDefinition([$this->foo]);
-        $this->assertEquals(['foo' => $this->foo], $definition->getOptions(), '->addOptions() adds an array of InputOption objects');
+        $this->assertSame(['foo' => $this->foo], $definition->getOptions(), '->addOptions() adds an array of InputOption objects');
         $definition->addOptions([$this->bar]);
-        $this->assertEquals(['foo' => $this->foo, 'bar' => $this->bar], $definition->getOptions(), '->addOptions() does not clear existing InputOption objects');
+        $this->assertSame(['foo' => $this->foo, 'bar' => $this->bar], $definition->getOptions(), '->addOptions() does not clear existing InputOption objects');
     }
 
     public function testAddOption()
@@ -226,9 +226,9 @@ class InputDefinitionTest extends TestCase
 
         $definition = new InputDefinition();
         $definition->addOption($this->foo);
-        $this->assertEquals(['foo' => $this->foo], $definition->getOptions(), '->addOption() adds a InputOption object');
+        $this->assertSame(['foo' => $this->foo], $definition->getOptions(), '->addOption() adds a InputOption object');
         $definition->addOption($this->bar);
-        $this->assertEquals(['foo' => $this->foo, 'bar' => $this->bar], $definition->getOptions(), '->addOption() adds a InputOption object');
+        $this->assertSame(['foo' => $this->foo, 'bar' => $this->bar], $definition->getOptions(), '->addOption() adds a InputOption object');
     }
 
     public function testAddDuplicateOption()
@@ -278,7 +278,7 @@ class InputDefinitionTest extends TestCase
         $this->initializeOptions();
 
         $definition = new InputDefinition([$this->foo]);
-        $this->assertEquals($this->foo, $definition->getOption('foo'), '->getOption() returns a InputOption by its name');
+        $this->assertSame($this->foo, $definition->getOption('foo'), '->getOption() returns a InputOption by its name');
     }
 
     public function testGetInvalidOption()
@@ -314,7 +314,7 @@ class InputDefinitionTest extends TestCase
         $this->initializeOptions();
 
         $definition = new InputDefinition([$this->foo]);
-        $this->assertEquals($this->foo, $definition->getOptionForShortcut('f'), '->getOptionForShortcut() returns a InputOption by its shortcut');
+        $this->assertSame($this->foo, $definition->getOptionForShortcut('f'), '->getOptionForShortcut() returns a InputOption by its shortcut');
     }
 
     public function testGetOptionForMultiShortcut()
@@ -322,8 +322,8 @@ class InputDefinitionTest extends TestCase
         $this->initializeOptions();
 
         $definition = new InputDefinition([$this->multi]);
-        $this->assertEquals($this->multi, $definition->getOptionForShortcut('m'), '->getOptionForShortcut() returns a InputOption by its shortcut');
-        $this->assertEquals($this->multi, $definition->getOptionForShortcut('mmm'), '->getOptionForShortcut() returns a InputOption by its shortcut');
+        $this->assertSame($this->multi, $definition->getOptionForShortcut('m'), '->getOptionForShortcut() returns a InputOption by its shortcut');
+        $this->assertSame($this->multi, $definition->getOptionForShortcut('mmm'), '->getOptionForShortcut() returns a InputOption by its shortcut');
     }
 
     public function testGetOptionForInvalidShortcut()
@@ -364,7 +364,7 @@ class InputDefinitionTest extends TestCase
      */
     public function testGetSynopsis(InputDefinition $definition, $expectedSynopsis, $message = null)
     {
-        $this->assertEquals($expectedSynopsis, $definition->getSynopsis(), $message ? '->getSynopsis() '.$message : '');
+        $this->assertSame($expectedSynopsis, $definition->getSynopsis(), $message ? '->getSynopsis() '.$message : '');
     }
 
     public static function getGetSynopsisData()
@@ -388,7 +388,7 @@ class InputDefinitionTest extends TestCase
     public function testGetShortSynopsis()
     {
         $definition = new InputDefinition([new InputOption('foo'), new InputOption('bar'), new InputArgument('cat')]);
-        $this->assertEquals('[options] [--] [<cat>]', $definition->getSynopsis(true), '->getSynopsis(true) groups options in [options]');
+        $this->assertSame('[options] [--] [<cat>]', $definition->getSynopsis(true), '->getSynopsis(true) groups options in [options]');
     }
 
     protected function initializeArguments()

--- a/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
@@ -23,9 +23,9 @@ class InputOptionTest extends TestCase
     public function testConstructor()
     {
         $option = new InputOption('foo');
-        $this->assertEquals('foo', $option->getName(), '__construct() takes a name as its first argument');
+        $this->assertSame('foo', $option->getName(), '__construct() takes a name as its first argument');
         $option = new InputOption('--foo');
-        $this->assertEquals('foo', $option->getName(), '__construct() removes the leading -- of the option name');
+        $this->assertSame('foo', $option->getName(), '__construct() removes the leading -- of the option name');
     }
 
     public function testArrayModeWithoutValue()
@@ -52,11 +52,11 @@ class InputOptionTest extends TestCase
     public function testShortcut()
     {
         $option = new InputOption('foo', 'f');
-        $this->assertEquals('f', $option->getShortcut(), '__construct() can take a shortcut as its second argument');
+        $this->assertSame('f', $option->getShortcut(), '__construct() can take a shortcut as its second argument');
         $option = new InputOption('foo', '-f|-ff|fff');
-        $this->assertEquals('f|ff|fff', $option->getShortcut(), '__construct() removes the leading - of the shortcuts');
+        $this->assertSame('f|ff|fff', $option->getShortcut(), '__construct() removes the leading - of the shortcuts');
         $option = new InputOption('foo', ['f', 'ff', '-fff']);
-        $this->assertEquals('f|ff|fff', $option->getShortcut(), '__construct() removes the leading - of the shortcuts');
+        $this->assertSame('f|ff|fff', $option->getShortcut(), '__construct() removes the leading - of the shortcuts');
         $option = new InputOption('foo');
         $this->assertNull($option->getShortcut(), '__construct() makes the shortcut null by default');
         $option = new InputOption('foo', '');
@@ -64,15 +64,15 @@ class InputOptionTest extends TestCase
         $option = new InputOption('foo', []);
         $this->assertNull($option->getShortcut(), '__construct() makes the shortcut null when given an empty array');
         $option = new InputOption('foo', ['f', '', 'fff']);
-        $this->assertEquals('f|fff', $option->getShortcut(), '__construct() removes empty shortcuts');
+        $this->assertSame('f|fff', $option->getShortcut(), '__construct() removes empty shortcuts');
         $option = new InputOption('foo', 'f||fff');
-        $this->assertEquals('f|fff', $option->getShortcut(), '__construct() removes empty shortcuts');
+        $this->assertSame('f|fff', $option->getShortcut(), '__construct() removes empty shortcuts');
         $option = new InputOption('foo', '0');
-        $this->assertEquals('0', $option->getShortcut(), '-0 is an acceptable shortcut value');
+        $this->assertSame('0', $option->getShortcut(), '-0 is an acceptable shortcut value');
         $option = new InputOption('foo', ['0', 'z']);
-        $this->assertEquals('0|z', $option->getShortcut(), '-0 is an acceptable shortcut value when embedded in an array');
+        $this->assertSame('0|z', $option->getShortcut(), '-0 is an acceptable shortcut value when embedded in an array');
         $option = new InputOption('foo', '0|z');
-        $this->assertEquals('0|z', $option->getShortcut(), '-0 is an acceptable shortcut value when embedded in a string-list');
+        $this->assertSame('0|z', $option->getShortcut(), '-0 is an acceptable shortcut value when embedded in a string-list');
         $option = new InputOption('foo', false);
         $this->assertNull($option->getShortcut(), '__construct() makes the shortcut null when given a false as value');
     }
@@ -142,22 +142,22 @@ class InputOptionTest extends TestCase
     public function testGetDescription()
     {
         $option = new InputOption('foo', 'f', null, 'Some description');
-        $this->assertEquals('Some description', $option->getDescription(), '->getDescription() returns the description message');
+        $this->assertSame('Some description', $option->getDescription(), '->getDescription() returns the description message');
     }
 
     public function testGetDefault()
     {
         $option = new InputOption('foo', null, InputOption::VALUE_OPTIONAL, '', 'default');
-        $this->assertEquals('default', $option->getDefault(), '->getDefault() returns the default value');
+        $this->assertSame('default', $option->getDefault(), '->getDefault() returns the default value');
 
         $option = new InputOption('foo', null, InputOption::VALUE_REQUIRED, '', 'default');
-        $this->assertEquals('default', $option->getDefault(), '->getDefault() returns the default value');
+        $this->assertSame('default', $option->getDefault(), '->getDefault() returns the default value');
 
         $option = new InputOption('foo', null, InputOption::VALUE_REQUIRED);
         $this->assertNull($option->getDefault(), '->getDefault() returns null if no default value is configured');
 
         $option = new InputOption('foo', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY);
-        $this->assertEquals([], $option->getDefault(), '->getDefault() returns an empty array if option is an array');
+        $this->assertSame([], $option->getDefault(), '->getDefault() returns an empty array if option is an array');
 
         $option = new InputOption('foo', null, InputOption::VALUE_NONE);
         $this->assertFalse($option->getDefault(), '->getDefault() returns false if the option does not take a value');
@@ -169,11 +169,11 @@ class InputOptionTest extends TestCase
         $option->setDefault(null);
         $this->assertNull($option->getDefault(), '->setDefault() can reset the default value by passing null');
         $option->setDefault('another');
-        $this->assertEquals('another', $option->getDefault(), '->setDefault() changes the default value');
+        $this->assertSame('another', $option->getDefault(), '->setDefault() changes the default value');
 
         $option = new InputOption('foo', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY);
         $option->setDefault([1, 2]);
-        $this->assertEquals([1, 2], $option->getDefault(), '->setDefault() changes the default value');
+        $this->assertSame([1, 2], $option->getDefault(), '->setDefault() changes the default value');
     }
 
     public function testDefaultValueWithValueNoneMode()

--- a/src/Symfony/Component/Console/Tests/Input/InputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputTest.php
@@ -22,29 +22,29 @@ class InputTest extends TestCase
     public function testConstructor()
     {
         $input = new ArrayInput(['name' => 'foo'], new InputDefinition([new InputArgument('name')]));
-        $this->assertEquals('foo', $input->getArgument('name'), '->__construct() takes a InputDefinition as an argument');
+        $this->assertSame('foo', $input->getArgument('name'), '->__construct() takes a InputDefinition as an argument');
     }
 
     public function testOptions()
     {
         $input = new ArrayInput(['--name' => 'foo'], new InputDefinition([new InputOption('name')]));
-        $this->assertEquals('foo', $input->getOption('name'), '->getOption() returns the value for the given option');
+        $this->assertSame('foo', $input->getOption('name'), '->getOption() returns the value for the given option');
 
         $input->setOption('name', 'bar');
-        $this->assertEquals('bar', $input->getOption('name'), '->setOption() sets the value for a given option');
-        $this->assertEquals(['name' => 'bar'], $input->getOptions(), '->getOptions() returns all option values');
+        $this->assertSame('bar', $input->getOption('name'), '->setOption() sets the value for a given option');
+        $this->assertSame(['name' => 'bar'], $input->getOptions(), '->getOptions() returns all option values');
 
         $input = new ArrayInput(['--name' => 'foo'], new InputDefinition([new InputOption('name'), new InputOption('bar', '', InputOption::VALUE_OPTIONAL, '', 'default')]));
-        $this->assertEquals('default', $input->getOption('bar'), '->getOption() returns the default value for optional options');
-        $this->assertEquals(['name' => 'foo', 'bar' => 'default'], $input->getOptions(), '->getOptions() returns all option values, even optional ones');
+        $this->assertSame('default', $input->getOption('bar'), '->getOption() returns the default value for optional options');
+        $this->assertSame(['name' => 'foo', 'bar' => 'default'], $input->getOptions(), '->getOptions() returns all option values, even optional ones');
 
         $input = new ArrayInput(['--name' => 'foo', '--bar' => ''], new InputDefinition([new InputOption('name'), new InputOption('bar', '', InputOption::VALUE_OPTIONAL, '', 'default')]));
-        $this->assertEquals('', $input->getOption('bar'), '->getOption() returns null for options explicitly passed without value (or an empty value)');
-        $this->assertEquals(['name' => 'foo', 'bar' => ''], $input->getOptions(), '->getOptions() returns all option values.');
+        $this->assertSame('', $input->getOption('bar'), '->getOption() returns null for options explicitly passed without value (or an empty value)');
+        $this->assertSame(['name' => 'foo', 'bar' => ''], $input->getOptions(), '->getOptions() returns all option values.');
 
         $input = new ArrayInput(['--name' => 'foo', '--bar' => null], new InputDefinition([new InputOption('name'), new InputOption('bar', '', InputOption::VALUE_OPTIONAL, '', 'default')]));
         $this->assertNull($input->getOption('bar'), '->getOption() returns null for options explicitly passed without value (or an empty value)');
-        $this->assertEquals(['name' => 'foo', 'bar' => null], $input->getOptions(), '->getOptions() returns all option values');
+        $this->assertSame(['name' => 'foo', 'bar' => null], $input->getOptions(), '->getOptions() returns all option values');
 
         $input = new ArrayInput(['--name' => null], new InputDefinition([new InputOption('name', null, InputOption::VALUE_NEGATABLE)]));
         $this->assertTrue($input->hasOption('name'));
@@ -84,15 +84,15 @@ class InputTest extends TestCase
     public function testArguments()
     {
         $input = new ArrayInput(['name' => 'foo'], new InputDefinition([new InputArgument('name')]));
-        $this->assertEquals('foo', $input->getArgument('name'), '->getArgument() returns the value for the given argument');
+        $this->assertSame('foo', $input->getArgument('name'), '->getArgument() returns the value for the given argument');
 
         $input->setArgument('name', 'bar');
-        $this->assertEquals('bar', $input->getArgument('name'), '->setArgument() sets the value for a given argument');
-        $this->assertEquals(['name' => 'bar'], $input->getArguments(), '->getArguments() returns all argument values');
+        $this->assertSame('bar', $input->getArgument('name'), '->setArgument() sets the value for a given argument');
+        $this->assertSame(['name' => 'bar'], $input->getArguments(), '->getArguments() returns all argument values');
 
         $input = new ArrayInput(['name' => 'foo'], new InputDefinition([new InputArgument('name'), new InputArgument('bar', InputArgument::OPTIONAL, '', 'default')]));
-        $this->assertEquals('default', $input->getArgument('bar'), '->getArgument() returns the default value for optional arguments');
-        $this->assertEquals(['name' => 'foo', 'bar' => 'default'], $input->getArguments(), '->getArguments() returns all argument values, even optional ones');
+        $this->assertSame('default', $input->getArgument('bar'), '->getArgument() returns the default value for optional arguments');
+        $this->assertSame(['name' => 'foo', 'bar' => 'default'], $input->getArguments(), '->getArguments() returns all argument values, even optional ones');
     }
 
     public function testSetInvalidArgument()

--- a/src/Symfony/Component/Console/Tests/Input/StringInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/StringInputTest.php
@@ -27,7 +27,7 @@ class StringInputTest extends TestCase
         $input = new StringInput($input);
         $r = new \ReflectionClass(ArgvInput::class);
         $p = $r->getProperty('tokens');
-        $this->assertEquals($tokens, $p->getValue($input), $message);
+        $this->assertSame($tokens, $p->getValue($input), $message);
     }
 
     public function testInputOptionWithGivenString()
@@ -39,7 +39,7 @@ class StringInputTest extends TestCase
         // call to bind
         $input = new StringInput('--foo=bar');
         $input->bind($definition);
-        $this->assertEquals('bar', $input->getOption('foo'));
+        $this->assertSame('bar', $input->getOption('foo'));
     }
 
     public static function getTokenizeData()
@@ -77,12 +77,12 @@ class StringInputTest extends TestCase
     public function testToString()
     {
         $input = new StringInput('-f foo');
-        $this->assertEquals('-f foo', (string) $input);
+        $this->assertSame('-f foo', (string) $input);
 
         $input = new StringInput('-f --bar=foo "a b c d"');
-        $this->assertEquals('-f --bar=foo '.escapeshellarg('a b c d'), (string) $input);
+        $this->assertSame('-f --bar=foo '.escapeshellarg('a b c d'), (string) $input);
 
         $input = new StringInput('-f --bar=foo \'a b c d\' '."'A\nB\\'C'");
-        $this->assertEquals('-f --bar=foo '.escapeshellarg('a b c d').' '.escapeshellarg("A\nB'C"), (string) $input);
+        $this->assertSame('-f --bar=foo '.escapeshellarg('a b c d').' '.escapeshellarg("A\nB'C"), (string) $input);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no (test refactor)
| New feature?  | no
| Deprecations? | no
| Issues        | None
| License       | MIT

This is a test refactor hence I am targeting 7.2 to avoid propagating noise. I originally intended to do it as part of #57598 as per @OskarStark comment but it turns out there is a few side effects so I preferred a dedicated PR to avoid confusion.
