### PR TITLE
[TwigBridge][TwigBundle] add `asset_mapper_source()` function

### DIFF
--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Deprecate passing a tag to the constructor of `FormThemeNode`
+ * Add `asset_mapper_source()` Twig function
 
 7.1
 ---

--- a/src/Symfony/Bridge/Twig/Extension/AssetMapperExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/AssetMapperExtension.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Twig\Extension;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class AssetMapperExtension extends AbstractExtension
+{
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('asset_mapper_source', [AssetMapperRuntime::class, 'source'], ['is_safe' => ['all']]),
+        ];
+    }
+}

--- a/src/Symfony/Bridge/Twig/Extension/AssetMapperRuntime.php
+++ b/src/Symfony/Bridge/Twig/Extension/AssetMapperRuntime.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Twig\Extension;
+
+use Symfony\Component\AssetMapper\AssetMapperInterface;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class AssetMapperRuntime
+{
+    public function __construct(
+        private readonly AssetMapperInterface $assetMapper,
+    ) {
+    }
+
+    public function source(string $logicalPath): string
+    {
+        if (!$asset = $this->assetMapper->getAsset($logicalPath)) {
+            throw new \LogicException(\sprintf('The asset "%s" was not found.', $logicalPath));
+        }
+
+        if ($asset->content) {
+            return $asset->content;
+        }
+
+        if (false === $content = file_get_contents($asset->sourcePath)) {
+            throw new \RuntimeException(\sprintf('The asset "%s" could not be read.', $asset->sourcePath));
+        }
+
+        return $content;
+    }
+}

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AssetMapperExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AssetMapperExtensionTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Twig\Tests\Extension;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Twig\Extension\AssetMapperExtension;
+use Symfony\Bridge\Twig\Extension\AssetMapperRuntime;
+use Symfony\Component\AssetMapper\AssetMapperInterface;
+use Symfony\Component\AssetMapper\MappedAsset;
+use Twig\Environment;
+use Twig\Error\RuntimeError;
+use Twig\Loader\ArrayLoader;
+use Twig\RuntimeLoader\RuntimeLoaderInterface;
+
+class AssetMapperExtensionTest extends TestCase
+{
+    public function testItRendersSourceFromContent()
+    {
+        $twig = $this->createTwig(
+            '{{ asset_mapper_source("asset-source.txt") }}',
+            'asset-source.txt',
+            new MappedAsset(
+                logicalPath: 'asset-source.txt',
+                sourcePath: __DIR__.'/Fixtures/asset-source.txt',
+                content: 'from content'
+            ),
+        );
+
+        $this->assertSame('from content', $twig->render('template'));
+    }
+
+    public function testItRendersSourceFromSourcePath()
+    {
+        $twig = $this->createTwig(
+            '{{ asset_mapper_source("asset-source.txt") }}',
+            'asset-source.txt',
+            new MappedAsset(
+                logicalPath: 'asset-source.txt',
+                sourcePath: $path = __DIR__.'/Fixtures/asset-source.txt',
+            ),
+        );
+
+        $this->assertSame(file_get_contents($path), $twig->render('template'));
+    }
+
+    public function testItFailsIfAssetNotFound()
+    {
+        $twig = $this->createTwig('{{ asset_mapper_source("invalid") }}', 'invalid', null);
+
+        $this->expectException(RuntimeError::class);
+        $this->expectExceptionMessage('The asset "invalid" was not found.');
+
+        $twig->render('template');
+    }
+
+    private function createTwig(string $template, string $logicalPath, ?MappedAsset $asset): Environment
+    {
+        $twig = new Environment(new ArrayLoader([
+            'template' => $template,
+        ]), ['debug' => true, 'cache' => false, 'autoescape' => 'html', 'optimizations' => 0]);
+        $twig->addExtension(new AssetMapperExtension());
+        $assetMapper = $this->createMock(AssetMapperInterface::class);
+        $assetMapper->expects($this->once())
+            ->method('getAsset')
+            ->with($logicalPath)
+            ->willReturn($asset);
+        $runtime = new AssetMapperRuntime($assetMapper);
+        $mockRuntimeLoader = $this->createMock(RuntimeLoaderInterface::class);
+        $mockRuntimeLoader
+            ->method('load')
+            ->willReturnMap([
+                [AssetMapperRuntime::class, $runtime],
+            ])
+        ;
+        $twig->addRuntimeLoader($mockRuntimeLoader);
+
+        return $twig;
+    }
+}

--- a/src/Symfony/Bridge/Twig/Tests/Extension/Fixtures/asset-source.txt
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/Fixtures/asset-source.txt
@@ -1,0 +1,1 @@
+from file

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
@@ -52,6 +52,8 @@ class ExtensionPass implements CompilerPassInterface
             // edge case where AssetMapper is installed, but not enabled
             $container->removeDefinition('twig.extension.importmap');
             $container->removeDefinition('twig.runtime.importmap');
+            $container->removeDefinition('twig.extension.asset_mapper');
+            $container->removeDefinition('twig.runtime.asset_mapper');
         }
 
         $viewDir = \dirname((new \ReflectionClass(\Symfony\Bridge\Twig\Extension\FormExtension::class))->getFileName(), 2).'/Resources/views';

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/importmap.php
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/importmap.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Symfony\Bridge\Twig\Extension\AssetMapperExtension;
+use Symfony\Bridge\Twig\Extension\AssetMapperRuntime;
 use Symfony\Bridge\Twig\Extension\ImportMapExtension;
 use Symfony\Bridge\Twig\Extension\ImportMapRuntime;
 
@@ -22,6 +24,13 @@ return static function (ContainerConfigurator $container) {
             ->tag('twig.runtime')
 
         ->set('twig.extension.importmap', ImportMapExtension::class)
+            ->tag('twig.extension')
+
+        ->set('twig.runtime.asset_mapper', AssetMapperRuntime::class)
+            ->args([service('asset_mapper')])
+            ->tag('twig.runtime')
+
+        ->set('twig.extension.asset_mapper', AssetMapperExtension::class)
             ->tag('twig.extension')
     ;
 };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | n/a
| License       | MIT

This adds an `asset_mapper_source()` Twig function. The use-case is inlining css for emails:

```twig
{% apply inline_css(asset_mapper_source('vendor/foundation-emails/dist/foundation-emails.min.css'), asset_mapper_source('styles/email.css')) %}
    {# ... #}
{% endapply %}
```

This will also work with asset mapper assets that are compiled with css/less/tailwind/etc.