### PR TITLE
[Dotenv] Add `--override` option

### DIFF
--- a/src/Symfony/Component/Dotenv/CHANGELOG.md
+++ b/src/Symfony/Component/Dotenv/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+* Introduce an --override option to specify whether to overwrite existing .env.local.php file
+
 7.1
 ---
 

--- a/src/Symfony/Component/Dotenv/CHANGELOG.md
+++ b/src/Symfony/Component/Dotenv/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 7.2
 ---
 
-* Introduce an --override option to specify whether to overwrite existing .env.local.php file
+ * Introduce an --override option to specify whether to overwrite existing .env.local.php file
 
 7.1
 ---

--- a/src/Symfony/Component/Dotenv/Command/DotenvDumpCommand.php
+++ b/src/Symfony/Component/Dotenv/Command/DotenvDumpCommand.php
@@ -73,6 +73,11 @@ EOT
             $env = $vars[$envKey];
         }
 
+        if(\is_file($dotenvPath.'.local.php')) {
+            $oldVars = require $dotenvPath.'.local.php';
+            $vars = $oldVars + $vars;
+        }
+
         $vars = var_export($vars, true);
         $vars = <<<EOF
 <?php
@@ -82,6 +87,7 @@ EOT
 return $vars;
 
 EOF;
+
         file_put_contents($dotenvPath.'.local.php', $vars, \LOCK_EX);
 
         $output->writeln(\sprintf('Successfully dumped .env files in <info>.env.local.php</> for the <info>%s</> environment.', $env));

--- a/src/Symfony/Component/Dotenv/Command/DotenvDumpCommand.php
+++ b/src/Symfony/Component/Dotenv/Command/DotenvDumpCommand.php
@@ -76,7 +76,7 @@ EOT
 
         $override = $input->getOption('override');
 
-        if(!$override && \is_file($dotenvPath.'.local.php')) {
+        if (!$override && is_file($dotenvPath.'.local.php')) {
             $oldVars = require $dotenvPath.'.local.php';
             $vars = $oldVars + $vars;
         }

--- a/src/Symfony/Component/Dotenv/Command/DotenvDumpCommand.php
+++ b/src/Symfony/Component/Dotenv/Command/DotenvDumpCommand.php
@@ -41,6 +41,7 @@ final class DotenvDumpCommand extends Command
         $this
             ->setDefinition([
                 new InputArgument('env', null === $this->defaultEnv ? InputArgument::REQUIRED : InputArgument::OPTIONAL, 'The application environment to dump .env files for - e.g. "prod".'),
+                new InputOption('override', null, InputOption::VALUE_OPTIONAL, 'Specify whether to override existing .env.local.php, if exists, files or not.', false),
             ])
             ->addOption('empty', null, InputOption::VALUE_NONE, 'Ignore the content of .env files')
             ->setHelp(<<<'EOT'
@@ -73,7 +74,9 @@ EOT
             $env = $vars[$envKey];
         }
 
-        if(\is_file($dotenvPath.'.local.php')) {
+        $override = $input->getOption('override');
+
+        if(!$override && \is_file($dotenvPath.'.local.php')) {
             $oldVars = require $dotenvPath.'.local.php';
             $vars = $oldVars + $vars;
         }

--- a/src/Symfony/Component/Dotenv/Tests/Command/DotenvDumpCommandTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/Command/DotenvDumpCommandTest.php
@@ -23,11 +23,22 @@ class DotenvDumpCommandTest extends TestCase
         file_put_contents(__DIR__.'/.env', <<<EOF
 APP_ENV=dev
 APP_SECRET=abc123
+COMPILED_FIRST=test_override
 EOF
         );
 
         file_put_contents(__DIR__.'/.env.local', <<<EOF
 APP_LOCAL=yes
+COMPILED_FIRST=test_override_local
+EOF
+        );
+
+        file_put_contents(__DIR__.'/.env.local.php', <<<EOF
+<?php
+return [
+    'TEST_EXISTING_VAR' => 'test',
+    'COMPILED_FIRST' => 'this should not be overridden',
+];
 EOF
         );
     }
@@ -51,6 +62,8 @@ EOF
 
         $vars = require __DIR__.'/.env.local.php';
         $this->assertSame([
+            'TEST_EXISTING_VAR' => 'test',
+            'COMPILED_FIRST' => 'this should not be overridden',
             'APP_ENV' => 'test',
             'APP_SECRET' => 'abc123',
         ], $vars);
@@ -67,7 +80,11 @@ EOF
         $this->assertFileExists(__DIR__.'/.env.local.php');
 
         $vars = require __DIR__.'/.env.local.php';
-        $this->assertSame(['APP_ENV' => 'test'], $vars);
+        $this->assertSame([
+            'TEST_EXISTING_VAR' => 'test',
+            'COMPILED_FIRST' => 'this should not be overridden',
+            'APP_ENV' => 'test'
+        ], $vars);
     }
 
     public function testExecuteTestEnvs()
@@ -86,6 +103,8 @@ EOF
 
         $vars = require __DIR__.'/.env.local.php';
         $this->assertSame([
+            'TEST_EXISTING_VAR' => 'test',
+            'COMPILED_FIRST' => 'this should not be overridden',
             'APP_ENV' => 'test',
             'APP_SECRET' => 'abc123',
             'APP_LOCAL' => 'yes',

--- a/src/Symfony/Component/Dotenv/Tests/Command/DotenvDumpCommandTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/Command/DotenvDumpCommandTest.php
@@ -83,7 +83,7 @@ EOF
         $this->assertSame([
             'TEST_EXISTING_VAR' => 'test',
             'COMPILED_FIRST' => 'this should not be overridden',
-            'APP_ENV' => 'test'
+            'APP_ENV' => 'test',
         ], $vars);
     }
 
@@ -101,7 +101,7 @@ EOF
         $this->assertSame([
             'APP_ENV' => 'test',
             'APP_SECRET' => 'abc123',
-            'COMPILED_FIRST' => 'test_override'
+            'COMPILED_FIRST' => 'test_override',
         ], $vars);
     }
 

--- a/src/Symfony/Component/Dotenv/Tests/Command/DotenvDumpCommandTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/Command/DotenvDumpCommandTest.php
@@ -87,6 +87,24 @@ EOF
         ], $vars);
     }
 
+    public function testExecuteOverride()
+    {
+        $command = $this->createCommand();
+        $command->execute([
+            'env' => 'test',
+            '--override' => true,
+        ]);
+
+        $this->assertFileExists(__DIR__.'/.env.local.php');
+
+        $vars = require __DIR__.'/.env.local.php';
+        $this->assertSame([
+            'APP_ENV' => 'test',
+            'APP_SECRET' => 'abc123',
+            'COMPILED_FIRST' => 'test_override'
+        ], $vars);
+    }
+
     public function testExecuteTestEnvs()
     {
         file_put_contents(__DIR__.'/composer.json', <<<EOF


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | N/D
| License       | MIT

This PR modifies `DotenvDumpCommand` to include existing variables from `.env.local.php` (if exists) when dumping new environment variables. Added corresponding tests to ensure pre-existing values are preserved and not overridden by the new dump process.

Add override option to DotenvDumpCommand

Introduce an --override option to specify whether to overwrite existing .env.local.php files. This update includes test coverage to ensure the new functionality works as expected.
