### PR TITLE
[Intl] skip tests requiring the intl extension if it's not installed

### DIFF
--- a/src/Symfony/Component/Intl/Tests/CountriesTest.php
+++ b/src/Symfony/Component/Intl/Tests/CountriesTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Intl\Tests;
 
 use Symfony\Component\Intl\Countries;
 use Symfony\Component\Intl\Exception\MissingResourceException;
+use Symfony\Component\Intl\Util\IntlTestHelper;
 
 /**
  * @group intl-data
@@ -535,6 +536,10 @@ class CountriesTest extends ResourceBundleTestCase
      */
     public function testGetNames($displayLocale)
     {
+        if ('en' !== $displayLocale) {
+            IntlTestHelper::requireFullIntl($this);
+        }
+
         $countries = array_keys(Countries::getNames($displayLocale));
 
         sort($countries);
@@ -544,6 +549,8 @@ class CountriesTest extends ResourceBundleTestCase
 
     public function testGetNamesDefaultLocale()
     {
+        IntlTestHelper::requireFullIntl($this);
+
         \Locale::setDefault('de_AT');
 
         $this->assertSame(Countries::getNames('de_AT'), Countries::getNames());
@@ -554,6 +561,10 @@ class CountriesTest extends ResourceBundleTestCase
      */
     public function testGetNamesSupportsAliases($alias, $ofLocale)
     {
+        if ('en' !== $ofLocale) {
+            IntlTestHelper::requireFullIntl($this);
+        }
+
         // Can't use assertSame(), because some aliases contain scripts with
         // different collation (=order of output) than their aliased locale
         // e.g. sr_Latn_ME => sr_ME
@@ -565,6 +576,10 @@ class CountriesTest extends ResourceBundleTestCase
      */
     public function testGetName($displayLocale)
     {
+        if ('en' !== $displayLocale) {
+            IntlTestHelper::requireFullIntl($this);
+        }
+
         $names = Countries::getNames($displayLocale);
 
         foreach ($names as $country => $name) {
@@ -636,6 +651,10 @@ class CountriesTest extends ResourceBundleTestCase
      */
     public function testGetAlpha3Name($displayLocale)
     {
+        if ('en' !== $displayLocale) {
+            IntlTestHelper::requireFullIntl($this);
+        }
+
         $names = Countries::getNames($displayLocale);
 
         foreach ($names as $alpha2 => $name) {
@@ -656,6 +675,10 @@ class CountriesTest extends ResourceBundleTestCase
      */
     public function testGetAlpha3Names($displayLocale)
     {
+        if ('en' !== $displayLocale) {
+            IntlTestHelper::requireFullIntl($this);
+        }
+
         $names = Countries::getAlpha3Names($displayLocale);
 
         $alpha3Codes = array_keys($names);

--- a/src/Symfony/Component/Intl/Tests/CurrenciesTest.php
+++ b/src/Symfony/Component/Intl/Tests/CurrenciesTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Intl\Tests;
 
 use Symfony\Component\Intl\Currencies;
 use Symfony\Component\Intl\Exception\MissingResourceException;
+use Symfony\Component\Intl\Util\IntlTestHelper;
 
 /**
  * @group intl-data
@@ -600,6 +601,10 @@ class CurrenciesTest extends ResourceBundleTestCase
      */
     public function testGetNames($displayLocale)
     {
+        if ('en' !== $displayLocale) {
+            IntlTestHelper::requireFullIntl($this);
+        }
+
         $names = Currencies::getNames($displayLocale);
 
         $keys = array_keys($names);
@@ -618,6 +623,8 @@ class CurrenciesTest extends ResourceBundleTestCase
 
     public function testGetNamesDefaultLocale()
     {
+        IntlTestHelper::requireFullIntl($this);
+
         \Locale::setDefault('de_AT');
 
         $this->assertSame(Currencies::getNames('de_AT'), Currencies::getNames());
@@ -628,6 +635,10 @@ class CurrenciesTest extends ResourceBundleTestCase
      */
     public function testGetNamesSupportsAliases($alias, $ofLocale)
     {
+        if ('en' !== $ofLocale) {
+            IntlTestHelper::requireFullIntl($this);
+        }
+
         // Can't use assertSame(), because some aliases contain scripts with
         // different collation (=order of output) than their aliased locale
         // e.g. sr_Latn_ME => sr_ME
@@ -639,6 +650,10 @@ class CurrenciesTest extends ResourceBundleTestCase
      */
     public function testGetName($displayLocale)
     {
+        if ('en' !== $displayLocale) {
+            IntlTestHelper::requireFullIntl($this);
+        }
+
         $expected = Currencies::getNames($displayLocale);
         $actual = [];
 
@@ -651,6 +666,8 @@ class CurrenciesTest extends ResourceBundleTestCase
 
     public function testGetNameDefaultLocale()
     {
+        IntlTestHelper::requireFullIntl($this);
+
         \Locale::setDefault('de_AT');
 
         $expected = Currencies::getNames('de_AT');

--- a/src/Symfony/Component/Intl/Tests/LanguagesTest.php
+++ b/src/Symfony/Component/Intl/Tests/LanguagesTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Intl\Tests;
 
 use Symfony\Component\Intl\Exception\MissingResourceException;
 use Symfony\Component\Intl\Languages;
+use Symfony\Component\Intl\Util\IntlTestHelper;
 
 /**
  * @group intl-data
@@ -1713,6 +1714,10 @@ class LanguagesTest extends ResourceBundleTestCase
      */
     public function testGetNames($displayLocale)
     {
+        if ('en' !== $displayLocale) {
+            IntlTestHelper::requireFullIntl($this);
+        }
+
         $languages = array_keys($names = Languages::getNames($displayLocale));
 
         sort($languages);
@@ -1730,6 +1735,8 @@ class LanguagesTest extends ResourceBundleTestCase
 
     public function testGetNamesDefaultLocale()
     {
+        IntlTestHelper::requireFullIntl($this);
+
         \Locale::setDefault('de_AT');
 
         $this->assertSame(Languages::getNames('de_AT'), Languages::getNames());
@@ -1740,6 +1747,10 @@ class LanguagesTest extends ResourceBundleTestCase
      */
     public function testGetNamesSupportsAliases($alias, $ofLocale)
     {
+        if ('en' !== $ofLocale) {
+            IntlTestHelper::requireFullIntl($this);
+        }
+
         // Can't use assertSame(), because some aliases contain scripts with
         // different collation (=order of output) than their aliased locale
         // e.g. sr_Latn_ME => sr_ME
@@ -1751,6 +1762,10 @@ class LanguagesTest extends ResourceBundleTestCase
      */
     public function testGetName($displayLocale)
     {
+        if ('en' !== $displayLocale) {
+            IntlTestHelper::requireFullIntl($this);
+        }
+
         $names = Languages::getNames($displayLocale);
 
         foreach ($names as $language => $name) {
@@ -1767,6 +1782,8 @@ class LanguagesTest extends ResourceBundleTestCase
 
     public function testGetNameDefaultLocale()
     {
+        IntlTestHelper::requireFullIntl($this);
+
         \Locale::setDefault('de_AT');
 
         $names = Languages::getNames('de_AT');
@@ -1877,6 +1894,10 @@ class LanguagesTest extends ResourceBundleTestCase
      */
     public function testGetAlpha3Name($displayLocale)
     {
+        if ('en' !== $displayLocale) {
+            IntlTestHelper::requireFullIntl($this);
+        }
+
         $names = Languages::getAlpha3Names($displayLocale);
 
         foreach ($names as $language => $name) {
@@ -1896,6 +1917,10 @@ class LanguagesTest extends ResourceBundleTestCase
      */
     public function testGetAlpha3Names($displayLocale)
     {
+        if ('en' !== $displayLocale) {
+            IntlTestHelper::requireFullIntl($this);
+        }
+
         $languages = array_keys($names = Languages::getAlpha3Names($displayLocale));
 
         sort($languages);

--- a/src/Symfony/Component/Intl/Tests/LocalesTest.php
+++ b/src/Symfony/Component/Intl/Tests/LocalesTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Intl\Tests;
 
 use Symfony\Component\Intl\Exception\MissingResourceException;
 use Symfony\Component\Intl\Locales;
+use Symfony\Component\Intl\Util\IntlTestHelper;
 
 /**
  * @group intl-data
@@ -34,6 +35,10 @@ class LocalesTest extends ResourceBundleTestCase
      */
     public function testGetNames($displayLocale)
     {
+        if ('en' !== $displayLocale) {
+            IntlTestHelper::requireFullIntl($this);
+        }
+
         $locales = array_keys(Locales::getNames($displayLocale));
 
         sort($locales);
@@ -46,6 +51,8 @@ class LocalesTest extends ResourceBundleTestCase
 
     public function testGetNamesDefaultLocale()
     {
+        IntlTestHelper::requireFullIntl($this);
+
         \Locale::setDefault('de_AT');
 
         $this->assertSame(Locales::getNames('de_AT'), Locales::getNames());
@@ -56,6 +63,10 @@ class LocalesTest extends ResourceBundleTestCase
      */
     public function testGetNamesSupportsAliases($alias, $ofLocale)
     {
+        if ('en' !== $ofLocale) {
+            IntlTestHelper::requireFullIntl($this);
+        }
+
         // Can't use assertSame(), because some aliases contain scripts with
         // different collation (=order of output) than their aliased locale
         // e.g. sr_Latn_ME => sr_ME
@@ -67,6 +78,10 @@ class LocalesTest extends ResourceBundleTestCase
      */
     public function testGetName($displayLocale)
     {
+        if ('en' !== $displayLocale) {
+            IntlTestHelper::requireFullIntl($this);
+        }
+
         $names = Locales::getNames($displayLocale);
 
         foreach ($names as $locale => $name) {
@@ -76,6 +91,8 @@ class LocalesTest extends ResourceBundleTestCase
 
     public function testGetNameDefaultLocale()
     {
+        IntlTestHelper::requireFullIntl($this);
+
         \Locale::setDefault('de_AT');
 
         $names = Locales::getNames('de_AT');

--- a/src/Symfony/Component/Intl/Tests/ScriptsTest.php
+++ b/src/Symfony/Component/Intl/Tests/ScriptsTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Intl\Tests;
 
 use Symfony\Component\Intl\Exception\MissingResourceException;
 use Symfony\Component\Intl\Scripts;
+use Symfony\Component\Intl\Util\IntlTestHelper;
 
 /**
  * @group intl-data
@@ -235,6 +236,10 @@ class ScriptsTest extends ResourceBundleTestCase
      */
     public function testGetNames($displayLocale)
     {
+        if ('en' !== $displayLocale) {
+            IntlTestHelper::requireFullIntl($this);
+        }
+
         $scripts = array_keys(Scripts::getNames($displayLocale));
 
         sort($scripts);
@@ -247,6 +252,8 @@ class ScriptsTest extends ResourceBundleTestCase
 
     public function testGetNamesDefaultLocale()
     {
+        IntlTestHelper::requireFullIntl($this);
+
         \Locale::setDefault('de_AT');
 
         $this->assertSame(Scripts::getNames('de_AT'), Scripts::getNames());
@@ -257,6 +264,10 @@ class ScriptsTest extends ResourceBundleTestCase
      */
     public function testGetNamesSupportsAliases($alias, $ofLocale)
     {
+        if ('en' !== $ofLocale) {
+            IntlTestHelper::requireFullIntl($this);
+        }
+
         // Can't use assertSame(), because some aliases contain scripts with
         // different collation (=order of output) than their aliased locale
         // e.g. sr_Latn_ME => sr_ME
@@ -268,6 +279,10 @@ class ScriptsTest extends ResourceBundleTestCase
      */
     public function testGetName($displayLocale)
     {
+        if ('en' !== $displayLocale) {
+            IntlTestHelper::requireFullIntl($this);
+        }
+
         $names = Scripts::getNames($displayLocale);
 
         foreach ($names as $script => $name) {
@@ -277,6 +292,8 @@ class ScriptsTest extends ResourceBundleTestCase
 
     public function testGetNameDefaultLocale()
     {
+        IntlTestHelper::requireFullIntl($this);
+
         \Locale::setDefault('de_AT');
 
         $names = Scripts::getNames('de_AT');

--- a/src/Symfony/Component/Intl/Tests/TimezonesTest.php
+++ b/src/Symfony/Component/Intl/Tests/TimezonesTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Intl\Tests;
 use Symfony\Component\Intl\Countries;
 use Symfony\Component\Intl\Exception\MissingResourceException;
 use Symfony\Component\Intl\Timezones;
+use Symfony\Component\Intl\Util\IntlTestHelper;
 
 /**
  * @group intl-data
@@ -468,6 +469,10 @@ class TimezonesTest extends ResourceBundleTestCase
      */
     public function testGetNames($displayLocale)
     {
+        if ('en' !== $displayLocale) {
+            IntlTestHelper::requireFullIntl($this);
+        }
+
         $zones = array_keys(Timezones::getNames($displayLocale));
 
         sort($zones);
@@ -478,6 +483,8 @@ class TimezonesTest extends ResourceBundleTestCase
 
     public function testGetNamesDefaultLocale()
     {
+        IntlTestHelper::requireFullIntl($this);
+
         \Locale::setDefault('de_AT');
 
         $this->assertSame(Timezones::getNames('de_AT'), Timezones::getNames());
@@ -488,6 +495,10 @@ class TimezonesTest extends ResourceBundleTestCase
      */
     public function testGetNamesSupportsAliases($alias, $ofLocale)
     {
+        if ('en' !== $ofLocale) {
+            IntlTestHelper::requireFullIntl($this);
+        }
+
         // Can't use assertSame(), because some aliases contain scripts with
         // different collation (=order of output) than their aliased locale
         // e.g. sr_Latn_ME => sr_ME
@@ -499,6 +510,10 @@ class TimezonesTest extends ResourceBundleTestCase
      */
     public function testGetName($displayLocale)
     {
+        if ('en' !== $displayLocale) {
+            IntlTestHelper::requireFullIntl($this);
+        }
+
         $names = Timezones::getNames($displayLocale);
 
         foreach ($names as $language => $name) {
@@ -508,6 +523,8 @@ class TimezonesTest extends ResourceBundleTestCase
 
     public function testGetNameDefaultLocale()
     {
+        IntlTestHelper::requireFullIntl($this);
+
         \Locale::setDefault('de_AT');
 
         $names = Timezones::getNames('de_AT');
@@ -603,6 +620,12 @@ class TimezonesTest extends ResourceBundleTestCase
      */
     public function testGetGmtOffsetAvailability(string $timezone)
     {
+        try {
+            new \DateTimeZone($timezone);
+        } catch (\Exception $e) {
+           $this->markTestSkipped(sprintf('The timezone "%s" is not available.', $timezone));
+        }
+
         // ensure each timezone identifier has a corresponding GMT offset
         Timezones::getRawOffset($timezone);
         Timezones::getGmtOffset($timezone);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT