### PR TITLE
[Cache] Revert "Initialize RedisAdapter cursor to 0"

### DIFF
--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -490,7 +490,7 @@ trait RedisTrait
                 continue;
             }
 
-            $cursor = 0;
+            $cursor = null;
             do {
                 $keys = $host instanceof \Predis\ClientInterface ? $host->scan($cursor, 'MATCH', $pattern, 'COUNT', 1000) : $host->scan($cursor, $pattern, 1000);
                 if (isset($keys[1]) && \is_array($keys[1])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

I missed integration tests being red, and #58661 is the most likely cause.
/cc @thomas-hiron