### PR TITLE
[Serializer] Fix `AbstractObjectNormalizer` to allow scalar values to be normalized

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -210,12 +210,11 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
         foreach ($stack as $attribute => $attributeValue) {
             $attributeContext = $this->getAttributeNormalizationContext($object, $attribute, $context);
 
-            if (null === $attributeValue || \is_scalar($attributeValue)) {
-                $data = $this->updateData($data, $attribute, $attributeValue, $class, $format, $attributeContext, $attributesMetadata, $classMetadata);
-                continue;
-            }
-
             if (!$this->serializer instanceof NormalizerInterface) {
+                if (null === $attributeValue || \is_scalar($attributeValue)) {
+                    $data = $this->updateData($data, $attribute, $attributeValue, $class, $format, $attributeContext, $attributesMetadata, $classMetadata);
+                    continue;
+                }
                 throw new LogicException(\sprintf('Cannot normalize attribute "%s" because the injected serializer is not a normalizer.', $attribute));
             }
 
@@ -465,7 +464,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
 
             // This try-catch should cover all NotNormalizableValueException (and all return branches after the first
             // exception) so we could try denormalizing all types of an union type. If the target type is not an union
-            // type, we will just re-throw the catched exception.
+            // type, we will just re-throw the caught exception.
             // In the case of no denormalization succeeds with an union type, it will fall back to the default exception
             // with the acceptable types list.
             try {

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/ScalarNormalizer.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/ScalarNormalizer.php
@@ -15,7 +15,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class ScalarNormalizer implements NormalizerInterface
 {
-    public function normalize(mixed $object, ?string $format = null, array $context = [])
+    public function normalize(mixed $object, ?string $format = null, array $context = []): string
     {
         $data = $object;
 
@@ -26,7 +26,7 @@ class ScalarNormalizer implements NormalizerInterface
         return strtoupper($data);
     }
 
-    public function supportsNormalization(mixed $data, ?string $format = null, array $context = [])
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
         return \is_scalar($data);
     }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/ScalarNormalizer.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/ScalarNormalizer.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class ScalarNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $object, ?string $format = null, array $context = [])
+    {
+        $data = $object;
+
+        if (!\is_string($data)) {
+            $data = (string) $object;
+        }
+
+        return strtoupper($data);
+    }
+
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = [])
+    {
+        return \is_scalar($data);
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            'native-boolean' => true,
+            'native-integer' => true,
+            'native-string' => true,
+        ];
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/StdClassNormalizer.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/StdClassNormalizer.php
@@ -15,12 +15,12 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class StdClassNormalizer implements NormalizerInterface
 {
-    public function normalize(mixed $object, ?string $format = null, array $context = [])
+    public function normalize(mixed $object, ?string $format = null, array $context = []): string
     {
         return 'string_object';
     }
 
-    public function supportsNormalization(mixed $data, ?string $format = null, array $context = [])
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
         return $data instanceof \stdClass;
     }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/StdClassNormalizer.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/StdClassNormalizer.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class StdClassNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $object, ?string $format = null, array $context = [])
+    {
+        return 'string_object';
+    }
+
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = [])
+    {
+        return $data instanceof \stdClass;
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            \stdClass::class => true,
+        ];
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -960,7 +960,7 @@ class AbstractObjectNormalizerTest extends TestCase
         $this->assertSame($firstChildContextCacheKey, $secondChildContextCacheKey);
     }
 
