### PR TITLE
Rename annotations to attributes in `AttributeLoader`

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/Attribute/ContextTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Attribute/ContextTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Serializer\Tests\Annotation;
+namespace Symfony\Component\Serializer\Tests\Attribute;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Attribute\Context;

--- a/src/Symfony/Component/Serializer/Tests/Attribute/DiscriminatorMapTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Attribute/DiscriminatorMapTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Serializer\Tests\Annotation;
+namespace Symfony\Component\Serializer\Tests\Attribute;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Attribute\DiscriminatorMap;
@@ -22,16 +22,16 @@ class DiscriminatorMapTest extends TestCase
 {
     public function testGetTypePropertyAndMapping()
     {
-        $annotation = new DiscriminatorMap(typeProperty: 'type', mapping: [
+        $attribute = new DiscriminatorMap(typeProperty: 'type', mapping: [
             'foo' => 'FooClass',
             'bar' => 'BarClass',
         ]);
 
-        $this->assertEquals('type', $annotation->getTypeProperty());
+        $this->assertEquals('type', $attribute->getTypeProperty());
         $this->assertEquals([
             'foo' => 'FooClass',
             'bar' => 'BarClass',
-        ], $annotation->getMapping());
+        ], $attribute->getMapping());
     }
 
     public function testExceptionWithEmptyTypeProperty()

--- a/src/Symfony/Component/Serializer/Tests/Attribute/GroupsTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Attribute/GroupsTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Serializer\Tests\Annotation;
+namespace Symfony\Component\Serializer\Tests\Attribute;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Attribute\Groups;

--- a/src/Symfony/Component/Serializer/Tests/Attribute/MaxDepthTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Attribute/MaxDepthTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Serializer\Tests\Annotation;
+namespace Symfony\Component\Serializer\Tests\Attribute;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Attribute\MaxDepth;

--- a/src/Symfony/Component/Serializer/Tests/Attribute/SerializedNameTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Attribute/SerializedNameTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Serializer\Tests\Annotation;
+namespace Symfony\Component\Serializer\Tests\Attribute;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Attribute\SerializedName;

--- a/src/Symfony/Component/Serializer/Tests/Attribute/SerializedPathTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Attribute/SerializedPathTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Serializer\Tests\Annotation;
+namespace Symfony\Component\Serializer\Tests\Attribute;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyAccess\PropertyPath;

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/GroupDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/GroupDummy.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Serializer\Tests\Fixtures\Attributes;
 
 use Symfony\Component\Serializer\Attribute\Groups;
-use Symfony\Component\Serializer\Tests\Fixtures\ChildOfGroupsAnnotationDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\ChildOfGroupsAttributeDummy;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
@@ -23,7 +23,7 @@ class GroupDummy extends GroupDummyParent implements GroupDummyInterface
     private $foo;
     #[Groups(['b', 'c', 'name_converter'])]
     protected $bar;
-    #[ChildOfGroupsAnnotationDummy]
+    #[ChildOfGroupsAttributeDummy]
     protected $quux;
     private $fooBar;
     private $symfony;

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/IgnoreDummyAdditionalGetterWithoutIgnoreAttributes.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/IgnoreDummyAdditionalGetterWithoutIgnoreAttributes.php
@@ -2,7 +2,7 @@
 
 namespace Symfony\Component\Serializer\Tests\Fixtures\Attributes;
 
-class IgnoreDummyAdditionalGetterWithoutIgnoreAnnotations
+class IgnoreDummyAdditionalGetterWithoutIgnoreAttributes
 {
     private $myValue;
 

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/ChildOfGroupsAttributeDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/ChildOfGroupsAttributeDummy.php
@@ -5,7 +5,7 @@ namespace Symfony\Component\Serializer\Tests\Fixtures;
 use Symfony\Component\Serializer\Attribute\Groups;
 
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
-final class ChildOfGroupsAnnotationDummy extends Groups
+final class ChildOfGroupsAttributeDummy extends Groups
 {
     public function __construct()
     {

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AttributeLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AttributeLoaderTest.php
@@ -33,7 +33,7 @@ use Symfony\Component\Serializer\Tests\Fixtures\Attributes\GroupDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Attributes\GroupDummyParent;
 use Symfony\Component\Serializer\Tests\Fixtures\Attributes\IgnoreDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Attributes\IgnoreDummyAdditionalGetter;
-use Symfony\Component\Serializer\Tests\Fixtures\Attributes\IgnoreDummyAdditionalGetterWithoutIgnoreAnnotations;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\IgnoreDummyAdditionalGetterWithoutIgnoreAttributes;
 use Symfony\Component\Serializer\Tests\Fixtures\Attributes\MaxDepthDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Attributes\SerializedNameDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Attributes\SerializedPathDummy;
@@ -181,7 +181,7 @@ class AttributeLoaderTest extends TestCase
         $this->assertSame(['id'], array_keys($metadata->getAttributesMetadata()));
     }
 
-    public function testIgnoreGetterWithRequiredParameterIfIgnoreAnnotationIsUsed()
+    public function testIgnoreGetterWithRequiredParameterIfIgnoreAttributeIsUsed()
     {
         $classMetadata = new ClassMetadata(IgnoreDummyAdditionalGetter::class);
         $this->getLoaderForContextMapping()->loadClassMetadata($classMetadata);
@@ -191,9 +191,9 @@ class AttributeLoaderTest extends TestCase
         self::assertArrayHasKey('extraValue2', $attributes);
     }
 
-    public function testIgnoreGetterWithRequiredParameterIfIgnoreAnnotationIsNotUsed()
+    public function testIgnoreGetterWithRequiredParameterIfIgnoreAttributeIsNotUsed()
     {
-        $classMetadata = new ClassMetadata(IgnoreDummyAdditionalGetterWithoutIgnoreAnnotations::class);
+        $classMetadata = new ClassMetadata(IgnoreDummyAdditionalGetterWithoutIgnoreAttributes::class);
         $this->getLoaderForContextMapping()->loadClassMetadata($classMetadata);
 
         $attributes = $classMetadata->getAttributesMetadata();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

Annotations are not supported anymore in AttributeLoader, so we can rename some variables