### PR TITLE
[Routing] Fix: lost priority when defining hosts in configuration

### DIFF
--- a/src/Symfony/Component/Routing/Loader/Configurator/Traits/HostTrait.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/Traits/HostTrait.php
@@ -28,6 +28,7 @@ trait HostTrait
 
         foreach ($routes->all() as $name => $route) {
             if (null === $locale = $route->getDefault('_locale')) {
+                $priority = $routes->getPriority($name) ?? 0;
                 $routes->remove($name);
                 foreach ($hosts as $locale => $host) {
                     $localizedRoute = clone $route;
@@ -35,14 +36,14 @@ trait HostTrait
                     $localizedRoute->setRequirement('_locale', preg_quote($locale));
                     $localizedRoute->setDefault('_canonical_route', $name);
                     $localizedRoute->setHost($host);
-                    $routes->add($name.'.'.$locale, $localizedRoute);
+                    $routes->add($name.'.'.$locale, $localizedRoute, $priority);
                 }
             } elseif (!isset($hosts[$locale])) {
                 throw new \InvalidArgumentException(sprintf('Route "%s" with locale "%s" is missing a corresponding host in its parent collection.', $name, $locale));
             } else {
                 $route->setHost($hosts[$locale]);
                 $route->setRequirement('_locale', preg_quote($locale));
-                $routes->add($name, $route);
+                $routes->add($name, $route, $routes->getPriority($name) ?? 0);
             }
         }
     }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/priorized-host.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/priorized-host.yml
@@ -1,0 +1,6 @@
+controllers:
+  resource: Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures\RouteWithPriorityController
+  type: annotation
+  host:
+    cs: www.domain.cs
+    en: www.domain.com

--- a/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
@@ -484,4 +484,27 @@ class YamlFileLoaderTest extends TestCase
         $this->assertSame(2, $routes->getPriority('important.en'));
         $this->assertSame(1, $routes->getPriority('also_important'));
     }
+
+    public function testPriorityWithHost()
+    {
+        new LoaderResolver([
+            $loader = new YamlFileLoader(new FileLocator(\dirname(__DIR__).'/Fixtures/locale_and_host')),
+            new class(new AnnotationReader(), null) extends AnnotationClassLoader {
+                protected function configureRoute(
+                    Route $route,
+                    \ReflectionClass $class,
+                    \ReflectionMethod $method,
+                    object $annot
+                ): void {
+                    $route->setDefault('_controller', $class->getName().'::'.$method->getName());
+                }
+            },
+        ]);
+
+        $routes = $loader->load('priorized-host.yml');
+
+        $this->assertSame(2, $routes->getPriority('important.cs'));
+        $this->assertSame(2, $routes->getPriority('important.en'));
+        $this->assertSame(1, $routes->getPriority('also_important'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | https://github.com/symfony/symfony/issues/58843
| License       | MIT

When host are configured in routing, the original route is removed from the collection and then re-added. During this process, the route's priority is lost as it's not preserved during the removal and re-addition.

Bug has similarities with #52912 (resolved for prefix)