### PR TITLE
[PhpUnitBridge] support `ClockMock` and `DnsMock` with PHPUnit 10+

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -239,3 +239,11 @@ jobs:
           mkdir -p /opt/php/lib
           echo memory_limit=-1 > /opt/php/lib/php.ini
           ./build/php/bin/php ./phpunit --colors=always src/Symfony/Component/Process
+
+      - name: Run PhpUnitBridge tests with PHPUnit 11
+        if: '! matrix.mode'
+        run: |
+          ./phpunit src/Symfony/Bridge/PhpUnit
+        env:
+          SYMFONY_PHPUNIT_VERSION: '11.3'
+          SYMFONY_DEPRECATIONS_HELPER: 'disabled'

--- a/src/Symfony/Bridge/PhpUnit/CHANGELOG.md
+++ b/src/Symfony/Bridge/PhpUnit/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 7.2
 ---
 
+ * Add a PHPUnit extension that registers the clock mock and DNS mock and the `DebugClassLoader` from the ErrorHandler component if present
  * Add `ExpectUserDeprecationMessageTrait` with a polyfill of PHPUnit's `expectUserDeprecationMessage()`
  * Use `total` for asserting deprecation count when a group is not defined
 

--- a/src/Symfony/Bridge/PhpUnit/Extension/DisableClockMockSubscriber.php
+++ b/src/Symfony/Bridge/PhpUnit/Extension/DisableClockMockSubscriber.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Extension;
+
+use PHPUnit\Event\Code\TestMethod;
+use PHPUnit\Event\Test\Finished;
+use PHPUnit\Event\Test\FinishedSubscriber;
+use PHPUnit\Metadata\Group;
+use Symfony\Bridge\PhpUnit\ClockMock;
+
+/**
+ * @internal
+ */
+class DisableClockMockSubscriber implements FinishedSubscriber
+{
+    public function notify(Finished $event): void
+    {
+        $test = $event->test();
+
+        if (!$test instanceof TestMethod) {
+            return;
+        }
+
+        foreach ($test->metadata() as $metadata) {
+            if ($metadata instanceof Group && 'time-sensitive' === $metadata->groupName()) {
+                ClockMock::withClockMock(false);
+            }
+        }
+    }
+}

--- a/src/Symfony/Bridge/PhpUnit/Extension/DisableDnsMockSubscriber.php
+++ b/src/Symfony/Bridge/PhpUnit/Extension/DisableDnsMockSubscriber.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Extension;
+
+use PHPUnit\Event\Code\TestMethod;
+use PHPUnit\Event\Test\Finished;
+use PHPUnit\Event\Test\FinishedSubscriber;
+use PHPUnit\Metadata\Group;
+use Symfony\Bridge\PhpUnit\DnsMock;
+
+/**
+ * @internal
+ */
+class DisableDnsMockSubscriber implements FinishedSubscriber
+{
+    public function notify(Finished $event): void
+    {
+        $test = $event->test();
+
+        if (!$test instanceof TestMethod) {
+            return;
+        }
+
+        foreach ($test->metadata() as $metadata) {
+            if ($metadata instanceof Group && 'dns-sensitive' === $metadata->groupName()) {
+                DnsMock::withMockedHosts([]);
+            }
+        }
+    }
+}

--- a/src/Symfony/Bridge/PhpUnit/Extension/EnableClockMockSubscriber.php
+++ b/src/Symfony/Bridge/PhpUnit/Extension/EnableClockMockSubscriber.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Extension;
+
+use PHPUnit\Event\Code\TestMethod;
+use PHPUnit\Event\Test\PreparationStarted;
+use PHPUnit\Event\Test\PreparationStartedSubscriber;
+use PHPUnit\Metadata\Group;
+use Symfony\Bridge\PhpUnit\ClockMock;
+
+/**
+ * @internal
+ */
+class EnableClockMockSubscriber implements PreparationStartedSubscriber
+{
+    public function notify(PreparationStarted $event): void
+    {
+        $test = $event->test();
+
+        if (!$test instanceof TestMethod) {
+            return;
+        }
+
+        foreach ($test->metadata() as $metadata) {
+            if ($metadata instanceof Group && 'time-sensitive' === $metadata->groupName()) {
+                ClockMock::withClockMock(true);
+            }
+        }
+    }
+}

