### PR TITLE
[Finder] Allow finder to set the `UNIX_PATH` flag when recursing directories

### DIFF
--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -54,6 +54,7 @@ class Finder implements \IteratorAggregate, \Countable
     private array $depths = [];
     private array $sizes = [];
     private bool $followLinks = false;
+    private bool $unixPaths = false;
     private bool $reverseSorting = false;
     private \Closure|int|false $sort = false;
     private int $ignore = 0;
@@ -612,6 +613,18 @@ class Finder implements \IteratorAggregate, \Countable
     }
 
     /**
+     * Force the use of UNIX paths when recursing directories.
+     *
+     * @return $this
+     */
+    public function useUnixPaths(): static
+    {
+        $this->unixPaths = true;
+
+        return $this;
+    }
+
+    /**
      * Tells finder to ignore unreadable directories.
      *
      * By default, scanning unreadable directories content throws an AccessDeniedException.
@@ -780,6 +793,10 @@ class Finder implements \IteratorAggregate, \Countable
 
         if ($this->followLinks) {
             $flags |= \RecursiveDirectoryIterator::FOLLOW_SYMLINKS;
+        }
+
+        if ($this->unixPaths) {
+            $flags |= \RecursiveDirectoryIterator::UNIX_PATHS;
         }
 
         $iterator = new Iterator\RecursiveDirectoryIterator($dir, $flags, $this->ignoreUnreadableDirs);

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -1087,6 +1087,20 @@ class FinderTest extends Iterator\RealIteratorTestCase
         ]), $finder->in(self::$tmpDir)->getIterator());
     }
 
+    public function testUseUnixPaths()
+    {
+        $fixturesDirectory = __DIR__.\DIRECTORY_SEPARATOR.'Fixtures';
+
+        // Fix __DIR__ on Windows giving us backslashes.
+        $fixturesDirectory = str_replace('\\', '/', $fixturesDirectory);
+
+        $finder = $this->buildFinder();
+        $this->assertSame($finder, $finder->useUnixPaths());
+        foreach ($finder->in($fixturesDirectory) as $file) {
+            $this->assertStringNotContainsString('\\', $file->getPathname(), 'Paths should be in UNIX style.');
+        }
+    }
+
     public function testIn()
     {
         $finder = $this->buildFinder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #54269
| License       | MIT
