### PR TITLE
[Cache] add tests covering getMultiple() with a wrapped tag aware adapter

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Psr16CacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Psr16CacheTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Cache\Tests;
 use Cache\IntegrationTests\SimpleCacheTest;
 use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 use Symfony\Component\Cache\PruneableInterface;
 use Symfony\Component\Cache\Psr16Cache;
 
@@ -172,6 +173,22 @@ class Psr16CacheTest extends SimpleCacheTest
         $getFileMethod->setAccessible(true);
 
         return !file_exists($getFileMethod->invoke($pool, $name));
+    }
+
+    public function testGetMultipleWithTagAwareAdapter()
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $cache = new Psr16Cache(new TagAwareAdapter(new FilesystemAdapter()));
+
+        $cache->set('foo', 'foo-val');
+        $cache->set('bar', 'bar-val');
+        $cache->set('baz', 'baz-val');
+        $cache->set('qux', 'qux-val');
+
+        $this->assertEquals(['foo' => 'foo-val', 'bar' => 'bar-val', 'baz' => 'baz-val', 'qux' => 'qux-val'], $cache->getMultiple(['foo', 'bar', 'baz', 'qux']));
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

This is the same test that is included in the bugfix PR #58639 proving that the `getMultiple()` method worked as expected in 5.4 before the refactoring that happened in #42997.