### PR TITLE
[PhpUnitBridge] Don't use `die()` in PHPT `--SKIPIF--`

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/log_file.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/log_file.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test DeprecationErrorHandler with log file
 --SKIPIF--
-<?php if (!getenv('SYMFONY_PHPUNIT_VERSION') || version_compare(getenv('SYMFONY_PHPUNIT_VERSION'), '10.0', '>=')) die('Skipping on PHPUnit 10+');
+<?php if (!getenv('SYMFONY_PHPUNIT_VERSION') || version_compare(getenv('SYMFONY_PHPUNIT_VERSION'), '10.0', '>=')) echo 'Skipping on PHPUnit 10+';
 --FILE--
 <?php
 $filename = tempnam(sys_get_temp_dir(), 'sf-');

--- a/src/Symfony/Bridge/PhpUnit/Tests/expectdeprecationfail.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/expectdeprecationfail.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ExpectDeprecationTrait failing tests
 --SKIPIF--
-<?php if (!getenv('SYMFONY_PHPUNIT_VERSION') || version_compare(getenv('SYMFONY_PHPUNIT_VERSION'), '10.0', '>=')) die('Skipping on PHPUnit 10+');
+<?php if (!getenv('SYMFONY_PHPUNIT_VERSION') || version_compare(getenv('SYMFONY_PHPUNIT_VERSION'), '10.0', '>=')) echo 'Skipping on PHPUnit 10+';
 --FILE--
 <?php
 $test =  realpath(__DIR__.'/FailTests/ExpectDeprecationTraitTestFail.php');

--- a/src/Symfony/Bridge/PhpUnit/Tests/expectnotrisky.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/expectnotrisky.phpt
@@ -2,8 +2,8 @@
 Test NoAssertionsTestNotRisky not risky test
 --SKIPIF--
 <?php
-if ('\\' === DIRECTORY_SEPARATOR && !extension_loaded('mbstring')) die('Skipping on Windows without mbstring');
-if (!getenv('SYMFONY_PHPUNIT_VERSION') || version_compare(getenv('SYMFONY_PHPUNIT_VERSION'), '10.0', '>=')) die('Skipping on PHPUnit 10+');
+if ('\\' === DIRECTORY_SEPARATOR && !extension_loaded('mbstring')) echo 'Skipping on Windows without mbstring';
+if (!getenv('SYMFONY_PHPUNIT_VERSION') || version_compare(getenv('SYMFONY_PHPUNIT_VERSION'), '10.0', '>=')) echo 'Skipping on PHPUnit 10+';
 --FILE--
 <?php
 $test =  realpath(__DIR__.'/FailTests/NoAssertionsTestNotRisky.php');

--- a/src/Symfony/Bridge/PhpUnit/Tests/expectrisky.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/expectrisky.phpt
@@ -2,8 +2,8 @@
 Test NoAssertionsTestRisky risky test
 --SKIPIF--
 <?php
-if ('\\' === DIRECTORY_SEPARATOR && !extension_loaded('mbstring')) die('Skipping on Windows without mbstring');
-if (!getenv('SYMFONY_PHPUNIT_VERSION') || version_compare(getenv('SYMFONY_PHPUNIT_VERSION'), '10.0', '>=')) die('Skipping on PHPUnit 10+');
+if ('\\' === DIRECTORY_SEPARATOR && !extension_loaded('mbstring')) echo 'Skipping on Windows without mbstring';
+if (!getenv('SYMFONY_PHPUNIT_VERSION') || version_compare(getenv('SYMFONY_PHPUNIT_VERSION'), '10.0', '>=')) echo 'Skipping on PHPUnit 10+';
 --FILE--
 <?php
 $test =  realpath(__DIR__.'/FailTests/NoAssertionsTestRisky.php');

--- a/src/Symfony/Bridge/PhpUnit/Tests/symfonyextension.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/symfonyextension.phpt
@@ -1,7 +1,7 @@
 --TEST--
 --SKIPIF--
 <?php
