### PR TITLE
[Serializer][Validator] prevent failures around not existing TypeInfo classes

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -938,7 +938,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
      */
     private function getPropertyType(string $className, string $property): Type|array|null
     {
-        if (method_exists($this->propertyTypeExtractor, 'getType')) {
+        if (class_exists(Type::class) && method_exists($this->propertyTypeExtractor, 'getType')) {
             return $this->propertyTypeExtractor->getType($className, $property);
         }
 

--- a/src/Symfony/Component/Validator/Mapping/Loader/PropertyInfoLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/PropertyInfoLoader.php
@@ -175,7 +175,7 @@ final class PropertyInfoLoader implements LoaderInterface
      */
     private function getPropertyTypes(string $className, string $property): TypeInfoType|array|null
     {
-        if (method_exists($this->typeExtractor, 'getType')) {
+        if (class_exists(TypeInfoType::class) && method_exists($this->typeExtractor, 'getType')) {
             return $this->typeExtractor->getType($className, $property);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Having a `getType()` method on an extractor is not enough. Such a method may exist to be forward-compatible with the TypeInfo component. We still must not call it if the TypeInfo component is not installed to prevent running into errors for not-defined classes when the TypeInfo component is not installed.
