### PR TITLE
[Config] Allow using `defaultNull()` on `BooleanNodeDefinition`

### DIFF
--- a/src/Symfony/Component/Config/CHANGELOG.md
+++ b/src/Symfony/Component/Config/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add `#[WhenNot]` attribute to prevent service from being registered in a specific environment
  * Generate a meta file in JSON format for resource tracking
  * Add `SkippingResourceChecker`
+ * Add support for `defaultNull()` on `BooleanNode`
 
 7.1
 ---

--- a/src/Symfony/Component/Config/Definition/BooleanNode.php
+++ b/src/Symfony/Component/Config/Definition/BooleanNode.php
@@ -20,10 +20,23 @@ use Symfony\Component\Config\Definition\Exception\InvalidTypeException;
  */
 class BooleanNode extends ScalarNode
 {
+    public function __construct(
+        ?string $name,
+        ?NodeInterface $parent = null,
+        string $pathSeparator = self::DEFAULT_PATH_SEPARATOR,
+        private bool $nullable = false,
+    ) {
+        parent::__construct($name, $parent, $pathSeparator);
+    }
+
     protected function validateType(mixed $value): void
     {
         if (!\is_bool($value)) {
-            $ex = new InvalidTypeException(\sprintf('Invalid type for path "%s". Expected "bool", but got "%s".', $this->getPath(), get_debug_type($value)));
+            if (null === $value && $this->nullable) {
+                return;
+            }
+
+            $ex = new InvalidTypeException(\sprintf('Invalid type for path "%s". Expected "bool%s", but got "%s".', $this->getPath(), $this->nullable ? '" or "null' : '', get_debug_type($value)));
             if ($hint = $this->getInfo()) {
                 $ex->addHint($hint);
             }

--- a/src/Symfony/Component/Config/Definition/Builder/BooleanNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/BooleanNodeDefinition.php
@@ -33,7 +33,7 @@ class BooleanNodeDefinition extends ScalarNodeDefinition
      */
     protected function instantiateNode(): BooleanNode
     {
-        return new BooleanNode($this->name, $this->parent, $this->pathSeparator);
+        return new BooleanNode($this->name, $this->parent, $this->pathSeparator, null === $this->nullEquivalent);
     }
 
     /**
@@ -42,5 +42,21 @@ class BooleanNodeDefinition extends ScalarNodeDefinition
     public function cannotBeEmpty(): static
     {
         throw new InvalidDefinitionException('->cannotBeEmpty() is not applicable to BooleanNodeDefinition.');
+    }
+
+    public function defaultNull(): static
+    {
+        $this->nullEquivalent = null;
+
+        return parent::defaultNull();
+    }
+
+    public function defaultValue(mixed $value): static
+    {
+        if (null === $value) {
+            $this->nullEquivalent = null;
+        }
+
+        return parent::defaultValue($value);
     }
 }

--- a/src/Symfony/Component/Config/Tests/Definition/BooleanNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/BooleanNodeTest.php
@@ -26,6 +26,33 @@ class BooleanNodeTest extends TestCase
         $this->assertSame($value, $node->normalize($value));
     }
 
+    public function testNullValueOnNullable()
+    {
+        $node = new BooleanNode('test', null, '.', true);
+
+        $this->assertNull($node->normalize(null));
+    }
+
+    public function testNullValueOnNotNullable()
+    {
+        $node = new BooleanNode('test', null, '.', false);
+
+        $this->expectException(InvalidTypeException::class);
+        $this->expectExceptionMessage('Invalid type for path "test". Expected "bool", but got "null".');
+
+        $this->assertNull($node->normalize(null));
+    }
+
+    public function testInvalidValueOnNullable()
+    {
+        $node = new BooleanNode('test', null, '.', true);
+
+        $this->expectException(InvalidTypeException::class);
+        $this->expectExceptionMessage('Invalid type for path "test". Expected "bool" or "null", but got "int".');
+
+        $node->normalize(123);
+    }
+
     /**
      * @dataProvider getValidValues
      */
@@ -60,7 +87,6 @@ class BooleanNodeTest extends TestCase
     public static function getInvalidValues(): array
     {
         return [
-            [null],
             [''],
             ['foo'],
             [0],

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/BooleanNodeDefinitionTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/BooleanNodeDefinitionTest.php
@@ -25,6 +25,30 @@ class BooleanNodeDefinitionTest extends TestCase
         $def->cannotBeEmpty();
     }
 
+    public function testBooleanNodeWithDefaultNull()
+    {
+        $def = new BooleanNodeDefinition('foo');
+        $def->defaultNull();
+
+        $node = $def->getNode();
+        $this->assertTrue($node->hasDefaultValue());
+        $this->assertNull($node->getDefaultValue());
+
+        $this->assertNull($node->normalize(null));
+    }
+
+    public function testBooleanNodeWithDefaultValueAtNull()
+    {
+        $def = new BooleanNodeDefinition('foo');
+        $def->defaultValue(null);
+
+        $node = $def->getNode();
+        $this->assertTrue($node->hasDefaultValue());
+        $this->assertNull($node->getDefaultValue());
+
+        $this->assertNull($node->normalize(null));
+    }
+
     public function testSetDeprecated()
     {
         $def = new BooleanNodeDefinition('foo');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes-ish
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

After [this comment](https://github.com/symfony/symfony/pull/58095/files#r1740417930). Currently, `defaultNull()` on BooleanNode doesn't work well: the value always casts to `true`. This PR allows to make the node nullable by calling `defaultNull()` or `defaultValue(null)`.

Given the following configuration on a brand new project (with `composer require symfony/form symfony/csrf-protection`):

```yaml
framework:
    csrf_protection: true

    session: true

    form:
        csrf_protection:
            enabled: null
```

Dumping `$config['form']['csrf_protection']['enabled']` reveals the `enabled` option is casted to `true` when set to `null` in the config. The following condition is **never** true:

https://github.com/symfony/symfony/blob/b61db2f7242c22e17d83807580b7fe9ed15d5cb0/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php#L755

With this PR, the `enabled` option keeps the `null` value when defining the node as it already is in the code:

https://github.com/symfony/symfony/blob/b61db2f7242c22e17d83807580b7fe9ed15d5cb0/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php#L214