### PR TITLE
[Process] On Windows, don't rely on the OS to find executables

### DIFF
--- a/src/Symfony/Component/Process/Tests/ProcessFailedExceptionTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessFailedExceptionTest.php
@@ -80,8 +80,8 @@ class ProcessFailedExceptionTest extends TestCase
 
         $exception = new ProcessFailedException($process);
 
-        $this->assertEquals(
-            "The command \"$cmd\" failed.\n\nExit Code: $exitCode($exitText)\n\nWorking directory: {$workingDirectory}\n\nOutput:\n================\n{$output}\n\nError Output:\n================\n{$errorOutput}",
+        $this->assertStringMatchesFormat(
+            "The command \"%s\" failed.\n\nExit Code: $exitCode($exitText)\n\nWorking directory: {$workingDirectory}\n\nOutput:\n================\n{$output}\n\nError Output:\n================\n{$errorOutput}",
             str_replace("'php'", 'php', $exception->getMessage())
         );
     }
@@ -126,9 +126,9 @@ class ProcessFailedExceptionTest extends TestCase
 
         $exception = new ProcessFailedException($process);
 
-        $this->assertEquals(
-            "The command \"$cmd\" failed.\n\nExit Code: $exitCode($exitText)\n\nWorking directory: {$workingDirectory}",
-            str_replace("'php'", 'php', $exception->getMessage())
+        $this->assertStringMatchesFormat(
+            "The command \"%s\" failed.\n\nExit Code: $exitCode($exitText)\n\nWorking directory: {$workingDirectory}",
+            $exception->getMessage()
         );
     }
 }

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -1687,6 +1687,17 @@ class ProcessTest extends TestCase
         $this->assertSame(\SIGTERM, $process->getTermSignal());
     }
 
+    public function testPathResolutionOnWindows()
+    {
+        if ('\\' !== \DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('This test is for Windows platform only');
+        }
+
+        $process = $this->getProcess(['where']);
+
+        $this->assertSame('C:\\Windows\\system32\\where.EXE', $process->getCommandLine());
+    }
+
     private function getProcess(string|array $commandline, ?string $cwd = null, ?array $env = null, mixed $input = null, ?int $timeout = 60): Process
     {
         if (\is_string($commandline)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Porting part of https://github.com/composer/composer/pull/12180 here:

On Windows, when searching for an executable, the OS always looks at the current directory before using the PATH variable. This makes it easier than desired to hijack executables. Unix-like OSes don't have this issue.

This PR proposes to rely on ExecutableFinder instead.