--- a/src/Symfony/Bridge/PhpUnit/Extension/RegisterClockMockSubscriber.php
+++ b/src/Symfony/Bridge/PhpUnit/Extension/RegisterClockMockSubscriber.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Extension;
+
+use PHPUnit\Event\Code\TestMethod;
+use PHPUnit\Event\TestSuite\Loaded;
+use PHPUnit\Event\TestSuite\LoadedSubscriber;
+use PHPUnit\Metadata\Group;
+use Symfony\Bridge\PhpUnit\ClockMock;
+
+/**
+ * @internal
+ */
+class RegisterClockMockSubscriber implements LoadedSubscriber
+{
+    public function notify(Loaded $event): void
+    {
+        foreach ($event->testSuite()->tests() as $test) {
+            if (!$test instanceof TestMethod) {
+                continue;
+            }
+
+            foreach ($test->metadata() as $metadata) {
+                if ($metadata instanceof Group && 'time-sensitive' === $metadata->groupName()) {
+                    ClockMock::register($test->className());
+                }
+            }
+        }
+    }
+}

--- a/src/Symfony/Bridge/PhpUnit/Extension/RegisterDnsMockSubscriber.php
+++ b/src/Symfony/Bridge/PhpUnit/Extension/RegisterDnsMockSubscriber.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Extension;
+
+use PHPUnit\Event\Code\TestMethod;
+use PHPUnit\Event\TestSuite\Loaded;
+use PHPUnit\Event\TestSuite\LoadedSubscriber;
+use PHPUnit\Metadata\Group;
+use Symfony\Bridge\PhpUnit\DnsMock;
+
+/**
+ * @internal
+ */
+class RegisterDnsMockSubscriber implements LoadedSubscriber
+{
+    public function notify(Loaded $event): void
+    {
+        foreach ($event->testSuite()->tests() as $test) {
+            if (!$test instanceof TestMethod) {
+                continue;
+            }
+
+            foreach ($test->metadata() as $metadata) {
+                if ($metadata instanceof Group && 'dns-sensitive' === $metadata->groupName()) {
+                    DnsMock::register($test->className());
+                }
+            }
+        }
+    }
+}

--- a/src/Symfony/Bridge/PhpUnit/SymfonyExtension.php
+++ b/src/Symfony/Bridge/PhpUnit/SymfonyExtension.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit;
+
+use PHPUnit\Runner\Extension\Extension;
+use PHPUnit\Runner\Extension\Facade;
+use PHPUnit\Runner\Extension\ParameterCollection;
+use PHPUnit\TextUI\Configuration\Configuration;
+use Symfony\Bridge\PhpUnit\Extension\DisableClockMockSubscriber;
+use Symfony\Bridge\PhpUnit\Extension\DisableDnsMockSubscriber;
+use Symfony\Bridge\PhpUnit\Extension\EnableClockMockSubscriber;
+use Symfony\Bridge\PhpUnit\Extension\RegisterClockMockSubscriber;
+use Symfony\Bridge\PhpUnit\Extension\RegisterDnsMockSubscriber;
+use Symfony\Component\ErrorHandler\DebugClassLoader;
+
+class SymfonyExtension implements Extension
+{
+    public function bootstrap(Configuration $configuration, Facade $facade, ParameterCollection $parameters): void
+    {
+        if (class_exists(DebugClassLoader::class)) {
+            DebugClassLoader::enable();
+        }
+
+        if ($parameters->has('clock-mock-namespaces')) {
+            foreach (explode(',', $parameters->get('clock-mock-namespaces')) as $namespace) {
+                ClockMock::register($namespace.'\DummyClass');
+            }
+        }
+
+        $facade->registerSubscriber(new RegisterClockMockSubscriber());
+        $facade->registerSubscriber(new EnableClockMockSubscriber());
+        $facade->registerSubscriber(new DisableClockMockSubscriber());
+
+        if ($parameters->has('dns-mock-namespaces')) {
+            foreach (explode(',', $parameters->get('dns-mock-namespaces')) as $namespace) {
+                DnsMock::register($namespace.'\DummyClass');
+            }
+        }
+
+        $facade->registerSubscriber(new RegisterDnsMockSubscriber());
+        $facade->registerSubscriber(new DisableDnsMockSubscriber());
+    }
+}

