### PR TITLE
[Validator] Improve type for the `mode` property of the Bic constraint

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Bic.php
+++ b/src/Symfony/Component/Validator/Constraints/Bic.php
@@ -58,14 +58,17 @@ class Bic extends Constraint
     public string $ibanMessage = 'This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.';
     public ?string $iban = null;
     public ?string $ibanPropertyPath = null;
-    public ?string $mode = self::VALIDATION_MODE_STRICT;
+    /**
+     * @var self::VALIDATION_MODE_*
+     */
+    public string $mode = self::VALIDATION_MODE_STRICT;
 
     /**
-     * @param array<string,mixed>|null $options
-     * @param string|null              $iban             An IBAN value to validate that its country code is the same as the BIC's one
-     * @param string|null              $ibanPropertyPath Property path to the IBAN value when validating objects
-     * @param string[]|null            $groups
-     * @param string|null              $mode             The mode used to validate the BIC; pass null to use the default mode (strict)
+     * @param array<string,mixed>|null     $options
+     * @param string|null                  $iban             An IBAN value to validate that its country code is the same as the BIC's one
+     * @param string|null                  $ibanPropertyPath Property path to the IBAN value when validating objects
+     * @param string[]|null                $groups
+     * @param self::VALIDATION_MODE_*|null $mode             The mode used to validate the BIC; pass null to use the default mode (strict)
      */
     public function __construct(
         ?array $options = null,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

- the property should not be nullable as the constructor prevents assigning null and the validator does not expect it either
- phpdoc types are added to let static analysis tool know about the valid modes thanks to the available class constants

This improves the new feature introduced in 7.2 (before the BC policy prevents us from fixing the nullability of the public property)