### PR TITLE
[HttpClient] Add `total_time` to the response log

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/TransportResponseTrait.php
+++ b/src/Symfony/Component/HttpClient/Response/TransportResponseTrait.php
@@ -231,7 +231,11 @@ trait TransportResponseTrait
                         } elseif ($chunk instanceof FirstChunk) {
                             if ($response->logger) {
                                 $info = $response->getInfo();
-                                $response->logger->info(\sprintf('Response: "%s %s"', $info['http_code'], $info['url']));
+                                $response->logger->info('Response: "{http_code} {url}" {total_time} seconds', [
+                                    'http_code' => $info['http_code'],
+                                    'url' => $info['url'],
+                                    'total_time' => $info['total_time'],
+                                ]);
                             }
 
                             $response->inflate = \extension_loaded('zlib') && $response->inflate && 'gzip' === ($response->headers['content-encoding'][0] ?? null) ? inflate_init(\ZLIB_ENCODING_GZIP) : null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

This pull request adds the response `total_time` to the info log.

- [x] Thoughts on the formatting? Usually in my app code I pass variables to the 2nd argument of `info()` to pass context instead of using sprintf, that way I can parse out variables the logs more easily.