### PR TITLE
[FrameworkBundle] Add support for setting headers to `TemplateController::__invoke()`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/TemplateController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/TemplateController.php
@@ -71,8 +71,8 @@ class TemplateController
     /**
      * @param int $statusCode The HTTP status code (200 "OK" by default)
      */
-    public function __invoke(string $template, ?int $maxAge = null, ?int $sharedAge = null, ?bool $private = null, array $context = [], int $statusCode = 200): Response
+    public function __invoke(string $template, ?int $maxAge = null, ?int $sharedAge = null, ?bool $private = null, array $context = [], int $statusCode = 200, array $headers = []): Response
     {
-        return $this->templateAction($template, $maxAge, $sharedAge, $private, $context, $statusCode);
+        return $this->templateAction($template, $maxAge, $sharedAge, $private, $context, $statusCode, $headers);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/TemplateControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/TemplateControllerTest.php
@@ -21,6 +21,19 @@ use Twig\Loader\ArrayLoader;
  */
 class TemplateControllerTest extends TestCase
 {
+    public function testMethodSignaturesMatch()
+    {
+        $ref = new \ReflectionClass(TemplateController::class);
+
+        $templateActionRef = $ref->getMethod('templateAction');
+        $invokeRef = $ref->getMethod('__invoke');
+
+        $this->assertSame(
+            array_map(strval(...), $templateActionRef->getParameters()),
+            array_map(strval(...), $invokeRef->getParameters()),
+        );
+    }
+
     public function testTwig()
     {
         $twig = $this->createMock(Environment::class);
@@ -82,7 +95,10 @@ class TemplateControllerTest extends TestCase
         $controller = new TemplateController($twig);
 
         $this->assertSame(201, $controller->templateAction($templateName, null, null, null, [], $statusCode)->getStatusCode());
+        $this->assertSame(201, $controller($templateName, null, null, null, [], $statusCode)->getStatusCode());
+
         $this->assertSame(200, $controller->templateAction($templateName)->getStatusCode());
+        $this->assertSame(200, $controller($templateName)->getStatusCode());
     }
 
     public function testHeaders()
@@ -96,6 +112,9 @@ class TemplateControllerTest extends TestCase
         $controller = new TemplateController($twig);
 
         $this->assertSame('image/svg+xml', $controller->templateAction($templateName, headers: ['Content-Type' => 'image/svg+xml'])->headers->get('Content-Type'));
+        $this->assertSame('image/svg+xml', $controller($templateName, headers: ['Content-Type' => 'image/svg+xml'])->headers->get('Content-Type'));
+
         $this->assertNull($controller->templateAction($templateName)->headers->get('Content-Type'));
+        $this->assertNull($controller($templateName)->headers->get('Content-Type'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Followup to #54678

Looks like I forgot to add it to the `__invoke()` method, :facepalm: 