### PR TITLE
[Process] ignore case of built-in cmd.exe commands

### DIFF
--- a/src/Symfony/Component/Process/Tests/ExecutableFinderTest.php
+++ b/src/Symfony/Component/Process/Tests/ExecutableFinderTest.php
@@ -166,9 +166,9 @@ class ExecutableFinderTest extends TestCase
         }
 
         $finder = new ExecutableFinder();
-        $this->assertSame('rmdir', $finder->find('RMDIR'));
-        $this->assertSame('cd', $finder->find('cd'));
-        $this->assertSame('move', $finder->find('MoVe'));
+        $this->assertSame('rmdir', strtolower($finder->find('RMDIR')));
+        $this->assertSame('cd', strtolower($finder->find('cd')));
+        $this->assertSame('move', strtolower($finder->find('MoVe')));
     }
 
     private function assertSamePath($expected, $tested)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT