### PR TITLE
[DependencyInjection][HttpClient][Routing] Reject URIs that contain invalid characters

### DIFF
--- a/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
+++ b/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
@@ -310,6 +310,12 @@ class EnvVarProcessor implements EnvVarProcessorInterface, ResetInterface
             if (!isset($params['scheme'], $params['host'])) {
                 throw new RuntimeException(\sprintf('Invalid URL in env var "%s": scheme and host expected.', $name));
             }
+            if (('\\' !== \DIRECTORY_SEPARATOR || 'file' !== $params['scheme']) && false !== ($i = strpos($env, '\\')) && $i < strcspn($env, '?#')) {
+                throw new RuntimeException(\sprintf('Invalid URL in env var "%s": backslashes are not allowed.', $name));
+            }
+            if (\ord($env[0]) <= 32 || \ord($env[-1]) <= 32 || \strlen($env) !== strcspn($env, "\r\n\t")) {
+                throw new RuntimeException(\sprintf('Invalid URL in env var "%s": leading/trailing ASCII control characters or whitespaces are not allowed.', $name));
+            }
             $params += [
                 'port' => null,
                 'user' => null,

--- a/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
@@ -997,6 +997,27 @@ CSV;
     }
 
     /**
+     * @testWith ["http://foo.com\\bar"]
+     *           ["\\\\foo.com/bar"]
+     *           ["a\rb"]
+     *           ["a\nb"]
+     *           ["a\tb"]
+     *           ["\u0000foo"]
+     *           ["foo\u0000"]
+     *           [" foo"]
+     *           ["foo "]
+     *           [":"]
+     */
+    public function testGetEnvBadUrl(string $url)
+    {
+        $this->expectException(RuntimeException::class);
+
+        (new EnvVarProcessor(new Container()))->getEnv('url', 'foo', static function () use ($url): string {
+            return $url;
+        });
+    }
+
+    /**
      * @testWith    ["", "string"]
      *              [null, ""]
      *              [false, "bool"]

--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -625,6 +625,16 @@ trait HttpClientTrait
      */
     private static function parseUrl(string $url, array $query = [], array $allowedSchemes = ['http' => 80, 'https' => 443]): array
     {
+        if (false !== ($i = strpos($url, '\\')) && $i < strcspn($url, '?#')) {
+            throw new InvalidArgumentException(\sprintf('Malformed URL "%s": backslashes are not allowed.', $url));
+        }
+        if (\strlen($url) !== strcspn($url, "\r\n\t")) {
+            throw new InvalidArgumentException(\sprintf('Malformed URL "%s": CR/LF/TAB characters are not allowed.', $url));
+        }
+        if ('' !== $url && (\ord($url[0]) <= 32 || \ord($url[-1]) <= 32)) {
+            throw new InvalidArgumentException(\sprintf('Malformed URL "%s": leading/trailing ASCII control characters or spaces are not allowed.', $url));
+        }
+
         if (false === $parts = parse_url($url)) {
             if ('/' !== ($url[0] ?? '') || false === $parts = parse_url($url.'#')) {
                 throw new InvalidArgumentException(\sprintf('Malformed URL "%s".', $url));

--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTraitTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTraitTest.php
@@ -239,11 +239,30 @@ class HttpClientTraitTest extends TestCase
         self::resolveUrl(self::parseUrl('localhost:8080'), null);
     }
 
-    public function testResolveBaseUrlWitoutScheme()
+    public function testResolveBaseUrlWithoutScheme()
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid URL: scheme is missing in "//localhost:8081". Did you forget to add "http(s)://"?');
         self::resolveUrl(self::parseUrl('/foo'), self::parseUrl('localhost:8081'));
+    }
+
+    /**
+     * @testWith ["http://foo.com\\bar"]
+     *           ["\\\\foo.com/bar"]
+     *           ["a\rb"]
+     *           ["a\nb"]
+     *           ["a\tb"]
+     *           ["\u0000foo"]
+     *           ["foo\u0000"]
+     *           [" foo"]
+     *           ["foo "]
+     *           [":"]
+     */
+    public function testParseMalformedUrl(string $url)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Malformed URL');
+        self::parseUrl($url);
     }
 
     /**

--- a/src/Symfony/Component/Routing/RequestContext.php
+++ b/src/Symfony/Component/Routing/RequestContext.php
@@ -47,6 +47,13 @@ class RequestContext
 
     public static function fromUri(string $uri, string $host = 'localhost', string $scheme = 'http', int $httpPort = 80, int $httpsPort = 443): self
     {
+        if (false !== ($i = strpos($uri, '\\')) && $i < strcspn($uri, '?#')) {
+            $uri = '';
+        }
+        if ('' !== $uri && (\ord($uri[0]) <= 32 || \ord($uri[-1]) <= 32 || \strlen($uri) !== strcspn($uri, "\r\n\t"))) {
+            $uri = '';
+        }
+
         $uri = parse_url($uri);
         $scheme = $uri['scheme'] ?? $scheme;
         $host = $uri['host'] ?? $host;

--- a/src/Symfony/Component/Routing/Tests/RequestContextTest.php
+++ b/src/Symfony/Component/Routing/Tests/RequestContextTest.php
@@ -85,6 +85,28 @@ class RequestContextTest extends TestCase
         $this->assertSame('/', $requestContext->getPathInfo());
     }
 
+    /**
+     * @testWith ["http://foo.com\\bar"]
+     *           ["\\\\foo.com/bar"]
+     *           ["a\rb"]
+     *           ["a\nb"]
+     *           ["a\tb"]
+     *           ["\u0000foo"]
+     *           ["foo\u0000"]
+     *           [" foo"]
+     *           ["foo "]
+     *           [":"]
+     */
+    public function testFromBadUri(string $uri)
+    {
+        $context = RequestContext::fromUri($uri);
+
+        $this->assertSame('http', $context->getScheme());
+        $this->assertSame('localhost', $context->getHost());
+        $this->assertSame('', $context->getBaseUrl());
+        $this->assertSame('/', $context->getPathInfo());
+    }
+
     public function testFromRequest()
     {
         $request = Request::create('https://test.com:444/foo?bar=baz');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The behavior of `parse_url()` doesn't match how browsers parse URLs. This PR ensures we won't accept URLs that are invalid per https://url.spec.whatwg.org/:
- URLs that contain a backslash
- or start/end with a control-char or a space
- or contain a CR/LF/TAB character