### PR TITLE
[Messenger] silence PHP warnings issued by `Redis::connect()`

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
@@ -37,8 +37,8 @@ class ConnectionTest extends TestCase
             new Connection(['stream' => 'queue', 'delete_after_ack' => true], [
                 'host' => 'localhost',
                 'port' => 6379,
-            ], [], $this->createMock(\Redis::class)),
-            Connection::fromDsn('redis://localhost/queue?delete_after_ack=1', [], $this->createMock(\Redis::class))
+            ], [], $this->createRedisMock()),
+            Connection::fromDsn('redis://localhost/queue?delete_after_ack=1', [], $this->createRedisMock())
         );
     }
 
@@ -48,24 +48,24 @@ class ConnectionTest extends TestCase
             new Connection(['stream' => 'queue', 'delete_after_ack' => true], [
                 'host' => '/var/run/redis/redis.sock',
                 'port' => 0,
-            ], [], $redis = $this->createMock(\Redis::class)),
-            Connection::fromDsn('redis:///var/run/redis/redis.sock', ['stream' => 'queue', 'delete_after_ack' => true], $redis)
+            ], [], $this->createRedisMock()),
+            Connection::fromDsn('redis:///var/run/redis/redis.sock', ['stream' => 'queue', 'delete_after_ack' => true], $this->createRedisMock())
         );
     }
 
     public function testFromDsnWithOptions()
     {
         $this->assertEquals(
-            Connection::fromDsn('redis://localhost', ['stream' => 'queue', 'group' => 'group1', 'consumer' => 'consumer1', 'auto_setup' => false, 'serializer' => 2, 'delete_after_ack' => true], $this->createMock(\Redis::class)),
-            Connection::fromDsn('redis://localhost/queue/group1/consumer1?serializer=2&auto_setup=0&delete_after_ack=1', [], $this->createMock(\Redis::class))
+            Connection::fromDsn('redis://localhost', ['stream' => 'queue', 'group' => 'group1', 'consumer' => 'consumer1', 'auto_setup' => false, 'serializer' => 2, 'delete_after_ack' => true], $this->createRedisMock()),
+            Connection::fromDsn('redis://localhost/queue/group1/consumer1?serializer=2&auto_setup=0&delete_after_ack=1', [], $this->createRedisMock())
         );
     }
 
     public function testFromDsnWithOptionsAndTrailingSlash()
     {
         $this->assertEquals(
-            Connection::fromDsn('redis://localhost/', ['stream' => 'queue', 'group' => 'group1', 'consumer' => 'consumer1', 'auto_setup' => false, 'serializer' => 2, 'delete_after_ack' => true], $this->createMock(\Redis::class)),
-            Connection::fromDsn('redis://localhost/queue/group1/consumer1?serializer=2&auto_setup=0&delete_after_ack=1', [], $this->createMock(\Redis::class))
+            Connection::fromDsn('redis://localhost/', ['stream' => 'queue', 'group' => 'group1', 'consumer' => 'consumer1', 'auto_setup' => false, 'serializer' => 2, 'delete_after_ack' => true], $this->createRedisMock()),
+            Connection::fromDsn('redis://localhost/queue/group1/consumer1?serializer=2&auto_setup=0&delete_after_ack=1', [], $this->createRedisMock())
         );
     }
 
@@ -79,6 +79,9 @@ class ConnectionTest extends TestCase
             ->method('connect')
             ->with('tls://127.0.0.1', 6379)
             ->willReturn(true);
+        $redis->expects($this->any())
+            ->method('isConnected')
+            ->willReturnOnConsecutiveCalls(false, true);
 
         Connection::fromDsn('redis://127.0.0.1?tls=1', [], $redis);
     }
@@ -93,6 +96,9 @@ class ConnectionTest extends TestCase
             ->method('connect')
             ->with('tls://127.0.0.1', 6379)
             ->willReturn(true);
+        $redis->expects($this->any())
+            ->method('isConnected')
+            ->willReturnOnConsecutiveCalls(false, true);
 
         Connection::fromDsn('redis://127.0.0.1', ['tls' => true], $redis);
     }
@@ -104,6 +110,9 @@ class ConnectionTest extends TestCase
             ->method('connect')
             ->with('tls://127.0.0.1', 6379)
             ->willReturn(true);
+        $redis->expects($this->any())
+            ->method('isConnected')
+            ->willReturnOnConsecutiveCalls(false, true);
 
         Connection::fromDsn('rediss://127.0.0.1?delete_after_ack=true', [], $redis);
     }
