### PR TITLE
[Serializer] Skip test if `symfony/property-info` doesn't support `phpstan/phpdoc-parser:2.0` yet

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
+use Composer\InstalledVersions;
 use Doctrine\Common\Annotations\AnnotationReader;
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
 use PHPUnit\Framework\TestCase;
@@ -751,6 +752,15 @@ class ObjectNormalizerTest extends TestCase
     {
         if (!class_exists(PhpStanExtractor::class) || !class_exists(PhpDocParser::class)) {
             $this->markTestSkipped('phpstan/phpdoc-parser required for this test');
+        }
+
+        $versionRange = InstalledVersions::getVersionRanges('symfony/property-info');
+
+        if (
+            '5.4.x-dev' !== $versionRange && version_compare($versionRange, '5.4.47', '<')
+            || version_compare($versionRange, '6', '>=') && '6.4.x-dev' !== $versionRange && version_compare($versionRange, '6.4.15', '<')
+        ) {
+            $this->markTestSkipped('PropertyInfo >= 5.4.47 or >= 6.4.15 is required for this test');
         }
 
         $extractor = new PropertyInfoExtractor([], [new PhpStanExtractor(), new PhpDocExtractor(), new ReflectionExtractor()]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The support for `phpstan/phpdoc-parser` 2.0 was introduced in PropertyInfo lately (cc @xabbuh). Unfortunately, Serializer cannot benefit from this in 5.4 because the highest version of PropertyInfo installable is 6.3 (see [the failing job](https://github.com/symfony/symfony/actions/runs/12014213386/job/33489484938)). Before running this particular test, we need to ensure PropertyInfo is installed with a version that supports `phpstan/phpdoc-parser` 2.0.