### PR TITLE
[PropertyInfo][Serializer] Fix default groups

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/SerializerExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/SerializerExtractor.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\PropertyInfo\Extractor;
 
 use Symfony\Component\PropertyInfo\PropertyListExtractorInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 
 /**
  * Lists available properties using Symfony Serializer Component metadata.
@@ -38,15 +39,34 @@ class SerializerExtractor implements PropertyListExtractorInterface
             return null;
         }
 
+        $enableDefaultGroups = $context[AbstractNormalizer::ENABLE_DEFAULT_GROUPS] ?? false;
+
         $groups = $context['serializer_groups'] ?? [];
-        $groupsHasBeenDefined = [] !== $groups;
-        $groups = array_merge($groups, ['Default', (false !== $nsSep = strrpos($class, '\\')) ? substr($class, $nsSep + 1) : $class]);
+        $defaultGroups = ['Default', (false !== $nsSep = strrpos($class, '\\')) ? substr($class, $nsSep + 1) : $class];
+
+        $groupsHasBeenDefined = $enableDefaultGroups
+            ? [] !== $groups
+            : null !== ($context['serializer_groups'] ?? null);
+
+        $customGroupsHasBeenDefined = (bool) array_diff($groups, $defaultGroups);
+
+        if ($enableDefaultGroups && !$customGroupsHasBeenDefined) {
+            $groups = array_merge($groups, $defaultGroups);
+        }
 
         $properties = [];
         $serializerClassMetadata = $this->classMetadataFactory->getMetadataFor($class);
 
         foreach ($serializerClassMetadata->getAttributesMetadata() as $serializerAttributeMetadata) {
-            if (!$serializerAttributeMetadata->isIgnored() && (!$groupsHasBeenDefined || array_intersect(array_merge($serializerAttributeMetadata->getGroups(), ['*']), $groups))) {
+            if ($serializerAttributeMetadata->isIgnored()) {
+                continue;
+            }
+
+            if (!($attributeGroups = $serializerAttributeMetadata->getGroups()) && $enableDefaultGroups && !$customGroupsHasBeenDefined) {
+                $attributeGroups = $defaultGroups;
+            }
+
+            if (!$groupsHasBeenDefined || array_intersect(array_merge($attributeGroups, ['*']), $groups)) {
                 $properties[] = $serializerAttributeMetadata->getName();
             }
         }

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/SerializerExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/SerializerExtractorTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Extractor\SerializerExtractor;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\AdderRemoverDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\GroupPropertyDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\IgnorePropertyDummy;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
@@ -43,12 +44,91 @@ class SerializerExtractorTest extends TestCase
     public function testGetPropertiesWithIgnoredProperties()
     {
         $this->assertSame(['visibleProperty'], $this->extractor->getProperties(IgnorePropertyDummy::class, ['serializer_groups' => ['a']]));
-        $this->assertSame(['visibleProperty'], $this->extractor->getProperties(IgnorePropertyDummy::class, ['serializer_groups' => ['Default']]));
-        $this->assertSame(['visibleProperty'], $this->extractor->getProperties(IgnorePropertyDummy::class, ['serializer_groups' => ['IgnorePropertyDummy']]));
     }
 
     public function testGetPropertiesWithAnyGroup()
     {
         $this->assertSame(['analyses', 'feet'], $this->extractor->getProperties(AdderRemoverDummy::class, ['serializer_groups' => null]));
+    }
+
+    public function testGetPropertiesWithDefaultGroups()
+    {
+        $this->assertSame(
+            ['noGroup', 'customGroup', 'defaultGroup', 'classGroup'],
+            $this->extractor->getProperties(GroupPropertyDummy::class, ['serializer_groups' => null]),
+        );
+
+        $this->assertSame(
+            [],
+            $this->extractor->getProperties(GroupPropertyDummy::class, ['serializer_groups' => []]),
+        );
+
+        $this->assertSame(
+            ['noGroup', 'customGroup', 'defaultGroup', 'classGroup'],
+            $this->extractor->getProperties(GroupPropertyDummy::class, ['serializer_groups' => ['*']]),
+        );
+
+        $this->assertSame(
+            ['customGroup'],
+            $this->extractor->getProperties(GroupPropertyDummy::class, ['serializer_groups' => ['custom']]),
+        );
+
+        $this->assertSame(
+            ['defaultGroup'],
+            $this->extractor->getProperties(GroupPropertyDummy::class, ['serializer_groups' => ['Default']]),
+        );
+
+        $this->assertSame(
+            ['classGroup'],
+            $this->extractor->getProperties(GroupPropertyDummy::class, ['serializer_groups' => ['GroupPropertyDummy']]),
+        );
+
+        $this->assertSame(
+            ['noGroup', 'customGroup', 'defaultGroup', 'classGroup'],
+            $this->extractor->getProperties(GroupPropertyDummy::class, [
+                'enable_default_groups' => true,
+                'serializer_groups' => null,
+            ]),
+        );
+
+        $this->assertSame(
+            ['noGroup', 'customGroup', 'defaultGroup', 'classGroup'],
+            $this->extractor->getProperties(GroupPropertyDummy::class, [
+                'enable_default_groups' => true,
+                'serializer_groups' => [],
+            ]),
+        );
+
+        $this->assertSame(
+            ['noGroup', 'customGroup', 'defaultGroup', 'classGroup'],
+            $this->extractor->getProperties(GroupPropertyDummy::class, [
+                'enable_default_groups' => true,
+                'serializer_groups' => ['*'],
+            ]),
+        );
+
+        $this->assertSame(
+            ['customGroup'],
+            $this->extractor->getProperties(GroupPropertyDummy::class, [
+                'enable_default_groups' => true,
+                'serializer_groups' => ['custom'],
+            ]),
+        );
+
+        $this->assertSame(
+            ['noGroup', 'defaultGroup', 'classGroup'],
+            $this->extractor->getProperties(GroupPropertyDummy::class, [
+                'enable_default_groups' => true,
+                'serializer_groups' => ['Default'],
+            ]),
+        );
+
+        $this->assertSame(
+            ['noGroup', 'defaultGroup', 'classGroup'],
+            $this->extractor->getProperties(GroupPropertyDummy::class, [
+                'enable_default_groups' => true,
+                'serializer_groups' => ['GroupPropertyDummy'],
+            ]),
+        );
     }
 }

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/GroupPropertyDummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/GroupPropertyDummy.php
@@ -12,16 +12,17 @@
 namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
 
 use Symfony\Component\Serializer\Attribute\Groups;
-use Symfony\Component\Serializer\Attribute\Ignore;
 
-/**
- * @author Vadim Borodavko <vadim.borodavko@gmail.com>
- */
-class IgnorePropertyDummy
+class GroupPropertyDummy
 {
-    #[Groups(['a'])]
-    public $visibleProperty;
+    public bool $noGroup = true;
 
-    #[Groups(['a']), Ignore]
-    private $ignoredProperty;
+    #[Groups('custom')]
+    public bool $customGroup = true;
+
+    #[Groups('Default')]
+    public bool $defaultGroup = true;
+
+    #[Groups('GroupPropertyDummy')]
+    public bool $classGroup = true;
 }

