### PR TITLE
[Scheduler] silence PHP warning when an invalid date interval format string is used

### DIFF
--- a/src/Symfony/Component/Scheduler/Tests/Trigger/PeriodicalTriggerTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Trigger/PeriodicalTriggerTest.php
@@ -60,21 +60,22 @@ class PeriodicalTriggerTest extends TestCase
     /**
      * @dataProvider getInvalidIntervals
      */
-    public function testInvalidInterval($interval)
+    public function testInvalidInterval($interval, $expectedExceptionMessage)
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($expectedExceptionMessage);
 
         new PeriodicalTrigger($interval, $now = new \DateTimeImmutable(), $now->modify('1 day'));
     }
 
     public static function getInvalidIntervals(): iterable
     {
-        yield ['wrong'];
-        yield ['3600.5'];
-        yield ['-3600'];
-        yield [-3600];
-        yield ['0'];
-        yield [0];
+        yield ['wrong', 'Unknown or bad format (wrong) at position 0 (w): The timezone could not be found in the database'];
+        yield ['3600.5', 'Unknown or bad format (3600.5) at position 5 (5): Unexpected character'];
+        yield ['-3600', 'Unknown or bad format (-3600) at position 3 (0): Unexpected character'];
+        yield [-3600, 'The "$interval" argument must be greater than zero.'];
+        yield ['0', 'The "$interval" argument must be greater than zero.'];
+        yield [0, 'The "$interval" argument must be greater than zero.'];
     }
 
     /**

--- a/src/Symfony/Component/Scheduler/Trigger/PeriodicalTrigger.php
+++ b/src/Symfony/Component/Scheduler/Trigger/PeriodicalTrigger.php
@@ -52,7 +52,11 @@ class PeriodicalTrigger implements StatefulTriggerInterface
             $i = $interval;
             if (\is_string($interval)) {
                 $this->description = sprintf('every %s', $interval);
-                $i = \DateInterval::createFromDateString($interval);
+                $i = @\DateInterval::createFromDateString($interval);
+
+                if (false === $i) {
+                    throw new InvalidArgumentException(sprintf('Invalid interval "%s": ', $interval).error_get_last()['message']);
+                }
             } else {
                 $a = (array) $interval;
                 $this->description = \PHP_VERSION_ID >= 80200 && $a['from_string'] ? $a['date_string'] : 'DateInterval';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT
