### PR TITLE
[Cache] APCu adapter delete array of keys without foreach

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/ApcuAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ApcuAdapter.php
@@ -85,9 +85,7 @@ class ApcuAdapter extends AbstractAdapter
 
     protected function doDelete(array $ids): bool
     {
-        foreach ($ids as $id) {
-            apcu_delete($id);
-        }
+        apcu_delete($ids);
 
         return true;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | none
| License       | MIT

apcu_delete accepts array of keys, so it is faster than iterate and call for each key.
