### PR TITLE
[HtmlSanitizer] Add ability to sanitize a whole document

### DIFF
--- a/src/Symfony/Component/HtmlSanitizer/README.md
+++ b/src/Symfony/Component/HtmlSanitizer/README.md
@@ -98,6 +98,12 @@ $sanitizer->sanitize($userInput);
 // Sanitize the given string for a usage in a <head> tag
 $sanitizer->sanitizeFor('head', $userInput);
 
+// Sanitize the given string for a usage in a <body> tag
+$sanitizer->sanitizeFor('body', $userInput);
+
+// Sanitize the given string as a whole document (including <head> and <body>)
+$sanitizer->sanitizeFor('document', $userInput);
+
 // Sanitize the given string for a usage in another tag
 $sanitizer->sanitizeFor('title', $userInput); // Will encode as HTML entities
 $sanitizer->sanitizeFor('textarea', $userInput); // Will encode as HTML entities

--- a/src/Symfony/Component/HtmlSanitizer/Reference/W3CReference.php
+++ b/src/Symfony/Component/HtmlSanitizer/Reference/W3CReference.php
@@ -28,13 +28,16 @@ final class W3CReference
      * A parent element name can be passed as an argument to {@see HtmlSanitizer::sanitizeFor()}.
      * When doing so, depending on the given context, different elements will be allowed.
      */
+    public const CONTEXT_DOCUMENT = 'document';
     public const CONTEXT_HEAD = 'head';
     public const CONTEXT_BODY = 'body';
     public const CONTEXT_TEXT = 'text';
 
     // Which context to apply depending on the passed parent element name
     public const CONTEXTS_MAP = [
+        'document' => self::CONTEXT_DOCUMENT,
         'head' => self::CONTEXT_HEAD,
+        'body' => self::CONTEXT_BODY,
         'textarea' => self::CONTEXT_TEXT,
         'title' => self::CONTEXT_TEXT,
     ];

--- a/src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerAllTest.php
+++ b/src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerAllTest.php
@@ -32,6 +32,32 @@ class HtmlSanitizerAllTest extends TestCase
     }
 
     /**
+     * @dataProvider provideSanitizeDocument
+     */
+    public function testSanitizeDocument(string $input, string $expected)
+    {
+        $this->assertSame($expected, $this->createSanitizer()->sanitizeFor('document', $input));
+    }
+
+    public static function provideSanitizeDocument()
+    {
+        $heads = iterator_to_array(self::provideSanitizeHead());
+        $bodies = iterator_to_array(self::provideSanitizeBody());
+
+        $cases = [];
+        foreach ($heads as $head) {
+            foreach ($bodies as $body) {
+                $cases[] = [
+                    '<!DOCTYPE html><html><head>'.$head[0].'</head><body>'.$body[0].'</body></html>',
+                    '<!DOCTYPE html><html><head>'.$head[1].'</head><body>'.$body[1].'</body></html>',
+                ];
+            }
+        }
+
+        return $cases;
+    }
+
+    /**
      * @dataProvider provideSanitizeHead
      */
     public function testSanitizeHead(string $input, string $expected)

--- a/src/Symfony/Component/HtmlSanitizer/Visitor/Model/Cursor.php
+++ b/src/Symfony/Component/HtmlSanitizer/Visitor/Model/Cursor.php
@@ -20,7 +20,9 @@ use Symfony\Component\HtmlSanitizer\Visitor\Node\NodeInterface;
  */
 final class Cursor
 {
-    public function __construct(public ?NodeInterface $node)
-    {
+    public function __construct(
+        public array $contextsPath,
+        public ?NodeInterface $node
+    ) {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony/issues/58426
| License       | MIT

This PR adds the ability to sanitize a whole document:

```php
use Symfony\Component\HtmlSanitizer\HtmlSanitizer;
use Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig;

$config = (new HtmlSanitizerConfig)->allowSafeElements();

$html = '<html><head><title>Example</title></head><body><p>Example</p></body></html>';

echo (new HtmlSanitizer($config))->sanitizeFor('document', $html);
// Display <html><head><title>Example</title></head><body><p>Example</p></body></html>
```

To achieve this while keeping the expected behavior (removing head elements from body tags and vice versa), it introduces a system of contexts path in the cursor to know in which sanitization context the DOM visitor is running in node sanitizers.