### PR TITLE
`Definition::$class` may not be `class-string`

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -180,8 +180,6 @@ class Definition
 
     /**
      * Gets the service class.
-     *
-     * @return class-string|null
      */
     public function getClass(): ?string
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | none
| License       | MIT

[Example](https://github.com/php-amqplib/RabbitMqBundle/blob/fc816b77d3dee4045f8044b70059942832b079b3/DependencyInjection/OldSoundRabbitMqExtension.php#L214) of non-class-string usage.