### PR TITLE
[Mailer] Fix TypeError in on SMTP error

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -243,7 +243,7 @@ jobs:
     name: PHP ${{ matrix.php }} - Windows
 
     env:
-      extensions: xsl,apcu,igbinary,intl,mbstring,memcached,redis-5.3.4
+      extensions: mongodb,xsl,apcu,igbinary,intl,mbstring,memcached,redis-5.3.4
 
     strategy:
       matrix:
@@ -256,7 +256,7 @@ jobs:
             mode: low-deps
           - php: '8.3'
           - php: '8.4'
-            extensions: amqp,apcu,igbinary,intl,mbstring,memcached,redis
+            extensions: mongodb,xsl,amqp,apcu,igbinary,intl,mbstring,memcached,redis
             #mode: experimental
       fail-fast: false
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -248,16 +248,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - php: '7.2'
-          - php: '7.4'
           - php: '8.2'
             mode: high-deps
           - php: '8.2'
             mode: low-deps
-          - php: '8.3'
-          - php: '8.4'
-            extensions: mongodb,xsl,amqp,apcu,igbinary,intl,mbstring,memcached,redis
-            #mode: experimental
       fail-fast: false
 
     steps:
@@ -286,7 +280,7 @@ jobs:
           ([ -d "$COMPOSER_HOME" ] || mkdir "$COMPOSER_HOME") && cp .github/composer-config.json "$COMPOSER_HOME/config.json"
 
           echo COLUMNS=120 >> $GITHUB_ENV
-          echo PHPUNIT="$(pwd)/phpunit --exclude-group tty,benchmark,intl-data,integration" >> $GITHUB_ENV
+          echo PHPUNIT="$(pwd)/phpunit --testdox --exclude-group tty,benchmark,intl-data,integration" >> $GITHUB_ENV
           echo COMPOSER_UP='composer update --no-progress --ansi'$([[ "${{ matrix.mode }}" != low-deps ]] && echo ' --ignore-platform-req=php+') >> $GITHUB_ENV
           echo SYMFONY_DEPRECATIONS_HELPER="baselineFile=$(pwd)/.github/deprecations-baseline.json" >> $GITHUB_ENV
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -396,13 +396,13 @@ jobs:
           export -f _run_tests
 
           if [[ ! "${{ matrix.mode }}" = *-deps ]]; then
-            echo "$COMPONENTS" | xargs -d' ' -I{} bash -c "_run_tests {} '$PHPUNIT {}'"
+            bash -c "_run_tests src/Symfony/Component/Mailer '$PHPUNIT src/Symfony/Component/Mailer'"
 
             exit 0
           fi
 
           if [[ "${{ matrix.mode }}" = low-deps ]]; then
-            echo "$COMPONENTS" | xargs -d' ' -I{} bash -c "_run_tests {} 'cd {} && $COMPOSER_UP --prefer-lowest --prefer-stable && $PHPUNIT'"
+            bash -c "_run_tests src/Symfony/Component/Mailer 'cd src/Symfony/Component/Mailer && $COMPOSER_UP --prefer-lowest --prefer-stable && $PHPUNIT'"
 
             exit 0
           fi
@@ -411,7 +411,7 @@ jobs:
           (cd src/Symfony/Component/Lock; cp composer.json composer.bak; composer require --dev --no-update mongodb/mongodb)
 
           # matrix.mode = high-deps
-          echo "$COMPONENTS" | xargs -d' ' -I{} "_run_tests {} 'cd {} && $COMPOSER_UP && $PHPUNIT$LEGACY'" || X=1
+          bash -c "_run_tests src/Symfony/Component/Mailer 'cd src/Symfony/Component/Mailer && $COMPOSER_UP && $PHPUNIT$LEGACY'" || X=1
 
           # get a list of the patched components (relies on .github/build-packages.php being called in the previous step)
           (cd src/Symfony/Component/HttpFoundation; mv composer.bak composer.json)
