### PR TITLE
[Console] skip autocomplete test when stty is not available

### DIFF
--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -914,6 +914,10 @@ EOD;
 
     public function testAutocompleteMoveCursorBackwards()
     {
+        if (!Terminal::hasSttyAvailable()) {
+            $this->markTestSkipped('`stty` is required to test autocomplete functionality');
+        }
+
         // F<TAB><BACKSPACE><BACKSPACE><BACKSPACE>
         $inputStream = $this->getInputStream("F\t\177\177\177");
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT
