### PR TITLE
[Notifier] support `SmsMessage` with 'from' set

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/FakeSms/FakeSmsEmailTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/FakeSms/FakeSmsEmailTransport.php
@@ -60,14 +60,14 @@ final class FakeSmsEmailTransport extends AbstractTransport
      */
     protected function doSend(MessageInterface $message): SentMessage
     {
-        if (!$this->supports($message)) {
+        if (!$message instanceof SmsMessage) {
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
         $email = (new Email())
-            ->from($message->getFrom() ?: $this->from)
+            ->from($this->from)
             ->to($this->to)
-            ->subject(sprintf('New SMS on phone number: %s', $message->getPhone()))
+            ->subject('New SMS to phone number ' . $message->getPhone() . ($message->getFrom() ? ' from ' . $message->getFrom() : ''))
             ->html($message->getSubject())
             ->text($message->getSubject());
 

--- a/src/Symfony/Component/Notifier/Bridge/FakeSms/FakeSmsLoggerTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/FakeSms/FakeSmsLoggerTransport.php
@@ -51,11 +51,11 @@ final class FakeSmsLoggerTransport extends AbstractTransport
      */
     protected function doSend(MessageInterface $message): SentMessage
     {
-        if (!$this->supports($message)) {
+        if (!$message instanceof SmsMessage) {
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
-        $this->logger->info(sprintf('New SMS on phone number: %s', $message->getPhone()));
+        $this->logger->info('New SMS to phone number ' . $message->getPhone() . ($message->getFrom() ? ' from ' . $message->getFrom() : ''));
 
         return new SentMessage($message, (string) $this);
     }

--- a/src/Symfony/Component/Notifier/Bridge/FakeSms/Tests/FakeSmsEmailTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/FakeSms/Tests/FakeSmsEmailTransportTest.php
@@ -70,7 +70,30 @@ final class FakeSmsEmailTransportTest extends TransportTestCase
         $this->assertInstanceOf(Email::class, $sentEmail);
         $this->assertSame($to, $sentEmail->getTo()[0]->getEncodedAddress());
         $this->assertSame($from, $sentEmail->getFrom()[0]->getEncodedAddress());
-        $this->assertSame(sprintf('New SMS on phone number: %s', $phone), $sentEmail->getSubject());
+        $this->assertSame(\sprintf('New SMS to phone number %s', $phone), $sentEmail->getSubject());
+        $this->assertSame($subject, $sentEmail->getTextBody());
+        $this->assertFalse($sentEmail->getHeaders()->has('X-Transport'));
+    }
+
+    public function testSendWithFrom()
+    {
+        $transportName = null;
+
+        $message = new SmsMessage($phone = '0611223344', $subject = 'Hello!', $fromPhone = '0655667788');
+
+        $mailer = new DummyMailer();
+
+        $transport = (new FakeSmsEmailTransport($mailer, $to = 'recipient@email.net', $from = 'sender@email.net'));
+        $transport->setHost($transportName);
+
+        $transport->send($message);
+
+        /** @var Email $sentEmail */
+        $sentEmail = $mailer->getSentEmail();
+        $this->assertInstanceOf(Email::class, $sentEmail);
+        $this->assertSame($to, $sentEmail->getTo()[0]->getEncodedAddress());
+        $this->assertSame($from, $sentEmail->getFrom()[0]->getEncodedAddress());
+        $this->assertSame(\sprintf('New SMS to phone number %s from %s', $phone, $fromPhone), $sentEmail->getSubject());
         $this->assertSame($subject, $sentEmail->getTextBody());
         $this->assertFalse($sentEmail->getHeaders()->has('X-Transport'));
     }
@@ -93,7 +116,7 @@ final class FakeSmsEmailTransportTest extends TransportTestCase
         $this->assertInstanceOf(Email::class, $sentEmail);
         $this->assertSame($to, $sentEmail->getTo()[0]->getEncodedAddress());
         $this->assertSame($from, $sentEmail->getFrom()[0]->getEncodedAddress());
-        $this->assertSame(sprintf('New SMS on phone number: %s', $phone), $sentEmail->getSubject());
+        $this->assertSame(\sprintf('New SMS to phone number %s', $phone), $sentEmail->getSubject());
         $this->assertSame($subject, $sentEmail->getTextBody());
         $this->assertTrue($sentEmail->getHeaders()->has('X-Transport'));
         $this->assertSame($transportName, $sentEmail->getHeaders()->get('X-Transport')->getBody());

--- a/src/Symfony/Component/Notifier/Bridge/FakeSms/Tests/FakeSmsLoggerTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/FakeSms/Tests/FakeSmsLoggerTransportTest.php
@@ -61,7 +61,7 @@ final class FakeSmsLoggerTransportTest extends TransportTestCase
         $this->assertNotEmpty($logs);
 
         $log = $logs[0];
-        $this->assertSame(sprintf('New SMS on phone number: %s', $phone), $log['message']);
+        $this->assertSame(\sprintf('New SMS to phone number %s', $phone), $log['message']);
         $this->assertSame('info', $log['level']);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58535
| License       | MIT

Fixes `Error Email does not comply with addr-spec of RFC 2822`

See
* #58535