### PR TITLE
[Messenger] Check for `#[AsMessage]` attributes on parents

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessageInterfaceWithAttribute1.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessageInterfaceWithAttribute1.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+use Symfony\Component\Messenger\Attribute\AsMessage;
+
+#[AsMessage(transport: ['first_sender', 'third_sender'])]
+interface DummyMessageInterfaceWithAttribute1
+{
+}

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessageInterfaceWithAttribute2.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessageInterfaceWithAttribute2.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+use Symfony\Component\Messenger\Attribute\AsMessage;
+
+#[AsMessage(transport: 'second_sender')]
+interface DummyMessageInterfaceWithAttribute2
+{
+}

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessageWithInterfaceWithAttribute.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessageWithInterfaceWithAttribute.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+class DummyMessageWithInterfaceWithAttribute implements DummyMessageInterfaceWithAttribute1, DummyMessageInterfaceWithAttribute2
+{
+    public function __construct(
+        private string $message,
+    ) {
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessageWithParentWithAttribute.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessageWithParentWithAttribute.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+use Symfony\Component\Messenger\Attribute\AsMessage;
+
+#[AsMessage(transport: 'third_sender')]
+class DummyMessageWithParentWithAttribute extends DummyMessageWithAttribute
+{
+}

--- a/src/Symfony/Component/Messenger/Tests/Transport/Sender/SendersLocatorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Sender/SendersLocatorTest.php
@@ -55,19 +55,26 @@ class SendersLocatorTest extends TestCase
         $this->assertSame([], iterator_to_array($locator->getSenders(new Envelope(new SecondMessage()))));
     }
 
-    public function testItReturnsTheSenderBasedOnAsMessageAttribute()
+    /**
+     * @testWith ["\\Symfony\\Component\\Messenger\\Tests\\Fixtures\\DummyMessageWithAttribute", ["first_sender", "second_sender"]]
+     *           ["\\Symfony\\Component\\Messenger\\Tests\\Fixtures\\DummyMessageWithParentWithAttribute", ["third_sender", "first_sender", "second_sender"]]
+     *           ["\\Symfony\\Component\\Messenger\\Tests\\Fixtures\\DummyMessageWithInterfaceWithAttribute", ["first_sender", "third_sender", "second_sender"]]
+     */
+    public function testItReturnsTheSenderBasedOnAsMessageAttribute(string $messageClass, array $expectedSenders)
     {
         $firstSender = $this->createMock(SenderInterface::class);
         $secondSender = $this->createMock(SenderInterface::class);
+        $thirdSender = $this->createMock(SenderInterface::class);
         $otherSender = $this->createMock(SenderInterface::class);
         $sendersLocator = $this->createContainer([
             'first_sender' => $firstSender,
             'second_sender' => $secondSender,
+            'third_sender' => $thirdSender,
             'other_sender' => $otherSender,
         ]);
         $locator = new SendersLocator([], $sendersLocator);
 
-        $this->assertSame(['first_sender' => $firstSender, 'second_sender' => $secondSender], iterator_to_array($locator->getSenders(new Envelope(new DummyMessageWithAttribute('a')))));
+        $this->assertSame($expectedSenders, array_keys(iterator_to_array($locator->getSenders(new Envelope(new $messageClass('a'))))));
         $this->assertSame([], iterator_to_array($locator->getSenders(new Envelope(new SecondMessage()))));
     }
 

--- a/src/Symfony/Component/Messenger/Transport/Sender/SendersLocator.php
+++ b/src/Symfony/Component/Messenger/Transport/Sender/SendersLocator.php
@@ -80,13 +80,15 @@ class SendersLocator implements SendersLocatorInterface
     private function getTransportNamesFromAttribute(Envelope $envelope): array
     {
         $transports = [];
-        $message = $envelope->getMessage();
+        $messageClass = $envelope->getMessage()::class;
 
-        foreach ((new \ReflectionClass($message))->getAttributes(AsMessage::class, \ReflectionAttribute::IS_INSTANCEOF) as $refAttr) {
-            $asMessage = $refAttr->newInstance();
+        foreach ([$messageClass] + class_parents($messageClass) + class_implements($messageClass) as $class) {
+            foreach ((new \ReflectionClass($class))->getAttributes(AsMessage::class, \ReflectionAttribute::IS_INSTANCEOF) as $refAttr) {
+                $asMessage = $refAttr->newInstance();
 
-            if ($asMessage->transport) {
-                $transports = \array_merge($transports, (array) $asMessage->transport);
+                if ($asMessage->transport) {
+                    $transports = array_merge($transports, (array) $asMessage->transport);
+                }
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

I've been testing the `#[AsMessage]` attribute and noticed that the attribute is not being read from parent classes or interfaces. This is different to how the `routing` option works, so currently, attributes can't fully replace the option.