### PR TITLE
[Validator] Fix 58691 (missing plural-options in serbian language translation)

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.sr_Cyrl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sr_Cyrl.xlf
@@ -144,11 +144,11 @@
             </trans-unit>
             <trans-unit id="39">
                 <source>This value is not a valid locale.</source>
-                <target>Вредност није валидан локал.</target>
+                <target>Вредност није валидна међународна ознака језика.</target>
             </trans-unit>
             <trans-unit id="40">
                 <source>This value is not a valid country.</source>
-                <target>Вредност није валидна земља.</target>
+                <target>Вредност није валидна држава.</target>
             </trans-unit>
             <trans-unit id="41">
                 <source>This value is already used.</source>
@@ -160,19 +160,19 @@
             </trans-unit>
             <trans-unit id="43">
                 <source>The image width is too big ({{ width }}px). Allowed maximum width is {{ max_width }}px.</source>
-                <target>Ширина слике је превелика ({{ width }}px). Најећа дозвољена ширина је {{ max_width }}px.</target>
+                <target>Ширина слике је превелика ({{ width }} пиксела). Најећа дозвољена ширина је {{ max_width }} пиксела.</target>
             </trans-unit>
             <trans-unit id="44">
                 <source>The image width is too small ({{ width }}px). Minimum width expected is {{ min_width }}px.</source>
-                <target>Ширина слике је премала ({{ width }}px). Најмања дозвољена ширина је {{ min_width }}px.</target>
+                <target>Ширина слике је премала ({{ width }} пиксела). Најмања дозвољена ширина је {{ min_width }} пиксела.</target>
             </trans-unit>
             <trans-unit id="45">
                 <source>The image height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px.</source>
-                <target>Висина слике је превелика ({{ height }}px). Најећа дозвољена висина је {{ max_height }}px.</target>
+                <target>Висина слике је превелика ({{ height }} пиксела). Најећа дозвољена висина је {{ max_height }} пиксела.</target>
             </trans-unit>
             <trans-unit id="46">
                 <source>The image height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px.</source>
-                <target>Висина слике је премала ({{ height }}px). Најмања дозвољена висина је {{ min_height }}px.</target>
+                <target>Висина слике је премала ({{ height }} пиксела). Најмања дозвољена висина је {{ min_height }} пиксела.</target>
             </trans-unit>
             <trans-unit id="47">
                 <source>This value should be the user's current password.</source>
@@ -184,7 +184,7 @@
             </trans-unit>
             <trans-unit id="49">
                 <source>The file was only partially uploaded.</source>
-                <target>Датотека је само парцијално отпремљена.</target>
+                <target>Датотека је само делимично отпремљена.</target>
             </trans-unit>
             <trans-unit id="50">
                 <source>No file was uploaded.</source>
@@ -228,23 +228,23 @@
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
-                <target>Ово није валидан ISBN-10.</target>
+                <target>Ова вредност није валидан ISBN-10.</target>
             </trans-unit>
             <trans-unit id="61">
                 <source>This value is not a valid ISBN-13.</source>
-                <target>Ово није валидан ISBN-13.</target>
+                <target>Ова вредност није валидан ISBN-13.</target>
             </trans-unit>
             <trans-unit id="62">
                 <source>This value is neither a valid ISBN-10 nor a valid ISBN-13.</source>
-                <target>Ово није валидан ISBN-10 или ISBN-13.</target>
+                <target>Овa вредност није ни валидан ISBN-10 ни валидан ISBN-13.</target>
             </trans-unit>
             <trans-unit id="63">
                 <source>This value is not a valid ISSN.</source>
-                <target>Ово није валидан ISSN.</target>
+                <target>Ова вредност није валидан ISSN.</target>
             </trans-unit>
             <trans-unit id="64">
                 <source>This value is not a valid currency.</source>
-                <target>Ово није валидна валута.</target>
+                <target>Ово вредност није валидна валута.</target>
             </trans-unit>
             <trans-unit id="65">
                 <source>This value should be equal to {{ compared_value }}.</source>
@@ -288,15 +288,15 @@
             </trans-unit>
             <trans-unit id="75">
                 <source>The image is square ({{ width }}x{{ height }}px). Square images are not allowed.</source>
-                <target>Слика је квадратна ({{ width }}x{{ height }}px). Квадратне слике нису дозвољене.</target>
+                <target>Слика је квадратна ({{ width }}x{{ height }} пиксела). Квадратне слике нису дозвољене.</target>
             </trans-unit>
             <trans-unit id="76">
                 <source>The image is landscape oriented ({{ width }}x{{ height }}px). Landscape oriented images are not allowed.</source>
-                <target>Слика је оријентације пејзажа ({{ width }}x{{ height }}px). Пејзажна оријентација слика није дозвољена.</target>
+                <target>Слика је оријентације пејзажа ({{ width }}x{{ height }} пиксела). Пејзажна оријентација слика није дозвољена.</target>
             </trans-unit>
             <trans-unit id="77">
                 <source>The image is portrait oriented ({{ width }}x{{ height }}px). Portrait oriented images are not allowed.</source>
