### PR TITLE
[Process] Properly deal with not-found executables on Windows

### DIFF
--- a/src/Symfony/Component/Process/ExecutableFinder.php
+++ b/src/Symfony/Component/Process/ExecutableFinder.php
@@ -70,8 +70,14 @@ class ExecutableFinder
             }
         }
 
-        $command = '\\' === \DIRECTORY_SEPARATOR ? 'where' : 'command -v --';
-        if (\function_exists('exec') && ($executablePath = strtok(@exec($command.' '.escapeshellarg($name)), \PHP_EOL)) && @is_executable($executablePath)) {
+        if (!\function_exists('exec') || \strlen($name) !== strcspn($name, '/'.\DIRECTORY_SEPARATOR)) {
+            return $default;
+        }
+
+        $command = '\\' === \DIRECTORY_SEPARATOR ? 'where %s 2> NUL' : 'command -v -- %s';
+        $execResult = exec(\sprintf($command, escapeshellarg($name)));
+
+        if (($executablePath = substr($execResult, 0, strpos($execResult, \PHP_EOL) ?: null)) && @is_executable($executablePath)) {
             return $executablePath;
         }
 

--- a/src/Symfony/Component/Process/PhpExecutableFinder.php
+++ b/src/Symfony/Component/Process/PhpExecutableFinder.php
@@ -35,12 +35,16 @@ class PhpExecutableFinder
     {
         if ($php = getenv('PHP_BINARY')) {
             if (!is_executable($php)) {
-                $command = '\\' === \DIRECTORY_SEPARATOR ? 'where' : 'command -v --';
-                if (\function_exists('exec') && $php = strtok(exec($command.' '.escapeshellarg($php)), \PHP_EOL)) {
-                    if (!is_executable($php)) {
-                        return false;
-                    }
-                } else {
+                if (!\function_exists('exec') || \strlen($php) !== strcspn($php, '/'.\DIRECTORY_SEPARATOR)) {
+                    return false;
+                }
+
+                $command = '\\' === \DIRECTORY_SEPARATOR ? 'where %s 2> NUL' : 'command -v -- %s';
+                $execResult = exec(\sprintf($command, escapeshellarg($php)));
+                if (!$php = substr($execResult, 0, strpos($execResult, \PHP_EOL) ?: null)) {
+                    return false;
+                }
+                if (!is_executable($php)) {
                     return false;
                 }
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Removing the unexpected notices that we see on appveyor:

Before:
![image](https://github.com/user-attachments/assets/d9c788ad-7b29-4b0c-9170-aa08953a5ca2)

After:
![image](https://github.com/user-attachments/assets/a3dc1cc7-ce4c-4fd0-b422-1a6c745bc3d9)
