### PR TITLE
Dynamically fix compatibility with doctrine/data-fixtures v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -127,7 +127,7 @@
         "doctrine/annotations": "^1.13.1|^2",
         "doctrine/cache": "^1.11|^2.0",
         "doctrine/collections": "^1.0|^2.0",
-        "doctrine/data-fixtures": "^1.1",
+        "doctrine/data-fixtures": "^1.1|^2",
         "doctrine/dbal": "^2.13.1|^3.0",
         "doctrine/orm": "^2.7.4",
         "guzzlehttp/promises": "^1.4|^2.0",

--- a/src/Symfony/Bridge/Doctrine/DataFixtures/AddFixtureImplementation.php
+++ b/src/Symfony/Bridge/Doctrine/DataFixtures/AddFixtureImplementation.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\DataFixtures;
+
+use Doctrine\Common\DataFixtures\FixtureInterface;
+use Doctrine\Common\DataFixtures\ReferenceRepository;
+
+if (method_exists(ReferenceRepository::class, 'getReferences')) {
+    /** @internal */
+    trait AddFixtureImplementation
+    {
+        public function addFixture(FixtureInterface $fixture)
+        {
+            $this->doAddFixture($fixture);
+        }
+    }
+} else {
+    /** @internal */
+    trait AddFixtureImplementation
+    {
+        public function addFixture(FixtureInterface $fixture): void
+        {
+            $this->doAddFixture($fixture);
+        }
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/DataFixtures/ContainerAwareLoader.php
+++ b/src/Symfony/Bridge/Doctrine/DataFixtures/ContainerAwareLoader.php
@@ -25,6 +25,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class ContainerAwareLoader extends Loader
 {
+    use AddFixtureImplementation;
+
     private $container;
 
     public function __construct(ContainerInterface $container)
@@ -32,10 +34,7 @@ class ContainerAwareLoader extends Loader
         $this->container = $container;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function addFixture(FixtureInterface $fixture)
+    private function doAddFixture(FixtureInterface $fixture): void
     {
         if ($fixture instanceof ContainerAwareInterface) {
             $fixture->setContainer($this->container);

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -45,7 +45,7 @@
         "symfony/var-dumper": "^4.4|^5.0|^6.0",
         "doctrine/annotations": "^1.10.4|^2",
         "doctrine/collections": "^1.0|^2.0",
-        "doctrine/data-fixtures": "^1.1",
+        "doctrine/data-fixtures": "^1.1|^2",
         "doctrine/dbal": "^2.13.1|^3|^4",
         "doctrine/orm": "^2.7.4|^3",
         "psr/log": "^1|^2|^3"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | see explanation below
| License       | MIT

While working on [allowing v2 of doctrine/data-fixtures in the bundle](https://github.com/doctrine/DoctrineFixturesBundle/pull/457), I stumbled upon an issue that only affects some versions of Symfony that still have a `ContainerAwareLoader` class.

The signature of `ContainerAwareLoader::addFixture()` is not compatible with the v2 signature of the `Loader` interface from `doctrine/data-fixtures`, as per this fatal error:

```
Declaration of Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader::addFixture(Doctrine\Common\DataFixtures\FixtureInterface $fixture)
             must be compatible with Doctrine\Common\DataFixtures\Loader::addFixture(Doctrine\Common\DataFixtures\FixtureInterface $fixture): void
```

Classes that extend ContainerAwareLoader have to also extend Loader, meaning this is no breaking change because it can be argued that the incompatibility of the extending class would be with the Loader interface.

Closes #58861, Closes #58863