### PR TITLE
Release v6.4.14

### DIFF
--- a/CHANGELOG-6.4.md
+++ b/CHANGELOG-6.4.md
@@ -7,6 +7,26 @@ in 6.4 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v6.4.0...v6.4.1
 
+* 6.4.14 (2024-11-06)
+
+ * bug #58772 [DoctrineBridge] Backport detection fix of Xml/Yaml driver in DoctrineExtension (MatTheCat)
+ * security #cve-2024-51736 [Process] Use PATH before CD to load the shell on Windows (nicolas-grekas)
+ * security #cve-2024-50342 [HttpClient] Filter private IPs before connecting when Host == IP (nicolas-grekas)
+ * security #cve-2024-50345 [HttpFoundation] Reject URIs that contain invalid characters (nicolas-grekas)
+ * security #cve-2024-50340 [Runtime] Do not read from argv on non-CLI SAPIs (wouterj)
+ * bug #58765 [VarDumper] fix detecting anonymous exception classes on Windows and PHP 7 (xabbuh)
+ * bug #58757 [RateLimiter] Fix DateInterval normalization (danydev)
+ * bug #58754 [Security] Store original token in token storage when implicitly exiting impersonation (wouterj)
+ * bug #58753 [Cache] Fix clear() when using Predis (nicolas-grekas)
+ * bug #58713 [Config] Handle Phar absolute path in `FileLocator` (alexandre-daubois)
+ * bug #58728 [WebProfilerBundle] Re-add missing Profiler shortcuts on Profiler homepage (welcoMattic)
+ * bug #58739 [WebProfilerBoundle] form data collector check passed and resolved options are defined (vltrof)
+ * bug #58752 [Process] Fix escaping /X arguments on Windows (nicolas-grekas)
+ * bug #58735 [Process] Return built-in cmd.exe commands directly in ExecutableFinder (Seldaek)
+ * bug #58723 [Process] Properly deal with not-found executables on Windows (nicolas-grekas)
+ * bug #58711 [Process] Fix handling empty path found in the PATH env var with ExecutableFinder (nicolas-grekas)
+ * bug #58704 [HttpClient] fix for HttpClientDataCollector fails if proc_open is disabled via php.ini (ZaneCEO)
+
 * 6.4.13 (2024-10-27)
 
  * bug #58669 [Cache] Revert "Initialize RedisAdapter cursor to 0" (nicolas-grekas)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -76,12 +76,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     private static array $freshCache = [];
 
-    public const VERSION = '6.4.14-DEV';
+    public const VERSION = '6.4.14';
     public const VERSION_ID = 60414;
     public const MAJOR_VERSION = 6;
     public const MINOR_VERSION = 4;
     public const RELEASE_VERSION = 14;
-    public const EXTRA_VERSION = 'DEV';
+    public const EXTRA_VERSION = '';
 
     public const END_OF_MAINTENANCE = '11/2026';
     public const END_OF_LIFE = '11/2027';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v6.4.13...v6.4.14)

 * bug #58772 [DoctrineBridge] Backport detection fix of Xml/Yaml driver in DoctrineExtension (@MatTheCat)
 * security #cve-2024-51736 [Process] Use PATH before CD to load the shell on Windows (@nicolas-grekas)
 * security #cve-2024-50342 [HttpClient] Filter private IPs before connecting when Host == IP (@nicolas-grekas)
 * security #cve-2024-50345 [HttpFoundation] Reject URIs that contain invalid characters (@nicolas-grekas)
 * security #cve-2024-50340 [Runtime] Do not read from argv on non-CLI SAPIs (@wouterj)
 * bug #58765 [VarDumper] fix detecting anonymous exception classes on Windows and PHP 7 (@xabbuh)
 * bug #58757 [RateLimiter] Fix DateInterval normalization (@danydev)
 * bug #58754 [Security] Store original token in token storage when implicitly exiting impersonation (@wouterj)
 * bug #58753 [Cache] Fix clear() when using Predis (@nicolas-grekas)
 * bug #58713 [Config] Handle Phar absolute path in `FileLocator` (@alexandre-daubois)
 * bug #58728 [WebProfilerBundle] Re-add missing Profiler shortcuts on Profiler homepage (@welcoMattic)
 * bug #58739 [WebProfilerBoundle] form data collector check passed and resolved options are defined (@vltrof)
 * bug #58752 [Process] Fix escaping /X arguments on Windows (@nicolas-grekas)
 * bug #58735 [Process] Return built-in cmd.exe commands directly in ExecutableFinder (@Seldaek)
 * bug #58723 [Process] Properly deal with not-found executables on Windows (@nicolas-grekas)
 * bug #58711 [Process] Fix handling empty path found in the PATH env var with ExecutableFinder (@nicolas-grekas)
 * bug #58704 [HttpClient] fix for HttpClientDataCollector fails if proc_open is disabled via php.ini (@ZaneCEO)
