### PR TITLE
[Serializer] Revert Default groups

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/SerializerExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/SerializerExtractor.php
@@ -38,15 +38,11 @@ class SerializerExtractor implements PropertyListExtractorInterface
             return null;
         }
 
-        $groups = $context['serializer_groups'] ?? [];
-        $groupsHasBeenDefined = [] !== $groups;
-        $groups = array_merge($groups, ['Default', (false !== $nsSep = strrpos($class, '\\')) ? substr($class, $nsSep + 1) : $class]);
-
         $properties = [];
         $serializerClassMetadata = $this->classMetadataFactory->getMetadataFor($class);
 
         foreach ($serializerClassMetadata->getAttributesMetadata() as $serializerAttributeMetadata) {
-            if (!$serializerAttributeMetadata->isIgnored() && (!$groupsHasBeenDefined || array_intersect(array_merge($serializerAttributeMetadata->getGroups(), ['*']), $groups))) {
+            if (!$serializerAttributeMetadata->isIgnored() && (null === $context['serializer_groups'] || \in_array('*', $context['serializer_groups'], true) || array_intersect($serializerAttributeMetadata->getGroups(), $context['serializer_groups']))) {
                 $properties[] = $serializerAttributeMetadata->getName();
             }
         }

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/SerializerExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/SerializerExtractorTest.php
@@ -43,8 +43,6 @@ class SerializerExtractorTest extends TestCase
     public function testGetPropertiesWithIgnoredProperties()
     {
         $this->assertSame(['visibleProperty'], $this->extractor->getProperties(IgnorePropertyDummy::class, ['serializer_groups' => ['a']]));
-        $this->assertSame(['visibleProperty'], $this->extractor->getProperties(IgnorePropertyDummy::class, ['serializer_groups' => ['Default']]));
-        $this->assertSame(['visibleProperty'], $this->extractor->getProperties(IgnorePropertyDummy::class, ['serializer_groups' => ['IgnorePropertyDummy']]));
     }
 
     public function testGetPropertiesWithAnyGroup()

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/IgnorePropertyDummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/IgnorePropertyDummy.php
@@ -19,7 +19,7 @@ use Symfony\Component\Serializer\Attribute\Ignore;
  */
 class IgnorePropertyDummy
 {
-    #[Groups(['a', 'Default', 'IgnorePropertyDummy'])]
+    #[Groups(['a'])]
     public $visibleProperty;
 
     #[Groups(['a']), Ignore]

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -6,7 +6,6 @@ CHANGELOG
 
  * Add arguments `$class`, `$format` and `$context` to `NameConverterInterface::normalize()` and `NameConverterInterface::denormalize()`
  * Add `DateTimeNormalizer::CAST_KEY` context option
- * Add `Default` and "class name" default groups
  * Add `AbstractNormalizer::FILTER_BOOL` context option
  * Add `CamelCaseToSnakeCaseNameConverter::REQUIRE_SNAKE_CASE_PROPERTIES` context option
  * Deprecate `AbstractNormalizerContextBuilder::withDefaultContructorArguments(?array $defaultContructorArguments)`, use `withDefaultConstructorArguments(?array $defaultConstructorArguments)` instead (note the missing `s` character in Contructor word in deprecated method)

--- a/src/Symfony/Component/Serializer/NameConverter/MetadataAwareNameConverter.php
+++ b/src/Symfony/Component/Serializer/NameConverter/MetadataAwareNameConverter.php
@@ -128,16 +128,13 @@ final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
             }
 
             $metadataGroups = $metadata->getGroups();
-
             $contextGroups = (array) ($context[AbstractNormalizer::GROUPS] ?? []);
-            $contextGroupsHasBeenDefined = [] !== $contextGroups;
-            $contextGroups = array_merge($contextGroups, ['Default', (false !== $nsSep = strrpos($class, '\\')) ? substr($class, $nsSep + 1) : $class]);
 
-            if ($contextGroupsHasBeenDefined && !$metadataGroups) {
+            if ($contextGroups && !$metadataGroups) {
                 continue;
             }
 
-            if ($metadataGroups && !array_intersect(array_merge($metadataGroups, ['*']), $contextGroups)) {
+            if ($metadataGroups && !array_intersect($metadataGroups, $contextGroups) && !\in_array('*', $contextGroups, true)) {
                 continue;
             }
 

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/GroupDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/GroupDummy.php
@@ -27,10 +27,6 @@ class GroupDummy extends GroupDummyParent implements GroupDummyInterface
     protected $quux;
     private $fooBar;
     private $symfony;
-    #[Groups(['Default'])]
-    private $default;
-    #[Groups(['GroupDummy'])]
-    private $className;
 
     #[Groups(['b'])]
     public function setBar($bar)
@@ -83,25 +79,5 @@ class GroupDummy extends GroupDummyParent implements GroupDummyInterface
     public function setQuux($quux): void
     {
         $this->quux = $quux;
-    }
-
-    public function setDefault($default)
-    {
-        $this->default = $default;
-    }
-
-    public function getDefault()
-    {
-        return $this->default;
-    }
-
-    public function setClassName($className)
-    {
-        $this->className = $className;
-    }
-
-    public function getClassName()
-    {
-        return $this->className;
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Mapping/TestClassMetadataFactory.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/TestClassMetadataFactory.php
@@ -63,14 +63,6 @@ class TestClassMetadataFactory
             $symfony->addGroup('name_converter');
         }
 
-        $default = new AttributeMetadata('default');
-        $default->addGroup('Default');
-        $expected->addAttributeMetadata($default);
-
-        $className = new AttributeMetadata('className');
-        $className->addGroup('GroupDummy');
-        $expected->addAttributeMetadata($className);
-
         // load reflection class so that the comparison passes
         $expected->getReflectionClass();
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/GroupsTestTrait.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/GroupsTestTrait.php
@@ -36,13 +36,9 @@ trait GroupsTestTrait
         $obj->setSymfony('symfony');
         $obj->setKevin('kevin');
         $obj->setCoopTilleuls('coopTilleuls');
-        $obj->setDefault('default');
-        $obj->setClassName('className');
 
         $this->assertEquals([
             'bar' => 'bar',
-            'default' => 'default',
-            'className' => 'className',
         ], $normalizer->normalize($obj, null, ['groups' => ['c']]));
 
         $this->assertEquals([
@@ -52,26 +48,7 @@ trait GroupsTestTrait
             'bar' => 'bar',
             'kevin' => 'kevin',
             'coopTilleuls' => 'coopTilleuls',
-            'default' => 'default',
-            'className' => 'className',
         ], $normalizer->normalize($obj, null, ['groups' => ['a', 'c']]));
-
-        $this->assertEquals([
-            'default' => 'default',
-            'className' => 'className',
-        ], $normalizer->normalize($obj, null, ['groups' => ['unknown']]));
-
-        $this->assertEquals([
-            'quux' => 'quux',
-            'symfony' => 'symfony',
-            'foo' => 'foo',
-            'fooBar' => 'fooBar',
-            'bar' => 'bar',
-            'kevin' => 'kevin',
-            'coopTilleuls' => 'coopTilleuls',
-            'default' => 'default',
-            'className' => 'className',
-        ], $normalizer->normalize($obj));
     }
 
     public function testGroupsDenormalize()
@@ -79,26 +56,9 @@ trait GroupsTestTrait
         $normalizer = $this->getDenormalizerForGroups();
 
         $obj = new GroupDummy();
-        $obj->setDefault('default');
-        $obj->setClassName('className');
-
-        $data = [
-            'foo' => 'foo',
-            'bar' => 'bar',
-            'quux' => 'quux',
-            'default' => 'default',
-            'className' => 'className',
-        ];
-
-        $denormalized = $normalizer->denormalize(
-            $data,
-            GroupDummy::class,
-            null,
-            ['groups' => ['unknown']]
-        );
-        $this->assertEquals($obj, $denormalized);
-
         $obj->setFoo('foo');
+
+        $data = ['foo' => 'foo', 'bar' => 'bar'];
 
         $denormalized = $normalizer->denormalize(
             $data,
@@ -117,11 +77,6 @@ trait GroupsTestTrait
             ['groups' => ['a', 'b']]
         );
         $this->assertEquals($obj, $denormalized);
-
-        $obj->setQuux('quux');
-
-        $denormalized = $normalizer->denormalize($data, GroupDummy::class);
-        $this->assertEquals($obj, $denormalized);
     }
 
     public function testNormalizeNoPropertyInGroup()
@@ -130,12 +85,7 @@ trait GroupsTestTrait
 
         $obj = new GroupDummy();
         $obj->setFoo('foo');
-        $obj->setDefault('default');
-        $obj->setClassName('className');
 
-        $this->assertEquals([
-            'default' => 'default',
-            'className' => 'className',
-        ], $normalizer->normalize($obj, null, ['groups' => ['notExist']]));
+        $this->assertEquals([], $normalizer->normalize($obj, null, ['groups' => ['notExist']]));
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -302,8 +302,6 @@ class GetSetMethodNormalizerTest extends TestCase
                 'bar' => null,
                 'foo_bar' => '@dunglas',
                 'symfony' => '@coopTilleuls',
-                'default' => null,
-                'class_name' => null,
             ],
             $this->normalizer->normalize($obj, null, [GetSetMethodNormalizer::GROUPS => ['name_converter']])
         );

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -507,8 +507,6 @@ class ObjectNormalizerTest extends TestCase
                 'bar' => null,
                 'foo_bar' => '@dunglas',
                 'symfony' => '@coopTilleuls',
-                'default' => null,
-                'class_name' => null,
             ],
             $this->normalizer->normalize($obj, null, [ObjectNormalizer::GROUPS => ['name_converter']])
         );

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -195,8 +195,6 @@ class PropertyNormalizerTest extends TestCase
                 'fooBar' => null,
                 'symfony' => null,
                 'baz' => 'baz',
-                'default' => null,
-                'className' => null,
             ],
             $this->normalizer->normalize($group, 'any')
         );
@@ -321,8 +319,6 @@ class PropertyNormalizerTest extends TestCase
                 'bar' => null,
                 'foo_bar' => '@dunglas',
                 'symfony' => '@coopTilleuls',
-                'default' => null,
-                'class_name' => null,
             ],
             $this->normalizer->normalize($obj, null, [PropertyNormalizer::GROUPS => ['name_converter']])
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58576, Fix #57350
| License       | MIT

When introduced in #51514, the behavior of group selection was wrong and introduced BC breaks (see the two related issues).

This PR reverts this introduction so that they can be added properly in 7.3 (see #58656).