### PR TITLE
[PropertyInfo][Serializer][Validator] TypeInfo 7.2 compatibility

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
@@ -27,6 +27,7 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\TraitUsage\DummyUsedInTrait;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\TraitUsage\DummyUsingTrait;
 use Symfony\Component\PropertyInfo\Type as LegacyType;
 use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\Type\NullableType;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
@@ -562,7 +563,14 @@ class PhpDocExtractorTest extends TestCase
         yield ['f', Type::list(Type::object(\DateTimeImmutable::class)), null, null];
         yield ['g', Type::nullable(Type::array()), 'Nullable array.', null];
         yield ['h', Type::nullable(Type::string()), null, null];
-        yield ['i', Type::union(Type::int(), Type::string(), Type::null()), null, null];
+
+        // BC layer for type-info < 7.2
+        if (!class_exists(NullableType::class)) {
+            yield ['i', Type::union(Type::int(), Type::string(), Type::null()), null, null];
+        } else {
+            yield ['i', Type::nullable(Type::union(Type::int(), Type::string())), null, null];
+        }
+
         yield ['j', Type::nullable(Type::object(\DateTimeImmutable::class)), null, null];
         yield ['nullableCollectionOfNonNullableElements', Type::nullable(Type::list(Type::int())), null, null];
         yield ['donotexist', null, null, null];
@@ -629,7 +637,14 @@ class PhpDocExtractorTest extends TestCase
         yield ['f', null];
         yield ['g', Type::nullable(Type::array())];
         yield ['h', Type::nullable(Type::string())];
-        yield ['i', Type::union(Type::int(), Type::string(), Type::null())];
+
+        // BC layer for type-info < 7.2
+        if (!class_exists(NullableType::class)) {
+            yield ['i', Type::union(Type::int(), Type::string(), Type::null())];
+        } else {
+            yield ['i', Type::nullable(Type::union(Type::int(), Type::string()))];
+        }
+
         yield ['j', Type::nullable(Type::object(\DateTimeImmutable::class))];
         yield ['nullableCollectionOfNonNullableElements', Type::nullable(Type::list(Type::int()))];
         yield ['donotexist', null];
@@ -693,7 +708,14 @@ class PhpDocExtractorTest extends TestCase
         yield ['f', Type::list(Type::object(\DateTimeImmutable::class))];
         yield ['g', Type::nullable(Type::array())];
         yield ['h', Type::nullable(Type::string())];
-        yield ['i', Type::union(Type::int(), Type::string(), Type::null())];
+
+        // BC layer for type-info < 7.2
+        if (!class_exists(NullableType::class)) {
+            yield ['i', Type::union(Type::int(), Type::string(), Type::null())];
+        } else {
+            yield ['i', Type::nullable(Type::union(Type::int(), Type::string()))];
+        }
+
         yield ['j', Type::nullable(Type::object(\DateTimeImmutable::class))];
         yield ['nullableCollectionOfNonNullableElements', Type::nullable(Type::list(Type::int()))];
         yield ['nonNullableCollectionOfNullableElements', Type::list(Type::nullable(Type::int()))];

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
@@ -36,6 +36,7 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\TraitUsage\DummyUsingTrait;
 use Symfony\Component\PropertyInfo\Type as LegacyType;
 use Symfony\Component\TypeInfo\Exception\LogicException;
 use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\Type\WrappingTypeInterface;
 
 require_once __DIR__.'/../Fixtures/Extractor/DummyNamespace.php';
 