--- a/src/Symfony/Bridge/PhpUnit/Tests/CoverageListenerTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/CoverageListenerTest.php
@@ -13,6 +13,9 @@ namespace Symfony\Bridge\PhpUnit\Tests;
 
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @requires PHPUnit < 10
+ */
 class CoverageListenerTest extends TestCase
 {
     public function test()

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/ConfigurationTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/ConfigurationTest.php
@@ -463,6 +463,9 @@ class ConfigurationTest extends TestCase
         $this->assertEquals(json_encode($expected, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES), file_get_contents($filename));
     }
 
+    /**
+     * @requires PHPUnit < 10
+     */
     public function testBaselineGenerationWithDeprecationTriggeredByDebugClassLoader()
     {
         $filename = $this->createFile();

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/log_file.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/log_file.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test DeprecationErrorHandler with log file
+--SKIPIF--
+<?php if (!getenv('SYMFONY_PHPUNIT_VERSION') || version_compare(getenv('SYMFONY_PHPUNIT_VERSION'), '10.0', '>=')) die('Skipping on PHPUnit 10+');
 --FILE--
 <?php
 $filename = tempnam(sys_get_temp_dir(), 'sf-');

--- a/src/Symfony/Bridge/PhpUnit/Tests/ExpectDeprecationTraitTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/ExpectDeprecationTraitTest.php
@@ -14,6 +14,9 @@ namespace Symfony\Bridge\PhpUnit\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
+/**
+ * @requires PHPUnit < 10
+ */
 final class ExpectDeprecationTraitTest extends TestCase
 {
     use ExpectDeprecationTrait;

--- a/src/Symfony/Bridge/PhpUnit/Tests/ExpectedDeprecationAnnotationTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/ExpectedDeprecationAnnotationTest.php
@@ -13,6 +13,9 @@ namespace Symfony\Bridge\PhpUnit\Tests;
 
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @requires PHPUnit < 10
+ */
 final class ExpectedDeprecationAnnotationTest extends TestCase
 {
     /**

--- a/src/Symfony/Bridge/PhpUnit/Tests/FailTests/ExpectDeprecationTraitTestFail.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/FailTests/ExpectDeprecationTraitTestFail.php
@@ -19,6 +19,8 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
  *
  * This class is deliberately suffixed with *TestFail.php so that it is ignored
  * by PHPUnit. This test is designed to fail. See ../expectdeprecationfail.phpt.
+ *
+ * @requires PHPUnit < 10
  */
 final class ExpectDeprecationTraitTestFail extends TestCase
 {

--- a/src/Symfony/Bridge/PhpUnit/Tests/FailTests/NoAssertionsTestNotRisky.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/FailTests/NoAssertionsTestNotRisky.php
@@ -17,6 +17,8 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 /**
  * This class is deliberately suffixed with *TestRisky.php so that it is ignored
  * by PHPUnit. This test is designed to fail. See ../expectnotrisky.phpt.
+ *
+ * @requires PHPUnit < 10
  */
 final class NoAssertionsTestNotRisky extends TestCase
 {

--- a/src/Symfony/Bridge/PhpUnit/Tests/FailTests/NoAssertionsTestRisky.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/FailTests/NoAssertionsTestRisky.php
@@ -17,6 +17,8 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 /**
  * This class is deliberately suffixed with *TestRisky.php so that it is ignored
  * by PHPUnit. This test is designed to fail. See ../expectrisky.phpt.
+ *
+ * @requires PHPUnit < 10
  */
 final class NoAssertionsTestRisky extends TestCase
 {

--- a/src/Symfony/Bridge/PhpUnit/Tests/Fixtures/symfonyextension/phpunit-with-extension.xml.dist
+++ b/src/Symfony/Bridge/PhpUnit/Tests/Fixtures/symfonyextension/phpunit-with-extension.xml.dist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.3/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="tests/bootstrap.php"
+         failOnRisky="true"
+         failOnWarning="true"
+         cacheDirectory=".phpunit.cache"
+>
+    <testsuites>
+        <testsuite name="Fixtures/symfonyextension Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source ignoreSuppressionOfDeprecations="true">
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+
+    <extensions>
+        <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension">
+            <parameter name="clock-mock-namespaces" value="App" />
+            <parameter name="dns-mock-namespaces" value="App" />
+        </bootstrap>
+    </extensions>
+</phpunit>

--- a/src/Symfony/Bridge/PhpUnit/Tests/Fixtures/symfonyextension/phpunit-without-extension.xml.dist
+++ b/src/Symfony/Bridge/PhpUnit/Tests/Fixtures/symfonyextension/phpunit-without-extension.xml.dist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.3/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="tests/bootstrap.php"
+         failOnRisky="true"
+         failOnWarning="true"
+         cacheDirectory=".phpunit.cache"
+>
+    <testsuites>
+        <testsuite name="Fixtures/symfonyextension Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source ignoreSuppressionOfDeprecations="true">
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/src/Symfony/Bridge/PhpUnit/Tests/Fixtures/symfonyextension/src/ClassExtendingFinalClass.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/Fixtures/symfonyextension/src/ClassExtendingFinalClass.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Tests\Fixtures\symfonyextension\src;
+
+class ClassExtendingFinalClass extends FinalClass
+{
+}

--- a/src/Symfony/Bridge/PhpUnit/Tests/Fixtures/symfonyextension/src/FinalClass.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/Fixtures/symfonyextension/src/FinalClass.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Tests\Fixtures\symfonyextension\src;
+
+/**
+ * @final
+ */
+class FinalClass
+{
+}

--- a/src/Symfony/Bridge/PhpUnit/Tests/Fixtures/symfonyextension/tests/bootstrap.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/Fixtures/symfonyextension/tests/bootstrap.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Bridge\PhpUnit\Tests\Fixtures\symfonyextension\src\ClassExtendingFinalClass;
+use Symfony\Bridge\PhpUnit\Tests\Fixtures\symfonyextension\src\FinalClass;
+
+spl_autoload_register(function ($class) {
+    if (FinalClass::class === $class) {
+        require __DIR__.'/../src/FinalClass.php';
+    } elseif (ClassExtendingFinalClass::class === $class) {
+        require __DIR__.'/../src/ClassExtendingFinalClass.php';
+    }
+});
+
+require __DIR__.'/../../../../SymfonyExtension.php';
+require __DIR__.'/../../../../Extension/DisableClockMockSubscriber.php';
+require __DIR__.'/../../../../Extension/DisableDnsMockSubscriber.php';
+require __DIR__.'/../../../../Extension/EnableClockMockSubscriber.php';
+require __DIR__.'/../../../../Extension/RegisterClockMockSubscriber.php';
+require __DIR__.'/../../../../Extension/RegisterDnsMockSubscriber.php';
+
+if (file_exists(__DIR__.'/../../../../vendor/autoload.php')) {
+    require __DIR__.'/../../../../vendor/autoload.php';
+} elseif (file_exists(__DIR__.'/../../../..//../../../../vendor/autoload.php')) {
+    require __DIR__.'/../../../../../../../../vendor/autoload.php';
+}

--- a/src/Symfony/Bridge/PhpUnit/Tests/ProcessIsolationTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/ProcessIsolationTest.php
@@ -19,6 +19,8 @@ use PHPUnit\Framework\TestCase;
  * @group legacy
  *
  * @runTestsInSeparateProcesses
+ *
+ * @requires PHPUnit < 10
  */
 class ProcessIsolationTest extends TestCase
 {

--- a/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\Tests\Fixtures\symfonyextension\src\ClassExtendingFinalClass;
+use Symfony\Bridge\PhpUnit\Tests\Fixtures\symfonyextension\src\FinalClass;
+
+class SymfonyExtension extends TestCase
+{
+    public function testExtensionOfFinalClass()
+    {
+        $this->expectUserDeprecationMessage(\sprintf('The "%s" class is considered final. It may change without further notice as of its next major version. You should not extend it from "%s".', FinalClass::class, ClassExtendingFinalClass::class));
+
+        new ClassExtendingFinalClass();
+    }
+
+    #[DataProvider('mockedNamespaces')]
+    #[Group('time-sensitive')]
+    public function testTimeMockIsRegistered(string $namespace)
+    {
+        $this->assertTrue(\function_exists(\sprintf('%s\time', $namespace)));
+    }
+
+    #[DataProvider('mockedNamespaces')]
+    #[Group('time-sensitive')]
+    public function testMicrotimeMockIsRegistered(string $namespace)
+    {
+        $this->assertTrue(\function_exists(\sprintf('%s\microtime', $namespace)));
+    }
+
+    #[DataProvider('mockedNamespaces')]
+    #[Group('time-sensitive')]
+    public function testSleepMockIsRegistered(string $namespace)
+    {
+        $this->assertTrue(\function_exists(\sprintf('%s\sleep', $namespace)));
+    }
+
+    #[DataProvider('mockedNamespaces')]
+    #[Group('time-sensitive')]
+    public function testUsleepMockIsRegistered(string $namespace)
+    {
+        $this->assertTrue(\function_exists(\sprintf('%s\usleep', $namespace)));
+    }
+
+    #[DataProvider('mockedNamespaces')]
+    #[Group('time-sensitive')]
+    public function testDateMockIsRegistered(string $namespace)
+    {
+        $this->assertTrue(\function_exists(\sprintf('%s\date', $namespace)));
+    }
+
+    #[DataProvider('mockedNamespaces')]
+    #[Group('time-sensitive')]
+    public function testGmdateMockIsRegistered(string $namespace)
+    {
+        $this->assertTrue(\function_exists(\sprintf('%s\gmdate', $namespace)));
+    }
+
+    #[DataProvider('mockedNamespaces')]
+    #[Group('time-sensitive')]
+    public function testHrtimeMockIsRegistered(string $namespace)
+    {
+        $this->assertTrue(\function_exists(\sprintf('%s\hrtime', $namespace)));
+    }
+
+    #[DataProvider('mockedNamespaces')]
+    #[Group('dns-sensitive')]
+    public function testCheckdnsrrMockIsRegistered(string $namespace)
+    {
+        $this->assertTrue(\function_exists(\sprintf('%s\checkdnsrr', $namespace)));
+    }
+
+    #[DataProvider('mockedNamespaces')]
+    #[Group('dns-sensitive')]
+    public function testDnsCheckRecordMockIsRegistered(string $namespace)
+    {
+        $this->assertTrue(\function_exists(\sprintf('%s\dns_check_record', $namespace)));
+    }
+
+    #[DataProvider('mockedNamespaces')]
+    #[Group('dns-sensitive')]
+    public function testGetmxrrMockIsRegistered(string $namespace)
+    {
+        $this->assertTrue(\function_exists(\sprintf('%s\getmxrr', $namespace)));
+    }
+
+    #[DataProvider('mockedNamespaces')]
+    #[Group('dns-sensitive')]
+    public function testDnsGetMxMockIsRegistered(string $namespace)
+    {
+        $this->assertTrue(\function_exists(\sprintf('%s\dns_get_mx', $namespace)));
+    }
+
+    #[DataProvider('mockedNamespaces')]
+    #[Group('dns-sensitive')]
+    public function testGethostbyaddrMockIsRegistered(string $namespace)
+    {
+        $this->assertTrue(\function_exists(\sprintf('%s\gethostbyaddr', $namespace)));
+    }
+
+    #[DataProvider('mockedNamespaces')]
+    #[Group('dns-sensitive')]
+    public function testGethostbynameMockIsRegistered(string $namespace)
+    {
+        $this->assertTrue(\function_exists(\sprintf('%s\gethostbyname', $namespace)));
+    }
+
+    #[DataProvider('mockedNamespaces')]
+    #[Group('dns-sensitive')]
+    public function testGethostbynamelMockIsRegistered(string $namespace)
+    {
+        $this->assertTrue(\function_exists(\sprintf('%s\gethostbynamel', $namespace)));
+    }
+
+    #[DataProvider('mockedNamespaces')]
+    #[Group('dns-sensitive')]
+    public function testDnsGetRecordMockIsRegistered(string $namespace)
+    {
+        $this->assertTrue(\function_exists(\sprintf('%s\dns_get_record', $namespace)));
+    }
+
+    public static function mockedNamespaces(): iterable
+    {
+        yield 'test class namespace' => [__NAMESPACE__];
+        yield 'namespace derived from test namespace' => ['Symfony\Bridge\PhpUnit'];
+        yield 'explicitly configured namespace' => ['App'];
+    }
+}

--- a/src/Symfony/Bridge/PhpUnit/Tests/expectdeprecationfail.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/expectdeprecationfail.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test ExpectDeprecationTrait failing tests
+--SKIPIF--
+<?php if (!getenv('SYMFONY_PHPUNIT_VERSION') || version_compare(getenv('SYMFONY_PHPUNIT_VERSION'), '10.0', '>=')) die('Skipping on PHPUnit 10+');
 --FILE--
 <?php
 $test =  realpath(__DIR__.'/FailTests/ExpectDeprecationTraitTestFail.php');

--- a/src/Symfony/Bridge/PhpUnit/Tests/expectnotrisky.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/expectnotrisky.phpt
@@ -1,7 +1,9 @@
 --TEST--
 Test NoAssertionsTestNotRisky not risky test
 --SKIPIF--
-<?php if ('\\' === DIRECTORY_SEPARATOR && !extension_loaded('mbstring')) die('Skipping on Windows without mbstring');
+<?php
+if ('\\' === DIRECTORY_SEPARATOR && !extension_loaded('mbstring')) die('Skipping on Windows without mbstring');
+if (!getenv('SYMFONY_PHPUNIT_VERSION') || version_compare(getenv('SYMFONY_PHPUNIT_VERSION'), '10.0', '>=')) die('Skipping on PHPUnit 10+');
 --FILE--
 <?php
 $test =  realpath(__DIR__.'/FailTests/NoAssertionsTestNotRisky.php');

--- a/src/Symfony/Bridge/PhpUnit/Tests/expectrisky.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/expectrisky.phpt
@@ -1,7 +1,9 @@
 --TEST--
 Test NoAssertionsTestRisky risky test
 --SKIPIF--
-<?php if ('\\' === DIRECTORY_SEPARATOR && !extension_loaded('mbstring')) die('Skipping on Windows without mbstring');
+<?php
+if ('\\' === DIRECTORY_SEPARATOR && !extension_loaded('mbstring')) die('Skipping on Windows without mbstring');
+if (!getenv('SYMFONY_PHPUNIT_VERSION') || version_compare(getenv('SYMFONY_PHPUNIT_VERSION'), '10.0', '>=')) die('Skipping on PHPUnit 10+');
 --FILE--
 <?php
 $test =  realpath(__DIR__.'/FailTests/NoAssertionsTestRisky.php');

--- a/src/Symfony/Bridge/PhpUnit/Tests/symfonyextension.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/symfonyextension.phpt
@@ -1,0 +1,19 @@
+--TEST--
+--SKIPIF--
+<?php
+if (!getenv('SYMFONY_PHPUNIT_VERSION') || version_compare(getenv('SYMFONY_PHPUNIT_VERSION'), '10', '<')) die('Skipping on PHPUnit < 10');
+--FILE--
+<?php
+passthru(\sprintf('NO_COLOR=1 php %s/simple-phpunit.php -c %s/Fixtures/symfonyextension/phpunit-with-extension.xml.dist %s/SymfonyExtension.php', getenv('SYMFONY_SIMPLE_PHPUNIT_BIN_DIR'), __DIR__, __DIR__));
+--EXPECTF--
+PHPUnit %s
+
+Runtime:       PHP %s
+Configuration: %s/src/Symfony/Bridge/PhpUnit/Tests/Fixtures/symfonyextension/phpunit-with-extension.xml.dist
+
+D.............................................                    46 / 46 (100%)
+
+Time: %s, Memory: %s
+
+OK, but there were issues!
+Tests: 46, Assertions: 46, Deprecations: 1.

--- a/src/Symfony/Bridge/PhpUnit/Tests/symfonyextensionnotregistered.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/symfonyextensionnotregistered.phpt
@@ -1,0 +1,296 @@
+--TEST--
+--SKIPIF--
+<?php
+if (!getenv('SYMFONY_PHPUNIT_VERSION') || version_compare(getenv('SYMFONY_PHPUNIT_VERSION'), '10', '<')) die('Skipping on PHPUnit < 10');
+--FILE--
+<?php
+passthru(\sprintf('NO_COLOR=1 php %s/simple-phpunit.php -c %s/Fixtures/symfonyextension/phpunit-without-extension.xml.dist %s/SymfonyExtension.php', getenv('SYMFONY_SIMPLE_PHPUNIT_BIN_DIR'), __DIR__, __DIR__));
+--EXPECTF--
+PHPUnit %s
+
+Runtime:       PHP %s
+Configuration: %s/src/Symfony/Bridge/PhpUnit/Tests/Fixtures/symfonyextension/phpunit-without-extension.xml.dist
+
+FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF                    46 / 46 (100%)
+
+Time: %s, Memory: %s
+
+There were 46 failures:
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testExtensionOfFinalClass
+Expected deprecation with message "The "Symfony\Bridge\PhpUnit\Tests\Fixtures\symfonyextension\src\FinalClass" class is considered final. It may change without further notice as of its next major version. You should not extend it from "Symfony\Bridge\PhpUnit\Tests\Fixtures\symfonyextension\src\ClassExtendingFinalClass"." was not triggered
+
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testTimeMockIsRegistered with data set "test class namespace" ('Symfony\Bridge\PhpUnit\Tests')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testTimeMockIsRegistered with data set "namespace derived from test namespace" ('Symfony\Bridge\PhpUnit')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testTimeMockIsRegistered with data set "explicitly configured namespace" ('App')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testMicrotimeMockIsRegistered with data set "test class namespace" ('Symfony\Bridge\PhpUnit\Tests')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testMicrotimeMockIsRegistered with data set "namespace derived from test namespace" ('Symfony\Bridge\PhpUnit')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testMicrotimeMockIsRegistered with data set "explicitly configured namespace" ('App')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testSleepMockIsRegistered with data set "test class namespace" ('Symfony\Bridge\PhpUnit\Tests')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testSleepMockIsRegistered with data set "namespace derived from test namespace" ('Symfony\Bridge\PhpUnit')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testSleepMockIsRegistered with data set "explicitly configured namespace" ('App')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testUsleepMockIsRegistered with data set "test class namespace" ('Symfony\Bridge\PhpUnit\Tests')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testUsleepMockIsRegistered with data set "namespace derived from test namespace" ('Symfony\Bridge\PhpUnit')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testUsleepMockIsRegistered with data set "explicitly configured namespace" ('App')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testDateMockIsRegistered with data set "test class namespace" ('Symfony\Bridge\PhpUnit\Tests')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testDateMockIsRegistered with data set "namespace derived from test namespace" ('Symfony\Bridge\PhpUnit')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testDateMockIsRegistered with data set "explicitly configured namespace" ('App')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testGmdateMockIsRegistered with data set "test class namespace" ('Symfony\Bridge\PhpUnit\Tests')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testGmdateMockIsRegistered with data set "namespace derived from test namespace" ('Symfony\Bridge\PhpUnit')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testGmdateMockIsRegistered with data set "explicitly configured namespace" ('App')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testHrtimeMockIsRegistered with data set "test class namespace" ('Symfony\Bridge\PhpUnit\Tests')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testHrtimeMockIsRegistered with data set "namespace derived from test namespace" ('Symfony\Bridge\PhpUnit')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testHrtimeMockIsRegistered with data set "explicitly configured namespace" ('App')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testCheckdnsrrMockIsRegistered with data set "test class namespace" ('Symfony\Bridge\PhpUnit\Tests')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testCheckdnsrrMockIsRegistered with data set "namespace derived from test namespace" ('Symfony\Bridge\PhpUnit')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testCheckdnsrrMockIsRegistered with data set "explicitly configured namespace" ('App')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testDnsCheckRecordMockIsRegistered with data set "test class namespace" ('Symfony\Bridge\PhpUnit\Tests')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testDnsCheckRecordMockIsRegistered with data set "namespace derived from test namespace" ('Symfony\Bridge\PhpUnit')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testDnsCheckRecordMockIsRegistered with data set "explicitly configured namespace" ('App')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testGetmxrrMockIsRegistered with data set "test class namespace" ('Symfony\Bridge\PhpUnit\Tests')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testGetmxrrMockIsRegistered with data set "namespace derived from test namespace" ('Symfony\Bridge\PhpUnit')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testGetmxrrMockIsRegistered with data set "explicitly configured namespace" ('App')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testDnsGetMxMockIsRegistered with data set "test class namespace" ('Symfony\Bridge\PhpUnit\Tests')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testDnsGetMxMockIsRegistered with data set "namespace derived from test namespace" ('Symfony\Bridge\PhpUnit')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testDnsGetMxMockIsRegistered with data set "explicitly configured namespace" ('App')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testGethostbyaddrMockIsRegistered with data set "test class namespace" ('Symfony\Bridge\PhpUnit\Tests')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testGethostbyaddrMockIsRegistered with data set "namespace derived from test namespace" ('Symfony\Bridge\PhpUnit')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testGethostbyaddrMockIsRegistered with data set "explicitly configured namespace" ('App')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testGethostbynameMockIsRegistered with data set "test class namespace" ('Symfony\Bridge\PhpUnit\Tests')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testGethostbynameMockIsRegistered with data set "namespace derived from test namespace" ('Symfony\Bridge\PhpUnit')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testGethostbynameMockIsRegistered with data set "explicitly configured namespace" ('App')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testGethostbynamelMockIsRegistered with data set "test class namespace" ('Symfony\Bridge\PhpUnit\Tests')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testGethostbynamelMockIsRegistered with data set "namespace derived from test namespace" ('Symfony\Bridge\PhpUnit')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testGethostbynamelMockIsRegistered with data set "explicitly configured namespace" ('App')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testDnsGetRecordMockIsRegistered with data set "test class namespace" ('Symfony\Bridge\PhpUnit\Tests')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testDnsGetRecordMockIsRegistered with data set "namespace derived from test namespace" ('Symfony\Bridge\PhpUnit')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testDnsGetRecordMockIsRegistered with data set "explicitly configured namespace" ('App')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+FAILURES!
+Tests: 46, Assertions: 46, Failures: 46.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #49069
| License       | MIT
