### PR TITLE
[FrameworkBundle] Add `--no-fill` option to `translation:extract` command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -20,6 +20,7 @@ CHANGELOG
  * Add the ability to use an existing service as a lock/semaphore resource
  * Add support for configuring multiple serializer instances via the configuration
  * Add support for `SYMFONY_TRUSTED_PROXIES`, `SYMFONY_TRUSTED_HEADERS`, `SYMFONY_TRUST_X_SENDFILE_TYPE_HEADER` and `SYMFONY_TRUSTED_HOSTS` env vars
+ * Add `--no-fill` option to `translation:extract` command
 
 7.1
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -19,7 +19,6 @@ use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\HttpKernel\KernelInterface;
@@ -49,6 +48,7 @@ class TranslationUpdateCommand extends Command
         'xlf12' => ['xlf', '1.2'],
         'xlf20' => ['xlf', '2.0'],
     ];
+    private const NO_FILL_PREFIX = "\0NoFill\0";
 
     public function __construct(
         private TranslationWriterInterface $writer,
@@ -71,6 +71,7 @@ class TranslationUpdateCommand extends Command
                 new InputArgument('locale', InputArgument::REQUIRED, 'The locale'),
                 new InputArgument('bundle', InputArgument::OPTIONAL, 'The bundle name or directory where to load the messages'),
                 new InputOption('prefix', null, InputOption::VALUE_OPTIONAL, 'Override the default prefix', '__'),
+                new InputOption('no-fill', null, InputOption::VALUE_NONE, 'Extract translation keys without filling in values'),
                 new InputOption('format', null, InputOption::VALUE_OPTIONAL, 'Override the default output format', 'xlf12'),
                 new InputOption('dump-messages', null, InputOption::VALUE_NONE, 'Should the messages be dumped in the console'),
                 new InputOption('force', null, InputOption::VALUE_NONE, 'Should the extract be done'),
@@ -85,7 +86,8 @@ of a given bundle or the default translations directory. It can display them or 
 the new ones into the translation files.
 
 When new translation strings are found it can automatically add a prefix to the translation
-message.
+message. However, if the <comment>--no-fill</comment> option is used, the <comment>--prefix</comment>
+option has no effect, since the translation values are left empty.
 
 Example running against a Bundle (AcmeBundle)
 
@@ -113,9 +115,6 @@ EOF
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $io = new SymfonyStyle($input, $output);
-        $errorIo = $output instanceof ConsoleOutputInterface ? new SymfonyStyle($input, $output->getErrorOutput()) : $io;
-
         $io = new SymfonyStyle($input, $output);
         $errorIo = $io->getErrorStyle();
 
@@ -181,7 +180,8 @@ EOF
         $io->comment(\sprintf('Generating "<info>%s</info>" translation files for "<info>%s</info>"', $input->getArgument('locale'), $currentName));
 
         $io->comment('Parsing templates...');
-        $extractedCatalogue = $this->extractMessages($input->getArgument('locale'), $codePaths, $input->getOption('prefix'));
+        $prefix = $input->getOption('no-fill') ? self::NO_FILL_PREFIX : $input->getOption('prefix');
+        $extractedCatalogue = $this->extractMessages($input->getArgument('locale'), $codePaths, $prefix);
 
         $io->comment('Loading translation files...');
         $currentCatalogue = $this->loadCurrentMessages($input->getArgument('locale'), $transPaths);
@@ -269,6 +269,10 @@ EOF
             $operationResult = $operation->getResult();
             if ($sort) {
                 $operationResult = $this->sortCatalogue($operationResult, $sort);
+            }
+
+            if (true === $input->getOption('no-fill')) {
+                $this->removeNoFillTranslations($operationResult);
             }
 
             $this->writer->write($operationResult, $format, ['path' => $bundleTransPath, 'default_locale' => $this->defaultLocale, 'xliff_version' => $xliffVersion, 'as_tree' => $input->getOption('as-tree'), 'inline' => $input->getOption('as-tree') ?? 0]);
@@ -484,5 +488,14 @@ EOF
         }
 
         return $codePaths;
+    }
+
+    private function removeNoFillTranslations(MessageCatalogueInterface $operation): void
+    {
+        foreach ($operation->all('messages') as $key => $message) {
+            if (str_starts_with($message, self::NO_FILL_PREFIX)) {
+                $operation->set($key, '', 'messages');
+            }
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #58451 
| License       | MIT

This PR adds the `--no-fill` option to `translation:extract` command.
With this option, only translation keys are generated in the output file, while the translation values are left blank.

Example:

```console
bin/console translation:extract --force --no-fill fr
```
When `--no-fill` is used the `--prefix` option has no effect.

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
