### PR TITLE
[Cache] do not mix named and positional arguments in data provider definitions

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Traits/RedisTraitTest.php
+++ b/src/Symfony/Component/Cache/Tests/Traits/RedisTraitTest.php
@@ -74,7 +74,7 @@ class RedisTraitTest extends TestCase
                 'Redis',
             ],
             [
-                'dsn' => sprintf('redis:?%s', implode('&', \array_slice($hosts, 0, 2))),
+                sprintf('redis:?%s', implode('&', \array_slice($hosts, 0, 2))),
                 'RedisArray',
             ],
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT
