### PR TITLE
[Serializer] Trigger deprecation when could not parse date with default format

### DIFF
--- a/UPGRADE-8.1.md
+++ b/UPGRADE-8.1.md
@@ -50,6 +50,11 @@ Security
 
  * Deprecate `SameOriginCsrfTokenManager::onKernelResponse()`, `SameOriginCsrfTokenManager::clearCookies()` and `SameOriginCsrfTokenManager::persistStrategy()`; this logic is now handled automatically by `SameOriginCsrfListener`
 
+Serializer
+----------
+
+ * Deprecate datetime constructor as a fallback, in version 9.0 a `Symfony\Component\Serializer\Exception\NotNormalizableValueException` will be thrown when a date could not be parsed using the default format
+
 Uid
 ---
 

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Improve `NotNormalizableValueException` exception messages in `BackedEnumNormalizer` to contain more useful information
+ * Trigger a deprecation when a date could not be parsed using the default format
 
 8.0
 ---

--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
@@ -130,7 +130,13 @@ final class DateTimeNormalizer implements NormalizerInterface, DenormalizerInter
                 }
             }
 
-            return $this->enforceTimezone(new $type($data, $timezone), $context);
+            $dateTimeObject = new $type($data, $timezone);
+
+            if (null !== $defaultDateTimeFormat) {
+                trigger_deprecation('symfony/serializer', '8.1', \sprintf('A "%s" will be thrown when a date could not be parsed using the default format "%s".', NotNormalizableValueException::class, $defaultDateTimeFormat));
+            }
+
+            return $this->enforceTimezone($dateTimeObject, $context);
         } catch (NotNormalizableValueException $e) {
             throw $e;
         } catch (\Exception $e) {

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Exception\UnexpectedValueException;
@@ -235,13 +237,34 @@ class DateTimeNormalizerTest extends TestCase
         $this->assertEquals(new \DateTimeImmutable('2016/01/01', new \DateTimeZone('UTC')), $this->normalizer->denormalize('2016-01-01T00:00:00+00:00', \DateTimeInterface::class));
         $this->assertEquals(new \DateTimeImmutable('2016/01/01', new \DateTimeZone('UTC')), $this->normalizer->denormalize('2016-01-01T00:00:00+00:00', \DateTimeImmutable::class));
         $this->assertEquals(new \DateTime('2016/01/01', new \DateTimeZone('UTC')), $this->normalizer->denormalize('2016-01-01T00:00:00+00:00', \DateTime::class));
-        $this->assertEquals(new \DateTime('2016/01/01', new \DateTimeZone('UTC')), $this->normalizer->denormalize('  2016-01-01T00:00:00+00:00  ', \DateTime::class));
         $this->assertEquals(new DateTimeImmutableChild('2016/01/01', new \DateTimeZone('UTC')), $this->normalizer->denormalize('2016-01-01T00:00:00+00:00', DateTimeImmutableChild::class));
         $this->assertEquals(new DateTimeImmutableChild('2016/01/01', new \DateTimeZone('UTC')), $this->normalizer->denormalize('2016-01-01T00:00:00+00:00', DateTimeImmutableChild::class));
         $this->assertEquals(new DateTimeChild('2016/01/01', new \DateTimeZone('UTC')), $this->normalizer->denormalize('2016-01-01T00:00:00+00:00', DateTimeChild::class));
-        $this->assertEquals(new DateTimeChild('2016/01/01', new \DateTimeZone('UTC')), $this->normalizer->denormalize('  2016-01-01T00:00:00+00:00  ', DateTimeChild::class));
         $this->assertEquals(new \DateTimeImmutable('2023-05-06T17:35:34.000000+0000', new \DateTimeZone('UTC')), $this->normalizer->denormalize(1683394534, \DateTimeImmutable::class, null, [DateTimeNormalizer::FORMAT_KEY => 'U']));
         $this->assertEquals(new \DateTimeImmutable('2023-05-06T17:35:34.123400+0000', new \DateTimeZone('UTC')), $this->normalizer->denormalize(1683394534.1234, \DateTimeImmutable::class, null, [DateTimeNormalizer::FORMAT_KEY => 'U.u']));
+    }
+
+    public function testDenormalizeWithNullDefaultFormat()
+    {
+        $normalizer = new DateTimeNormalizer([DateTimeNormalizer::FORMAT_KEY => null]);
+
+        $this->assertEquals(new \DateTimeImmutable('2016-01-01T00:00:00+00:00'), $normalizer->denormalize('2016-01-01T00:00:00+00:00', \DateTimeImmutable::class));
+    }
+
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testDenormalizeAndShowDeprecationForDateTime()
+    {
+        $this->expectUserDeprecationMessage('Since symfony/serializer 8.1: A "Symfony\\Component\\Serializer\\Exception\\NotNormalizableValueException" will be thrown when a date could not be parsed using the default format "Y-m-d\\TH:i:sP".');
+        $this->assertEquals(new \DateTime('2016/01/01', new \DateTimeZone('UTC')), $this->normalizer->denormalize('  2016-01-01T00:00:00+00:00  ', \DateTime::class));
+    }
+
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testDenormalizeAndShowDeprecationForDateTimeChild()
+    {
+        $this->expectUserDeprecationMessage('Since symfony/serializer 8.1: A "Symfony\\Component\\Serializer\\Exception\\NotNormalizableValueException" will be thrown when a date could not be parsed using the default format "Y-m-d\\TH:i:sP".');
+        $this->assertEquals(new DateTimeChild('2016/01/01', new \DateTimeZone('UTC')), $this->normalizer->denormalize('  2016-01-01T00:00:00+00:00  ', DateTimeChild::class, null, [DateTimeNormalizer::FORMAT_KEY => null]));
     }
 
     public function testDenormalizeUsingTimezonePassedInConstructor()
