### PR TITLE
handle multi-line comments in AssetMapper javascript compiler

### DIFF
--- a/src/Symfony/Component/AssetMapper/Compiler/JavaScriptImportPathCompiler.php
+++ b/src/Symfony/Component/AssetMapper/Compiler/JavaScriptImportPathCompiler.php
@@ -155,6 +155,11 @@ final class JavaScriptImportPathCompiler implements AssetCompilerInterface
             return true;
         }
 
+        // inside a multi-line comment, since javascript can't start with a '* '
+        if ('* ' === $firstTwoChars) {
+            return true;
+        }
+
         if ('/*' === $firstTwoChars) {
             $commentEnd = strpos($fullContent, '*/', $lineStart);
             // if we can't find the end comment, be cautious: assume this is not a comment

--- a/src/Symfony/Component/AssetMapper/Tests/Compiler/JavaScriptImportPathCompilerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Compiler/JavaScriptImportPathCompilerTest.php
@@ -95,41 +95,9 @@ class JavaScriptImportPathCompilerTest extends TestCase
     {
         yield 'import_in_multiline_comment' => [
             'input' => <<<EOF
-// Asynchronous loading
 /**
- * Used in conjunction with the `m` component to reduce bundle size.
- *
- * `m` is a version of the `motion` component that only loads functionality
- * critical for the initial render.
- *
- * `LazyMotion` can then be used to either synchronously or asynchronously
- * load animation and gesture support.
- *
- * ```jsx
- * // Synchronous loading
- * import { LazyMotion, m, domAnimations } from "framer-motion"
- *
- * function App() {
- *   return (
- *     <LazyMotion features={domAnimations}>
- *       <m.div animate={{ scale: 2 }} />
- *     </LazyMotion>
- *   )
- * }
- *
- * // Asynchronous loading
- * import { LazyMotion, m } from "framer-motion"
- *
- * function App() {
- *   return (
- *     <LazyMotion features={() => import('./path/to/domAnimations')}>
- *       <m.div animate={{ scale: 2 }} />
- *     </LazyMotion>
- *   )
- * }
+ *     <LazyMotion features={() => import('./path/to/domAnimations')} />
  * ```
- *
- * @public
  */
 EOF,
             'expectedJavaScriptImports' => [],

--- a/src/Symfony/Component/AssetMapper/Tests/Compiler/JavaScriptImportPathCompilerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Compiler/JavaScriptImportPathCompilerTest.php
@@ -93,6 +93,48 @@ class JavaScriptImportPathCompilerTest extends TestCase
 
     public static function provideCompileTests(): iterable
     {
+        yield 'import_in_multiline_comment' => [
+            'input' => <<<EOF
+// Asynchronous loading
+/**
+ * Used in conjunction with the `m` component to reduce bundle size.
+ *
+ * `m` is a version of the `motion` component that only loads functionality
+ * critical for the initial render.
+ *
+ * `LazyMotion` can then be used to either synchronously or asynchronously
+ * load animation and gesture support.
+ *
+ * ```jsx
+ * // Synchronous loading
+ * import { LazyMotion, m, domAnimations } from "framer-motion"
+ *
+ * function App() {
+ *   return (
+ *     <LazyMotion features={domAnimations}>
+ *       <m.div animate={{ scale: 2 }} />
+ *     </LazyMotion>
+ *   )
+ * }
+ *
+ * // Asynchronous loading
+ * import { LazyMotion, m } from "framer-motion"
+ *
+ * function App() {
+ *   return (
+ *     <LazyMotion features={() => import('./path/to/domAnimations')}>
+ *       <m.div animate={{ scale: 2 }} />
+ *     </LazyMotion>
+ *   )
+ * }
+ * ```
+ *
+ * @public
+ */
+EOF,
+            'expectedJavaScriptImports' => [],
+        ];
+
         yield 'standard_symfony_app_js' => [
             'input' => <<<EOF
             import './bootstrap.js';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Issues        | Fix #58928
| License       | MIT

This fixes the issue where assetmapper tries to include a javascript import that is embedded in a comment.