### PR TITLE
[HttpClient] fix tests

### DIFF
--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTraitTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTraitTest.php
@@ -122,7 +122,7 @@ class HttpClientTraitTest extends TestCase
     public function testNormalizeBodyMultipartForwardStream($stream)
     {
         $body = [
-            'logo' => $stream,
+            'logo' => $stream(),
         ];
 
         $headers = [];
@@ -153,8 +153,8 @@ class HttpClientTraitTest extends TestCase
 
     public static function provideNormalizeBodyMultipartForwardStream()
     {
-        yield 'native' => [fopen('https://github.githubassets.com/images/icons/emoji/unicode/1f44d.png', 'r')];
-        yield 'symfony' => [HttpClient::create()->request('GET', 'https://github.githubassets.com/images/icons/emoji/unicode/1f44d.png')->toStream()];
+        yield 'native' => [static fn () => fopen('https://github.githubassets.com/images/icons/emoji/unicode/1f44d.png', 'r')];
+        yield 'symfony' => [static fn () => HttpClient::create()->request('GET', 'https://github.githubassets.com/images/icons/emoji/unicode/1f44d.png')->toStream()];
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

The data provider was depending on the openssl extension being present.

see https://ci.appveyor.com/project/fabpot/symfony/builds/50740623#L1903
