### PR TITLE
[TypeInfo] Remove conflict with other components

### DIFF
--- a/src/Symfony/Component/TypeInfo/composer.json
+++ b/src/Symfony/Component/TypeInfo/composer.json
@@ -36,11 +36,9 @@
     "conflict": {
         "phpstan/phpdoc-parser": "<1.0",
         "symfony/dependency-injection": "<6.4",
-        "symfony/doctrine-bridge": "7.1.*",
-        "symfony/framework-bundle": "7.1.*",
-        "symfony/property-info": "7.1.*",
-        "symfony/serializer": "7.1.*",
-        "symfony/validator": "7.1.*"
+        "symfony/property-info": ">=7.1,<7.1.9",
+        "symfony/serializer": ">=7.1,<7.1.9",
+        "symfony/validator": ">=7.1,<7.1.9"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\TypeInfo\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Update conflicts of Serializer, Validator and PropertyInfo components, as https://github.com/symfony/symfony/pull/58872 makes them compatible with 7.2