### PR TITLE
Fix command ask param

### DIFF
--- a/src/Symfony/Component/Console/Style/StyleInterface.php
+++ b/src/Symfony/Component/Console/Style/StyleInterface.php
@@ -85,7 +85,7 @@ interface StyleInterface
      *
      * @return mixed
      */
-    public function ask(string $question, ?string $default = null, ?callable $validator = null);
+    public function ask(string $question, mixed $default = null, ?callable $validator = null);
 
     /**
      * Asks a question with the user input hidden.

--- a/src/Symfony/Component/Console/Style/StyleInterface.php
+++ b/src/Symfony/Component/Console/Style/StyleInterface.php
@@ -83,9 +83,11 @@ interface StyleInterface
     /**
      * Asks a question.
      *
+     * @param string|bool|int|float|null $default
+     * 
      * @return mixed
      */
-    public function ask(string $question, mixed $default = null, ?callable $validator = null);
+    public function ask(string $question, $default = null, ?callable $validator = null);
 
     /**
      * Asks a question with the user input hidden.

--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -250,7 +250,7 @@ class SymfonyStyle extends OutputStyle
     /**
      * {@inheritdoc}
      */
-    public function ask(string $question, mixed $default = null, ?callable $validator = null)
+    public function ask(string $question, string|bool|int|float|null $default = null, ?callable $validator = null)
     {
         $question = new Question($question, $default);
         $question->setValidator($validator);

--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -250,7 +250,7 @@ class SymfonyStyle extends OutputStyle
     /**
      * {@inheritdoc}
      */
-    public function ask(string $question, mixed $default = null, ?callable $validator = null)
+    public function ask(string $question, $default = null, ?callable $validator = null)
     {
         $question = new Question($question, $default);
         $question->setValidator($validator);

--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -250,7 +250,7 @@ class SymfonyStyle extends OutputStyle
     /**
      * {@inheritdoc}
      */
-    public function ask(string $question, ?string $default = null, ?callable $validator = null)
+    public function ask(string $question, mixed $default = null, ?callable $validator = null)
     {
         $question = new Question($question, $default);
         $question->setValidator($validator);

--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -250,7 +250,7 @@ class SymfonyStyle extends OutputStyle
     /**
      * {@inheritdoc}
      */
-    public function ask(string $question, string|bool|int|float|null $default = null, ?callable $validator = null)
+    public function ask(string $question, mixed $default = null, ?callable $validator = null)
     {
         $question = new Question($question, $default);
         $question->setValidator($validator);

--- a/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
@@ -139,6 +139,7 @@ class CommandTesterTest extends TestCase
             'What\'s your name?',
             'How are you?',
             'Where do you come from?',
+            'How old are you?'
         ];
 
         $command = new Command('foo');
@@ -148,10 +149,11 @@ class CommandTesterTest extends TestCase
             $helper->ask($input, $output, new Question($questions[0], 'Bobby'));
             $helper->ask($input, $output, new Question($questions[1], 'Fine'));
             $helper->ask($input, $output, new Question($questions[2], 'France'));
+            $helper->ask($input, $output, new Question($questions[3], 21));
         });
 
         $tester = new CommandTester($command);
-        $tester->setInputs(['', '', '']);
+        $tester->setInputs(['', '', '', '']);
         $tester->execute([]);
 
         $tester->assertCommandIsSuccessful();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT


The Question class allows string, bool, int, float, or null types for the $default parameter. Therefore, the $default parameter in this method should reflect these valid types via the PHPDoc. This change ensures that the types align with the Question class.

```php
/**
 * @param string|bool|int|float|null $default
 */
public function ask(string $question, $default = null, ?callable $validator = null)
{
    $question = new Question($question, $default);
    $question->setValidator($validator);

    return $this->askQuestion($question);
}
```

Also updated a unit test to confirm new change.
