### PR TITLE
[HttpClient] Fix destructor throwing while timeout was handled

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/TransportResponseTrait.php
+++ b/src/Symfony/Component/HttpClient/Response/TransportResponseTrait.php
@@ -45,6 +45,7 @@ trait TransportResponseTrait
     private \InflateContext|bool|null $inflate = null;
     private ?array $finalInfo = null;
     private ?LoggerInterface $logger = null;
+    private bool $didTimeout = false;
 
     public function getStatusCode(): int
     {
@@ -126,7 +127,7 @@ trait TransportResponseTrait
     {
         $this->shouldBuffer = true;
 
-        if ($this->initializer && null === $this->info['error']) {
+        if ($this->initializer && null === $this->info['error'] && !$this->didTimeout) {
             self::initialize($this);
             $this->checkStatusCode();
         }
@@ -183,6 +184,7 @@ trait TransportResponseTrait
                         unset($responses[$j]);
                         continue;
                     } elseif ($elapsedTimeout >= $timeoutMax) {
+                        $response->didTimeout = true;
                         $multi->handlesActivity[$j] = [new ErrorChunk($response->offset, \sprintf('Idle timeout reached for "%s".', $response->getInfo('url')))];
                         $multi->lastTimeout ??= $lastActivity;
                         $elapsedTimeout = $timeoutMax;

--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpClient\Exception\InvalidArgumentException;
 use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpClient\Internal\ClientState;
 use Symfony\Component\HttpClient\NoPrivateNetworkHttpClient;
+use Symfony\Component\HttpClient\RetryableHttpClient;
 use Symfony\Component\HttpClient\Response\StreamWrapper;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
@@ -650,6 +651,55 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
         ]);
 
         $this->assertSame(['abc' => 'def', 'content-type' => 'application/json', 'REQUEST_METHOD' => 'POST'], $response->toArray());
+    }
+
+    public function testDoesNotThrowOnDestructIfExceptionCaughtEarlierWithGetStatusCode()
+    {
+        $client = new RetryableHttpClient($this->getHttpClient(__FUNCTION__));
+        $client = $client->withOptions([
+            'max_duration' => 0.1,
+            'timeout' => 0.1,
+        ]);
+
+        $response = $client->request('GET', 'https://127.0.0.1:8000/api/cheeses');
+
+        try {
+            $response->getStatusCode();
+            $this->fail('TransportException expected');
+        } catch (TransportException) {
+        }
+
+        try {
+            unset($response);
+        } catch (TransportException $e) {
+            $this->fail('Caught '.$e::class.'('.$e->getMessage().') but destruct should not throw');
+        }
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testDoesNotThrowOnDestructIfExceptionCaughtEarlierEvenWithoutGetStatusCode()
+    {
+        $client = new RetryableHttpClient($this->getHttpClient(__FUNCTION__));
+        $client = $client->withOptions([
+            'max_duration' => 0.1,
+            'timeout' => 0.1,
+        ]);
+
+        $response = $client->request('GET', 'https://127.0.0.1:8000/api/cheeses');
+
+        try {
+            foreach ($client->stream($response) as $chunk) {
+            }
+            $this->fail('TransportException expected');
+        } catch (TransportException) {
+        }
+
+        try {
+            unset($response);
+        } catch (TransportException $e) {
+            $this->fail('Caught '.$e::class.'('.$e->getMessage().') but destruct should not throw');
+        }
+        $this->expectNotToPerformAssertions();
     }
 
     public function testHeadRequestWithClosureBody()

--- a/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
@@ -580,4 +580,14 @@ class MockHttpClientTest extends HttpClientTestCase
         $client->request('GET', 'https://example.com');
         $client->request('GET', 'https://example.com');
     }
+
+    public function testDoesNotThrowOnDestructIfExceptionCaughtEarlierWithGetStatusCode()
+    {
+        $this->markTestSkipped('Not supported');
+    }
+
+    public function testDoesNotThrowOnDestructIfExceptionCaughtEarlierEvenWithoutGetStatusCode()
+    {
+        $this->markTestSkipped('Not supported');
+    }
 }


### PR DESCRIPTION
Special PR for @nicolas-grekas with a failing test

Note how the first command passes, but the second fails 
```
../../../../vendor/bin/simple-phpunit --filter testDoesNotThrowOnDestructIfExceptionCaughtEarlierWithGetStatusCode
../../../../vendor/bin/simple-phpunit --filter testDoesNotThrowOnDestructIfExceptionCaughtEarlierEvenWithoutGetStatusCode
```

I manually trigger __destruct in the test, but if not it then throws at the end of the phpunit execution.

calling `$response->getStatusCode()` to trigger `response::initialize` is the only difference between the two test cases.