### PR TITLE
[WebProfilerBundle] re-add missing profiler shortcuts on profiler homepage

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/results.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/results.html.twig
@@ -36,6 +36,7 @@
 
 {% block sidebar_search_css_class %}{% endblock %}
 {% block sidebar_shortcuts_links %}
+    {{ parent() }}
     {{ render(controller('web_profiler.controller.profiler::searchBarAction', query={type: profile_type }|merge(request.query.all))) }}
 {% endblock %}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58693
| License       | MIT