--- a/src/Symfony/Component/Serializer/Context/Normalizer/AbstractObjectNormalizerContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Normalizer/AbstractObjectNormalizerContextBuilder.php
@@ -128,4 +128,13 @@ abstract class AbstractObjectNormalizerContextBuilder extends AbstractNormalizer
     {
         return $this->with(AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS, $preserveEmptyObjects);
     }
+
+    /**
+     * Configures whether 'Default' and 'ClassNames' groups are added when no
+     * custom group is specified.
+     */
+    public function withEnableDefaultGroups(?bool $enableDefaultGroups): static
+    {
+        return $this->with(AbstractObjectNormalizer::ENABLE_DEFAULT_GROUPS, $enableDefaultGroups);
+    }
 }

--- a/src/Symfony/Component/Serializer/Tests/Context/Normalizer/AbstractObjectNormalizerContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/Normalizer/AbstractObjectNormalizerContextBuilderTest.php
@@ -45,6 +45,7 @@ class AbstractObjectNormalizerContextBuilderTest extends TestCase
             ->withExcludeFromCacheKeys($values[AbstractObjectNormalizer::EXCLUDE_FROM_CACHE_KEY])
             ->withDeepObjectToPopulate($values[AbstractObjectNormalizer::DEEP_OBJECT_TO_POPULATE])
             ->withPreserveEmptyObjects($values[AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS])
+            ->withEnableDefaultGroups($values[AbstractObjectNormalizer::ENABLE_DEFAULT_GROUPS])
             ->toArray();
 
         $this->assertSame($values, $context);
@@ -65,6 +66,7 @@ class AbstractObjectNormalizerContextBuilderTest extends TestCase
             AbstractObjectNormalizer::EXCLUDE_FROM_CACHE_KEY => ['key'],
             AbstractObjectNormalizer::DEEP_OBJECT_TO_POPULATE => true,
             AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS => false,
