### PR TITLE
[HttpFoundation] require Cache component versions compatible with Redis 6.1

### DIFF
--- a/src/Symfony/Component/HttpFoundation/composer.json
+++ b/src/Symfony/Component/HttpFoundation/composer.json
@@ -24,7 +24,7 @@
     "require-dev": {
         "doctrine/dbal": "^2.13.1|^3|^4",
         "predis/predis": "^1.1|^2.0",
-        "symfony/cache": "^6.3|^7.0",
+        "symfony/cache": "^6.4.12|^7.1.5",
         "symfony/dependency-injection": "^5.4|^6.0|^7.0",
         "symfony/http-kernel": "^5.4.12|^6.0.12|^6.1.4|^7.0",
         "symfony/mime": "^5.4|^6.0|^7.0",
@@ -32,7 +32,7 @@
         "symfony/rate-limiter": "^5.4|^6.0|^7.0"
     },
     "conflict": {
-        "symfony/cache": "<6.3"
+        "symfony/cache": "<6.4.12|>=7.0,<7.1.5"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\HttpFoundation\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT