### PR TITLE
[ExpressionLanguage] Add missing test case for `Lexer`

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Tests/LexerTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/LexerTest.php
@@ -54,6 +54,16 @@ class LexerTest extends TestCase
         $this->lexer->tokenize($expression);
     }
 
+    public function testTokenizeOnNotOpenedBracket()
+    {
+        $this->expectException(SyntaxError::class);
+        $this->expectExceptionMessage('Unexpected ")" around position 7 for expression `service)not.opened.expression.dummyMethod()`.');
+
+        $expression = 'service)not.opened.expression.dummyMethod()';
+
+        $this->lexer->tokenize($expression);
+    }
+
     public static function getTokenizeData()
     {
         return [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Adds a missing test case for `Lexer`. Unclosed brackets are already tested, but not closing bracket without abnormal opening one.