### PR TITLE
[Dotenv] read runtime config from composer.json in debug dotenv command

### DIFF
--- a/src/Symfony/Component/Dotenv/Command/DebugCommand.php
+++ b/src/Symfony/Component/Dotenv/Command/DebugCommand.php
@@ -50,7 +50,17 @@ final class DebugCommand extends Command
             return 1;
         }
 
-        $filePath = $this->projectDirectory.\DIRECTORY_SEPARATOR.'.env';
+        $dotenvPath = $this->projectDirectory;
+
+        if (is_file($composerFile = $this->projectDirectory.'/composer.json')) {
+            $runtimeConfig = (json_decode(file_get_contents($composerFile), true))['extra']['runtime'] ?? [];
+
+            if (isset($runtimeConfig['dotenv_path'])) {
+                $dotenvPath = $this->projectDirectory.'/'.$runtimeConfig['dotenv_path'];
+            }
+        }
+
+        $filePath = $dotenvPath.'/.env';
         $envFiles = $this->getEnvFiles($filePath);
         $availableFiles = array_filter($envFiles, 'is_file');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58987
| License       | MIT

same approach as what we already did for the dump command in #45430
