### PR TITLE
[Mailer] use microsecond precision SMTP logging

### DIFF
--- a/src/Symfony/Component/Mailer/Transport/Smtp/Stream/AbstractStream.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/Stream/AbstractStream.php
@@ -37,7 +37,7 @@ abstract class AbstractStream
     public function write(string $bytes, bool $debug = true): void
     {
         if ($debug) {
-            $timestamp = date('c');
+            $timestamp = (new \DateTimeImmutable())->format('Y-m-d\TH:i:s.up');
             foreach (explode("\n", trim($bytes)) as $line) {
                 $this->debug .= \sprintf("[%s] > %s\n", $timestamp, $line);
             }
@@ -93,7 +93,7 @@ abstract class AbstractStream
             }
         }
 
-        $this->debug .= \sprintf('[%s] < %s', date('c'), $line);
+        $this->debug .= \sprintf('[%s] < %s', (new \DateTimeImmutable())->format('Y-m-d\TH:i:s.up'), $line);
 
         return $line;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Replaced `date('c')` with `(new \DateTimeImmutable())->format('Y-m-d\TH:i:s.up')` to have microsecond precision.

Before: `2024-11-06T12:57:35+00:00` (ISO 8601)
After: `2024-11-06T12:57:35.123456Z` (ISO 8601 with microseconds)

This change makes possible to inspect each SMTP command's time consumption.