### PR TITLE
[WebProfilerBundle] Twig deprecations

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/notifier.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/notifier.html.twig
@@ -138,7 +138,7 @@
                                                             {{- 'Content: ' ~ notification.getContent() }}<br/>
                                                             {{- 'Importance: ' ~ notification.getImportance() }}<br/>
                                                             {{- 'Emoji: ' ~ (notification.getEmoji() is empty ? '(empty)' : notification.getEmoji()) }}<br/>
-                                                            {{- 'Exception: ' ~ notification.getException() ?? '(empty)' }}<br/>
+                                                            {{- 'Exception: ' ~ (notification.getException() ?? '(empty)') }}<br/>
                                                             {{- 'ExceptionAsString: ' ~ (notification.getExceptionAsString() is empty ? '(empty)' : notification.getExceptionAsString()) }}
                                                         </pre>
                                                     </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | N/A
| License       | MIT

This fixes some twig deprecations in the Web Profiler Bundle.
Since twig/twig 3.15: Add explicit parentheses around the "??" binary operator to avoid behavior change in the next major version as its precedence will change in "@WebProfiler/Collector/notifier.html.twig" at line 141


Not entirely sure which branch this should go against. Also not sure if this is a bugfix as it isn't really a bug.
Please feel free to correct it
