### PR TITLE
[String] Add `AbstractString::pascal()` method

### DIFF
--- a/src/Symfony/Component/String/AbstractString.php
+++ b/src/Symfony/Component/String/AbstractString.php
@@ -438,6 +438,11 @@ abstract class AbstractString implements \Stringable, \JsonSerializable
         return $this->snake()->replace('_', '-');
     }
 
+    public function pascal(): static
+    {
+        return $this->camel()->title();
+    }
+
     abstract public function splice(string $replacement, int $start = 0, ?int $length = null): static;
 
     /**

--- a/src/Symfony/Component/String/CHANGELOG.md
+++ b/src/Symfony/Component/String/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.3
+---
+
+* Add the `AbstractString::pascal()` method
+
 7.2
 ---
 

--- a/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
@@ -1119,6 +1119,33 @@ abstract class AbstractAsciiTestCase extends TestCase
     }
 
     /**
+     * @dataProvider providePascal
+     */
+    public function testPascal(string $expectedString, string $origin)
+    {
+        $instance = static::createFromString($origin)->pascal();
+
+        $this->assertEquals(static::createFromString($expectedString), $instance);
+        $this->assertNotSame($origin, $instance, 'Strings should be immutable');
+    }
+
+    public static function providePascal(): array
+    {
+        return [
+            ['', ''],
+            ['XY', 'x_y'],
+            ['XuYo', 'xu_yo'],
+            ['SymfonyIsGreat', 'symfony_is_great'],
+            ['Symfony5IsGreat', 'symfony_5_is_great'],
+            ['SymfonyIsGreat', 'Symfony is great'],
+            ['SYMFONYISGREAT', 'SYMFONY_IS_GREAT'],
+            ['SymfonyIsAGreatFramework', 'Symfony is a great framework'],
+            ['SymfonyIsGREAT', '*Symfony* is GREAT!!'],
+            ['SYMFONY', 'SYMFONY'],
+        ];
+    }
+
+    /**
      * @dataProvider provideStartsWith
      */
     public function testStartsWith(bool $expected, string $origin, $prefix, ?int $form = null)

--- a/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
@@ -655,6 +655,17 @@ END'],
         );
     }
 
+    public static function providePascal(): array
+    {
+        return array_merge(
+            parent::providePascal(),
+            [
+                ['SymfonyIstÄußerstCool', 'symfonyIstÄußerstCool'],
+                ['SymfonyWithEmojis', 'Symfony with 😃 emojis'],
+            ]
+        );
+    }
+
     public static function provideSnake()
     {
         return array_merge(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

Introduce a new `pascal()` method to the `AbstractString` class to transform strings to PascalCase. 
Accompany the implementation with relevant test cases to ensure correctness and immutability.

Update the changelog to document this new method.
