### PR TITLE
[PhpUnitBridge] do not patch the TestCase class with PHPUnit 10+

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit.php
+++ b/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit.php
@@ -109,6 +109,11 @@ if ($MAX_PHPUNIT_VERSION && version_compare($MAX_PHPUNIT_VERSION, $PHPUNIT_VERSI
     $PHPUNIT_VERSION = $MAX_PHPUNIT_VERSION;
 }
 
+if (version_compare($PHPUNIT_VERSION, '10.0', '>=') && version_compare($PHPUNIT_VERSION, '11.0', '<')) {
+    fwrite(STDERR, 'This script does not work with PHPUnit 10.'.\PHP_EOL);
+    exit(1);
+}
+
 $PHPUNIT_REMOVE_RETURN_TYPEHINT = filter_var($getEnvVar('SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT', '0'), \FILTER_VALIDATE_BOOLEAN);
 
 $COMPOSER_JSON = getenv('COMPOSER') ?: 'composer.json';
@@ -143,7 +148,7 @@ foreach ($defaultEnvs as $envName => $envValue) {
     }
 }
 
-if ('disabled' === $getEnvVar('SYMFONY_DEPRECATIONS_HELPER')) {
+if ('disabled' === $getEnvVar('SYMFONY_DEPRECATIONS_HELPER') || version_compare($PHPUNIT_VERSION, '11.0', '>=')) {
     putenv('SYMFONY_DEPRECATIONS_HELPER=disabled');
 }
 
@@ -273,19 +278,20 @@ if (!file_exists("$PHPUNIT_DIR/$PHPUNIT_VERSION_DIR/phpunit") || $configurationH
     }
 
     // Mutate TestCase code
-    $alteredCode = file_get_contents($alteredFile = './src/Framework/TestCase.php');
-    if ($PHPUNIT_REMOVE_RETURN_TYPEHINT) {
-        $alteredCode = preg_replace('/^    ((?:protected|public)(?: static)? function \w+\(\)): void/m', '    $1', $alteredCode);
-    }
-    $alteredCode = preg_replace('/abstract class TestCase[^\{]+\{/', '$0 '.\PHP_EOL."    use \Symfony\Bridge\PhpUnit\Legacy\PolyfillTestCaseTrait;", $alteredCode, 1);
-    file_put_contents($alteredFile, $alteredCode);
+    if (version_compare($PHPUNIT_VERSION, '11.0', '<')) {
+        $alteredCode = file_get_contents($alteredFile = './src/Framework/TestCase.php');
+        if ($PHPUNIT_REMOVE_RETURN_TYPEHINT) {
+            $alteredCode = preg_replace('/^    ((?:protected|public)(?: static)? function \w+\(\)): void/m', '    $1', $alteredCode);
+        }
+        $alteredCode = preg_replace('/abstract class TestCase[^\{]+\{/', '$0 '.\PHP_EOL."    use \Symfony\Bridge\PhpUnit\Legacy\PolyfillTestCaseTrait;", $alteredCode, 1);
+        file_put_contents($alteredFile, $alteredCode);
 
-    // Mutate Assert code
-    $alteredCode = file_get_contents($alteredFile = './src/Framework/Assert.php');
-    $alteredCode = preg_replace('/abstract class Assert[^\{]+\{/', '$0 '.\PHP_EOL."    use \Symfony\Bridge\PhpUnit\Legacy\PolyfillAssertTrait;", $alteredCode, 1);
-    file_put_contents($alteredFile, $alteredCode);
+        // Mutate Assert code
+        $alteredCode = file_get_contents($alteredFile = './src/Framework/Assert.php');
+        $alteredCode = preg_replace('/abstract class Assert[^\{]+\{/', '$0 '.\PHP_EOL."    use \Symfony\Bridge\PhpUnit\Legacy\PolyfillAssertTrait;", $alteredCode, 1);
+        file_put_contents($alteredFile, $alteredCode);
 
-    file_put_contents('phpunit', <<<'EOPHP'
+        file_put_contents('phpunit', <<<'EOPHP'
 <?php
 
 define('PHPUNIT_COMPOSER_INSTALL', __DIR__.'/vendor/autoload.php');
@@ -310,7 +316,9 @@ if (method_exists(\PHPUnit\Util\ExcludeList::class, 'addDirectory')) {
 Symfony\Bridge\PhpUnit\TextUI\Command::main();
 
 EOPHP
-    );
+        );
+    }
+
     chdir('..');
     file_put_contents(".$PHPUNIT_VERSION_DIR.md5", $configurationHash);
     chdir($oldPwd);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

The PHPUnit\TextUI\Command class was removed in PHPUnit 10. Since the sole purpose of the class extended the base Command class is to register a the Symfony test listener we can completely stop patching it as support for the listener-based event system was also removed in PHPUnit 10.