### PR TITLE
[MonologBridge] simplify test

### DIFF
--- a/src/Symfony/Bridge/Monolog/Tests/Handler/ChromePhpHandlerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/ChromePhpHandlerTest.php
@@ -22,19 +22,15 @@ class ChromePhpHandlerTest extends TestCase
 {
     public function testOnKernelResponseShouldNotTriggerDeprecation()
     {
+        $this->expectNotToPerformAssertions();
+
         $request = Request::create('/');
         $request->headers->remove('User-Agent');
 
         $response = new Response('foo');
         $event = new ResponseEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST, $response);
 
-        $error = null;
-        set_error_handler(function ($type, $message) use (&$error) { $error = $message; }, \E_DEPRECATED);
-
         $listener = new ChromePhpHandler();
         $listener->onKernelResponse($event);
-        restore_error_handler();
-
-        $this->assertNull($error);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

we can simplify the test added in #58492 by dropping the custom exception handler as a triggered deprecation would let the test fail anyway
