### PR TITLE
[ErrorHandler] resolve class constant types when patching return types

### DIFF
--- a/src/Symfony/Component/ErrorHandler/Tests/DebugClassLoaderTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/DebugClassLoaderTest.php
@@ -401,6 +401,26 @@ class DebugClassLoaderTest extends TestCase
             'Method "Symfony\Component\ErrorHandler\Tests\Fixtures\ReturnTypeParent::true()" might add "true" as a native return type declaration in the future. Do the same in child class "Test\Symfony\Component\ErrorHandler\Tests\ReturnType" now to avoid errors or add an explicit @return annotation to suppress this message.',
             'Method "Symfony\Component\ErrorHandler\Tests\Fixtures\ReturnTypeParent::never()" might add "never" as a native return type declaration in the future. Do the same in child class "Test\Symfony\Component\ErrorHandler\Tests\ReturnType" now to avoid errors or add an explicit @return annotation to suppress this message.',
             'Method "Symfony\Component\ErrorHandler\Tests\Fixtures\ReturnTypeParent::null()" might add "null" as a native return type declaration in the future. Do the same in child class "Test\Symfony\Component\ErrorHandler\Tests\ReturnType" now to avoid errors or add an explicit @return annotation to suppress this message.',
+            'Method "Symfony\Component\ErrorHandler\Tests\Fixtures\ReturnTypeParent::classConstant()" might add "string" as a native return type declaration in the future. Do the same in child class "Test\Symfony\Component\ErrorHandler\Tests\ReturnType" now to avoid errors or add an explicit @return annotation to suppress this message.',
+        ], $deprecations);
+    }
+
+    /**
+     * @requires PHP >= 8.3
+     */
+    public function testReturnTypePhp83()
+    {
+        $deprecations = [];
+        set_error_handler(function ($type, $msg) use (&$deprecations) { $deprecations[] = $msg; });
+        $e = error_reporting(E_USER_DEPRECATED);
+
+        class_exists('Test\\'.ReturnTypePhp83::class, true);
+
+        error_reporting($e);
+        restore_error_handler();
+
+        $this->assertSame([
+            'Method "Symfony\Component\ErrorHandler\Tests\Fixtures\ReturnTypeParentPhp83::classConstantWithType()" might add "string" as a native return type declaration in the future. Do the same in child class "Test\Symfony\Component\ErrorHandler\Tests\ReturnTypePhp83" now to avoid errors or add an explicit @return annotation to suppress this message.',
         ], $deprecations);
     }
 
@@ -542,6 +562,8 @@ class ClassLoader
             }');
         } elseif ('Test\\'.ReturnType::class === $class) {
             return $fixtureDir.\DIRECTORY_SEPARATOR.'ReturnType.php';
+        } elseif ('Test\\'.ReturnTypePhp83::class === $class) {
+            return $fixtureDir.\DIRECTORY_SEPARATOR.'ReturnTypePhp83.php';
         } elseif ('Test\\'.Fixtures\OutsideInterface::class === $class) {
             return $fixtureDir.\DIRECTORY_SEPARATOR.'OutsideInterface.php';
         } elseif ('Test\\'.OverrideOutsideFinalProperty::class === $class) {

--- a/src/Symfony/Component/ErrorHandler/Tests/Fixtures/ReturnType.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Fixtures/ReturnType.php
@@ -51,4 +51,5 @@ class ReturnType extends ReturnTypeParent implements ReturnTypeInterface, Fixtur
     public function never() { }
     public function null() { }
     public function outsideMethod() { }
+    public function classConstant() { }
 }

--- a/src/Symfony/Component/ErrorHandler/Tests/Fixtures/ReturnTypeParent.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Fixtures/ReturnTypeParent.php
@@ -4,6 +4,8 @@ namespace Symfony\Component\ErrorHandler\Tests\Fixtures;
 
 abstract class ReturnTypeParent extends ReturnTypeGrandParent implements ReturnTypeParentInterface
 {
+    const FOO = 'foo';
+
     /**
      * @return void
      */
@@ -252,6 +254,13 @@ abstract class ReturnTypeParent extends ReturnTypeGrandParent implements ReturnT
      * @return int
      */
     public function notExtended()
+    {
+    }
+
+    /**
+     * @return self::FOO
+     */
+    public function classConstant()
     {
     }
 }

--- a/src/Symfony/Component/ErrorHandler/Tests/Fixtures/ReturnTypeParentPhp83.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Fixtures/ReturnTypeParentPhp83.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Symfony\Component\ErrorHandler\Tests\Fixtures;
+
+abstract class ReturnTypeParentPhp83
+{
+    const string FOO = 'foo';
+    const string|int BAR = 'bar';
+
+    /**
+     * @return self::FOO
+     */
+    public function classConstantWithType()
+    {
+    }
+
+    /**
+     * @return self::BAR
+     */
+    public function classConstantWithUnionType()
+    {
+    }
+}

--- a/src/Symfony/Component/ErrorHandler/Tests/Fixtures/ReturnTypePhp83.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Fixtures/ReturnTypePhp83.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Test\Symfony\Component\ErrorHandler\Tests;
+
+use Symfony\Component\ErrorHandler\Tests\Fixtures\ReturnTypeParentPhp83;
+
+class ReturnTypePhp83 extends ReturnTypeParentPhp83
+{
+    public function classConstantWithType() { }
+    public function classConstantWithUnionType() { }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

account for types like the ones added in #58493