### PR TITLE
[TwigBridge] Use INTERNAL_VAR_NAME instead of getVarName

### DIFF
--- a/src/Symfony/Bridge/Twig/NodeVisitor/TranslationDefaultDomainNodeVisitor.php
+++ b/src/Symfony/Bridge/Twig/NodeVisitor/TranslationDefaultDomainNodeVisitor.php
@@ -55,9 +55,8 @@ final class TranslationDefaultDomainNodeVisitor implements NodeVisitorInterface
                 return $node;
             }
 
-            $var = $this->getVarName();
-            $name = class_exists(AssignContextVariable::class) ? new AssignContextVariable($var, $node->getTemplateLine()) : new AssignNameExpression($var, $node->getTemplateLine());
-            $this->scope->set('domain', class_exists(ContextVariable::class) ? new ContextVariable($var, $node->getTemplateLine()) : new NameExpression($var, $node->getTemplateLine()));
+            $name = class_exists(AssignContextVariable::class) ? new AssignContextVariable(self::INTERNAL_VAR_NAME, $node->getTemplateLine()) : new AssignNameExpression(self::INTERNAL_VAR_NAME, $node->getTemplateLine());
+            $this->scope->set('domain', class_exists(ContextVariable::class) ? new ContextVariable(self::INTERNAL_VAR_NAME, $node->getTemplateLine()) : new NameExpression(self::INTERNAL_VAR_NAME, $node->getTemplateLine()));
 
             if (class_exists(Nodes::class)) {
                 return new SetNode(false, new Nodes([$name]), new Nodes([$node->getNode('expr')]), $node->getTemplateLine());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58702
| License       | MIT

Reapply https://github.com/symfony/symfony/commit/ab116bb5021c03889c3aa0c1c1d6067c7a67740c. This PR is tested and should be worked.

![CleanShot 2024-10-29 at 10 55 17@2x](https://github.com/user-attachments/assets/0639d8b1-a471-4ea0-ae52-b9fd815fd4f8)