### PR TITLE
[Messenger] use official YAML media type

### DIFF
--- a/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
@@ -173,7 +173,7 @@ class Serializer implements SerializerInterface
             'json' => 'application/json',
             'xml' => 'application/xml',
             'yml',
-            'yaml' => 'application/x-yaml',
+            'yaml' => 'application/yaml',
             'csv' => 'text/csv',
             default => null,
         };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | n/a
| License       | MIT

YAML is now a RFC and has an official media type: https://www.rfc-editor.org/rfc/rfc9512.html#name-media-type-application-yaml

However, this kind be a BC break, so I'm not sure if this should target 6.4 or 7.2.
