### PR TITLE
[OptionsResolver] Allow Union/Intersection Types in Resolved Closures

### DIFF
--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -232,7 +232,7 @@ class OptionsResolver implements Options
                 return $this;
             }
 
-            if (isset($params[0]) && null !== ($type = $params[0]->getType()) && self::class === $type->getName() && (!isset($params[1]) || (($type = $params[1]->getType()) instanceof \ReflectionNamedType && Options::class === $type->getName()))) {
+            if (isset($params[0]) && ($type = $params[0]->getType()) instanceof \ReflectionNamedType && self::class === $type->getName() && (!isset($params[1]) || (($type = $params[1]->getType()) instanceof \ReflectionNamedType && Options::class === $type->getName()))) {
                 // Store closure for later evaluation
                 $this->nested[$option][] = $value;
                 $this->defaults[$option] = [];

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -159,6 +159,28 @@ class OptionsResolverTest extends TestCase
         $this->assertSame(['foo' => $closure], $this->resolver->resolve());
     }
 
+    public function testClosureWithUnionTypesNotInvoked()
+    {
+        $closure = function (int|string|null $value) {
+            Assert::fail('Should not be called');
+        };
+
+        $this->resolver->setDefault('foo', $closure);
+
+        $this->assertSame(['foo' => $closure], $this->resolver->resolve());
+    }
+
+    public function testClosureWithIntersectionTypesNotInvoked()
+    {
+        $closure = function (\Stringable&\JsonSerializable $value) {
+            Assert::fail('Should not be called');
+        };
+
+        $this->resolver->setDefault('foo', $closure);
+
+        $this->assertSame(['foo' => $closure], $this->resolver->resolve());
+    }
+
     public function testAccessPreviousDefaultValue()
     {
         // defined by superclass


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | _N/A_
| License       | MIT

Using intersection/union types in Closures set in OptionsResolver currently causes the fatal error:
`Attempted to call an undefined method named "getName" of class "ReflectionUnionType".`
in `vendor/symfony/options-resolver/OptionsResolver.php` (line 235).

This can be re-created with following form type:

```php
class ExampleType extends AbstractType
{
    public function getParent(): string
    {
        return Type\ChoiceType::class;
    }

    public function configureOptions(OptionsResolver $resolver): void
    {
        $resolver->setDefaults([
            'data_class' => MyEntity::class,
            'choice_value' => fn (\Stringable|string|null $entity): string => (string) $entity,
        ]);
    }
}
```