### PR TITLE
[ExpressionLanguage] lint should return bool

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
+++ b/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
@@ -98,7 +98,7 @@ class ExpressionLanguage
      *
      * @throws SyntaxError When the passed expression is invalid
      */
-    public function lint(Expression|string $expression, ?array $names, int $flags = 0): void
+    public function lint(Expression|string $expression, ?array $names, int $flags = 0): bool
     {
         if (null === $names) {
             trigger_deprecation('symfony/expression-language', '7.1', 'Passing "null" as the second argument of "%s()" is deprecated, pass "%s\Parser::IGNORE_UNKNOWN_VARIABLES" instead as a third argument.', __METHOD__, __NAMESPACE__);
@@ -108,10 +108,10 @@ class ExpressionLanguage
         }
 
         if ($expression instanceof ParsedExpression) {
-            return;
+            return false;
         }
 
-        $this->getParser()->lint($this->getLexer()->tokenize((string) $expression), $names, $flags);
+        return $this->getParser()->lint($this->getLexer()->tokenize((string) $expression), $names, $flags);
     }
 
     /**

--- a/src/Symfony/Component/ExpressionLanguage/Parser.php
+++ b/src/Symfony/Component/ExpressionLanguage/Parser.php
@@ -113,7 +113,7 @@ class Parser
      *
      * @throws SyntaxError When the passed expression is invalid
      */