@@ -279,11 +302,13 @@ class DateTimeNormalizerTest extends TestCase
             '2016/12/01 17:35:00',
             new \DateTimeImmutable('2016/12/01 17:35:00', new \DateTimeZone('Asia/Tokyo')),
             new \DateTimeZone('Asia/Tokyo'),
+            'Y/m/d H:i:s',
         ];
         yield 'with timezone as string' => [
             '2016/12/01 17:35:00',
             new \DateTimeImmutable('2016/12/01 17:35:00', new \DateTimeZone('Asia/Tokyo')),
             'Asia/Tokyo',
+            'Y/m/d H:i:s',
         ];
         yield 'with format without timezone information' => [
             '2016.12.01 17:35:00',
@@ -420,10 +445,13 @@ class DateTimeNormalizerTest extends TestCase
         $this->assertSame('01/10/2018', $denormalizedDate->format($format));
     }
 
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
     public function testDenormalizeDateTimeStringWithDefaultContextAllowsErrorFormat()
     {
         $format = 'd/m/Y'; // the default format
         $string = '2020-01-01'; // the value which is in the wrong format, but is accepted because of `new \DateTimeImmutable` in DateTimeNormalizer::denormalize
+        $this->expectUserDeprecationMessage('Since symfony/serializer 8.1: A "Symfony\\Component\\Serializer\\Exception\\NotNormalizableValueException" will be thrown when a date could not be parsed using the default format "d/m/Y".');
 
         $normalizer = new DateTimeNormalizer([DateTimeNormalizer::FORMAT_KEY => $format]);
         $denormalizedDate = $normalizer->denormalize($string, \DateTimeInterface::class);

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -760,7 +760,7 @@ class ObjectNormalizerTest extends TestCase
             'inner' => ['foo' => 'foo', 'bar' => 'bar'],
             'date' => '1988/01/21',
             'inners' => [['foo' => 1], ['foo' => 2]],
-        ], ObjectOuter::class);
+        ], ObjectOuter::class, null, ['datetime_format' => 'Y/m/d']);
 
         $this->assertSame('foo', $obj->getInner()->foo);
         $this->assertSame('bar', $obj->getInner()->bar);

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=8.4",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/polyfill-ctype": "^1.8"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | 
| License       | MIT

Relates to https://github.com/symfony/symfony/pull/43329#discussion_r738505208