### PR TITLE
[RateLimiter] Add `RateLimiterFactoryInterface`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add JsonEncoder services and configuration
  * Add new `framework.property_info.with_constructor_extractor` option to allow enabling or disabling the constructor extractor integration
  * Deprecate the `--show-arguments` option of the `container:debug` command, as arguments are now always shown
+ * Add `RateLimiterFactoryInterface` as an alias of the `limiter` service
 
 7.2
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/rate_limiter.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/rate_limiter.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
@@ -27,4 +28,9 @@ return static function (ContainerConfigurator $container) {
                 null,
             ])
     ;
+
+    if (interface_exists(RateLimiterFactoryInterface::class)) {
+        $container->services()
+            ->alias(RateLimiterFactoryInterface::class, 'limiter');
+    }
 };

--- a/src/Symfony/Component/RateLimiter/CHANGELOG.md
+++ b/src/Symfony/Component/RateLimiter/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.3
+---
+
+ * Add `RateLimiterFactoryInterface`
+
 6.4
 ---
 

--- a/src/Symfony/Component/RateLimiter/RateLimiterFactory.php
+++ b/src/Symfony/Component/RateLimiter/RateLimiterFactory.php
@@ -24,7 +24,7 @@ use Symfony\Component\RateLimiter\Storage\StorageInterface;
 /**
  * @author Wouter de Jong <wouter@wouterj.nl>
  */
-final class RateLimiterFactory
+final class RateLimiterFactory implements RateLimiterFactoryInterface
 {
     private array $config;
 
@@ -53,7 +53,7 @@ final class RateLimiterFactory
         };
     }
 
-    protected static function configureOptions(OptionsResolver $options): void
+    private static function configureOptions(OptionsResolver $options): void
     {
         $intervalNormalizer = static function (Options $options, string $interval): \DateInterval {
             // Create DateTimeImmutable from unix timesatmp, so the default timezone is ignored and we don't need to

--- a/src/Symfony/Component/RateLimiter/RateLimiterFactoryInterface.php
+++ b/src/Symfony/Component/RateLimiter/RateLimiterFactoryInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\RateLimiter;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ */
+interface RateLimiterFactoryInterface
+{
+    /**
+     * @param string|null $key an optional key used to identify the limiter
+     */
+    public function create(?string $key = null): LimiterInterface;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #58920
| License       | MIT

I think it makes sense to create this interface for both being able to implement your own factory logic as well as type-hint against an interface when injecting it.

I would however not make the class non-final as suggested in the issue. The interface only contains one method with not that much logic inside the current implementation.