### PR TITLE
[Validator] Fix Ulid validation with unicode char

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/UlidValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UlidValidator.php
@@ -43,10 +43,10 @@ class UlidValidator extends ConstraintValidator
 
         $value = (string) $value;
 
-        if (26 !== \strlen($value)) {
+        if (26 !== \mb_strlen($value)) {
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ value }}', $this->formatValue($value))
-                ->setCode(26 > \strlen($value) ? Ulid::TOO_SHORT_ERROR : Ulid::TOO_LONG_ERROR)
+                ->setCode(26 > \mb_strlen($value) ? Ulid::TOO_SHORT_ERROR : Ulid::TOO_LONG_ERROR)
                 ->addViolation();
 
             return;

--- a/src/Symfony/Component/Validator/Tests/Constraints/UlidValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UlidValidatorTest.php
@@ -95,4 +95,32 @@ class UlidValidatorTest extends ConstraintValidatorTestCase
             ->setCode(Ulid::TOO_SHORT_ERROR)
             ->assertRaised();
     }
+
+    public function testTooShortUlidWithUnicode()
+    {
+        $constraint = new Ulid([
+            'message' => 'testMessage',
+        ]);
+
+        $this->validator->validate('ÄÄÄÄÄÄÄÄÄÄÄÄÄ', $constraint); // 13 chars represented on 26 bytes
+
+        $this->buildViolation('testMessage')
+            ->setParameter('{{ value }}', '"ÄÄÄÄÄÄÄÄÄÄÄÄÄ"')
+            ->setCode(Ulid::TOO_SHORT_ERROR)
+            ->assertRaised();
+    }
+
+    public function testIllegalCharsUlidWithUnicode()
+    {
+        $constraint = new Ulid([
+            'message' => 'testMessage',
+        ]);
+
+        $this->validator->validate('01ARZ3NDEKTSV4RRFFQ69G5FÄV', $constraint);
+
+        $this->buildViolation('testMessage')
+            ->setParameter('{{ value }}', '"01ARZ3NDEKTSV4RRFFQ69G5FÄV"')
+            ->setCode(Ulid::INVALID_CHARACTERS_ERROR)
+            ->assertRaised();
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Because the Validator uses `strlen()`, a Ulid of 25 chars (instead of 26) containing unicode could return a `Ulid::INVALID_CHARACTERS_ERROR`. However, characters validity is checked after the length assertion.

I suggest using `mb_strlen()` in order to return `Ulid::TOO_SHORT_ERROR` properly, which seems more meaningful in terms of UX.