### PR TITLE
[Cache] recreate the schema for every single test

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/DoctrineDbalAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/DoctrineDbalAdapterTest.php
@@ -48,6 +48,10 @@ class DoctrineDbalAdapterTest extends AdapterTestCase
 
     public function testConfigureSchemaDecoratedDbalDriver()
     {
+        if (file_exists(self::$dbFile)) {
+            @unlink(self::$dbFile);
+        }
+
         $connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => self::$dbFile], $this->getDbalConfig());
         if (!interface_exists(Middleware::class)) {
             $this->markTestSkipped('doctrine/dbal v2 does not support custom drivers using middleware');
@@ -73,6 +77,10 @@ class DoctrineDbalAdapterTest extends AdapterTestCase
 
     public function testConfigureSchema()
     {
+        if (file_exists(self::$dbFile)) {
+            @unlink(self::$dbFile);
+        }
+
         $connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => self::$dbFile], $this->getDbalConfig());
         $schema = new Schema();
 
@@ -83,6 +91,10 @@ class DoctrineDbalAdapterTest extends AdapterTestCase
 
     public function testConfigureSchemaDifferentDbalConnection()
     {
+        if (file_exists(self::$dbFile)) {
+            @unlink(self::$dbFile);
+        }
+
         $otherConnection = $this->createConnectionMock();
         $schema = new Schema();
 
@@ -93,6 +105,10 @@ class DoctrineDbalAdapterTest extends AdapterTestCase
 
     public function testConfigureSchemaTableExists()
     {
+        if (file_exists(self::$dbFile)) {
+            @unlink(self::$dbFile);
+        }
+
         $connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => self::$dbFile], $this->getDbalConfig());
         $schema = new Schema();
         $schema->createTable('cache_items');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

The former test implementation relied on the order in which tests are executed assuming that tests explicitly creating the schema were executed first. This assumption leads to test failures on PHPUnit 10+ were tests defined in parent classes are run first where they were run later with PHPUnit 9.6.