### PR TITLE
[Runtime] Negate `register_argc_argv` when `On`

### DIFF
--- a/src/Symfony/Component/Runtime/SymfonyRuntime.php
+++ b/src/Symfony/Component/Runtime/SymfonyRuntime.php
@@ -93,6 +93,12 @@ class SymfonyRuntime extends GenericRuntime
         $envKey = $options['env_var_name'] ??= 'APP_ENV';
         $debugKey = $options['debug_var_name'] ??= 'APP_DEBUG';
 
+        if (isset($_SERVER['argv']) && !empty($_GET)) {
+            // register_argc_argv=On is too risky in web servers
+            $_SERVER['argv'] = [];
+            $_SERVER['argc'] = 0;
+        }
+
         if (isset($options['env'])) {
             $_SERVER[$envKey] = $options['env'];
         } elseif (empty($_GET) && isset($_SERVER['argv']) && class_exists(ArgvInput::class)) {
@@ -203,10 +209,6 @@ class SymfonyRuntime extends GenericRuntime
 
     private function getInput(): ArgvInput
     {
-        if (!empty($_GET) && filter_var(ini_get('register_argc_argv'), \FILTER_VALIDATE_BOOL)) {
-            throw new \Exception('CLI applications cannot be run safely on non-CLI SAPIs with register_argc_argv=On.');
-        }
-
         if (isset($this->input)) {
             return $this->input;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The `register_argc_argv` ini setting is a terrible idea from the past that can have dramatic consequences:
https://symfony.com/blog/cve-2024-50340-ability-to-change-environment-from-query

While Symfony itself will ignore argv injected via GET, apps are still at risk.
With this PR, I propose to harden all Symfony apps by always emptying argv/argc, so that their value cannot be hijacked.
There are no legitimate use case for this setting anyway.

Linking to https://github.com/php/php-src/issues/12344 for cross-reference.