### PR TITLE
[Messenger][RateLimiter] fix additional message handled when using a rate limiter

### DIFF
--- a/src/Symfony/Component/Messenger/Worker.php
+++ b/src/Symfony/Component/Messenger/Worker.php
@@ -86,7 +86,7 @@ class Worker
             // if queue names are specified, all receivers must implement the QueueReceiverInterface
             foreach ($this->receivers as $transportName => $receiver) {
                 if (!$receiver instanceof QueueReceiverInterface) {
-                    throw new RuntimeException(sprintf('Receiver for "%s" does not implement "%s".', $transportName, QueueReceiverInterface::class));
+                    throw new RuntimeException(\sprintf('Receiver for "%s" does not implement "%s".', $transportName, QueueReceiverInterface::class));
                 }
             }
         }
@@ -242,6 +242,7 @@ class Worker
 
         $this->eventDispatcher?->dispatch(new WorkerRateLimitedEvent($rateLimiter, $transportName));
         $rateLimiter->reserve()->wait();
+        $rateLimiter->consume();
     }
 
     private function flush(bool $force): bool


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #57230 
| License       | MIT

Fix additional message handled by Messenger when using a rate limiter. A token was reserved but not consumed. See #57230 

With the following configuration:
```yaml
framework:
  rate_limiter:
    test:
      policy: 'fixed_window'
      limit: 1
      interval: '10 seconds'

  messenger:
    transports:
      test:
        dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
        rate_limiter: 'test'
    routing:
      'App\Messenger\DoSomething': 'test'
```

Log generated by the MessageHandler:
```bash
$ bin/console messenger:consume test

                                                                                                                        
 [OK] Consuming messages from transport "test".                                                                         
                                                                                                                        

 // The worker will automatically exit once it has received a stop signal via the messenger:stop-workers command.       

 // Quit the worker with CONTROL-C.                                                                                     

 // Re-run the command with a -vv option to see logs about consumed messages.                                           

09:13:48 WARNING   [app] Message handled
09:13:58 WARNING   [app] Message handled
09:13:58 WARNING   [app] Message handled # Duplicated
09:14:08 WARNING   [app] Message handled
09:14:08 WARNING   [app] Message handled # Duplicated
09:14:18 WARNING   [app] Message handled
09:14:18 WARNING   [app] Message handled # Duplicated
```

After fix:
```bash
bin/console messenger:consume test

                                                                                                                        
 [OK] Consuming messages from transport "test".                                                                         
                                                                                                                        

 // The worker will automatically exit once it has received a stop signal via the messenger:stop-workers command.       

 // Quit the worker with CONTROL-C.                                                                                     

 // Re-run the command with a -vv option to see logs about consumed messages.                                           

09:18:54 WARNING   [app] Message handled
09:19:04 WARNING   [app] Message handled
09:19:14 WARNING   [app] Message handled
09:19:24 WARNING   [app] Message handled
```