### PR TITLE
[AssetMapper] Fix MappedAssetFactory::isVendor() when vendor dir is null

### DIFF
--- a/src/Symfony/Component/AssetMapper/Factory/MappedAssetFactory.php
+++ b/src/Symfony/Component/AssetMapper/Factory/MappedAssetFactory.php
@@ -128,6 +128,6 @@ class MappedAssetFactory implements MappedAssetFactoryInterface
         $sourcePath = realpath($sourcePath);
         $vendorDir = realpath($this->vendorDir);
 
-        return $sourcePath && str_starts_with($sourcePath, $vendorDir);
+        return $sourcePath && $vendorDir && str_starts_with($sourcePath, $vendorDir);
     }
 }

--- a/src/Symfony/Component/AssetMapper/Tests/Factory/MappedAssetFactoryTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Factory/MappedAssetFactoryTest.php
@@ -185,4 +185,20 @@ class MappedAssetFactoryTest extends TestCase
 
         return $factory;
     }
+
+    public function testIsVendorWhenVendorDirDoesNotExists()
+    {
+        $pathResolver = $this->createMock(PublicAssetsPathResolverInterface::class);
+        $compiler = $this->createMock(AssetMapperCompiler::class);
+
+        $factory = new MappedAssetFactory(
+            $pathResolver,
+            $compiler,
+            '/foo/bar/baz',
+        );
+
+        $method = (new \ReflectionClass($factory))->getMethod('isVendor');
+
+        $this->assertFalse($method->invoke($factory, '/'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Issues        | Fix #58858
| License       | MIT

Good catch in #58858, we never check the `%kernel_projectDir%/assets/vendors` exists.