### PR TITLE
[AssetMapper] Add Integrity Hashes to ImportMap (wip)

### DIFF
--- a/src/Symfony/Component/AssetMapper/Factory/MappedAssetFactory.php
+++ b/src/Symfony/Component/AssetMapper/Factory/MappedAssetFactory.php
@@ -63,6 +63,7 @@ class MappedAssetFactory implements MappedAssetFactoryInterface
                 $asset->getDependencies(),
                 $asset->getFileDependencies(),
                 $asset->getJavaScriptImports(),
+                $this->getIntegrity($asset, $content),
             );
 
             $this->assetsCache[$logicalPath] = $asset;
@@ -71,6 +72,18 @@ class MappedAssetFactory implements MappedAssetFactoryInterface
         unset($this->assetsBeingCreated[$logicalPath]);
 
         return $this->assetsCache[$logicalPath];
+    }
+
+    /**
+     * Returns an SRI integrity hash for the given asset.
+     */
+    private function getIntegrity(MappedAsset $asset, ?string $content): string
+    {
+        if (null !== $content) {
+            return 'sha384-'.base64_encode(hash('sha384', $content, true));
+        }
+
+        return 'sha384-'.base64_encode(hash_file('sha384', $asset->sourcePath, true));
     }
 
     /**

--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapGenerator.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapGenerator.php
@@ -50,7 +50,7 @@ class ImportMapGenerator
     /**
      * @param string[] $entrypointNames
      *
-     * @return array<string, array{path: string, type: string, preload?: bool}>
+     * @return array<string, array{path: string, type: string, preload?: bool, integrity?: string}>
      *
      * @internal
      */
@@ -83,7 +83,7 @@ class ImportMapGenerator
     /**
      * @internal
      *
-     * @return array<string, array{path: string, type: string}>
+     * @return array<string, array{path: string, type: string, integrity?: string}>
      */
     public function getRawImportMapData(): array
     {
@@ -106,6 +106,9 @@ class ImportMapGenerator
 
             $path = $asset->publicPath;
             $data = ['path' => $path, 'type' => $entry->type->value];
+            if ($asset->integrity) {
+                $data['integrity'] = $asset->integrity;
+            }
             $rawImportMapData[$entry->importName] = $data;
         }
 

--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapRenderer.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapRenderer.php
@@ -78,7 +78,7 @@ class ImportMapRenderer
                     $integrityMap[$path] = $integrity;
                 }
                 if ($preload) {
-                    $modulePreloads[] = $path;
+                    $modulePreloads[] = ['path' => $path, 'integrity' => $integrity];
                 }
             } elseif ($preload) {
                 $cssLinks[] = $path;
@@ -142,10 +142,13 @@ class ImportMapRenderer
                 HTML;
         }
 
