### PR TITLE
add comment explaining why HttpClient tests are run separately

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -110,6 +110,7 @@ jobs:
           Remove-Item -Path src\Symfony\Bridge\PhpUnit -Recurse
           mv src\Symfony\Component\HttpClient\phpunit.xml.dist src\Symfony\Component\HttpClient\phpunit.xml
           php phpunit src\Symfony --exclude-group tty,benchmark,intl-data,network,transient-on-windows || ($x = 1)
+          # HttpClient tests need to run separately, they block when run with other components' tests concurrently
           php phpunit src\Symfony\Component\HttpClient || ($x = 1)
 
           exit $x
@@ -123,6 +124,7 @@ jobs:
 
           Copy c:\php\php.ini-max c:\php\php.ini
           php phpunit src\Symfony --exclude-group tty,benchmark,intl-data,network,transient-on-windows || ($x = 1)
+          # HttpClient tests need to run separately, they block when run with other components' tests concurrently
           php phpunit src\Symfony\Component\HttpClient || ($x = 1)
 
           exit $x


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

see https://github.com/symfony/symfony/pull/35115 and https://github.com/symfony/symfony/pull/58916