### PR TITLE
[HtmlSanitizer] Fix `force_attributes` not replacing existing attribute in initial data

### DIFF
--- a/src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerCustomTest.php
+++ b/src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerCustomTest.php
@@ -232,9 +232,16 @@ class HtmlSanitizerCustomTest extends TestCase
     {
         $config = (new HtmlSanitizerConfig())
             ->allowElement('div')
+            ->allowElement('img', '*')
             ->allowElement('a', ['href'])
             ->forceAttribute('a', 'rel', 'noopener noreferrer')
+            ->forceAttribute('img', 'loading', 'lazy')
         ;
+
+        $this->assertSame(
+            '<img title="My image" src="https://example.com/image.png" loading="lazy" />',
+            $this->sanitize($config, '<img title="My image" src="https://example.com/image.png" loading="eager" onerror="alert(\'1234\')" />')
+        );
 
         $this->assertSame(
             '<a rel="noopener noreferrer">Hello</a> world',
@@ -249,6 +256,11 @@ class HtmlSanitizerCustomTest extends TestCase
         $this->assertSame(
             '<div>Hello</div> world',
             $this->sanitize($config, '<div style="width: 100px">Hello</div> world')
+        );
+
+        $this->assertSame(
+            '<a href="https://symfony.com" rel="noopener noreferrer">Hello</a> world',
+            $this->sanitize($config, '<a href="https://symfony.com" rel="noopener">Hello</a> world')
         );
     }
 

--- a/src/Symfony/Component/HtmlSanitizer/Visitor/DomVisitor.php
+++ b/src/Symfony/Component/HtmlSanitizer/Visitor/DomVisitor.php
@@ -120,7 +120,7 @@ final class DomVisitor
 
         // Force configured attributes
         foreach ($this->forcedAttributes[$domNodeName] ?? [] as $attribute => $value) {
-            $node->setAttribute($attribute, $value);
+            $node->setAttribute($attribute, $value, true);
         }
 
         $cursor->node->addChild($node);

--- a/src/Symfony/Component/HtmlSanitizer/Visitor/Node/Node.php
+++ b/src/Symfony/Component/HtmlSanitizer/Visitor/Node/Node.php
@@ -58,10 +58,10 @@ final class Node implements NodeInterface
         return $this->attributes[$name] ?? null;
     }
 
-    public function setAttribute(string $name, ?string $value): void
+    public function setAttribute(string $name, ?string $value, bool $override = false): void
     {
         // Always use only the first declaration (ease sanitization)
-        if (!\array_key_exists($name, $this->attributes)) {
+        if ($override || !\array_key_exists($name, $this->attributes)) {
             $this->attributes[$name] = $value;
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony/issues/58065
| License       | MIT

Fix the override of an existing attribute value.