### PR TITLE
[Notifier] Improve Telegrams markdown escaping

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransport.php
@@ -89,7 +89,20 @@ final class TelegramTransport extends AbstractTransport
 
         if (!isset($options['parse_mode']) || TelegramOptions::PARSE_MODE_MARKDOWN_V2 === $options['parse_mode']) {
             $options['parse_mode'] = TelegramOptions::PARSE_MODE_MARKDOWN_V2;
-            $text = preg_replace('/([_*\[\]()~`>#+\-=|{}.!\\\\])/', '\\\\$1', $text);
+            /*
+             * Just replace the obvious chars according to Telegram documentation.
+             * Do not try to find pairs or replace chars, that occur in pairs like
+             *  - *bold text*
+             *  - _italic text_
+             *  - __underlined text__
+             *  - various notations of images, f. ex. [title](url)
+             *  - `code samples`.
+             * 
+             * These formats should be taken care of when the message is constructed.
+             *
+             * @see https://core.telegram.org/bots/api#markdownv2-style
+             */
+            $text = preg_replace('/([.!#>+-=|{}~])/', '\\\\$1', $text);
         }
 
         if (isset($options['upload'])) {

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportTest.php
@@ -265,7 +265,7 @@ final class TelegramTransportTest extends TransportTestCase
 
         $expectedBody = [
             'chat_id' => 'testChannel',
-            'text' => 'I contain special characters \_ \* \[ \] \( \) \~ \` \> \# \+ \- \= \| \{ \} \. \! \\\\ to send\.',
+            'text' => 'I contain special characters _ * [ ] ( ) \~ ` \> \# \+ \- \= \| \{ \} \. \! \ to send\.',
             'parse_mode' => 'MarkdownV2',
         ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #51330 
| License       | MIT

This PR reverts/improves the escaping of Telegrams MarkdownV2 characters. It fixes the currently broken escaping of every single Markdown char while not taking into account that they come in pairs.
