### PR TITLE
[DependencyInjection] Fix parsing nested AutowireInline attributes

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
@@ -198,3 +198,18 @@ class AutowireInlineAttributes3
     ) {
     }
 }
+
+class NestedAutowireInlineAttribute
+{
+    public function __construct(
+        #[AutowireInline(
+            AutowireInlineAttributesBar::class,
+            arguments: [
+                new AutowireInline(Foo::class),
+                'testString',
+            ],
+        )]
+        public AutowireInlineAttributesBar $inlined,
+    ) {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

A service definition like the following is supposed to work, yet we missed parsing it correctly. This fixes it.

```php
    public function __construct(
        #[AutowireInline(
            MarkdownConverter::class,
            [
                new AutowireInline(
                    Environment::class,
                    calls: [
                        ['addExtension', [new AutowireInline(CommonMarkCoreExtension::class)]],
                        ['addExtension', [new AutowireInline(AutolinkExtension::class)]],
                    ],
                )
            ]
        )]
        private ConverterInterface $markdownConverter,
    ) {
    }
```