-                <target>Слика је оријантације портрета ({{ width }}x{{ height }}px). Портретна оријентација слика није дозвољена.</target>
+                <target>Слика је оријантације портрета ({{ width }}x{{ height }} пиксела). Портретна оријентација слика није дозвољена.</target>
             </trans-unit>
             <trans-unit id="78">
                 <source>An empty file is not allowed.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81" resname="This is not a valid Business Identifier Code (BIC).">
                 <source>This value is not a valid Business Identifier Code (BIC).</source>
-                <target>Ова вредност није валидна Код за идентификацију бизниса (BIC).</target>
+                <target>Ова вредност није валидан Код за идентификацију бизниса (BIC).</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -324,7 +324,7 @@
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
-                <target>Ова вредност би требало да буде дељива са {{ compared_value }}.</target>
+                <target>Ова вредност треба да буде дељива са {{ compared_value }}.</target>
             </trans-unit>
             <trans-unit id="85">
                 <source>This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.</source>
@@ -332,27 +332,27 @@
             </trans-unit>
             <trans-unit id="86">
                 <source>This value should be valid JSON.</source>
-                <target>Ова вредност би требало да буде валидан JSON.</target>
+                <target>Ова вредност треба да буде валидан JSON.</target>
             </trans-unit>
             <trans-unit id="87">
                 <source>This collection should contain only unique elements.</source>
-                <target>Ова колекција би требала да садржи само јединствене елементе.</target>
+                <target>Ова колекција треба да садржи само јединствене елементе.</target>
             </trans-unit>
             <trans-unit id="88">
                 <source>This value should be positive.</source>
-                <target>Ова вредност би требала бити позитивна.</target>
+                <target>Ова вредност треба да буде позитивна.</target>
             </trans-unit>
             <trans-unit id="89">
                 <source>This value should be either positive or zero.</source>
-                <target>Ова вредност би требала бити позитивна или нула.</target>
+                <target>Ова вредност треба да буде или позитивна или нула.</target>
             </trans-unit>
             <trans-unit id="90">
                 <source>This value should be negative.</source>
-                <target>Ова вредност би требала бити негативна.</target>
+                <target>Ова вредност треба да буде негативна.</target>
             </trans-unit>
             <trans-unit id="91">
                 <source>This value should be either negative or zero.</source>
-                <target>Ова вредност би требала бити позитивна или нула.</target>
+                <target>Ова вредност треба да буде или негативна или нула.</target>
             </trans-unit>
             <trans-unit id="92">
                 <source>This value is not a valid timezone.</source>
@@ -372,19 +372,19 @@
             </trans-unit>
             <trans-unit id="96">
                 <source>The number of elements in this collection should be a multiple of {{ compared_value }}.</source>
-                <target>Број елемената у овој колекцији би требало да буде дељив са {{ compared_value }}.</target>
+                <target>Број елемената у овој колекцији треба да буде дељив са {{ compared_value }}.</target>
             </trans-unit>
             <trans-unit id="97">
                 <source>This value should satisfy at least one of the following constraints:</source>
-                <target>Ова вредност би требало да задовољава најмање једно од наредних ограничења:</target>
+                <target>Ова вредност треба да задовољава најмање једно од наредних ограничења:</target>
             </trans-unit>
             <trans-unit id="98">
                 <source>Each element of this collection should satisfy its own set of constraints.</source>
-                <target>Сваки елемент ове колекције би требало да задовољи сопствени скуп ограничења.</target>
+                <target>Сваки елемент ове колекције треба да задовољи сопствени скуп ограничења.</target>
             </trans-unit>
             <trans-unit id="99">
                 <source>This value is not a valid International Securities Identification Number (ISIN).</source>
-                <target>Ова вредност није исправна међународна идентификациона ознака хартија од вредности (ISIN).</target>
+                <target>Ова вредност није валидна међународна идентификациона ознака хартија од вредности (ISIN).</target>
             </trans-unit>
             <trans-unit id="100">
                 <source>This value should be a valid expression.</source>
@@ -392,19 +392,19 @@
             </trans-unit>
             <trans-unit id="101">
                 <source>This value is not a valid CSS color.</source>
-                <target>Ова вредност није исправна CSS боја.</target>
+                <target>Ова вредност није валидна CSS боја.</target>
             </trans-unit>
             <trans-unit id="102">
                 <source>This value is not a valid CIDR notation.</source>
-                <target>Ова вредност није исправна CIDR нотација.</target>
+                <target>Ова вредност није валидна CIDR нотација.</target>
             </trans-unit>
             <trans-unit id="103">
                 <source>The value of the netmask should be between {{ min }} and {{ max }}.</source>
-                <target>Вредност мрежне маске треба бити између {{ min }} и {{ max }}.</target>
+                <target>Вредност мрежне маске треба да буде између {{ min }} и {{ max }}.</target>
             </trans-unit>
             <trans-unit id="104">
                 <source>The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</source>
