### PR TITLE
[TwigBridge] Add missing return type

### DIFF
--- a/.github/expected-missing-return-types.diff
+++ b/.github/expected-missing-return-types.diff
@@ -7,16 +7,6 @@ git checkout src/Symfony/Contracts/Service/ResetInterface.php
 (echo "$head" && echo && git diff -U2 src/ | grep '^index ' -v) > .github/expected-missing-return-types.diff
 git checkout composer.json src/
 
-diff --git a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractLayoutTestCase.php b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractLayoutTestCase.php
---- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractLayoutTestCase.php
-+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractLayoutTestCase.php
-@@ -49,5 +49,5 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
-      * @return FormExtensionInterface[]
-      */
--    protected function getExtensions()
-+    protected function getExtensions(): array
-     {
-         return [
 diff --git a/src/Symfony/Component/BrowserKit/AbstractBrowser.php b/src/Symfony/Component/BrowserKit/AbstractBrowser.php
 --- a/src/Symfony/Component/BrowserKit/AbstractBrowser.php
 +++ b/src/Symfony/Component/BrowserKit/AbstractBrowser.php

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractLayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractLayoutTestCase.php
@@ -48,7 +48,7 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
     /**
      * @return FormExtensionInterface[]
      */
-    protected function getExtensions()
+    protected function getExtensions(): array
     {
         return [
             new CsrfExtension($this->csrfTokenManager),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

If I don't miss anything, this exception could be removed from `.github/expected-missing-return-types.diff` and the return type can be added, the class is internal to Symfony.