### PR TITLE
[Mailer] [Amazon] Add support for custom headers in ses+api

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.2
+---
+
+* Add support for custom headers in ses+api
+
 7.1
 ---
 

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php
@@ -92,6 +92,7 @@ class SesApiAsyncAwsTransportTest extends TestCase
             $this->assertSame('bounces@example.com', $content['FeedbackForwardingEmailAddress']);
             $this->assertSame([['Name' => 'tagName1', 'Value' => 'tag Value1'], ['Name' => 'tagName2', 'Value' => 'tag Value2']], $content['EmailTags']);
             $this->assertSame(['ContactListName' => 'TestContactList', 'TopicName' => 'TestNewsletter'], $content['ListManagementOptions']);
+            $this->assertSame([['Name' => 'X-Custom-Header', 'Value' => 'foobar']], $content['Content']['Simple']['Headers']);
 
             $json = '{"MessageId": "foobar"}';
 
@@ -115,6 +116,7 @@ class SesApiAsyncAwsTransportTest extends TestCase
         $mail->getHeaders()->addTextHeader('X-SES-CONFIGURATION-SET', 'aws-configuration-set-name');
         $mail->getHeaders()->addTextHeader('X-SES-SOURCE-ARN', 'aws-source-arn');
         $mail->getHeaders()->addTextHeader('X-SES-LIST-MANAGEMENT-OPTIONS', 'contactListName=TestContactList;topicName=TestNewsletter');
+        $mail->getHeaders()->addTextHeader('X-Custom-Header', 'foobar');
         $mail->getHeaders()->add(new MetadataHeader('tagName1', 'tag Value1'));
         $mail->getHeaders()->add(new MetadataHeader('tagName2', 'tag Value2'));
 

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=8.2",
-        "async-aws/ses": "^1.3",
+        "async-aws/ses": "^1.8",
         "symfony/mailer": "^7.2"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #45168 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

Until recently it was not possible to add custom headers when using AWS SES API with `Simple` mode, see #45168.
This problem is also mentioned in Mailer's docs:
> If you send custom headers when using the [Amazon SES](https://github.com/symfony/symfony/blob/7.1/src/Symfony/Component/Mailer/Bridge/Amazon/README.md) transport (to receive them later via a webhook), make sure to use the ses+https provider because it's the only one that supports them.

However, changes have been made to the SendEmail API and now this will be possible from approximately 2024/03/05.
References:
https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_SendEmail.html
https://awsapichanges.com/archive/changes/539fb6-email.html

In this change I add all custom headers to the request, excluding the standard ones, similar to other transports.

Example:
```php
$mail->getHeaders()->addTextHeader('X-Custom-Header', 'foobar');
```