### PR TITLE
[Config] Do not generate unreachable configuration paths

### DIFF
--- a/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
+++ b/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
@@ -127,10 +127,13 @@ public function NAME(): string
         $class->addRequire($childClass);
         $this->classes[] = $childClass;
 
+        $nodeTypes = $this->getParameterTypes($node);
+        $paramType = $this->getParamType($nodeTypes);
+
         $hasNormalizationClosures = $this->hasNormalizationClosures($node);
         $comment = $this->getComment($node);
-        if ($hasNormalizationClosures) {
-            $comment = \sprintf(" * @template TValue\n * @param TValue \$value\n%s", $comment);
+        if ($hasNormalizationClosures && 'array' !== $paramType) {
+            $comment = \sprintf(" * @template TValue of %s\n * @param TValue \$value\n%s", $paramType, $comment);
             $comment .= \sprintf(' * @return %s|$this'."\n", $childClass->getFqcn());
             $comment .= \sprintf(' * @psalm-return (TValue is array ? %s : static)'."\n ", $childClass->getFqcn());
         }
@@ -142,8 +145,7 @@ public function NAME(): string
             $node->getName(),
             $this->getType($childClass->getFqcn(), $hasNormalizationClosures)
         );
-        $nodeTypes = $this->getParameterTypes($node);
-        $body = $hasNormalizationClosures ? '
+        $body = $hasNormalizationClosures && 'array' !== $paramType ? '
 COMMENTpublic function NAME(PARAM_TYPE $value = []): CLASS|static
 {
     if (!\is_array($value)) {
@@ -178,7 +180,7 @@ COMMENTpublic function NAME(array $value = []): CLASS
             'COMMENT' => $comment,
             'PROPERTY' => $property->getName(),
             'CLASS' => $childClass->getFqcn(),
-            'PARAM_TYPE' => \in_array('mixed', $nodeTypes, true) ? 'mixed' : implode('|', $nodeTypes),
+            'PARAM_TYPE' => $paramType,
         ]);
 
         $this->buildNode($node, $childClass, $this->getSubNamespace($childClass));
@@ -218,10 +220,11 @@ public function NAME(mixed $valueDEFAULT): static
 
         $nodeParameterTypes = $this->getParameterTypes($node);
         $prototypeParameterTypes = $this->getParameterTypes($prototype);
+        $noKey = null === $key = $node->getKeyAttribute();
         if (!$prototype instanceof ArrayNode || ($prototype instanceof PrototypedArrayNode && $prototype->getPrototype() instanceof ScalarNode)) {
             $class->addUse(ParamConfigurator::class);
             $property = $class->addProperty($node->getName());
-            if (null === $key = $node->getKeyAttribute()) {
+            if ($noKey) {
                 // This is an array of values; don't use singular name
                 $nodeTypesWithoutArray = array_filter($nodeParameterTypes, static fn ($type) => 'array' !== $type);
                 $body = '
@@ -242,7 +245,7 @@ public function NAME(PARAM_TYPE $value): static
                     'PROPERTY' => $property->getName(),
                     'PROTOTYPE_TYPE' => implode('|', $prototypeParameterTypes),
                     'EXTRA_TYPE' => $nodeTypesWithoutArray ? '|'.implode('|', $nodeTypesWithoutArray) : '',
-                    'PARAM_TYPE' => \in_array('mixed', $nodeParameterTypes, true) ? 'mixed' : 'ParamConfigurator|'.implode('|', $nodeParameterTypes),
+                    'PARAM_TYPE' => $this->getParamType($nodeParameterTypes, true),
                 ]);
             } else {
                 $body = '
@@ -259,7 +262,7 @@ public function NAME(string $VAR, TYPE $VALUE): static
 
                 $class->addMethod($methodName, $body, [
                     'PROPERTY' => $property->getName(),
-                    'TYPE' => \in_array('mixed', $prototypeParameterTypes, true) ? 'mixed' : 'ParamConfigurator|'.implode('|', $prototypeParameterTypes),
+                    'TYPE' => $this->getParamType($prototypeParameterTypes, true),
                     'VAR' => '' === $key ? 'key' : $key,
                     'VALUE' => 'value' === $key ? 'data' : 'value',
                 ]);
@@ -280,18 +283,27 @@ public function NAME(string $VAR, TYPE $VALUE): static
             $this->getType($childClass->getFqcn().'[]', $hasNormalizationClosures)
         );
 
