### PR TITLE
Release v5.4.46

### DIFF
--- a/CHANGELOG-5.4.md
+++ b/CHANGELOG-5.4.md
@@ -7,6 +7,24 @@ in 5.4 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v5.4.0...v5.4.1
 
+* 5.4.46 (2024-11-06)
+
+ * bug #58772 [DoctrineBridge] Backport detection fix of Xml/Yaml driver in DoctrineExtension (MatTheCat)
+ * security #cve-2024-51736 [Process] Use PATH before CD to load the shell on Windows (nicolas-grekas)
+ * security #cve-2024-50342 [HttpClient] Filter private IPs before connecting when Host == IP (nicolas-grekas)
+ * security #cve-2024-50345 [HttpFoundation] Reject URIs that contain invalid characters (nicolas-grekas)
+ * security #cve-2024-50340 [Runtime] Do not read from argv on non-CLI SAPIs (wouterj)
+ * bug #58765 [VarDumper] fix detecting anonymous exception classes on Windows and PHP 7 (xabbuh)
+ * bug #58757 [RateLimiter] Fix DateInterval normalization (danydev)
+ * bug #58754 [Security] Store original token in token storage when implicitly exiting impersonation (wouterj)
+ * bug #58753 [Cache] Fix clear() when using Predis (nicolas-grekas)
+ * bug #58713 [Config] Handle Phar absolute path in `FileLocator` (alexandre-daubois)
+ * bug #58739 [WebProfilerBoundle] form data collector check passed and resolved options are defined (vltrof)
+ * bug #58752 [Process] Fix escaping /X arguments on Windows (nicolas-grekas)
+ * bug #58735 [Process] Return built-in cmd.exe commands directly in ExecutableFinder (Seldaek)
+ * bug #58723 [Process] Properly deal with not-found executables on Windows (nicolas-grekas)
+ * bug #58711 [Process] Fix handling empty path found in the PATH env var with ExecutableFinder (nicolas-grekas)
+
 * 5.4.45 (2024-10-27)
 
  * bug #58669 [Cache] Revert "Initialize RedisAdapter cursor to 0" (nicolas-grekas)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -853,6 +853,7 @@ The Symfony Connect username in parenthesis allows to get more information
  - Robert-Jan de Dreu
  - Fabrice Bernhard (fabriceb)
  - Matthijs van den Bos (matthijs)
+ - Markus S. (staabm)
  - Bhavinkumar Nakrani (bhavin4u)
  - Jaik Dean (jaikdean)
  - Krzysztof Piasecki (krzysztek)
@@ -946,6 +947,7 @@ The Symfony Connect username in parenthesis allows to get more information
  - Julien Boudry
  - vitaliytv
  - Franck RANAIVO-HARISOA (franckranaivo)
+ - Yi-Jyun Pan
  - Egor Taranov
  - Andreas Hennings
  - Arnaud Frézet
@@ -1474,7 +1476,6 @@ The Symfony Connect username in parenthesis allows to get more information
  - Marcos Gómez Vilches (markitosgv)
  - Matthew Davis (mdavis1982)
  - Paulo Ribeiro (paulo)
- - Markus S. (staabm)
  - Marc Laporte
  - Michał Jusięga
  - Kay Wei
@@ -1544,7 +1545,6 @@ The Symfony Connect username in parenthesis allows to get more information
  - Mihail Krasilnikov (krasilnikovm)
  - Uladzimir Tsykun
  - iamvar
- - Yi-Jyun Pan
  - Amaury Leroux de Lens (amo__)
  - Rene de Lima Barbosa (renedelima)
  - Christian Jul Jensen
@@ -1615,6 +1615,7 @@ The Symfony Connect username in parenthesis allows to get more information
  - ttomor
  - Mei Gwilym (meigwilym)
  - Michael H. Arieli
+ - Miloš Milutinović
  - Jitendra Adhikari (adhocore)
  - Nicolas Martin (cocorambo)
  - Tom Panier (neemzy)
@@ -2941,6 +2942,7 @@ The Symfony Connect username in parenthesis allows to get more information
  - Walther Lalk
  - Adam
  - Ivo
+ - vltrof
  - Ismo Vuorinen
  - Markus Staab
  - Valentin
@@ -3588,10 +3590,12 @@ The Symfony Connect username in parenthesis allows to get more information
  - Sean Templeton
  - Willem Mouwen
  - db306
+ - Dr. Gianluigi &quot;Zane&quot; Zanettini
  - Michaël VEROUX
  - Julia
  - Lin Lu
  - arduanov
+ - Valmonzo
  - sualko
  - Marc Bennewitz
  - Fabien

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -78,12 +78,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     private static $freshCache = [];
 
-    public const VERSION = '5.4.46-DEV';
+    public const VERSION = '5.4.46';
     public const VERSION_ID = 50446;
     public const MAJOR_VERSION = 5;
     public const MINOR_VERSION = 4;
     public const RELEASE_VERSION = 46;
-    public const EXTRA_VERSION = 'DEV';
+    public const EXTRA_VERSION = '';
 
     public const END_OF_MAINTENANCE = '11/2024';
     public const END_OF_LIFE = '02/2029';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v5.4.45...v5.4.46)

 * bug #58772 [DoctrineBridge] Backport detection fix of Xml/Yaml driver in DoctrineExtension (@MatTheCat)
 * security #cve-2024-51736 [Process] Use PATH before CD to load the shell on Windows (@nicolas-grekas)
 * security #cve-2024-50342 [HttpClient] Filter private IPs before connecting when Host == IP (@nicolas-grekas)
 * security #cve-2024-50345 [HttpFoundation] Reject URIs that contain invalid characters (@nicolas-grekas)
 * security #cve-2024-50340 [Runtime] Do not read from argv on non-CLI SAPIs (@wouterj)
 * bug #58765 [VarDumper] fix detecting anonymous exception classes on Windows and PHP 7 (@xabbuh)
 * bug #58757 [RateLimiter] Fix DateInterval normalization (@danydev)
 * bug #58754 [Security] Store original token in token storage when implicitly exiting impersonation (@wouterj)
 * bug #58753 [Cache] Fix clear() when using Predis (@nicolas-grekas)
 * bug #58713 [Config] Handle Phar absolute path in `FileLocator` (@alexandre-daubois)
 * bug #58739 [WebProfilerBoundle] form data collector check passed and resolved options are defined (@vltrof)
 * bug #58752 [Process] Fix escaping /X arguments on Windows (@nicolas-grekas)
 * bug #58735 [Process] Return built-in cmd.exe commands directly in ExecutableFinder (@Seldaek)
 * bug #58723 [Process] Properly deal with not-found executables on Windows (@nicolas-grekas)
 * bug #58711 [Process] Fix handling empty path found in the PATH env var with ExecutableFinder (@nicolas-grekas)