@@ -116,21 +125,21 @@ class ConnectionTest extends TestCase
                 'port' => 6379,
             ], [
                 'serializer' => 2,
-            ], $this->createMock(\Redis::class)),
-            Connection::fromDsn('redis://localhost/queue/group1/consumer1?serializer=2&delete_after_ack=1', [], $this->createMock(\Redis::class))
+            ], $this->createRedisMock()),
+            Connection::fromDsn('redis://localhost/queue/group1/consumer1?serializer=2&delete_after_ack=1', [], $this->createRedisMock())
         );
     }
 
     public function testFromDsnWithMixDsnQueryOptions()
     {
         $this->assertEquals(
-            Connection::fromDsn('redis://localhost/queue/group1?serializer=2', ['consumer' => 'specific-consumer', 'delete_after_ack' => true], $this->createMock(\Redis::class)),
-            Connection::fromDsn('redis://localhost/queue/group1/specific-consumer?serializer=2&delete_after_ack=1', [], $this->createMock(\Redis::class))
+            Connection::fromDsn('redis://localhost/queue/group1?serializer=2', ['consumer' => 'specific-consumer', 'delete_after_ack' => true], $this->createRedisMock()),
+            Connection::fromDsn('redis://localhost/queue/group1/specific-consumer?serializer=2&delete_after_ack=1', [], $this->createRedisMock())
         );
 
         $this->assertEquals(
-            Connection::fromDsn('redis://localhost/queue/group1/consumer1', ['consumer' => 'specific-consumer', 'delete_after_ack' => true], $this->createMock(\Redis::class)),
-            Connection::fromDsn('redis://localhost/queue/group1/consumer1', ['delete_after_ack' => true], $this->createMock(\Redis::class))
+            Connection::fromDsn('redis://localhost/queue/group1/consumer1', ['consumer' => 'specific-consumer', 'delete_after_ack' => true], $this->createRedisMock()),
+            Connection::fromDsn('redis://localhost/queue/group1/consumer1', ['delete_after_ack' => true], $this->createRedisMock())
         );
     }
 
@@ -140,7 +149,7 @@ class ConnectionTest extends TestCase
     public function testDeprecationIfInvalidOptionIsPassedWithDsn()
     {
         $this->expectDeprecation('Since symfony/messenger 5.1: Invalid option(s) "foo" passed to the Redis Messenger transport. Passing invalid options is deprecated.');
-        Connection::fromDsn('redis://localhost/queue?foo=bar', [], $this->createMock(\Redis::class));
+        Connection::fromDsn('redis://localhost/queue?foo=bar', [], $this->createRedisMock());
     }
 
     public function testRedisClusterInstanceIsSupported()
