### PR TITLE
Add ability to set `message` and `format` in the `ProgressBar` constructor

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -67,13 +67,7 @@ final class ProgressBar
     /**
      * @param int $max Maximum steps (0 if unknown)
      */
-    public function __construct(
-        OutputInterface $output, 
-        int $max = 0, 
-        float $minSecondsBetweenRedraws = 1 / 25,
-        ?string $message = null,
-        ?string $format = null,
-    ) {
+    public function __construct(OutputInterface $output, int $max = 0, float $minSecondsBetweenRedraws = 1 / 25, ?string $message = null, ?string $format = null) {
         if ($output instanceof ConsoleOutputInterface) {
             $output = $output->getErrorOutput();
         }

--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -67,7 +67,8 @@ final class ProgressBar
     /**
      * @param int $max Maximum steps (0 if unknown)
      */
-    public function __construct(OutputInterface $output, int $max = 0, float $minSecondsBetweenRedraws = 1 / 25, ?string $message = null, ?string $format = null) {
+    public function __construct(OutputInterface $output, int $max = 0, float $minSecondsBetweenRedraws = 1 / 25, ?string $message = null, ?string $format = null)
+    {
         if ($output instanceof ConsoleOutputInterface) {
             $output = $output->getErrorOutput();
         }

--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -67,8 +67,13 @@ final class ProgressBar
     /**
      * @param int $max Maximum steps (0 if unknown)
      */
-    public function __construct(OutputInterface $output, int $max = 0, float $minSecondsBetweenRedraws = 1 / 25)
-    {
+    public function __construct(
+        OutputInterface $output, 
+        int $max = 0, 
+        float $minSecondsBetweenRedraws = 1 / 25,
+        ?string $message = null,
+        ?string $format = null,
+    ) {
         if ($output instanceof ConsoleOutputInterface) {
             $output = $output->getErrorOutput();
         }
@@ -92,6 +97,14 @@ final class ProgressBar
 
         $this->startTime = time();
         $this->cursor = new Cursor($output);
+
+        if ($message) {
+            $this->setMessage($message);
+        }
+
+        if ($format) {
+            $this->setFormat($format);
+        }
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #58829
| License       | MIT

### Description

Currently, the `ProgressBar` class is marked as `final`, which prevents developers from extending the class. 

The format and message properties are very common in using this object, adding them to the constructor would be very handy.