### PR TITLE
Update deprecations baseline

### DIFF
--- a/.github/deprecations-baseline.json
+++ b/.github/deprecations-baseline.json
@@ -2,7 +2,7 @@
     {
         "location": "Symfony\\Component\\Messenger\\Bridge\\Doctrine\\Tests\\Transport\\DoctrinePostgreSqlIntegrationTest::setUp",
         "message": "Connection::fetchColumn() is deprecated, use Connection::fetchOne() API instead. (Connection.php:662 called by PostgreSqlSchemaManager.php:63, https://github.com/doctrine/dbal/pull/4019, package doctrine/dbal)",
-        "count": 2
+        "count": 3
     },
     {
         "location": "Symfony\\Component\\Messenger\\Bridge\\Doctrine\\Tests\\Transport\\DoctrinePostgreSqlIntegrationTest::setUp",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

A deprecation happens once more after #58528, the baseline should be updated accordingly. This fixes the "Integration (7.2)" job.