### PR TITLE
[HttpClient] Prevent setting a `\Closure` as header value

### DIFF
--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -292,7 +292,7 @@ trait HttpClientTrait
                 [$name, $values] = explode(':', $values, 2);
                 $values = [ltrim($values)];
             } elseif (!is_iterable($values)) {
-                if (\is_object($values)) {
+                if (!\is_string($values)) {
                     throw new InvalidArgumentException(\sprintf('Invalid value for header "%s": expected string, "%s" given.', $name, get_debug_type($values)));
                 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2 
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no 
| Issues        | Fix #58439
| License       | MIT

There was no test checking the `InvalidArgumentException` but I can add one.