### PR TITLE
[Serializer] Add a `force_collection` option to `XmlEncoder`

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Add the `force_collection` context option to `XmlEncoder` to always decode the given tags as a collection
  * Add `AbstractNormalizer::SKIP_INVALID_ATTRIBUTES` to denormalize the attributes whose value cannot be used as if they were absent from the input
  * Add `AbstractNormalizer::IGNORED_GROUPS` to exclude the attributes belonging to the given groups
  * Allow passing an associative array to `CsvEncoder::HEADERS_KEY` to map and reorder columns when encoding

--- a/src/Symfony/Component/Serializer/Context/Encoder/XmlEncoderContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Encoder/XmlEncoderContextBuilder.php
@@ -186,4 +186,14 @@ final class XmlEncoderContextBuilder implements ContextBuilderInterface
     {
         return $this->with(XmlEncoder::BOOLEAN_REPR, $booleanRepr);
     }
+
+    /**
+     * Configures which tags must always be decoded as a collection, even with a single child.
+     *
+     * @param list<string>|null $forceCollection
+     */
+    public function withForceCollection(?array $forceCollection): static
+    {
+        return $this->with(XmlEncoder::FORCE_COLLECTION, $forceCollection);
+    }
 }

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -236,10 +236,10 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
         $value = $this->parseXmlValue($node, $context);
 
         if (\is_array($value)
-            && \count($value) === 1
+            && ($childNodeName = $node->firstChild?->nodeName)
+            && 1 === \count($value)
             && \in_array($nodeName, $context[self::FORCE_COLLECTION] ?? [], strict: true)
         ) {
-            $childNodeName = $node->firstChild?->nodeName;
             return [$childNodeName => [$value[$childNodeName]]];
         }
 

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -422,7 +422,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
             return $this->appendNode($parentNode, $data, $format, $context, 'data');
         }
 
-        throw new NotEncodableValueException('An unexpected value could not be serialized: '.(!\is_resource($data) ? var_export($data, true) : \sprintf('%s resource', get_resource_type($data))));
+        throw new NotEncodableValueException('An unexpected value could not be serialized: '.(!\is_resource($data) ? var_export($data, true) : \sprintf('"%s" resource', get_resource_type($data))));
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -238,7 +238,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
         if (\is_array($value)
             && ($childNodeName = $node->firstChild?->nodeName)
             && 1 === \count($value)
-            && \in_array($nodeName, $context[self::FORCE_COLLECTION] ?? [], strict: true)
+            && \in_array($nodeName, $context[self::FORCE_COLLECTION] ?? [], true)
         ) {
             return [$childNodeName => [$value[$childNodeName]]];
         }

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -422,7 +422,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
             return $this->appendNode($parentNode, $data, $format, $context, 'data');
         }
 
-        throw new NotEncodableValueException('An unexpected value could not be serialized: '.(!\is_resource($data) ? var_export($data, true) : \sprintf('"%s" resource', get_resource_type($data))));
+        throw new NotEncodableValueException('An unexpected value could not be serialized: '.(!\is_resource($data) ? var_export($data, true) : \sprintf('%s resource', get_resource_type($data))));
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -77,6 +77,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
         self::TYPE_CAST_ATTRIBUTES => true,
         self::CDATA_WRAPPING => true,
         self::CDATA_WRAPPING_PATTERN => '/[<>&]/',
+        self::FORCE_COLLECTION => [],
     ];
 
     public function __construct(array $defaultContext = [])
@@ -238,7 +239,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
         if (\is_array($value)
             && ($childNodeName = $node->firstChild?->nodeName)
             && 1 === \count($value)
-            && \in_array($nodeName, $context[self::FORCE_COLLECTION] ?? [], true)
+            && \in_array($nodeName, $context[self::FORCE_COLLECTION] ?? $this->defaultContext[self::FORCE_COLLECTION], true)
         ) {
             return [$childNodeName => [$value[$childNodeName]]];
         }

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -33,6 +33,11 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
     public const AS_COLLECTION = 'as_collection';
 
     /**
+     * An array of XML tags who should always be treated as a collection, even when it has only one child.
+     */
+    public const FORCE_COLLECTION = 'force_collection';
+
+    /**
      * An array of ignored XML node types while decoding, each one of the DOM Predefined XML_* constants.
      */
     public const DECODER_IGNORED_NODE_TYPES = 'decoder_ignored_node_types';
@@ -86,6 +91,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
         self::IGNORE_EMPTY_ATTRIBUTES => false,
         self::PRESERVE_NUMERIC_KEYS => false,
         self::BOOLEAN_REPR => null,
+        self::FORCE_COLLECTION => [],
     ];
 
     public function __construct(array $defaultContext = [])
@@ -241,6 +247,14 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
         $data = $this->parseXmlAttributes($node, $context);
 
         $value = $this->parseXmlValue($node, $context);
