### PR TITLE
Fixing message Too many failed login attempts in LV language

### DIFF
--- a/src/Symfony/Component/Security/Core/Resources/translations/security.lv.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.lv.xlf
@@ -76,7 +76,7 @@
             </trans-unit>
             <trans-unit id="20">
                 <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target>Pārāk daudz neveiksmīgu autentifikācijas mēģinājumu, lūdzu, mēģiniet vēlreiz pēc %minutes% minūtes.|Pārāk daudz neveiksmīgu autentifikācijas mēģinājumu, lūdzu, mēģiniet vēlreiz pēc %minutes% minūtēm.</target>
+                <target>Pārāk daudz neveiksmīgu autentifikācijas mēģinājumu, lūdzu, mēģiniet vēlreiz pēc %minutes% minūtēm.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58904
| License       | MIT


This distinction is based on Latvian grammar.
	1.	Pēc %minutes% minūtes – This form is used for singular.
	•	Example: Pēc 1 minūtes (After 1 minute).
	2.	Pēc %minutes% minūtēm – This form is used for plural.
	•	Example: Pēc 5 minūtēm (After 5 minutes).

When to use:

	•	If %minutes% = 1, use minūtes.
	•	If %minutes% > 1 (e.g., 2, 3, 10), use minūtēm.
