### PR TITLE
[HttpClient] Stream request body in HttplugClient and Psr18Client

### DIFF
--- a/src/Symfony/Component/HttpClient/HttplugClient.php
+++ b/src/Symfony/Component/HttpClient/HttplugClient.php
@@ -229,9 +229,14 @@ final class HttplugClient implements ClientInterface, HttpAsyncClient, RequestFa
                 $body->seek(0);
             }
 
+            $headers = $request->getHeaders();
+            if (!$request->hasHeader('content-length') && 0 <= $size = $body->getSize() ?? -1) {
+                $headers['Content-Length'] = [$size];
+            }
+
             $options = [
-                'headers' => $request->getHeaders(),
-                'body' => $body->getContents(),
+                'headers' => $headers,
+                'body' => static fn (int $size) => $body->read($size),
                 'buffer' => $buffer,
             ];
 

--- a/src/Symfony/Component/HttpClient/Psr18Client.php
+++ b/src/Symfony/Component/HttpClient/Psr18Client.php
@@ -93,9 +93,14 @@ final class Psr18Client implements ClientInterface, RequestFactoryInterface, Str
                 $body->seek(0);
             }
 
+            $headers = $request->getHeaders();
+            if (!$request->hasHeader('content-length') && 0 <= $size = $body->getSize() ?? -1) {
+                $headers['Content-Length'] = [$size];
+            }
+
             $options = [
-                'headers' => $request->getHeaders(),
-                'body' => $body->getContents(),
+                'headers' => $headers,
+                'body' => static fn (int $size) => $body->read($size),
             ];
 
             if ('1.0' === $request->getProtocolVersion()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Currently, `Psr18Client` and `HttplugClient` will simply call `getContents()` on the stream, loading the entire stream content into a string before passing it to the underlying `HttpClient`. When sending a request with a large body, this can lead to the PHP process running out of memory.
This pull request changes both clients to instead pass a Closure that reads from the request body stream to the underlying `HttpClient`.

The HttpClient documentation states that "each time, the closure should return a string smaller than the amount requested as argument", which would mean that if the closure was called requesting a size of 10 bytes, you are only allowed to return at most 9 bytes. I assume that is an inaccuracy in the docs, but please correct me if I'm wrong here.
I'm also not fully sure whether this would be considered a new feature or a bug fix.
