### PR TITLE
[DoctrineBridge] fix: DoctrineTokenProvider not oracle compatible

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
@@ -55,15 +55,17 @@ class DoctrineTokenProvider implements TokenProviderInterface, TokenVerifierInte
      */
     public function loadTokenBySeries(string $series)
     {
-        // the alias for lastUsed works around case insensitivity in PostgreSQL
-        $sql = 'SELECT class, username, value, lastUsed AS last_used FROM rememberme_token WHERE series=:series';
+        $sql = 'SELECT class, username, value, lastUsed FROM rememberme_token WHERE series=:series';
         $paramValues = ['series' => $series];
         $paramTypes = ['series' => ParameterType::STRING];
         $stmt = $this->conn->executeQuery($sql, $paramValues, $paramTypes);
-        $row = $stmt instanceof Result || $stmt instanceof DriverResult ? $stmt->fetchAssociative() : $stmt->fetch(\PDO::FETCH_ASSOC);
+
+        // fetching numeric because column name casing depends on platform, eg. Oracle converts all not quoted names to uppercase
+        $row = $stmt instanceof Result || $stmt instanceof DriverResult ? $stmt->fetchNumeric() : $stmt->fetch(\PDO::FETCH_NUM);
 
         if ($row) {
-            return new PersistentToken($row['class'], $row['username'], $series, $row['value'], new \DateTime($row['last_used']));
+            [$class, $username, $value, $last_used] = $row;
+            return new PersistentToken($class, $username, $series, $value, new \DateTime($last_used));
         }
 
         throw new TokenNotFoundException('No token found.');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | see below
| License       | MIT

Problem: 
Oracle DB returns all not quoted names in uppercase
(vs. SQLite for example returns non quoted column names as lowercase)

On systems with oracle DB this leads to the Warning/Exception attached below.

see also: [PHP Documentation - function.oci-fetch-array- Return Values](https://www.php.net/manual/en/function.oci-fetch-array.php#refsect1-function.oci-fetch-array-returnvalues)

![Screenshot Warning Access to undefined array key](https://github.com/user-attachments/assets/de3dfddd-a46d-472f-9234-ad432d09be6b)

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