-    public function lint(TokenStream $stream, ?array $names = [], int $flags = 0): void
+    public function lint(TokenStream $stream, ?array $names = [], int $flags = 0): bool
     {
         if (null === $names) {
             trigger_deprecation('symfony/expression-language', '7.1', 'Passing "null" as the second argument of "%s()" is deprecated, pass "%s::IGNORE_UNKNOWN_VARIABLES" instead as a third argument.', __METHOD__, __CLASS__);
@@ -122,7 +122,13 @@ class Parser
             $names = [];
         }
 
-        $this->doParse($stream, $names, $flags);
+        try {
+            $this->doParse($stream, $names, $flags);
+        } catch (SyntaxError) {
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
@@ -484,9 +484,8 @@ class ExpressionLanguageTest extends TestCase
     public function testLintAllowsComments($expression)
     {
         $el = new ExpressionLanguage();
-        $el->lint($expression, []);
 
-        $this->expectNotToPerformAssertions();
+        $this->assertTrue($el->lint($expression, []));
     }
 
     public static function invalidCommentProvider()
@@ -499,30 +498,25 @@ class ExpressionLanguageTest extends TestCase
     /**
      * @dataProvider invalidCommentProvider
      */
-    public function testLintThrowsOnInvalidComments($expression)
+    public function testLintFalseOnInvalidComments($expression)
     {
         $el = new ExpressionLanguage();
 
-        $this->expectException(SyntaxError::class);
-        $el->lint($expression, []);
+        $this->assertFalse($el->lint($expression, []));
     }
 
-    public function testLintDoesntThrowOnValidExpression()
+    public function testLintSuccess()
     {
         $el = new ExpressionLanguage();
-        $el->lint('1 + 1', []);
 
-        $this->expectNotToPerformAssertions();
+        $this->assertTrue($el->lint('1 + 1', []));
     }
 
-    public function testLintThrowsOnInvalidExpression()
+    public function testLintFalseOnInvalidExpression()
     {
         $el = new ExpressionLanguage();
 
-        $this->expectException(SyntaxError::class);
-        $this->expectExceptionMessage('Unexpected end of expression around position 6 for expression `node.`.');
-
-        $el->lint('node.', ['node']);
+        $this->assertFalse($el->lint('node.', ['node']));
     }
 
     public function testCommentsIgnored()

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
@@ -315,19 +315,12 @@ class ParserTest extends TestCase
     /**
      * @dataProvider getLintData
      */
-    public function testLint($expression, $names, int $checks = 0, ?string $exception = null)
+    public function testLint($expression, $names, int $checks = 0, bool $expectedResult = true)
     {
-        if ($exception) {
-            $this->expectException(SyntaxError::class);
-            $this->expectExceptionMessage($exception);
-        }
-
         $lexer = new Lexer();
         $parser = new Parser([]);
-        $parser->lint($lexer->tokenize($expression), $names, $checks);
 
-        // Parser does't return anything when the correct expression is passed
-        $this->expectNotToPerformAssertions();
+        $this->assertSame($expectedResult, $parser->lint($lexer->tokenize($expression), $names, $checks));
     }
 
     public static function getLintData(): array
@@ -368,13 +361,13 @@ class ParserTest extends TestCase
                 'expression' => 'foo.bar',
                 'names' => [],
                 'checks' => 0,
-                'exception' => 'Variable "foo" is not valid around position 1 for expression `foo.bar',
+                'expectedResult' => false,
             ],
             'disallow expression with unknown functions by default' => [
                 'expression' => 'foo()',
                 'names' => [],
                 'checks' => 0,
-                'exception' => 'The function "foo" does not exist around position 1 for expression `foo()',
+                'expectedResult' => false,
             ],
             'operator collisions' => [
                 'expression' => 'foo.not in [bar]',
@@ -384,69 +377,61 @@ class ParserTest extends TestCase
                 'expression' => 'foo["a"] foo["b"]',
                 'names' => ['foo'],
                 'checks' => 0,
-                'exception' => 'Unexpected token "name" of value "foo" '.
-                    'around position 10 for expression `foo["a"] foo["b"]`.',
+                'expectedResult' => false,
             ],
             'incorrect operator' => [
                 'expression' => 'foo["some_key"] // 2',
                 'names' => ['foo'],
                 'checks' => 0,
-                'exception' => 'Unexpected token "operator" of value "/" '.
-                    'around position 18 for expression `foo["some_key"] // 2`.',
+                'expectedResult' => false,
             ],
             'incorrect array' => [
                 'expression' => '[value1, value2 value3]',
                 'names' => ['value1', 'value2', 'value3'],
                 'checks' => 0,
-                'exception' => 'An array element must be followed by a comma. '.
-                    'Unexpected token "name" of value "value3" ("punctuation" expected with value ",") '.
-                    'around position 17 for expression `[value1, value2 value3]`.',
+                'expectedResult' => false,
             ],
             'incorrect array element' => [
                 'expression' => 'foo["some_key")',
                 'names' => ['foo'],
                 'checks' => 0,
-                'exception' => 'Unclosed "[" around position 3 for expression `foo["some_key")`.',
+                'expectedResult' => false,
             ],
             'incorrect hash key' => [
                 'expression' => '{+: value1}',
                 'names' => ['value1'],
                 'checks' => 0,
-                'exception' => 'A hash key must be a quoted string, a number, a name, or an expression enclosed in parentheses (unexpected token "operator" of value "+" around position 2 for expression `{+: value1}`.',
+                'expectedResult' => false,
             ],
             'missed array key' => [
                 'expression' => 'foo[]',
                 'names' => ['foo'],
                 'checks' => 0,
-                'exception' => 'Unexpected token "punctuation" of value "]" around position 5 for expression `foo[]`.',
+                'expectedResult' => false,
             ],
             'missed closing bracket in sub expression' => [
                 'expression' => 'foo[(bar ? bar : "default"]',
                 'names' => ['foo', 'bar'],
                 'checks' => 0,
-                'exception' => 'Unclosed "(" around position 4 for expression `foo[(bar ? bar : "default"]`.',
+                'expectedResult' => false,
             ],
             'incorrect hash following' => [
                 'expression' => '{key: foo key2: bar}',
                 'names' => ['foo', 'bar'],
                 'checks' => 0,
-                'exception' => 'A hash value must be followed by a comma. '.
-                    'Unexpected token "name" of value "key2" ("punctuation" expected with value ",") '.
-                    'around position 11 for expression `{key: foo key2: bar}`.',
+                'expectedResult' => false,
             ],
             'incorrect hash assign' => [
                 'expression' => '{key => foo}',
                 'names' => ['foo'],
                 'checks' => 0,
-                'exception' => 'Unexpected character "=" around position 5 for expression `{key => foo}`.',
+                'expectedResult' => false,
             ],
             'incorrect array as hash using' => [
                 'expression' => '[foo: foo]',
                 'names' => ['foo'],
                 'checks' => 0,
-                'exception' => 'An array element must be followed by a comma. '.
-                    'Unexpected token "punctuation" of value ":" ("punctuation" expected with value ",") '.
-                    'around position 5 for expression `[foo: foo]`.',
+                'expectedResult' => false,
             ],
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | i don't really know
| New feature?  | yes and no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | yes?
| License       | MIT

I don't know how to qualify this : [Documentation](https://symfony.com/doc/current/components/expression_language.html#parsing-and-linting-expressions) says lint should return boolean, but when you check the code, it's a void value, so should I update doc first, and then add it to a new branch as a new feature? 

Depending on the point of view, if the documentation is the source of truth, this means it's a bug fix. But if the code is the source of truth, then, this is a new Features which introduces breaking changes :thinking: 

And It seems like some non-related tests in this component don't work?

