### PR TITLE
[DependencyInjection] Add support for `default_value` as env var processor

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.3
+---
+
+ * Add support for `default_value` as env var processor
+
 7.2
 ---
 

--- a/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
+++ b/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
@@ -54,6 +54,7 @@ class EnvVarProcessor implements EnvVarProcessorInterface, ResetInterface
             'query_string' => 'array',
             'resolve' => 'string',
             'default' => 'bool|int|float|string|array',
+            'default_value' => 'bool|int|float|string|array',
             'string' => 'string',
             'trim' => 'string',
             'require' => 'bool|int|float|string|array',
@@ -114,6 +115,27 @@ class EnvVarProcessor implements EnvVarProcessorInterface, ResetInterface
             } catch (EnvNotFoundException) {
                 return false;
             }
+        }
+
+        if ('default_value' === $prefix) {
+            if (false === $i) {
+                throw new RuntimeException(sprintf('Invalid env "default_value:%s": a fallback parameter should be provided.', $name));
+            }
+
+            $next = substr($name, $i + 1);
+            $default = substr($name, 0, $i);
+
+            try {
+                $env = $getEnv($next);
+
+                if ('' !== $env && null !== $env) {
+                    return $env;
+                }
+            } catch (EnvNotFoundException) {
+                // no-op
+            }
+
+            return '' === $default ? null : $default;
         }
 
         if ('default' === $prefix) {

--- a/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
@@ -977,6 +977,21 @@ CSV;
     }
 
     /**
+     * @testWith  ["true", null]
+     *            ["true", ""]
+     *            ["true", "true"]
+     *            ["false", "false"]
+     */
+    public function testGetWithDefault($expected, $envValue)
+    {
+        $processor = new EnvVarProcessor(new Container());
+
+        $value = $processor->getEnv('default_value', 'true:FOO', fn () => $envValue);
+
+        $this->assertSame($expected, $value);
+    }
+
+    /**
      * @dataProvider provideGetEnvUrlPath
      */
     public function testGetEnvUrlPath(?string $expected, string $url)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        |
| License       | MIT

This is the second time where I face this "bugs".
I wrote:
```php
public function __construct(
    #[Autowire(env: 'bool:default:true:CASTOR_GENERATE_STUBS')]
    public $generateStubs,
) {
}
```

And I got this message:
```
>…egoire/dev/github.com/jolicode/castor(config-stubs *) CASTOR_GENERATE_STUBS=false castor 
Symfony\Component\DependencyInjection\Exception\RuntimeException^ {#471
  #message: "Invalid env fallback in "default:true:CASTOR_GENERATE_STUBS": parameter "true" not found."
  #code: 0
  #file: "./vendor/symfony/dependency-injection/EnvVarProcessor.php"
  #line: 145
  trace: {
```

I now understand the meaning of `default`, but there are many cases where we want to define
a raw default value.

So I want to introduce the `default_value` processor.
