### PR TITLE
[Serializer] Add xml context option to ignore empty attributes

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -1,11 +1,16 @@
 CHANGELOG
 =========
 
+7.3
+---
+
+ * Deprecate the `CompiledClassMetadataFactory` and `CompiledClassMetadataCacheWarmer` classes
+
 7.2
 ---
 
- * Deprecate the `csv_escape_char` context option of `CsvEncoder` and the `CsvEncoder::ESCAPE_CHAR_KEY` constant
- * Deprecate `CsvEncoderContextBuilder::withEscapeChar()` method
+ * Deprecate the `csv_escape_char` context option of `CsvEncoder`, the `CsvEncoder::ESCAPE_CHAR_KEY` constant
+   and the `CsvEncoderContextBuilder::withEscapeChar()` method, following its deprecation in PHP 8.4
  * Add `SnakeCaseToCamelCaseNameConverter`
  * Support subclasses of `\DateTime` and `\DateTimeImmutable` for denormalization
  * Add the `UidNormalizer::NORMALIZATION_FORMAT_RFC9562` constant
@@ -19,7 +24,6 @@ CHANGELOG
 
  * Add arguments `$class`, `$format` and `$context` to `NameConverterInterface::normalize()` and `NameConverterInterface::denormalize()`
  * Add `DateTimeNormalizer::CAST_KEY` context option
- * Add `Default` and "class name" default groups
  * Add `AbstractNormalizer::FILTER_BOOL` context option
  * Add `CamelCaseToSnakeCaseNameConverter::REQUIRE_SNAKE_CASE_PROPERTIES` context option
  * Deprecate `AbstractNormalizerContextBuilder::withDefaultContructorArguments(?array $defaultContructorArguments)`, use `withDefaultConstructorArguments(?array $defaultConstructorArguments)` instead (note the missing `s` character in Contructor word in deprecated method)

--- a/src/Symfony/Component/Serializer/Context/Encoder/XmlEncoderContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Encoder/XmlEncoderContextBuilder.php
@@ -160,4 +160,12 @@ final class XmlEncoderContextBuilder implements ContextBuilderInterface
     {
         return $this->with(XmlEncoder::CDATA_WRAPPING_PATTERN, $cdataWrappingPattern);
     }
+
+    /**
+     * Configures whether to ignore empty attributes.
+     */
+    public function withIgnoreEmptyAttributes(?bool $ignoreEmptyAttributes): static
+    {
+        return $this->with(XmlEncoder::IGNORE_EMPTY_ATTRIBUTES, $ignoreEmptyAttributes);
+    }
 }

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -60,6 +60,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
     public const VERSION = 'xml_version';
     public const CDATA_WRAPPING = 'cdata_wrapping';
     public const CDATA_WRAPPING_PATTERN = 'cdata_wrapping_pattern';
+    public const IGNORE_EMPTY_ATTRIBUTES = 'ignore_empty_attributes';
 
     private array $defaultContext = [
         self::AS_COLLECTION => false,
@@ -72,6 +73,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
         self::TYPE_CAST_ATTRIBUTES => true,
         self::CDATA_WRAPPING => true,
         self::CDATA_WRAPPING_PATTERN => '/[<>&]/',
+        self::IGNORE_EMPTY_ATTRIBUTES => false,
     ];
 
     public function __construct(array $defaultContext = [])
@@ -355,6 +357,13 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
                     if (\is_bool($data)) {
                         $data = (int) $data;
                     }
+
+                    if ($context[self::IGNORE_EMPTY_ATTRIBUTES] ?? $this->defaultContext[self::IGNORE_EMPTY_ATTRIBUTES]) {
+                        if (null === $data || '' === $data) {
+                            continue;
+                        }
+                    }
+
                     $parentNode->setAttribute($attributeName, $data);
                 } elseif ('#' === $key) {
                     $append = $this->selectNodeType($parentNode, $data, $format, $context);

--- a/src/Symfony/Component/Serializer/Tests/Context/Encoder/XmlEncoderContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/Encoder/XmlEncoderContextBuilderTest.php
@@ -47,6 +47,7 @@ class XmlEncoderContextBuilderTest extends TestCase
             ->withVersion($values[XmlEncoder::VERSION])
             ->withCdataWrapping($values[XmlEncoder::CDATA_WRAPPING])
             ->withCdataWrappingPattern($values[XmlEncoder::CDATA_WRAPPING_PATTERN])
+            ->withIgnoreEmptyAttributes($values[XmlEncoder::IGNORE_EMPTY_ATTRIBUTES])
             ->toArray();
 
         $this->assertSame($values, $context);
@@ -69,6 +70,7 @@ class XmlEncoderContextBuilderTest extends TestCase
             XmlEncoder::VERSION => '1.0',
             XmlEncoder::CDATA_WRAPPING => false,
             XmlEncoder::CDATA_WRAPPING_PATTERN => '/[<>&"\']/',
+            XmlEncoder::IGNORE_EMPTY_ATTRIBUTES => true,
         ]];
 
         yield 'With null values' => [[
@@ -86,6 +88,7 @@ class XmlEncoderContextBuilderTest extends TestCase
             XmlEncoder::VERSION => null,
             XmlEncoder::CDATA_WRAPPING => null,
             XmlEncoder::CDATA_WRAPPING_PATTERN => null,
+            XmlEncoder::IGNORE_EMPTY_ATTRIBUTES => null,
         ]];
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -1004,4 +1004,17 @@ XML;
 <response><foo dateTime="%s"/></response>
 ', $this->exampleDateTimeString);
     }
+
+    public function testEncodeIgnoringEmptyAttribute()
+    {
+        $expected = <<<'XML'
+<?xml version="1.0"?>
+<response>Test</response>
+
+XML;
+
+        $data = ['#' => 'Test', '@attribute' => '', '@attribute2' => null];
+
+        $this->assertEquals($expected, $this->encoder->encode($data, 'xml', ['ignore_empty_attributes' => true]));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      |no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

Sometimes XML attributes are optional and should not be present in the serialized data.

This PR adds the option to skip empty attributes (null or empty) during encoding.