+            AbstractObjectNormalizer::ENABLE_DEFAULT_GROUPS => false,
         ]];
 
         yield 'With null values' => [[
@@ -77,6 +79,7 @@ class AbstractObjectNormalizerContextBuilderTest extends TestCase
             AbstractObjectNormalizer::EXCLUDE_FROM_CACHE_KEY => null,
             AbstractObjectNormalizer::DEEP_OBJECT_TO_POPULATE => null,
             AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS => null,
+            AbstractObjectNormalizer::ENABLE_DEFAULT_GROUPS => null,
         ]];
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/OtherSerializedNameDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/OtherSerializedNameDummy.php
@@ -19,6 +19,18 @@ use Symfony\Component\Serializer\Attribute\SerializedName;
  */
 class OtherSerializedNameDummy
 {
+    #[Groups(['Default']), SerializedName('renamedDefaultGroup')]
+    private $defaultGroup;
+
+    #[Groups(['OtherSerializedNameDummy']), SerializedName('renamedClassGroup')]
+    public $classGroup;
+
+    #[SerializedName('renamedNoGroup')]
+    public $noGroup;
+
+    #[Groups(['custom']), SerializedName('renamedCustomGroup')]
+    public $customGroup;
+
     #[Groups(['a'])]
     private $buz;
 

--- a/src/Symfony/Component/Serializer/Tests/NameConverter/MetadataAwareNameConverterTest.php
+++ b/src/Symfony/Component/Serializer/Tests/NameConverter/MetadataAwareNameConverterTest.php
@@ -116,6 +116,7 @@ final class MetadataAwareNameConverterTest extends TestCase
     }
 
     /**
+     * @group wip
      * @dataProvider attributeAndContextProvider
      */
     public function testNormalizeWithGroups(string $propertyName, string $expected, array $context = [])
@@ -128,6 +129,7 @@ final class MetadataAwareNameConverterTest extends TestCase
     }
 
     /**
+     * @group wip
      * @dataProvider attributeAndContextProvider
      */
     public function testDenormalizeWithGroups(string $expected, string $propertyName, array $context = [])
@@ -142,13 +144,62 @@ final class MetadataAwareNameConverterTest extends TestCase
     public static function attributeAndContextProvider(): array
     {
         return [
-            ['buz', 'buz', ['groups' => ['a']]],
             ['buzForExport', 'buz', ['groups' => ['b']]],
             ['buz', 'buz', ['groups' => 'a']],
             ['buzForExport', 'buz', ['groups' => 'b']],
             ['buz', 'buz', ['groups' => ['c']]],
             ['buz', 'buz', []],
             ['buzForExport', 'buz', ['groups' => ['*']]],
+
+            ['defaultGroup', 'defaultGroup', ['groups' => []]],
+            ['classGroup', 'classGroup', ['groups' => []]],
+            ['noGroup', 'renamedNoGroup', ['groups' => []]],
+            ['customGroup', 'customGroup', ['groups' => []]],
+
+            ['defaultGroup', 'renamedDefaultGroup', ['groups' => ['*']]],
+            ['classGroup', 'renamedClassGroup', ['groups' => ['*']]],
+            ['noGroup', 'renamedNoGroup', ['groups' => ['*']]],
+            ['customGroup', 'renamedCustomGroup', ['groups' => ['*']]],
+
+            ['defaultGroup', 'renamedDefaultGroup', ['groups' => ['Default']]],
+            ['classGroup', 'classGroup', ['groups' => ['Default']]],
+            ['noGroup', 'noGroup', ['groups' => ['Default']]],
+            ['customGroup', 'customGroup', ['groups' => ['Default']]],
+
+            ['defaultGroup', 'defaultGroup', ['groups' => ['OtherSerializedNameDummy']]],
+            ['classGroup', 'renamedClassGroup', ['groups' => ['OtherSerializedNameDummy']]],
+            ['noGroup', 'noGroup', ['groups' => ['OtherSerializedNameDummy']]],
+            ['customGroup', 'customGroup', ['groups' => ['OtherSerializedNameDummy']]],
+
+            ['defaultGroup', 'defaultGroup', ['groups' => ['custom']]],
+            ['classGroup', 'classGroup', ['groups' => ['custom']]],
+            ['noGroup', 'noGroup', ['groups' => ['custom']]],
+            ['customGroup', 'renamedCustomGroup', ['groups' => ['custom']]],
+
+            ['defaultGroup', 'renamedDefaultGroup', ['groups' => [], 'enable_default_groups' => true]],
+            ['classGroup', 'renamedClassGroup', ['groups' => [], 'enable_default_groups' => true]],
+            ['noGroup', 'renamedNoGroup', ['groups' => [], 'enable_default_groups' => true]],
+            ['customGroup', 'customGroup', ['groups' => [], 'enable_default_groups' => true]],
+
+            ['defaultGroup', 'renamedDefaultGroup', ['groups' => ['*'], 'enable_default_groups' => true]],
+            ['classGroup', 'renamedClassGroup', ['groups' => ['*'], 'enable_default_groups' => true]],
+            ['noGroup', 'renamedNoGroup', ['groups' => ['*'], 'enable_default_groups' => true]],
+            ['customGroup', 'renamedCustomGroup', ['groups' => ['*'], 'enable_default_groups' => true]],
+
+            ['defaultGroup', 'renamedDefaultGroup', ['groups' => ['Default'], 'enable_default_groups' => true]],
+            ['classGroup', 'renamedClassGroup', ['groups' => ['Default'], 'enable_default_groups' => true]],
+            ['noGroup', 'noGroup', ['groups' => ['Default'], 'enable_default_groups' => true]],
+            ['customGroup', 'customGroup', ['groups' => ['Default'], 'enable_default_groups' => true]],
+
+            ['defaultGroup', 'renamedDefaultGroup', ['groups' => ['OtherSerializedNameDummy'], 'enable_default_groups' => true]],
+            ['classGroup', 'renamedClassGroup', ['groups' => ['OtherSerializedNameDummy'], 'enable_default_groups' => true]],
+            ['noGroup', 'noGroup', ['groups' => ['OtherSerializedNameDummy'], 'enable_default_groups' => true]],
+            ['customGroup', 'customGroup', ['groups' => ['OtherSerializedNameDummy'], 'enable_default_groups' => true]],
+
+            ['defaultGroup', 'defaultGroup', ['groups' => ['custom'], 'enable_default_groups' => true]],
+            ['classGroup', 'classGroup', ['groups' => ['custom'], 'enable_default_groups' => true]],
+            ['noGroup', 'noGroup', ['groups' => ['custom'], 'enable_default_groups' => true]],
+            ['customGroup', 'renamedCustomGroup', ['groups' => ['custom'], 'enable_default_groups' => true]],
         ];
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -302,8 +302,6 @@ class GetSetMethodNormalizerTest extends TestCase
                 'bar' => null,
                 'foo_bar' => '@dunglas',
                 'symfony' => '@coopTilleuls',
-                'default' => null,
-                'class_name' => null,
             ],
             $this->normalizer->normalize($obj, null, [GetSetMethodNormalizer::GROUPS => ['name_converter']])
         );

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -507,8 +507,6 @@ class ObjectNormalizerTest extends TestCase
                 'bar' => null,
                 'foo_bar' => '@dunglas',
                 'symfony' => '@coopTilleuls',
