### PR TITLE
[Process] Return built-in cmd.exe commands directly in ExecutableFinder

### DIFF
--- a/src/Symfony/Component/Process/ExecutableFinder.php
+++ b/src/Symfony/Component/Process/ExecutableFinder.php
@@ -20,6 +20,13 @@ namespace Symfony\Component\Process;
 class ExecutableFinder
 {
     private $suffixes = ['.exe', '.bat', '.cmd', '.com'];
+    private const CMD_BUILTINS = [
+        'assoc', 'break', 'call', 'cd', 'chdir', 'cls', 'color', 'copy', 'date',
+        'del', 'dir', 'echo', 'endlocal', 'erase', 'exit', 'for', 'ftype', 'goto',
+        'help', 'if', 'label', 'md', 'mkdir', 'mklink', 'move', 'path', 'pause',
+        'popd', 'prompt', 'pushd', 'rd', 'rem', 'ren', 'rename', 'rmdir', 'set',
+        'setlocal', 'shift', 'start', 'time', 'title', 'type', 'ver', 'vol',
+    ];
 
     /**
      * Replaces default suffixes of executable.
@@ -48,6 +55,11 @@ class ExecutableFinder
      */
     public function find(string $name, ?string $default = null, array $extraDirs = [])
     {
+        // windows built-in commands that are present in cmd.exe should not be resolved using PATH as they do not exist as exes
+        if ('\\' === \DIRECTORY_SEPARATOR && \in_array(strtolower($name), self::CMD_BUILTINS, true)) {
+            return $name;
+        }
+
         $dirs = array_merge(
             explode(\PATH_SEPARATOR, getenv('PATH') ?: getenv('Path')),
             $extraDirs

--- a/src/Symfony/Component/Process/Tests/ExecutableFinderTest.php
+++ b/src/Symfony/Component/Process/Tests/ExecutableFinderTest.php
@@ -159,6 +159,18 @@ class ExecutableFinderTest extends TestCase
         unlink('executable');
     }
 
+    public function testFindBuiltInCommandOnWindows()
+    {
+        if ('\\' !== \DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('Can be only tested on windows');
+        }
+
+        $finder = new ExecutableFinder();
+        $this->assertSame('rmdir', $finder->find('RMDIR'));
+        $this->assertSame('cd', $finder->find('cd'));
+        $this->assertSame('move', $finder->find('MoVe'));
+    }
+
     private function assertSamePath($expected, $tested)
     {
         if ('\\' === \DIRECTORY_SEPARATOR) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Refs #58734
| License       | MIT

