### PR TITLE
Fix PasswordType.php

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/PasswordType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/PasswordType.php
@@ -20,7 +20,7 @@ class PasswordType extends AbstractType
 {
     public function buildView(FormView $view, FormInterface $form, array $options): void
     {
-        if ($options['always_empty'] || !$form->isSubmitted()) {
+        if ($options['always_empty'] && !$form->isSubmitted()) {
             $view->vars['value'] = '';
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | All
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Fixing the bug where the 'always_empty' parameter always showed the input field empty.

Even if always_empty was set to true or false, the input was always empty and the previous value was lost in the database when the form was submitted. This change fixes this bug.