### PR TITLE
Symfony 5.4 LTS will get security fixes until Feb 2029 thanks to Ibexa' sponsoring

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -86,7 +86,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
     public const EXTRA_VERSION = 'DEV';
 
     public const END_OF_MAINTENANCE = '11/2024';
-    public const END_OF_LIFE = '11/2025';
+    public const END_OF_LIFE = '02/2029';
 
     public function __construct(string $environment, bool $debug)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

As part of the sponsoring of Symfony 5.4 by Ibexa, we agreed to extend the security-only maintenance period until February 2029 (which matches the EOL of Ibexa's DXP 4.6 LTS).

Thanks to them!
(but please don't make this an excuse to postpone upgrading to Symfony++ everybody :pray:  )

Labeling this PR as a bugfix so that it gets some visibility in the changelog.

/cc @adamwojs FYI