### PR TITLE
[FrameworkBundle] Generate `Config` class

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
  * Add `framework.type_info.aliases` option
  * Add `KernelBrowser::getSession()`
  * Add support for configuring workflow places with glob patterns matching consts/backed enums
+ * Add configuration class and config traits generation
 
 7.3
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ConfigBuilderCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ConfigBuilderCacheWarmer.php
@@ -13,7 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\CacheWarmer;
 
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Config\Builder\ConfigBuilderGenerator;
-use Symfony\Component\Config\Builder\ConfigBuilderGeneratorInterface;
+use Symfony\Component\Config\Builder\ConfigClassAwareBuilderGeneratorInterface;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -29,6 +29,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
  * Generate all config builders.
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
  *
  * @final since Symfony 7.1
  */
@@ -68,19 +69,31 @@ class ConfigBuilderCacheWarmer implements CacheWarmerInterface
             }
         }
 
+        $configurations = [];
         foreach ($extensions as $extension) {
+            if (null === $configuration = $this->getConfigurationFromExtension($extension)) {
+                continue;
+            }
+
+            $alias = lcfirst(str_replace('_', '', ucwords($extension->getAlias(), '_')));
+            $configurations[$alias] = $configuration;
+
             try {
-                $this->dumpExtension($extension, $generator);
+                $generator->build($configurations[$alias]);
             } catch (\Exception $e) {
                 $this->logger?->warning('Failed to generate ConfigBuilder for extension {extensionClass}: '.$e->getMessage(), ['exception' => $e, 'extensionClass' => $extension::class]);
             }
+        }
+
+        if ($generator instanceof ConfigClassAwareBuilderGeneratorInterface && $configurations) {
+            $generator->buildConfigClassAndTraits($configurations);
         }
 
         // No need to preload anything
         return [];
     }
 
-    private function dumpExtension(ExtensionInterface $extension, ConfigBuilderGeneratorInterface $generator): void
+    private function getConfigurationFromExtension(ExtensionInterface $extension): ?ConfigurationInterface
     {
         $configuration = null;
         if ($extension instanceof ConfigurationInterface) {
@@ -90,11 +103,7 @@ class ConfigBuilderCacheWarmer implements CacheWarmerInterface
             $configuration = $extension->getConfiguration([], new ContainerBuilder($container instanceof Container ? new ContainerBag($container) : new ParameterBag()));
         }
 
-        if (!$configuration) {
-            return;
-        }
-
-        $generator->build($configuration);
+        return $configuration;
     }
 
     public function isOptional(): bool

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/ConfigBuilderCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/ConfigBuilderCacheWarmerTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\CacheWarmer;
 use Symfony\Bundle\FrameworkBundle\CacheWarmer\ConfigBuilderCacheWarmer;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use Symfony\Component\Config\Builder\ConfigClassAwareBuilderGeneratorInterface;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -182,6 +183,11 @@ class ConfigBuilderCacheWarmerTest extends TestCase
         $warmer->warmUp($kernel->getCacheDir(), $kernel->getBuildDir());
 
         self::assertFileExists($kernel->getBuildDir().'/Symfony/Config/FrameworkConfig.php');
+
+        if (interface_exists(ConfigClassAwareBuilderGeneratorInterface::class)) {
+            self::assertFileExists($kernel->getBuildDir().'/Symfony/Config/FrameworkTrait.php');
+            self::assertFileExists($kernel->getBuildDir().'/Symfony/Config/Config.php');
+        }
     }
 
     public function testExtensionAddedInKernel()
@@ -222,6 +228,11 @@ class ConfigBuilderCacheWarmerTest extends TestCase
 
         self::assertFileExists($kernel->getBuildDir().'/Symfony/Config/FrameworkConfig.php');
         self::assertFileExists($kernel->getBuildDir().'/Symfony/Config/AppConfig.php');
+
+        if (interface_exists(ConfigClassAwareBuilderGeneratorInterface::class)) {
+            self::assertFileExists($kernel->getBuildDir().'/Symfony/Config/FrameworkTrait.php');
+            self::assertFileExists($kernel->getBuildDir().'/Symfony/Config/Config.php');
+        }
     }
 
     public function testKernelAsExtension()
@@ -267,6 +278,11 @@ class ConfigBuilderCacheWarmerTest extends TestCase
 
         self::assertFileExists($kernel->getBuildDir().'/Symfony/Config/FrameworkConfig.php');
         self::assertFileExists($kernel->getBuildDir().'/Symfony/Config/KernelConfig.php');
+
+        if (interface_exists(ConfigClassAwareBuilderGeneratorInterface::class)) {
+            self::assertFileExists($kernel->getBuildDir().'/Symfony/Config/FrameworkTrait.php');
+            self::assertFileExists($kernel->getBuildDir().'/Symfony/Config/Config.php');
+        }
     }
 
     public function testExtensionsExtendedInBuildMethods()
@@ -333,6 +349,11 @@ class ConfigBuilderCacheWarmerTest extends TestCase
         self::assertFileExists($kernel->getBuildDir().'/Symfony/Config/Security/FirewallConfig.php');
         self::assertFileExists($kernel->getBuildDir().'/Symfony/Config/Security/FirewallConfig/FormLoginConfig.php');
         self::assertFileExists($kernel->getBuildDir().'/Symfony/Config/Security/FirewallConfig/TokenConfig.php');
+
+        if (interface_exists(ConfigClassAwareBuilderGeneratorInterface::class)) {
+            self::assertFileExists($kernel->getBuildDir().'/Symfony/Config/FrameworkTrait.php');
+            self::assertFileExists($kernel->getBuildDir().'/Symfony/Config/Config.php');
+        }
     }
 }
 

--- a/src/Symfony/Component/Config/Builder/ArrayShapeGenerator.php
+++ b/src/Symfony/Component/Config/Builder/ArrayShapeGenerator.php
@@ -1,0 +1,153 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Builder;
+
+use Symfony\Component\Config\Definition\ArrayNode;
+use Symfony\Component\Config\Definition\BaseNode;
+use Symfony\Component\Config\Definition\BooleanNode;
+use Symfony\Component\Config\Definition\EnumNode;
+use Symfony\Component\Config\Definition\FloatNode;
+use Symfony\Component\Config\Definition\IntegerNode;
+use Symfony\Component\Config\Definition\NodeInterface;
+use Symfony\Component\Config\Definition\NumericNode;
+use Symfony\Component\Config\Definition\PrototypedArrayNode;
+use Symfony\Component\Config\Definition\ScalarNode;
+use Symfony\Component\Config\Definition\StringNode;
+use Symfony\Component\Config\Definition\VariableNode;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ *
+ * @internal
+ */
+final class ArrayShapeGenerator
+{
+    public static function generate(ArrayNode $node): string
+    {
+        return self::prependPhpDocWithStar(self::doGeneratePhpDoc($node));
+    }
+
+    private static function doGeneratePhpDoc(NodeInterface $node, int $nestingLevel = 1): string
+    {
+        if (!$node instanceof ArrayNode) {
+            return $node->getName();
+        }
+
+        if ($node instanceof PrototypedArrayNode) {
+            $isHashmap = (bool) $node->getKeyAttribute();
+
+            $prototype = $node->getPrototype();
+            if ($prototype instanceof ArrayNode) {
+                return 'array<'.($isHashmap ? 'string, ' : '').self::doGeneratePhpDoc($prototype, $nestingLevel).'>';
+            }
+
+            return 'array<'.($isHashmap ? 'string, ' : '').self::handleScalarNode($prototype).'>';
+        }
+
+        if (!($children = $node->getChildren()) && !$node->getParent() instanceof PrototypedArrayNode) {
+            return 'array<array-key, mixed>';
+        }
+
+        $arrayShape = \sprintf("array{%s\n", self::generateInlinePhpDocForNode($node));
+
+        /** @var NodeInterface $child */
+        foreach ($children as $child) {
+            $arrayShape .= str_repeat(' ', $nestingLevel * 4).self::dumpNodeKey($child).': ';
+
+            if ($child instanceof PrototypedArrayNode) {
+                $isHashmap = (bool) $child->getKeyAttribute();
+
+                $arrayShape .= 'array<'.($isHashmap ? 'string, ' : '').self::handleNode($child->getPrototype(), $nestingLevel).'>';
+            } else {
+                $arrayShape .= self::handleNode($child, $nestingLevel);
+            }
+
+            $arrayShape .= \sprintf(",%s\n", !$child instanceof ArrayNode ? self::generateInlinePhpDocForNode($child) : '');
+        }
+
+        return $arrayShape.str_repeat(' ', 4 * ($nestingLevel - 1)).'}';
+    }
+
+    private static function dumpNodeKey(NodeInterface $node): string
+    {
+        $name = $node->getName();
+        $quoted = str_starts_with($name, '@')
+            || \in_array(strtolower($name), ['int', 'float', 'bool', 'null', 'scalar'], true)
+            || strpbrk($name, '\'"');
+
+        if ($quoted) {
+            $name = "'".addslashes($name)."'";
+        }
+
+        return $name.($node->isRequired() ? '' : '?');
+    }
+
+    private static function handleNumericNode(NumericNode $node): string
+    {
+        $min = $node->getMin() ?? 'min';
+        $max = $node->getMax() ?? 'max';
+
+        if ($node instanceof IntegerNode) {
+            return \sprintf('int<%s, %s>', $min, $max);
+        } elseif ($node instanceof FloatNode) {
+            return 'float';
+        }
+
+        return \sprintf('int<%s, %s>|float', $min, $max);
+    }
+
+    private static function prependPhpDocWithStar(string $shape): string
+    {
+        return str_replace("\n", "\n * ", $shape);
+    }
+
+    private static function generateInlinePhpDocForNode(BaseNode $node): string
+    {
+        $comment = '';
+        if ($node->hasDefaultValue() || $node->getInfo() || $node->isDeprecated()) {
+            if ($node->isDeprecated()) {
+                $comment .= 'Deprecated: '.$node->getDeprecation($node->getName(), $node->getPath())['message'].' ';
+            }
+
+            if ($info = $node->getInfo()) {
+                $comment .= $info.' ';
+            }
+
+            if ($node->hasDefaultValue() && !\is_array($defaultValue = $node->getDefaultValue())) {
+                $comment .= 'Default: '.json_encode($defaultValue, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE | \JSON_PRESERVE_ZERO_FRACTION);
+            }
+        }
+
+        return $comment ? ' // '.rtrim(preg_replace('/\s+/', ' ', $comment)) : '';
+    }
+
+    private static function handleNode(NodeInterface $node, int $nestingLevel): string
+    {
+        if ($node instanceof ArrayNode) {
+            return self::doGeneratePhpDoc($node, 1 + $nestingLevel);
+        }
+
+        return self::handleScalarNode($node);
+    }
+
+    private static function handleScalarNode(NodeInterface $node): string
+    {
+        return match (true) {
+            $node instanceof BooleanNode => 'bool',
+            $node instanceof StringNode => 'string',
+            $node instanceof NumericNode => self::handleNumericNode($node),
+            $node instanceof EnumNode => $node->getPermissibleValues('|'),
+            $node instanceof ScalarNode => 'string|int|float|bool',
+            $node instanceof VariableNode => 'mixed',
+        };
+    }
+}

