### PR TITLE
[Cache] fix test

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisTransportFactoryTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisTransportFactoryTest.php
@@ -66,10 +66,12 @@ class RedisTransportFactoryTest extends TestCase
             ['stream' => 'bar', 'delete_after_ack' => true],
         ];
 
-        yield 'redis_sentinel' => [
-            'redis:?host['.str_replace(' ', ']&host[', getenv('REDIS_SENTINEL_HOSTS')).']',
-            ['sentinel_master' => getenv('REDIS_SENTINEL_SERVICE')],
-        ];
+        if (false !== getenv('REDIS_SENTINEL_HOSTS') && false !== getenv('REDIS_SENTINEL_SERVICE')) {
+            yield 'redis_sentinel' => [
+                'redis:?host['.str_replace(' ', ']&host[', getenv('REDIS_SENTINEL_HOSTS')).']',
+                ['sentinel_master' => getenv('REDIS_SENTINEL_SERVICE')],
+            ];
+        }
     }
 
     private function skipIfRedisUnavailable()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Do not yield Redis Sentinel test data if the required environment variables are not configured.

see https://github.com/symfony/symfony/actions/runs/12025721914/job/33523351272#step:9:615
