### PR TITLE
[Validator] [Choice] Fix callback option if not array returned

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
@@ -55,6 +55,9 @@ class ChoiceValidator extends ConstraintValidator
                 throw new ConstraintDefinitionException('The Choice constraint expects a valid callback.');
             }
             $choices = $choices();
+            if (!is_array($choices)) {
+                throw new ConstraintDefinitionException(sprintf('The Choice constraint callback "%s" is expected to return an array, but returned "%s".', trim($this->formatValue($constraint->callback), '"'), get_debug_type($choices)));
+            }
         } else {
             $choices = $constraint->choices;
         }

--- a/src/Symfony/Component/Validator/Tests/Constraints/ChoiceValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ChoiceValidatorTest.php
@@ -39,6 +39,11 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
         return ['foo', 'bar'];
     }
 
+    public static function staticCallbackInvalid()
+    {
+        return null;
+    }
+
     public function testExpectArrayIfMultipleIsTrue()
     {
         $this->expectException(UnexpectedValueException::class);
@@ -132,6 +137,19 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate('bar', $constraint);
 
         $this->assertNoViolation();
+    }
+
+    public function testInvalidChoiceCallbackContextMethod()
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('The Choice constraint callback "staticCallbackInvalid" is expected to return an array, but returned "null".');
+
+        // search $this for "staticCallbackInvalid"
+        $this->setObject($this);
+
+        $constraint = new Choice(['callback' => 'staticCallbackInvalid']);
+
+        $this->validator->validate('bar', $constraint);
     }
 
     public function testValidChoiceCallbackContextObjectMethod()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58610
| License       | MIT

### Issue
When using the Choice validator `callback` option, and the callback method provided does not return an array or iterable, it causes a PHP error.
See all details and how to reproduce it in the issue https://github.com/symfony/symfony/issues/58610

### Solution
In this PR
 - Add some checks if the callback method provided returns an array or iterable
 - Add tests for exception and iterable

________________
**NOTE** : This PR replaces [the old one](https://github.com/symfony/symfony/pull/58611) _(I messed up with the branch rebase)_
