### PR TITLE
[FrameworkBundle] Add support custom config/bundles.php for environment

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.3
+---
+
+* Add support custom `config/bundles.php` for environment
+
 7.2
 ---
 
@@ -21,7 +26,6 @@ CHANGELOG
  * Add support for configuring multiple serializer instances via the configuration
  * Add support for `SYMFONY_TRUSTED_PROXIES`, `SYMFONY_TRUSTED_HEADERS`, `SYMFONY_TRUST_X_SENDFILE_TYPE_HEADER` and `SYMFONY_TRUSTED_HOSTS` env vars
  * Add `--no-fill` option to `translation:extract` command
- * Add support custom config/bundles.php for environment
 
 7.1
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -21,6 +21,7 @@ CHANGELOG
  * Add support for configuring multiple serializer instances via the configuration
  * Add support for `SYMFONY_TRUSTED_PROXIES`, `SYMFONY_TRUSTED_HEADERS`, `SYMFONY_TRUST_X_SENDFILE_TYPE_HEADER` and `SYMFONY_TRUSTED_HOSTS` env vars
  * Add `--no-fill` option to `translation:extract` command
+ * Add support custom config/bundles.php for environment
 
 7.1
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
@@ -103,7 +103,13 @@ trait MicroKernelTrait
      */
     private function getBundlesPath(): string
     {
-        return $this->getConfigDir().'/bundles.php';
+        $configDir = $this->getConfigDir();
+
+        if (is_file($configDir.'/bundles_'.$this->environment.'.php')) {
+            return $configDir.'/bundles_'.$this->environment.'.php';
+        }
+
+        return $configDir.'/bundles.php';
     }
 
     public function getCacheDir(): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

This PR adds support custom `config/bundles.php` for environment.

For example, we don't want to use a some bundle on the specific environment:
Use **Twig** and **Nelmio** packages (build /api/doc) for _dev_ and _test_ only, without _prod_.

Now, we are forced to move packages from _required-dev_ section to _required_ for successful build application after `composer install` with `--no-dev` flag.

After this PR merged we will be able create `config/bundles_prod.php` and remove extra bundles.
