### PR TITLE
[TwigBridge] Fix emojify as function in Undefined Handler

### DIFF
--- a/src/Symfony/Bridge/Twig/UndefinedCallableHandler.php
+++ b/src/Symfony/Bridge/Twig/UndefinedCallableHandler.php
@@ -23,6 +23,7 @@ use Twig\TwigFunction;
 class UndefinedCallableHandler
 {
     private const FILTER_COMPONENTS = [
+        'emojify' => 'emoji',
         'humanize' => 'form',
         'form_encode_currency' => 'form',
         'serialize' => 'serializer',
@@ -37,7 +38,6 @@ class UndefinedCallableHandler
         'asset_version' => 'asset',
         'importmap' => 'asset-mapper',
         'dump' => 'debug-bundle',
-        'emojify' => 'emoji',
         'encore_entry_link_tags' => 'webpack-encore-bundle',
         'encore_entry_script_tags' => 'webpack-encore-bundle',
         'expression' => 'expression-language',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #...
| License       | MIT

Bug is a strong word here, but `emojify` was registered as a function in UndefinedCallableHandler, instead of a filter.

* https://symfony.com/doc/current/reference/twig_reference.html#emojify
* https://twig.symfony.com/doc/3.x/#symfony-filters

