### PR TITLE
[AssetMapper] ignore missing directory in `isVendor()`

### DIFF
--- a/src/Symfony/Component/AssetMapper/Factory/MappedAssetFactory.php
+++ b/src/Symfony/Component/AssetMapper/Factory/MappedAssetFactory.php
@@ -128,6 +128,6 @@ class MappedAssetFactory implements MappedAssetFactoryInterface
         $sourcePath = realpath($sourcePath);
         $vendorDir = realpath($this->vendorDir);
 
-        return $sourcePath && str_starts_with($sourcePath, $vendorDir);
+        return $sourcePath && $vendorDir && str_starts_with($sourcePath, $vendorDir);
     }
 }

--- a/src/Symfony/Component/AssetMapper/Tests/Factory/MappedAssetFactoryTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Factory/MappedAssetFactoryTest.php
@@ -26,6 +26,8 @@ use Symfony\Component\AssetMapper\Path\PublicAssetsPathResolverInterface;
 
 class MappedAssetFactoryTest extends TestCase
 {
+    private const DEFAULT_FIXTURES = __DIR__.'/../Fixtures/assets/vendor';
+
     private AssetMapperInterface&MockObject $assetMapper;
 
     public function testCreateMappedAsset()
@@ -137,7 +139,15 @@ class MappedAssetFactoryTest extends TestCase
         $this->assertTrue($asset->isVendor);
     }
 
-    private function createFactory(?AssetCompilerInterface $extraCompiler = null): MappedAssetFactory
+    public function testCreateMappedAssetInMissingVendor()
+    {
+        $assetMapper = $this->createFactory(null, '/this-path-does-not-exist/');
+        $asset = $assetMapper->createMappedAsset('lodash.js', __DIR__.'/../Fixtures/assets/vendor/lodash/lodash.index.js');
+        $this->assertSame('lodash.js', $asset->logicalPath);
+        $this->assertFalse($asset->isVendor);
+    }
+
+    private function createFactory(?AssetCompilerInterface $extraCompiler = null, ?string $vendorDir = self::DEFAULT_FIXTURES): MappedAssetFactory
     {
         $compilers = [
             new JavaScriptImportPathCompiler($this->createMock(ImportMapConfigReader::class)),
@@ -162,7 +172,7 @@ class MappedAssetFactoryTest extends TestCase
         $factory = new MappedAssetFactory(
             $pathResolver,
             $compiler,
-            __DIR__.'/../Fixtures/assets/vendor',
+            $vendorDir,
         );
 
         // mock the AssetMapper to behave like normal: by calling back to the factory


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58858
| License       | MIT

~~I don't know how to add tests yet, because this method is private.~~