### PR TITLE
[RateLimiter] Fix bucket size reduced when previously created with bigger size

### DIFF
--- a/src/Symfony/Component/RateLimiter/Policy/TokenBucketLimiter.php
+++ b/src/Symfony/Component/RateLimiter/Policy/TokenBucketLimiter.php
@@ -67,6 +67,10 @@ final class TokenBucketLimiter implements LimiterInterface
             $now = microtime(true);
             $availableTokens = $bucket->getAvailableTokens($now);
 
+            if ($availableTokens > $this->maxBurst) {
+                $availableTokens = $this->maxBurst;
+            }
+
             if ($availableTokens >= $tokens) {
                 // tokens are now available, update bucket
                 $bucket->setTokens($availableTokens - $tokens);

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/TokenBucketLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/TokenBucketLimiterTest.php
@@ -56,6 +56,18 @@ class TokenBucketLimiterTest extends TestCase
         $limiter->reserve(15);
     }
 
+    public function testReduceBucketSizeWhenAlreadyExistInStorageWithBiggerBucketSize()
+    {
+        $limiter = $this->createLimiter(100);
+
+        $limiter->consume();
+
+        $limiter2 = $this->createLimiter(1);
+        $limiter2->consume();
+
+        $this->assertFalse($limiter2->consume()->isAccepted());
+    }
+
     public function testReserveMaxWaitingTime()
     {
         $this->expectException(MaxWaitDurationExceededException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #
| License       | MIT

```yaml
foo:
      policy: 'token_bucket'
      limit: 1000
      rate: { interval: '15 minutes', amount: 5 }
      cache_pool: rate_limiter.cache_pool
      lock_factory: 'lock.rate_limiter.factory'
```
`rate_limiter.cache_pool` => it's a persistent cache pool like redis

When using previously this configuration and consume the token bucket with 1 token it was save on the storage with 999 tokens available.

If you update the configuration with a lower token limit
```yaml
foo:
      policy: 'token_bucket'
      limit: 10
      rate: { interval: '15 minutes', amount: 5 }
      cache_pool: rate_limiter.cache_pool
      lock_factory: 'lock.rate_limiter.factory'
```

You can consume 999 tokens before triggering the bucket limit without flushing the cache. The purpose of this PR is to update and use the new configuration limit.
