### PR TITLE
relax format assertions for fstat() results on Windows

### DIFF
--- a/src/Symfony/Component/VarDumper/Tests/Caster/SplCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/SplCasterTest.php
@@ -104,7 +104,7 @@ SplFileObject {
   flags: DROP_NEW_LINE|SKIP_EMPTY
   maxLineLen: 0
   fstat: array:26 [
-    "dev" => %d
+    "dev" => %i
     "ino" => %i
     "nlink" => %d
     "rdev" => 0


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

According to https://www.php.net/manual/en/function.stat.php the serial
number of the volume that contains the file is returned for the "dev" entry
as a 64-bit unsigned integer which may overflow.