### PR TITLE
[AssetMapper] Fix `JavaScriptImportPathCompiler` regex for non-latin characters

### DIFF
--- a/src/Symfony/Component/AssetMapper/Compiler/JavaScriptImportPathCompiler.php
+++ b/src/Symfony/Component/AssetMapper/Compiler/JavaScriptImportPathCompiler.php
@@ -50,7 +50,7 @@ final class JavaScriptImportPathCompiler implements AssetCompilerInterface
             )
             \s*[\'"`](\.\/[^\'"`\n]++|(\.\.\/)*+[^\'"`\n]++)[\'"`]\s*[;\)]
         ?
-    /mx';
+    /mxu';
 
     public function __construct(
         private readonly ImportMapConfigReader $importMapConfigReader,

--- a/src/Symfony/Component/AssetMapper/Tests/Compiler/JavaScriptImportPathCompilerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Compiler/JavaScriptImportPathCompilerTest.php
@@ -172,6 +172,22 @@ class JavaScriptImportPathCompilerTest extends TestCase
             'expectedJavaScriptImports' => ['/assets/other.js' => ['lazy' => false, 'asset' => 'other.js', 'add' => true]],
         ];
 
+        yield 'static_named_import_with_unicode_character' => [
+            'input' => 'import { ɵmyFunction } from "./other.js";',
+            'expectedJavaScriptImports' => ['/assets/other.js' => ['lazy' => false, 'asset' => 'other.js', 'add' => true]],
+        ];
+
+        yield 'static_multiple_named_imports' => [
+            'input' => <<<EOF
+                import {
+                    myFunction,
+                    helperFunction
+                } from "./other.js";
+                EOF
+            ,
+            'expectedJavaScriptImports' => ['/assets/other.js' => ['lazy' => false, 'asset' => 'other.js', 'add' => true]],
+        ];
+
         yield 'static_import_everything' => [
             'input' => 'import * as myModule from "./other.js";',
             'expectedJavaScriptImports' => ['/assets/other.js' => ['lazy' => false, 'asset' => 'other.js', 'add' => true]],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58657
| License       | MIT

Update the regex in `JavaScriptImportPathCompiler` so that imported functions having non-latin characters still match the regex.


### Example

```
import { ɵmyFunction } from './others.js'
```

The code above was not working prio to this fix, because of the `ɵ`