### PR TITLE
[DependencyInjection] Fix checking for interfaces in ContainerBuilder::getReflectionClass()

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -369,7 +369,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
                 $resource = new ClassExistenceResource($class, false);
                 $classReflector = $resource->isFresh(0) ? false : new \ReflectionClass($class);
             } else {
-                $classReflector = class_exists($class) ? new \ReflectionClass($class) : false;
+                $classReflector = class_exists($class) || interface_exists($class, false) ? new \ReflectionClass($class) : false;
             }
         } catch (\ReflectionException $e) {
             if ($throw) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58821.
| License       | MIT

Currently, `ContainerBuilder::getReflectionClass()` supports interfaces only if `symfony/config` package is present.
With this fix, it will do so without `symfony/config`.

> Always add tests and ensure they pass.

Not sure how to do this.
All tests run in the monorepo, with all packages present, so `class_exists(ClassExistenceResource::class)` will always be TRUE.
To make this testable, we should make the condition dependent on resource tracking.

> Never break backward compatibility (see https://symfony.com/bc).

This is TBD.
This change would enable autowire for some services where this was previously not the case.