### PR TITLE
[Notifier] [Twitter] Fix post INIT upload

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Twitter/Tests/TwitterTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Twitter/Tests/TwitterTransportTest.php
@@ -66,7 +66,9 @@ class TwitterTransportTest extends TransportTestCase
         $transport = $this->createTransport(new MockHttpClient((function () {
             yield function (string $method, string $url, array $options) {
                 $this->assertSame('POST', $method);
-                $this->assertSame('https://upload.twitter.com/1.1/media/upload.json?command=INIT&total_bytes=185&media_type=image/gif&media_category=tweet_image', $url);
+                $this->assertSame('https://upload.twitter.com/1.1/media/upload.json', $url);
+                $this->assertArrayHasKey('body', $options);
+                $this->assertSame($options['body'], 'command=INIT&total_bytes=185&media_type=image%2Fgif&media_category=tweet_image');
                 $this->assertArrayHasKey('authorization', $options['normalized_headers']);
 
                 return new MockResponse('{"media_id_string":"gif123"}');
@@ -127,7 +129,9 @@ class TwitterTransportTest extends TransportTestCase
         $transport = $this->createTransport(new MockHttpClient((function () {
             yield function (string $method, string $url, array $options) {
                 $this->assertSame('POST', $method);
-                $this->assertSame('https://upload.twitter.com/1.1/media/upload.json?command=INIT&total_bytes=185&media_type=image/gif&media_category=tweet_video', $url);
+                $this->assertSame('https://upload.twitter.com/1.1/media/upload.json', $url);
+                $this->assertArrayHasKey('body', $options);
+                $this->assertSame($options['body'], 'command=INIT&total_bytes=185&media_type=image%2Fgif&media_category=tweet_video');
                 $this->assertArrayHasKey('authorization', $options['normalized_headers']);
 
                 return new MockResponse('{"media_id_string":"gif123"}');
@@ -135,7 +139,9 @@ class TwitterTransportTest extends TransportTestCase
 
             yield function (string $method, string $url, array $options) {
                 $this->assertSame('POST', $method);
-                $this->assertSame('https://upload.twitter.com/1.1/media/upload.json?command=INIT&total_bytes=185&media_type=image/gif&media_category=subtitles', $url);
+                $this->assertSame('https://upload.twitter.com/1.1/media/upload.json', $url);
+                $this->assertArrayHasKey('body', $options);
+                $this->assertSame($options['body'], 'command=INIT&total_bytes=185&media_type=image%2Fgif&media_category=subtitles');
                 $this->assertArrayHasKey('authorization', $options['normalized_headers']);
 
                 return new MockResponse('{"media_id_string":"sub234"}');

--- a/src/Symfony/Component/Notifier/Bridge/Twitter/TwitterTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Twitter/TwitterTransport.php
@@ -160,32 +160,32 @@ final class TwitterTransport extends AbstractTransport
             'category' => $category,
             'owners' => $extraOwners,
         ]) {
-            $query = [
+            $body = [
                 'command' => 'INIT',
                 'total_bytes' => $file->getSize(),
                 'media_type' => $file->getContentType(),
             ];
 
             if ($category) {
-                $query['media_category'] = $category;
+                $body['media_category'] = $category;
             }
 
             if ($extraOwners) {
-                $query['additional_owners'] = implode(',', $extraOwners);
+                $body['additional_owners'] = implode(',', $extraOwners);
             }
 
             $pool[++$i] = $this->request('POST', '/1.1/media/upload.json', [
-                'query' => $query,
+                'body' => $body,
                 'user_data' => [$i, null, 0, fopen($file->getPath(), 'r'), $alt, $subtitles],
             ]);
 
             if ($subtitles) {
-                $query['total_bytes'] = $subtitles->getSize();
-                $query['media_type'] = $subtitles->getContentType();
-                $query['media_category'] = 'subtitles';
+                $body['total_bytes'] = $subtitles->getSize();
+                $body['media_type'] = $subtitles->getContentType();
+                $body['media_category'] = 'subtitles';
 
                 $pool[++$i] = $this->request('POST', '/1.1/media/upload.json', [
-                    'query' => $query,
+                    'body' => $body,
                     'user_data' => [$i, null, 0, fopen($subtitles->getPath(), 'r'), null, $subtitles],
                 ]);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix Twitter Notifier when attaching a media. <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

The procedure is described here : [https://developer.x.com/en/docs/x-api/v1/media/upload-media/api-reference/post-media-upload-init](https://developer.x.com/en/docs/x-api/v1/media/upload-media/api-reference/post-media-upload-init). This is tricky as on example Example Request the `media_type` query parameter value is raw encoded : `image/jpeg` or `video/mp4` for exemple.

On Postman, query param value is raw encoded too on the interface, but with PHP CURL generated, it's [Percent encoded](https://developer.x.com/en/docs/authentication/oauth-1-0a/percent-encoding-parameters) or `rawurl encoded` : `video%252Fmp4`. I did test the CURL generation and it was OK. But it's not the case on Twitter Notifier component that produce `[Symfony\Component\Notifier\Exception\TransportException (32)] Could not authenticate you` (so this fix).

<img width="1396" alt="postman" src="https://github.com/user-attachments/assets/172418bf-655f-4e55-87ec-f7a18e322103">

It did several tests, first I think it was the OAuth, but looking at the code on `Symfony\Component\Notifier\Bridge\Twitter\TwitterTransport::request` method and twitter docs, it was fine by comparing the php curl generated by postman and the curl generated by Symfony\Component\HttpClient\CurlHttpClient. 
- [https://developer.x.com/en/docs/authentication/oauth-1-0a/authorizing-a-request](https://developer.x.com/en/docs/authentication/oauth-1-0a/authorizing-a-request)
- [https://developer.x.com/en/docs/authentication/oauth-1-0a/creating-a-signature](https://developer.x.com/en/docs/authentication/oauth-1-0a/creating-a-signature)

The difference was on the query (look at media_type param that is raw). This one without the fix produce the Exception.

```bash
[1:27:06][math@mathieus-mbp ~/Sites/darkwood/flow-live] (wave-function-collapse)$ bin/console app:wave-function-collapse -vvv
23:27:44 INFO      [http_client] Request: "POST https://upload.twitter.com/1.1/media/upload.json?command=INIT&total_bytes=56740&media_type=video/mp4&media_category=tweet_video"
23:27:44 INFO      [http_client] Response: "401 https://upload.twitter.com/1.1/media/upload.json?command=INIT&total_bytes=56740&media_type=video/mp4&media_category=tweet_video"

In TwitterTransport.php line 247:
                                                                  
  [Symfony\Component\Notifier\Exception\TransportException (32)]  
  Could not authenticate you                                      
                                                                  

Exception trace:
  at /Users/math/Sites/darkwood/flow-live/vendor/symfony/twitter-notifier/TwitterTransport.php:247
 Symfony\Component\Notifier\Bridge\Twitter\TwitterTransport->processChunk() at /Users/math/Sites/darkwood/flow-live/vendor/symfony/twitter-notifier/TwitterTransport.php:198
 Symfony\Component\Notifier\Bridge\Twitter\TwitterTransport->uploadMedia() at /Users/math/Sites/darkwood/flow-live/vendor/symfony/twitter-notifier/TwitterTransport.php:120
 Symfony\Component\Notifier\Bridge\Twitter\TwitterTransport->doSend() at /Users/math/Sites/darkwood/flow-live/vendor/symfony/notifier/Transport/AbstractTransport.php:80
 Symfony\Component\Notifier\Transport\AbstractTransport->send() at /Users/math/Sites/darkwood/flow-live/vendor/symfony/notifier/Transport/Transports.php:74
 Symfony\Component\Notifier\Transport\Transports->send() at /Users/math/Sites/darkwood/flow-live/vendor/symfony/notifier/Chatter.php:46
 Symfony\Component\Notifier\Chatter->send() at /Users/math/Sites/darkwood/flow-live/src/Command/WaveFunctionCollapseCommand.php:61
 App\Command\WaveFunctionCollapseCommand->execute() at /Users/math/Sites/darkwood/flow-live/vendor/symfony/console/Command/Command.php:279
 Symfony\Component\Console\Command\Command->run() at /Users/math/Sites/darkwood/flow-live/vendor/symfony/console/Application.php:1047
 Symfony\Component\Console\Application->doRunCommand() at /Users/math/Sites/darkwood/flow-live/vendor/symfony/framework-bundle/Console/Application.php:123
 Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand() at /Users/math/Sites/darkwood/flow-live/vendor/symfony/console/Application.php:316
 Symfony\Component\Console\Application->doRun() at /Users/math/Sites/darkwood/flow-live/vendor/symfony/framework-bundle/Console/Application.php:77
 Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at /Users/math/Sites/darkwood/flow-live/vendor/symfony/console/Application.php:167
 Symfony\Component\Console\Application->run() at /Users/math/Sites/darkwood/flow-live/vendor/symfony/runtime/Runner/Symfony/ConsoleApplicationRunner.php:49
 Symfony\Component\Runtime\Runner\Symfony\ConsoleApplicationRunner->run() at /Users/math/Sites/darkwood/flow-live/vendor/autoload_runtime.php:29
 require_once() at /Users/math/Sites/darkwood/flow-live/bin/console:15

app:wave-function-collapse [--width [WIDTH]] [--height [HEIGHT]] [--dataset [DATASET]]
```

And this one with the fix produce is OK.  (look at media_type param that is rawurl encoded)

```bash
[0:11:12][math@mathieus-mbp ~/Sites/darkwood/flow-live] (wave-function-collapse)$ bin/console app:wave-function-collapse -vvv
22:11:18 INFO      [http_client] Request: "POST https://upload.twitter.com/1.1/media/upload.json?command=INIT&total_bytes=56740&media_type=video%252Fmp4&media_category=tweet_video"
22:11:18 INFO      [http_client] Response: "202 https://upload.twitter.com/1.1/media/upload.json?command=INIT&total_bytes=56740&media_type=video%252Fmp4&media_category=tweet_video"
22:11:18 INFO      [http_client] Request: "POST https://upload.twitter.com/1.1/media/upload.json?command=APPEND&media_id=1849574415295537152&segment_index=0"
22:11:18 INFO      [http_client] Response: "204 https://upload.twitter.com/1.1/media/upload.json?command=APPEND&media_id=1849574415295537152&segment_index=0"
22:11:18 INFO      [http_client] Request: "POST https://upload.twitter.com/1.1/media/upload.json?command=FINALIZE&media_id=1849574415295537152"
22:11:19 INFO      [http_client] Response: "200 https://upload.twitter.com/1.1/media/upload.json?command=FINALIZE&media_id=1849574415295537152"
22:11:19 INFO      [http_client] Request: "GET https://upload.twitter.com/1.1/media/upload.json?command=STATUS&media_id=1849574415295537152"
22:11:20 INFO      [http_client] Response: "200 https://upload.twitter.com/1.1/media/upload.json?command=STATUS&media_id=1849574415295537152"
22:11:20 INFO      [http_client] Request: "POST https://api.twitter.com/2/tweets"
22:11:20 INFO      [http_client] Response: "201 https://api.twitter.com/2/tweets"
```

To reproduce it :

```php
/** @var ChatterInterface $chatter */
$videoFile = new \Symfony\Component\Mime\Part\File('var/cache/dev/wave_function_collapse/wave_function_collapse_6716bd83ad525.mp4');
$message = (new ChatMessage('Daily Flow generation.', (new TwitterOptions())->attachVideo($videoFile)))->transport('twitter');
$chatter->send($message);
```

My tests were only with mp4 file. I didn't test with gif or media_category = 'subtitles' but I assume it's the same logic.
It was a real test done with a tweeter account, so can't really reproduce it without creating your own keys [Twitter notifier docs](https://github.com/symfony/twitter-notifier) with read and write Twitter Access Token + Secret with a twitter account.