### PR TITLE
revert allowing Twig 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "ext-xml": "*",
         "doctrine/event-manager": "^2",
         "doctrine/persistence": "^3.1",
-        "twig/twig": "^3.12|^4.0",
+        "twig/twig": "^3.12",
         "psr/cache": "^2.0|^3.0",
         "psr/clock": "^1.0",
         "psr/container": "^1.1|^2.0",

--- a/src/Symfony/Bridge/Twig/Tests/Node/TransNodeTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Node/TransNodeTest.php
@@ -18,7 +18,6 @@ use Twig\Environment;
 use Twig\Loader\LoaderInterface;
 use Twig\Node\Expression\NameExpression;
 use Twig\Node\TextNode;
-use Twig\Runtime\LoopIterator;
 
 /**
  * @author Asmir Mustafic <goetas@gmail.com>
@@ -51,11 +50,6 @@ class TransNodeTest extends TestCase
 
     protected function getVariableGetterWithStrictCheck($name)
     {
-        if (class_exists(LoopIterator::class)) {
-            return \sprintf('(array_key_exists("%1$s", $context) ? $context["%1$s"] : throw new RuntimeError(\'Variable "%1$s" does not exist.\', 0, $this->source))', $name);
-        }
-
-        // for Twig 3 and older, can be removed when support for Twig 3 is dropped
         return \sprintf('(isset($context["%1$s"]) || array_key_exists("%1$s", $context) ? $context["%1$s"] : (function () { throw new RuntimeError(\'Variable "%1$s" does not exist.\', 0, $this->source); })())', $name);
     }
 }

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -19,7 +19,7 @@
         "php": ">=8.2",
         "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/translation-contracts": "^2.5|^3",
-        "twig/twig": "^3.12|^4.0"
+        "twig/twig": "^3.12"
     },
     "require-dev": {
         "egulias/email-validator": "^2.1.10|^3|^4",

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -73,7 +73,7 @@
         "symfony/web-link": "^6.4|^7.0",
         "symfony/webhook": "^7.2",
         "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
-        "twig/twig": "^3.12|^4.0"
+        "twig/twig": "^3.12"
     },
     "conflict": {
         "doctrine/persistence": "<1.3",

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -50,7 +50,7 @@
         "symfony/twig-bridge": "^6.4|^7.0",
         "symfony/validator": "^6.4|^7.0",
         "symfony/yaml": "^6.4|^7.0",
-        "twig/twig": "^3.12|^4.0",
+        "twig/twig": "^3.12",
         "web-token/jwt-library": "^3.3.2|^4.0"
     },
     "conflict": {

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -23,7 +23,7 @@
         "symfony/twig-bridge": "^6.4|^7.0",
         "symfony/http-foundation": "^6.4|^7.0",
         "symfony/http-kernel": "^6.4|^7.0",
-        "twig/twig": "^3.12|^4.0"
+        "twig/twig": "^3.12"
     },
     "require-dev": {
         "symfony/asset": "^6.4|^7.0",

--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -22,7 +22,7 @@
         "symfony/http-kernel": "^6.4|^7.0",
         "symfony/routing": "^6.4|^7.0",
         "symfony/twig-bundle": "^6.4|^7.0",
-        "twig/twig": "^3.12|^4.0"
+        "twig/twig": "^3.12"
     },
     "require-dev": {
         "symfony/browser-kit": "^6.4|^7.0",

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -47,7 +47,7 @@
         "symfony/var-dumper": "^6.4|^7.0",
         "symfony/var-exporter": "^6.4|^7.0",
         "psr/cache": "^1.0|^2.0|^3.0",
-        "twig/twig": "^3.12|^4.0"
+        "twig/twig": "^3.12"
     },
     "provide": {
         "psr/log-implementation": "1.0|2.0|3.0"

--- a/src/Symfony/Component/VarDumper/composer.json
+++ b/src/Symfony/Component/VarDumper/composer.json
@@ -25,7 +25,7 @@
         "symfony/http-kernel": "^6.4|^7.0",
         "symfony/process": "^6.4|^7.0",
         "symfony/uid": "^6.4|^7.0",
-        "twig/twig": "^3.12|^4.0"
+        "twig/twig": "^3.12"
     },
     "conflict": {
         "symfony/console": "<6.4"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | reverts #58145
| License       | MIT

As Twig 4 will not be released before Symfony 7.2 we should not claim compatibility before a stable Twig 4 release.
