### PR TITLE
[ErrorHandler] Fix patch return type

### DIFF
--- a/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
+++ b/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
@@ -868,8 +868,8 @@ class DebugClassLoader
             }
 
             if (!preg_match('/^(?:\\\\?[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*)+$/', $n)) {
-                // exclude any invalid PHP class name (e.g. `Cookie::SAMESITE_*`)
-                continue;
+                // avoid changing return type if there is any invalid PHP class name (e.g. `Cookie::SAMESITE_*`)
+                return;
             }
 
             if (!isset($phpTypes[''])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no
| Issues        | 
| License       | MIT

When trying to patch return types, the following
```php
/**
 * @return self::CLASS_CONSTRAINT|self::PROPERTY_CONSTRAINT|array<self::CLASS_CONSTRAINT|self::PROPERTY_CONSTRAINT>
 */
public function getTargets(): string|array
{
    // ...
}
```
becomes
```php
/**
 * @return self::CLASS_CONSTRAINT|self::PROPERTY_CONSTRAINT|array<self::CLASS_CONSTRAINT|self::PROPERTY_CONSTRAINT>
 */
public function getTargets(): array
{
    // ...
}
```
because `self::XXX` constants are considered invalid. And therefore only the `array` is kept.
But this behavior is wrong, so this PR prevents the return type from changing if a constant is detected.