### PR TITLE
[HttpFoundation] session names must not be empty

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/AbstractRedisSessionHandlerTestCase.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/AbstractRedisSessionHandlerTestCase.php
@@ -106,7 +106,7 @@ abstract class AbstractRedisSessionHandlerTestCase extends TestCase
 
     public function testDestroySession()
     {
-        $this->storage->open('', '');
+        $this->storage->open('', 'test');
         $this->redisClient->set(self::PREFIX.'id', 'foo');
 
         $this->assertTrue((bool) $this->redisClient->exists(self::PREFIX.'id'));

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MemcachedSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MemcachedSessionHandlerTest.php
@@ -119,7 +119,7 @@ class MemcachedSessionHandlerTest extends TestCase
 
     public function testDestroySession()
     {
-        $this->storage->open('', '');
+        $this->storage->open('', 'sid');
         $this->memcached
             ->expects($this->once())
             ->method('delete')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

The changes done in #58453 were not enough. Since the session name is used as the cookie name it must not be the empty string.