### PR TITLE
fix(Validator): update return type of getTargets() to array in multiple constraints

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Callback.php
+++ b/src/Symfony/Component/Validator/Constraints/Callback.php
@@ -48,7 +48,7 @@ class Callback extends Constraint
         return 'callback';
     }
 
-    public function getTargets(): string|array
+    public function getTargets(): array
     {
         return [self::CLASS_CONSTRAINT, self::PROPERTY_CONSTRAINT];
     }

--- a/src/Symfony/Component/Validator/Constraints/DisableAutoMapping.php
+++ b/src/Symfony/Component/Validator/Constraints/DisableAutoMapping.php
@@ -36,7 +36,7 @@ class DisableAutoMapping extends Constraint
         parent::__construct($options);
     }
 
-    public function getTargets(): string|array
+    public function getTargets(): array
     {
         return [self::PROPERTY_CONSTRAINT, self::CLASS_CONSTRAINT];
     }

--- a/src/Symfony/Component/Validator/Constraints/EnableAutoMapping.php
+++ b/src/Symfony/Component/Validator/Constraints/EnableAutoMapping.php
@@ -36,7 +36,7 @@ class EnableAutoMapping extends Constraint
         parent::__construct($options);
     }
 
-    public function getTargets(): string|array
+    public function getTargets(): array
     {
         return [self::PROPERTY_CONSTRAINT, self::CLASS_CONSTRAINT];
     }

--- a/src/Symfony/Component/Validator/Constraints/Expression.php
+++ b/src/Symfony/Component/Validator/Constraints/Expression.php
@@ -78,7 +78,7 @@ class Expression extends Constraint
         return ['expression'];
     }
 
-    public function getTargets(): string|array
+    public function getTargets(): array
     {
         return [self::CLASS_CONSTRAINT, self::PROPERTY_CONSTRAINT];
     }

--- a/src/Symfony/Component/Validator/Constraints/Sequentially.php
+++ b/src/Symfony/Component/Validator/Constraints/Sequentially.php
@@ -45,7 +45,7 @@ class Sequentially extends Composite
         return 'constraints';
     }
 
-    public function getTargets(): string|array
+    public function getTargets(): array
     {
         return [self::CLASS_CONSTRAINT, self::PROPERTY_CONSTRAINT];
     }

--- a/src/Symfony/Component/Validator/Constraints/When.php
+++ b/src/Symfony/Component/Validator/Constraints/When.php
@@ -62,7 +62,7 @@ class When extends Composite
         return ['expression', 'constraints'];
     }
 
-    public function getTargets(): string|array
+    public function getTargets(): array
     {
         return [self::CLASS_CONSTRAINT, self::PROPERTY_CONSTRAINT];
     }

--- a/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintA.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintA.php
@@ -25,7 +25,7 @@ class ConstraintA extends Constraint
         return 'property2';
     }
 
-    public function getTargets(): string|array
+    public function getTargets(): array
     {
         return [self::PROPERTY_CONSTRAINT, self::CLASS_CONSTRAINT];
     }

--- a/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintB.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintB.php
@@ -16,7 +16,7 @@ use Symfony\Component\Validator\Constraint;
 /** @Annotation */
 class ConstraintB extends Constraint
 {
-    public function getTargets(): string|array
+    public function getTargets(): array
     {
         return [self::PROPERTY_CONSTRAINT, self::CLASS_CONSTRAINT];
     }

--- a/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintC.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintC.php
@@ -23,7 +23,7 @@ class ConstraintC extends Constraint
         return ['option1'];
     }
 
-    public function getTargets(): string|array
+    public function getTargets(): array
     {
         return [self::PROPERTY_CONSTRAINT, self::CLASS_CONSTRAINT];
     }

--- a/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintWithValue.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintWithValue.php
@@ -24,7 +24,7 @@ class ConstraintWithValue extends Constraint
         return 'property';
     }
 
-    public function getTargets(): string|array
+    public function getTargets(): array
     {
         return [self::PROPERTY_CONSTRAINT, self::CLASS_CONSTRAINT];
     }

--- a/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintWithValueAsDefault.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintWithValueAsDefault.php
@@ -24,7 +24,7 @@ class ConstraintWithValueAsDefault extends Constraint
         return 'value';
     }
 
-    public function getTargets(): string|array
+    public function getTargets(): array
     {
         return [self::PROPERTY_CONSTRAINT, self::CLASS_CONSTRAINT];
     }

--- a/src/Symfony/Component/Validator/Tests/Fixtures/FailingConstraint.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/FailingConstraint.php
@@ -17,7 +17,7 @@ class FailingConstraint extends Constraint
 {
     public $message = 'Failed';
 
-    public function getTargets(): string|array
+    public function getTargets(): array
     {
         return [self::PROPERTY_CONSTRAINT, self::CLASS_CONSTRAINT];
     }

--- a/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
@@ -401,7 +401,7 @@ class ClassCompositeConstraint extends Composite
         return 'nested';
     }
 
-    public function getTargets(): string|array
+    public function getTargets(): array
     {
         return [self::CLASS_CONSTRAINT];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

### Description

Hi,

This fix updates the return type of the `getTargets()` method in multiple constraint classes within the Validator component as well as in the fixtures. Previously, the return type was declared as `string|array`, and the method always returns an array.

Thank you,
Cezar
