### PR TITLE
[Doctrine][Messenger] Oracle sequences are suffixed with `_seq`

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/ConnectionTest.php
@@ -698,4 +698,21 @@ class ConnectionTest extends TestCase
             ];
         }
     }
+
+    public function testConfigureSchemaOracleSequenceNameSuffixed()
+    {
+        $driverConnection = $this->createMock(DBALConnection::class);
+        $driverConnection->method('getDatabasePlatform')->willReturn(new OraclePlatform());
+        $schema = new Schema();
+
+        $connection = new Connection(['table_name' => 'messenger_messages'], $driverConnection);
+        $connection->configureSchema($schema, $driverConnection, fn () => true);
+        
+        $expectedSuffix = '_seq';
+        $sequences = $schema->getSequences();
+        $this->assertCount(1, $sequences);
+        $sequence = array_pop($sequences);
+        $sequenceNameSuffix = substr($sequence->getName(), -strlen($expectedSuffix));
+        $this->assertSame($expectedSuffix, $sequenceNameSuffix);
+    }
 }

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
@@ -53,6 +53,8 @@ class Connection implements ResetInterface
         'auto_setup' => true,
     ];
 
+    private const ORACLE_SEQUENCES_SUFFIX = '_seq';
+
     /**
      * Configuration of the connection.
      *
@@ -471,7 +473,7 @@ class Connection implements ResetInterface
                     throw new TransportException('no id was returned by PostgreSQL from RETURNING clause.');
                 }
             } elseif ($this->driverConnection->getDatabasePlatform() instanceof OraclePlatform) {
-                $sequenceName = 'seq_'.$this->configuration['table_name'];
+                $sequenceName = $this->configuration['table_name'].self::ORACLE_SEQUENCES_SUFFIX;
 
                 $this->driverConnection->executeStatement($sql, $parameters, $types);
 
@@ -542,9 +544,9 @@ class Connection implements ResetInterface
 
         // We need to create a sequence for Oracle and set the id column to get the correct nextval
         if ($this->driverConnection->getDatabasePlatform() instanceof OraclePlatform) {
-            $idColumn->setDefault('seq_'.$this->configuration['table_name'].'.nextval');
+            $idColumn->setDefault($this->configuration['table_name'].self::ORACLE_SEQUENCES_SUFFIX.'.nextval');
 
-            $schema->createSequence('seq_'.$this->configuration['table_name']);
+            $schema->createSequence($this->configuration['table_name'].self::ORACLE_SEQUENCES_SUFFIX);
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58504
| License       | MIT

Generated sequences, by doctrine or in this case by the auto_setup of messenger, are suffixed with `_seq`.