--- a/src/Symfony/Component/Config/Builder/ClassBuilder.php
+++ b/src/Symfony/Component/Config/Builder/ClassBuilder.php
@@ -31,6 +31,7 @@ class ClassBuilder
     private array $use = [];
     private array $implements = [];
     private bool $allowExtraKeys = false;
+    private array $traits = [];
 
     public function __construct(
         private string $namespace,
@@ -72,6 +73,9 @@ class ClassBuilder
 
         $implements = [] === $this->implements ? '' : 'implements '.implode(', ', $this->implements);
         $body = '';
+        foreach ($this->traits as $trait) {
+            $body .= '    use '.$trait.";\n";
+        }
         foreach ($this->properties as $property) {
             $body .= '    '.$property->getContent()."\n";
         }
@@ -105,6 +109,11 @@ BODY
     public function addUse(string $class): void
     {
         $this->use[$class] = true;
+    }
+
+    public function addTrait(string $trait): void
+    {
+        $this->traits[] = '\\'.ltrim($trait, '\\');
     }
 
     public function addImplements(string $interface): void

--- a/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
+++ b/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Config\Builder;
 
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Configuration;
 use Symfony\Component\Config\Definition\ArrayNode;
 use Symfony\Component\Config\Definition\BaseNode;
 use Symfony\Component\Config\Definition\BooleanNode;
@@ -25,13 +26,17 @@ use Symfony\Component\Config\Definition\PrototypedArrayNode;
 use Symfony\Component\Config\Definition\ScalarNode;
 use Symfony\Component\Config\Definition\VariableNode;
 use Symfony\Component\Config\Loader\ParamConfigurator;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\DependencyInjection\Resource\ImportsTrait;
+use Symfony\Component\DependencyInjection\Resource\ParametersTrait;
+use Symfony\Component\DependencyInjection\Resource\ServicesTrait;
 
 /**
  * Generate ConfigBuilders to help create valid config.
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class ConfigBuilderGenerator implements ConfigBuilderGeneratorInterface
+class ConfigBuilderGenerator implements ConfigBuilderGeneratorInterface, ConfigClassAwareBuilderGeneratorInterface
 {
     /**
      * @var ClassBuilder[]
@@ -55,9 +60,9 @@ class ConfigBuilderGenerator implements ConfigBuilderGeneratorInterface
 
         $path = $this->getFullPath($rootClass);
         if (!is_file($path)) {
-            // Generate the class if the file not exists
-            $this->classes[] = $rootClass;
+            // Generate the class if the file doesn't exist
             $this->buildNode($rootNode, $rootClass, $this->getSubNamespace($rootClass));
+            $this->buildConfigureOption($rootNode, $rootClass);
             $rootClass->addImplements(ConfigBuilderInterface::class);
             $rootClass->addMethod('getExtensionAlias', '
 public function NAME(): string
@@ -65,6 +70,7 @@ public function NAME(): string
     return \'ALIAS\';
 }', ['ALIAS' => $rootNode->getPath()]);
 
+            $this->writeRootClass($rootClass);
             $this->writeClasses();
         }
 
@@ -76,6 +82,68 @@ public function NAME(): string
         };
     }
 
+    /**
+     * @param array<Configuration> $configurations
+     */
+    public function buildConfigClassAndTraits(array $configurations): \Closure
+    {
+        $traitsClosure = (new ConfigTraitsGenerator($this->outputDir))->build($configurations);
+
+        $class = new ClassBuilder('Symfony\\Config', '');
+        $class->addTrait(ImportsTrait::class);
+        $class->addTrait(ParametersTrait::class);
+        $class->addTrait(ServicesTrait::class);
+        $class->addUse(ContainerConfigurator::class);
+
+        $class->addProperty('builders', 'array');
+
+        foreach ($configurations as $alias => $configuration) {
+            $class->addUse('Symfony\\Config\\'.ucfirst($this->camelCase($alias)).'Config');
+            $class->addTrait('Symfony\\Config\\'.ucfirst($this->camelCase($alias)).'Trait');
+        }
+
+        $configurationKeys = array_keys($configurations);
+
+        foreach ($configurationKeys as $configurationKey) {
+            $camelCaseKey = $this->camelCase($configurationKey);
+
+            $class->addProperty(sprintf('%sConfig', $camelCaseKey), sprintf('%sConfig', ucfirst($camelCaseKey)));
+        }
+
+        $class->addMethod('__construct', <<<'PHP'
+            public function __construct(public readonly ?string $env)
+            {
+            CONFIGS
+                $this->builders = [BUILDERS];
+            }
+            PHP, [
+                'BUILDERS' => implode(", ", array_map(fn ($alias) => sprintf('$this->%sConfig', $this->camelCase($alias)), $configurationKeys)),
+                'CONFIGS' => implode("\n", array_map(fn ($alias) => sprintf('    $this->%sConfig = new %sConfig();', $this->camelCase($alias), ucfirst($this->camelCase($alias))), $configurationKeys)),
+        ]);
+
+        $class->addMethod('getBuilders', <<<'PHP'
+            public function getBuilders(): array
+            {
+                return $this->builders;
+            }
+            PHP);
+
+        $path = $this->getFullPath($class);
+        file_put_contents($path, $class->build());
+
+        return function () use ($path, $traitsClosure) {
+            $traitsClosure();
+            return require_once $path;
+        };
+    }
+
+    private function camelCase(string $input): string
+    {
+        $output = lcfirst(str_replace(' ', '', ucwords(str_replace('_', ' ', $input))));
+
+        return preg_replace('#\W#', '', $output);
+    }
+
     private function getFullPath(ClassBuilder $class): string
     {
         $directory = $this->outputDir.\DIRECTORY_SEPARATOR.$class->getDirectory();
@@ -84,6 +152,18 @@ public function NAME(): string
         }
 
         return $directory.\DIRECTORY_SEPARATOR.$class->getFilename();
+    }
+
+    private function writeRootClass(ClassBuilder $rootClass): void
+    {
+        $this->buildConstructor($rootClass);
+        $this->buildToArray($rootClass, true);
+        if ($rootClass->getProperties()) {
+            $rootClass->addProperty('_usedProperties', null, '[]');
+        }
+        $this->buildSetExtraKey($rootClass);
+
+        file_put_contents($this->getFullPath($rootClass), $rootClass->build());
     }
 
     private function writeClasses(): void
