### PR TITLE
[DoctrineBridge] Fix `Connection::createSchemaManager()` for Doctrine DBAL v2

### DIFF
--- a/src/Symfony/Bridge/Doctrine/SchemaListener/AbstractSchemaListener.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/AbstractSchemaListener.php
@@ -24,8 +24,7 @@ abstract class AbstractSchemaListener
     protected function getIsSameDatabaseChecker(Connection $connection): \Closure
     {
         return static function (\Closure $exec) use ($connection): bool {
-            $schemaManager = $connection->createSchemaManager();
-
+            $schemaManager = method_exists($connection, 'createSchemaManager') ? $connection->createSchemaManager() : $connection->getSchemaManager();
             $checkTable = 'schema_subscriber_check_'.bin2hex(random_bytes(7));
             $table = new Table($checkTable);
             $table->addColumn('id', Types::INTEGER)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58955
| License       | MIT

As the 6.4 symfony/doctrine-bridge is compatible with doctrine/dbal 2.13  we need to check for createSchemaManager existance and use getSchemaManager instead if necessary (like it's already done in the messenger component for instance)