@@ -869,7 +870,14 @@ class PhpStanExtractorTest extends TestCase
     public static function pseudoTypesProvider(): iterable
     {
         yield ['classString', Type::string()];
-        yield ['classStringGeneric', Type::generic(Type::string(), Type::object(\stdClass::class))];
+
+        // BC layer for type-info < 7.2
+        if (!interface_exists(WrappingTypeInterface::class)) {
+            yield ['classStringGeneric', Type::generic(Type::string(), Type::object(\stdClass::class))];
+        } else {
+            yield ['classStringGeneric', Type::string()];
+        }
+
         yield ['htmlEscapedString', Type::string()];
         yield ['lowercaseString', Type::string()];
         yield ['nonEmptyLowercaseString', Type::string()];

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -33,6 +33,7 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\Php82Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\SnakeCaseDummy;
 use Symfony\Component\PropertyInfo\Type as LegacyType;
 use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\Type\NullableType;
 use Symfony\Component\TypeInfo\TypeResolver\PhpDocAwareReflectionTypeResolver;
 
 /**
@@ -772,7 +773,14 @@ class ReflectionExtractorTest extends TestCase
         yield ['foo', Type::nullable(Type::array())];
         yield ['bar', Type::nullable(Type::int())];
         yield ['timeout', Type::union(Type::int(), Type::float())];
-        yield ['optional', Type::union(Type::nullable(Type::int()), Type::nullable(Type::float()))];
+
+        // BC layer for type-info < 7.2
+        if (!class_exists(NullableType::class)) {
+            yield ['optional', Type::union(Type::nullable(Type::int()), Type::nullable(Type::float()))];
+        } else {
+            yield ['optional', Type::nullable(Type::union(Type::float(), Type::int()))];
+        }
+
         yield ['string', Type::union(Type::string(), Type::object(\Stringable::class))];
         yield ['payload', Type::mixed()];
         yield ['data', Type::mixed()];

--- a/src/Symfony/Component/PropertyInfo/Util/PhpDocTypeHelper.php
+++ b/src/Symfony/Component/PropertyInfo/Util/PhpDocTypeHelper.php
@@ -128,7 +128,9 @@ final class PhpDocTypeHelper
                 $nullable = true;
             }
 
-            return $this->createType($varType, $nullable);
+            $type = $this->createType($varType);
+
+            return $nullable ? Type::nullable($type) : $type;
         }
 
         $varTypes = [];
@@ -156,8 +158,7 @@ final class PhpDocTypeHelper
 
         $unionTypes = [];
         foreach ($varTypes as $varType) {
-            $t = $this->createType($varType, $nullable);
-            if (null !== $t) {
+            if (null !== $t = $this->createType($varType)) {
                 $unionTypes[] = $t;
             }
         }
@@ -238,7 +239,7 @@ final class PhpDocTypeHelper
     /**
      * Creates a {@see Type} from a PHPDoc type.
      */
-    private function createType(DocType $docType, bool $nullable): ?Type
+    private function createType(DocType $docType): ?Type
     {
         $docTypeString = (string) $docType;
 
@@ -262,9 +263,8 @@ final class PhpDocTypeHelper
             }
 
             $type = null !== $class ? Type::object($class) : Type::builtin($phpType);
-            $type = Type::collection($type, ...$variableTypes);
 
-            return $nullable ? Type::nullable($type) : $type;
+            return Type::collection($type, ...$variableTypes);
         }
 
         if (!$docTypeString) {
@@ -277,9 +277,8 @@ final class PhpDocTypeHelper
 
         if (str_starts_with($docTypeString, 'list<') && $docType instanceof Array_) {
             $collectionValueType = $this->getType($docType->getValueType());
-            $type = Type::list($collectionValueType);
 
-            return $nullable ? Type::nullable($type) : $type;
+            return Type::list($collectionValueType);
         }
 
         if (str_starts_with($docTypeString, 'array<') && $docType instanceof Array_) {
@@ -288,16 +287,14 @@ final class PhpDocTypeHelper
             $collectionKeyType = $this->getType($docType->getKeyType());
             $collectionValueType = $this->getType($docType->getValueType());
 
-            $type = Type::array($collectionValueType, $collectionKeyType);
-
-            return $nullable ? Type::nullable($type) : $type;
+            return Type::array($collectionValueType, $collectionKeyType);
         }
 
         if ($docType instanceof PseudoType) {
             if ($docType->underlyingType() instanceof Integer) {
-                return $nullable ? Type::nullable(Type::int()) : Type::int();
+                return Type::int();
             } elseif ($docType->underlyingType() instanceof String_) {
-                return $nullable ? Type::nullable(Type::string()) : Type::string();
+                return Type::string();
             }
         }
 
@@ -314,12 +311,10 @@ final class PhpDocTypeHelper
         [$phpType, $class] = $this->getPhpTypeAndClass($docTypeString);
 
         if ('array' === $docTypeString) {
-            return $nullable ? Type::nullable(Type::array()) : Type::array();
+            return Type::array();
         }
 
-        $type = null !== $class ? Type::object($class) : Type::builtin($phpType);
-
-        return $nullable ? Type::nullable($type) : $type;
+        return null !== $class ? Type::object($class) : Type::builtin($phpType);
     }
 
     private function normalizeType(string $docType): string

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -34,10 +34,13 @@ use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 use Symfony\Component\TypeInfo\Exception\LogicException as TypeInfoLogicException;
 use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\Type\BuiltinType;
 use Symfony\Component\TypeInfo\Type\CollectionType;
 use Symfony\Component\TypeInfo\Type\IntersectionType;
