### PR TITLE
[HttpFoundation] Fix support for `\SplTempFileObject` in `BinaryFileResponse`

### DIFF
--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -126,7 +126,7 @@ class BinaryFileResponse extends Response
      */
     public function setAutoLastModified(): static
     {
-        $this->setLastModified(\DateTimeImmutable::createFromFormat('U', $this->file->getMTime()));
+        $this->setLastModified(\DateTimeImmutable::createFromFormat('U', $this->tempFileObject ? time() : $this->file->getMTime()));
 
         return $this;
     }
@@ -197,7 +197,9 @@ class BinaryFileResponse extends Response
         $this->offset = 0;
         $this->maxlen = -1;
 
-        if (false === $fileSize = $this->file->getSize()) {
+        if ($this->tempFileObject) {
+            $fileSize = $this->tempFileObject->fstat()['size'];
+        } elseif (false === $fileSize = $this->file->getSize()) {
             return $this;
         }
         $this->headers->remove('Transfer-Encoding');

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -451,6 +451,9 @@ class BinaryFileResponseTest extends ResponseTestCase
         $this->assertEquals('attachment; filename=temp', $response->headers->get('Content-Disposition'));
 
         ob_start();
+        $response->setAutoLastModified();
+        $response->prepare(new Request());
+        $this->assertSame('7', $response->headers->get('Content-Length'));
         $response->sendContent();
         $string = ob_get_clean();
         $this->assertSame('foo,bar', $string);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| PR original Feature | #49144
| New feature?  | no
| Deprecations? | no
| Issues        |  -
| License       | MIT

We can not call some methods with an object of `\SplTempFileObject()`. We get this error: `[...] stat failed for php://temp`.

I have checked the code against methods listed in [this note](https://www.php.net/manual/en/class.spltempfileobject.php#128962).

I have found:
- `getMTime()` called in `BinaryFileResponse::setAutoLastModified()`
- `getSize()` called in `BinaryFileResponse::prepare()`
- `isReadable()` called in `BinaryFileResponse::setFile()` (already safe)

I have updated the unit test and patched the class `BinaryFileResponse`.

Note: calling `SplFileObject::fstat()` gives `mtime` equals to `0`. I think it is nonsense to use that as value for last modified. I have decided to use `time()` because i guess, we can not do better. Indeed, we have no idea how much time have passed between making the temp file and the call to `setAutoLastModified()` by the developper.


