### PR TITLE
[PhpUnitBridge] fix dumping tests to skip with data providers

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\PhpUnit\Legacy;
 
 use Doctrine\Common\Annotations\AnnotationRegistry;
 use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\DataProviderTestSuite;
 use PHPUnit\Framework\RiskyTestError;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\TestSuite;
@@ -196,7 +197,13 @@ class SymfonyTestsListenerTrait
     public function addSkippedTest($test, \Exception $e, $time)
     {
         if (0 < $this->state) {
-            $this->isSkipped[\get_class($test)][$test->getName()] = 1;
+            if ($test instanceof DataProviderTestSuite) {
+                foreach ($test->tests() as $testWithDataProvider) {
+                    $this->isSkipped[\get_class($testWithDataProvider)][$testWithDataProvider->getName()] = 1;
+                }
+            } else {
+                $this->isSkipped[\get_class($test)][$test->getName()] = 1;
+            }
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Without the fix running `SYMFONY_PHPUNIT_SKIPPED_TESTS='phpunit.skipped' php ./phpunit src/Symfony/Component/Lock/Tests/Store/DoctrineDbalPostgreSqlStoreTest.php` without the `pdo_pgsql` extension enabled the generated skip file looked like this:

```
<?php return array (
  'PHPUnit\\Framework\\DataProviderTestSuite' =>
  array (
    'Symfony\\Component\\Lock\\Tests\\Store\\DoctrineDbalPostgreSqlStoreTest::testInvalidDriver' => 1,
  ),
  'Symfony\\Component\\Lock\\Tests\\Store\\DoctrineDbalPostgreSqlStoreTest' =>
  array (
    'testSaveAfterConflict' => 1,
    'testWaitAndSaveAfterConflictReleasesLockFromInternalStore' => 1,
    'testWaitAndSaveReadAfterConflictReleasesLockFromInternalStore' => 1,
    'testSave' => 1,
    'testSaveWithDifferentResources' => 1,
    'testSaveWithDifferentKeysOnSameResources' => 1,
    'testSaveTwice' => 1,
    'testDeleteIsolated' => 1,
    'testBlockingLocks' => 1,
    'testSharedLockReadFirst' => 1,
    'testSharedLockWriteFirst' => 1,
    'testSharedLockPromote' => 1,
    'testSharedLockPromoteAllowed' => 1,
    'testSharedLockDemote' => 1,
  ),
);
```

Thus, running the tests again with the extension enabled would only run 14 tests instead of the expected total number of 16 tests.

With the patch applied the generated skip file looks like this:

```
<?php return array (
  'Symfony\\Component\\Lock\\Tests\\Store\\DoctrineDbalPostgreSqlStoreTest' =>
  array (
    'testInvalidDriver with data set #0' => 1,
    'testInvalidDriver with data set #1' => 1,
    'testSaveAfterConflict' => 1,
    'testWaitAndSaveAfterConflictReleasesLockFromInternalStore' => 1,
    'testWaitAndSaveReadAfterConflictReleasesLockFromInternalStore' => 1,
    'testSave' => 1,
    'testSaveWithDifferentResources' => 1,
    'testSaveWithDifferentKeysOnSameResources' => 1,
    'testSaveTwice' => 1,
    'testDeleteIsolated' => 1,
    'testBlockingLocks' => 1,
    'testSharedLockReadFirst' => 1,
    'testSharedLockWriteFirst' => 1,
    'testSharedLockPromote' => 1,
    'testSharedLockPromoteAllowed' => 1,
    'testSharedLockDemote' => 1,
  ),
);
```