+use Symfony\Component\TypeInfo\Type\NullableType;
 use Symfony\Component\TypeInfo\Type\ObjectType;
 use Symfony\Component\TypeInfo\Type\UnionType;
+use Symfony\Component\TypeInfo\Type\WrappingTypeInterface;
 use Symfony\Component\TypeInfo\TypeIdentifier;
 
 /**
@@ -644,7 +647,14 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
     private function validateAndDenormalize(Type $type, string $currentClass, string $attribute, mixed $data, ?string $format, array $context): mixed
     {
         $expectedTypes = [];
-        $isUnionType = $type->asNonNullable() instanceof UnionType;
+
+        // BC layer for type-info < 7.2
+        if (method_exists(Type::class, 'asNonNullable')) {
+            $isUnionType = $type->asNonNullable() instanceof UnionType;
+        } else {
+            $isUnionType = $type instanceof UnionType;
+        }
+
         $e = null;
         $extraAttributesException = null;
         $missingConstructorArgumentsException = null;
@@ -667,12 +677,23 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                 $collectionValueType = $t->getCollectionValueType();
             }
 
-            $t = $t->getBaseType();
+            // BC layer for type-info < 7.2
+            if (method_exists(Type::class, 'getBaseType')) {
+                $t = $t->getBaseType();
+            } else {
+                while ($t instanceof WrappingTypeInterface) {
+                    $t = $t->getWrappedType();
+                }
+            }
 
             // Fix a collection that contains the only one element
             // This is special to xml format only
-            if ('xml' === $format && $collectionValueType && !$collectionValueType->isA(TypeIdentifier::MIXED) && (!\is_array($data) || !\is_int(key($data)))) {
-                $data = [$data];
+            if ('xml' === $format && $collectionValueType && (!\is_array($data) || !\is_int(key($data)))) {
+                // BC layer for type-info < 7.2
+                $isMixedType = method_exists(Type::class, 'isA') ? $collectionValueType->isA(TypeIdentifier::MIXED) : $collectionValueType->isIdentifiedBy(TypeIdentifier::MIXED);
+                if (!$isMixedType) {
+                    $data = [$data];
+                }
             }
 
             // This try-catch should cover all NotNormalizableValueException (and all return branches after the first
@@ -695,7 +716,10 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                             return '';
                         }
 
-                        $isNullable = $isNullable ?: $type->isNullable();
+                        // BC layer for type-info < 7.2
+                        if (method_exists(Type::class, 'isNullable')) {
+                            $isNullable = $isNullable ?: $type->isNullable();
+                        }
                     }
 
                     switch ($typeIdentifier) {
@@ -732,7 +756,16 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
 
                 if ($collectionValueType) {
                     try {
-                        $collectionValueBaseType = $collectionValueType->getBaseType();
+                        $collectionValueBaseType = $collectionValueType;
+
+                        // BC layer for type-info < 7.2
+                        if (!interface_exists(WrappingTypeInterface::class)) {
+                            $collectionValueBaseType = $collectionValueType->getBaseType();
+                        } else {
+                            while ($collectionValueBaseType instanceof WrappingTypeInterface) {
+                                $collectionValueBaseType = $collectionValueBaseType->getWrappedType();
+                            }
+                        }
                     } catch (TypeInfoLogicException) {
                         $collectionValueBaseType = Type::mixed();
                     }
@@ -742,15 +775,29 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                         $class = $collectionValueBaseType->getClassName().'[]';
                         $context['key_type'] = $collectionKeyType;
                         $context['value_type'] = $collectionValueType;
-                    } elseif (TypeIdentifier::ARRAY === $collectionValueBaseType->getTypeIdentifier()) {
+                    } elseif (
+                        // BC layer for type-info < 7.2
+                        !class_exists(NullableType::class) && TypeIdentifier::ARRAY === $collectionValueBaseType->getTypeIdentifier()
+                        || $collectionValueBaseType instanceof BuiltinType && TypeIdentifier::ARRAY === $collectionValueBaseType->getTypeIdentifier()
+                    ) {
                         // get inner type for any nested array
                         $innerType = $collectionValueType;
+                        if ($innerType instanceof NullableType) {
+                            $innerType = $innerType->getWrappedType();
+                        }
 
                         // note that it will break for any other builtinType
                         $dimensions = '[]';
                         while ($innerType instanceof CollectionType) {
                             $dimensions .= '[]';
                             $innerType = $innerType->getCollectionValueType();
+                            if ($innerType instanceof NullableType) {
+                                $innerType = $innerType->getWrappedType();
+                            }
+                        }
+
+                        while ($innerType instanceof WrappingTypeInterface) {
+                            $innerType = $innerType->getWrappedType();
                         }
 
                         if ($innerType instanceof ObjectType) {
@@ -862,8 +909,15 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             throw $missingConstructorArgumentsException;
         }
 
-        if (!$isUnionType && $e) {
-            throw $e;
+        // BC layer for type-info < 7.2
+        if (!class_exists(NullableType::class)) {
+            if (!$isUnionType && $e) {
+                throw $e;
+            }
+        } else {
+            if ($e && !($type instanceof UnionType && !$type instanceof NullableType)) {
+                throw $e;
+            }
         }
 
         if ($context[self::DISABLE_TYPE_ENFORCEMENT] ?? $this->defaultContext[self::DISABLE_TYPE_ENFORCEMENT] ?? false) {

--- a/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
@@ -16,7 +16,9 @@ use Symfony\Component\Serializer\Exception\BadMethodCallException;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
 use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\Type\BuiltinType;
 use Symfony\Component\TypeInfo\Type\UnionType;
+use Symfony\Component\TypeInfo\TypeIdentifier;
 
 /**
  * Denormalizes arrays of objects.
@@ -59,7 +61,15 @@ class ArrayDenormalizer implements DenormalizerInterface, DenormalizerAwareInter
         $typeIdentifiers = [];
         if (null !== $keyType = ($context['key_type'] ?? null)) {
             if ($keyType instanceof Type) {
-                $typeIdentifiers = array_map(fn (Type $t): string => $t->getBaseType()->getTypeIdentifier()->value, $keyType instanceof UnionType ? $keyType->getTypes() : [$keyType]);
+                // BC layer for type-info < 7.2
+                if (method_exists(Type::class, 'getBaseType')) {
+                    $typeIdentifiers = array_map(fn (Type $t): string => $t->getBaseType()->getTypeIdentifier()->value, $keyType instanceof UnionType ? $keyType->getTypes() : [$keyType]);
+                } else {
+                    /** @var list<BuiltinType<TypeIdentifier::INT>|BuiltinType<TypeIdentifier::STRING>> */
+                    $keyTypes = $keyType instanceof UnionType ? $keyType->getTypes() : [$keyType];
+
+                    $typeIdentifiers = array_map(fn (BuiltinType $t): string => $t->getTypeIdentifier()->value, $keyTypes);
+                }
             } else {
                 $typeIdentifiers = array_map(fn (LegacyType $t): string => $t->getBuiltinType(), \is_array($keyType) ? $keyType : [$keyType]);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Make Serializer, PropertyInfo, and Validator components compatible with TypeInfo 7.2 breaking changes (https://github.com/symfony/symfony/pull/57630) so that we can remove the conflicts in TypeInfo's `composer.json` file in 7.2 