### PR TITLE
[Process] Fix handling empty path found in the PATH env var with ExecutableFinder

### DIFF
--- a/src/Symfony/Component/Process/ExecutableFinder.php
+++ b/src/Symfony/Component/Process/ExecutableFinder.php
@@ -60,6 +60,9 @@ class ExecutableFinder
         }
         foreach ($suffixes as $suffix) {
             foreach ($dirs as $dir) {
+                if ('' === $dir) {
+                    $dir = '.';
+                }
                 if (@is_file($file = $dir.\DIRECTORY_SEPARATOR.$name.$suffix) && ('\\' === \DIRECTORY_SEPARATOR || @is_executable($file))) {
                     return $file;
                 }

--- a/src/Symfony/Component/Process/Tests/ExecutableFinderTest.php
+++ b/src/Symfony/Component/Process/Tests/ExecutableFinderTest.php
@@ -111,6 +111,9 @@ class ExecutableFinderTest extends TestCase
         }
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testFindBatchExecutableOnWindows()
     {
         if (\ini_get('open_basedir')) {
@@ -136,6 +139,24 @@ class ExecutableFinderTest extends TestCase
         unlink($target.'.BAT');
 
         $this->assertSamePath($target.'.BAT', $result);
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testEmptyDirInPath()
+    {
+        putenv(sprintf('PATH=%s:', \dirname(\PHP_BINARY)));
+
+        touch('executable');
+        chmod('executable', 0700);
+
+        $finder = new ExecutableFinder();
+        $result = $finder->find('executable');
+
+        $this->assertSame('./executable', $result);
+
+        unlink('executable');
     }
 
     private function assertSamePath($expected, $tested)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

