### PR TITLE
[HttpClient] fix for HttpClientDataCollector fails if proc_open is disabled via php.ini

### DIFF
--- a/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
+++ b/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
@@ -253,7 +253,7 @@ final class HttpClientDataCollector extends DataCollector implements LateDataCol
         static $useProcess;
 
         if ($useProcess ??= function_exists('proc_open') && class_exists(Process::class)) {
-            return (new Process([$payload]))->getCommandLine();
+            return substr((new Process(['', $payload]))->getCommandLine(), 3);
         }
 
         if ('\\' === \DIRECTORY_SEPARATOR) {

--- a/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
+++ b/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
@@ -252,7 +252,7 @@ final class HttpClientDataCollector extends DataCollector implements LateDataCol
     {
         static $useProcess;
 
-        if ($useProcess ??= class_exists(Process::class)) {
+        if ($useProcess ??= function_exists('proc_open') && class_exists(Process::class)) {
             return (new Process([$payload]))->getCommandLine();
         }
 


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58700
| License       | MIT


[HttpClientDataCollector::escapePayload](https://github.com/symfony/symfony/blob/7.1/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php#L256) creates a `new Process()` -> it fails if `proc_open` is disabled:

> The Process class relies on proc_open, which is not available on your PHP installation.

https://github.com/symfony/symfony/issues/58700
