### PR TITLE
[HttpClientAssertionsTrait] rework function assertHttpClientRequest

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/HttpClientTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/HttpClientTest.php
@@ -17,7 +17,7 @@ class HttpClientTest extends AbstractWebTestCase
     {
         $client = $this->createClient(['test_case' => 'HttpClient', 'root_config' => 'config.yml', 'debug' => true]);
         $client->enableProfiler();
-        $client->request('GET', '/http_client_call');
+        $client->request('GET', '/http_client_call', ['headers' => ['X-Test-Header' => 'foo']]);
 
         $this->assertHttpClientRequest('https://symfony.com/');
         $this->assertHttpClientRequest('https://symfony.com/', httpClientId: 'symfony.http_client');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2 for features / 5.4, 6.4, and 7.1 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

**Enhancing the assertHttpClientRequest Function to Address False Positives**

In the current implementation of the assertHttpClientRequest function, we verify whether a specific HTTP client request has been made by checking the expected URL, method, body, and headers against the recorded traces. While this method serves its purpose, it does not adequately address the issue of false positives—instances where the function mistakenly concludes that an expected request has been made when it actually has not. This need for modification is particularly crucial due to a project that utilizes this function.

Importance of Addressing False Positives

- Accuracy of Test Results: False positives can lead to misleading test outcomes. When tests incorrectly report that a request has been made, developers may overlook genuine issues in their code, resulting in a lack of confidence in the test suite's effectiveness.

- Debugging Challenges: If tests indicate success despite failures in the underlying logic, it complicates debugging efforts. Developers may spend unnecessary time investigating issues that are not rooted in the actual behavior of the code.

- Quality Assurance: A robust testing framework is crucial for maintaining high-quality software. Addressing false positives helps ensure that tests accurately reflect the system's behavior, contributing to overall software reliability.

Proposed Modifications
To enhance the assertHttpClientRequest function, we can introduce stricter checks to differentiate between genuinely matching requests and those that merely fulfill some conditions:

- Improve Matching Logic: We should refine the criteria for determining a match by considering all aspects—URL, method, body, and headers—before concluding that a request has been found. Instead of stopping at the first condition met, we could ensure that all relevant conditions align before confirming the match.

- Detailed Error Reporting: Enhancing the failure messages to indicate which specific condition was not met can help developers identify discrepancies more quickly, aiding in troubleshooting.

- Incorporate Logging: Adding logging to capture detailed information about the requests being evaluated can provide insights during test execution, making it easier to trace issues related to false positives.

By implementing these changes, we can significantly reduce the likelihood of false positives, leading to a more reliable and effective testing process. This enhancement is particularly important for the ongoing project, as it strengthens trust in the automated testing framework and improves the developer experience.


