### PR TITLE
[Form] `BirthdayType` has automatic `attr` when `widget` is `single_text`

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Allow injecting a `ViolationMapperInterface` into `FormTypeValidatorExtension`
  * Deprecate passing boolean as the second argument of `ValidatorExtension` and `FormTypeValidatorExtension`'s constructors; pass a `ViolationMapperInterface` instead
  * Add argument `$violationMapper` to `ValidatorExtensionTrait` and `TypeTestCase`'s `getExtensions()` methods
+ * Add default `min`/`max` attributes to `BirthdayType` when `widget` is `single_text`
 
 8.0
 ---

--- a/src/Symfony/Component/Form/Extension/Core/Type/BirthdayType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/BirthdayType.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class BirthdayType extends AbstractType
@@ -19,7 +21,7 @@ class BirthdayType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'years' => range((int) date('Y') - 120, date('Y')),
+            'years' => range(date('Y') - 120, date('Y')),
             'invalid_message' => 'Please enter a valid birthdate.',
         ]);
 
@@ -34,5 +36,13 @@ class BirthdayType extends AbstractType
     public function getBlockPrefix(): string
     {
         return 'birthday';
+    }
+
+    public function buildView(FormView $view, FormInterface $form, array $options): void
+    {
+        if ('single_text' === $options['widget']) {
+            $view->vars['attr']['min'] ??= \sprintf('%d-01-01', min($options['years']));
+            $view->vars['attr']['max'] ??= \sprintf('%d-12-31', max($options['years']));
+        }
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/BirthdayTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/BirthdayTypeTest.php
@@ -29,4 +29,43 @@ class BirthdayTypeTest extends DateTypeTest
             'widget' => 'choice',
         ]);
     }
+
+    public function testWidgetSingleTextHasDefaultAttrMinMax()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'widget' => 'single_text',
+        ]);
+        $formView = $form->createView();
+        $options = $form->getConfig()->getOptions();
+        $expectedMin = \sprintf('%d-01-01', min($options['years']));
+        $expectedMax = \sprintf('%d-12-31', max($options['years']));
+        $this->assertSame($expectedMin, $formView->vars['attr']['min']);
+        $this->assertSame($expectedMax, $formView->vars['attr']['max']);
+    }
+
+    public function testWidgetSingleTextDoesntRemoveUserAttr()
+    {
+        $expectedMin = date('Y-m-d', strtotime('10 years ago'));
+        $expectedMax = date('Y-m-d', strtotime('1 years ago'));
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'widget' => 'single_text',
+            'attr' => [
+                'min' => $expectedMin,
+                'max' => $expectedMax,
+            ],
+        ]);
+        $formView = $form->createView();
+        $this->assertSame($expectedMin, $formView->vars['attr']['min']);
+        $this->assertSame($expectedMax, $formView->vars['attr']['max']);
+    }
+
+    public function testWidgetChoiceDoesNotSetMinMaxAttr()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'widget' => 'choice',
+        ]);
+        $formView = $form->createView();
+        $this->assertArrayNotHasKey('min', $formView->vars['attr']);
+        $this->assertArrayNotHasKey('max', $formView->vars['attr']);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #58621 
| License       | MIT

I change the logic to @stof advises. So I change the vars in the form view with the `buildView` function instead of using `configureOptions` function.

I feel that I am doing something wrong since the default value of attr['min'] and attr['max'] are defined with `date()` function (+ years provided in the options). Final user day can be another one because of his timezone. Is it possible to get the user timezone from there ? Or it's not a big matter ?