### PR TITLE
[Security] Store original token in token storage when implicitly exiting impersonation

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -109,7 +109,7 @@ class SwitchUserListener extends AbstractListener
         }
 
         if (self::EXIT_VALUE === $username) {
-            $this->tokenStorage->setToken($this->attemptExitUser($request));
+            $this->attemptExitUser($request);
         } else {
             try {
                 $this->tokenStorage->setToken($this->attemptSwitchUser($request, $username));
@@ -220,6 +220,8 @@ class SwitchUserListener extends AbstractListener
             $this->dispatcher->dispatch($switchEvent, SecurityEvents::SWITCH_USER);
             $original = $switchEvent->getToken();
         }
+
+        $this->tokenStorage->setToken($original);
 
         return $original;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

If you impersonate user A and then start impersonation for user B, Symfony explicitly exits the first impersonation before starting the second one. However, we did not update the token in the token storage at this moment.

This creates issues when using a custom voter [like the one documented](https://symfony.com/doc/current/security/impersonating_user.html#limiting-user-switching), as this uses `Security::isGranted()`, which relies on the token in the token storage. So instead of checking if the original user can impersonate, it will check if user A can impersonate.