+
+        if (\is_array($value)
+            && ($childNodeName = $node->firstChild?->nodeName)
+            && 1 === \count($value)
+            && \in_array($node->nodeName, $context[self::FORCE_COLLECTION] ?? $this->defaultContext[self::FORCE_COLLECTION], true)
+        ) {
+            return [$childNodeName => [$value[$childNodeName]]];
+        }
 
         if (!$data) {
             return $value;

--- a/src/Symfony/Component/Serializer/Tests/Context/Encoder/XmlEncoderContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/Encoder/XmlEncoderContextBuilderTest.php
@@ -36,6 +36,7 @@ class XmlEncoderContextBuilderTest extends TestCase
             ->withDecoderIgnoredNodeTypes($values[XmlEncoder::DECODER_IGNORED_NODE_TYPES])
             ->withEncoderIgnoredNodeTypes($values[XmlEncoder::ENCODER_IGNORED_NODE_TYPES])
             ->withEncoding($values[XmlEncoder::ENCODING])
+            ->withForceCollection($values[XmlEncoder::FORCE_COLLECTION])
             ->withFormatOutput($values[XmlEncoder::FORMAT_OUTPUT])
             ->withLoadOptions($values[XmlEncoder::LOAD_OPTIONS])
             ->withSaveOptions($values[XmlEncoder::SAVE_OPTIONS])
@@ -60,6 +61,7 @@ class XmlEncoderContextBuilderTest extends TestCase
             XmlEncoder::DECODER_IGNORED_NODE_TYPES => [\XML_PI_NODE, \XML_COMMENT_NODE],
             XmlEncoder::ENCODER_IGNORED_NODE_TYPES => [\XML_TEXT_NODE],
             XmlEncoder::ENCODING => 'UTF-8',
+            XmlEncoder::FORCE_COLLECTION => ['order'],
             XmlEncoder::FORMAT_OUTPUT => false,
             XmlEncoder::LOAD_OPTIONS => \LIBXML_COMPACT,
             XmlEncoder::SAVE_OPTIONS => \LIBXML_NOERROR,
@@ -79,6 +81,7 @@ class XmlEncoderContextBuilderTest extends TestCase
             XmlEncoder::DECODER_IGNORED_NODE_TYPES => null,
             XmlEncoder::ENCODER_IGNORED_NODE_TYPES => null,
             XmlEncoder::ENCODING => null,
+            XmlEncoder::FORCE_COLLECTION => null,
             XmlEncoder::FORMAT_OUTPUT => null,
             XmlEncoder::LOAD_OPTIONS => null,
             XmlEncoder::SAVE_OPTIONS => null,

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -897,7 +897,7 @@ XML;
     public function testNotEncodableValueExceptionMessageForAResource()
     {
         $this->expectException(NotEncodableValueException::class);
-        $this->expectExceptionMessage('An unexpected value could not be serialized: "stream" resource');
+        $this->expectExceptionMessage('An unexpected value could not be serialized: stream resource');
 
         (new XmlEncoder())->encode(tmpfile(), 'xml');
     }

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -704,6 +704,25 @@ XML;
         $this->assertEquals($expected, $this->encoder->decode($source, 'xml', ['as_collection' => true]));
     }
 
+    public function testDecodeGivenAttributeAlwaysAsCollection()
+    {
+        $source = <<<'XML'
+<order_rows>
+    <order_row>
+        <id>1</id>
+        <price>1200</price>
+    </order_row>
+</order_rows>
+XML;
+        $expected = [
+            'order_row' => [
+                ['id' => 1, 'price' => 1200]
+            ],
+        ];
+
+        $this->assertEquals($expected, $this->encoder->decode($source, 'xml', [XmlEncoder::FORCE_COLLECTION => ['order_rows']]));
+    }
+
     public function testDecodeWithoutItemHash()
     {
         $obj = new ScalarDummy();

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -716,7 +716,7 @@ XML;
 XML;
         $expected = [
             'order_row' => [
-                ['id' => 1, 'price' => 1200]
+                ['id' => 1, 'price' => 1200],
             ],
         ];
 
@@ -897,7 +897,7 @@ XML;
     public function testNotEncodableValueExceptionMessageForAResource()
     {
         $this->expectException(NotEncodableValueException::class);
-        $this->expectExceptionMessage('An unexpected value could not be serialized: stream resource');
+        $this->expectExceptionMessage('An unexpected value could not be serialized: "stream" resource');
 
         (new XmlEncoder())->encode(tmpfile(), 'xml');
     }

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -725,6 +725,25 @@ class XmlEncoderTest extends TestCase
         $this->assertEquals($expected, $this->encoder->decode($source, 'xml', ['as_collection' => true]));
     }
 
+    public function testDecodeGivenAttributeAlwaysAsCollection()
+    {
+        $source = <<<'XML'
+            <order_rows>
+                <order_row>
+                    <id>1</id>
+                    <price>1200</price>
+                </order_row>
+            </order_rows>
+            XML;
+        $expected = [
+            'order_row' => [
+                ['id' => 1, 'price' => 1200],
+            ],
+        ];
+
+        $this->assertEquals($expected, $this->encoder->decode($source, 'xml', [XmlEncoder::FORCE_COLLECTION => ['order_rows']]));
+    }
+
     public function testDecodeWithoutItemHash()
     {
         $obj = new ScalarDummy();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

When `XmlEncoder` decodes a tag holding a single child, it returns that child rather than a list. The shape of the decoded data therefore depends on how many children the document happens to carry, which is awkward when the XML is a source of truth and a collection may legitimately hold one entry.

```xml
<order_rows>
    <order_row><id>1</id></order_row>
</order_rows>
```

decodes to `['order_row' => ['id' => 1]]`, while the same document with two rows decodes to `['order_row' => [['id' => 1], ['id' => 2]]]`.

The new `force_collection` context option takes the list of tag names that must always decode as a collection:

```php
$decoded = $encoder->decode($xml, 'xml', [XmlEncoder::FORCE_COLLECTION => ['order_rows']]);
// ['order_row' => [['id' => 1]]] whatever the number of rows
```

It is also available on the context builder:

```php
$context = (new XmlEncoderContextBuilder())->withForceCollection(['order_rows'])->toArray();
```

The option defaults to an empty list, so documents decode exactly as before unless a tag is named.

Documentation should cover: the option and its builder method, that it is keyed by the *parent* tag name, and that it only affects decoding.
