### PR TITLE
[MonologBridge] Fix PHP deprecation with `preg_match()`

### DIFF
--- a/src/Symfony/Bridge/Monolog/Handler/ChromePhpHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/ChromePhpHandler.php
@@ -40,7 +40,7 @@ class ChromePhpHandler extends BaseChromePhpHandler
             return;
         }
 
-        if (!preg_match(static::USER_AGENT_REGEX, $event->getRequest()->headers->get('User-Agent'))) {
+        if (!preg_match(static::USER_AGENT_REGEX, $event->getRequest()->headers->get('User-Agent', ''))) {
             self::$sendHeaders = false;
             $this->headers = [];
 

--- a/src/Symfony/Bridge/Monolog/Tests/Handler/ChromePhpHandlerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/ChromePhpHandlerTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Monolog\Tests\Handler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Monolog\Handler\ChromePhpHandler;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class ChromePhpHandlerTest extends TestCase
+{
+    public function testOnKernelResponseShouldNotTriggerDeprecation()
+    {
+        $request = Request::create('/');
+        $request->headers->remove('User-Agent');
+
+        $response = new Response('foo');
+        $event = new ResponseEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST, $response);
+
+        $error = null;
+        set_error_handler(function ($type, $message) use (&$error) { $error = $message; }, \E_DEPRECATED);
+
+        $listener = new ChromePhpHandler();
+        $listener->onKernelResponse($event);
+        restore_error_handler();
+
+        $this->assertNull($error);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

```
preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated
```
