### PR TITLE
[Messenger][FrameworkBundle] Allow chaining multiple failure transports

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2415,8 +2415,10 @@ class FrameworkExtension extends Extension
                 throw new LogicException(\sprintf('Invalid Messenger configuration: the failure transport "%s" is not a valid transport or service id.', $config['failure_transport']));
             }
 
-            $container->setAlias('messenger.failure_transports.default', 'messenger.transport.'.$config['failure_transport']);
-            $failureTransports[] = $config['failure_transport'];
+            if (!isset($config['transports'][$config['failure_transport']]['failure_transport'])) {
+                $container->setAlias('messenger.failure_transports.default', 'messenger.transport.'.$config['failure_transport']);
+                $failureTransports[] = $config['failure_transport'];
+            }
         }
 
         $failureTransportsByName = [];
@@ -2426,6 +2428,12 @@ class FrameworkExtension extends Extension
                 $failureTransportsByName[$name] = $transport['failure_transport'];
             } elseif ($config['failure_transport']) {
                 $failureTransportsByName[$name] = $config['failure_transport'];
+            }
+        }
+
+        foreach ($failureTransports as $key => $failureTransport) {
+            if (isset($config['transports'][$failureTransport]['failure_transport'])) {
+                unset($failureTransports[$key]);
             }
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_failure_transport_chain.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_failure_transport_chain.php
@@ -1,0 +1,21 @@
+<?php
+
+$container->loadFromExtension('framework', [
+    'annotations' => false,
+    'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
+    'messenger' => [
+        'transports' => [
+            'transport_1' => [
+                'dsn' => 'null://',
+                'failure_transport' => 'transport_2',
+            ],
+            'transport_2' => [
+                'dsn' => 'null://',
+                'failure_transport' => 'failure_transport_1',
+            ],
+            'failure_transport_1' => 'null://',
+        ],
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_failure_transport_chain.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_failure_transport_chain.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:framework="http://symfony.com/schema/dic/symfony"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config http-method-override="false" handle-all-throwables="true">
+        <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
+        <framework:messenger>
+            <framework:transport name="transport_1" dsn="null://" failure-transport="transport_2" />
+            <framework:transport name="transport_2" dsn="null://" failure-transport="failure_transport_1"/>
+            <framework:transport name="failure_transport_1" dsn="null://" />
+        </framework:messenger>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_failure_transport_chain.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_failure_transport_chain.yml
@@ -1,0 +1,15 @@
+framework:
+    annotations: false
+    http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
+    messenger:
+        transports:
+            transport_1:
+                dsn: 'null://'
+                failure_transport: transport_2
+            transport_2:
+                dsn: 'null://'
+                failure_transport: failure_transport_1
+            failure_transport_1: 'null://'

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -900,6 +900,41 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->assertEquals($expectedTransportsByFailureTransports, $failureTransportsReferences);
     }
 
+    public function testMessengerFailureTransportChain()
+    {
+        $container = $this->createContainerFromFile('messenger_failure_transport_chain');
+
+        $failureTransport1Definition = $container->getDefinition('messenger.transport.failure_transport_1');
+        $failureTransport1Tags = $failureTransport1Definition->getTag('messenger.receiver')[0];
+
+        $this->assertEquals([
+            'alias' => 'failure_transport_1',
+            'is_failure_transport' => true,
+        ], $failureTransport1Tags);
+
+        $intermediateFailureTransportDefinition = $container->getDefinition('messenger.transport.transport_2');
+        $failureTransport3Tags = $intermediateFailureTransportDefinition->getTag('messenger.receiver')[0];
+
+        $this->assertEquals([
+            'alias' => 'transport_2',
+            'is_failure_transport' => false,
+        ], $failureTransport3Tags);
+
+        $failureTransportsByTransportNameServiceLocator = $container->getDefinition('messenger.failure.send_failed_message_to_failure_transport_listener')->getArgument(0);
+        $failureTransports = $container->getDefinition((string) $failureTransportsByTransportNameServiceLocator)->getArgument(0);
+        $expectedTransportsByFailureTransports = [
+            'transport_1' => new Reference('messenger.transport.transport_2'),
+            'transport_2' => new Reference('messenger.transport.failure_transport_1'),
+        ];
+
+        $failureTransportsReferences = array_map(function (ServiceClosureArgument $serviceClosureArgument) {
+            $values = $serviceClosureArgument->getValues();
+
+            return array_shift($values);
+        }, $failureTransports);
+        $this->assertEquals($expectedTransportsByFailureTransports, $failureTransportsReferences);
+    }
+
     public function testMessengerMultipleFailureTransportsWithGlobalFailureTransport()
     {
         $container = $this->createContainerFromFile('messenger_multiple_failure_transports_global');

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Add `--class-filter` option to the `messenger:failed:remove` command
  * Add `$stamps` parameter to `HandleTrait::handle`
  * Add `Symfony\Component\Messenger\EventListener\ResetMemoryUsageListener` to reset PHP's peak memory usage for each processed message
+ * Add ability to chain failure transports. A failed message will process through the respective failure transports until arriving at the final one.
 
 7.2
 ---

--- a/src/Symfony/Component/Messenger/EventListener/SendFailedMessageToFailureTransportListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/SendFailedMessageToFailureTransportListener.php
@@ -47,9 +47,11 @@ class SendFailedMessageToFailureTransportListener implements EventSubscriberInte
 
         $envelope = $event->getEnvelope();
 
-        // avoid re-sending to the failed sender
-        if (null !== $envelope->last(SentToFailureTransportStamp::class)) {
-            return;
+        // avoid re-sending to same failed sender again
+        foreach ($envelope->all(SentToFailureTransportStamp::class) as $stamp) {
+            if ($stamp->getOriginalReceiverName() === $event->getReceiverName()) {
+                return;
+            }
         }
 
         $envelope = $envelope->with(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

This adds the ability to chain multiple failure transports together. 

If a message fails, it will be redispatched to the configured failure transport. Until now, this could only happen once, as each envelope could only have one `SentToFailureTransportStamp`. This limitation got removed, allowing an envelope to fail and be redispatched to the failure transport multiple times. To prevent endless dispatch loops, an envelope does not get redispatched if it had already been dispatched to the same transport.

Let's say we have the following transports:
```yaml
framework:
    messenger:
        transports:
            transport_1:
                dsn: 'null://'
                failure_transport: transport_2
            transport_2:
                dsn: 'null://'
                failure_transport: failure_transport_1
            failure_transport_1: 'null://'
```
A message dispatched to `transport_1` would fail and be redispatched to `transport_2`. If it fails again in `transport_2` (after the configured retry strategy etc.), it would then be redispatched to `failure_transport_1`.

All "intermediate" failure transports (i.e. those that a have failure transport themselves) do not get tagged as failure transports. This way they will now show up in the `messenger:failed:*` commands.