### PR TITLE
Work around `parse_url()` bug (bis)

### DIFF
--- a/src/Symfony/Component/DomCrawler/Tests/UriResolverTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/UriResolverTest.php
@@ -87,6 +87,8 @@ class UriResolverTest extends TestCase
 
             ['http://', 'http://localhost', 'http://'],
             ['/foo:123', 'http://localhost', 'http://localhost/foo:123'],
+            ['foo:123', 'http://localhost/', 'foo:123'],
+            ['foo/bar:1/baz', 'http://localhost/', 'http://localhost/foo/bar:1/baz'],
         ];
     }
 }

--- a/src/Symfony/Component/DomCrawler/UriResolver.php
+++ b/src/Symfony/Component/DomCrawler/UriResolver.php
@@ -32,12 +32,8 @@ class UriResolver
     {
         $uri = trim($uri);
 
-        if (false === ($scheme = parse_url($uri, \PHP_URL_SCHEME)) && '/' === ($uri[0] ?? '')) {
-            $scheme = parse_url($uri.'#', \PHP_URL_SCHEME);
-        }
-
         // absolute URL?
-        if (null !== $scheme) {
+        if (null !== parse_url(\strlen($uri) !== strcspn($uri, '?#') ? $uri : $uri.'#', \PHP_URL_SCHEME)) {
             return $uri;
         }
 

--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -514,29 +514,37 @@ trait HttpClientTrait
      */
     private static function parseUrl(string $url, array $query = [], array $allowedSchemes = ['http' => 80, 'https' => 443]): array
     {
-        if (false === $parts = parse_url($url)) {
-            if ('/' !== ($url[0] ?? '') || false === $parts = parse_url($url.'#')) {
-                throw new InvalidArgumentException(sprintf('Malformed URL "%s".', $url));
-            }
-            unset($parts['fragment']);
+        $tail = '';
+
+        if (false === $parts = parse_url(\strlen($url) !== strcspn($url, '?#') ? $url : $url.$tail = '#')) {
+            throw new InvalidArgumentException(sprintf('Malformed URL "%s".', $url));
         }
 
         if ($query) {
             $parts['query'] = self::mergeQueryString($parts['query'] ?? null, $query, true);
         }
 
+        $scheme = $parts['scheme'] ?? null;
+        $host = $parts['host'] ?? null;
+
+        if (!$scheme && $host && !str_starts_with($url, '//')) {
+            $parts = parse_url(':/'.$url.$tail);
+            $parts['path'] = substr($parts['path'], 2);
+            $scheme = $host = null;
+        }
+
         $port = $parts['port'] ?? 0;
 
-        if (null !== $scheme = $parts['scheme'] ?? null) {
+        if (null !== $scheme) {
             if (!isset($allowedSchemes[$scheme = strtolower($scheme)])) {
-                throw new InvalidArgumentException(sprintf('Unsupported scheme in "%s".', $url));
+                throw new InvalidArgumentException(sprintf('Unsupported scheme in "%s": "%s" expected.', $url, implode('" or "', array_keys($allowedSchemes))));
             }
 
             $port = $allowedSchemes[$scheme] === $port ? 0 : $port;
             $scheme .= ':';
         }
 
-        if (null !== $host = $parts['host'] ?? null) {
+        if (null !== $host) {
             if (!\defined('INTL_IDNA_VARIANT_UTS46') && preg_match('/[\x80-\xFF]/', $host)) {
                 throw new InvalidArgumentException(sprintf('Unsupported IDN "%s", try enabling the "intl" PHP extension or running "composer require symfony/polyfill-intl-idn".', $host));
             }
@@ -564,7 +572,7 @@ trait HttpClientTrait
             'authority' => null !== $host ? '//'.(isset($parts['user']) ? $parts['user'].(isset($parts['pass']) ? ':'.$parts['pass'] : '').'@' : '').$host : null,
             'path' => isset($parts['path'][0]) ? $parts['path'] : null,
             'query' => isset($parts['query']) ? '?'.$parts['query'] : null,
-            'fragment' => isset($parts['fragment']) ? '#'.$parts['fragment'] : null,
+            'fragment' => isset($parts['fragment']) && !$tail ? '#'.$parts['fragment'] : null,
         ];
     }
 

--- a/src/Symfony/Component/HttpClient/NativeHttpClient.php
+++ b/src/Symfony/Component/HttpClient/NativeHttpClient.php
@@ -389,6 +389,7 @@ final class NativeHttpClient implements HttpClientInterface, LoggerAwareInterfac
                 return null;
             }
 
+            $locationHasHost = isset($url['authority']);
             $url = self::resolveUrl($url, $info['url']);
             $info['redirect_url'] = implode('', $url);
 
@@ -424,7 +425,7 @@ final class NativeHttpClient implements HttpClientInterface, LoggerAwareInterfac
 
             [$host, $port] = self::parseHostPort($url, $info);
 
-            if (false !== (parse_url($location.'#', \PHP_URL_HOST) ?? false)) {
+            if ($locationHasHost) {
                 // Authorization and Cookie headers MUST NOT follow except for the initial host name
                 $requestHeaders = $redirectHeaders['host'] === $host ? $redirectHeaders['with_auth'] : $redirectHeaders['no_auth'];
                 $requestHeaders[] = 'Host: '.$host.$port;

--- a/src/Symfony/Component/HttpClient/Response/CurlResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/CurlResponse.php
@@ -436,17 +436,18 @@ final class CurlResponse implements ResponseInterface, StreamableInterface
                 $info['http_method'] = 'HEAD' === $info['http_method'] ? 'HEAD' : 'GET';
                 curl_setopt($ch, \CURLOPT_CUSTOMREQUEST, $info['http_method']);
             }
+            $locationHasHost = false;
 
-            if (null === $info['redirect_url'] = $resolveRedirect($ch, $location, $noContent)) {
+            if (null === $info['redirect_url'] = $resolveRedirect($ch, $location, $noContent, $locationHasHost)) {
                 $options['max_redirects'] = curl_getinfo($ch, \CURLINFO_REDIRECT_COUNT);
                 curl_setopt($ch, \CURLOPT_FOLLOWLOCATION, false);
                 curl_setopt($ch, \CURLOPT_MAXREDIRS, $options['max_redirects']);
-            } else {
-                $url = parse_url($location ?? ':');
+            } elseif ($locationHasHost) {
+                $url = parse_url($info['redirect_url']);
 
-                if (isset($url['host']) && null !== $ip = $multi->dnsCache->hostnames[$url['host'] = strtolower($url['host'])] ?? null) {
+                if (null !== $ip = $multi->dnsCache->hostnames[$url['host'] = strtolower($url['host'])] ?? null) {
                     // Populate DNS cache for redirects if needed
-                    $port = $url['port'] ?? ('http' === ($url['scheme'] ?? parse_url(curl_getinfo($ch, \CURLINFO_EFFECTIVE_URL), \PHP_URL_SCHEME)) ? 80 : 443);
+                    $port = $url['port'] ?? ('http' === $url['scheme'] ? 80 : 443);
                     curl_setopt($ch, \CURLOPT_RESOLVE, ["{$url['host']}:$port:$ip"]);
                     $multi->dnsCache->removals["-{$url['host']}:$port"] = "-{$url['host']}:$port";
                 }

--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
@@ -489,4 +489,13 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
 
         $client->request('GET', 'http://symfony.com', ['resolve' => ['symfony.com' => '127.0.0.1']]);
     }
+
+    public function testNoRedirectWithInvalidLocation()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+
+        $response = $client->request('GET', 'http://localhost:8057/302-no-scheme');
+
+        $this->assertSame(302, $response->getStatusCode());
+    }
 }

--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTraitTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTraitTest.php
@@ -102,6 +102,7 @@ class HttpClientTraitTest extends TestCase
             [self::RFC3986_BASE, 'g/../h',        'http://a/b/c/h'],
             [self::RFC3986_BASE, 'g;x=1/./y',     'http://a/b/c/g;x=1/y'],
             [self::RFC3986_BASE, 'g;x=1/../y',    'http://a/b/c/y'],
+            [self::RFC3986_BASE, 'g/h:123/i',     'http://a/b/c/g/h:123/i'],
             // dot-segments in the query or fragment
             [self::RFC3986_BASE, 'g?y/./x',       'http://a/b/c/g?y/./x'],
             [self::RFC3986_BASE, 'g?y/../x',      'http://a/b/c/g?y/../x'],
@@ -127,14 +128,14 @@ class HttpClientTraitTest extends TestCase
     public function testResolveUrlWithoutScheme()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid URL: scheme is missing in "//localhost:8080". Did you forget to add "http(s)://"?');
+        $this->expectExceptionMessage('Unsupported scheme in "localhost:8080": "http" or "https" expected.');
         self::resolveUrl(self::parseUrl('localhost:8080'), null);
     }
 
-    public function testResolveBaseUrlWitoutScheme()
+    public function testResolveBaseUrlWithoutScheme()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid URL: scheme is missing in "//localhost:8081". Did you forget to add "http(s)://"?');
+        $this->expectExceptionMessage('Unsupported scheme in "localhost:8081": "http" or "https" expected.');
         self::resolveUrl(self::parseUrl('/foo'), self::parseUrl('localhost:8081'));
     }
 

--- a/src/Symfony/Component/HttpClient/composer.json
+++ b/src/Symfony/Component/HttpClient/composer.json
@@ -25,7 +25,7 @@
         "php": ">=7.2.5",
         "psr/log": "^1|^2|^3",
         "symfony/deprecation-contracts": "^2.1|^3",
-        "symfony/http-client-contracts": "^2.5.3",
+        "symfony/http-client-contracts": "^2.5.4",
         "symfony/polyfill-php73": "^1.11",
         "symfony/polyfill-php80": "^1.16",
         "symfony/service-contracts": "^1.0|^2|^3"

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -358,12 +358,7 @@ class Request
         $server['PATH_INFO'] = '';
         $server['REQUEST_METHOD'] = strtoupper($method);
 
-        if (false === ($components = parse_url($uri)) && '/' === ($uri[0] ?? '')) {
-            $components = parse_url($uri.'#');
-            unset($components['fragment']);
-        }
-
-        if (false === $components) {
+        if (false === $components = parse_url(\strlen($uri) !== strcspn($uri, '?#') ? $uri : $uri.'#')) {
             throw new BadRequestException('Invalid URI.');
         }
 
@@ -386,9 +381,11 @@ class Request
             if ('https' === $components['scheme']) {
                 $server['HTTPS'] = 'on';
                 $server['SERVER_PORT'] = 443;
-            } else {
+            } elseif ('http' === $components['scheme']) {
                 unset($server['HTTPS']);
                 $server['SERVER_PORT'] = 80;
+            } else {
+                throw new BadRequestException('Invalid URI: http(s) scheme expected.');
             }
         }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -310,7 +310,8 @@ class RequestTest extends TestCase
      *           ["foo\u0000"]
      *           [" foo"]
      *           ["foo "]
-     *           [":"]
+     *           ["//"]
+     *           ["foo:bar"]
      */
     public function testCreateWithBadRequestUri(string $uri)
     {

--- a/src/Symfony/Contracts/HttpClient/Test/Fixtures/web/index.php
+++ b/src/Symfony/Contracts/HttpClient/Test/Fixtures/web/index.php
@@ -98,6 +98,12 @@ switch ($vars['REQUEST_URI']) {
         }
         break;
 
+    case '/302-no-scheme':
+        if (!isset($vars['HTTP_AUTHORIZATION'])) {
+            header('Location: localhost:8067', true, 302);
+        }
+        break;
+
     case '/302/relative':
         header('Location: ..', true, 302);
         break;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | #58313
| License       | MIT

This PR is a follow up of #58218

parse_url behaves incorrectly when parsing some URLs that don't contain `?` or `#`.
This PR ensures that one of those chars is always found when calling the function.