### PR TITLE
[FrameworkBundle] pass the test name to the `WebTestCase` constructor

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Test/WebTestCaseTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Test/WebTestCaseTest.php
@@ -339,7 +339,7 @@ class WebTestCaseTest extends TestCase
 
     private function getTester(KernelBrowser $client): WebTestCase
     {
-        $tester = new class() extends WebTestCase {
+        $tester = new class(method_exists($this, 'name') ? $this->name() : $this->getName()) extends WebTestCase {
             use WebTestAssertionsTrait {
                 getClient as public;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

The test name argument is mandatory since PHPUnit 10.