-                <target>Назив датотеке је сувише дугачак. Треба да има {{ filename_max_length }} карактер или мање.|Назив датотеке је сувише дугачак. Треба да има {{ filename_max_length }} карактера или мање.</target>
+                <target>Назив датотеке је сувише дугачак. Треба да има {{ filename_max_length }} карактер или мање.|Назив датотеке је сувише дугачак. Треба да има {{ filename_max_length }} карактера или мање.|Назив датотеке је сувише дугачак. Треба да има {{ filename_max_length }} карактера или мање.</target>
             </trans-unit>
             <trans-unit id="105">
                 <source>The password strength is too low. Please use a stronger password.</source>
@@ -432,7 +432,7 @@
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target>Откривено кодирање знакова је неважеће ({{ detected }}). Дозвољена кодирања су {{  encodings }}.</target>
+                <target>Детектовано кодирање знакова није валидно ({{ detected }}). Дозвољена кодирања су {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This value is not a valid MAC address.</source>
@@ -440,15 +440,15 @@
             </trans-unit>
             <trans-unit id="113">
                 <source>This URL is missing a top-level domain.</source>
-                <target>Овом УРЛ-у недостаје домен највишег нивоа.</target>
+                <target>Овом URL-у недостаје домен највишег нивоа.</target>
             </trans-unit>
             <trans-unit id="114">
                 <source>This value is too short. It should contain at least one word.|This value is too short. It should contain at least {{ min }} words.</source>
-                <target>Ова вредност је прекратка. Треба да садржи макар једну реч.|Ова вредност је прекратка. Треба да садржи макар {{ min }} речи.</target>
+                <target>Ова вредност је прекратка. Треба да садржи макар једну реч.|Ова вредност је прекратка. Треба да садржи макар {{ min }} речи.|Ова вредност је прекратка. Треба да садржи макар {{ min }} речи.</target>
             </trans-unit>
             <trans-unit id="115">
                 <source>This value is too long. It should contain one word.|This value is too long. It should contain {{ max }} words or less.</source>
-                <target>Ова вредност је предугачка. Треба да садржи само једну реч.|Ова вредност је предугачка. Треба да садржи највише {{ max }} речи.</target>
+                <target>Ова вредност је предугачка. Треба да садржи само једну реч.|Ова вредност је предугачка. Треба да садржи највише {{ max }} речи.|Ова вредност је предугачка. Треба да садржи највише {{ max }} речи.</target>
             </trans-unit>
             <trans-unit id="116">
                 <source>This value does not represent a valid week in the ISO 8601 format.</source>
@@ -460,11 +460,11 @@
             </trans-unit>
             <trans-unit id="118">
                 <source>This value should not be before week "{{ min }}".</source>
-                <target>Ова вредност не би требала да буде пре недеље "{{ min }}".</target>
+                <target>Ова вредност не треба да буде пре недеље "{{ min }}".</target>
             </trans-unit>
             <trans-unit id="119">
                 <source>This value should not be after week "{{ max }}".</source>
-                <target>Ова вредност не би требала да буде после недеље "{{ max }}".</target>
+                <target>Ова вредност не треба да буде после недеље "{{ max }}".</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.sr_Latn.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sr_Latn.xlf
@@ -4,35 +4,35 @@
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
-                <target>Vrednost bi trebala da bude netačna.</target>
+                <target>Vrednost treba da bude netačna.</target>
             </trans-unit>
             <trans-unit id="2">
                 <source>This value should be true.</source>
-                <target>Vrednost bi trebala da bude tačna.</target>
+                <target>Vrednost treba da bude tačna.</target>
             </trans-unit>
             <trans-unit id="3">
                 <source>This value should be of type {{ type }}.</source>
-                <target>Vrednost bi trebala da bude tipa {{ type }}.</target>
+                <target>Vrednost treba da bude tipa {{ type }}.</target>
             </trans-unit>
             <trans-unit id="4">
                 <source>This value should be blank.</source>
-                <target>Vrednost bi trebala da bude prazna.</target>
+                <target>Vrednost treba da bude prazna.</target>
             </trans-unit>
             <trans-unit id="5">
                 <source>The value you selected is not a valid choice.</source>
-                <target>Vrednost koju ste izabrali nije validan izbor.</target>
+                <target>Vrednost treba da bude jedna od ponuđenih.</target>
             </trans-unit>
             <trans-unit id="6">
                 <source>You must select at least {{ limit }} choice.|You must select at least {{ limit }} choices.</source>
-                <target>Morate izabrati najmanje {{ limit }} mogućnosti.|Morate izabrati najmanje {{ limit }} mogućnosti.</target>
+                <target>Izaberite bar {{ limit }} mogućnost.|Izaberite bar {{ limit }} mogućnosti.|Izaberite bar {{ limit }} mogućnosti.</target>
             </trans-unit>
             <trans-unit id="7">
                 <source>You must select at most {{ limit }} choice.|You must select at most {{ limit }} choices.</source>
-                <target>Morate izabrati najviše {{ limit }} mogućnosti.|Morate izabrati najviše {{ limit }} mogućnosti.</target>
+                <target>Izaberite najviše {{ limit }} mogućnost.|Izaberite najviše {{ limit }} mogućnosti.|Izaberite najviše {{ limit }} mogućnosti.</target>
             </trans-unit>
             <trans-unit id="8">
                 <source>One or more of the given values is invalid.</source>
-                <target>Jedna ili više od odabranih vrednosti nisu validne.</target>
+                <target>Jedna ili više vrednosti je nevalidna.</target>
             </trans-unit>
             <trans-unit id="9">
                 <source>This field was not expected.</source>
@@ -44,11 +44,11 @@
             </trans-unit>
             <trans-unit id="11">
                 <source>This value is not a valid date.</source>
-                <target>Vrednost nije validna kao datum.</target>
+                <target>Vrednost nije validan datum.</target>
             </trans-unit>
             <trans-unit id="12">
                 <source>This value is not a valid datetime.</source>
-                <target>Vrednost nije validna kao datum i vreme.</target>
+                <target>Vrednost nije validan datum-vreme.</target>
             </trans-unit>
             <trans-unit id="13">
                 <source>This value is not a valid email address.</source>
@@ -56,47 +56,47 @@
             </trans-unit>
             <trans-unit id="14">
                 <source>The file could not be found.</source>
-                <target>Fajl ne može biti pronađen.</target>
+                <target>Datoteka ne može biti pronađena.</target>
             </trans-unit>
             <trans-unit id="15">
                 <source>The file is not readable.</source>
-                <target>Fajl nije čitljiv.</target>
+                <target>Datoteka nije čitljiva.</target>
             </trans-unit>
             <trans-unit id="16">
                 <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
-                <target>Fajl je preveliki ({{ size }} {{ suffix }}). Najveća dozvoljena veličina fajla je {{ limit }} {{ suffix }}.</target>
+                <target>Datoteka je prevelika ({{ size }} {{ suffix }}). Najveća dozvoljena veličina je {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>
-                <target>MIME tip fajla nije validan ({{ type }}). Dozvoljeni MIME tipovi su {{ types }}.</target>
+                <target>MIME tip datoteke nije validan ({{ type }}). Dozvoljeni MIME tipovi su {{ types }}.</target>
             </trans-unit>
             <trans-unit id="18">
                 <source>This value should be {{ limit }} or less.</source>
-                <target>Vrednost bi trebala da bude {{ limit }} ili manje.</target>
+                <target>Vrednost treba da bude {{ limit }} ili manje.</target>
             </trans-unit>
             <trans-unit id="19">
                 <source>This value is too long. It should have {{ limit }} character or less.|This value is too long. It should have {{ limit }} characters or less.</source>
-                <target>Vrednost je predugačka. Trebalo bi da ima {{ limit }} karaktera ili manje.|Vrednost je predugačka. Trebalo bi da ima {{ limit }} karaktera ili manje.</target>
+                <target>Vrednost je predugačka. Treba da ima {{ limit }} karakter ili manje.|Vrednost je predugačka. Treba da ima {{ limit }} karaktera ili manje.|Vrednost je predugačka. Treba da ima {{ limit }} karaktera ili manje.</target>
             </trans-unit>
             <trans-unit id="20">
                 <source>This value should be {{ limit }} or more.</source>
-                <target>Vrednost bi trebala da bude {{ limit }} ili više.</target>
+                <target>Vrednost treba da bude {{ limit }} ili više.</target>
             </trans-unit>
             <trans-unit id="21">
                 <source>This value is too short. It should have {{ limit }} character or more.|This value is too short. It should have {{ limit }} characters or more.</source>
-                <target>Vrednost je prekratka. Trebalo bi da ima {{ limit }} karaktera ili više.|Vrednost je prekratka. Trebalo bi da ima {{ limit }} karaktera ili više.</target>
+                <target>Vrednost je prekratka. Treba da ima {{ limit }} karakter ili više.|Vrednost je prekratka. Treba da ima {{ limit }} karaktera ili više.|Vrednost je prekratka. Treba da ima {{ limit }} karaktera ili više.</target>
             </trans-unit>
             <trans-unit id="22">
                 <source>This value should not be blank.</source>
-                <target>Vrednost ne bi trebala da bude prazna.</target>
+                <target>Vrednost ne treba da bude prazna.</target>
             </trans-unit>
             <trans-unit id="23">
                 <source>This value should not be null.</source>
-                <target>Vrednost ne bi trebala da bude null.</target>
+                <target>Vrednost ne treba da bude null.</target>
             </trans-unit>
             <trans-unit id="24">
                 <source>This value should be null.</source>
-                <target>Vrednost bi trebala da bude null.</target>
+                <target>Vrednost treba da bude null.</target>
             </trans-unit>
             <trans-unit id="25">
                 <source>This value is not valid.</source>
@@ -112,27 +112,27 @@
             </trans-unit>
             <trans-unit id="31">
                 <source>The two values should be equal.</source>
-                <target>Obe vrednosti bi trebale da budu jednake.</target>
+                <target>Obe vrednosti treba da budu jednake.</target>
             </trans-unit>
             <trans-unit id="32">
                 <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
-                <target>Fajl je preveliki. Najveća dozvoljena veličina je {{ limit }} {{ suffix }}.</target>
+                <target>Datoteka je prevelika. Najveća dozvoljena veličina je {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>
-                <target>Fajl je preveliki.</target>
+                <target>Datoteka je prevelikia.</target>
             </trans-unit>
             <trans-unit id="34">
                 <source>The file could not be uploaded.</source>
-                <target>Fajl ne može biti otpremljen.</target>
+                <target>Datoteka ne može biti otpremljena.</target>
             </trans-unit>
             <trans-unit id="35">
                 <source>This value should be a valid number.</source>
-                <target>Vrednost bi trebala da bude validan broj.</target>
+                <target>Vrednost treba da bude validan broj.</target>
             </trans-unit>
             <trans-unit id="36">
                 <source>This file is not a valid image.</source>
-                <target>Ovaj fajl nije validan kao slika.</target>
+                <target>Ova datoteka nije validna slika.</target>
             </trans-unit>
             <trans-unit id="37" resname="This is not a valid IP address.">
                 <source>This value is not a valid IP address.</source>
@@ -176,27 +176,27 @@
             </trans-unit>
             <trans-unit id="47">
                 <source>This value should be the user's current password.</source>
-                <target>Vrednost bi trebala da bude trenutna korisnička lozinka.</target>
+                <target>Vrednost treba da bude trenutna korisnička lozinka.</target>
             </trans-unit>
             <trans-unit id="48">
                 <source>This value should have exactly {{ limit }} character.|This value should have exactly {{ limit }} characters.</source>
-                <target>Vrednost bi trebala da ima tačno {{ limit }} karaktera.|Vrednost bi trebala da ima tačno {{ limit }} karaktera.</target>
+                <target>Vrednost treba da ima tačno {{ limit }} karakter.|Vrednost treba da ima tačno {{ limit }} karaktera.|Vrednost treba da ima tačno {{ limit }} karaktera.</target>
             </trans-unit>
             <trans-unit id="49">
                 <source>The file was only partially uploaded.</source>
-                <target>Fajl je samo parcijalno otpremljena.</target>
+                <target>Datoteka je samo delimično otpremljena.</target>
             </trans-unit>
             <trans-unit id="50">
                 <source>No file was uploaded.</source>
-                <target>Fajl nije otpremljen.</target>
+                <target>Datoteka nije otpremljena.</target>
             </trans-unit>
             <trans-unit id="51" resname="No temporary folder was configured in php.ini.">
                 <source>No temporary folder was configured in php.ini, or the configured folder does not exist.</source>
-                <target>Privremeni direktorijum nije konfigurisan u php.ini, ili direktorijum koji je konfigurisan ne postoji.</target>
+                <target>Privremeni direktorijum nije konfigurisan u php.ini, ili konfigurisani direktorijum ne postoji.</target>
             </trans-unit>
             <trans-unit id="52">
                 <source>Cannot write temporary file to disk.</source>
-                <target>Nije moguće upisati privremeni fajl na disk.</target>
+                <target>Nemoguće pisanje privremene datoteke na disk.</target>
             </trans-unit>
             <trans-unit id="53">
                 <source>A PHP extension caused the upload to fail.</source>
@@ -204,15 +204,15 @@
             </trans-unit>
             <trans-unit id="54">
                 <source>This collection should contain {{ limit }} element or more.|This collection should contain {{ limit }} elements or more.</source>
-                <target>Ova kolekcija bi trebala da sadrži {{ limit }} ili više elemenata.|Ova kolekcija bi trebala da sadrži {{ limit }} ili više elemenata.</target>
+                <target>Ova kolekcija treba da sadrži {{ limit }} ili više elemenata.|Ova kolekcija treba da sadrži {{ limit }} ili više elemenata.|Ova kolekcija treba da sadrži {{ limit }} ili više elemenata.</target>
             </trans-unit>
             <trans-unit id="55">
                 <source>This collection should contain {{ limit }} element or less.|This collection should contain {{ limit }} elements or less.</source>
-                <target>Ova kolekcija bi trebala da sadrži {{ limit }} ili manje elemenata.|Ova kolekcija bi trebala da sadrži {{ limit }} ili manje elemenata.</target>
+                <target>Ova kolekcija treba da sadrži {{ limit }} ili manje elemenata.|Ova kolekcija treba da sadrži {{ limit }} ili manje elemenata.|Ova kolekcija treba da sadrži {{ limit }} ili manje elemenata.</target>
             </trans-unit>
             <trans-unit id="56">
                 <source>This collection should contain exactly {{ limit }} element.|This collection should contain exactly {{ limit }} elements.</source>
-                <target>Ova kolekcija bi trebala da sadrži tačno {{ limit }} element.|Ova kolekcija bi trebala da sadrži tačno {{ limit }} elementa.</target>
+                <target>Ova kolekcija treba da sadrži tačno {{ limit }} element.|Ova kolekcija treba da sadrži tačno {{ limit }} elementa.|Ova kolekcija treba da sadrži tačno {{ limit }} elemenata.</target>
             </trans-unit>
             <trans-unit id="57">
                 <source>Invalid card number.</source>
@@ -220,7 +220,7 @@
             </trans-unit>
             <trans-unit id="58">
                 <source>Unsupported card type or invalid card number.</source>
-                <target>Nevalidan broj kartice ili nepodržan tip kartice.</target>
+                <target>Nevalidan broj kartice ili tip kartice nije podržan.</target>
             </trans-unit>
             <trans-unit id="59" resname="This is not a valid International Bank Account Number (IBAN).">
                 <source>This value is not a valid International Bank Account Number (IBAN).</source>
@@ -228,55 +228,55 @@
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
-                <target>Nevalidna vrednost ISBN-10.</target>
+                <target>Ova vrednost nije validan ISBN-10.</target>
             </trans-unit>
             <trans-unit id="61">
                 <source>This value is not a valid ISBN-13.</source>
-                <target>Nevalidna vrednost ISBN-13.</target>
+                <target>Ova vrednost nije validan ISBN-13.</target>
             </trans-unit>
             <trans-unit id="62">
                 <source>This value is neither a valid ISBN-10 nor a valid ISBN-13.</source>
-                <target>Vrednost nije ni validan ISBN-10 ni validan ISBN-13.</target>
+                <target>Ova vrednost nije ni validan ISBN-10 ni validan ISBN-13.</target>
             </trans-unit>
             <trans-unit id="63">
                 <source>This value is not a valid ISSN.</source>
-                <target>Nevalidna vrednost ISSN.</target>
+                <target>Ova vrednost nije validan ISSN.</target>
             </trans-unit>
             <trans-unit id="64">
                 <source>This value is not a valid currency.</source>
-                <target>Vrednost nije validna valuta.</target>
+                <target>Ova vrednost nije validna valuta.</target>
             </trans-unit>
             <trans-unit id="65">
                 <source>This value should be equal to {{ compared_value }}.</source>
-                <target>Ova vrednost bi trebala da bude jednaka {{ compared_value }}.</target>
+                <target>Ova vrednost treba da bude {{ compared_value }}.</target>
             </trans-unit>
             <trans-unit id="66">
                 <source>This value should be greater than {{ compared_value }}.</source>
-                <target>Ova vrednost bi trebala da bude veća od {{ compared_value }}.</target>
+                <target>Ova vrednost treba da bude veća od {{ compared_value }}.</target>
             </trans-unit>
             <trans-unit id="67">
                 <source>This value should be greater than or equal to {{ compared_value }}.</source>
-                <target>Ova vrednost bi trebala da je veća ili jednaka {{ compared_value }}.</target>
+                <target>Ova vrednost treba da bude veća ili jednaka {{ compared_value }}.</target>
             </trans-unit>
             <trans-unit id="68">
                 <source>This value should be identical to {{ compared_value_type }} {{ compared_value }}.</source>
-                <target>Ova vrednost bi trebala da bude identična sa {{ compared_value_type }} {{ compared_value }}.</target>
+                <target>Ova vrednost treba da bude identična sa {{ compared_value_type }} {{ compared_value }}.</target>
             </trans-unit>
             <trans-unit id="69">
                 <source>This value should be less than {{ compared_value }}.</source>
-                <target>Ova vrednost bi trebala da bude manja od {{ compared_value }}.</target>
+                <target>Ova vrednost treba da bude manja od {{ compared_value }}.</target>
             </trans-unit>
             <trans-unit id="70">
                 <source>This value should be less than or equal to {{ compared_value }}.</source>
-                <target>Ova vrednost bi trebala da bude manja ili jednaka {{ compared_value }}.</target>
+                <target>Ova vrednost treba da bude manja ili jednaka {{ compared_value }}.</target>
             </trans-unit>
             <trans-unit id="71">
                 <source>This value should not be equal to {{ compared_value }}.</source>
-                <target>Ova vrednost ne bi trebala da bude jednaka {{ compared_value }}.</target>
+                <target>Ova vrednost ne treba da bude jednaka {{ compared_value }}.</target>
             </trans-unit>
             <trans-unit id="72">
                 <source>This value should not be identical to {{ compared_value_type }} {{ compared_value }}.</source>
-                <target>Ova vrednost ne bi trebala da bude identična sa {{ compared_value_type }} {{ compared_value }}.</target>
+                <target>Ova vrednost ne treba da bude identična sa {{ compared_value_type }} {{ compared_value }}.</target>
             </trans-unit>
             <trans-unit id="73">
                 <source>The image ratio is too big ({{ ratio }}). Allowed maximum ratio is {{ max_ratio }}.</source>
@@ -292,15 +292,15 @@
             </trans-unit>
             <trans-unit id="76">
                 <source>The image is landscape oriented ({{ width }}x{{ height }}px). Landscape oriented images are not allowed.</source>
-                <target>Slika je pejzažno orijentisana ({{ width }}x{{ height }} piksela). Pejzažno orijentisane slike nisu dozvoljene.</target>
+                <target>Slika je orijentacije pejzaža ({{ width }}x{{ height }} piksela). Pejzažna orijentacija slika nije dozvoljena.</target>
             </trans-unit>
             <trans-unit id="77">
                 <source>The image is portrait oriented ({{ width }}x{{ height }}px). Portrait oriented images are not allowed.</source>
-                <target>Slika je portretno orijentisana ({{ width }}x{{ height }} piksela). Portretno orijentisane slike nisu dozvoljene.</target>
+                <target>Slika je orijentacije portreta ({{ width }}x{{ height }} piksela). Portretna orijentacija slika nije dozvoljena.</target>
             </trans-unit>
             <trans-unit id="78">
                 <source>An empty file is not allowed.</source>
-                <target>Prazan fajl nije dozvoljen.</target>
+                <target>Prazna datoteka nije dozvoljena.</target>
             </trans-unit>
             <trans-unit id="79">
                 <source>The host could not be resolved.</source>
@@ -324,7 +324,7 @@
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
-                <target>Ova vrednost bi trebala da bude višestruka u odnosu na {{ compared_value }}.</target>
+                <target>Ova vrednost treba da bude deljiva sa {{ compared_value }}.</target>
             </trans-unit>
             <trans-unit id="85">
                 <source>This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.</source>
@@ -332,27 +332,27 @@
             </trans-unit>
             <trans-unit id="86">
                 <source>This value should be valid JSON.</source>
-                <target>Ova vrednost bi trebala da bude validan JSON.</target>
+                <target>Ova vrednost treba da bude validan JSON.</target>
             </trans-unit>
             <trans-unit id="87">
                 <source>This collection should contain only unique elements.</source>
-                <target>Ova kolekcija bi trebala da sadrži samo jedinstvene elemente.</target>
+                <target>Ova kolekcija treba da sadrži samo jedinstvene elemente.</target>
             </trans-unit>
             <trans-unit id="88">
                 <source>This value should be positive.</source>
-                <target>Ova vrednost bi trebala biti pozitivna.</target>
+                <target>Ova vrednost treba da bude pozitivna.</target>
             </trans-unit>
             <trans-unit id="89">
                 <source>This value should be either positive or zero.</source>
-                <target>Ova vrednost bi trebala biti ili pozitivna ili nula.</target>
+                <target>Ova vrednost treba da bude ili pozitivna ili nula.</target>
             </trans-unit>
             <trans-unit id="90">
                 <source>This value should be negative.</source>
-                <target>Ova vrednost bi trebala biti negativna.</target>
+                <target>Ova vrednost treba da bude negativna.</target>
             </trans-unit>
             <trans-unit id="91">
                 <source>This value should be either negative or zero.</source>
-                <target>Ova vrednost bi trebala biti ili negativna ili nula.</target>
+                <target>Ova vrednost treba da bude ili negativna ili nula.</target>
             </trans-unit>
             <trans-unit id="92">
                 <source>This value is not a valid timezone.</source>
@@ -360,7 +360,7 @@
             </trans-unit>
             <trans-unit id="93">
                 <source>This password has been leaked in a data breach, it must not be used. Please use another password.</source>
-                <target>Lozinka je kompromitovana prilikom curenja podataka usled napada, nemojte je koristiti. Koristite drugu lozinku.</target>
+                <target>Ova lozinka je kompromitovana prilikom prethodnih napada, nemojte je koristiti. Koristite drugu lozinku.</target>
             </trans-unit>
             <trans-unit id="94">
                 <source>This value should be between {{ min }} and {{ max }}.</source>
@@ -368,23 +368,23 @@
             </trans-unit>
             <trans-unit id="95">
                 <source>This value is not a valid hostname.</source>
-                <target>Ova vrednost nije ispravno ime poslužitelja (hostname).</target>
+                <target>Ova vrednost nije ispravno ime hosta.</target>
             </trans-unit>
             <trans-unit id="96">
                 <source>The number of elements in this collection should be a multiple of {{ compared_value }}.</source>
-                <target>Broj elemenata u ovoj kolekciji bi trebala da bude višestruka u odnosu na {{ compared_value }}.</target>
+                <target>Broj elemenata u ovoj kolekciji treba da bude deljiv sa {{ compared_value }}.</target>
             </trans-unit>
             <trans-unit id="97">
                 <source>This value should satisfy at least one of the following constraints:</source>
-                <target>Ova vrednost bi trebala da zadovoljava namjanje jedno od narednih ograničenja:</target>
+                <target>Ova vrednost treba da zadovoljava namjanje jedno od narednih ograničenja:</target>
             </trans-unit>
             <trans-unit id="98">
                 <source>Each element of this collection should satisfy its own set of constraints.</source>
-                <target>Svaki element ove kolekcije bi trebalo da zadovolji sopstveni skup ograničenja.</target>
+                <target>Svaki element ove kolekcije treba da zadovolji sopstveni skup ograničenja.</target>
             </trans-unit>
             <trans-unit id="99">
                 <source>This value is not a valid International Securities Identification Number (ISIN).</source>
-                <target>Ova vrednost nije ispravan međunarodni sigurnosni i identifikacioni broj (ISIN).</target>
+                <target>Ova vrednost nije validna međunarodna identifikaciona oznaka hartija od vrednosti (ISIN).</target>
             </trans-unit>
             <trans-unit id="100">
                 <source>This value should be a valid expression.</source>
@@ -400,11 +400,11 @@
             </trans-unit>
             <trans-unit id="103">
                 <source>The value of the netmask should be between {{ min }} and {{ max }}.</source>
-                <target>Vrednost mrežne maske treba biti između {{ min }} i {{ max }}.</target>
+                <target>Vrednost mrežne maske treba da bude između {{ min }} i {{ max }}.</target>
             </trans-unit>
             <trans-unit id="104">
                 <source>The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</source>
-                <target>Naziv fajla je suviše dugačak. Treba da ima {{ filename_max_length }} karaktera ili manje.|Naziv fajla je suviše dugačak. Treba da ima {{ filename_max_length }} karaktera ili manje.</target>
+                <target>Naziv datoteke je suviše dugačak. Treba da ima {{ filename_max_length }} karakter ili manje.|Naziv datoteke je suviše dugačak. Treba da ima {{ filename_max_length }} karaktera ili manje.|Naziv datoteke je suviše dugačak. Treba da ima {{ filename_max_length }} karaktera ili manje.</target>
             </trans-unit>
             <trans-unit id="105">
                 <source>The password strength is too low. Please use a stronger password.</source>
@@ -424,15 +424,15 @@
             </trans-unit>
             <trans-unit id="109">
                 <source>Using hidden overlay characters is not allowed.</source>
-                <target>Korišćenje skrivenih pokrivenih karaktera nije dozvoljeno.</target>
+                <target>Korišćenje skrivenih preklopnih karaktera nije dozvoljeno.</target>
             </trans-unit>
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
-                <target>Ekstenzija fajla je nevalidna ({{ extension }}). Dozvoljene ekstenzije su {{ extensions }}.</target>
+                <target>Ekstenzija fajla nije validna ({{ extension }}). Dozvoljene ekstenzije su {{ extensions }}.</target>
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target>Detektovani enkoding karaktera nije validan ({{ detected }}). Dozvoljne vrednosti za enkoding su: {{ encodings }}.</target>
+                <target>Detektovano kodiranje znakova nije validno ({{ detected }}). Dozvoljena kodiranja su {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This value is not a valid MAC address.</source>
@@ -444,11 +444,11 @@
             </trans-unit>
             <trans-unit id="114">
                 <source>This value is too short. It should contain at least one word.|This value is too short. It should contain at least {{ min }} words.</source>
-                <target>Ova vrednost je prekratka. Treba da sadrži makar jednu reč.|Ova vrednost je prekratka. Treba da sadrži makar {{ min }} reči.</target>
+                <target>Ova vrednost je prekratka. Treba da sadrži makar jednu reč.|Ova vrednost je prekratka. Treba da sadrži makar {{ min }} reči.|Ova vrednost je prekratka. Treba da sadrži makar {{ min }} reči.</target>
             </trans-unit>
             <trans-unit id="115">
                 <source>This value is too long. It should contain one word.|This value is too long. It should contain {{ max }} words or less.</source>
-                <target>Ova vrednost je predugačka. Treba da sadrži samo jednu reč.|Ova vrednost je predugačka. Treba da sadrži najviše {{ max }} reči.</target>
+                <target>Ova vrednost je predugačka. Treba da sadrži samo jednu reč.|Ova vrednost je predugačka. Treba da sadrži najviše {{ max }} reči.|Ova vrednost je predugačka. Treba da sadrži najviše {{ max }} reči.</target>
             </trans-unit>
             <trans-unit id="116">
                 <source>This value does not represent a valid week in the ISO 8601 format.</source>
@@ -460,11 +460,11 @@
             </trans-unit>
             <trans-unit id="118">
                 <source>This value should not be before week "{{ min }}".</source>
-                <target>Ova vrednost ne bi trebala da bude pre nedelje "{{ min }}".</target>
+                <target>Ova vrednost ne treba da bude pre nedelje "{{ min }}".</target>
             </trans-unit>
             <trans-unit id="119">
                 <source>This value should not be after week "{{ max }}".</source>
-                <target>Ova vrednost ne bi trebala da bude posle nedelje "{{ max }}".</target>
+                <target>Ova vrednost ne treba da bude posle nedelje "{{ max }}".</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58691
| License       | MIT

Pull request contains two commits that do the following:

1. Fix Serbian translations - wrong number of plural options that was causing a crash, see https://github.com/symfony/symfony/issues/58691
2. General improvements of Serbian translation:
    * Serbian-latin and Serbian-cyrillic translations should use the exact same wording, only the alphabet used should differ
    * Some minor changes to make the translation more consistent


