### PR TITLE
[Security] Add route params in `LoginLinkHandler`

### DIFF
--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Deprecate argument `$secret` of `RememberMeAuthenticator`
  * Deprecate passing an empty string as `$userIdentifier` argument to `UserBadge` constructor
  * Allow passing passport attributes to the `UserAuthenticatorInterface::authenticateUser()` method
+ * Added route_params in `LoginLinkHandler` constructor options param 
 
 7.1
 ---

--- a/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandler.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandler.php
@@ -38,6 +38,7 @@ final class LoginLinkHandler implements LoginLinkHandlerInterface
     ) {
         $this->options = array_merge([
             'route_name' => null,
+            'route_params' => [],
             'lifetime' => 600,
         ], $options);
     }
@@ -52,6 +53,8 @@ final class LoginLinkHandler implements LoginLinkHandlerInterface
             'expires' => $expires,
             'hash' => $this->signatureHasher->computeSignatureHash($user, $expires),
         ];
+
+        $parameters = array_merge($parameters, $this->options['route_params']);
 
         if ($request) {
             $currentRequestContext = $this->urlGenerator->getContext();

--- a/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandler.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandler.php
@@ -54,7 +54,7 @@ final class LoginLinkHandler implements LoginLinkHandlerInterface
             'hash' => $this->signatureHasher->computeSignatureHash($user, $expires),
         ];
 
-        $parameters = array_merge($parameters, $this->options['route_params']);
+        $parameters = $parameters + $this->options['route_params'];
 
         if ($request) {
             $currentRequestContext = $this->urlGenerator->getContext();

--- a/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
@@ -152,6 +152,37 @@ class LoginLinkHandlerTest extends TestCase
         $this->assertSame('https://example.com/login/verify?user=weaverryan&hash=abchash&expires=1654244256', $loginLink->getUrl());
     }
 
+    public function testCreateLoginLinkWithRouteParams()
+    {
+        $extraProperties = ['emailProperty' => 'ryan@symfonycasts.com', 'passwordProperty' => 'pwhash'];
+        $routeParams = ['custom_param' => 'custom_value'];
+
+        $this->router->expects($this->once())
+            ->method('generate')
+            ->with(
+                'app_check_login_link_route',
+                $this->callback(fn($parameters) =>
+                    'weaverryan' === $parameters['user']
+                    && isset($parameters['expires'])
+                    && abs(time() + 600 - $parameters['expires']) <= 1
+                    && isset($parameters['hash'])
+                    && $parameters['custom_param'] === 'custom_value'
+                    && $parameters['hash'] === $this->createSignatureHash('weaverryan', $parameters['expires'], $extraProperties)
+                ),
+                UrlGeneratorInterface::ABSOLUTE_URL
+            )
+            ->willReturn('https://example.com/login/verify?user=weaverryan&hash=abchash&expires=1601235000&custom_param=custom_value');
+
+        $user = new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash');
+
+        $loginLink = $this->createLinker(['route_params' => $routeParams], array_keys($extraProperties))->createLoginLink($user);
+
+        $this->assertSame(
+            'https://example.com/login/verify?user=weaverryan&hash=abchash&expires=1601235000&custom_param=custom_value',
+            $loginLink->getUrl()
+        );
+    }
+
     public function testConsumeLoginLink()
     {
         $expires = time() + 500;
@@ -253,6 +284,7 @@ class LoginLinkHandlerTest extends TestCase
         $options = array_merge([
             'lifetime' => 600,
             'route_name' => 'app_check_login_link_route',
+            'route_params' => [],
         ], $options);
 
         return new LoginLinkHandler($this->router, $this->userProvider, new SignatureHasher($this->propertyAccessor, $extraProperties, 's3cret', $this->expiredLinkStorage, $options['max_uses'] ?? null), $options);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | no
| License       | MIT


## Add Support for Route Parameters in LoginLinkHandler
This pull request enhances the `LoginLinkHandler` to support passing route parameters when generating login links. This is achieved by adding a new option, `route_params`, which allows specifying additional parameters to be included in the generated URL.

**Changes:**
- Added `'route_params' => []` to the default options in the constructor.
- Merged `route_params` with the existing parameters in the `createLoginLink` method.

This feature is important for use cases where additional route parameters are required for generating login links.