### PR TITLE
[HttpClient] Fix typo in deprecation message

### DIFF
--- a/src/Symfony/Component/HttpClient/NoPrivateNetworkHttpClient.php
+++ b/src/Symfony/Component/HttpClient/NoPrivateNetworkHttpClient.php
@@ -78,11 +78,11 @@ final class NoPrivateNetworkHttpClient implements HttpClientInterface, LoggerAwa
     }
 
     /**
-     * @deprecated since Symfony 7.1, configure the logger on the wrapper HTTP client directly instead
+     * @deprecated since Symfony 7.1, configure the logger on the wrapped HTTP client directly instead
      */
     public function setLogger(LoggerInterface $logger): void
     {
-        trigger_deprecation('symfony/http-client', '7.1', 'Configure the logger on the wrapper HTTP client directly instead.');
+        trigger_deprecation('symfony/http-client', '7.1', 'Configure the logger on the wrapped HTTP client directly instead.');
 
         if ($this->client instanceof LoggerAwareInterface) {
             $this->client->setLogger($logger);

--- a/src/Symfony/Component/HttpClient/ScopingHttpClient.php
+++ b/src/Symfony/Component/HttpClient/ScopingHttpClient.php
@@ -101,11 +101,11 @@ class ScopingHttpClient implements HttpClientInterface, ResetInterface, LoggerAw
     }
 
     /**
-     * @deprecated since Symfony 7.1, configure the logger on the wrapper HTTP client directly instead
+     * @deprecated since Symfony 7.1, configure the logger on the wrapped HTTP client directly instead
      */
     public function setLogger(LoggerInterface $logger): void
     {
-        trigger_deprecation('symfony/http-client', '7.1', 'Configure the logger on the wrapper HTTP client directly instead.');
+        trigger_deprecation('symfony/http-client', '7.1', 'Configure the logger on the wrapped HTTP client directly instead.');
 
         if ($this->client instanceof LoggerAwareInterface) {
             $this->client->setLogger($logger);

--- a/src/Symfony/Component/HttpClient/TraceableHttpClient.php
+++ b/src/Symfony/Component/HttpClient/TraceableHttpClient.php
@@ -90,11 +90,11 @@ final class TraceableHttpClient implements HttpClientInterface, ResetInterface, 
     }
 
     /**
-     * @deprecated since Symfony 7.1, configure the logger on the wrapper HTTP client directly instead
+     * @deprecated since Symfony 7.1, configure the logger on the wrapped HTTP client directly instead
      */
     public function setLogger(LoggerInterface $logger): void
     {
-        trigger_deprecation('symfony/http-client', '7.1', 'Configure the logger on the wrapper HTTP client directly instead.');
+        trigger_deprecation('symfony/http-client', '7.1', 'Configure the logger on the wrapped HTTP client directly instead.');
 
         if ($this->client instanceof LoggerAwareInterface) {
             $this->client->setLogger($logger);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

Just a typo fix from https://github.com/symfony/symfony/pull/54806

This confused me initially because I thought I had to configure it on a wrapper, so add one more layer, but couldn't find a logging wrapper client.. 

Anyway @xabbuh one more question do I understand it correctly that if one just uses autowiring and the framework.http_client config to create a client, then the loggers will be set by default and nothing has to be done? No need to call setLogger explicitly on the client right?