-        foreach ($modulePreloads as $url) {
-            $url = $this->escapeAttributeValue($url);
+        foreach ($modulePreloads as $modulePreload) {
+            $url = $this->escapeAttributeValue($modulePreload['path']);
+            if ($integrity = $modulePreload['integrity']) {
+                $integrity = " integrity=\"$integrity\"";
+            }
 
-            $output .= "\n<link rel=\"modulepreload\" href=\"$url\">";
+            $output .= "\n<link rel=\"modulepreload\" href=\"$url\"$integrity>";
         }
 
         if (\count($entryPoint) > 0) {

--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapRenderer.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapRenderer.php
@@ -47,6 +47,7 @@ class ImportMapRenderer
 
         $importMapData = $this->importMapGenerator->getImportMapData($entryPoint);
         $importMap = [];
+        $integrityMap = [];
         $modulePreloads = [];
         $cssLinks = [];
         $polyfillPath = null;
@@ -70,8 +71,12 @@ class ImportMapRenderer
             }
 
             $preload = $data['preload'] ?? false;
+            $integrity = $data['integrity'] ?? null;
             if ('css' !== $data['type']) {
                 $importMap[$importName] = $path;
+                if ($integrity) {
+                    $integrityMap[$path] = $integrity;
+                }
                 if ($preload) {
                     $modulePreloads[] = $path;
                 }
@@ -96,7 +101,7 @@ class ImportMapRenderer
         }
 
         $scriptAttributes = $attributes || $this->scriptAttributes ? ' '.$this->createAttributesString($attributes) : '';
-        $importMapJson = json_encode(['imports' => $importMap], \JSON_THROW_ON_ERROR | \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_HEX_TAG);
+        $importMapJson = json_encode(['imports' => $importMap, 'integrity' => $integrityMap], \JSON_THROW_ON_ERROR | \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_HEX_TAG);
         $output .= <<<HTML
 
             <script type="importmap"$scriptAttributes>

--- a/src/Symfony/Component/AssetMapper/MappedAsset.php
+++ b/src/Symfony/Component/AssetMapper/MappedAsset.php
@@ -52,6 +52,7 @@ final class MappedAsset
         private array $dependencies = [],
         private array $fileDependencies = [],
         private array $javaScriptImports = [],
+        public readonly ?string $integrity = null,
     ) {
         if (null !== $sourcePath) {
             $this->sourcePath = $sourcePath;
@@ -70,6 +71,11 @@ final class MappedAsset
         if (null !== $isPredigested) {
             $this->isPredigested = $isPredigested;
         }
+    }
+
+    public function getIntegrity(): ?string
+    {
+        return $this->integrity;
     }
 
     /**

--- a/src/Symfony/Component/AssetMapper/Tests/Factory/MappedAssetFactoryTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Factory/MappedAssetFactoryTest.php
@@ -36,7 +36,7 @@ class MappedAssetFactoryTest extends TestCase
         $this->assertSame('file2.js', $asset->logicalPath);
         $this->assertMatchesRegularExpression('/^\/final-assets\/file2-[a-zA-Z0-9]{7,128}\.js$/', $asset->publicPath);
         $this->assertSame('/final-assets/file2.js', $asset->publicPathWithoutDigest);
-        $this->assertSame('sha384-ZDljYTViYzY0NTgyZjA4ZTBmMjgwODY1NDNlMmRhMTY2NTVlOTNhYTlkZjMwZGY5YzU0NjdlNDExMThjY2RjNGFmNWZkNDhmZDg0ODIzMmVmMjkyNmIwNGE2NGJkMjdi', $asset->integrity);
+        $this->assertSame('sha384-2cpbxkWC8I4PKAhlQ+LaFmVek6qd8w35xUZ+QRGMzcSvX9SP2EgjLvKSawSmS9J7', $asset->integrity);
     }
 
     public function testCreateMappedAssetRespectsPreDigestedPaths()
@@ -47,7 +47,7 @@ class MappedAssetFactoryTest extends TestCase
         $this->assertSame('/final-assets/already-abcdefVWXYZ0123456789.digested.css', $asset->publicPath);
         // for pre-digested files, the digest *is* part of the public path
         $this->assertSame('/final-assets/already-abcdefVWXYZ0123456789.digested.css', $asset->publicPathWithoutDigest);
-        $this->assertSame('sha384-YThlMTY4MzI3MGY3ZjFlNTk0M2VhMDQ0MzMyYjEwYjRkNGQ2NjU4YzZlMDZjYjA3YTgwNDUzNjUwOTQyOGI4NjQ1YmFiMmIyMzg4ZWZhOGRiMGQ5MjU4MjJjNThlOTkz', $asset->integrity);
+        $this->assertSame('sha384-qOFoMnD38eWUPqBEMysQtNTWZYxuBssHqARTZQlCi4ZFurKyOI76jbDZJYIsWOmT', $asset->integrity);
     }
 
     public function testCreateMappedAssetWithContentThatChanged()

--- a/src/Symfony/Component/AssetMapper/Tests/Factory/MappedAssetFactoryTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Factory/MappedAssetFactoryTest.php
@@ -52,7 +52,7 @@ class MappedAssetFactoryTest extends TestCase
 
     public function testCreateMappedAssetWithContentThatChanged()
     {
-        $file1Compiler = new class () implements AssetCompilerInterface {
+        $file1Compiler = new class implements AssetCompilerInterface {
             public function supports(MappedAsset $asset): bool
             {
                 return true;
@@ -105,7 +105,7 @@ class MappedAssetFactoryTest extends TestCase
 
     public function testCreateMappedAssetWithDigest()
     {
-        $file6Compiler = new class () implements AssetCompilerInterface {
+        $file6Compiler = new class implements AssetCompilerInterface {
             public function supports(MappedAsset $asset): bool
             {
                 return true;

--- a/src/Symfony/Component/AssetMapper/Tests/Factory/MappedAssetFactoryTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Factory/MappedAssetFactoryTest.php
@@ -36,6 +36,7 @@ class MappedAssetFactoryTest extends TestCase
         $this->assertSame('file2.js', $asset->logicalPath);
         $this->assertMatchesRegularExpression('/^\/final-assets\/file2-[a-zA-Z0-9]{7,128}\.js$/', $asset->publicPath);
         $this->assertSame('/final-assets/file2.js', $asset->publicPathWithoutDigest);
+        $this->assertSame('sha384-ZDljYTViYzY0NTgyZjA4ZTBmMjgwODY1NDNlMmRhMTY2NTVlOTNhYTlkZjMwZGY5YzU0NjdlNDExMThjY2RjNGFmNWZkNDhmZDg0ODIzMmVmMjkyNmIwNGE2NGJkMjdi', $asset->integrity);
     }
 
     public function testCreateMappedAssetRespectsPreDigestedPaths()
@@ -46,11 +47,12 @@ class MappedAssetFactoryTest extends TestCase
         $this->assertSame('/final-assets/already-abcdefVWXYZ0123456789.digested.css', $asset->publicPath);
         // for pre-digested files, the digest *is* part of the public path
         $this->assertSame('/final-assets/already-abcdefVWXYZ0123456789.digested.css', $asset->publicPathWithoutDigest);
+        $this->assertSame('sha384-YThlMTY4MzI3MGY3ZjFlNTk0M2VhMDQ0MzMyYjEwYjRkNGQ2NjU4YzZlMDZjYjA3YTgwNDUzNjUwOTQyOGI4NjQ1YmFiMmIyMzg4ZWZhOGRiMGQ5MjU4MjJjNThlOTkz', $asset->integrity);
     }
 
     public function testCreateMappedAssetWithContentThatChanged()
     {
-        $file1Compiler = new class implements AssetCompilerInterface {
+        $file1Compiler = new class () implements AssetCompilerInterface {
             public function supports(MappedAsset $asset): bool
             {
                 return true;
@@ -81,6 +83,17 @@ class MappedAssetFactoryTest extends TestCase
         $this->assertNull($asset->content);
     }
 
+    public function testCreateMappedAssetComputeIntegrity()
+    {
+        $assetMapper = $this->createFactory();
+
+        $asset = $assetMapper->createMappedAsset('file1.css', __DIR__.'/../Fixtures/dir1/file1.css');
+        $this->assertSame('sha384-XgVLYsLqVK+VujG5zkQyFuRtBc98ql0YRAQYP8CT8paQgxTtAUAdgcvTO9TxlUXp', $asset->integrity);
+
+        $asset = $assetMapper->createMappedAsset('file2.js', __DIR__.'/../Fixtures/dir1/file2.js');
+        $this->assertSame('sha384-2cpbxkWC8I4PKAhlQ+LaFmVek6qd8w35xUZ+QRGMzcSvX9SP2EgjLvKSawSmS9J7', $asset->integrity);
+    }
+
     public function testCreateMappedAssetWithContentErrorsOnCircularReferences()
     {
         $factory = $this->createFactory();
@@ -92,7 +105,7 @@ class MappedAssetFactoryTest extends TestCase
 
     public function testCreateMappedAssetWithDigest()
     {
-        $file6Compiler = new class implements AssetCompilerInterface {
+        $file6Compiler = new class () implements AssetCompilerInterface {
             public function supports(MappedAsset $asset): bool
             {
                 return true;
@@ -119,6 +132,7 @@ class MappedAssetFactoryTest extends TestCase
         $factory = $this->createFactory($file6Compiler);
         $asset = $factory->createMappedAsset('subdir/file6.js', __DIR__.'/../Fixtures/dir2/subdir/file6.js');
         $this->assertSame('7e4f24ebddd4ab2a3bcf0d89270b9f30', $asset->digest);
+        $this->assertSame('sha384-1GNXqZ7KhQjqjTLnfTOAln3lJn8wex5coUWjjZ7DT40GKkCb5XK+P6kNTHjdnXs/', $asset->integrity);
     }
 
     public function testCreateMappedAssetWithPredigested()

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapGeneratorTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapGeneratorTest.php
@@ -348,6 +348,7 @@ class ImportMapGeneratorTest extends TestCase
             '/path/to/simple.js',
             publicPathWithoutDigest: '/assets/simple.js',
             publicPath: '/assets/simple-d1g3st.js',
+            integrity: 'simple-integrity',
         );
         yield 'it adds dependency to the importmap' => [
             [
@@ -360,7 +361,7 @@ class ImportMapGeneratorTest extends TestCase
                 new MappedAsset(
                     'app.js',
                     publicPath: '/assets/app-d1g3st.js',
-                    javaScriptImports: [new JavaScriptImport('/assets/simple.js', assetLogicalPath: $simpleAsset->logicalPath, assetSourcePath: $simpleAsset->sourcePath, isLazy: false, addImplicitlyToImportMap: true)]
+                    javaScriptImports: [new JavaScriptImport('/assets/simple.js', assetLogicalPath: $simpleAsset->logicalPath, assetSourcePath: $simpleAsset->sourcePath, isLazy: false, addImplicitlyToImportMap: true)],
                 ),
                 $simpleAsset,
             ],
@@ -372,6 +373,7 @@ class ImportMapGeneratorTest extends TestCase
                 '/assets/simple.js' => [
                     'path' => '/assets/simple-d1g3st.js',
                     'type' => 'js',
+                    'integrity' => 'simple-integrity',
                 ],
             ],
         ];
@@ -401,6 +403,7 @@ class ImportMapGeneratorTest extends TestCase
                 '/assets/simple.js' => [
                     'path' => '/assets/simple-d1g3st.js',
                     'type' => 'js',
+                    'integrity' => 'simple-integrity',
                 ],
             ],
         ];
@@ -440,6 +443,7 @@ class ImportMapGeneratorTest extends TestCase
                 '/assets/simple.js' => [
                     'path' => '/assets/simple-d1g3st.js',
                     'type' => 'js',
+                    'integrity' => 'simple-integrity',
                 ],
             ],
         ];
@@ -472,6 +476,7 @@ class ImportMapGeneratorTest extends TestCase
                 '/assets/simple.js' => [
                     'path' => '/assets/simple-d1g3st.js',
                     'type' => 'js',
+                    'integrity' => 'simple-integrity',
                 ],
                 'imports_simple' => [
                     'path' => '/assets/imports_simple-d1g3st.js',

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapRendererTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapRendererTest.php
@@ -212,7 +212,7 @@ class ImportMapRendererTest extends TestCase
         $this->assertSame('/assets/styles/app-preload-d1g35t.css', $linkProvider->getLinks()[0]->getHref());
     }
 
-    public function testIntegrityMap(): void
+    public function testIntegrityMap()
     {
         $importMapGenerator = $this->createMock(ImportMapGenerator::class);
         $importMapGenerator->expects($this->once())
@@ -237,7 +237,7 @@ class ImportMapRendererTest extends TestCase
                 'app_css_no_preload' => [
                     'path' => '/assets/styles/app-nopreload-d1g35t.css',
                     'type' => 'css',
-                    'integrity' => 'sha384-abc123-css-no'
+                    'integrity' => 'sha384-abc123-css-no',
                 ],
             ]);
 
@@ -267,6 +267,5 @@ class ImportMapRendererTest extends TestCase
                 "/subdirectory/assets/app-no-preload-d1g35t.js": "sha384-abc123-js-no"
             }
         EOTXT, $html);
-
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #54249
| License       | MIT

 -- Opening early to (hopefully) gather feedback and ideas --

This is a basic implementation to support integrity hashes within import maps:
- Computes a base64-encoded SHA-384 digest in the factory.
- Renders the integrity attribute for JavaScript files in the import map.

**TODO**
- [ ] Make the integrity hash optional (e.g., through a constructor argument in the factory)
- [ ] Compute hashes only for certain assets / types / paths ?
- [ ] Expose configuration settings
- [ ] Adapt the FrameworkBundle / DI
- [ ] Determine handling approach for CSS files

**Sources**
- [Subresource Integrity (SRI) Goals - W3C](https://www.w3.org/TR/SRI/#goals)
- [JSPM: JS Integrity with Import Maps](https://jspm.org/js-integrity-with-import-maps)

_PS: I'm a bit short on time lately... so if anyone wants to help or take over, please feel free!_

