### PR TITLE
[HttpClient] Ignore RuntimeExceptions thrown when rewinding the PSR-7 created in HttplugWaitLoop::createPsr7Response

### DIFF
--- a/src/Symfony/Component/HttpClient/HttplugClient.php
+++ b/src/Symfony/Component/HttpClient/HttplugClient.php
@@ -202,7 +202,11 @@ final class HttplugClient implements ClientInterface, HttpAsyncClient, RequestFa
         }
 
         if ($stream->isSeekable()) {
-            $stream->seek(0);
+            try {
+                $stream->seek(0);
+            } catch (\RuntimeException) {
+                // ignore
+            }
         }
 
         return $stream;
@@ -274,7 +278,11 @@ final class HttplugClient implements ClientInterface, HttpAsyncClient, RequestFa
             $body = $request->getBody();
 
             if ($body->isSeekable()) {
-                $body->seek(0);
+                try {
+                    $body->seek(0);
+                } catch (\RuntimeException) {
+                    // ignore
+                }
             }
 
             $options = [

--- a/src/Symfony/Component/HttpClient/Internal/HttplugWaitLoop.php
+++ b/src/Symfony/Component/HttpClient/Internal/HttplugWaitLoop.php
@@ -145,7 +145,11 @@ final class HttplugWaitLoop
         }
 
         if ($body->isSeekable()) {
-            $body->seek(0);
+            try {
+                $body->seek(0);
+            } catch (\RuntimeException) {
+                // ignore
+            }
         }
 
         return $psrResponse->withBody($body);

--- a/src/Symfony/Component/HttpClient/Psr18Client.php
+++ b/src/Symfony/Component/HttpClient/Psr18Client.php
@@ -90,7 +90,11 @@ final class Psr18Client implements ClientInterface, RequestFactoryInterface, Str
             $body = $request->getBody();
 
             if ($body->isSeekable()) {
-                $body->seek(0);
+                try {
+                    $body->seek(0);
+                } catch (\RuntimeException) {
+                    // ignore
+                }
             }
 
             $options = [
@@ -136,7 +140,11 @@ final class Psr18Client implements ClientInterface, RequestFactoryInterface, Str
         $stream = $this->streamFactory->createStream($content);
 
         if ($stream->isSeekable()) {
-            $stream->seek(0);
+            try {
+                $stream->seek(0);
+            } catch (\RuntimeException) {
+                // ignore
+            }
         }
 
         return $stream;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

To create a PSR-7 response from a regular Symfony HTTP response in Psr18Client and HttplugClient, the static method `HttplugWaitLoop::createPsr7Response` is used. It also converts the response body stream to a PSR-7 stream, which generally happens in two steps: First, the `ResponseStreamInterface` is made into a resource using a custom stream wrapper, and then this resource is made into a PSR-7 stream using the `createStreamFromResource` of whatever stream factory is used.

Finally, if the resulting PSR-7 stream is seekable, it is rewound to its start. Depending on the used stream implementation, it is, however, possible that calling `->seek(0)` throws an exception, despite `->isSeekable()` returning true. This is because the way some PSR-7 stream implementations check if the underlying resource is seekable is by looking at the `seekable` stream meta property. For custom stream wrappers, this metadata value appears to be always true, no matter if the stream wrapper implements seeking or not.

Some stream implementations, like the one in nyholm/psr7, prevent this by just trying to call `fseek` on the resource when the stream is first created and considering it not seekable if the operation fails. Other implementations like guzzle/psr7 don't do this extra check, which is why using the Symfony Psr18Client with a Guzzle stream factory fails. Since the Psr18Client automatically discovers stream factory implementations if none is specified, the Guzzle implementation can become the default if Guzzle happens to be installed in the project.

The solution I'm proposing here is to simply ignore any RuntimeException thrown when trying to seek to the start of the stream. Since rewinding the stream is already optional, this shouldn't cause any issues.
