### PR TITLE
[FrameworkBundle] Add params to share the stateless-CSRF config

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1836,10 +1836,11 @@ class FrameworkExtension extends Extension
             return;
         }
 
+        $container->setParameter('framework.csrf_protection.check_header', $config['check_header']);
+        $container->setParameter('framework.csrf_protection.cookie_name', $config['cookie_name']);
+
         $container->getDefinition('security.csrf.same_origin_token_manager')
-            ->replaceArgument(3, $config['stateless_token_ids'])
-            ->replaceArgument(4, $config['check_header'])
-            ->replaceArgument(5, $config['cookie_name']);
+            ->replaceArgument(3, $config['stateless_token_ids']);
 
         if (!$this->isInitializedConfigEnabled('session')) {
             $container->setAlias('security.csrf.token_manager', 'security.csrf.same_origin_token_manager');

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/security_csrf.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/security_csrf.php
@@ -55,8 +55,8 @@ return static function (ContainerConfigurator $container) {
                 service('logger')->nullOnInvalid(),
                 service('.inner'),
                 abstract_arg('framework.csrf_protection.stateless_token_ids'),
-                abstract_arg('framework.csrf_protection.check_header'),
-                abstract_arg('framework.csrf_protection.cookie_name'),
+                param('framework.csrf_protection.check_header'),
+                param('framework.csrf_protection.cookie_name'),
             ])
             ->tag('monolog.logger', ['channel' => 'request'])
             ->tag('kernel.event_listener', ['event' => 'kernel.response', 'method' => 'onKernelResponse'])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Trying to leverage the stateless CSRF token manager on UX Live Components, I figured out it'd be useful to be able to read these config settings from another bundle.