### PR TITLE
[Messenger] Allow auto creation of sqs queue

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -270,6 +270,7 @@ jobs:
           MESSENGER_AMQP_DSN: amqp://localhost/%2f/messages
           MESSENGER_SQS_DSN: "sqs://localhost:4566/messages?sslmode=disable&poll_timeout=0.01"
           MESSENGER_SQS_FIFO_QUEUE_DSN: "sqs://localhost:4566/messages.fifo?sslmode=disable&poll_timeout=0.01"
+          AWS_ENDPOINT_URL: "http://localhost:4566"
           KAFKA_BROKER: 127.0.0.1:9092
           POSTGRES_HOST: localhost
           PGBOUNCER_HOST: localhost:6432

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Allow auto-setup to create the queue when the DSN names the account the client already authenticates as
+
 7.4
 ---
 

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\Messenger\Bridge\AmazonSqs\Tests\Transport;
 
 use AsyncAws\Core\Exception\Http\HttpException;
 use AsyncAws\Core\Exception\Http\NetworkException;
+use AsyncAws\Core\Sts\Result\GetCallerIdentityResponse;
+use AsyncAws\Core\Sts\StsClient;
 use AsyncAws\Core\Test\ResultMockFactory;
 use AsyncAws\Sqs\Enum\QueueAttributeName;
 use AsyncAws\Sqs\Result\GetQueueUrlResult;
@@ -29,6 +31,7 @@ use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\HttpClient\Response\ResponseStream;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\Connection;
+use Symfony\Component\Messenger\Exception\InvalidArgumentException;
 use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -603,6 +606,54 @@ class ConnectionTest extends TestCase
         $this->expectException(TransportException::class);
         $this->expectExceptionMessage('SQS visibility_timeout (1s) cannot be smaller than the keepalive interval (2s).');
         $connection->keepalive('123', 2);
+    }
+
+    public function testSetupDoesNotAskStsWhenNoAccountIsConfigured()
+    {
+        $client = $this->createMock(SqsClient::class);
+        $client->method('queueExists')->willReturn(ResultMockFactory::waiter(QueueExistsWaiter::class, QueueExistsWaiter::STATE_FAILURE));
+        $client->expects($this->once())->method('createQueue');
+
+        $stsClient = $this->createMock(StsClient::class);
+        $stsClient->expects($this->never())->method('getCallerIdentity');
+
+        $connection = new Connection(['queue_name' => 'queue'], $client, null, $stsClient);
+
+        $this->expectException(TransportException::class);
+        $connection->setup();
+    }
+
+    public function testSetupCreatesTheQueueWhenTheConfiguredAccountIsTheCallerOne()
+    {
+        $client = $this->createMock(SqsClient::class);
+        $client->method('queueExists')->willReturn(ResultMockFactory::waiter(QueueExistsWaiter::class, QueueExistsWaiter::STATE_FAILURE));
+        $client->expects($this->once())->method('createQueue');
+
+        $stsClient = $this->createMock(StsClient::class);
+        $stsClient->expects($this->once())->method('getCallerIdentity')
+            ->willReturn(ResultMockFactory::create(GetCallerIdentityResponse::class, ['Account' => '123']));
+
+        $connection = new Connection(['queue_name' => 'queue', 'account' => '123'], $client, null, $stsClient);
+
+        $this->expectException(TransportException::class);
+        $connection->setup();
+    }
+
+    public function testSetupThrowsWhenTheConfiguredAccountIsAnotherOne()
+    {
+        $client = $this->createMock(SqsClient::class);
+        $client->method('queueExists')->willReturn(ResultMockFactory::waiter(QueueExistsWaiter::class, QueueExistsWaiter::STATE_FAILURE));
+        $client->expects($this->never())->method('createQueue');
+
+        $stsClient = $this->createMock(StsClient::class);
+        $stsClient->expects($this->once())->method('getCallerIdentity')
+            ->willReturn(ResultMockFactory::create(GetCallerIdentityResponse::class, ['Account' => '999']));
+
+        $connection = new Connection(['queue_name' => 'queue', 'account' => '123'], $client, null, $stsClient);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('can\'t be created when another account is provided');
+        $connection->setup();
     }
 
     public function testQueueAttributesAndTags()

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Messenger\Bridge\AmazonSqs\Transport;
 
+use AsyncAws\Core\Sts\StsClient;
 use AsyncAws\Sqs\Enum\MessageSystemAttributeName;
 use AsyncAws\Sqs\Enum\QueueAttributeName;
 use AsyncAws\Sqs\Result\ReceiveMessageResult;
@@ -65,6 +66,7 @@ class Connection
         array $configuration,
         ?SqsClient $client = null,
         private ?string $queueUrl = null,
+        private ?StsClient $stsClient = null,
     ) {
         $this->configuration = array_replace_recursive(self::DEFAULT_OPTIONS, $configuration);
         $this->client = $client ?? new SqsClient([]);
@@ -290,8 +292,13 @@ class Connection
             return;
         }
 
+        // the queue can still be created when the DSN names the account we are already calling with
         if (null !== $this->configuration['account']) {
-            throw new InvalidArgumentException(\sprintf('The Amazon SQS queue "%s" does not exist (or you don\'t have permissions on it), and can\'t be created when an account is provided.', $this->configuration['queue_name']));
+            $callerAccount = ($this->stsClient ??= new StsClient([]))->getCallerIdentity()->getAccount();
+
+            if ($callerAccount !== $this->configuration['account']) {
+                throw new InvalidArgumentException(\sprintf('The Amazon SQS queue "%s" does not exist (or you don\'t have permissions on it), and can\'t be created when another account is provided.', $this->configuration['queue_name']));
+            }
         }
 
         $parameters = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #42208
| License       | MIT

I had a look at #44021, which was closed. I implemented the proposed solution in [this comment](https://github.com/symfony/symfony/pull/44021#issuecomment-1066907362).

In the `setup` function, the code now validates whether the account ID of the current caller identity matches the account ID specified in the DSN. If the IDs match, the queue is created; otherwise, it is not.