@@ -434,7 +434,7 @@ jobs:
                 echo "::group::install phpunit"
                 ./phpunit install
                 echo "::endgroup::"
-                echo "$PATCHED_COMPONENTS" | xargs -d' ' -I{} "_run_tests {} 'cd {} && rm composer.lock vendor/ -Rf && $COMPOSER_UP && $PHPUNIT$LEGACY'" || X=1
+                bash -c "_run_tests src/Symfony/Component/Mailer 'cd src/Symfony/Component/Mailer && rm composer.lock vendor/ -Rf && $COMPOSER_UP && $PHPUNIT$LEGACY'" || X=1
               fi
           fi
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -396,13 +396,13 @@ jobs:
           export -f _run_tests
 
           if [[ ! "${{ matrix.mode }}" = *-deps ]]; then
-            echo "$COMPONENTS" | xargs -n1 | parallel -j +3 "_run_tests {} '$PHPUNIT {}'"
+            echo "$COMPONENTS" | xargs -n1 bash -c "_run_tests {} '$PHPUNIT {}'"
 
             exit 0
           fi
 
           if [[ "${{ matrix.mode }}" = low-deps ]]; then
-            echo "$COMPONENTS" | xargs -n1 | parallel -j +3 "_run_tests {} 'cd {} && $COMPOSER_UP --prefer-lowest --prefer-stable && $PHPUNIT'"
+            echo "$COMPONENTS" | xargs -n1 bash -c "_run_tests {} 'cd {} && $COMPOSER_UP --prefer-lowest --prefer-stable && $PHPUNIT'"
 
             exit 0
           fi
@@ -411,7 +411,7 @@ jobs:
           (cd src/Symfony/Component/Lock; cp composer.json composer.bak; composer require --dev --no-update mongodb/mongodb)
 
           # matrix.mode = high-deps
-          echo "$COMPONENTS" | xargs -n1 | parallel -j +3 "_run_tests {} 'cd {} && $COMPOSER_UP && $PHPUNIT$LEGACY'" || X=1
+          echo "$COMPONENTS" | xargs -n1 bash -c "_run_tests {} 'cd {} && $COMPOSER_UP && $PHPUNIT$LEGACY'" || X=1
 
           # get a list of the patched components (relies on .github/build-packages.php being called in the previous step)
           (cd src/Symfony/Component/HttpFoundation; mv composer.bak composer.json)
@@ -434,7 +434,7 @@ jobs:
                 echo "::group::install phpunit"
                 ./phpunit install
                 echo "::endgroup::"
-                echo "$PATCHED_COMPONENTS" | parallel -j +3 "_run_tests {} 'cd {} && rm composer.lock vendor/ -Rf && $COMPOSER_UP && $PHPUNIT$LEGACY'" || X=1
+                echo "$PATCHED_COMPONENTS" | bash -c "_run_tests {} 'cd {} && rm composer.lock vendor/ -Rf && $COMPOSER_UP && $PHPUNIT$LEGACY'" || X=1
               fi
           fi
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,7 +17,9 @@ permissions:
 
 jobs:
 
-  tests:
+  linux-tests:
+    runs-on: ubuntu-20.04
+
     name: Unit Tests
 
     env:
@@ -37,8 +39,6 @@ jobs:
             extensions: amqp,apcu,igbinary,intl,mbstring,memcached,redis
             #mode: experimental
       fail-fast: false
-
-    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout
@@ -224,6 +224,226 @@ jobs:
         if: "! matrix.mode"
         run: |
             script -e -c './phpunit --group tty' /dev/null
