### PR TITLE
[AssetMapper] use the filesystem component to avoid side cases into MappedAssetFactory

### DIFF
--- a/src/Symfony/Component/AssetMapper/Factory/MappedAssetFactory.php
+++ b/src/Symfony/Component/AssetMapper/Factory/MappedAssetFactory.php
@@ -126,9 +126,13 @@ class MappedAssetFactory implements MappedAssetFactoryInterface
 
     private function isVendor(string $sourcePath): bool
     {
-        $sourcePath = realpath($sourcePath);
-        $vendorDir = realpath($this->vendorDir);
+        $filesystem = new Filesystem();
+        $sourcePath = $filesystem->readlink($sourcePath, true);
+        $vendorDir = $filesystem->readlink($this->vendorDir, true);
 
-        return $sourcePath && $vendorDir && str_starts_with($sourcePath, $vendorDir);
+        return null !== $sourcePath
+            && null !== $vendorDir
+            && str_starts_with($sourcePath, $vendorDir)
+        ;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

Hello,

To avoid side cases fixed into the filesystem component

Thanks