### PR TITLE
[Translation] [Bridge][Lokalise] Fix empty keys array in PUT, DELETE requests causing Lokalise API error

### DIFF
--- a/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProvider.php
@@ -129,6 +129,10 @@ final class LokaliseProvider implements ProviderInterface
             $keysIds += $this->getKeysIds($keysToDelete, $domain);
         }
 
+        if (!$keysIds) {
+            return;
+        }
+
         $response = $this->client->request('DELETE', 'keys', [
             'json' => ['keys' => array_values($keysIds)],
         ]);
@@ -259,6 +263,10 @@ final class LokaliseProvider implements ProviderInterface
                     }, []),
                 ];
             }
+        }
+
+        if (!$keysToUpdate) {
+            return;
         }
 
         $response = $this->client->request('PUT', 'keys', [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | /
| License       | MIT

This PR fixes two cases where an empty `keys` array is passed to a `PUT`/`DELETE` request, resulting in a Lokalise API error.

The empty arrays are the result of a `Symfony\Component\Translation\TranslatorBag` containing one or more `Symfony\Component\Translation\MessageCatalogue` _without any_ messages getting passed into the `Symfony\Component\Translation\Bridge\Lokalise\LokaliseProvider` (which is expected behaviour, see [here](https://github.com/symfony/symfony/blob/7.3/src/Symfony/Component/Translation/Command/TranslationPushCommand.php#L153) and below).

This is the case if either
* `bin/console translation:push lokalise`
* `bin/console translation:push lokalise --delete-missing`

is called when both the local translations as well as the translations on Lokalise match 1:1 for a given translation domain.

This will fix the following erros that might be observed while running the mentioned commands:

<details>
<summary>Before/after for <code>translation:push lokalise</code></summary>

**Before:**
```console
$ bin/console translation:push lokalise --domains=validators

ERROR     [app] Unable to get keys ids from Lokalise: "{"error":{"message":"`filter_filenames` parameter has invalid values","code":400}}".

                                                                                                                     
 [OK] All local translations has been sent to "lokalise" (for "de, en, fr, it" locale(s), and "validators"           
      domain(s)).
```

**After:**
```console
$ bin/console translation:push lokalise --domains=validators

                                                                                                                     
 [OK] All local translations has been sent to "lokalise" (for "de, en, fr, it" locale(s), and "validators"           
      domain(s)).
```

</details>

<details>
<summary>Before/after for <code>translation:push lokalise --delete-missing</code></summary>

**Before:**
```console
$ bin/console translation:push lokalise --domains=validators --delete-missing

In LokaliseProvider.php line 135:
                                                                                                            
  Unable to delete keys from Lokalise: "{"error":{"message":"`keys` parameter is not valid","code":400}}".  
                                                                                                            

translation:push [--force] [--delete-missing] [--domains [DOMAINS]] [--locales [LOCALES]] [--] [<provider>]
```

**After:**
```console
$ bin/console translation:push lokalise --domains=validators --delete-missing

                                                                                                                     
 [OK] Missing translations on "lokalise" has been deleted (for "de, en, fr, it" locale(s), and "validators"           
      domain(s)).

                                                                                                                     
 [OK] All local translations has been sent to "lokalise" (for "de, en, fr, it" locale(s), and "validators"           
      domain(s)).
```

</details>