### PR TITLE
[ExpressionLanguage] Improve tests on `BinaryNode`

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Node/BinaryNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/BinaryNode.php
@@ -152,10 +152,6 @@ class BinaryNode extends Node
                 return $left >= $right;
             case '<=':
                 return $left <= $right;
-            case 'not in':
-                return !\in_array($left, $right, true);
-            case 'in':
-                return \in_array($left, $right, true);
             case '+':
                 return $left + $right;
             case '-':
@@ -179,6 +175,8 @@ class BinaryNode extends Node
             case 'matches':
                 return $this->evaluateMatches($right, $left);
         }
+
+        throw new \LogicException(\sprintf('"%s" does not support the "%s" operator.', __CLASS__, $operator));
     }
 
     public function toArray(): array

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/BinaryNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/BinaryNodeTest.php
@@ -258,4 +258,14 @@ class BinaryNodeTest extends AbstractNodeTestCase
 
         $this->assertFalse($node->evaluate([], []));
     }
+
+    public function testEvaluateUnsupportedOperator()
+    {
+        $node = new BinaryNode('unsupported', new ConstantNode(1), new ConstantNode(2));
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('"Symfony\Component\ExpressionLanguage\Node\BinaryNode" does not support the "unsupported" operator.');
+
+        $node->evaluate([], []);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`in` and `not in` have a shortcut above the operator switch. Also, `BinaryNode::evaluate()` may throw an error, lacking a return value when the operator is unsupported.