### PR TITLE
[Notifier] silence warnings triggered when malformed XML is parsed

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/KazInfoTeh/KazInfoTehTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/KazInfoTeh/KazInfoTehTransport.php
@@ -80,7 +80,7 @@ class KazInfoTehTransport extends AbstractTransport
         }
 
         try {
-            $content = new \SimpleXMLElement($response->getContent(false));
+            $content = @new \SimpleXMLElement($response->getContent(false));
         } catch (\Exception $e) {
             throw new TransportException('Unable to send the SMS: "Couldn\'t read response".', $response, previous: $e);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

The constructor of the `SimpleXMLElement` class issues a warning if the passed data is not valid.
