### PR TITLE
[HttpKernel] Ensure `HttpCache::getTraceKey()` does not throw exception

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -17,6 +17,7 @@
 
 namespace Symfony\Component\HttpKernel\HttpCache;
 
+use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -715,7 +716,11 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
             $path .= '?'.$qs;
         }
 
-        return $request->getMethod().' '.$path;
+        try {
+            return $request->getMethod().' '.$path;
+        } catch (SuspiciousOperationException $e) {
+            return '_BAD_METHOD_ '.$path;
+        }
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
@@ -61,6 +61,17 @@ class HttpCacheTest extends HttpCacheTestCase
         $this->assertFalse($this->response->headers->has('Age'));
     }
 
+    public function testPassesSuspiciousMethodRequests()
+    {
+        $this->setNextResponse(200);
+        $this->request('POST', '/', ['HTTP_X-HTTP-Method-Override' => '__CONSTRUCT']);
+        $this->assertHttpKernelIsCalled();
+        $this->assertResponseOk();
+        $this->assertTraceNotContains('stale');
+        $this->assertTraceNotContains('invalid');
+        $this->assertFalse($this->response->headers->has('Age'));
+    }
+
     public function testInvalidatesOnPostPutDeleteRequests()
     {
         foreach (['post', 'put', 'delete'] as $method) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

We have such logs in our logs. It's in our raw PHP logs. They are not caught by monolog, it's too early

```
[11-Oct-2024 01:23:33 UTC] PHP Fatal error:  Uncaught Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException: Invalid method override "__CONSTRUCT". in /var/www/redirection.io/backend/blue/vendor/symfony/http-foundation/Request.php:1234
Stack trace:
#0 /var/www/redirection.io/backend/blue/vendor/symfony/http-kernel/HttpCache/HttpCache.php(728): Symfony\Component\HttpFoundation\Request->getMethod()
#1 /var/www/redirection.io/backend/blue/vendor/symfony/http-kernel/HttpCache/HttpCache.php(207): Symfony\Component\HttpKernel\HttpCache\HttpCache->getTraceKey()
#2 /var/www/redirection.io/backend/blue/vendor/symfony/http-kernel/Kernel.php(188): Symfony\Component\HttpKernel\HttpCache\HttpCache->handle()
#3 /var/www/redirection.io/backend/blue/web/app.php(9): Symfony\Component\HttpKernel\Kernel->handle()
#4 {main}
  thrown in /var/www/redirection.io/backend/blue/vendor/symfony/http-foundation/Request.php on line 1234

```

I managed to reproduced locally.
* Before the patch, without the http_cache, symfony returns a 405
* After the patch, without the http_cache, symfony returns a 405
* Before the patch, with the http_cache, symfony returns a 500, without any information (too early)
* After the patch, with the http_cache, symfony returns a 405
