### PR TITLE
[Contracts] add missing properties

### DIFF
--- a/src/Symfony/Contracts/Tests/Service/LegacyTestService.php
+++ b/src/Symfony/Contracts/Tests/Service/LegacyTestService.php
@@ -33,6 +33,8 @@ class LegacyTestService extends LegacyParentTestService implements ServiceSubscr
 {
     use ServiceSubscriberTrait;
 
+    protected $container;
+
     #[SubscribedService]
     public function aService(): Service2
     {

--- a/src/Symfony/Contracts/Tests/Service/ServiceSubscriberTraitTest.php
+++ b/src/Symfony/Contracts/Tests/Service/ServiceSubscriberTraitTest.php
@@ -56,6 +56,8 @@ class ServiceSubscriberTraitTest extends TestCase
         };
         $service = new class() extends ParentWithMagicCall {
             use ServiceSubscriberTrait;
+
+            private $container;
         };
 
         $this->assertNull($service->setContainer($container));
@@ -69,6 +71,8 @@ class ServiceSubscriberTraitTest extends TestCase
         };
         $service = new class() {
             use ServiceSubscriberTrait;
+
+            private $container;
         };
 
         $this->assertNull($service->setContainer($container));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Since #54496 the property is no longer part of the `ServiceSubscriberTrait` triggering a PHP deprecation like:

> Creation of dynamic property Symfony\Contracts\Tests\Service\LegacyTestService::$container is deprecated
