### PR TITLE
[DependencyInjection] Fix linting factories implemented via __callStatic

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AbstractRecursivePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AbstractRecursivePass.php
@@ -202,6 +202,10 @@ abstract class AbstractRecursivePass implements CompilerPassInterface
                 return new \ReflectionMethod(static function (...$arguments) {}, '__invoke');
             }
 
+            if ($r->hasMethod('__callStatic') && ($r = $r->getMethod('__callStatic')) && $r->isPublic()) {
+                return new \ReflectionMethod(static function (...$arguments) {}, '__invoke');
+            }
+
             throw new RuntimeException(sprintf('Invalid service "%s": method "%s()" does not exist.', $this->currentId, $class !== $this->currentId ? $class.'::'.$method : $method));
         }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckTypeDeclarationsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckTypeDeclarationsPassTest.php
@@ -1015,6 +1015,17 @@ class CheckTypeDeclarationsPassTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
+    public function testStaticCallableClass()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', StaticCallableClass::class)
+            ->setFactory([StaticCallableClass::class, 'staticMethodCall']);
+
+        (new CheckTypeDeclarationsPass())->process($container);
+
+        $this->addToAssertionCount(1);
+    }
+
     public function testIgnoreDefinitionFactoryArgument()
     {
         $container = new ContainerBuilder();
@@ -1047,6 +1058,13 @@ class CheckTypeDeclarationsPassTest extends TestCase
 class CallableClass
 {
     public function __call($name, $arguments)
+    {
+    }
+}
+
+class StaticCallableClass
+{
+    public static function __callStatic($name, $arguments)
     {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58614  
| License       | MIT

This PR is an extension of an old fix made back in https://github.com/symfony/symfony/pull/44710.
Factory calls to static methods handled by the `__callStatic` method currently throw the "Invalid service DYZ: method Class::method() does not exist".
