### PR TITLE
[PhpUnitBridge] Use `total` for asserting deprecation count when a group is not defined

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/CHANGELOG.md
+++ b/src/Symfony/Bridge/PhpUnit/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `ExpectUserDeprecationMessageTrait` with a polyfill of PHPUnit's `expectUserDeprecationMessage()`
+ * Use `total` for asserting deprecation count when a group is not defined
 
 6.4
 ---

--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Configuration.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Configuration.php
@@ -96,7 +96,7 @@ class Configuration
         }
         foreach ($groups as $group) {
             if (!isset($this->thresholds[$group])) {
-                $this->thresholds[$group] = 999999;
+                $this->thresholds[$group] = $this->thresholds['total'] ?? 999999;
             }
         }
         $this->regex = $regex;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT
