### PR TITLE
[PropertyInfo][Serializer][TypeInfo][Validator] TypeInfo 7.1 compatibility

### DIFF
--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -39,7 +39,7 @@
         "symfony/security-core": "^6.4|^7.0",
         "symfony/stopwatch": "^6.4|^7.0",
         "symfony/translation": "^6.4|^7.0",
-        "symfony/type-info": "^7.2",
+        "symfony/type-info": "^7.1",
         "symfony/uid": "^6.4|^7.0",
         "symfony/validator": "^6.4|^7.0",
         "symfony/var-dumper": "^6.4|^7.0",

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -64,7 +64,7 @@
         "symfony/string": "^6.4|^7.0",
         "symfony/translation": "^6.4|^7.0",
         "symfony/twig-bundle": "^6.4|^7.0",
-        "symfony/type-info": "^7.2",
+        "symfony/type-info": "^7.1",
         "symfony/validator": "^6.4|^7.0",
         "symfony/workflow": "^6.4|^7.0",
         "symfony/yaml": "^6.4|^7.0",

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
@@ -27,6 +27,7 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\TraitUsage\DummyUsedInTrait;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\TraitUsage\DummyUsingTrait;
 use Symfony\Component\PropertyInfo\Type as LegacyType;
 use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\Type\NullableType;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
@@ -562,7 +563,14 @@ class PhpDocExtractorTest extends TestCase
         yield ['f', Type::list(Type::object(\DateTimeImmutable::class)), null, null];
         yield ['g', Type::nullable(Type::array()), 'Nullable array.', null];
         yield ['h', Type::nullable(Type::string()), null, null];
-        yield ['i', Type::union(Type::int(), Type::string(), Type::null()), null, null];
+
+        // BC layer for type-info < 7.2
+        if (!class_exists(NullableType::class)) {
+            yield ['i', Type::union(Type::int(), Type::string(), Type::null()), null, null];
+        } else {
+            yield ['i', Type::nullable(Type::union(Type::int(), Type::string())), null, null];
+        }
+
         yield ['j', Type::nullable(Type::object(\DateTimeImmutable::class)), null, null];
         yield ['nullableCollectionOfNonNullableElements', Type::nullable(Type::list(Type::int())), null, null];
         yield ['donotexist', null, null, null];
@@ -629,7 +637,14 @@ class PhpDocExtractorTest extends TestCase
         yield ['f', null];
         yield ['g', Type::nullable(Type::array())];
         yield ['h', Type::nullable(Type::string())];
-        yield ['i', Type::union(Type::int(), Type::string(), Type::null())];
+
+        // BC layer for type-info < 7.2
+        if (!class_exists(NullableType::class)) {
+            yield ['i', Type::union(Type::int(), Type::string(), Type::null())];
+        } else {
+            yield ['i', Type::nullable(Type::union(Type::int(), Type::string()))];
+        }
+
         yield ['j', Type::nullable(Type::object(\DateTimeImmutable::class))];
         yield ['nullableCollectionOfNonNullableElements', Type::nullable(Type::list(Type::int()))];
         yield ['donotexist', null];
@@ -693,7 +708,14 @@ class PhpDocExtractorTest extends TestCase
         yield ['f', Type::list(Type::object(\DateTimeImmutable::class))];
         yield ['g', Type::nullable(Type::array())];
         yield ['h', Type::nullable(Type::string())];
-        yield ['i', Type::nullable(Type::union(Type::int(), Type::string()))];
+
+        // BC layer for type-info < 7.2
+        if (!class_exists(NullableType::class)) {
+            yield ['i', Type::union(Type::int(), Type::string(), Type::null())];
+        } else {
+            yield ['i', Type::nullable(Type::union(Type::int(), Type::string()))];
+        }
+
         yield ['j', Type::nullable(Type::object(\DateTimeImmutable::class))];
         yield ['nullableCollectionOfNonNullableElements', Type::nullable(Type::list(Type::int()))];
         yield ['nonNullableCollectionOfNullableElements', Type::list(Type::nullable(Type::int()))];

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
@@ -36,6 +36,7 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\TraitUsage\DummyUsingTrait;
 use Symfony\Component\PropertyInfo\Type as LegacyType;
 use Symfony\Component\TypeInfo\Exception\LogicException;
 use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\Type\WrappingTypeInterface;
 
 require_once __DIR__.'/../Fixtures/Extractor/DummyNamespace.php';
 
