### PR TITLE
[WebProfilerBundle] Re-add missing Profiler shortcuts on Profiler homepage

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/results.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/results.html.twig
@@ -35,7 +35,9 @@
 {% endblock %}
 
 {% block sidebar_search_css_class %}{% endblock %}
-{% block sidebar_shortcuts_links %}{% endblock %}
+{% block sidebar_shortcuts_links %}
+    {{ parent() }}
+{% endblock %}
 
 {% block panel %}
     <div class="sf-tabs" data-processed="true">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #58693 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

Before Profiler redesign, on "homepage" (`/_profiler` path), there was sidebar shortcuts ("Last 10", "Latest", and "Search").
![Screenshot 2024-10-31 at 15-04-50 Symfony Profiler](https://github.com/user-attachments/assets/018847dd-c67c-41ae-a62d-4975904bf478)


Since this redesign, as mentioned in the related issue, shortcuts have disappeared
![Screenshot 2024-10-31 at 15-05-22 Symfony Profiler](https://github.com/user-attachments/assets/eb58515d-839d-4675-8c1a-761f55a8bcb8)


I've fixed it on this PR, it works exactly like before the redesign

![Screenshot 2024-10-31 at 15-05-46 Symfony Profiler](https://github.com/user-attachments/assets/fddcdf3e-01e8-4b39-921b-0d998e5f1231)