### PR TITLE
Fix deprecation for `cache.app` adapter with tags

### DIFF
--- a/UPGRADE-7.2.md
+++ b/UPGRADE-7.2.md
@@ -12,7 +12,7 @@ Cache
 -----
 
  * `igbinary_serialize()` is not used by default when the igbinary extension is installed
- * Deprecate making `cache.app` adapter taggable, use the `cache.app.taggable` adapter instead
+ * Deprecate making `cache.app` pool taggable, use the `cache.app.taggable` pool instead
 
 Console
 -------

--- a/UPGRADE-7.2.md
+++ b/UPGRADE-7.2.md
@@ -12,7 +12,7 @@ Cache
 -----
 
  * `igbinary_serialize()` is not used by default when the igbinary extension is installed
- * Deprecate making `cache.app` pool taggable, use the `cache.app.taggable` pool instead
+ * Deprecate making `cache.app` tag aware, use the `cache.app.taggable` service instead
 
 Console
 -------

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2389,6 +2389,16 @@ class FrameworkExtension extends Extension
             }
         }
         foreach (['app', 'system'] as $name) {
+            if ('cache.adapter.redis_tag_aware' === $config[$name]) {
+                trigger_deprecation('symfony/framework-bundle', '7.2', sprintf(
+                    'Using the "cache.adapter.redis_tag_aware" adapter for "cache.%s" is deprecated. You can use the "cache.app.taggable" service instead (aliased to the TagAwareCacheInterface for autowiring).',
+                    $name
+                ));
+                // throw new LogicException(sprintf(
+                //                    'Using the "cache.adapter.redis_tag_aware" adapter for "cache.%s" is deprecated. You can use the "cache.app.taggable" service instead (aliased to the TagAwareCacheInterface for autowiring).',
+                //                    $name
+                //                ));
+            }
             $config['pools']['cache.'.$name] = [
                 'adapters' => [$config[$name]],
                 'public' => true,
@@ -2396,11 +2406,6 @@ class FrameworkExtension extends Extension
             ];
         }
         foreach ($config['pools'] as $name => $pool) {
-            if ('cache.app' === $name && $pool['tags']) {
-                trigger_deprecation('symfony/framework-bundle', '7.2', 'Using the "tags" option with the "cache.app" pool is deprecated. You can use the "cache.app.taggable" pool instead (aliased to the TagAwareCacheInterface for autowiring).');
-                // throw new LogicException('The "tags" option cannot be used with the "cache.app" pool. You can use the "cache.app.taggable" pool instead (aliased to the TagAwareCacheInterface for autowiring).');
-            }
-
             $pool['adapters'] = $pool['adapters'] ?: ['cache.app'];
 
             $isRedisTagAware = ['cache.adapter.redis_tag_aware'] === $pool['adapters'];

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2396,9 +2396,9 @@ class FrameworkExtension extends Extension
             ];
         }
         foreach ($config['pools'] as $name => $pool) {
-            if (\in_array('cache.app', $pool['adapters'] ?? [], true) && $pool['tags']) {
-                trigger_deprecation('symfony/framework-bundle', '7.2', 'Using the "tags" option with the "cache.app" adapter is deprecated. You can use the "cache.app.taggable" adapter instead (aliased to the TagAwareCacheInterface for autowiring).');
-                // throw new LogicException('The "tags" option cannot be used with the "cache.app" adapter. You can use the "cache.app.taggable" adapter instead (aliased to the TagAwareCacheInterface for autowiring).');
+            if ('cache.app' === $name && $pool['tags']) {
+                trigger_deprecation('symfony/framework-bundle', '7.2', 'Using the "tags" option with the "cache.app" pool is deprecated. You can use the "cache.app.taggable" pool instead (aliased to the TagAwareCacheInterface for autowiring).');
+                // throw new LogicException('The "tags" option cannot be used with the "cache.app" pool. You can use the "cache.app.taggable" pool instead (aliased to the TagAwareCacheInterface for autowiring).');
             }
 
             $pool['adapters'] = $pool['adapters'] ?: ['cache.app'];

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache_cacheapp_tagaware.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache_cacheapp_tagaware.php
@@ -6,10 +6,6 @@ $container->loadFromExtension('framework', [
     'handle_all_throwables' => true,
     'php_errors' => ['log' => true],
     'cache' => [
-        'pools' => [
-            'cache.app' => [
-                'tags' => true,
-            ],
-        ],
+        'app' => 'cache.adapter.redis_tag_aware',
     ],
 ]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache_cacheapp_tagaware.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache_cacheapp_tagaware.php
@@ -7,8 +7,7 @@ $container->loadFromExtension('framework', [
     'php_errors' => ['log' => true],
     'cache' => [
         'pools' => [
-            'app.tagaware' => [
-                'adapter' => 'cache.app',
+            'cache.app' => [
                 'tags' => true,
             ],
         ],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/cache_cacheapp_tagaware.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/cache_cacheapp_tagaware.xml
@@ -9,7 +9,7 @@
         <framework:annotations enabled="false" />
         <framework:php-errors log="true" />
         <framework:cache>
-            <framework:pool name="app.tagaware" adapter="cache.app" tags="true" />
+            <framework:pool name="cache.app" tags="true" />
         </framework:cache>
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/cache_cacheapp_tagaware.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/cache_cacheapp_tagaware.xml
@@ -8,8 +8,6 @@
     <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
         <framework:php-errors log="true" />
-        <framework:cache>
-            <framework:pool name="cache.app" tags="true" />
-        </framework:cache>
+        <framework:cache app="cache.adapter.redis_tag_aware"/>
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/cache_cacheapp_tagaware.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/cache_cacheapp_tagaware.yml
@@ -5,6 +5,4 @@ framework:
     php_errors:
         log: true
     cache:
-        pools:
-            cache.app:
-                tags: true
+        app: cache.adapter.redis_tag_aware

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/cache_cacheapp_tagaware.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/cache_cacheapp_tagaware.yml
@@ -6,6 +6,5 @@ framework:
         log: true
     cache:
         pools:
-            app.tagaware:
-                adapter: cache.app
+            cache.app:
                 tags: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -1861,7 +1861,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
      */
     public function testTaggableCacheAppIsDeprecated()
     {
-        $this->expectUserDeprecationMessage('Since symfony/framework-bundle 7.2: Using the "tags" option with the "cache.app" adapter is deprecated. You can use the "cache.app.taggable" adapter instead (aliased to the TagAwareCacheInterface for autowiring).');
+        $this->expectUserDeprecationMessage('Since symfony/framework-bundle 7.2: Using the "tags" option with the "cache.app" pool is deprecated. You can use the "cache.app.taggable" pool instead (aliased to the TagAwareCacheInterface for autowiring).');
 
         $this->createContainerFromFile('cache_cacheapp_tagaware');
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -1861,7 +1861,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
      */
     public function testTaggableCacheAppIsDeprecated()
     {
-        $this->expectUserDeprecationMessage('Since symfony/framework-bundle 7.2: Using the "tags" option with the "cache.app" pool is deprecated. You can use the "cache.app.taggable" pool instead (aliased to the TagAwareCacheInterface for autowiring).');
+        $this->expectUserDeprecationMessage('Since symfony/framework-bundle 7.2: Using the "cache.adapter.redis_tag_aware" adapter for "cache.app" is deprecated. You can use the "cache.app.taggable" service instead (aliased to the TagAwareCacheInterface for autowiring).');
 
         $this->createContainerFromFile('cache_cacheapp_tagaware');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | changed
| Issues        | Fix #58790
| License       | MIT

As discussed in the issue and looking at the code and the original issues here
https://github.com/symfony/symfony/issues/54339
and
https://github.com/twigphp/Twig/issues/3869
I figured that the deprecation actually never did what it intended to do.

When I use the `cache.app` adapter in a new pool together with the tags option symfony creates a new tag aware pool, however `cache.app` itself won't be taggable. The only case I see how to make `app.cache` an instance of TagAware would be to declare that pool manually.

As detailed in the issue actually using `cache.app.taggable` as adapter won't even work. 

@rpkamp & @alexandre-daubois maybe you could verify as you where involved in the original issues.