-    public function testChildContextKeepsOriginalContextCacheKey()
+    public function testChildContextChangesContextCacheKey()
     {
         $foobar = new Dummy();
         $foobar->foo = new EmptyDummy();
@@ -992,7 +992,7 @@ class AbstractObjectNormalizerTest extends TestCase
         $serializer = new Serializer([$normalizer]);
         $serializer->normalize($foobar, null, ['cache_key' => 'hardcoded', 'iri' => '/dummy/1']);
 
-        $this->assertSame('hardcoded-foo', $normalizer->childContextCacheKey);
+        $this->assertSame('hardcoded-baz', $normalizer->childContextCacheKey);
     }
 
     public function testChildContextCacheKeyStaysFalseWhenOriginalCacheKeyIsFalse()

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -968,7 +968,7 @@ class AbstractObjectNormalizerTest extends TestCase
         $foobar->baz = 'baz';
 
         $normalizer = new class extends AbstractObjectNormalizerDummy {
-            public $childContextCacheKey;
+            public array $childContextCacheKeys = [];
 
             protected function extractAttributes(object $object, ?string $format = null, array $context = []): array
             {
@@ -983,7 +983,7 @@ class AbstractObjectNormalizerTest extends TestCase
             protected function createChildContext(array $parentContext, string $attribute, ?string $format): array
             {
                 $childContext = parent::createChildContext($parentContext, $attribute, $format);
-                $this->childContextCacheKey = $childContext['cache_key'];
+                $this->childContextCacheKeys[$attribute] = $childContext['cache_key'];
 
                 return $childContext;
             }
@@ -992,7 +992,7 @@ class AbstractObjectNormalizerTest extends TestCase
         $serializer = new Serializer([$normalizer]);
         $serializer->normalize($foobar, null, ['cache_key' => 'hardcoded', 'iri' => '/dummy/1']);
 
-        $this->assertSame('hardcoded-baz', $normalizer->childContextCacheKey);
+        $this->assertSame(['foo' => 'hardcoded-foo', 'bar' => 'hardcoded-bar', 'baz' => 'hardcoded-baz'], $normalizer->childContextCacheKeys);
     }
 
     public function testChildContextCacheKeyStaysFalseWhenOriginalCacheKeyIsFalse()

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
@@ -34,7 +33,9 @@ use Symfony\Component\Serializer\Tests\Fixtures\Attributes\ClassWithIgnoreAnnota
 use Symfony\Component\Serializer\Tests\Fixtures\Attributes\ClassWithIgnoreAttribute;
 use Symfony\Component\Serializer\Tests\Fixtures\Attributes\GroupDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\CircularReferenceDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\ScalarNormalizer;
 use Symfony\Component\Serializer\Tests\Fixtures\SiblingHolder;
+use Symfony\Component\Serializer\Tests\Fixtures\StdClassNormalizer;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\CacheableObjectAttributesTestTrait;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\CallbacksTestTrait;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\CircularReferenceTestTrait;
@@ -61,7 +62,7 @@ class GetSetMethodNormalizerTest extends TestCase
     use TypeEnforcementTestTrait;
 
     private GetSetMethodNormalizer $normalizer;
-    private SerializerInterface&NormalizerInterface&MockObject $serializer;
+    private SerializerInterface&NormalizerInterface $serializer;
 
     protected function setUp(): void
     {
@@ -70,8 +71,8 @@ class GetSetMethodNormalizerTest extends TestCase
 
     private function createNormalizer(array $defaultContext = []): void
     {
-        $this->serializer = $this->createMock(SerializerNormalizer::class);
         $this->normalizer = new GetSetMethodNormalizer(null, null, null, null, null, $defaultContext);
+        $this->serializer = new Serializer([$this->normalizer, new StdClassNormalizer()]);
         $this->normalizer->setSerializer($this->serializer);
     }
 
@@ -90,11 +91,6 @@ class GetSetMethodNormalizerTest extends TestCase
         $obj->setBaz(true);
         $obj->setCamelCase('camelcase');
         $obj->setObject($object);
-
-        $this->serializer
-            ->method('normalize')
-            ->willReturnCallback(fn ($data) => $data === $object ? 'string_object' : $data)
-        ;
 
         $this->assertEquals(
             [
@@ -146,7 +142,6 @@ class GetSetMethodNormalizerTest extends TestCase
 
     public function testIgnoredAttributesInContext()
     {
-        $this->serializer->method('normalize')->willReturnArgument(0);
         $ignoredAttributes = ['foo', 'bar', 'baz', 'object'];
         $obj = new GetSetDummy();
         $obj->setFoo('foo');
@@ -303,7 +298,6 @@ class GetSetMethodNormalizerTest extends TestCase
 
     public function testGroupsNormalizeWithNameConverter()
     {
-        $this->serializer->method('normalize')->willReturnArgument(0);
         $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
         $this->normalizer = new GetSetMethodNormalizer($classMetadataFactory, new CamelCaseToSnakeCaseNameConverter());
         $this->normalizer->setSerializer($this->serializer);
@@ -400,8 +394,7 @@ class GetSetMethodNormalizerTest extends TestCase
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Cannot normalize attribute "object" because the injected serializer is not a normalizer');
-        $serializer = $this->createMock(SerializerInterface::class);
-        $this->normalizer->setSerializer($serializer);
+        $this->normalizer->setSerializer($this->createMock(SerializerInterface::class));
 
         $obj = new GetSetDummy();
         $object = new \stdClass();
@@ -483,7 +476,6 @@ class GetSetMethodNormalizerTest extends TestCase
 
     public function testHasGetterNormalize()
     {
-        $this->serializer->method('normalize')->willReturnArgument(0);
         $obj = new ObjectWithHasGetterDummy();
         $obj->setFoo(true);
 
@@ -501,7 +493,6 @@ class GetSetMethodNormalizerTest extends TestCase
 
     public function testCallMagicMethodNormalize()
     {
-        $this->serializer->method('normalize')->willReturnArgument(0);
         $obj = new ObjectWithMagicMethod();
 
         $this->assertSame(
@@ -548,6 +539,30 @@ class GetSetMethodNormalizerTest extends TestCase
         $this->assertSame(['class' => 'class', 123 => 123], $normalizer->normalize(new GetSetWithAccessorishMethod()));
     }
 
+    public function testNormalizeWithScalarValueNormalizer()
+    {
+        $normalizer = new GetSetMethodNormalizer();
+        $normalizer->setSerializer(new Serializer([$normalizer, new ScalarNormalizer()]));
+
+        $obj = new GetSetDummy();
+        $obj->setFoo('foo');
+        $obj->setBar(10);
+        $obj->setBaz(true);
+        $obj->setCamelCase('camelcase');
+
+        $this->assertSame(
+            [
+                'foo' => 'FOO',
+                'bar' => '10',
+                'baz' => '1',
+                'fooBar' => 'FOO10',
+                'camelCase' => 'CAMELCASE',
+                'object' => null,
+            ],
+            $normalizer->normalize($obj, 'any')
+        );
+    }
+
     public function testDenormalizeWithDiscriminator()
     {
         $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
@@ -562,7 +577,6 @@ class GetSetMethodNormalizerTest extends TestCase
 
     public function testSupportsAndNormalizeWithOnlyParentGetter()
     {
-        $this->serializer->method('normalize')->willReturnArgument(0);
         $obj = new GetSetDummyChild();
         $obj->setFoo('foo');
 
@@ -725,10 +739,6 @@ class GetConstructorDummy
     {
         throw new \RuntimeException('Dummy::otherMethod() should not be called');
     }
-}
-
-abstract class SerializerNormalizer implements SerializerInterface, NormalizerInterface
-{
 }
 
 class GetConstructorOptionalArgsDummy

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -92,10 +92,8 @@ class GetSetMethodNormalizerTest extends TestCase
         $obj->setObject($object);
 
         $this->serializer
-            ->expects($this->once())
             ->method('normalize')
-            ->with($object, 'any')
-            ->willReturn('string_object')
+            ->willReturnCallback(fn ($data) => $data === $object ? 'string_object' : $data)
         ;
 
         $this->assertEquals(
@@ -106,6 +104,29 @@ class GetSetMethodNormalizerTest extends TestCase
                 'fooBar' => 'foobar',
                 'camelCase' => 'camelcase',
                 'object' => 'string_object',
+            ],
+            $this->normalizer->normalize($obj, 'any')
+        );
+    }
+
+    public function testNormalizeWithoutSerializer()
+    {
+        $obj = new GetSetDummy();
+        $obj->setFoo('foo');
+        $obj->setBar('bar');
+        $obj->setBaz(true);
+        $obj->setCamelCase('camelcase');
+
+        $this->normalizer = new GetSetMethodNormalizer();
+
+        $this->assertEquals(
+            [
+                'foo' => 'foo',
+                'bar' => 'bar',
+                'baz' => true,
+                'fooBar' => 'foobar',
+                'camelCase' => 'camelcase',
+                'object' => null,
             ],
             $this->normalizer->normalize($obj, 'any')
         );
@@ -125,6 +146,7 @@ class GetSetMethodNormalizerTest extends TestCase
 
     public function testIgnoredAttributesInContext()
     {
+        $this->serializer->method('normalize')->willReturnArgument(0);
         $ignoredAttributes = ['foo', 'bar', 'baz', 'object'];
         $obj = new GetSetDummy();
         $obj->setFoo('foo');
@@ -281,6 +303,7 @@ class GetSetMethodNormalizerTest extends TestCase
 
     public function testGroupsNormalizeWithNameConverter()
     {
+        $this->serializer->method('normalize')->willReturnArgument(0);
         $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
         $this->normalizer = new GetSetMethodNormalizer($classMetadataFactory, new CamelCaseToSnakeCaseNameConverter());
         $this->normalizer->setSerializer($this->serializer);
@@ -460,6 +483,7 @@ class GetSetMethodNormalizerTest extends TestCase
 
     public function testHasGetterNormalize()
     {
+        $this->serializer->method('normalize')->willReturnArgument(0);
         $obj = new ObjectWithHasGetterDummy();
         $obj->setFoo(true);
 
@@ -477,6 +501,7 @@ class GetSetMethodNormalizerTest extends TestCase
 
     public function testCallMagicMethodNormalize()
     {
+        $this->serializer->method('normalize')->willReturnArgument(0);
         $obj = new ObjectWithMagicMethod();
 
         $this->assertSame(
@@ -537,6 +562,7 @@ class GetSetMethodNormalizerTest extends TestCase
 
     public function testSupportsAndNormalizeWithOnlyParentGetter()
     {
+        $this->serializer->method('normalize')->willReturnArgument(0);
         $obj = new GetSetDummyChild();
         $obj->setFoo('foo');
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyAccess\PropertyAccessorBuilder;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
@@ -49,6 +48,7 @@ use Symfony\Component\Serializer\Tests\Fixtures\Php74Dummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Php74DummyPrivate;
 use Symfony\Component\Serializer\Tests\Fixtures\Php80Dummy;
 use Symfony\Component\Serializer\Tests\Fixtures\SiblingHolder;
+use Symfony\Component\Serializer\Tests\Fixtures\StdClassNormalizer;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\AttributesTestTrait;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\CacheableObjectAttributesTestTrait;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\CallbacksTestTrait;
@@ -86,7 +86,7 @@ class ObjectNormalizerTest extends TestCase
     use TypeEnforcementTestTrait;
 
     private ObjectNormalizer $normalizer;
-    private SerializerInterface&NormalizerInterface&MockObject $serializer;
+    private SerializerInterface&NormalizerInterface $serializer;
 
     protected function setUp(): void
     {
@@ -95,8 +95,8 @@ class ObjectNormalizerTest extends TestCase
 
     private function createNormalizer(array $defaultContext = [], ?ClassMetadataFactoryInterface $classMetadataFactory = null): void
     {
-        $this->serializer = $this->createMock(ObjectSerializerNormalizer::class);
         $this->normalizer = new ObjectNormalizer($classMetadataFactory, null, null, null, null, null, $defaultContext);
+        $this->serializer = new Serializer([new StdClassNormalizer(), $this->normalizer]);
         $this->normalizer->setSerializer($this->serializer);
     }
 
@@ -110,11 +110,6 @@ class ObjectNormalizerTest extends TestCase
         $obj->setCamelCase('camelcase');
         $obj->setObject($object);
         $obj->setGo(true);
-
-        $this->serializer
-            ->method('normalize')
-            ->willReturnCallback(static fn ($data) => $data === $object ? 'string_object' : $data)
-        ;
 
         $this->assertEquals(
             [
@@ -158,7 +153,6 @@ class ObjectNormalizerTest extends TestCase
 
     public function testNormalizeObjectWithUninitializedProperties()
     {
-        $this->serializer->method('normalize')->willReturnArgument(0);
         $obj = new Php74Dummy();
         $this->assertEquals(
             ['initializedProperty' => 'defaultValue'],
@@ -178,7 +172,6 @@ class ObjectNormalizerTest extends TestCase
 
     public function testNormalizeObjectWithLazyProperties()
     {
-        $this->serializer->method('normalize')->willReturnArgument(0);
         $obj = new LazyObjectInner();
         unset($obj->foo);
         $this->assertEquals(
@@ -189,7 +182,6 @@ class ObjectNormalizerTest extends TestCase
 
     public function testNormalizeObjectWithUninitializedPrivateProperties()
     {
-        $this->serializer->method('normalize')->willReturnArgument(0);
         $obj = new Php74DummyPrivate();
         $this->assertEquals(
             ['initializedProperty' => 'defaultValue'],
@@ -199,7 +191,6 @@ class ObjectNormalizerTest extends TestCase
 
     public function testNormalizeObjectWithPrivatePropertyWithoutGetter()
     {
-        $this->serializer->method('normalize')->willReturnArgument(0);
         $obj = new DummyPrivatePropertyWithoutGetter();
         $this->assertEquals(
             ['bar' => 'bar'],
@@ -532,7 +523,6 @@ class ObjectNormalizerTest extends TestCase
 
     public function testGroupsNormalizeWithNameConverter()
     {
-        $this->serializer->method('normalize')->willReturnArgument(0);
         $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
         $this->normalizer = new ObjectNormalizer($classMetadataFactory, new CamelCaseToSnakeCaseNameConverter());
         $this->normalizer->setSerializer($this->serializer);
@@ -716,13 +706,11 @@ class ObjectNormalizerTest extends TestCase
 
     public function testNormalizeStatic()
     {
-        $this->serializer->method('normalize')->willReturnArgument(0);
         $this->assertEquals(['foo' => 'K'], $this->normalizer->normalize(new ObjectWithStaticPropertiesAndMethods()));
     }
 
     public function testNormalizeUpperCaseAttributes()
     {
-        $this->serializer->method('normalize')->willReturnArgument(0);
         $this->assertEquals(['Foo' => 'Foo', 'Bar' => 'BarBar'], $this->normalizer->normalize(new ObjectWithUpperCaseAttributeNames()));
     }
 
@@ -908,7 +896,6 @@ class ObjectNormalizerTest extends TestCase
 
     public function testNormalizeStdClass()
     {
-        $this->serializer->method('normalize')->willReturnArgument(0);
         $o1 = new \stdClass();
         $o1->foo = 'f';
         $o1->bar = 'b';

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -112,10 +112,8 @@ class ObjectNormalizerTest extends TestCase
         $obj->setGo(true);
 
         $this->serializer
-            ->expects($this->once())
             ->method('normalize')
-            ->with($object, 'any')
-            ->willReturn('string_object')
+            ->willReturnCallback(static fn ($data) => $data === $object ? 'string_object' : $data)
         ;
 
         $this->assertEquals(
@@ -132,8 +130,35 @@ class ObjectNormalizerTest extends TestCase
         );
     }
 
+    public function testNormalizeWithoutSerializer()
+    {
+        $obj = new ObjectDummy();
+        $obj->setFoo('foo');
+        $obj->bar = 'bar';
+        $obj->setBaz(true);
+        $obj->setCamelCase('camelcase');
+        $obj->setObject(null);
+        $obj->setGo(true);
+
+        $this->normalizer = new ObjectNormalizer();
+
+        $this->assertEquals(
+            [
+                'foo' => 'foo',
+                'bar' => 'bar',
+                'baz' => true,
+                'fooBar' => 'foobar',
+                'camelCase' => 'camelcase',
+                'object' => null,
+                'go' => true,
+            ],
+            $this->normalizer->normalize($obj, 'any')
+        );
+    }
+
     public function testNormalizeObjectWithUninitializedProperties()
     {
+        $this->serializer->method('normalize')->willReturnArgument(0);
         $obj = new Php74Dummy();
         $this->assertEquals(
             ['initializedProperty' => 'defaultValue'],
@@ -153,6 +178,7 @@ class ObjectNormalizerTest extends TestCase
 
     public function testNormalizeObjectWithLazyProperties()
     {
+        $this->serializer->method('normalize')->willReturnArgument(0);
         $obj = new LazyObjectInner();
         unset($obj->foo);
         $this->assertEquals(
@@ -163,6 +189,7 @@ class ObjectNormalizerTest extends TestCase
 
     public function testNormalizeObjectWithUninitializedPrivateProperties()
     {
+        $this->serializer->method('normalize')->willReturnArgument(0);
         $obj = new Php74DummyPrivate();
         $this->assertEquals(
             ['initializedProperty' => 'defaultValue'],
@@ -172,6 +199,7 @@ class ObjectNormalizerTest extends TestCase
 
     public function testNormalizeObjectWithPrivatePropertyWithoutGetter()
     {
+        $this->serializer->method('normalize')->willReturnArgument(0);
         $obj = new DummyPrivatePropertyWithoutGetter();
         $this->assertEquals(
             ['bar' => 'bar'],
@@ -504,6 +532,7 @@ class ObjectNormalizerTest extends TestCase
 
     public function testGroupsNormalizeWithNameConverter()
     {
+        $this->serializer->method('normalize')->willReturnArgument(0);
         $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
         $this->normalizer = new ObjectNormalizer($classMetadataFactory, new CamelCaseToSnakeCaseNameConverter());
         $this->normalizer->setSerializer($this->serializer);
@@ -687,11 +716,13 @@ class ObjectNormalizerTest extends TestCase
 
     public function testNormalizeStatic()
     {
+        $this->serializer->method('normalize')->willReturnArgument(0);
         $this->assertEquals(['foo' => 'K'], $this->normalizer->normalize(new ObjectWithStaticPropertiesAndMethods()));
     }
 
     public function testNormalizeUpperCaseAttributes()
     {
+        $this->serializer->method('normalize')->willReturnArgument(0);
         $this->assertEquals(['Foo' => 'Foo', 'Bar' => 'BarBar'], $this->normalizer->normalize(new ObjectWithUpperCaseAttributeNames()));
     }
 
@@ -877,6 +908,7 @@ class ObjectNormalizerTest extends TestCase
 
     public function testNormalizeStdClass()
     {
+        $this->serializer->method('normalize')->willReturnArgument(0);
         $o1 = new \stdClass();
         $o1->foo = 'f';
         $o1->bar = 'b';
@@ -962,7 +994,7 @@ class ObjectNormalizerTest extends TestCase
 
     protected function getNormalizerForAccessors($accessorPrefixes = null): ObjectNormalizer
     {
-        $accessorPrefixes = $accessorPrefixes ?? ReflectionExtractor::$defaultAccessorPrefixes;
+        $accessorPrefixes ??= ReflectionExtractor::$defaultAccessorPrefixes;
         $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
         $propertyAccessorBuilder = (new PropertyAccessorBuilder())
             ->setReadInfoExtractor(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        |  Fix #58056
| License       | MIT


It still does work when the Normalizer is used with Serializer (like it normally would?),