@@ -151,7 +160,7 @@ class ConnectionTest extends TestCase
 
     public function testKeepGettingPendingMessages()
     {
-        $redis = $this->createMock(\Redis::class);
+        $redis = $this->createRedisMock();
 
         $redis->expects($this->exactly(3))->method('xreadgroup')
             ->with('symfony', 'consumer', ['queue' => 0], 1, 1)
@@ -170,7 +179,7 @@ class ConnectionTest extends TestCase
      */
     public function testAuth($expected, string $dsn)
     {
-        $redis = $this->createMock(\Redis::class);
+        $redis = $this->createRedisMock();
 
         $redis->expects($this->exactly(1))->method('auth')
             ->with($expected)
@@ -190,7 +199,7 @@ class ConnectionTest extends TestCase
 
     public function testAuthFromOptions()
     {
-        $redis = $this->createMock(\Redis::class);
+        $redis = $this->createRedisMock();
 
         $redis->expects($this->exactly(1))->method('auth')
             ->with('password')
@@ -201,7 +210,7 @@ class ConnectionTest extends TestCase
 
     public function testAuthFromOptionsAndDsn()
     {
-        $redis = $this->createMock(\Redis::class);
+        $redis = $this->createRedisMock();
 
         $redis->expects($this->exactly(1))->method('auth')
             ->with('password2')
@@ -212,7 +221,7 @@ class ConnectionTest extends TestCase
 
     public function testNoAuthWithEmptyPassword()
     {
-        $redis = $this->createMock(\Redis::class);
+        $redis = $this->createRedisMock();
 
         $redis->expects($this->exactly(0))->method('auth')
             ->with('')
@@ -223,7 +232,7 @@ class ConnectionTest extends TestCase
 
     public function testAuthZeroPassword()
     {
-        $redis = $this->createMock(\Redis::class);
+        $redis = $this->createRedisMock();
 
         $redis->expects($this->exactly(1))->method('auth')
             ->with('0')
@@ -236,7 +245,7 @@ class ConnectionTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Redis connection ');
-        $redis = $this->createMock(\Redis::class);
+        $redis = $this->createRedisMock();
 
         $redis->expects($this->exactly(1))->method('auth')
             ->with('password')
@@ -247,7 +256,7 @@ class ConnectionTest extends TestCase
 
     public function testGetPendingMessageFirst()
     {
-        $redis = $this->createMock(\Redis::class);
+        $redis = $this->createRedisMock();
 
         $redis->expects($this->exactly(1))->method('xreadgroup')
             ->with('symfony', 'consumer', ['queue' => '0'], 1, 1)
@@ -269,7 +278,7 @@ class ConnectionTest extends TestCase
 
     public function testClaimAbandonedMessageWithRaceCondition()
     {
-        $redis = $this->createMock(\Redis::class);
+        $redis = $this->createRedisMock();
 
         $redis->expects($this->exactly(3))->method('xreadgroup')
             ->willReturnCallback(function (...$args) {
@@ -305,7 +314,7 @@ class ConnectionTest extends TestCase
 
     public function testClaimAbandonedMessage()
     {
-        $redis = $this->createMock(\Redis::class);
+        $redis = $this->createRedisMock();
 
         $redis->expects($this->exactly(2))->method('xreadgroup')
             ->willReturnCallback(function (...$args) {
@@ -341,7 +350,7 @@ class ConnectionTest extends TestCase
     {
         $this->expectException(TransportException::class);
         $this->expectExceptionMessage('Redis error happens');
-        $redis = $this->createMock(\Redis::class);
+        $redis = $this->createRedisMock();
         $redis->expects($this->once())->method('xreadgroup')->willReturn(false);
         $redis->expects($this->once())->method('getLastError')->willReturn('Redis error happens');
 
@@ -351,7 +360,7 @@ class ConnectionTest extends TestCase
 
     public function testMaxEntries()
     {
-        $redis = $this->createMock(\Redis::class);
+        $redis = $this->createRedisMock();
 
         $redis->expects($this->exactly(1))->method('xadd')
             ->with('queue', '*', ['message' => '{"body":"1","headers":[]}'], 20000, true)
@@ -363,7 +372,7 @@ class ConnectionTest extends TestCase
 
     public function testDeleteAfterAck()
     {
-        $redis = $this->createMock(\Redis::class);
+        $redis = $this->createRedisMock();
 
         $redis->expects($this->exactly(1))->method('xack')
             ->with('queue', 'symfony', ['1'])
@@ -383,12 +392,12 @@ class ConnectionTest extends TestCase
     {
         $this->expectDeprecation('Since symfony/redis-messenger 5.4: Not setting the "delete_after_ack" boolean option explicitly is deprecated, its default value will change to true in 6.0.');
 
-        Connection::fromDsn('redis://localhost/queue', [], $this->createMock(\Redis::class));
+        Connection::fromDsn('redis://localhost/queue', [], $this->createRedisMock(\Redis::class));
     }
 
     public function testDeleteAfterReject()
     {
-        $redis = $this->createMock(\Redis::class);
+        $redis = $this->createRedisMock();
 
         $redis->expects($this->exactly(1))->method('xack')
             ->with('queue', 'symfony', ['1'])
@@ -403,7 +412,7 @@ class ConnectionTest extends TestCase
 
     public function testLastErrorGetsCleared()
     {
-        $redis = $this->createMock(\Redis::class);
+        $redis = $this->createRedisMock();
 
         $redis->expects($this->once())->method('xadd')->willReturn('0');
         $redis->expects($this->once())->method('xack')->willReturn(0);
@@ -426,5 +435,18 @@ class ConnectionTest extends TestCase
         }
 
         $this->assertSame('xack error', $e->getMessage());
+    }
+
+    private function createRedisMock(): \Redis
+    {
+        $redis = $this->createMock(\Redis::class);
+        $redis->expects($this->any())
+            ->method('connect')
+            ->willReturn(true);
+        $redis->expects($this->any())
+            ->method('isConnected')
+            ->willReturnOnConsecutiveCalls(false, true);
+
+        return $redis;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

`Redis::connect()` may issue a warning when the host cannot be resolved (see https://github.com/symfony/symfony/actions/runs/11755592846/job/32750804715?pr=58370#step:8:2535)