-if (!getenv('SYMFONY_PHPUNIT_VERSION') || version_compare(getenv('SYMFONY_PHPUNIT_VERSION'), '10', '<')) die('Skipping on PHPUnit < 10');
+if (!getenv('SYMFONY_PHPUNIT_VERSION') || version_compare(getenv('SYMFONY_PHPUNIT_VERSION'), '10', '<')) echo 'Skipping on PHPUnit < 10';
 --FILE--
 <?php
 passthru(\sprintf('NO_COLOR=1 php %s/simple-phpunit.php -c %s/Fixtures/symfonyextension/phpunit-with-extension.xml.dist %s/SymfonyExtension.php', getenv('SYMFONY_SIMPLE_PHPUNIT_BIN_DIR'), __DIR__, __DIR__));

--- a/src/Symfony/Bridge/PhpUnit/Tests/symfonyextensionnotregistered.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/symfonyextensionnotregistered.phpt
@@ -1,7 +1,7 @@
 --TEST--
 --SKIPIF--
 <?php
-if (!getenv('SYMFONY_PHPUNIT_VERSION') || version_compare(getenv('SYMFONY_PHPUNIT_VERSION'), '10', '<')) die('Skipping on PHPUnit < 10');
+if (!getenv('SYMFONY_PHPUNIT_VERSION') || version_compare(getenv('SYMFONY_PHPUNIT_VERSION'), '10', '<')) echo 'Skipping on PHPUnit < 10';
 --FILE--
 <?php
 passthru(\sprintf('NO_COLOR=1 php %s/simple-phpunit.php -c %s/Fixtures/symfonyextension/phpunit-without-extension.xml.dist %s/SymfonyExtension.php', getenv('SYMFONY_SIMPLE_PHPUNIT_BIN_DIR'), __DIR__, __DIR__));

--- a/src/Symfony/Component/Console/Tests/phpt/alarm/command_exit.phpt
+++ b/src/Symfony/Component/Console/Tests/phpt/alarm/command_exit.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test command that exits
 --SKIPIF--
-<?php if (!extension_loaded("pcntl")) die("Skipped: pcntl extension required."); ?>
+<?php if (!extension_loaded("pcntl")) echo "Skipped: pcntl extension required."; ?>
 --FILE--
 <?php
 

--- a/src/Symfony/Component/Console/Tests/phpt/signal/command_exit.phpt
+++ b/src/Symfony/Component/Console/Tests/phpt/signal/command_exit.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test command that exits
 --SKIPIF--
-<?php if (!extension_loaded("pcntl")) die("Skipped: pcntl extension required."); ?>
+<?php if (!extension_loaded("pcntl")) echo "Skipped: pcntl extension required."; ?>
 --FILE--
 <?php
 

--- a/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload.phpt
+++ b/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test Dotenv overload
 --SKIPIF--
-<?php require dirname(__DIR__, 6).'/vendor/autoload.php'; if (4 > (new \ReflectionMethod(\Symfony\Component\Dotenv\Dotenv::class, 'bootEnv'))->getNumberOfParameters()) die('Skip because Dotenv version is too low');
+<?php require dirname(__DIR__, 6).'/vendor/autoload.php'; if (4 > (new \ReflectionMethod(\Symfony\Component\Dotenv\Dotenv::class, 'bootEnv'))->getNumberOfParameters()) echo 'Skip because Dotenv version is too low';
 --INI--
 display_errors=1
 --FILE--


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | --
| License       | MIT

Unlocks a performance optimization in PHPUnit 11.5.x

[PHPUnit 11.5.x will be able to avoid subprocess creation](https://github.com/sebastianbergmann/phpunit/pull/5998), when `--SKIPIF--` code in PHPT tests does not `exit()` or `die()` and the logic is side-effect free (output is allowed).

more details in https://staabm.github.io/2024/10/19/phpunit-codesprint-munich.html