### PR TITLE
[Scheduler] Add MessageHandler result to the `PostRunEvent`

### DIFF
--- a/src/Symfony/Component/Messenger/Handler/RedispatchMessageHandler.php
+++ b/src/Symfony/Component/Messenger/Handler/RedispatchMessageHandler.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Messenger\Handler;
 
 use Symfony\Component\Messenger\Message\RedispatchMessage;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\HandledStamp;
 use Symfony\Component\Messenger\Stamp\TransportNamesStamp;
 
 final class RedispatchMessageHandler
@@ -22,8 +23,10 @@ final class RedispatchMessageHandler
     ) {
     }
 
-    public function __invoke(RedispatchMessage $message): void
+    public function __invoke(RedispatchMessage $message): mixed
     {
-        $this->bus->dispatch($message->envelope, [new TransportNamesStamp($message->transportNames)]);
+        $envelope = $this->bus->dispatch($message->envelope, [new TransportNamesStamp($message->transportNames)]);
+
+        return $envelope->last(HandledStamp::class)?->getResult();
     }
 }

--- a/src/Symfony/Component/Scheduler/CHANGELOG.md
+++ b/src/Symfony/Component/Scheduler/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add capability to skip missed periodic tasks, only the last schedule will be called
+ * Add MessageHandler returned result to `PostRunEvent`
 
 6.4
 ---

--- a/src/Symfony/Component/Scheduler/Event/PostRunEvent.php
+++ b/src/Symfony/Component/Scheduler/Event/PostRunEvent.php
@@ -20,6 +20,7 @@ class PostRunEvent
         private readonly ScheduleProviderInterface $schedule,
         private readonly MessageContext $messageContext,
         private readonly object $message,
+        private readonly mixed $result,
     ) {
     }
 
@@ -36,5 +37,10 @@ class PostRunEvent
     public function getMessage(): object
     {
         return $this->message;
+    }
+
+    public function getResult(): mixed
+    {
+        return $this->result;
     }
 }

--- a/src/Symfony/Component/Scheduler/EventListener/DispatchSchedulerEventListener.php
+++ b/src/Symfony/Component/Scheduler/EventListener/DispatchSchedulerEventListener.php
@@ -18,6 +18,7 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
 use Symfony\Component\Messenger\Event\WorkerMessageHandledEvent;
 use Symfony\Component\Messenger\Event\WorkerMessageReceivedEvent;
+use Symfony\Component\Messenger\Stamp\HandledStamp;
 use Symfony\Component\Messenger\Stamp\StampInterface;
 use Symfony\Component\Scheduler\Event\FailureEvent;
 use Symfony\Component\Scheduler\Event\PostRunEvent;
@@ -40,7 +41,9 @@ class DispatchSchedulerEventListener implements EventSubscriberInterface
             return;
         }
 
-        $this->eventDispatcher->dispatch(new PostRunEvent($this->scheduleProviderLocator->get($scheduledStamp->messageContext->name), $scheduledStamp->messageContext, $envelope->getMessage()));
+        $result = $envelope->last(HandledStamp::class)?->getResult();
+
+        $this->eventDispatcher->dispatch(new PostRunEvent($this->scheduleProviderLocator->get($scheduledStamp->messageContext->name), $scheduledStamp->messageContext, $envelope->getMessage(), $result));
     }
 
     public function onMessageReceived(WorkerMessageReceivedEvent $event): void

--- a/src/Symfony/Component/Scheduler/Messenger/ServiceCallMessageHandler.php
+++ b/src/Symfony/Component/Scheduler/Messenger/ServiceCallMessageHandler.php
@@ -24,8 +24,8 @@ class ServiceCallMessageHandler
     {
     }
 
-    public function __invoke(ServiceCallMessage $message): void
+    public function __invoke(ServiceCallMessage $message): mixed
     {
-        $this->serviceLocator->get($message->getServiceId())->{$message->getMethod()}(...$message->getArguments());
+        return $this->serviceLocator->get($message->getServiceId())->{$message->getMethod()}(...$message->getArguments());
     }
 }

--- a/src/Symfony/Component/Scheduler/Scheduler.php
+++ b/src/Symfony/Component/Scheduler/Scheduler.php
@@ -83,10 +83,10 @@ final class Scheduler
                     }
 
                     try {
-                        $this->handlers[$message::class]($message);
+                        $result = $this->handlers[$message::class]($message);
                         $ran = true;
 
-                        $this->dispatcher->dispatch(new PostRunEvent($generator->getSchedule(), $context, $message));
+                        $this->dispatcher->dispatch(new PostRunEvent($generator->getSchedule(), $context, $message, $result));
                     } catch (\Throwable $error) {
                         $failureEvent = new FailureEvent($generator->getSchedule(), $context, $message, $error);
                         $this->dispatcher->dispatch($failureEvent);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

This PR will add the result of a MessageHandler to the PostRunEvent of the Scheduler Component. This can be used for example for retrieving the output of a RunCommandMessage scheduled by the scheduler component.

```
<?php

namespace App\Service;

use Symfony\Component\Console\Messenger\RunCommandMessage;
use Symfony\Component\Scheduler\Attribute\AsSchedule;
use Symfony\Component\Scheduler\RecurringMessage;
use Symfony\Component\Scheduler\Schedule;
use Symfony\Component\Scheduler\ScheduleProviderInterface;

#[AsSchedule]
class ScheduleProvider implements ScheduleProviderInterface
{
    public function getSchedule(): Schedule
    {
        $schedule = new Schedule();
        $schedule->add(RecurringMessage::cron('* * * * *', new RunCommandMessage('about')));

        return $schedule;
    }
}
```
```
<?php

namespace App\EventListener;

use Symfony\Component\Console\Messenger\RunCommandContext;
use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
use Symfony\Component\Scheduler\Event\PostRunEvent;

#[AsEventListener(event: PostRunEvent::class, method: 'onMessage')]
class SchedulerListener
{
    public function onMessage(PostRunEvent $event): void
    {
        $result = $event->getResult();

        if ($result instanceof RunCommandContext) {
            echo $result->output; //Log or store output somewhere
        }
    }
}
```


<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
