### PR TITLE
[BrowserKit][FrameworkBundle] do not access typed properties before initialization

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/KernelBrowser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/KernelBrowser.php
@@ -56,7 +56,7 @@ class KernelBrowser extends HttpKernelBrowser
      */
     public function getProfile(): HttpProfile|false|null
     {
-        if (null === $this->response || !$this->getContainer()->has('profiler')) {
+        if (!isset($this->response) || !$this->getContainer()->has('profiler')) {
             return false;
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/KernelBrowserTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/KernelBrowserTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Tests\Functional\AbstractWebTestCase;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 class KernelBrowserTest extends AbstractWebTestCase
 {
@@ -59,6 +60,13 @@ class KernelBrowserTest extends AbstractWebTestCase
         $client->request('GET', '/');
         static::ensureKernelShutdown();
         $client->request('GET', '/');
+    }
+
+    public function testGetProfileWithoutRequest()
+    {
+        $browser = new KernelBrowser($this->createMock(KernelInterface::class));
+
+        $this->assertFalse($browser->getProfile());
     }
 
     private function getKernelMock()

--- a/src/Symfony/Component/BrowserKit/AbstractBrowser.php
+++ b/src/Symfony/Component/BrowserKit/AbstractBrowser.php
@@ -531,7 +531,7 @@ abstract class AbstractBrowser
      */
     public function followRedirect(): Crawler
     {
-        if (!$this->redirect) {
+        if (!isset($this->redirect)) {
             throw new LogicException('The request was not redirected.');
         }
 

--- a/src/Symfony/Component/BrowserKit/Tests/AbstractBrowserTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/AbstractBrowserTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\BrowserKit\CookieJar;
 use Symfony\Component\BrowserKit\Exception\BadMethodCallException;
 use Symfony\Component\BrowserKit\Exception\InvalidArgumentException;
+use Symfony\Component\BrowserKit\Exception\LogicException;
 use Symfony\Component\BrowserKit\History;
 use Symfony\Component\BrowserKit\Request;
 use Symfony\Component\BrowserKit\Response;
@@ -888,5 +889,15 @@ class AbstractBrowserTest extends TestCase
         $this->expectExceptionMessage('The "request()" method must be called before "Symfony\\Component\\BrowserKit\\AbstractBrowser::getInternalRequest()".');
 
         $client->getInternalRequest();
+    }
+
+    public function testFollowRedirectWithoutRequest()
+    {
+        $browser = $this->getBrowser();
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The request was not redirected.');
+
+        $browser->followRedirect();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT