### PR TITLE
[Runtime] Remove unused `SKIPIF` from `dotenv_overload.phpt`

### DIFF
--- a/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload.phpt
+++ b/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Test Dotenv overload
---SKIPIF--
-<?php require dirname(__DIR__, 6).'/vendor/autoload.php'; if (4 > (new \ReflectionMethod(\Symfony\Component\Dotenv\Dotenv::class, 'bootEnv'))->getNumberOfParameters()) die('Skip because Dotenv version is too low');
 --INI--
 display_errors=1
 --FILE--


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Since`Runtime` requires `Dotenv` 5.4 version, this condition is useless because `Dotenv` introduced a fourth parameter in 5.4

