### PR TITLE
[HttpClient] Fix computing stats for PUSH with Amp

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/AmpResponseV4.php
+++ b/src/Symfony/Component/HttpClient/Response/AmpResponseV4.php
@@ -433,6 +433,17 @@ final class AmpResponseV4 implements ResponseInterface, StreamableInterface
                 }
             }
 
+            $info += [
+                'connect_time' => 0.0,
+                'pretransfer_time' => 0.0,
+                'starttransfer_time' => 0.0,
+                'total_time' => 0.0,
+                'namelookup_time' => 0.0,
+                'primary_ip' => '',
+                'primary_port' => 0,
+                'start_time' => microtime(true),
+            ];
+
             $pushDeferred->resolve();
             $logger?->debug(\sprintf('Accepting pushed response: "%s %s"', $info['http_method'], $info['url']));
             self::addResponseHeaders($response, $info, $headers);

--- a/src/Symfony/Component/HttpClient/Response/AmpResponseV5.php
+++ b/src/Symfony/Component/HttpClient/Response/AmpResponseV5.php
@@ -434,6 +434,17 @@ final class AmpResponseV5 implements ResponseInterface, StreamableInterface
                 }
             }
 
+            $info += [
+                'connect_time' => 0.0,
+                'pretransfer_time' => 0.0,
+                'starttransfer_time' => 0.0,
+                'total_time' => 0.0,
+                'namelookup_time' => 0.0,
+                'primary_ip' => '',
+                'primary_port' => 0,
+                'start_time' => microtime(true),
+            ];
+
             $pushDeferred->complete();
             $logger?->debug(\sprintf('Accepting pushed response: "%s %s"', $info['http_method'], $info['url']));
             self::addResponseHeaders($response, $info, $headers);

--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
@@ -200,20 +200,20 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
 
         $client->reset();
 
-        $expected = [
-            'Request: "GET https://127.0.0.1:3000/json"',
-            'Queueing pushed response: "https://127.0.0.1:3000/json/1"',
-            'Queueing pushed response: "https://127.0.0.1:3000/json/2"',
-            'Queueing pushed response: "https://127.0.0.1:3000/json/3"',
-            'Response: "200 https://127.0.0.1:3000/json"',
-            'Accepting pushed response: "GET https://127.0.0.1:3000/json/1"',
-            'Response: "200 https://127.0.0.1:3000/json/1"',
-            'Accepting pushed response: "GET https://127.0.0.1:3000/json/2"',
-            'Response: "200 https://127.0.0.1:3000/json/2"',
-            'Accepting pushed response: "GET https://127.0.0.1:3000/json/3"',
-            'Response: "200 https://127.0.0.1:3000/json/3"',
-        ];
-        $this->assertSame($expected, $logger->logs);
+        $expected = <<<EOTXT
+            Request: "GET https://127.0.0.1:3000/json"
+            Queueing pushed response: "https://127.0.0.1:3000/json/1"
+            Queueing pushed response: "https://127.0.0.1:3000/json/2"
+            Queueing pushed response: "https://127.0.0.1:3000/json/3"
+            Response: "200 https://127.0.0.1:3000/json" %f seconds
+            Accepting pushed response: "GET https://127.0.0.1:3000/json/1"
+            Response: "200 https://127.0.0.1:3000/json/1" %f seconds
+            Accepting pushed response: "GET https://127.0.0.1:3000/json/2"
+            Response: "200 https://127.0.0.1:3000/json/2" %f seconds
+            Accepting pushed response: "GET https://127.0.0.1:3000/json/3"
+            Response: "200 https://127.0.0.1:3000/json/3" %f seconds
+            EOTXT;
+        $this->assertStringMatchesFormat($expected, implode("\n", $logger->logs));
     }
 
     public function testPause()
@@ -288,19 +288,19 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
 
         $client->reset();
 
-        $expected = [
-            'Request: "GET https://127.0.0.1:3000/json"',
-            'Queueing pushed response: "https://127.0.0.1:3000/json/1"',
-            'Queueing pushed response: "https://127.0.0.1:3000/json/2"',
-            'Queueing pushed response: "https://127.0.0.1:3000/json/3"',
-            'Response: "200 https://127.0.0.1:3000/json"',
-            'Accepting pushed response: "GET https://127.0.0.1:3000/json/1"',
-            'Response: "200 https://127.0.0.1:3000/json/1"',
-            'Accepting pushed response: "GET https://127.0.0.1:3000/json/2"',
-            'Response: "200 https://127.0.0.1:3000/json/2"',
-            'Unused pushed response: "https://127.0.0.1:3000/json/3"',
-        ];
-        $this->assertSame($expected, $logger->logs);
+        $expected = <<<EOTXT
+            Request: "GET https://127.0.0.1:3000/json"
+            Queueing pushed response: "https://127.0.0.1:3000/json/1"
+            Queueing pushed response: "https://127.0.0.1:3000/json/2"
+            Queueing pushed response: "https://127.0.0.1:3000/json/3"
+            Response: "200 https://127.0.0.1:3000/json" %f seconds
+            Accepting pushed response: "GET https://127.0.0.1:3000/json/1"
+            Response: "200 https://127.0.0.1:3000/json/1" %f seconds
+            Accepting pushed response: "GET https://127.0.0.1:3000/json/2"
+            Response: "200 https://127.0.0.1:3000/json/2" %f seconds
+            Unused pushed response: "https://127.0.0.1:3000/json/3"
+            EOTXT;
+        $this->assertStringMatchesFormat($expected, implode("\n", $logger->logs));
     }
 
     public function testDnsFailure()

--- a/src/Symfony/Component/HttpClient/Tests/RetryableHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/RetryableHttpClientTest.php
@@ -176,7 +176,7 @@ class RetryableHttpClientTest extends TestCase
             $this->assertSame('Could not resolve host "does.not.exists".', $e->getMessage());
         }
         $this->assertCount(2, $logger->logs);
-        $this->assertSame('Try #{count} after {delay}ms: Could not resolve host "does.not.exists".', $logger->logs[0]);
+        $this->assertSame('Try #1 after 0ms: Could not resolve host "does.not.exists".', $logger->logs[0]);
     }
 
     public function testCancelOnTimeout()

--- a/src/Symfony/Component/HttpClient/Tests/TestLogger.php
+++ b/src/Symfony/Component/HttpClient/Tests/TestLogger.php
@@ -19,6 +19,6 @@ class TestLogger extends AbstractLogger
 
     public function log($level, $message, array $context = []): void
     {
-        $this->logs[] = $message;
+        $this->logs[] = preg_replace_callback('!\{([^\}\s]++)\}!', static fn ($m) => $context[$m[1]] ?? $m[0], $message);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Tests with PUSH/vulcain fail after #58555.

Computing stats for PUSH could be backported to lower versions, but let's keep things simple and consider this as an improvement, so not for lower branches.