### PR TITLE
[Cache] silence warnings issued by Redis Sentinel on connection issues

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -134,7 +134,7 @@ class Connection
                                     'readTimeout' => $options['read_timeout'],
                                 ];
 
-                                $sentinel = new \RedisSentinel($params);
+                                $sentinel = @new \RedisSentinel($params);
                             } else {
                                 $sentinel = @new $sentinelClass($host, $port, $options['timeout'], $options['persistent_id'], $options['retry_interval'], $options['read_timeout']);
                             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

related to #58365 and #58818

see https://github.com/symfony/symfony/actions/runs/11936530431/job/33270392688#step:9:607