### PR TITLE
[Validator] [DateTime] Add `format` to error messages

### DIFF
--- a/src/Symfony/Bridge/Monolog/Tests/Handler/ChromePhpHandlerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/ChromePhpHandlerTest.php
@@ -22,15 +22,19 @@ class ChromePhpHandlerTest extends TestCase
 {
     public function testOnKernelResponseShouldNotTriggerDeprecation()
     {
-        $this->expectNotToPerformAssertions();
-
         $request = Request::create('/');
         $request->headers->remove('User-Agent');
 
         $response = new Response('foo');
         $event = new ResponseEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST, $response);
 
+        $error = null;
+        set_error_handler(function ($type, $message) use (&$error) { $error = $message; }, \E_DEPRECATED);
+
         $listener = new ChromePhpHandler();
         $listener->onKernelResponse($event);
+        restore_error_handler();
+
+        $this->assertNull($error);
     }
 }

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -18,6 +18,7 @@ CHANGELOG
  * Add the `Week` constraint
  * Add `CompoundConstraintTestCase` to ease testing Compound Constraints
  * Add context variable to `WhenValidator`
+ * Add `format` parameter to `DateTime` constraint violation message
 
 7.1
 ---

--- a/src/Symfony/Component/Validator/Constraints/DateTimeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DateTimeValidator.php
@@ -44,6 +44,7 @@ class DateTimeValidator extends DateValidator
         if (0 < $errors['error_count']) {
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setParameter('{{ format }}', $this->formatValue($constraint->format))
                 ->setCode(DateTime::INVALID_FORMAT_ERROR)
                 ->addViolation();
 
@@ -58,16 +59,19 @@ class DateTimeValidator extends DateValidator
             if ('The parsed date was invalid' === $warning) {
                 $this->context->buildViolation($constraint->message)
                     ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setParameter('{{ format }}', $this->formatValue($constraint->format))
                     ->setCode(DateTime::INVALID_DATE_ERROR)
                     ->addViolation();
             } elseif ('The parsed time was invalid' === $warning) {
                 $this->context->buildViolation($constraint->message)
                     ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setParameter('{{ format }}', $this->formatValue($constraint->format))
                     ->setCode(DateTime::INVALID_TIME_ERROR)
                     ->addViolation();
             } else {
                 $this->context->buildViolation($constraint->message)
                     ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setParameter('{{ format }}', $this->formatValue($constraint->format))
                     ->setCode(DateTime::INVALID_FORMAT_ERROR)
                     ->addViolation();
             }

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateTimeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateTimeValidatorTest.php
@@ -53,6 +53,7 @@ class DateTimeValidatorTest extends ConstraintValidatorTestCase
 
         $this->buildViolation('This value is not a valid datetime.')
             ->setParameter('{{ value }}', '"1995-03-24"')
+            ->setParameter('{{ format }}', '"Y-m-d H:i:s"')
             ->setCode(DateTime::INVALID_FORMAT_ERROR)
             ->assertRaised();
     }
@@ -96,6 +97,7 @@ class DateTimeValidatorTest extends ConstraintValidatorTestCase
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$dateTime.'"')
+            ->setParameter('{{ format }}', '"'.$format.'"')
             ->setCode($code)
             ->assertRaised();
     }
@@ -124,6 +126,7 @@ class DateTimeValidatorTest extends ConstraintValidatorTestCase
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"2010-01-01 00:00:00"')
+            ->setParameter('{{ format }}', '"Y-m-d"')
             ->setCode(DateTime::INVALID_FORMAT_ERROR)
             ->assertRaised();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2 
| Bug fix?      | no
| New feature?  | yes 
| Deprecations? | no 
| Issues        | -
| License       | MIT

## Problem
Currently there is no way to dynamically add the `format` value into error messages when using the `DateTime` constraint. It has to be hardcoded on every `DateTime` constraint.   
For example:
```php
#[Assert\DateTime(format: 'Y-m-d', message: 'Value {{ value }} is invalid. Expected format: "Y-m-d"')]
public string $from;

#[Assert\DateTime(format: 'Y-m-d', message: 'Value {{ value }} is invalid. Expected format: "Y-m-d"')]
public string $to;
```

## Goal
The goal is to add the possibility to use a parameter instead of hardcoding the selected format.  
For example:
```php
#[Assert\DateTime(format: 'Y-m-d', message: 'Value {{ value }} is invalid. Expected format:{{ format }}')]
public string $from;
```
If using the [symfony translator](https://github.com/symfony/translation) we would even not need to set the message when creating the constraint.
For example:
```php
$translator = new Translator('en');
$translator->addLoader('array', new ArrayLoader());
$translator->addResource('array', [
    'This value is not a valid datetime.' => 'Value {{ value }} is invalid. Expected format:{{ format }}',
], 'en');
```
## Solution
When building the violations set a new parameter called `format` which represents the given `format` when the `DateTime` constraint is created.