### PR TITLE
[FrameworkBundle] Improve `http_port` and `https_port` options type

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -632,8 +632,16 @@ class Configuration implements ConfigurationInterface
                             ->info('The default URI used to generate URLs in a non-HTTP context.')
                             ->defaultNull()
                         ->end()
-                        ->scalarNode('http_port')->defaultValue(80)->end()
-                        ->scalarNode('https_port')->defaultValue(443)->end()
+                        ->integerNode('http_port')
+                            ->defaultValue(80)
+                            ->min(1)
+                            ->max(65535)
+                        ->end()
+                        ->integerNode('https_port')
+                            ->defaultValue(443)
+                            ->min(1)
+                            ->max(65535)
+                        ->end()
                         ->scalarNode('strict_requirements')
                             ->info(
                                 "set to true to throw an exception when a parameter does not match the requirements\n".


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Add bounds to the `http_port` and `https_port` options. Should this be considered a bug fix and target 5.4? Looks like an improvement more than a fix.