-                'default' => null,
-                'class_name' => null,
             ],
             $this->normalizer->normalize($obj, null, [ObjectNormalizer::GROUPS => ['name_converter']])
         );

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -321,8 +321,6 @@ class PropertyNormalizerTest extends TestCase
                 'bar' => null,
                 'foo_bar' => '@dunglas',
                 'symfony' => '@coopTilleuls',
-                'default' => null,
-                'class_name' => null,
             ],
             $this->normalizer->normalize($obj, null, [PropertyNormalizer::GROUPS => ['name_converter']])
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58576, Fix #57350
| License       | MIT

When introduced in #51514, the behavior of group selection was wrong and introduced BC breaks (see the two related issues).

This PR resolves them **by making that behavior opt-in**, hidden behind an `enable_default_groups` context value.

Plus, this PR handles (when opted-in) default groups as they should have been handled in the first place.
Let's say we have the following class:
```php
class Foo
{
    public bool $noGroup = true;

    #[Groups('custom')]
    public bool $customGroup = true;

    #[Groups('Default')]
    public bool $defaultGroup = true;

    #[Groups('ExampleObject57350')]
    public bool $classGroup = true;
}
```
The `SerializerExtractor` will return properties:
| group | properties
| -  | -
| `null`, `*`, `[]` | `noGroup`, `customGroup`, `defaultGroup`, `classGroup`
| `custom` | `customGroup`
| `Default`, `Foo`, `[]` | `noGroup`, `defaultGroup`, `classGroup`

The `AbstractNormalizer` will allow attributes:
| group | properties
| -  | -
| `null`, `[]`, `*` | `noGroup`, `customGroup`, `defaultGroup`, `classGroup`
| `custom` | `customGroup`
| `Default`, `Foo` | `noGroup`, `defaultGroup`, `classGroup`

The `MetadataAwareNameConverter` will allow attributes:
| group | properties
| -  | -
| `null`, `[]` | `noGroup`, `defaultGroup`, `classGroup`
| `*` | `noGroup`, `customGroup`, `defaultGroup`, `classGroup`
| `custom` | `customGroup`
| `Default`, `Foo` | `defaultGroup`, `classGroup`

On the contrary to `SerializerExtractor` and `AbstractNormalizer`, `noGroup` is not included when any group is specified, and `customGroup` is not included when no group is specified)

---

Another PR should be created in 7.3 in order to deprecate not setting the `enable_default_groups` context value, as it will default to `true` in 8.0.