@@ -100,6 +180,24 @@ public function NAME(): string
         }
 
         $this->classes = [];
+    }
+
+    private function buildConfigureOption(ArrayNode $node, ClassBuilder $class): void
+    {
+        $class->addProperty('configOutput', defaultValue: '[]');
+
+        $body = '
+public function NAME(
+    /** @var PHPDOC_ARRAY_SHAPE $config */
+    PARAM_TYPE $config = []): void
+{
+    $this->configOutput = $config;
+}';
+
+        $class->addMethod('configure', $body, [
+            'PARAM_TYPE' => 'array',
+            'PHPDOC_ARRAY_SHAPE' => str_replace("\n", "\n    ", ArrayShapeGenerator::generate($node)),
+        ]);
     }
 
     private function buildNode(NodeInterface $node, ClassBuilder $class, string $namespace): void
@@ -483,10 +581,24 @@ public function NAME($value): static
         return $name;
     }
 
-    private function buildToArray(ClassBuilder $class): void
+    private function buildToArray(ClassBuilder $class, bool $rootClass = false): void
     {
-        $body = '$output = [];';
+        $body = '';
+        if ($rootClass) {
+            $body = 'if ($this->configOutput) {
+        return $this->configOutput;
+    }
+
+    ';
+        }
+
+        $body .= '$output = [];';
+
         foreach ($class->getProperties() as $p) {
+            if ('configOutput' === $p->getName()) {
+                continue;
+            }
+
             $code = '$this->PROPERTY';
             if (null !== $p->getType()) {
                 if ($p->isArray()) {
@@ -523,6 +635,10 @@ public function NAME(): array
     {
         $body = '';
         foreach ($class->getProperties() as $p) {
+            if ('configOutput' === $p->getName()) {
+                continue;
+            }
+
             $code = '$value[\'ORG_NAME\']';
             if (null !== $p->getType()) {
                 if ($p->isArray()) {

--- a/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
+++ b/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
@@ -107,7 +107,7 @@ public function NAME(): string
         foreach ($configurationKeys as $configurationKey) {
             $camelCaseKey = $this->camelCase($configurationKey);
 
-            $class->addProperty(sprintf('%sConfig', $camelCaseKey), sprintf('%sConfig', ucfirst($camelCaseKey)));
+            $class->addProperty(\sprintf('%sConfig', $camelCaseKey), \sprintf('%sConfig', ucfirst($camelCaseKey)));
         }
 
         $class->addMethod('__construct', <<<'PHP'
@@ -117,8 +117,8 @@ public function NAME(): string
                 $this->builders = [BUILDERS];
             }
             PHP, [
-                'BUILDERS' => implode(", ", array_map(fn ($alias) => sprintf('$this->%sConfig', $this->camelCase($alias)), $configurationKeys)),
-                'CONFIGS' => implode("\n", array_map(fn ($alias) => sprintf('    $this->%sConfig = new %sConfig();', $this->camelCase($alias), ucfirst($this->camelCase($alias))), $configurationKeys)),
+            'BUILDERS' => implode(', ', array_map(fn ($alias) => \sprintf('$this->%sConfig', $this->camelCase($alias)), $configurationKeys)),
+            'CONFIGS' => implode("\n", array_map(fn ($alias) => \sprintf('    $this->%sConfig = new %sConfig();', $this->camelCase($alias), ucfirst($this->camelCase($alias))), $configurationKeys)),
         ]);
 
         $class->addMethod('getBuilders', <<<'PHP'
@@ -133,6 +133,7 @@ public function NAME(): string
 
         return function () use ($path, $traitsClosure) {
             $traitsClosure();
+
             return require_once $path;
         };
     }

--- a/src/Symfony/Component/Config/Builder/ConfigClassAwareBuilderGeneratorInterface.php
+++ b/src/Symfony/Component/Config/Builder/ConfigClassAwareBuilderGeneratorInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Builder;
+
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ */
+interface ConfigClassAwareBuilderGeneratorInterface
+{
+    /**
+     * @param array<string, ConfigurationInterface> $configurations Configurations indexed by their alias
+     */
+    public function buildConfigClassAndTraits(array $configurations): \Closure;
+}

--- a/src/Symfony/Component/Config/Builder/ConfigTraitsGenerator.php
+++ b/src/Symfony/Component/Config/Builder/ConfigTraitsGenerator.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Builder;
+
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ *
+ * @internal
+ */
+final class ConfigTraitsGenerator
+{
+    public function __construct(
+        private string $outputDir,
+    ) {
+    }
+
+    /**
+     * @param array<string, ConfigurationInterface> $configurations Configurations indexed by their alias
+     */
+    public function build(array $configurations): \Closure
+    {
+        $paths = [];
+        foreach ($configurations as $alias => $configuration) {
+            if (trait_exists('\Symfony\Config\\'.$alias.'Trait')) {
+                continue;
+            }
+
+            $class = new TraitBuilder('Symfony\Config', $alias);
+            $class->addMethod($alias, <<<'PHP'
+            /**
+             * @param COMMENT $config
+             */
+            public function NAME(array $config): static
+            {
+                $this->NAMEConfig->configure($config);
+
+                return $this;
+            }
+            PHP, [
+                'COMMENT' => ArrayShapeGenerator::generate($configuration->getConfigTreeBuilder()->buildTree()),
+                'NAME' => $alias,
+            ]);
+
+            $path = $this->getFullPath($class);
+            file_put_contents($path, $class->build());
+
+            $paths[] = $path;
+        }
+
+        return function () use ($paths) {
+            foreach ($paths as $path) {
+                require_once $path;
+            }
+        };
+    }
+
+    private function getFullPath(ClassBuilder|TraitBuilder $class): string
+    {
+        $directory = $this->outputDir . \DIRECTORY_SEPARATOR . $class->getDirectory();
+        if (!is_dir($directory)) {
+            @mkdir($directory, 0777, true);
+        }
+
+        return $directory . \DIRECTORY_SEPARATOR . $class->getFilename();
+    }
+}

--- a/src/Symfony/Component/Config/Builder/ConfigTraitsGenerator.php
+++ b/src/Symfony/Component/Config/Builder/ConfigTraitsGenerator.php
@@ -38,16 +38,16 @@ final class ConfigTraitsGenerator
 
             $class = new TraitBuilder('Symfony\Config', $alias);
             $class->addMethod($alias, <<<'PHP'
-            /**
-             * @param COMMENT $config
-             */
-            public function NAME(array $config): static
-            {
-                $this->NAMEConfig->configure($config);
+                /**
+                 * @param COMMENT $config
+                 */
+                public function NAME(array $config): static
+                {
+                    $this->NAMEConfig->configure($config);
 
-                return $this;
-            }
-            PHP, [
+                    return $this;
+                }
+                PHP, [
                 'COMMENT' => ArrayShapeGenerator::generate($configuration->getConfigTreeBuilder()->buildTree()),
                 'NAME' => $alias,
             ]);
@@ -67,11 +67,11 @@ final class ConfigTraitsGenerator
 
     private function getFullPath(ClassBuilder|TraitBuilder $class): string
     {
-        $directory = $this->outputDir . \DIRECTORY_SEPARATOR . $class->getDirectory();
+        $directory = $this->outputDir.\DIRECTORY_SEPARATOR.$class->getDirectory();
         if (!is_dir($directory)) {
-            @mkdir($directory, 0777, true);
+            @mkdir($directory, 0o777, true);
         }
 
-        return $directory . \DIRECTORY_SEPARATOR . $class->getFilename();
+        return $directory.\DIRECTORY_SEPARATOR.$class->getFilename();
     }
 }

--- a/src/Symfony/Component/Config/Builder/TraitBuilder.php
+++ b/src/Symfony/Component/Config/Builder/TraitBuilder.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Builder;
+
+/**
+ * Build PHP classes to generate config.
+ *
+ * @internal
+ *
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ */
+class TraitBuilder
+{
+    private string $name;
+
+    /** @var Method[] */
+    private array $methods = [];
+    private array $use = [];
+
+    public function __construct(
+        private string $namespace,
+        string $name,
+    ) {
+        $this->name = ucfirst($this->camelCase($name)).'Trait';
+    }
+
+    public function getDirectory(): string
+    {
+        return str_replace('\\', \DIRECTORY_SEPARATOR, $this->namespace);
+    }
+
+    public function getFilename(): string
+    {
+        return $this->name.'.php';
+    }
+
+    public function build(): string
+    {
+        $use = '';
+        foreach (array_keys($this->use) as $statement) {
+            $use .= \sprintf('use %s;', $statement)."\n";
+        }
+
+        $body = '';
+        foreach ($this->methods as $method) {
+            $lines = explode("\n", $method->getContent());
+            foreach ($lines as $line) {
+                $body .= ($line ? '    '.$line : '')."\n";
+            }
+        }
+
+        return strtr('<?php
+
+namespace NAMESPACE;
+
+USE
+/**
+ * This trait is automatically generated to help in creating a config.
+ */
+trait TRAIT
+{
+BODY
+}
+', ['NAMESPACE' => $this->namespace, 'USE' => $use, 'TRAIT' => $this->getName(), 'BODY' => $body]);
+    }
+
+    public function addUse(string $class): void
+    {
+        $this->use[$class] = true;
+    }
+
+    public function addMethod(string $name, string $body, array $params = []): void
+    {
+        $this->methods[] = new Method(strtr($body, ['NAME' => $this->camelCase($name)] + $params));
+    }
+
+    private function camelCase(string $input): string
+    {
+        $output = lcfirst(str_replace(' ', '', ucwords(str_replace('_', ' ', $input))));
+
+        return preg_replace('#\W#', '', $output);
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getNamespace(): string
+    {
+        return $this->namespace;
+    }
+
+    public function getFqcn(): string
+    {
+        return '\\'.$this->namespace.'\\'.$this->name;
+    }
+}

--- a/src/Symfony/Component/Config/Definition/NumericNode.php
+++ b/src/Symfony/Component/Config/Definition/NumericNode.php
@@ -50,6 +50,16 @@ class NumericNode extends ScalarNode
         return $value;
     }
 
+    public function getMin(): float|int|null
+    {
+        return $this->min;
+    }
+
+    public function getMax(): float|int|null
+    {
+        return $this->max;
+    }
+
     protected function isValueEmpty(mixed $value): bool
     {
         // a numeric value cannot be empty

--- a/src/Symfony/Component/Config/Tests/Builder/ArrayShapeGeneratorTest.php
+++ b/src/Symfony/Component/Config/Tests/Builder/ArrayShapeGeneratorTest.php
@@ -1,0 +1,165 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Tests\Builder;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Builder\ArrayShapeGenerator;
+use Symfony\Component\Config\Definition\ArrayNode;
+use Symfony\Component\Config\Definition\BooleanNode;
+use Symfony\Component\Config\Definition\EnumNode;
+use Symfony\Component\Config\Definition\FloatNode;
+use Symfony\Component\Config\Definition\IntegerNode;
+use Symfony\Component\Config\Definition\NodeInterface;
+use Symfony\Component\Config\Definition\PrototypedArrayNode;
+use Symfony\Component\Config\Definition\ScalarNode;
+use Symfony\Component\Config\Definition\StringNode;
+use Symfony\Component\Config\Definition\VariableNode;
+
+class ArrayShapeGeneratorTest extends TestCase
+{
+    #[DataProvider('provideNodes')]
+    public function testPhpDocHandlesNodeTypes(NodeInterface $node, string $expected)
+    {
+        $arrayNode = new ArrayNode('root');
+        $arrayNode->addChild($node);
+
+        $expected = 'node?: '.$expected;
+
+        $this->assertStringContainsString($expected, ArrayShapeGenerator::generate($arrayNode));
+    }
+
+    public static function provideNodes(): iterable
+    {
+        yield [new ArrayNode('node'), 'array<array-key, mixed>'];
+
+        yield [new StringNode('node'), 'string'];
+
+        yield [new BooleanNode('node'), 'bool'];
+        yield [new EnumNode('node', values: ['a', 'b']), '"a"|"b"'];
+        yield [new ScalarNode('node'), 'string|int|float|bool'];
+        yield [new VariableNode('node'), 'mixed'];
+
+        yield [new IntegerNode('node'), 'int<min, max>'];
+        yield [new IntegerNode('node', min: 1), 'int<1, max>'];
+        yield [new IntegerNode('node', max: 10), 'int<min, 10>'];
+        yield [new IntegerNode('node', min: 1, max: 10), 'int<1, 10>'];
+
+        yield [new FloatNode('node'), 'float'];
+        yield [new FloatNode('node', min: 1.1), 'float'];
+        yield [new FloatNode('node', max: 10.1), 'float'];
+        yield [new FloatNode('node', min: 1.1, max: 10.1), 'float'];
+    }
+
+    public function testPrototypedArrayNodePhpDoc()
+    {
+        $prototype = new PrototypedArrayNode('proto');
+        $prototype->setPrototype(new StringNode('child'));
+
+        $root = new ArrayNode('root');
+        $root->addChild($prototype);
+
+        $expected = "array{\n *     proto?: array<string>,\n * }";
+
+        $this->assertStringContainsString($expected, ArrayShapeGenerator::generate($root));
+    }
+
+    public function testPrototypedArrayNodePhpDocWithKeyAttribute()
+    {
+        $prototype = new PrototypedArrayNode('proto');
+        $prototype->setPrototype(new StringNode('child'));
+        $prototype->setKeyAttribute('name');
+
+        $root = new ArrayNode('root');
+        $root->addChild($prototype);
+
+        $expected = "array{\n *     proto?: array<string, string>,\n * }";
+
+        $this->assertStringContainsString($expected, ArrayShapeGenerator::generate($root));
+    }
+
+    public function testPhpDocHandlesRequiredNode()
+    {
+        $child = new BooleanNode('node');
+        $child->setRequired(true);
+
+        $root = new ArrayNode('root');
+        $root->addChild($child);
+
+        $expected = 'node: bool';
+
+        $this->assertStringContainsString($expected, ArrayShapeGenerator::generate($root));
+    }
+
+    public function testPhpDocHandleAdditionalDocumentation()
+    {
+        $child = new BooleanNode('node');
+        $child->setDeprecated('vendor/package', '1.0', 'The "%path%" option is deprecated.');
+        $child->setDefaultValue(true);
+        $child->setInfo('This is a boolean node.');
+
+        $root = new ArrayNode('root');
+        $root->addChild($child);
+
+        $this->assertStringContainsString('node?: bool, // Deprecated: The "node" option is deprecated. This is a boolean node. Default: true', ArrayShapeGenerator::generate($root));
+    }
+
+    public function testPhpDocHandleMultilineDoc()
+    {
+        $child = new BooleanNode('node');
+        $child->setDeprecated('vendor/package', '1.0', 'The "%path%" option is deprecated.');
+        $child->setDefaultValue(true);
+        $child->setInfo("This is a boolean node.\nSet to true to enable it.\r\nSet to false to disable it.");
+
+        $root = new ArrayNode('root');
+        $root->addChild($child);
+
+        $this->assertStringContainsString('node?: bool, // Deprecated: The "node" option is deprecated. This is a boolean node. Set to true to enable it. Set to false to disable it. Default: true', ArrayShapeGenerator::generate($root));
+    }
+
+    public function testPhpDocShapeSingleLevel()
+    {
+        $root = new ArrayNode('root');
+
+        $this->assertStringMatchesFormat('array<%s>', ArrayShapeGenerator::generate($root));
+    }
+
+    public function testPhpDocShapeMultiLevel()
+    {
+        $root = new ArrayNode('root');
+        $child = new ArrayNode('child');
+        $root->addChild($child);
+
+        $this->assertStringMatchesFormat('array{%Achild?: array<%s>,%A}', ArrayShapeGenerator::generate($root));
+    }
+
+    #[DataProvider('provideQuotedNodes')]
+    public function testPhpdocQuoteNodeName(NodeInterface $node, string $expected)
+    {
+        $arrayNode = new ArrayNode('root');
+        $arrayNode->addChild($node);
+
+        $this->assertStringContainsString($expected, ArrayShapeGenerator::generate($arrayNode));
+    }
+
+    public static function provideQuotedNodes(): \Generator
+    {
+        yield [new StringNode('int'), "'int'"];
+        yield [new StringNode('float'), "'float'"];
+        yield [new StringNode('null'), "'null'"];
+        yield [new StringNode('bool'), "'bool'"];
+        yield [new StringNode('scalar'), "'scalar'"];
+        yield [new StringNode('hell"o'), "'hell\\\"o'"];
+        yield [new StringNode("hell'o"), "'hell\\'o'"];
+        yield [new StringNode('@key'), "'@key'"];
+    }
+}

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList.config_function_output.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList.config_function_output.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Symfony\Config;
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Config\AddToListConfig;
+
+/**
+ * This class is automatically generated to help in creating a config.
+ */
+class Config 
+{
+    use \Symfony\Component\DependencyInjection\Resource\ImportsTrait;
+    use \Symfony\Component\DependencyInjection\Resource\ParametersTrait;
+    use \Symfony\Component\DependencyInjection\Resource\ServicesTrait;
+    use \Symfony\Config\AddToListTrait;
+    private $builders;
+    private $addToListConfig;
+    public function __construct(public readonly ?string $env)
+    {
+        $this->addToListConfig = new AddToListConfig();
+        $this->builders = [$this->addToListConfig];
+    }
+    public function getBuilders(): array
+    {
+        return $this->builders;
+    }
+
+}

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToListConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToListConfig.php
@@ -14,6 +14,7 @@ class AddToListConfig implements \Symfony\Component\Config\Builder\ConfigBuilder
 {
     private $translator;
     private $messenger;
+    private $configOutput = [];
     private $_usedProperties = [];
 
     public function translator(array $value = []): \Symfony\Config\AddToList\TranslatorConfig
@@ -38,6 +39,33 @@ class AddToListConfig implements \Symfony\Component\Config\Builder\ConfigBuilder
         }
 
         return $this->messenger;
+    }
+
+    public function configure(
+        /** @var array{
+         *     translator?: array{
+         *         fallbacks?: array<string|int|float|bool>,
+         *         sources?: array<string, string|int|float|bool>,
+         *         books?: array{ // Deprecated: The child node "books" at path "add_to_list.translator.books" is deprecated. looks for translation in old fashion way
+         *             page?: array<array{
+         *                 number?: int<min, max>,
+         *                 content?: string|int|float|bool,
+         *             }>,
+         *         },
+         *     },
+         *     messenger?: array{
+         *         routing?: array<string, array{
+         *             senders?: array<string|int|float|bool>,
+         *         }>,
+         *         receiving?: array<array{
+         *             priority?: int<min, max>,
+         *             color?: string|int|float|bool,
+         *         }>,
+         *     },
+         * } $config */
+        array $config = []): void
+    {
+        $this->configOutput = $config;
     }
 
     public function getExtensionAlias(): string
@@ -66,6 +94,10 @@ class AddToListConfig implements \Symfony\Component\Config\Builder\ConfigBuilder
 
     public function toArray(): array
     {
+        if ($this->configOutput) {
+            return $this->configOutput;
+        }
+
         $output = [];
         if (isset($this->_usedProperties['translator'])) {
             $output['translator'] = $this->translator->toArray();

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys.config_function_output.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys.config_function_output.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Symfony\Config;
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Config\ArrayExtraKeysConfig;
+
+/**
+ * This class is automatically generated to help in creating a config.
+ */
+class Config 
+{
+    use \Symfony\Component\DependencyInjection\Resource\ImportsTrait;
+    use \Symfony\Component\DependencyInjection\Resource\ParametersTrait;
+    use \Symfony\Component\DependencyInjection\Resource\ServicesTrait;
+    use \Symfony\Config\ArrayExtraKeysTrait;
+    private $builders;
+    private $arrayExtraKeysConfig;
+    public function __construct(public readonly ?string $env)
+    {
+        $this->arrayExtraKeysConfig = new ArrayExtraKeysConfig();
+        $this->builders = [$this->arrayExtraKeysConfig];
+    }
+    public function getBuilders(): array
+    {
+        return $this->builders;
+    }
+
+}

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeysConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeysConfig.php
@@ -16,6 +16,7 @@ class ArrayExtraKeysConfig implements \Symfony\Component\Config\Builder\ConfigBu
     private $foo;
     private $bar;
     private $baz;
+    private $configOutput = [];
     private $_usedProperties = [];
 
     public function foo(array $value = []): \Symfony\Config\ArrayExtraKeys\FooConfig
@@ -47,6 +48,23 @@ class ArrayExtraKeysConfig implements \Symfony\Component\Config\Builder\ConfigBu
         }
 
         return $this->baz;
+    }
+
+    public function configure(
+        /** @var array{
+         *     foo?: array{
+         *         baz?: string|int|float|bool,
+         *         qux?: string|int|float|bool,
+         *     },
+         *     bar?: array<array{
+         *         corge?: string|int|float|bool,
+         *         grault?: string|int|float|bool,
+         *     }>,
+         *     baz?: array<array-key, mixed>,
+         * } $config */
+        array $config = []): void
+    {
+        $this->configOutput = $config;
     }
 
     public function getExtensionAlias(): string
@@ -81,6 +99,10 @@ class ArrayExtraKeysConfig implements \Symfony\Component\Config\Builder\ConfigBu
 
     public function toArray(): array
     {
+        if ($this->configOutput) {
+            return $this->configOutput;
+        }
+
         $output = [];
         if (isset($this->_usedProperties['foo'])) {
             $output['foo'] = $this->foo->toArray();

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayValues/Symfony/Config/ArrayValuesConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayValues/Symfony/Config/ArrayValuesConfig.php
@@ -14,6 +14,7 @@ class ArrayValuesConfig implements \Symfony\Component\Config\Builder\ConfigBuild
 {
     private $transports;
     private $errorPages;
+    private $configOutput = [];
     private $_usedProperties = [];
 
     /**
@@ -56,6 +57,21 @@ class ArrayValuesConfig implements \Symfony\Component\Config\Builder\ConfigBuild
         return $this->errorPages;
     }
 
+    public function configure(
+        /** @var array{
+         *     transports?: array<string, array{
+         *         dsn?: string|int|float|bool,
+         *     }>,
+         *     error_pages?: array{
+         *         enabled?: bool, // Default: false
+         *         with_trace?: bool,
+         *     },
+         * } $config */
+        array $config = []): void
+    {
+        $this->configOutput = $config;
+    }
+
     public function getExtensionAlias(): string
     {
         return 'array_values';
@@ -82,6 +98,10 @@ class ArrayValuesConfig implements \Symfony\Component\Config\Builder\ConfigBuild
 
     public function toArray(): array
     {
+        if ($this->configOutput) {
+            return $this->configOutput;
+        }
+
         $output = [];
         if (isset($this->_usedProperties['transports'])) {
             $output['transports'] = array_map(fn ($v) => $v instanceof \Symfony\Config\ArrayValues\TransportsConfig ? $v->toArray() : $v, $this->transports);

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues.config_function_output.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues.config_function_output.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Symfony\Config;
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Config\NodeInitialValuesConfig;
+
+/**
+ * This class is automatically generated to help in creating a config.
+ */
+class Config 
+{
+    use \Symfony\Component\DependencyInjection\Resource\ImportsTrait;
+    use \Symfony\Component\DependencyInjection\Resource\ParametersTrait;
+    use \Symfony\Component\DependencyInjection\Resource\ServicesTrait;
+    use \Symfony\Config\NodeInitialValuesTrait;
+    private $builders;
+    private $nodeInitialValuesConfig;
+    public function __construct(public readonly ?string $env)
+    {
+        $this->nodeInitialValuesConfig = new NodeInitialValuesConfig();
+        $this->builders = [$this->nodeInitialValuesConfig];
+    }
+    public function getBuilders(): array
+    {
+        return $this->builders;
+    }
+
+}

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValuesConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValuesConfig.php
@@ -14,6 +14,7 @@ class NodeInitialValuesConfig implements \Symfony\Component\Config\Builder\Confi
 {
     private $someCleverName;
     private $messenger;
+    private $configOutput = [];
     private $_usedProperties = [];
 
     public function someCleverName(array $value = []): \Symfony\Config\NodeInitialValues\SomeCleverNameConfig
@@ -38,6 +39,26 @@ class NodeInitialValuesConfig implements \Symfony\Component\Config\Builder\Confi
         }
 
         return $this->messenger;
+    }
+
+    public function configure(
+        /** @var array{
+         *     some_clever_name?: array{
+         *         first?: string|int|float|bool,
+         *         second?: string|int|float|bool,
+         *         third?: string|int|float|bool,
+         *     },
+         *     messenger?: array{
+         *         transports?: array<string, array{
+         *             dsn?: string|int|float|bool, // The DSN to use. This is a required option. The info is used to describe the DSN, it can be multi-line.
+         *             serializer?: string|int|float|bool, // Default: null
+         *             options?: array<mixed>,
+         *         }>,
+         *     },
+         * } $config */
+        array $config = []): void
+    {
+        $this->configOutput = $config;
     }
 
     public function getExtensionAlias(): string
@@ -66,6 +87,10 @@ class NodeInitialValuesConfig implements \Symfony\Component\Config\Builder\Confi
 
     public function toArray(): array
     {
+        if ($this->configOutput) {
+            return $this->configOutput;
+        }
+
         $output = [];
         if (isset($this->_usedProperties['someCleverName'])) {
             $output['some_clever_name'] = $this->someCleverName->toArray();

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/Placeholders.config_function_output.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/Placeholders.config_function_output.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Symfony\Config;
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Config\PlaceholdersConfig;
+
+/**
+ * This class is automatically generated to help in creating a config.
+ */
+class Config 
+{
+    use \Symfony\Component\DependencyInjection\Resource\ImportsTrait;
+    use \Symfony\Component\DependencyInjection\Resource\ParametersTrait;
+    use \Symfony\Component\DependencyInjection\Resource\ServicesTrait;
+    use \Symfony\Config\PlaceholdersTrait;
+    private $builders;
+    private $placeholdersConfig;
+    public function __construct(public readonly ?string $env)
+    {
+        $this->placeholdersConfig = new PlaceholdersConfig();
+        $this->builders = [$this->placeholdersConfig];
+    }
+    public function getBuilders(): array
+    {
+        return $this->builders;
+    }
+
+}

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/Placeholders/Symfony/Config/PlaceholdersConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/Placeholders/Symfony/Config/PlaceholdersConfig.php
@@ -13,6 +13,7 @@ class PlaceholdersConfig implements \Symfony\Component\Config\Builder\ConfigBuil
     private $enabled;
     private $favoriteFloat;
     private $goodIntegers;
+    private $configOutput = [];
     private $_usedProperties = [];
 
     /**
@@ -54,6 +55,17 @@ class PlaceholdersConfig implements \Symfony\Component\Config\Builder\ConfigBuil
         return $this;
     }
 
+    public function configure(
+        /** @var array{
+         *     enabled?: bool, // Default: false
+         *     favorite_float?: float,
+         *     good_integers?: array<int<min, max>>,
+         * } $config */
+        array $config = []): void
+    {
+        $this->configOutput = $config;
+    }
+
     public function getExtensionAlias(): string
     {
         return 'placeholders';
@@ -86,6 +98,10 @@ class PlaceholdersConfig implements \Symfony\Component\Config\Builder\ConfigBuil
 
     public function toArray(): array
     {
+        if ($this->configOutput) {
+            return $this->configOutput;
+        }
+
         $output = [];
         if (isset($this->_usedProperties['enabled'])) {
             $output['enabled'] = $this->enabled;

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/PrimitiveTypes.config_function_output.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/PrimitiveTypes.config_function_output.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Symfony\Config;
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Config\PrimitiveTypesConfig;
+
+/**
+ * This class is automatically generated to help in creating a config.
+ */
+class Config 
+{
+    use \Symfony\Component\DependencyInjection\Resource\ImportsTrait;
+    use \Symfony\Component\DependencyInjection\Resource\ParametersTrait;
+    use \Symfony\Component\DependencyInjection\Resource\ServicesTrait;
+    use \Symfony\Config\PrimitiveTypesTrait;
+    private $builders;
+    private $primitiveTypesConfig;
+    public function __construct(public readonly ?string $env)
+    {
+        $this->primitiveTypesConfig = new PrimitiveTypesConfig();
+        $this->builders = [$this->primitiveTypesConfig];
+    }
+    public function getBuilders(): array
+    {
+        return $this->builders;
+    }
+
+}

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/PrimitiveTypes/Symfony/Config/PrimitiveTypesConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/PrimitiveTypes/Symfony/Config/PrimitiveTypesConfig.php
@@ -18,6 +18,7 @@ class PrimitiveTypesConfig implements \Symfony\Component\Config\Builder\ConfigBu
     private $integerNode;
     private $scalarNode;
     private $scalarNodeWithDefault;
+    private $configOutput = [];
     private $_usedProperties = [];
 
     /**
@@ -124,6 +125,22 @@ class PrimitiveTypesConfig implements \Symfony\Component\Config\Builder\ConfigBu
         return $this;
     }
 
+    public function configure(
+        /** @var array{
+         *     boolean_node?: bool,
+         *     enum_node?: "foo"|"bar"|"baz"|Symfony\Component\Config\Tests\Fixtures\TestEnum::Bar,
+         *     fqcn_enum_node?: foo|bar,
+         *     fqcn_unit_enum_node?: Symfony\Component\Config\Tests\Fixtures\TestEnum::Foo|Symfony\Component\Config\Tests\Fixtures\TestEnum::Bar|Symfony\Component\Config\Tests\Fixtures\TestEnum::Ccc,
+         *     float_node?: float,
+         *     integer_node?: int<min, max>,
+         *     scalar_node?: string|int|float|bool,
+         *     scalar_node_with_default?: string|int|float|bool, // Default: true
+         * } $config */
+        array $config = []): void
+    {
+        $this->configOutput = $config;
+    }
+
     public function getExtensionAlias(): string
     {
         return 'primitive_types';
@@ -186,6 +203,10 @@ class PrimitiveTypesConfig implements \Symfony\Component\Config\Builder\ConfigBu
 
     public function toArray(): array
     {
+        if ($this->configOutput) {
+            return $this->configOutput;
+        }
+
         $output = [];
         if (isset($this->_usedProperties['booleanNode'])) {
             $output['boolean_node'] = $this->booleanNode;

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes.config_function_output.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes.config_function_output.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Symfony\Config;
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Config\ScalarNormalizedTypesConfig;
+
+/**
+ * This class is automatically generated to help in creating a config.
+ */
+class Config 
+{
+    use \Symfony\Component\DependencyInjection\Resource\ImportsTrait;
+    use \Symfony\Component\DependencyInjection\Resource\ParametersTrait;
+    use \Symfony\Component\DependencyInjection\Resource\ServicesTrait;
+    use \Symfony\Config\ScalarNormalizedTypesTrait;
+    private $builders;
+    private $scalarNormalizedTypesConfig;
+    public function __construct(public readonly ?string $env)
+    {
+        $this->scalarNormalizedTypesConfig = new ScalarNormalizedTypesConfig();
+        $this->builders = [$this->scalarNormalizedTypesConfig];
+    }
+    public function getBuilders(): array
+    {
+        return $this->builders;
+    }
+
+}

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypesConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypesConfig.php
@@ -21,6 +21,7 @@ class ScalarNormalizedTypesConfig implements \Symfony\Component\Config\Builder\C
     private $listObject;
     private $keyedListObject;
     private $nested;
+    private $configOutput = [];
     private $_usedProperties = [];
 
     /**
@@ -128,6 +129,37 @@ class ScalarNormalizedTypesConfig implements \Symfony\Component\Config\Builder\C
         return $this->nested;
     }
 
+    public function configure(
+        /** @var array{
+         *     simple_array?: array<string|int|float|bool>,
+         *     keyed_array?: array<string, array<string|int|float|bool>>,
+         *     object?: array{
+         *         enabled?: bool, // Default: null
+         *         date_format?: string|int|float|bool,
+         *         remove_used_context_fields?: bool,
+         *     },
+         *     list_object: array<array{
+         *         name: string|int|float|bool,
+         *         data?: array<mixed>,
+         *     }>,
+         *     keyed_list_object?: array<string, array{
+         *         enabled?: bool, // Default: true
+         *         settings?: array<string|int|float|bool>,
+         *     }>,
+         *     nested?: array{
+         *         nested_object?: array{
+         *             enabled?: bool, // Default: null
+         *         },
+         *         nested_list_object?: array<array{
+         *             name: string|int|float|bool,
+         *         }>,
+         *     },
+         * } $config */
+        array $config = []): void
+    {
+        $this->configOutput = $config;
+    }
+
     public function getExtensionAlias(): string
     {
         return 'scalar_normalized_types';
@@ -178,6 +210,10 @@ class ScalarNormalizedTypesConfig implements \Symfony\Component\Config\Builder\C
 
     public function toArray(): array
     {
+        if ($this->configOutput) {
+            return $this->configOutput;
+        }
+
         $output = [];
         if (isset($this->_usedProperties['simpleArray'])) {
             $output['simple_array'] = $this->simpleArray;

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/VariableType.config_function_output.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/VariableType.config_function_output.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Symfony\Config;
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Config\VariableTypeConfig;
+
+/**
+ * This class is automatically generated to help in creating a config.
+ */
+class Config 
+{
+    use \Symfony\Component\DependencyInjection\Resource\ImportsTrait;
+    use \Symfony\Component\DependencyInjection\Resource\ParametersTrait;
+    use \Symfony\Component\DependencyInjection\Resource\ServicesTrait;
+    use \Symfony\Config\VariableTypeTrait;
+    private $builders;
+    private $variableTypeConfig;
+    public function __construct(public readonly ?string $env)
+    {
+        $this->variableTypeConfig = new VariableTypeConfig();
+        $this->builders = [$this->variableTypeConfig];
+    }
+    public function getBuilders(): array
+    {
+        return $this->builders;
+    }
+
+}

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/VariableType/Symfony/Config/VariableTypeConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/VariableType/Symfony/Config/VariableTypeConfig.php
@@ -11,6 +11,7 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 class VariableTypeConfig implements \Symfony\Component\Config\Builder\ConfigBuilderInterface
 {
     private $anyValue;
+    private $configOutput = [];
     private $_usedProperties = [];
 
     /**
@@ -25,6 +26,15 @@ class VariableTypeConfig implements \Symfony\Component\Config\Builder\ConfigBuil
         $this->anyValue = $value;
 
         return $this;
+    }
+
+    public function configure(
+        /** @var array{
+         *     any_value?: mixed,
+         * } $config */
+        array $config = []): void
+    {
+        $this->configOutput = $config;
     }
 
     public function getExtensionAlias(): string
@@ -47,6 +57,10 @@ class VariableTypeConfig implements \Symfony\Component\Config\Builder\ConfigBuil
 
     public function toArray(): array
     {
+        if ($this->configOutput) {
+            return $this->configOutput;
+        }
+
         $output = [];
         if (isset($this->_usedProperties['anyValue'])) {
             $output['any_value'] = $this->anyValue;

--- a/src/Symfony/Component/Config/Tests/Builder/GeneratedConfigTest.php
+++ b/src/Symfony/Component/Config/Tests/Builder/GeneratedConfigTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Builder\ClassBuilder;
 use Symfony\Component\Config\Builder\ConfigBuilderGenerator;
 use Symfony\Component\Config\Builder\ConfigBuilderInterface;
+use Symfony\Component\Config\Builder\ConfigTraitsGenerator;
 use Symfony\Component\Config\Builder\Method;
 use Symfony\Component\Config\Builder\Property;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
@@ -35,6 +36,7 @@ use Symfony\Config\AddToListConfig;
  */
 #[CoversClass(ClassBuilder::class)]
 #[CoversClass(ConfigBuilderGenerator::class)]
+#[CoversClass(ConfigTraitsGenerator::class)]
 #[CoversClass(Method::class)]
 #[CoversClass(Property::class)]
 class GeneratedConfigTest extends TestCase
@@ -78,7 +80,7 @@ class GeneratedConfigTest extends TestCase
     }
 
     #[DataProvider('fixtureNames')]
-    public function testConfig(string $name, string $alias)
+    public function testConfigClass(string $name, string $alias)
     {
         $basePath = __DIR__.'/Fixtures/';
         $callback = include $basePath.$name.'.config.php';
@@ -101,7 +103,20 @@ class GeneratedConfigTest extends TestCase
         if (class_exists(AbstractConfigurator::class)) {
             $output = AbstractConfigurator::processValue($output);
         }
+
         $this->assertSame($expectedOutput, $output);
+    }
+
+    #[DataProvider('fixtureNames')]
+    public function testConfigClassAndTraits(string $name, string $alias)
+    {
+        $basePath = __DIR__.'/Fixtures/';
+        $expectedOutput = $basePath.$name.'.config_function_output.php';
+
+        $this->generateConfigClassBuilder($alias, 'Symfony\\Component\\Config\\Tests\\Builder\\Fixtures\\'.$name, $outputDir);
+
+        file_put_contents($expectedOutput, file_get_contents($outputDir.'/Symfony/Config/Config.php'));
+        $this->assertFileEquals($expectedOutput, $outputDir.'/Symfony/Config/Config.php');
     }
 
     /**
@@ -179,6 +194,18 @@ class GeneratedConfigTest extends TestCase
         $loader = (new ConfigBuilderGenerator($outputDir))->build(new $configurationClass());
 
         return $loader();
+    }
+
+    private function generateConfigClassBuilder(string $alias, string $configurationClass, ?string &$outputDir = null)
+    {
+        $outputDir = tempnam(sys_get_temp_dir(), 'sf_config_builder_');
+        unlink($outputDir);
+        mkdir($outputDir);
+        $this->tempDir[] = $outputDir;
+
+        $configurationClass = new $configurationClass();
+
+        (new ConfigBuilderGenerator($outputDir))->buildConfigClassAndTraits([$alias => $configurationClass]);
     }
 
     private function assertDirectorySame($expected, $current)

--- a/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
@@ -228,10 +228,114 @@ class PhpFileLoader extends FileLoader
 
         $servicesConfigurator = $containerConfigurator->services();
         foreach ($config->getServices() as $id => $class) {
-            if (\is_array($class)) {
-                $servicesConfigurator->set($class['id'], $class['class'] ?? null);
-            } else {
+            if (!\is_array($class)) {
                 $servicesConfigurator->set($id, $class);
+
+                continue;
+            }
+
+            $serviceConfigurator = $servicesConfigurator->set($class['id'], $class['class'] ?? null);
+
+            if (isset($class['alias'])) {
+                $servicesConfigurator->alias($class['id'], $class['alias']);
+
+                // nothing else to do with aliases
+                continue;
+            }
+
+            if (isset($class['parent'])) {
+                $serviceConfigurator->parent($class['parent']);
+            }
+
+            if (isset($class['shared'])) {
+                $serviceConfigurator->share($class['shared']);
+            }
+
+            if (isset($class['synthetic'])) {
+                $serviceConfigurator->synthetic($class['synthetic']);
+            }
+
+            if (isset($class['lazy'])) {
+                $serviceConfigurator->lazy($class['lazy']);
+            }
+
+            if (null !== $public = $class['public'] ?? null) {
+                $serviceConfigurator->{$public ? 'public' : 'private'}();
+            }
+
+            if (isset($class['abstract'])) {
+                $serviceConfigurator->abstract($class['abstract']);
+            }
+
+            if (isset($class['deprecated'])) {
+                if (\is_array($class['deprecated'])) {
+                    $serviceConfigurator->deprecate($class['deprecated']['package'], $class['deprecated']['version'], $class['deprecated']['message'] ?? '');
+                } else {
+                    $serviceConfigurator->deprecate('', '', $class['deprecated']);
+                }
+            }
+
+            if (isset($class['factory'])) {
+                $serviceConfigurator->factory($class['factory']);
+            }
+
+            if (isset($class['constructor'])) {
+                $serviceConfigurator->constructor($class['constructor']);
+            }
+
+            if (isset($class['file'])) {
+                $serviceConfigurator->file($class['file']);
+            }
+
+            if (isset($class['arguments'])) {
+                $serviceConfigurator->args($class['arguments']);
+            }
+
+            foreach ($class['properties'] ?? [] as $property => $value) {
+                $serviceConfigurator->property($property, $value);
+            }
+
+            if (isset($class['configurator'])) {
+                $serviceConfigurator->configurator($class['configurator']);
+            }
+
+            foreach ($class['calls'] ?? [] as $call) {
+                if (isset($call['method'])) {
+                    $serviceConfigurator->call($call['method'], $call['arguments'] ?? [], $call['returns_clone'] ?? false);
+                } elseif (isset($call[0])) {
+                    $serviceConfigurator->call($call[0], $call[1] ?? [], $call[2] ?? false);
+                }
+            }
+
+            foreach ($class['tags'] ?? [] as $tag) {
+                if (\is_array($tag)) {
+                    $name = $tag['name'];
+                    unset($tag['name']);
+                    $serviceConfigurator->tag($name, $tag);
+                } else {
+                    $serviceConfigurator->tag($tag);
+                }
+            }
+
+            if (isset($class['decorates'])) {
+                $serviceConfigurator->decorate(
+                    $class['decorates'],
+                    $class['decoration_inner_name'] ?? null,
+                    $class['decoration_priority'] ?? 0,
+                    $class['decoration_on_invalid'] ?? 'exception'
+                );
+            }
+
+            if (isset($class['autowire'])) {
+                $serviceConfigurator->autowire($class['autowire']);
+            }
+
+            if (isset($class['autoconfigure'])) {
+                $serviceConfigurator->autoconfigure($class['autoconfigure']);
+            }
+
+            foreach ($class['bind'] ?? [] as $argument => $value) {
+                $serviceConfigurator->bind($argument, $value);
             }
         }
     }

--- a/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\Config\Builder\ConfigBuilderGenerator;
 use Symfony\Component\Config\Builder\ConfigBuilderGeneratorInterface;
 use Symfony\Component\Config\Builder\ConfigBuilderInterface;
+use Symfony\Component\Config\Builder\ConfigClassAwareBuilderGeneratorInterface;
 use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Component\DependencyInjection\Attribute\When;
 use Symfony\Component\DependencyInjection\Attribute\WhenNot;
@@ -24,6 +25,7 @@ use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Extension\ConfigurationExtensionInterface;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Config\Config;
 
 /**
  * PhpFileLoader loads service definitions from a PHP file.
@@ -36,6 +38,7 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 class PhpFileLoader extends FileLoader
 {
     protected bool $autoRegisterAliasesForSinglyImplementedInterfaces = false;
+    private array $configurations = [];
 
     public function __construct(
         ContainerBuilder $container,
@@ -57,16 +60,38 @@ class PhpFileLoader extends FileLoader
         $this->setCurrentDir(\dirname($path));
         $this->container->fileExists($path);
 
+        if ($this->generator instanceof ConfigClassAwareBuilderGeneratorInterface) {
+            foreach ($this->container->getExtensions() as $extension) {
+                if (!$extension instanceof ConfigurationExtensionInterface) {
+                    continue;
+                }
+
+                $this->configurations[$extension->getAlias()] ??= $extension->getConfiguration([], $this->container);
+
+                $this->generator->build($this->configurations[$extension->getAlias()])();
+            }
+
+            if (!class_exists(Config::class)) {
+                $this->generator->buildConfigClassAndTraits($this->configurations)();
+            }
+        }
+
         // the closure forbids access to the private scope in the included file
-        $load = \Closure::bind(function ($path, $env) use ($container, $loader, $resource, $type) {
+        $config = class_exists(Config::class) ? new Config($this->env) : null;
+        $load = \Closure::bind(function ($path, $env) use ($container, $loader, $resource, $type, $config) {
             return include $path;
         }, $this, ProtectedPhpFileLoader::class);
 
         try {
             $callback = $load($path, $this->env);
+            $containerConfigurator = new ContainerConfigurator($this->container, $this, $this->instanceof, $path, $resource, $this->env);
 
             if (\is_object($callback) && \is_callable($callback)) {
-                $this->executeCallback($callback, new ContainerConfigurator($this->container, $this, $this->instanceof, $path, $resource, $this->env), $path);
+                $this->executeCallback($callback, $containerConfigurator, $path);
+            }
+
+            if (null !== $config && $this->generator) {
+                $this->processConfigClass($config, $containerConfigurator);
             }
         } finally {
             $this->instanceof = [];
@@ -180,6 +205,37 @@ class PhpFileLoader extends FileLoader
         $this->loadExtensionConfigs();
     }
 
+    private function processConfigClass(Config $config, ContainerConfigurator $containerConfigurator): void
+    {
+        foreach ($config->getBuilders() as $configBuilder) {
+            $this->configBuilder($configBuilder::class);
+
+            $this->loadExtensionConfig($configBuilder->getExtensionAlias(), ContainerConfigurator::processValue($configBuilder->toArray()));
+        }
+
+        foreach ($config->getImports() as $import) {
+            if (\is_array($import)) {
+                $containerConfigurator->import($import['resource'], $import['type'] ?? null, $import['ignoreErrors'] ?? false);
+            } else {
+                $containerConfigurator->import($import);
+            }
+        }
+
+        $parametersConfigurator = $containerConfigurator->parameters();
+        foreach ($config->getParameters() as $key => $value) {
+            $parametersConfigurator->set($key, $value);
+        }
+
+        $servicesConfigurator = $containerConfigurator->services();
+        foreach ($config->getServices() as $id => $class) {
+            if (\is_array($class)) {
+                $servicesConfigurator->set($class['id'], $class['class'] ?? null);
+            } else {
+                $servicesConfigurator->set($id, $class);
+            }
+        }
+    }
+
     /**
      * @param string $namespace FQCN string for a class implementing ConfigBuilderInterface
      */
@@ -220,7 +276,7 @@ class PhpFileLoader extends FileLoader
             throw new \LogicException(\sprintf('You cannot use the config builder for "%s" because the extension does not implement "%s".', $namespace, ConfigurationExtensionInterface::class));
         }
 
-        $configuration = $extension->getConfiguration([], $this->container);
+        $configuration = $this->configurations[$alias] ?? $extension->getConfiguration([], $this->container);
         $loader = $this->generator->build($configuration);
 
         return $loader();

--- a/src/Symfony/Component/DependencyInjection/Resource/ImportsTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Resource/ImportsTrait.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Resource;
+
+trait ImportsTrait
+{
+    private array $imports = [];
+
+    /** @var array<array{
+     *     resource: string,
+     *     type?: string|int|float|bool,
+     *     ignoreErrors?: string|int|float|bool,
+     * }|non-empty-string> $imports */
+    public function imports(array $imports): static
+    {
+        $this->imports = $imports;
+
+        return $this;
+    }
+
+    public function getImports(): array
+    {
+        return $this->imports;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Resource/ParametersTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Resource/ParametersTrait.php
@@ -16,9 +16,9 @@ trait ParametersTrait
     private array $parameters = [];
 
     /**
-     * @var array<string, array|bool|string|int|float|\UnitEnum|null> $parameters
+     * @param array<string, array|bool|string|int|float|\UnitEnum|null> $parameters
      */
-    function parameters(array $parameters): static
+    public function parameters(array $parameters): static
     {
         $this->parameters = $parameters;
 

--- a/src/Symfony/Component/DependencyInjection/Resource/ParametersTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Resource/ParametersTrait.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Resource;
+
+trait ParametersTrait
+{
+    private array $parameters = [];
+
+    /**
+     * @var array<string, array|bool|string|int|float|\UnitEnum|null> $parameters
+     */
+    function parameters(array $parameters): static
+    {
+        $this->parameters = $parameters;
+
+        return $this;
+    }
+
+    public function getParameters(): array
+    {
+        return $this->parameters;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Resource/ServicesTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Resource/ServicesTrait.php
@@ -18,7 +18,31 @@ trait ServicesTrait
     /**
      * @var array<array{
      *     id: string,
-     *     class?: string|int|float|bool,
+     *     class?: string,
+     *     alias?: string,
+     *     parent?: string,
+     *     shared?: bool,
+     *     synthetic?: bool,
+     *     lazy?: bool|string,
+     *     public?: bool,
+     *     abstract?: bool,
+     *     deprecated?: string|array{package: string, version: string, message?: string},
+     *     factory?: string|array{0: string|null, 1: string},
+     *     constructor?: string,
+     *     file?: string,
+     *     arguments?: array,
+     *     properties?: array<string, mixed>,
+     *     configurator?: string|array{0: string|null, 1: string},
+     *     calls?: array<array{0: string, 1?: array, 2?: bool}|array{method: string, arguments?: array, returns_clone?: bool}>,
+     *     tags?: array<array{name: string, ...}|string>,
+     *     resource_tags?: array<array{name: string, ...}|string>,
+     *     decorates?: string,
+     *     decoration_inner_name?: string|null,
+     *     decoration_priority?: int,
+     *     decoration_on_invalid?: "exception"|"ignore"|null,
+     *     autowire?: bool,
+     *     autoconfigure?: bool,
+     *     bind?: array<string, mixed>,
      * }>|array<string, class-string|null> $services
      */
     public function services(array $services): static

--- a/src/Symfony/Component/DependencyInjection/Resource/ServicesTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Resource/ServicesTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Resource;
+
+trait ServicesTrait
+{
+    private array $services = [];
+
+    /**
+     * @var array<array{
+     *     id: string,
+     *     class?: string|int|float|bool,
+     * }>|array<string, class-string|null> $services
+     */
+    public function services(array $services): static
+    {
+        $this->services = $services;
+
+        return $this;
+    }
+
+    public function getServices(): array
+    {
+        return $this->services;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR adds a new `Config` class to configure a Symfony application:

```php
<?php

/** @var \Symfony\Config\Config $config */
$config->framework([
    'secret' => 'abc123',
]);

$config->parameters([
    'some_parameter' => 'some_value',
]);

$config
    ->imports(['test.php'])
    ->services([
        ['id' => 'some.service', 'class' => \App\Service\ConcreteService::class],
    ]);
```

One method exists for each extension, as well as `services()`, `imports()` and `parameters()`.

The class is generated at cache warmup, allowing to generate the corresponding phpdoc. Here a sneak peek of what the functions looks like:

```php
<?php

namespace Symfony\Config;

/**
 * This trait is automatically generated to help in creating a config.
 */
trait WebProfilerTrait
{
    /**
     * @param array{
     *     toolbar?: array{ // Profiler toolbar configuration
     *         enabled?: bool, // Default: false
     *         ajax_replace?: bool, // Replace toolbar on AJAX requests Default: false
     *     },
     *     intercept_redirects?: bool, // Default: false
     *     excluded_ajax_paths?: string|int|float|bool, // Default: "^/((index|app(_[\\w]+)?)\\.php/)?_wdt"
     * } $config
     */
    public function webProfiler(array $config): static
    {
        $this->webProfilerConfig->configure($config);

        return $this;
    }
}
```

This will bring nice IDE autocomplete as well as strong static analysis. Also, you're always one click away from the complete documentation.

---

Credits to Nicolas, Kevin and Ryan for the idea 🙂 