### PR TITLE
[HttpKernel] Support `Uid` in `#[MapQueryParameter]`

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `$key` argument to `#[MapQueryString]` that allows using a specific key for argument resolving
+ * Support `Uid` in `#[MapQueryParameter]`
 
 7.2
 ---

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/QueryParameterValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/QueryParameterValueResolver.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpKernel\Attribute\MapQueryParameter;
 use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Uid\AbstractUid;
 
 /**
  * Resolve arguments of type: array, string, int, float, bool, \BackedEnum from query parameters.
@@ -73,6 +74,12 @@ final class QueryParameterValueResolver implements ValueResolverInterface
             $options['flags'] |= \FILTER_REQUIRE_SCALAR;
         }
 
+        $uidType = null;
+        if (is_subclass_of($type, AbstractUid::class)) {
+            $uidType = $type;
+            $type = 'uid';
+        }
+
         $enumType = null;
         $filter = match ($type) {
             'array' => \FILTER_DEFAULT,
@@ -80,10 +87,11 @@ final class QueryParameterValueResolver implements ValueResolverInterface
             'int' => \FILTER_VALIDATE_INT,
             'float' => \FILTER_VALIDATE_FLOAT,
             'bool' => \FILTER_VALIDATE_BOOL,
+            'uid' => \FILTER_DEFAULT,
             default => match ($enumType = is_subclass_of($type, \BackedEnum::class) ? (new \ReflectionEnum($type))->getBackingType()->getName() : null) {
                 'int' => \FILTER_VALIDATE_INT,
                 'string' => \FILTER_DEFAULT,
-                default => throw new \LogicException(\sprintf('#[MapQueryParameter] cannot be used on controller argument "%s$%s" of type "%s"; one of array, string, int, float, bool or \BackedEnum should be used.', $argument->isVariadic() ? '...' : '', $argument->getName(), $type ?? 'mixed')),
+                default => throw new \LogicException(\sprintf('#[MapQueryParameter] cannot be used on controller argument "%s$%s" of type "%s"; one of array, string, int, float, bool, uid or \BackedEnum should be used.', $argument->isVariadic() ? '...' : '', $argument->getName(), $type ?? 'mixed')),
             },
         };
 
@@ -103,6 +111,10 @@ final class QueryParameterValueResolver implements ValueResolverInterface
             };
 
             $value = \is_array($value) ? array_map($enumFrom, $value) : $enumFrom($value);
+        }
+
+        if (null !== $uidType) {
+            $value = \is_array($value) ? array_map([$uidType, 'fromString'], $value) : $uidType::fromString($value);
         }
 
         if (null === $value && !($attribute->flags & \FILTER_NULL_ON_FAILURE)) {

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/QueryParameterValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/QueryParameterValueResolverTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Tests\Fixtures\Suit;
+use Symfony\Component\Uid\Ulid;
 
 class QueryParameterValueResolverTest extends TestCase
 {
@@ -44,7 +45,7 @@ class QueryParameterValueResolverTest extends TestCase
      */
     public function testResolvingSuccessfully(Request $request, ArgumentMetadata $metadata, array $expected)
     {
-        $this->assertSame($expected, $this->resolver->resolve($request, $metadata));
+        $this->assertEquals($expected, $this->resolver->resolve($request, $metadata));
     }
 
     /**
@@ -231,6 +232,12 @@ class QueryParameterValueResolverTest extends TestCase
             new ArgumentMetadata('firstName', 'string', false, true, false, attributes: [new MapQueryParameter()]),
             [],
         ];
+
+        yield 'parameter found and ULID' => [
+            Request::create('/', 'GET', ['groupId' => '01E439TP9XJZ9RPFH3T1PYBCR8']),
+            new ArgumentMetadata('groupId', Ulid::class, false, true, false, attributes: [new MapQueryParameter()]),
+            [Ulid::fromString('01E439TP9XJZ9RPFH3T1PYBCR8')],
+        ];
     }
 
     /**
@@ -245,13 +252,13 @@ class QueryParameterValueResolverTest extends TestCase
         yield 'unsupported type' => [
             Request::create('/', 'GET', ['standardClass' => 'test']),
             new ArgumentMetadata('standardClass', \stdClass::class, false, false, false, attributes: [new MapQueryParameter()]),
-            '#[MapQueryParameter] cannot be used on controller argument "$standardClass" of type "stdClass"; one of array, string, int, float, bool or \BackedEnum should be used.',
+            '#[MapQueryParameter] cannot be used on controller argument "$standardClass" of type "stdClass"; one of array, string, int, float, bool, uid or \BackedEnum should be used.',
         ];
 
         yield 'unsupported type variadic' => [
             Request::create('/', 'GET', ['standardClass' => 'test']),
             new ArgumentMetadata('standardClass', \stdClass::class, true, false, false, attributes: [new MapQueryParameter()]),
-            '#[MapQueryParameter] cannot be used on controller argument "...$standardClass" of type "stdClass"; one of array, string, int, float, bool or \BackedEnum should be used.',
+            '#[MapQueryParameter] cannot be used on controller argument "...$standardClass" of type "stdClass"; one of array, string, int, float, bool, uid or \BackedEnum should be used.',
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #51618
| License       | MIT

I added support `Uid` in `#[MapQueryParameter]`.  To use it, you must do this:

```php
#[Route(path: '/', name: 'user_show')]
public function indexAction(
    #[MapQueryParameter] ?Ulid $groupId = null,
)
```