### PR TITLE
Specifically refer to $namespace rather than arg index

### DIFF
--- a/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
+++ b/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
@@ -159,7 +159,7 @@ class CachePoolPass implements CompilerPassInterface
                             ->setFactory([ParameterNormalizer::class, 'normalizeDuration']);
                     }
 
-                    $pool->replaceArgument($i++, $argument);
+                    $pool->replaceArgument('$namespace', $argument);
                 }
                 unset($tags[0][$attr]);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

Currently, in the cache pool pass index $i is replaced by the namespace. This updates it to refer to the specific $namespace argument.
