### PR TITLE
[TypeInfo] Remove `@experimental` tag

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/ConstructorExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ConstructorExtractor.php
@@ -29,9 +29,6 @@ final class ConstructorExtractor implements PropertyTypeExtractorInterface
     ) {
     }
 
-    /**
-     * @experimental
-     */
     public function getType(string $class, string $property, array $context = []): ?Type
     {
         foreach ($this->extractors as $extractor) {

--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -194,9 +194,6 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
         return array_merge([], ...$types);
     }
 
-    /**
-     * @experimental
-     */
     public function getType(string $class, string $property, array $context = []): ?Type
     {
         /** @var DocBlock $docBlock */
@@ -256,9 +253,6 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
         return Type::list($type);
     }
 
-    /**
-     * @experimental
-     */
     public function getTypeFromConstructor(string $class, string $property): ?Type
     {
         if (!$docBlock = $this->getDocBlockFromConstructor($class, $property)) {

--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
@@ -185,9 +185,6 @@ final class PhpStanExtractor implements PropertyTypeExtractorInterface, Construc
         return $types;
     }
 
-    /**
-     * @experimental
-     */
     public function getType(string $class, string $property, array $context = []): ?Type
     {
         /** @var PhpDocNode|null $docNode */
@@ -234,9 +231,6 @@ final class PhpStanExtractor implements PropertyTypeExtractorInterface, Construc
         return Type::list($type);
     }
 
-    /**
-     * @experimental
-     */
     public function getTypeFromConstructor(string $class, string $property): ?Type
     {
         if (!$tagDocNode = $this->getDocBlockFromConstructor($class, $property)) {

--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -205,9 +205,6 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
         return $types;
     }
 
-    /**
-     * @experimental
-     */
     public function getType(string $class, string $property, array $context = []): ?Type
     {
         [$mutatorReflection, $prefix] = $this->getMutatorMethod($class, $property);
@@ -269,9 +266,6 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
         return $type;
     }
 
-    /**
-     * @experimental
-     */
     public function getTypeFromConstructor(string $class, string $property): ?Type
     {
         try {

--- a/src/Symfony/Component/PropertyInfo/PropertyInfoCacheExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyInfoCacheExtractor.php
@@ -56,9 +56,6 @@ class PropertyInfoCacheExtractor implements PropertyInfoExtractorInterface, Prop
         return $this->extract('getProperties', [$class, $context]);
     }
 
-    /**
-     * @experimental
-     */
     public function getType(string $class, string $property, array $context = []): ?Type
     {
         return $this->extract('getType', [$class, $property, $context]);

--- a/src/Symfony/Component/PropertyInfo/PropertyInfoExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyInfoExtractor.php
@@ -53,9 +53,6 @@ class PropertyInfoExtractor implements PropertyInfoExtractorInterface, PropertyI
         return $this->extract($this->descriptionExtractors, 'getLongDescription', [$class, $property, $context]);
     }
 
-    /**
-     * @experimental
-     */
     public function getType(string $class, string $property, array $context = []): ?Type
     {
         return $this->extract($this->typeExtractors, 'getType', [$class, $property, $context]);

--- a/src/Symfony/Component/PropertyInfo/Util/PhpDocTypeHelper.php
+++ b/src/Symfony/Component/PropertyInfo/Util/PhpDocTypeHelper.php
@@ -106,8 +106,6 @@ final class PhpDocTypeHelper
 
     /**
      * Creates a {@see Type} from a PHPDoc type.
-     *
-     * @experimental
      */
     public function getType(DocType $varType): ?Type
     {

--- a/src/Symfony/Component/TypeInfo/CHANGELOG.md
+++ b/src/Symfony/Component/TypeInfo/CHANGELOG.md
@@ -12,6 +12,8 @@ CHANGELOG
  * Remove `Type::getBaseType()`, `Type::asNonNullable()` and `Type::__call()` methods
  * Remove `CompositeTypeTrait`
  * Add `PhpDocAwareReflectionTypeResolver` resolver
+ * The type resolvers are not marked as `@internal` anymore
+ * The component is not marked as `@experimental` anymore
 
 7.1
 ---

--- a/src/Symfony/Component/TypeInfo/Exception/ExceptionInterface.php
+++ b/src/Symfony/Component/TypeInfo/Exception/ExceptionInterface.php
@@ -14,8 +14,6 @@ namespace Symfony\Component\TypeInfo\Exception;
 /**
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
- *
- * @experimental
  */
 interface ExceptionInterface extends \Throwable
 {

--- a/src/Symfony/Component/TypeInfo/Exception/InvalidArgumentException.php
+++ b/src/Symfony/Component/TypeInfo/Exception/InvalidArgumentException.php
@@ -14,8 +14,6 @@ namespace Symfony\Component\TypeInfo\Exception;
 /**
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
- *
- * @experimental
  */
 class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
 {

--- a/src/Symfony/Component/TypeInfo/Exception/LogicException.php
+++ b/src/Symfony/Component/TypeInfo/Exception/LogicException.php
@@ -14,8 +14,6 @@ namespace Symfony\Component\TypeInfo\Exception;
 /**
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
- *
- * @experimental
  */
 class LogicException extends \LogicException implements ExceptionInterface
 {

--- a/src/Symfony/Component/TypeInfo/Exception/RuntimeException.php
+++ b/src/Symfony/Component/TypeInfo/Exception/RuntimeException.php
@@ -14,8 +14,6 @@ namespace Symfony\Component\TypeInfo\Exception;
 /**
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
- *
- * @experimental
  */
 class RuntimeException extends \RuntimeException implements ExceptionInterface
 {

--- a/src/Symfony/Component/TypeInfo/Exception/UnsupportedException.php
+++ b/src/Symfony/Component/TypeInfo/Exception/UnsupportedException.php
@@ -14,8 +14,6 @@ namespace Symfony\Component\TypeInfo\Exception;
 /**
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
- *
- * @experimental
  */
 class UnsupportedException extends \LogicException implements ExceptionInterface
 {

--- a/src/Symfony/Component/TypeInfo/Type.php
+++ b/src/Symfony/Component/TypeInfo/Type.php
@@ -17,8 +17,6 @@ use Symfony\Component\TypeInfo\Type\WrappingTypeInterface;
 /**
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
- *
- * @experimental
  */
 abstract class Type implements \Stringable
 {

--- a/src/Symfony/Component/TypeInfo/Type/BackedEnumType.php
+++ b/src/Symfony/Component/TypeInfo/Type/BackedEnumType.php
@@ -22,8 +22,6 @@ use Symfony\Component\TypeInfo\TypeIdentifier;
  * @template U of BuiltinType<TypeIdentifier::INT>|BuiltinType<TypeIdentifier::STRING>
  *
  * @extends EnumType<T>
- *
- * @experimental
  */
 final class BackedEnumType extends EnumType
 {

--- a/src/Symfony/Component/TypeInfo/Type/BuiltinType.php
+++ b/src/Symfony/Component/TypeInfo/Type/BuiltinType.php
@@ -19,8 +19,6 @@ use Symfony\Component\TypeInfo\TypeIdentifier;
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
  *
  * @template T of TypeIdentifier
- *
- * @experimental
  */
 final class BuiltinType extends Type
 {

--- a/src/Symfony/Component/TypeInfo/Type/CollectionType.php
+++ b/src/Symfony/Component/TypeInfo/Type/CollectionType.php
@@ -24,8 +24,6 @@ use Symfony\Component\TypeInfo\TypeIdentifier;
  * @template T of BuiltinType<TypeIdentifier::ARRAY>|BuiltinType<TypeIdentifier::ITERABLE>|ObjectType|GenericType
  *
  * @implements WrappingTypeInterface<T>
- *
- * @experimental
  */
 final class CollectionType extends Type implements WrappingTypeInterface
 {

--- a/src/Symfony/Component/TypeInfo/Type/CompositeTypeInterface.php
+++ b/src/Symfony/Component/TypeInfo/Type/CompositeTypeInterface.php
@@ -19,8 +19,6 @@ use Symfony\Component\TypeInfo\Type;
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  *
  * @template T of Type
- *
- * @experimental
  */
 interface CompositeTypeInterface
 {

--- a/src/Symfony/Component/TypeInfo/Type/EnumType.php
+++ b/src/Symfony/Component/TypeInfo/Type/EnumType.php
@@ -18,8 +18,6 @@ namespace Symfony\Component\TypeInfo\Type;
  * @template T of class-string<\UnitEnum>
  *
  * @extends ObjectType<T>
- *
- * @experimental
  */
 class EnumType extends ObjectType
 {

--- a/src/Symfony/Component/TypeInfo/Type/GenericType.php
+++ b/src/Symfony/Component/TypeInfo/Type/GenericType.php
@@ -24,8 +24,6 @@ use Symfony\Component\TypeInfo\TypeIdentifier;
  * @template T of BuiltinType<TypeIdentifier::ARRAY>|BuiltinType<TypeIdentifier::ITERABLE>|ObjectType
  *
  * @implements WrappingTypeInterface<T>
- *
- * @experimental
  */
 final class GenericType extends Type implements WrappingTypeInterface
 {

--- a/src/Symfony/Component/TypeInfo/Type/IntersectionType.php
+++ b/src/Symfony/Component/TypeInfo/Type/IntersectionType.php
@@ -21,8 +21,6 @@ use Symfony\Component\TypeInfo\Type;
  * @template T of ObjectType|GenericType<ObjectType>|CollectionType<GenericType<ObjectType>>
  *
  * @implements CompositeTypeInterface<T>
- *
- * @experimental
  */
 final class IntersectionType extends Type implements CompositeTypeInterface
 {

--- a/src/Symfony/Component/TypeInfo/Type/NullableType.php
+++ b/src/Symfony/Component/TypeInfo/Type/NullableType.php
@@ -23,8 +23,6 @@ use Symfony\Component\TypeInfo\TypeIdentifier;
  * @extends UnionType<T|BuiltinType<TypeIdentifier::NULL>>
  *
  * @implements WrappingTypeInterface<T>
- *
- * @experimental
  */
 final class NullableType extends UnionType implements WrappingTypeInterface
 {

--- a/src/Symfony/Component/TypeInfo/Type/ObjectType.php
+++ b/src/Symfony/Component/TypeInfo/Type/ObjectType.php
@@ -19,8 +19,6 @@ use Symfony\Component\TypeInfo\TypeIdentifier;
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
  *
  * @template T of class-string
- *
- * @experimental
  */
 class ObjectType extends Type
 {

--- a/src/Symfony/Component/TypeInfo/Type/TemplateType.php
+++ b/src/Symfony/Component/TypeInfo/Type/TemplateType.php
@@ -22,8 +22,6 @@ use Symfony\Component\TypeInfo\Type;
  * @template T of Type
  *
  * @implements WrappingTypeInterface<T>
- *
- * @experimental
  */
 final class TemplateType extends Type implements WrappingTypeInterface
 {

--- a/src/Symfony/Component/TypeInfo/Type/UnionType.php
+++ b/src/Symfony/Component/TypeInfo/Type/UnionType.php
@@ -22,8 +22,6 @@ use Symfony\Component\TypeInfo\TypeIdentifier;
  * @template T of Type
  *
  * @implements CompositeTypeInterface<T>
- *
- * @experimental
  */
 class UnionType extends Type implements CompositeTypeInterface
 {

--- a/src/Symfony/Component/TypeInfo/Type/WrappingTypeInterface.php
+++ b/src/Symfony/Component/TypeInfo/Type/WrappingTypeInterface.php
@@ -19,8 +19,6 @@ use Symfony\Component\TypeInfo\Type;
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  *
  * @template T of Type
- *
- * @experimental
  */
 interface WrappingTypeInterface
 {

--- a/src/Symfony/Component/TypeInfo/TypeContext/TypeContext.php
+++ b/src/Symfony/Component/TypeInfo/TypeContext/TypeContext.php
@@ -22,8 +22,6 @@ use Symfony\Component\TypeInfo\Type;
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
- *
- * @experimental
  */
 final class TypeContext
 {

--- a/src/Symfony/Component/TypeInfo/TypeContext/TypeContextFactory.php
+++ b/src/Symfony/Component/TypeInfo/TypeContext/TypeContextFactory.php
@@ -28,8 +28,6 @@ use Symfony\Component\TypeInfo\TypeResolver\StringTypeResolver;
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
- *
- * @experimental
  */
 final class TypeContextFactory
 {

--- a/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
+++ b/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
@@ -27,8 +27,6 @@ use Symfony\Component\TypeInfo\Type\UnionType;
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
- *
- * @experimental
  */
 trait TypeFactoryTrait
 {

--- a/src/Symfony/Component/TypeInfo/TypeIdentifier.php
+++ b/src/Symfony/Component/TypeInfo/TypeIdentifier.php
@@ -16,8 +16,6 @@ namespace Symfony\Component\TypeInfo;
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
- *
- * @experimental
  */
 enum TypeIdentifier: string
 {

--- a/src/Symfony/Component/TypeInfo/TypeResolver/PhpDocAwareReflectionTypeResolver.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/PhpDocAwareReflectionTypeResolver.php
@@ -29,8 +29,6 @@ use Symfony\Component\TypeInfo\TypeContext\TypeContextFactory;
  * Resolves type on reflection prioriziting PHP documentation.
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
- *
- * @internal
  */
 final readonly class PhpDocAwareReflectionTypeResolver implements TypeResolverInterface
 {

--- a/src/Symfony/Component/TypeInfo/TypeResolver/ReflectionParameterTypeResolver.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/ReflectionParameterTypeResolver.php
@@ -21,8 +21,6 @@ use Symfony\Component\TypeInfo\TypeContext\TypeContextFactory;
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
- *
- * @internal
  */
 final readonly class ReflectionParameterTypeResolver implements TypeResolverInterface
 {

--- a/src/Symfony/Component/TypeInfo/TypeResolver/ReflectionPropertyTypeResolver.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/ReflectionPropertyTypeResolver.php
@@ -21,8 +21,6 @@ use Symfony\Component\TypeInfo\TypeContext\TypeContextFactory;
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
- *
- * @internal
  */
 final readonly class ReflectionPropertyTypeResolver implements TypeResolverInterface
 {

--- a/src/Symfony/Component/TypeInfo/TypeResolver/ReflectionReturnTypeResolver.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/ReflectionReturnTypeResolver.php
@@ -21,8 +21,6 @@ use Symfony\Component\TypeInfo\TypeContext\TypeContextFactory;
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
- *
- * @internal
  */
 final readonly class ReflectionReturnTypeResolver implements TypeResolverInterface
 {

--- a/src/Symfony/Component/TypeInfo/TypeResolver/ReflectionTypeResolver.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/ReflectionTypeResolver.php
@@ -22,8 +22,6 @@ use Symfony\Component\TypeInfo\TypeIdentifier;
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
- *
- * @internal
  */
 final class ReflectionTypeResolver implements TypeResolverInterface
 {

--- a/src/Symfony/Component/TypeInfo/TypeResolver/StringTypeResolver.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/StringTypeResolver.php
@@ -49,8 +49,6 @@ use Symfony\Component\TypeInfo\TypeIdentifier;
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
- *
- * @internal
  */
 final class StringTypeResolver implements TypeResolverInterface
 {

--- a/src/Symfony/Component/TypeInfo/TypeResolver/TypeResolver.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/TypeResolver.php
@@ -23,8 +23,6 @@ use Symfony\Component\TypeInfo\TypeContext\TypeContextFactory;
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
- *
- * @experimental
  */
 final readonly class TypeResolver implements TypeResolverInterface
 {

--- a/src/Symfony/Component/TypeInfo/TypeResolver/TypeResolverInterface.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/TypeResolverInterface.php
@@ -20,8 +20,6 @@ use Symfony\Component\TypeInfo\TypeContext\TypeContext;
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
- *
- * @experimental
  */
 interface TypeResolverInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

- Unmark `@experimental` for TypeInfo component
- Remove `@internal` tag over type resolvers, as they must be able to be used over other components
