### PR TITLE
[Validator] fix compatibility with PHP < 8.2.4

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/NoSuspiciousCharactersValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NoSuspiciousCharactersValidator.php
@@ -99,7 +99,17 @@ class NoSuspiciousCharactersValidator extends ConstraintValidator
         }
 
         foreach (self::CHECK_ERROR as $check => $error) {
-            if (!($errorCode & $check)) {
+            if (\PHP_VERSION_ID < 80204) {
+                if (!($checks & $check)) {
+                    continue;
+                }
+
+                $checker->setChecks($check);
+
+                if (!$checker->isSuspicious($value)) {
+                    continue;
+                }
+            } elseif (!($errorCode & $check)) {
                 continue;
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

The fix for php/php-src#10647 (on which #54062) relies on was first released with PHP 8.2.4.