+        $paramType = $this->getParamType($noKey ? $nodeParameterTypes : $prototypeParameterTypes);
+
         $comment = $this->getComment($node);
+<<<<<<< HEAD
         if ($hasNormalizationClosures) {
             $comment = \sprintf(" * @template TValue\n * @param TValue \$value\n%s", $comment);
             $comment .= \sprintf(' * @return %s|$this'."\n", $childClass->getFqcn());
             $comment .= \sprintf(' * @psalm-return (TValue is array ? %s : static)'."\n ", $childClass->getFqcn());
+=======
+        if ($hasNormalizationClosures && 'array' !== $paramType) {
+            $comment = sprintf(" * @template TValue of %s\n * @param TValue \$value\n%s", $paramType, $comment);
+            $comment .= sprintf(' * @return %s|$this'."\n", $childClass->getFqcn());
+            $comment .= sprintf(' * @psalm-return (TValue is array ? %s : static)'."\n ", $childClass->getFqcn());
+>>>>>>> 100c683018d ([Config] Do not generate unreachable configuration paths)
         }
         if ('' !== $comment) {
             $comment = "/**\n$comment*/\n";
         }
 
-        if (null === $key = $node->getKeyAttribute()) {
-            $body = $hasNormalizationClosures ? '
+        if ($noKey) {
+            $body = $hasNormalizationClosures && 'array' !== $paramType ? '
 COMMENTpublic function NAME(PARAM_TYPE $value = []): CLASS|static
 {
     $this->_usedProperties[\'PROPERTY\'] = true;
@@ -313,10 +325,10 @@ COMMENTpublic function NAME(array $value = []): CLASS
                 'COMMENT' => $comment,
                 'PROPERTY' => $property->getName(),
                 'CLASS' => $childClass->getFqcn(),
-                'PARAM_TYPE' => \in_array('mixed', $nodeParameterTypes, true) ? 'mixed' : implode('|', $nodeParameterTypes),
+                'PARAM_TYPE' => $paramType,
             ]);
         } else {
-            $body = $hasNormalizationClosures ? '
+            $body = $hasNormalizationClosures && 'array' !== $paramType ? '
 COMMENTpublic function NAME(string $VAR, PARAM_TYPE $VALUE = []): CLASS|static
 {
     if (!\is_array($VALUE)) {
@@ -352,7 +364,7 @@ COMMENTpublic function NAME(string $VAR, array $VALUE = []): CLASS
                 'CLASS' => $childClass->getFqcn(),
                 'VAR' => '' === $key ? 'key' : $key,
                 'VALUE' => 'value' === $key ? 'data' : 'value',
-                'PARAM_TYPE' => \in_array('mixed', $prototypeParameterTypes, true) ? 'mixed' : implode('|', $prototypeParameterTypes),
+                'PARAM_TYPE' => $paramType,
             ]);
         }
 
@@ -596,5 +608,10 @@ public function NAME(string $key, mixed $value): static
     private function getType(string $classType, bool $hasNormalizationClosures): string
     {
         return $classType.($hasNormalizationClosures ? '|scalar' : '');
+    }
+
+    private function getParamType(array $types, bool $withParamConfigurator = false): string
+    {
+        return \in_array('mixed', $types, true) ? 'mixed' : ($withParamConfigurator ? 'ParamConfigurator|' : '').implode('|', $types);
     }
 }

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayValues.config.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayValues.config.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Config\ArrayValuesConfig;
+
+return static function (ArrayValuesConfig $config) {
+    $config->transports('foo')->dsn('bar');
+    $config->transports('bar', ['dsn' => 'foobar']);
+
+    $config->errorPages()->withTrace(false);
+};

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayValues.output.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayValues.output.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return [
+    'transports' => [
+        'foo' => [
+            'dsn' => 'bar',
+        ],
+        'bar' => [
+            'dsn' => 'foobar',
+        ],
+    ],
+    'error_pages' => [
+        'with_trace' => false,
+    ]
+];

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayValues.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayValues.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Symfony\Component\Config\Tests\Builder\Fixtures;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class ArrayValues implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $tb = new TreeBuilder('array_values');
+        $rootNode = $tb->getRootNode();
+        $rootNode
+            ->children()
+                ->arrayNode('transports')
+                    ->normalizeKeys(false)
+                    ->useAttributeAsKey('name')
+                    ->arrayPrototype()
+                        ->beforeNormalization()
+                            ->ifString()
+                            ->then(function (string $dsn) {
+                                return ['dsn' => $dsn];
+                            })
+                        ->end()
+                        ->fixXmlConfig('option')
+                        ->children()
+                            ->scalarNode('dsn')->end()
+                        ->end()
+                    ->end()
+                ->end()
+                ->arrayNode('error_pages')
+                    ->canBeEnabled()
+                    ->children()
+                        ->booleanNode('with_trace')->end()
+                    ->end()
+                ->end()
+            ->end();
+
+        return $tb;
+    }
+}

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayValues/Symfony/Config/ArrayValues/ErrorPagesConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayValues/Symfony/Config/ArrayValues/ErrorPagesConfig.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Symfony\Config\ArrayValues;
+
+use Symfony\Component\Config\Loader\ParamConfigurator;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+
+/**
+ * This class is automatically generated to help in creating a config.
+ */
+class ErrorPagesConfig 
+{
+    private $enabled;
+    private $withTrace;
+    private $_usedProperties = [];
+
+    /**
+     * @default false
+     * @param ParamConfigurator|bool $value
+     * @return $this
+     */
+    public function enabled($value): static
+    {
+        $this->_usedProperties['enabled'] = true;
+        $this->enabled = $value;
+
+        return $this;
+    }
+
+    /**
+     * @default null
+     * @param ParamConfigurator|bool $value
+     * @return $this
+     */
+    public function withTrace($value): static
+    {
+        $this->_usedProperties['withTrace'] = true;
+        $this->withTrace = $value;
+
+        return $this;
+    }
+
+    public function __construct(array $value = [])
+    {
+        if (array_key_exists('enabled', $value)) {
+            $this->_usedProperties['enabled'] = true;
+            $this->enabled = $value['enabled'];
+            unset($value['enabled']);
+        }
+
+        if (array_key_exists('with_trace', $value)) {
+            $this->_usedProperties['withTrace'] = true;
+            $this->withTrace = $value['with_trace'];
+            unset($value['with_trace']);
+        }
+
+        if ([] !== $value) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        }
+    }
+
+    public function toArray(): array
+    {
+        $output = [];
+        if (isset($this->_usedProperties['enabled'])) {
+            $output['enabled'] = $this->enabled;
+        }
+        if (isset($this->_usedProperties['withTrace'])) {
+            $output['with_trace'] = $this->withTrace;
+        }
+
+        return $output;
+    }
+
+}

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayValues/Symfony/Config/ArrayValues/TransportsConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayValues/Symfony/Config/ArrayValues/TransportsConfig.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Symfony\Config\ArrayValues;
+
+use Symfony\Component\Config\Loader\ParamConfigurator;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+
+/**
+ * This class is automatically generated to help in creating a config.
+ */
+class TransportsConfig 
+{
+    private $dsn;
+    private $_usedProperties = [];
+
+    /**
+     * @default null
+     * @param ParamConfigurator|mixed $value
+     * @return $this
+     */
+    public function dsn($value): static
+    {
+        $this->_usedProperties['dsn'] = true;
+        $this->dsn = $value;
+
+        return $this;
+    }
+
+    public function __construct(array $value = [])
+    {
+        if (array_key_exists('dsn', $value)) {
+            $this->_usedProperties['dsn'] = true;
+            $this->dsn = $value['dsn'];
+            unset($value['dsn']);
+        }
+
+        if ([] !== $value) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        }
+    }
+
+    public function toArray(): array
+    {
+        $output = [];
+        if (isset($this->_usedProperties['dsn'])) {
+            $output['dsn'] = $this->dsn;
+        }
+
+        return $output;
+    }
+
+}

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayValues/Symfony/Config/ArrayValuesConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayValues/Symfony/Config/ArrayValuesConfig.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Symfony\Config;
+
+require_once __DIR__.\DIRECTORY_SEPARATOR.'ArrayValues'.\DIRECTORY_SEPARATOR.'TransportsConfig.php';
+require_once __DIR__.\DIRECTORY_SEPARATOR.'ArrayValues'.\DIRECTORY_SEPARATOR.'ErrorPagesConfig.php';
+
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+
+/**
+ * This class is automatically generated to help in creating a config.
+ */
+class ArrayValuesConfig implements \Symfony\Component\Config\Builder\ConfigBuilderInterface
+{
+    private $transports;
+    private $errorPages;
+    private $_usedProperties = [];
+
+    /**
+     * @template TValue of string|array
+     * @param TValue $value
+     * @return \Symfony\Config\ArrayValues\TransportsConfig|$this
+     * @psalm-return (TValue is array ? \Symfony\Config\ArrayValues\TransportsConfig : static)
+     */
+    public function transports(string $name, string|array $value = []): \Symfony\Config\ArrayValues\TransportsConfig|static
+    {
+        if (!\is_array($value)) {
+            $this->_usedProperties['transports'] = true;
+            $this->transports[$name] = $value;
+
+            return $this;
+        }
+
+        if (!isset($this->transports[$name]) || !$this->transports[$name] instanceof \Symfony\Config\ArrayValues\TransportsConfig) {
+            $this->_usedProperties['transports'] = true;
+            $this->transports[$name] = new \Symfony\Config\ArrayValues\TransportsConfig($value);
+        } elseif (1 < \func_num_args()) {
+            throw new InvalidConfigurationException('The node created by "transports()" has already been initialized. You cannot pass values the second time you call transports().');
+        }
+
+        return $this->transports[$name];
+    }
+
+    /**
+     * @default {"enabled":false}
+    */
+    public function errorPages(array $value = []): \Symfony\Config\ArrayValues\ErrorPagesConfig
+    {
+        if (null === $this->errorPages) {
+            $this->_usedProperties['errorPages'] = true;
+            $this->errorPages = new \Symfony\Config\ArrayValues\ErrorPagesConfig($value);
+        } elseif (0 < \func_num_args()) {
+            throw new InvalidConfigurationException('The node created by "errorPages()" has already been initialized. You cannot pass values the second time you call errorPages().');
+        }
+
+        return $this->errorPages;
+    }
+
+    public function getExtensionAlias(): string
+    {
+        return 'array_values';
+    }
+
+    public function __construct(array $value = [])
+    {
+        if (array_key_exists('transports', $value)) {
+            $this->_usedProperties['transports'] = true;
+            $this->transports = array_map(fn ($v) => \is_array($v) ? new \Symfony\Config\ArrayValues\TransportsConfig($v) : $v, $value['transports']);
+            unset($value['transports']);
+        }
+
+        if (array_key_exists('error_pages', $value)) {
+            $this->_usedProperties['errorPages'] = true;
+            $this->errorPages = \is_array($value['error_pages']) ? new \Symfony\Config\ArrayValues\ErrorPagesConfig($value['error_pages']) : $value['error_pages'];
+            unset($value['error_pages']);
+        }
+
+        if ([] !== $value) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        }
+    }
+
+    public function toArray(): array
+    {
+        $output = [];
+        if (isset($this->_usedProperties['transports'])) {
+            $output['transports'] = array_map(fn ($v) => $v instanceof \Symfony\Config\ArrayValues\TransportsConfig ? $v->toArray() : $v, $this->transports);
+        }
+        if (isset($this->_usedProperties['errorPages'])) {
+            $output['error_pages'] = $this->errorPages instanceof \Symfony\Config\ArrayValues\ErrorPagesConfig ? $this->errorPages->toArray() : $this->errorPages;
+        }
+
+        return $output;
+    }
+
+}

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/NestedConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/NestedConfig.php
@@ -17,7 +17,7 @@ class NestedConfig
     private $_usedProperties = [];
 
     /**
-     * @template TValue
+     * @template TValue of mixed
      * @param TValue $value
      * @default {"enabled":null}
      * @return \Symfony\Config\ScalarNormalizedTypes\Nested\NestedObjectConfig|$this
@@ -43,7 +43,7 @@ class NestedConfig
     }
 
     /**
-     * @template TValue
+     * @template TValue of mixed
      * @param TValue $value
      * @return \Symfony\Config\ScalarNormalizedTypes\Nested\NestedListObjectConfig|$this
      * @psalm-return (TValue is array ? \Symfony\Config\ScalarNormalizedTypes\Nested\NestedListObjectConfig : static)

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypesConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypesConfig.php
@@ -48,7 +48,7 @@ class ScalarNormalizedTypesConfig implements \Symfony\Component\Config\Builder\C
     }
 
     /**
-     * @template TValue
+     * @template TValue of mixed
      * @param TValue $value
      * @default {"enabled":null}
      * @return \Symfony\Config\ScalarNormalizedTypes\ObjectConfig|$this
@@ -74,7 +74,7 @@ class ScalarNormalizedTypesConfig implements \Symfony\Component\Config\Builder\C
     }
 
     /**
-     * @template TValue
+     * @template TValue of mixed
      * @param TValue $value
      * @return \Symfony\Config\ScalarNormalizedTypes\ListObjectConfig|$this
      * @psalm-return (TValue is array ? \Symfony\Config\ScalarNormalizedTypes\ListObjectConfig : static)
@@ -92,7 +92,7 @@ class ScalarNormalizedTypesConfig implements \Symfony\Component\Config\Builder\C
     }
 
     /**
-     * @template TValue
+     * @template TValue of mixed
      * @param TValue $value
      * @return \Symfony\Config\ScalarNormalizedTypes\KeyedListObjectConfig|$this
      * @psalm-return (TValue is array ? \Symfony\Config\ScalarNormalizedTypes\KeyedListObjectConfig : static)

--- a/src/Symfony/Component/Config/Tests/Builder/GeneratedConfigTest.php
+++ b/src/Symfony/Component/Config/Tests/Builder/GeneratedConfigTest.php
@@ -62,6 +62,7 @@ class GeneratedConfigTest extends TestCase
             'AddToList' => 'add_to_list',
             'NodeInitialValues' => 'node_initial_values',
             'ArrayExtraKeys' => 'array_extra_keys',
+            'ArrayValues' => 'array_values',
         ];
 
         foreach ($array as $name => $alias) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | - <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

PHPStan was having issues correctly inferring the returned type of a configuration function. 

Consider the following messages as example:

```
Call to an undefined method Symfony\Config\Framework\AnnotationsConfig|Symfony\Config\FrameworkConfig::enabled()
```

This came from the following generated config class:

```php
    /**
     * @template TValue
     * @param TValue $value
     * annotation configuration
     * @default {"enabled":false,"cache":"php_array","file_cache_dir":"%kernel.cache_dir%\/annotations","debug":true}
     * @return \Symfony\Config\Framework\AnnotationsConfig|$this
     * @psalm-return (TValue is array ? \Symfony\Config\Framework\AnnotationsConfig : static)
     */
    public function annotations(array $value = []): \Symfony\Config\Framework\AnnotationsConfig|static
    {
        if (!\is_array($value)) {
            $this->_usedProperties['annotations'] = true;
            $this->annotations = $value;

            return $this;
        }

        if (!$this->annotations instanceof \Symfony\Config\Framework\AnnotationsConfig) {
            $this->_usedProperties['annotations'] = true;
            $this->annotations = new \Symfony\Config\Framework\AnnotationsConfig($value);
        } elseif (0 < \func_num_args()) {
            throw new InvalidConfigurationException('The node created by "annotations()" has already been initialized. You cannot pass values the second time you call annotations().');
        }

        return $this->annotations;
    }