@@ -869,7 +870,14 @@ class PhpStanExtractorTest extends TestCase
     public static function pseudoTypesProvider(): iterable
     {
         yield ['classString', Type::string()];
-        yield ['classStringGeneric', Type::string()];
+
+        // BC layer for type-info < 7.2
+        if (!interface_exists(WrappingTypeInterface::class)) {
+            yield ['classStringGeneric', Type::generic(Type::string(), Type::object(\stdClass::class))];
+        } else {
+            yield ['classStringGeneric', Type::string()];
+        }
+
         yield ['htmlEscapedString', Type::string()];
         yield ['lowercaseString', Type::string()];
         yield ['nonEmptyLowercaseString', Type::string()];

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -33,6 +33,7 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\Php82Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\SnakeCaseDummy;
 use Symfony\Component\PropertyInfo\Type as LegacyType;
 use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\Type\NullableType;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
@@ -771,7 +772,14 @@ class ReflectionExtractorTest extends TestCase
         yield ['foo', Type::nullable(Type::array())];
         yield ['bar', Type::nullable(Type::int())];
         yield ['timeout', Type::union(Type::int(), Type::float())];
-        yield ['optional', Type::nullable(Type::union(Type::float(), Type::int()))];
+
+        // BC layer for type-info < 7.2
+        if (!class_exists(NullableType::class)) {
+            yield ['optional', Type::union(Type::nullable(Type::int()), Type::nullable(Type::float()))];
+        } else {
+            yield ['optional', Type::nullable(Type::union(Type::float(), Type::int()))];
+        }
+
         yield ['string', Type::union(Type::string(), Type::object(\Stringable::class))];
         yield ['payload', Type::mixed()];
         yield ['data', Type::mixed()];

--- a/src/Symfony/Component/PropertyInfo/composer.json
+++ b/src/Symfony/Component/PropertyInfo/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "php": ">=8.2",
         "symfony/string": "^6.4|^7.0",
-        "symfony/type-info": "^7.2"
+        "symfony/type-info": "^7.1"
     },
     "require-dev": {
         "symfony/serializer": "^6.4|^7.0",

--- a/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
@@ -56,10 +56,15 @@ class ArrayDenormalizer implements DenormalizerInterface, DenormalizerAwareInter
         $typeIdentifiers = [];
         if (null !== $keyType = ($context['key_type'] ?? null)) {
             if ($keyType instanceof Type) {
-                /** @var list<BuiltinType<TypeIdentifier::INT>|BuiltinType<TypeIdentifier::STRING>> */
-                $keyTypes = $keyType instanceof UnionType ? $keyType->getTypes() : [$keyType];
+                // BC layer for type-info < 7.2
+                if (method_exists(Type::class, 'getBaseType')) {
+                    $typeIdentifiers = array_map(fn (Type $t): string => $t->getBaseType()->getTypeIdentifier()->value, $keyType instanceof UnionType ? $keyType->getTypes() : [$keyType]);
+                } else {
+                    /** @var list<BuiltinType<TypeIdentifier::INT>|BuiltinType<TypeIdentifier::STRING>> */
+                    $keyTypes = $keyType instanceof UnionType ? $keyType->getTypes() : [$keyType];
 
-                $typeIdentifiers = array_map(fn (BuiltinType $t): string => $t->getTypeIdentifier()->value, $keyTypes);
+                    $typeIdentifiers = array_map(fn (BuiltinType $t): string => $t->getTypeIdentifier()->value, $keyTypes);
+                }
             } else {
                 $typeIdentifiers = array_map(fn (LegacyType $t): string => $t->getBuiltinType(), \is_array($keyType) ? $keyType : [$keyType]);
             }

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -38,7 +38,7 @@
         "symfony/property-access": "^6.4|^7.0",
         "symfony/property-info": "^6.4|^7.0",
         "symfony/translation-contracts": "^2.5|^3",
-        "symfony/type-info": "^7.2",
+        "symfony/type-info": "^7.1",
         "symfony/uid": "^6.4|^7.0",
         "symfony/validator": "^6.4|^7.0",
         "symfony/var-dumper": "^6.4|^7.0",
@@ -51,7 +51,6 @@
         "symfony/dependency-injection": "<6.4",
         "symfony/property-access": "<6.4",
         "symfony/property-info": "<6.4",
-        "symfony/type-info": "<7.2",
         "symfony/uid": "<6.4",
         "symfony/validator": "<6.4",
         "symfony/yaml": "<6.4"

--- a/src/Symfony/Component/TypeInfo/composer.json
+++ b/src/Symfony/Component/TypeInfo/composer.json
@@ -30,15 +30,11 @@
     },
     "require-dev": {
         "phpstan/phpdoc-parser": "^1.0|^2.0",
-        "symfony/dependency-injection": "^6.4|^7.0",
-        "symfony/property-info": "^7.2"
+        "symfony/dependency-injection": "^6.4|^7.0"
     },
     "conflict": {
         "phpstan/phpdoc-parser": "<1.0",
-        "symfony/dependency-injection": "<6.4",
-        "symfony/property-info": ">=7.1,<7.1.9",
-        "symfony/serializer": ">=7.1,<7.1.9",
-        "symfony/validator": ">=7.1,<7.1.9"
+        "symfony/dependency-injection": "<6.4"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\TypeInfo\\": "" },

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -39,7 +39,7 @@
         "symfony/property-access": "^6.4|^7.0",
         "symfony/property-info": "^6.4|^7.0",
         "symfony/translation": "^6.4.3|^7.0.3",
-        "symfony/type-info": "^7.2-RC1",
+        "symfony/type-info": "^7.1",
         "egulias/email-validator": "^2.1.10|^3|^4"
     },
     "conflict": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Upmerge https://github.com/symfony/symfony/pull/58872 to allow DoctrineBridge, Validator, Serializer and PropertyInfo to be compatible with TypeInfo 7.1