### PR TITLE
Add conflict with doctrine/data-fixtures >= 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -155,6 +155,7 @@
         "ext-psr": "<1.1|>=2",
         "async-aws/core": "<1.5",
         "doctrine/annotations": "<1.13.1",
+        "doctrine/data-fixtures": ">=2",
         "doctrine/dbal": "<2.13.1",
         "egulias/email-validator": "~3.0.0",
         "masterminds/html5": "<2.6",

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -51,6 +51,7 @@
         "psr/log": "^1|^2|^3"
     },
     "conflict": {
+        "doctrine/data-fixtures": ">=2",
         "doctrine/dbal": "<2.13.1",
         "doctrine/lexer": "<1.1",
         "doctrine/orm": "<2.7.4",


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | explanation below
| License       | MIT


While working on [allowing v2 of doctrine/data-fixtures in the bundle](https://github.com/doctrine/DoctrineFixturesBundle/pull/457), I stumbled upon an issue that only affects some versions of Symfony that still have a `ContainerAwareLoader` class.

The signature of `ContainerAwareLoader::addFixture()` is not compatible with the v2 signature of the `Loader` interface from `doctrine/data-fixtures`, as per this fatal error:

```
Declaration of Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader::addFixture(Doctrine\Common\DataFixtures\FixtureInterface $fixture)
             must be compatible with Doctrine\Common\DataFixtures\Loader::addFixture(Doctrine\Common\DataFixtures\FixtureInterface $fixture): void
```

The class is not final, which means adding the return type declaration would be a breaking change.

Let us add a conflict to signal this temporary incompatibility. Once this is merged up, the conflict can be bumped to v3 in branches where `ContainerAwareLoader` no longer exists. Once enough versions of Symfony with this fix are released, I will be able to use a version constraint on `symfony/doctrine-bridge` that will avoid the CI failure I experienced in the bundle.