### PR TITLE
[WebProfilerBoundle] form data collector check passed and resolved options are defined

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
@@ -650,8 +650,10 @@
                     <td>{{ profiler_dump(value) }}</td>
                     <td>
                         {# values can be stubs #}
-                        {% set option_value = value.value|default(value) %}
-                        {% set resolved_option_value = data.resolved_options[option].value|default(data.resolved_options[option]) %}
+                        {% set option_value = (value.value is defined) ? value.value : value %}
+                        {% set resolved_option_value = (data.resolved_options[option].value is defined)
+                            ? data.resolved_options[option].value
+                            : data.resolved_options[option] %}
                         {% if resolved_option_value == option_value %}
                             <em class="font-normal text-muted">same as passed value</em>
                         {% else %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?      | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58665 
| License       | MIT

Greetings! 
When passed or resolved value casted to false (null/false) it sets wrong value what cause exceptions described in issue. Explicit check if value defined prevent this behavior
Maybe codestyle should be fixed because of ternary 