### PR TITLE
[Validator] Pass context to expressions used in `When` constraints

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
  * Add the `WordCount` constraint
  * Add the `Week` constraint
  * Add `CompoundConstraintTestCase` to ease testing Compound Constraints
+ * Add context variable to `WhenValidator`
 
 7.1
 ---

--- a/src/Symfony/Component/Validator/Constraints/WhenValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/WhenValidator.php
@@ -33,6 +33,7 @@ final class WhenValidator extends ConstraintValidator
         $variables = $constraint->values;
         $variables['value'] = $value;
         $variables['this'] = $context->getObject();
+        $variables['context'] = $context;
 
         if ($this->getExpressionLanguage()->evaluate($constraint->expression, $variables)) {
             $context->getValidator()->inContext($context)

--- a/src/Symfony/Component/Validator/Tests/Constraints/WhenValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/WhenValidatorTest.php
@@ -85,6 +85,31 @@ final class WhenValidatorTest extends ConstraintValidatorTestCase
         ]));
     }
 
+    public function testConstraintsAreExecutedWithNestedObject()
+    {
+        $parent = new \stdClass();
+        $parent->child = new \stdClass();
+        $parent->ok = true;
+
+        $number = new \stdClass();
+        $number->value = 1;
+
+        $this->setObject($parent);
+        $this->setPropertyPath('child.value');
+        $this->setRoot($parent);
+
+        $constraints = [
+            new PositiveOrZero(),
+        ];
+
+        $this->expectValidateValue(0, $number->value, $constraints);
+
+        $this->validator->validate($number->value, new When([
+            'expression' => 'context.getRoot().ok === true',
+            'constraints' => $constraints,
+        ]));
+    }
+
     public function testConstraintsAreExecutedWithValue()
     {
         $constraints = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #58511
| License       | MIT

I encountered a problem with validation of nested entities and I needed to validate by parent field, if draft true then no validation is needed