+
+      - name: Run tests with SIGCHLD enabled PHP
+        if: "matrix.php == '7.2' && ! matrix.mode"
+        run: |
+          mkdir build
+          cd build
+          wget -q https://github.com/symfony/binary-utils/releases/download/v0.1/php-7.2.5-pcntl-sigchild.tar.bz2
+          tar -xjf php-7.2.5-pcntl-sigchild.tar.bz2
+          cd ..
+
+          ./build/php/bin/php ./phpunit --colors=always src/Symfony/Component/Process
+
+  windows_tests:
+
+    runs-on: windows-2022
+
+    name: PHP ${{ matrix.php }} - Windows
+
+    env:
+      extensions: amqp,apcu,igbinary,intl,mbstring,memcached,redis-5.3.4
+
+    strategy:
+      matrix:
+        include:
+          - php: '7.2'
+          - php: '7.4'
+          - php: '8.2'
+            mode: high-deps
+          - php: '8.2'
+            mode: low-deps
+          - php: '8.3'
+          - php: '8.4'
+            extensions: amqp,apcu,igbinary,intl,mbstring,memcached,redis
+            #mode: experimental
+      fail-fast: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          coverage: "none"
+          ini-values: date.timezone=UTC,memory_limit=-1,default_socket_timeout=10,session.gc_probability=0,apc.enable_cli=1,zend.assertions=1
+          php-version: "${{ matrix.php }}"
+          extensions: "${{ matrix.extensions || env.extensions }}"
+          tools: flex
+
+      - name: Configure environment
+        run: |
+          git config --global user.email ""
+          git config --global user.name "Symfony"
+          git config --global init.defaultBranch main
+          git config --global advice.detachedHead false
+
+          COMPOSER_HOME="$(composer config home)"
+          ([ -d "$COMPOSER_HOME" ] || mkdir "$COMPOSER_HOME") && cp .github/composer-config.json "$COMPOSER_HOME/config.json"
+
+          echo COLUMNS=120 >> $GITHUB_ENV
+          echo PHPUNIT="$(pwd)/phpunit --exclude-group tty,benchmark,intl-data,integration" >> $GITHUB_ENV
+          echo COMPOSER_UP='composer update --no-progress --ansi'$([[ "${{ matrix.mode }}" != low-deps ]] && echo ' --ignore-platform-req=php+') >> $GITHUB_ENV
+          echo SYMFONY_DEPRECATIONS_HELPER="baselineFile=$(pwd)/.github/deprecations-baseline.json" >> $GITHUB_ENV
+
+          SYMFONY_VERSIONS=$(git ls-remote -q --heads | cut -f2 | grep -o '/[1-9][0-9]*\.[0-9].*' | sort -V)
+          SYMFONY_VERSION=$(grep ' VERSION = ' src/Symfony/Component/HttpKernel/Kernel.php | cut -d "'" -f2 | cut -d '.' -f 1-2)
+          SYMFONY_FEATURE_BRANCH=$(curl -s https://raw.githubusercontent.com/symfony/recipes/flex/main/index.json | jq -r '.versions."dev-name"')
+
+          # Install the phpunit-bridge from a PR if required
+          #
+          # To run a PR with a patched phpunit-bridge, first submit the patch for the
+          # phpunit-bridge as a separate PR against the next feature-branch then
+          # uncomment and update the following line with that PR number
+          #SYMFONY_PHPUNIT_BRIDGE_PR=32886
+
+          if [[ $SYMFONY_PHPUNIT_BRIDGE_PR ]]; then
+            git fetch --depth=2 origin refs/pull/$SYMFONY_PHPUNIT_BRIDGE_PR/head
+            git rm -rq src/Symfony/Bridge/PhpUnit
+            git checkout -q FETCH_HEAD -- src/Symfony/Bridge/PhpUnit
+            SYMFONY_PHPUNIT_BRIDGE_REF=$(curl -s https://api.github.com/repos/symfony/symfony/pulls/$SYMFONY_PHPUNIT_BRIDGE_PR | jq -r .base.ref)
+            sed -i 's/"symfony\/phpunit-bridge": ".*"/"symfony\/phpunit-bridge": "'$SYMFONY_PHPUNIT_BRIDGE_REF'.x@dev"/' composer.json
+            rm -rf .phpunit
+          fi
+
+          # Create local composer packages for each patched components and reference them in composer.json files when cross-testing components
+          if [[ ! "${{ matrix.mode }}" = *-deps ]]; then
+              php .github/build-packages.php HEAD^ $SYMFONY_VERSION src/Symfony/Bridge/PhpUnit
+          else
+            echo SYMFONY_DEPRECATIONS_HELPER=weak >> $GITHUB_ENV
+            cp composer.json composer.json.orig
+            echo -e '{\n"require":{'"$(grep phpunit-bridge composer.json)"'"php":"*"},"minimum-stability":"dev"}' > composer.json
+            php .github/build-packages.php HEAD^ $SYMFONY_VERSION $(find src/Symfony -mindepth 2 -type f -name composer.json -printf '%h\n')
+            mv composer.json composer.json.phpunit
+            mv composer.json.orig composer.json
+          fi
+          if [[ $SYMFONY_PHPUNIT_BRIDGE_PR ]]; then
+            git rm -fq -- src/Symfony/Bridge/PhpUnit/composer.json
+            git diff --staged -- src/Symfony/Bridge/PhpUnit/ | git apply -R --index
+          fi
+
+          # For the highest branch, in high-deps mode, the version before it is checked out and tested with the locally patched components
+          if [[ "${{ matrix.mode }}" = high-deps && $SYMFONY_VERSION = $(echo "$SYMFONY_VERSIONS" | tail -n 1 | sed s/.//) ]]; then
+            echo FLIP='^' >> $GITHUB_ENV
+            SYMFONY_VERSION=$(echo "$SYMFONY_VERSIONS" | grep -FB1 /$SYMFONY_VERSION | head -n 1 | sed s/.//)
+            git fetch --depth=2 origin $SYMFONY_VERSION
+            git checkout -m FETCH_HEAD
+            echo COMPONENTS=$(find src/Symfony -mindepth 2 -type f -name phpunit.xml.dist -printf '%h ') >> $GITHUB_ENV
+          fi
+
+          # Skip the phpunit-bridge on bugfix-branches when not in *-deps mode
+          if [[ ! "${{ matrix.mode }}" = *-deps && $SYMFONY_VERSION != $SYMFONY_FEATURE_BRANCH ]]; then
+            echo COMPONENTS=$(find src/Symfony -mindepth 2 -type f -name phpunit.xml.dist -not -wholename '*/Bridge/PhpUnit/*' | xargs -I{} dirname {}) >> $GITHUB_ENV
+          else
+            echo COMPONENTS=$(find src/Symfony -mindepth 2 -type f -name phpunit.xml.dist | xargs -I{} dirname {}) >> $GITHUB_ENV
+          fi
+
+          # Legacy tests are skipped when deps=high and when the current branch version has not the same major version number as the next one
+          [[ "${{ matrix.mode }}" = high-deps && $SYMFONY_VERSION = *.4 ]] && echo LEGACY=,legacy >> $GITHUB_ENV || true
+
+          echo SYMFONY_VERSION=$SYMFONY_VERSION >> $GITHUB_ENV
+          echo COMPOSER_ROOT_VERSION=$SYMFONY_VERSION.x-dev >> $GITHUB_ENV
+          echo SYMFONY_REQUIRE=">=$([ '${{ matrix.mode }}' = low-deps ] && echo 4.4 || echo $SYMFONY_VERSION)" >> $GITHUB_ENV
+          [[ "${{ matrix.mode }}" = *-deps ]] && mv composer.json.phpunit composer.json || true
+
+      - name: Install dependencies
+        run: |
+          echo "::group::composer update"
+          $COMPOSER_UP
+          echo "::endgroup::"
+
+          echo "::group::install phpunit"
+          ./phpunit install
+          echo "::endgroup::"
+
+      - name: Patch return types
+        if: "matrix.php == '8.1' && ! matrix.mode"
+        run: |
+          sed -i 's/"\*\*\/Tests\/"//' composer.json
+          git add .
+          composer install -q --optimize-autoloader
+          SYMFONY_PATCH_TYPE_DECLARATIONS='force=1&php=7.2' php .github/patch-types.php
+          SYMFONY_PATCH_TYPE_DECLARATIONS='force=1&php=7.2' php .github/patch-types.php # ensure the script is idempotent
+          git diff --exit-code
+          echo PHPUNIT="$PHPUNIT,legacy" >> $GITHUB_ENV
+
+      - name: Run tests
+        run: |
+          _run_tests() {
+            local ok=0
+            local title="$1$FLIP"
+            local start=$(date -u +%s)
+            OUTPUT=$(bash -xc "$2" 2>&1) || ok=$?
+            local end=$(date -u +%s)
+
+            if [[ $ok -ne 0 ]]; then
+              printf "\n%-70s%10s\n" $title $(($end-$start))s
+              echo "$OUTPUT"
+              echo "Job exited with: $ok"
+              echo -e "\n::error::KO $title\\n"
+            else
+              printf "::group::%-68s%10s\n" $title $(($end-$start))s
+              echo "$OUTPUT"
+              echo -e "\n\\e[32mOK\\e[0m $title\\n\\n::endgroup::"
+            fi
+
+            [[ "${{ matrix.mode }}" = experimental ]] || (exit $ok)
+          }
+          export -f _run_tests
+
+          if [[ ! "${{ matrix.mode }}" = *-deps ]]; then
+            echo "$COMPONENTS" | xargs -n1 | parallel -j +3 "_run_tests {} '$PHPUNIT {}'"
+
+            exit 0
+          fi
+
+          if [[ "${{ matrix.mode }}" = low-deps ]]; then
+            echo "$COMPONENTS" | xargs -n1 | parallel -j +3 "_run_tests {} 'cd {} && $COMPOSER_UP --prefer-lowest --prefer-stable && $PHPUNIT'"
+
+            exit 0
+          fi
+
+          (cd src/Symfony/Component/HttpFoundation; cp composer.json composer.bak; composer require --dev --no-update mongodb/mongodb)
+          (cd src/Symfony/Component/Lock; cp composer.json composer.bak; composer require --dev --no-update mongodb/mongodb)
+
+          # matrix.mode = high-deps
+          echo "$COMPONENTS" | xargs -n1 | parallel -j +3 "_run_tests {} 'cd {} && $COMPOSER_UP && $PHPUNIT$LEGACY'" || X=1
+
+          # get a list of the patched components (relies on .github/build-packages.php being called in the previous step)
+          (cd src/Symfony/Component/HttpFoundation; mv composer.bak composer.json)
+          (cd src/Symfony/Component/Lock; mv composer.bak composer.json)
+          PATCHED_COMPONENTS=$(git diff --name-only src/ | grep composer.json || true)
+
+          # for 5.4 LTS, checkout and test previous major with the patched components (only for patched components)
+          if [[ $PATCHED_COMPONENTS && $SYMFONY_VERSION = 5.4 ]]; then
+              export FLIP='^'
+              SYMFONY_VERSION=$(echo $SYMFONY_VERSION | awk '{print $1 - 1}')
+              echo -e "\\n\\e[33;1mChecking out Symfony $SYMFONY_VERSION and running tests with patched components as deps\\e[0m"
+              export COMPOSER_ROOT_VERSION=$SYMFONY_VERSION.x-dev
+              export SYMFONY_REQUIRE=">=$SYMFONY_VERSION"
+              git fetch --depth=2 origin $SYMFONY_VERSION
+              git checkout -m FETCH_HEAD
+              PATCHED_COMPONENTS=$(echo "$PATCHED_COMPONENTS" | xargs dirname | xargs -n1 -I{} bash -c "[ -e '{}/phpunit.xml.dist' ] && echo '{}'" | sort || true)
+              (cd src/Symfony/Component/HttpFoundation; composer require --dev --no-update mongodb/mongodb)
+              (cd src/Symfony/Component/Lock; composer require --dev --no-update mongodb/mongodb)
+              if [[ $PATCHED_COMPONENTS ]]; then
+                echo "::group::install phpunit"
+                ./phpunit install
+                echo "::endgroup::"
+                echo "$PATCHED_COMPONENTS" | parallel -j +3 "_run_tests {} 'cd {} && rm composer.lock vendor/ -Rf && $COMPOSER_UP && $PHPUNIT$LEGACY'" || X=1
+              fi
+          fi
+
+          [[ ! $X ]] || (exit 1)
+
+      - name: Run TTY tests
+        if: "! matrix.mode"
+        run: |
+          script -e -c './phpunit --group tty' /dev/null
 
       - name: Run tests with SIGCHLD enabled PHP
         if: "matrix.php == '7.2' && ! matrix.mode"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -243,7 +243,7 @@ jobs:
     name: PHP ${{ matrix.php }} - Windows
 
     env:
-      extensions: amqp,apcu,igbinary,intl,mbstring,memcached,redis-5.3.4
+      extensions: xsl,apcu,igbinary,intl,mbstring,memcached,redis-5.3.4
 
     strategy:
       matrix:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -396,13 +396,13 @@ jobs:
           export -f _run_tests
 
           if [[ ! "${{ matrix.mode }}" = *-deps ]]; then
-            echo "$COMPONENTS" | xargs -n1 bash -c "_run_tests {} '$PHPUNIT {}'"
+            echo "$COMPONENTS" | xargs -d' ' -I{} bash -c "_run_tests {} '$PHPUNIT {}'"
 
             exit 0
           fi
 
           if [[ "${{ matrix.mode }}" = low-deps ]]; then
-            echo "$COMPONENTS" | xargs -n1 bash -c "_run_tests {} 'cd {} && $COMPOSER_UP --prefer-lowest --prefer-stable && $PHPUNIT'"
+            echo "$COMPONENTS" | xargs -d' ' -I{} bash -c "_run_tests {} 'cd {} && $COMPOSER_UP --prefer-lowest --prefer-stable && $PHPUNIT'"
 
             exit 0
           fi
@@ -411,7 +411,7 @@ jobs:
           (cd src/Symfony/Component/Lock; cp composer.json composer.bak; composer require --dev --no-update mongodb/mongodb)
 
           # matrix.mode = high-deps
-          echo "$COMPONENTS" | xargs -n1 bash -c "_run_tests {} 'cd {} && $COMPOSER_UP && $PHPUNIT$LEGACY'" || X=1
+          echo "$COMPONENTS" | xargs -d' ' -I{} "_run_tests {} 'cd {} && $COMPOSER_UP && $PHPUNIT$LEGACY'" || X=1
 
           # get a list of the patched components (relies on .github/build-packages.php being called in the previous step)
           (cd src/Symfony/Component/HttpFoundation; mv composer.bak composer.json)
@@ -434,7 +434,7 @@ jobs:
                 echo "::group::install phpunit"
                 ./phpunit install
                 echo "::endgroup::"
-                echo "$PATCHED_COMPONENTS" | bash -c "_run_tests {} 'cd {} && rm composer.lock vendor/ -Rf && $COMPOSER_UP && $PHPUNIT$LEGACY'" || X=1
+                echo "$PATCHED_COMPONENTS" | xargs -d' ' -I{} "_run_tests {} 'cd {} && rm composer.lock vendor/ -Rf && $COMPOSER_UP && $PHPUNIT$LEGACY'" || X=1
               fi
           fi
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -332,14 +332,14 @@ jobs:
             SYMFONY_VERSION=$(echo "$SYMFONY_VERSIONS" | grep -FB1 /$SYMFONY_VERSION | head -n 1 | sed s/.//)
             git fetch --depth=2 origin $SYMFONY_VERSION
             git checkout -m FETCH_HEAD
-            echo COMPONENTS=$(find src/Symfony -mindepth 2 -type f -name phpunit.xml.dist -printf '%h ') >> $GITHUB_ENV
+            echo COMPONENTS="src/Symfony/Component/Mailer" >> $GITHUB_ENV
           fi
 
           # Skip the phpunit-bridge on bugfix-branches when not in *-deps mode
           if [[ ! "${{ matrix.mode }}" = *-deps && $SYMFONY_VERSION != $SYMFONY_FEATURE_BRANCH ]]; then
-            echo COMPONENTS=$(find src/Symfony -mindepth 2 -type f -name phpunit.xml.dist -not -wholename '*/Bridge/PhpUnit/*' | xargs -I{} dirname {}) >> $GITHUB_ENV
+            echo COMPONENTS="src/Symfony/Component/Mailer" >> $GITHUB_ENV
           else
-            echo COMPONENTS=$(find src/Symfony -mindepth 2 -type f -name phpunit.xml.dist | xargs -I{} dirname {}) >> $GITHUB_ENV
+            echo COMPONENTS="src/Symfony/Component/Mailer" >> $GITHUB_ENV
           fi
 
           # Legacy tests are skipped when deps=high and when the current branch version has not the same major version number as the next one

--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportTest.php
@@ -12,9 +12,7 @@
 namespace Symfony\Component\Mailer\Tests\Transport\Smtp;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
-use Symfony\Component\Mime\Email;
 
 class EsmtpTransportTest extends TestCase
 {
@@ -41,28 +39,5 @@ class EsmtpTransportTest extends TestCase
 
         $t = new EsmtpTransport('example.com', 466, true);
         $this->assertEquals('smtps://example.com:466', (string) $t);
-    }
-
-    public function testTypeErrorInMailer()
-    {
-        $transport = new EsmtpTransport(
-            'smtp.mailtrap.io',
-            587,
-            null
-        );
-        $transport->setUsername('foo');
-        $transport->setPassword('bar');
-
-        $message = new Email();
-        $message->from('sender@example.org');
-        $message->addTo('recipient@example.org');
-        $message->text('.');
-
-        try {
-            $transport->send($message);
-            $this->fail('Symfony\Component\Mailer\Exception\TransportException to be thrown');
-        } catch (TransportException $e) {
-            $this->assertStringStartsWith('Failed to authenticate on SMTP server with username "foo" using the following authenticators: "CRAM-MD5", "LOGIN", "PLAIN".', $e->getMessage());
-        }
     }
 }

--- a/src/Symfony/Component/Mailer/Transport/Smtp/Stream/AbstractStream.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/Stream/AbstractStream.php
@@ -85,7 +85,7 @@ abstract class AbstractStream
                 throw new TransportException(sprintf('Connection to "%s" has been closed unexpectedly.', $this->getReadConnectionDescription()));
             }
             if (false === $line) {
-                throw new TransportException(sprintf('Unable to read from connection to "%s": ', $this->getReadConnectionDescription()).error_get_last()['message']);
+                throw new TransportException(sprintf('Unable to read from connection to "%s": ', $this->getReadConnectionDescription()).(error_get_last()['message'] ?? ''));
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

https://www.php.net/manual/en/function.error-get-last.php returns `?array`. If `null` is returned, it produces:
```
Trying to access array offset on value of type null
vendor\symfony\mailer\Transport\Smtp\Stream\AbstractStream.php:91
```

It's unclear to me how to reproduce the issue. However, it's in our best interests to correctly handle all return types.

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
