### PR TITLE
Run tests with doctrine/data-fixtures v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -130,7 +130,7 @@
         "async-aws/sns": "^1.0",
         "cache/integration-tests": "dev-master",
         "doctrine/collections": "^1.0|^2.0",
-        "doctrine/data-fixtures": "^1.1",
+        "doctrine/data-fixtures": "^1.1|^2.0",
         "doctrine/dbal": "^3.6|^4",
         "doctrine/orm": "^2.15|^3",
         "dragonmantank/cron-expression": "^3.1",
@@ -163,6 +163,7 @@
     "conflict": {
         "ext-psr": "<1.1|>=2",
         "async-aws/core": "<1.5",
+        "doctrine/data-fixtures": ">=3",
         "doctrine/dbal": "<3.6",
         "doctrine/orm": "<2.15",
         "egulias/email-validator": "~3.0.0",

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -44,12 +44,13 @@
         "symfony/validator": "^6.4|^7.0",
         "symfony/var-dumper": "^6.4|^7.0",
         "doctrine/collections": "^1.0|^2.0",
-        "doctrine/data-fixtures": "^1.1",
+        "doctrine/data-fixtures": "^1.1|^2.0",
         "doctrine/dbal": "^3.6|^4",
         "doctrine/orm": "^2.15|^3",
         "psr/log": "^1|^2|^3"
     },
     "conflict": {
+        "doctrine/data-fixtures": ">=3",
         "doctrine/dbal": "<3.6",
         "doctrine/lexer": "<1.1",
         "doctrine/orm": "<2.15",


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | n/a
| License       | MIT

Symfony does not conflict with doctrine/data-fixtures v2 and is compatible with it, so let us ensure it stays that way and test v2. I also added a conflict with future v3 so that compatibility is not advertised when it is missing.

I am targeting 7.1 because 5 and 6 are not compatible with doctrine/data-fixtures v2. The incompatibility is handled in https://github.com/symfony/symfony/pull/58861.