### PR TITLE
fix checking loadedVars in populate method

### DIFF
--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -197,7 +197,7 @@ final class Dotenv
             }
 
             // don't check existence with getenv() because of thread safety issues
-            if (!isset($loadedVars[$name]) && !$overrideExistingVars && isset($_ENV[$name])) {
+            if (isset($loadedVars[$name]) && !$overrideExistingVars && isset($_ENV[$name])) {
                 continue;
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54464
| License       | MIT

It seems that the populate method incorrectly checks for variables that are already filled in. Because of this, for example, the dump-env command does not take into account system env variables and overwrites their values ​​with the values ​​specified in the .env file