### PR TITLE
[DoctrineBridge] don't call `EntityManager::initializeObject()` with scalar values

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -104,7 +104,7 @@ class UniqueEntityValidator extends ConstraintValidator
 
             $criteria[$fieldName] = $fieldValue;
 
-            if (null !== $criteria[$fieldName] && $class->hasAssociation($fieldName)) {
+            if (\is_object($criteria[$fieldName]) && $class->hasAssociation($fieldName)) {
                 /* Ensure the Proxy is initialized before using reflection to
                  * read its identifiers. This is necessary because the wrapped
                  * getter methods in the Proxy are being bypassed.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58906
| License       | MIT

Calling `initializeObject()` with a scalar value (e.g. the id of the associated entity) was a no-op call with Doctrine ORM 2 where no type was set with the method signature. The `UnitOfWork` which was called with the given argument ignored anything that was not an `InternalProxy` or a `PersistentCollection` instance.

Calls like these now break with Doctrine ORM 3 as the method's argument is typed as object now.