```

When the determined parameter type is `array`, only that type can be passed meaning that the `is_array` is unnecessary. The same holds for the generated docblock: as only an array can be passed, there is no need to define a template and psalm returns.

With the changes in this PR this method is generated more cleanly:

```php
    /**
     * annotation configuration
     * @default {"enabled":false,"cache":"php_array","file_cache_dir":"%kernel.cache_dir%\/annotations","debug":true}
    */
    public function annotations(array $value = []): \Symfony\Config\Framework\AnnotationsConfig
    {
        if (null === $this->annotations) {
            $this->_usedProperties['annotations'] = true;
            $this->annotations = new \Symfony\Config\Framework\AnnotationsConfig($value);
        } elseif (0 < \func_num_args()) {
            throw new InvalidConfigurationException('The node created by "annotations()" has already been initialized. You cannot pass values the second time you call annotations().');
        }

        return $this->annotations;
    }
```

A similar issue happens with functions that do accept more than an array value:

```
Call to an undefined method Symfony\Config\Doctrine\Dbal\TypeConfig|Symfony\Config\Doctrine\DbalConfig::class()
```

This is caused by the following generated method:

```php
  /**
     * @template TValue
     * @param TValue $value
     * @return \Symfony\Config\Doctrine\Dbal\TypeConfig|$this
     * @psalm-return (TValue is array ? \Symfony\Config\Doctrine\Dbal\TypeConfig : static)
     */
    public function type(string $name, string|array $value = []): \Symfony\Config\Doctrine\Dbal\TypeConfig|static
    {
        if (!\is_array($value)) {
            $this->_usedProperties['types'] = true;
            $this->types[$name] = $value;

            return $this;
        }

        if (!isset($this->types[$name]) || !$this->types[$name] instanceof \Symfony\Config\Doctrine\Dbal\TypeConfig) {
            $this->_usedProperties['types'] = true;
            $this->types[$name] = new \Symfony\Config\Doctrine\Dbal\TypeConfig($value);
        } elseif (1 < \func_num_args()) {
            throw new InvalidConfigurationException('The node created by "type()" has already been initialized. You cannot pass values the second time you call type().');
        }

        return $this->types[$name];
    }
```

While the method seems fine, the `@template` definition is not correctly defined, see https://phpstan.org/r/09317897-4cc8-4f67-98ca-8b6da3671b31.

With the changes in this PR the template is now strictly defined so it matches the function signature:

```php
  /**
     * @template TValue of string|array
     * @param TValue $value
     * @return \Symfony\Config\Doctrine\Dbal\TypeConfig|$this
     * @psalm-return (TValue is array ? \Symfony\Config\Doctrine\Dbal\TypeConfig : static)
     */
```

See https://phpstan.org/r/986db325-9869-4a6f-8587-6af06c0612d4 for the results.

While the second change might actually be enough to fix the errors, I prefer both fixes as it no longers generates code that can not be executed anyways.
