### PR TITLE
[Mime] Don't require passing the encoder name to `TextPart`

### DIFF
--- a/src/Symfony/Component/Mime/Part/TextPart.php
+++ b/src/Symfony/Component/Mime/Part/TextPart.php
@@ -220,13 +220,13 @@ class TextPart extends AbstractPart
         return self::$encoders[$this->encoding];
     }
 
-    public static function addEncoder(string $name, ContentEncoderInterface $encoder): void
+    public static function addEncoder(ContentEncoderInterface $encoder): void
     {
-        if (\in_array($name, self::DEFAULT_ENCODERS, true)) {
+        if (\in_array($encoder->getName(), self::DEFAULT_ENCODERS, true)) {
             throw new InvalidArgumentException('You are not allowed to change the default encoders ("quoted-printable", "base64", and "8bit").');
         }
 
-        self::$encoders[$name] = $encoder;
+        self::$encoders[$encoder->getName()] = $encoder;
     }
 
     private function chooseEncoding(): string

--- a/src/Symfony/Component/Mime/Tests/Part/TextPartTest.php
+++ b/src/Symfony/Component/Mime/Tests/Part/TextPartTest.php
@@ -103,21 +103,29 @@ class TextPartTest extends TestCase
     public function testCustomEncoderNeedsToRegisterFirst()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The encoding must be one of "quoted-printable", "base64", "8bit", "exception_test" ("upper_encoder" given).');
-        TextPart::addEncoder('exception_test', $this->createMock(ContentEncoderInterface::class));
-        new TextPart('content', 'utf-8', 'plain', 'upper_encoder');
+        $this->expectExceptionMessage('The encoding must be one of "quoted-printable", "base64", "8bit", "upper_encoder" ("this_encoding_does_not_exist" given).');
+
+        $upperEncoder = $this->createMock(ContentEncoderInterface::class);
+        $upperEncoder->method('getName')->willReturn('upper_encoder');
+
+        TextPart::addEncoder($upperEncoder);
+        new TextPart('content', 'utf-8', 'plain', 'this_encoding_does_not_exist');
     }
 
     public function testOverwriteDefaultEncoder()
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('You are not allowed to change the default encoders ("quoted-printable", "base64", and "8bit").');
-        TextPart::addEncoder('8bit', $this->createMock(ContentEncoderInterface::class));
+
+        $base64Encoder = $this->createMock(ContentEncoderInterface::class);
+        $base64Encoder->method('getName')->willReturn('base64');
+
+        TextPart::addEncoder($base64Encoder);
     }
 
     public function testCustomEncoding()
     {
-        TextPart::addEncoder('upper_encoder', new class implements ContentEncoderInterface {
+        TextPart::addEncoder(new class implements ContentEncoderInterface {
             public function encodeByteStream($stream, int $maxLineLength = 0): iterable
             {
                 $filter = stream_filter_append($stream, 'string.toupper', \STREAM_FILTER_READ);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

While preparing this blog post: https://symfony.com/blog/new-in-symfony-7-2-mime-improvements

I realized that it's unnecessary to pass the encoder name as the first argument of `TextPart::addEncoder()` because the `ContentEncoderInterface` already requires defining a `getName()` method.