### PR TITLE
[Serializer] Handle default context in Serializer

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.php
@@ -60,7 +60,7 @@ return static function (ContainerConfigurator $container) {
 
     $container->services()
         ->set('serializer', Serializer::class)
-            ->args([[], []])
+            ->args([[], [], []])
 
         ->alias(SerializerInterface::class, 'serializer')
         ->alias(NormalizerInterface::class, 'serializer')

--- a/src/Symfony/Component/Serializer/DependencyInjection/SerializerPass.php
+++ b/src/Symfony/Component/Serializer/DependencyInjection/SerializerPass.php
@@ -56,6 +56,7 @@ class SerializerPass implements CompilerPassInterface
             }
 
             $container->getParameterBag()->remove('serializer.default_context');
+            $container->getDefinition('serializer')->setArgument('$defaultContext', $defaultContext);
         }
 
         if ($container->getParameter('kernel.debug') && $container->hasDefinition('serializer.data_collector')) {

--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -84,10 +84,12 @@ class Serializer implements SerializerInterface, ContextAwareNormalizerInterface
     /**
      * @param array<NormalizerInterface|DenormalizerInterface> $normalizers
      * @param array<EncoderInterface|DecoderInterface>         $encoders
+     * @param array<string, mixed>                             $defaultContext
      */
     public function __construct(
         private array $normalizers = [],
         array $encoders = [],
+        private array $defaultContext = [],
     ) {
         foreach ($normalizers as $normalizer) {
             if ($normalizer instanceof SerializerAwareInterface) {
@@ -163,12 +165,12 @@ class Serializer implements SerializerInterface, ContextAwareNormalizerInterface
             return $data;
         }
 
-        if (\is_array($data) && !$data && ($context[self::EMPTY_ARRAY_AS_OBJECT] ?? false)) {
+        if (\is_array($data) && !$data && ($context[self::EMPTY_ARRAY_AS_OBJECT] ?? $this->defaultContext[self::EMPTY_ARRAY_AS_OBJECT] ?? false)) {
             return new \ArrayObject();
         }
 
         if (is_iterable($data)) {
-            if ($data instanceof \Countable && ($context[AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS] ?? false) && !\count($data)) {
+            if ($data instanceof \Countable && ($context[AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS] ?? $this->defaultContext[AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS] ?? false) && !\count($data)) {
                 return new \ArrayObject();
             }
 
@@ -220,7 +222,7 @@ class Serializer implements SerializerInterface, ContextAwareNormalizerInterface
             throw new NotNormalizableValueException(sprintf('Could not denormalize object of type "%s", no supporting normalizer found.', $type));
         }
 
-        if (isset($context[DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS])) {
+        if (isset($context[DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS]) || isset($this->defaultContext[DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS])) {
             unset($context[DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS]);
             $context['not_normalizable_value_exceptions'] = [];
             $errors = &$context['not_normalizable_value_exceptions'];

--- a/src/Symfony/Component/Serializer/Tests/DependencyInjection/SerializerPassTest.php
+++ b/src/Symfony/Component/Serializer/Tests/DependencyInjection/SerializerPassTest.php
@@ -77,9 +77,11 @@ class SerializerPassTest extends TestCase
 
     public function testBindSerializerDefaultContext()
     {
+        $context = ['enable_max_depth' => true];
+
         $container = new ContainerBuilder();
         $container->setParameter('kernel.debug', false);
-        $container->register('serializer')->setArguments([null, null]);
+        $container->register('serializer')->setArguments([null, null, []]);
         $container->setParameter('serializer.default_context', ['enable_max_depth' => true]);
         $definition = $container->register('n1')->addTag('serializer.normalizer')->addTag('serializer.encoder');
 
@@ -87,7 +89,8 @@ class SerializerPassTest extends TestCase
         $serializerPass->process($container);
 
         $bindings = $definition->getBindings();
-        $this->assertEquals($bindings['array $defaultContext'], new BoundArgument(['enable_max_depth' => true], false));
+        $this->assertEquals($bindings['array $defaultContext'], new BoundArgument($context, false));
+        $this->assertEquals($context, $container->getDefinition('serializer')->getArgument('$defaultContext'));
     }
 
     public function testNormalizersAndEncodersAreDecoredAndOrderedWhenCollectingData()

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -1652,6 +1652,32 @@ class SerializerTest extends TestCase
             DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS => true,
         ]);
     }
+
+    public function testEmptyArrayAsObjectDefaultContext()
+    {
+        $serializer = new Serializer(
+            defaultContext: [Serializer::EMPTY_ARRAY_AS_OBJECT => true],
+        );
+        $this->assertEquals(new \ArrayObject(), $serializer->normalize([]));
+    }
+
+    public function testPreserveEmptyObjectsAsDefaultContext()
+    {
+        $serializer = new Serializer(
+            defaultContext: [AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS => true],
+        );
+        $this->assertEquals(new \ArrayObject(), $serializer->normalize(new \ArrayIterator()));
+    }
+
+    public function testCollectDenormalizationErrorsDefaultContext()
+    {
+        $data = ['variadic' => ['a random string']];
+        $serializer = new Serializer([new UidNormalizer(), new ObjectNormalizer()], [], [DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS => true]);
+
+        $this->expectException(PartialDenormalizationException::class);
+
+        $serializer->denormalize($data, DummyWithVariadicParameter::class);
+    }
 }
 
 class Model


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  |  no
| Deprecations? | no
| Issues        | Fix #58628
| License       | MIT

This fixes the default context not taken into account by the Serializer class.
