### PR TITLE
[HttpFoundation][Lock] Ensure compatibility with ext-mongodb v2

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
@@ -133,6 +133,8 @@ class MongoDbSessionHandlerTest extends TestCase
                 $this->assertInstanceOf(\MongoDB\BSON\UTCDateTime::class, $data[$this->options['time_field']]);
                 $this->assertInstanceOf(\MongoDB\BSON\UTCDateTime::class, $data[$this->options['expiry_field']]);
                 $this->assertGreaterThanOrEqual($expectedExpiry, round((string) $data[$this->options['expiry_field']] / 1000));
+
+                return $this->createMock(\MongoDB\UpdateResult::class);
             });
 
         $this->assertTrue($this->storage->write('foo', 'bar'));
@@ -153,6 +155,8 @@ class MongoDbSessionHandlerTest extends TestCase
             ->method('updateOne')
             ->willReturnCallback(function ($criteria, $updateData, $options) use (&$data) {
                 $data = $updateData;
+
+                return $this->createMock(\MongoDB\UpdateResult::class);
             });
 
         $this->storage->write('foo', 'bar');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The extension `mongodb` and the library `mongodb/mongodb` will soon have a version 2.0 that brings breaking changes (see [extension changes](https://jira.mongodb.org/issues/?jql=project%20%3D%20PHPC%20AND%20fixVersion%20%3D%202.0.0) and [library changes](https://jira.mongodb.org/issues/?jql=project%20%3D%20PHPLIB%20AND%20fixVersion%20%3D%202.0.0)). This PR ensures compatibility with the upcoming version for Symfony 5.4.

- Return types added to `MongoDB\Collection::updateOne()`, the closure in the mock `willReturnCallback` must return an object. https://github.com/mongodb/mongo-php-library/pull/1391
- `MongoDB\Driver\Exception\WriteException` removed in favor of `BulkWriteException` https://github.com/mongodb/mongo-php-driver/pull/1685. No need to keep catching `WriteException` since a the driver bulk API have always be used.
- `float` support to construct `MongoDB\BSON\UTCDateTime` is removed https://github.com/mongodb/mongo-php-driver/pull/1709