### PR TITLE
Added body size limit option to AmpHttpClient

### DIFF
--- a/src/Symfony/Component/HttpClient/AmpHttpClient.php
+++ b/src/Symfony/Component/HttpClient/AmpHttpClient.php
@@ -52,7 +52,6 @@ final class AmpHttpClient implements HttpClientInterface, LoggerAwareInterface, 
 
     public const OPTIONS_DEFAULTS = HttpClientInterface::OPTIONS_DEFAULTS + [
         'crypto_method' => \STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT,
-        'body_size_limit' => null,
     ];
 
     private array $defaultOptions = self::OPTIONS_DEFAULTS;
@@ -126,6 +125,7 @@ final class AmpHttpClient implements HttpClientInterface, LoggerAwareInterface, 
         }
 
         $request = new Request(implode('', $url), $method);
+        $request->setBodySizeLimit(0);
 
         if ($options['http_version']) {
             $request->setProtocolVersions(match ((float) $options['http_version']) {
@@ -133,10 +133,6 @@ final class AmpHttpClient implements HttpClientInterface, LoggerAwareInterface, 
                 1.1 => ['1.1', '1.0'],
                 default => ['2', '1.1', '1.0'],
             });
-        }
-
-        if ($options['body_size_limit']) {
-            $request->setBodySizeLimit($options['body_size_limit']);
         }
 
         foreach ($options['headers'] as $v) {

--- a/src/Symfony/Component/HttpClient/AmpHttpClient.php
+++ b/src/Symfony/Component/HttpClient/AmpHttpClient.php
@@ -52,6 +52,7 @@ final class AmpHttpClient implements HttpClientInterface, LoggerAwareInterface, 
 
     public const OPTIONS_DEFAULTS = HttpClientInterface::OPTIONS_DEFAULTS + [
         'crypto_method' => \STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT,
+        'body_size_limit' => null
     ];
 
     private array $defaultOptions = self::OPTIONS_DEFAULTS;
@@ -132,6 +133,10 @@ final class AmpHttpClient implements HttpClientInterface, LoggerAwareInterface, 
                 1.1 => ['1.1', '1.0'],
                 default => ['2', '1.1', '1.0'],
             });
+        }
+
+        if ($options['body_size_limit']) {
+            $request->setBodySizeLimit($options['body_size_limit']);
         }
 
         foreach ($options['headers'] as $v) {

--- a/src/Symfony/Component/HttpClient/AmpHttpClient.php
+++ b/src/Symfony/Component/HttpClient/AmpHttpClient.php
@@ -52,7 +52,7 @@ final class AmpHttpClient implements HttpClientInterface, LoggerAwareInterface, 
 
     public const OPTIONS_DEFAULTS = HttpClientInterface::OPTIONS_DEFAULTS + [
         'crypto_method' => \STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT,
-        'body_size_limit' => null
+        'body_size_limit' => null,
     ];
 
     private array $defaultOptions = self::OPTIONS_DEFAULTS;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        |  Body size limit always capped at ~10 MB with AmpHttpClient
| License       | MIT

I added the option `body_size_limit` to the AmpHttpClient to be able to increase the default from AmpHttpClient, wich is ~10 MB.