### PR TITLE
 [PropertyInfo] Check if the virtual property has a setter in `isAllowedProperty`

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -625,11 +625,8 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
                 return false;
             }
 
-            if (
-                $writeAccessRequired
-                    && method_exists($reflectionProperty, 'isVirtual')
-                    && method_exists($reflectionProperty, 'hasHook')
-                    && enum_exists('PropertyHookType')
+            if (\PHP_VERSION_ID >= 80400
+                    && $writeAccessRequired
                     && $reflectionProperty->isVirtual()
                     && !$reflectionProperty->hasHook(\PropertyHookType::Set)
             ) {

--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -625,6 +625,17 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
                 return false;
             }
 
+            if (
+                $writeAccessRequired
+                    && method_exists($reflectionProperty, 'isVirtual')
+                    && method_exists($reflectionProperty, 'hasHook')
+                    && enum_exists('PropertyHookType')
+                    && $reflectionProperty->isVirtual()
+                    && !$reflectionProperty->hasHook(\PropertyHookType::Set)
+            ) {
+                return false;
+            }
+
             return (bool) ($reflectionProperty->getModifiers() & $this->propertyReflectionFlags);
         } catch (\ReflectionException $e) {
             // Return false if the property doesn't exist

--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -617,20 +617,20 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
         try {
             $reflectionProperty = new \ReflectionProperty($class, $property);
 
-            if (\PHP_VERSION_ID >= 80100 && $writeAccessRequired && $reflectionProperty->isReadOnly()) {
-                return false;
-            }
+            if ($writeAccessRequired) {
+                if (\PHP_VERSION_ID >= 80100 && $reflectionProperty->isReadOnly()) {
+                    return false;
+                }
 
-            if (\PHP_VERSION_ID >= 80400 && $writeAccessRequired && ($reflectionProperty->isProtectedSet() || $reflectionProperty->isPrivateSet())) {
-                return false;
-            }
+                if (\PHP_VERSION_ID >= 80400) {
+                    if ($reflectionProperty->isProtectedSet() || $reflectionProperty->isPrivateSet()) {
+                        return false;
+                    }
 
-            if (\PHP_VERSION_ID >= 80400
-                    && $writeAccessRequired
-                    && $reflectionProperty->isVirtual()
-                    && !$reflectionProperty->hasHook(\PropertyHookType::Set)
-            ) {
-                return false;
+                    if ($reflectionProperty->isVirtual() && !$reflectionProperty->hasHook(\PropertyHookType::Set)) {
+                        return false;
+                    }
+                }
             }
 
             return (bool) ($reflectionProperty->getModifiers() & $this->propertyReflectionFlags);

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -28,6 +28,7 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\Php74Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php7Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php7ParentDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php81Dummy;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\VirtualProperties;
 use Symfony\Component\PropertyInfo\Type;
 
 /**
@@ -698,5 +699,18 @@ class ReflectionExtractorTest extends TestCase
         $this->assertFalse($this->extractor->isWritable(AsymmetricVisibility::class, 'publicPrivate'));
         $this->assertFalse($this->extractor->isWritable(AsymmetricVisibility::class, 'publicProtected'));
         $this->assertFalse($this->extractor->isWritable(AsymmetricVisibility::class, 'protectedPrivate'));
+    }
+
+    /**
+     * @requires PHP 8.4
+     */
+    public function testVirtualProperties()
+    {
+        $this->assertTrue($this->extractor->isReadable(VirtualProperties::class, 'virtualNoSetHook'));
+        $this->assertTrue($this->extractor->isReadable(VirtualProperties::class, 'virtualSetHookOnly'));
+        $this->assertTrue($this->extractor->isReadable(VirtualProperties::class, 'virtualHook'));
+        $this->assertFalse($this->extractor->isWritable(VirtualProperties::class, 'virtualNoSetHook'));
+        $this->assertTrue($this->extractor->isWritable(VirtualProperties::class, 'virtualSetHookOnly'));
+        $this->assertTrue($this->extractor->isWritable(VirtualProperties::class, 'virtualHook'));
     }
 }

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -28,7 +28,7 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\Php74Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php7Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php7ParentDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php81Dummy;
-use Symfony\Component\PropertyInfo\Tests\Fixtures\VirtualProperties;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\HookedProperties;
 use Symfony\Component\PropertyInfo\Type;
 
 /**
@@ -704,13 +704,20 @@ class ReflectionExtractorTest extends TestCase
     /**
      * @requires PHP 8.4
      */
-    public function testVirtualProperties()
+    public function testHookedProperties()
     {
-        $this->assertTrue($this->extractor->isReadable(VirtualProperties::class, 'virtualNoSetHook'));
-        $this->assertTrue($this->extractor->isReadable(VirtualProperties::class, 'virtualSetHookOnly'));
-        $this->assertTrue($this->extractor->isReadable(VirtualProperties::class, 'virtualHook'));
-        $this->assertFalse($this->extractor->isWritable(VirtualProperties::class, 'virtualNoSetHook'));
-        $this->assertTrue($this->extractor->isWritable(VirtualProperties::class, 'virtualSetHookOnly'));
-        $this->assertTrue($this->extractor->isWritable(VirtualProperties::class, 'virtualHook'));
+        $this->assertTrue($this->extractor->isReadable(HookedProperties::class, 'virtualNoSetHook'));
+        $this->assertTrue($this->extractor->isReadable(HookedProperties::class, 'virtualSetHookOnly'));
+        $this->assertTrue($this->extractor->isReadable(HookedProperties::class, 'virtualHook'));
+        $this->assertFalse($this->extractor->isWritable(HookedProperties::class, 'virtualNoSetHook'));
+        $this->assertTrue($this->extractor->isWritable(HookedProperties::class, 'virtualSetHookOnly'));
+        $this->assertTrue($this->extractor->isWritable(HookedProperties::class, 'virtualHook'));
+
+        $this->assertTrue($this->extractor->isReadable(HookedProperties::class, 'backedNoSetHook'));
+        $this->assertTrue($this->extractor->isReadable(HookedProperties::class, 'backedSetHookOnly'));
+        $this->assertTrue($this->extractor->isReadable(HookedProperties::class, 'backedHook'));
+        $this->assertTrue($this->extractor->isWritable(HookedProperties::class, 'backedNoSetHook'));
+        $this->assertTrue($this->extractor->isWritable(HookedProperties::class, 'backedSetHookOnly'));
+        $this->assertTrue($this->extractor->isWritable(HookedProperties::class, 'backedHook'));
     }
 }

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/HookedProperties.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/HookedProperties.php
@@ -11,9 +11,13 @@
 
 namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
 
-class VirtualProperties
+class HookedProperties
 {
     public bool $virtualNoSetHook { get => true; }
     public bool $virtualSetHookOnly { set => $value; }
     public bool $virtualHook { get => true; set => $value; }
+
+    public bool $backedNoSetHook = true { get => !$this->backedNoSetHook; }
+    public bool $backedSetHookOnly = true { set => $this->backedSetHookOnly = $value; }
+    public bool $backedHook = true { get => !$this->backedHook; set => $this->backedHook = $value; }
 }

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/VirtualProperties.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/VirtualProperties.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+  * This file is part of the Symfony package.
+  *
+  * (c) Fabien Potencier <fabien@symfony.com>
+  *
+  * For the full copyright and license information, please view the LICENSE
+  * file that was distributed with this source code.
+  */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+class VirtualProperties
+{
+    public bool $virtualNoSetHook { get => true; }
+    public bool $virtualSetHookOnly { set => $value; }
+    public bool $virtualHook { get => true; set => $value; }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | 
| Issues        | Fix #58556
| License       | MIT

Separate from #58960
<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
