### PR TITLE
[Ldap] Deprecate the `sizeLimit` query option

### DIFF
--- a/UPGRADE-7.2.md
+++ b/UPGRADE-7.2.md
@@ -46,6 +46,7 @@ Ldap
 ----
 
  * Add methods for `saslBind()` and `whoami()` to `ConnectionInterface` and `LdapInterface`
+ * Deprecate the `sizeLimit` option of `AbstractQuery`
 
 Mailer
 ------

--- a/src/Symfony/Component/Ldap/Adapter/AbstractQuery.php
+++ b/src/Symfony/Component/Ldap/Adapter/AbstractQuery.php
@@ -43,6 +43,8 @@ abstract class AbstractQuery implements QueryInterface
 
         $resolver->setNormalizer('filter', fn (Options $options, $value) => \is_array($value) ? $value : [$value]);
 
+        $resolver->setDeprecated('sizeLimit', 'symfony/ldap', '7.2', 'The "%name%" option is deprecated and will be removed in Symfony 8.0.');
+
         $this->options = $resolver->resolve($options);
     }
 }

--- a/src/Symfony/Component/Ldap/CHANGELOG.md
+++ b/src/Symfony/Component/Ldap/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add methods for `saslBind()` and `whoami()` to `ConnectionInterface` and `LdapInterface`
+ * Deprecate the `sizeLimit` option of `AbstractQuery`
 
 7.1
 ---

--- a/src/Symfony/Component/Ldap/Tests/Adapter/AbstractQueryTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Adapter/AbstractQueryTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Ldap\Tests\Adapter;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectUserDeprecationMessageTrait;
+use Symfony\Component\Ldap\Adapter\AbstractQuery;
+use Symfony\Component\Ldap\Adapter\CollectionInterface;
+use Symfony\Component\Ldap\Adapter\ConnectionInterface;
+
+class AbstractQueryTest extends TestCase
+{
+    use ExpectUserDeprecationMessageTrait;
+
+    /**
+     * @group legacy
+     */
+    public function testSizeLimitIsDeprecated()
+    {
+        $this->expectUserDeprecationMessage('Since symfony/ldap 7.2: The "sizeLimit" option is deprecated and will be removed in Symfony 8.0.');
+
+        new class($this->createMock(ConnectionInterface::class), '', '', ['filter' => '*', 'sizeLimit' => 1]) extends AbstractQuery {
+            public function execute(): CollectionInterface
+            {
+            }
+        };
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | Fix #58514
| License       | MIT

The `sizeLimit` option is never used, it is actually calculated with the `maxItems` option in `Query`. I propose to deprecate the option that is currently no-op anyway.