### PR TITLE
[PropertyInfo] Fix interface handling in `PhpStanTypeHelper`

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
@@ -14,10 +14,13 @@ namespace Symfony\Component\PropertyInfo\Tests\Extractor;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\Clazz;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\ConstructorDummyWithoutDocBlock;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DefaultValue;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyCollection;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyGeneric;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\IFace;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\ParentDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php80Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php80PromotedDummy;
@@ -482,7 +485,88 @@ class PhpStanExtractorTest extends TestCase
 
     public function testGenericInterface()
     {
-        $this->assertNull($this->extractor->getTypes(Dummy::class, 'genericInterface'));
+        $this->assertEquals(
+            [
+                new Type(
+                    builtinType: Type::BUILTIN_TYPE_OBJECT,
+                    class: \BackedEnum::class,
+                    collectionValueType: new Type(
+                        builtinType: Type::BUILTIN_TYPE_STRING,
+                    )
+                ),
+            ],
+            $this->extractor->getTypes(Dummy::class, 'genericInterface')
+        );
+    }
+
+    /**
+     * @param list<Type> $expectedTypes
+     * @dataProvider genericsProvider
+     */
+    public function testGenericsLegacy(string $property, array $expectedTypes)
+    {
+        $this->assertEquals($expectedTypes, $this->extractor->getTypes(DummyGeneric::class, $property));
+    }
+
+    /**
+     * @return iterable<array{0: string, 1: list<Type>}>
+     */
+    public static function genericsProvider(): iterable
+    {
+        yield [
+            'basicClass',
+            [
+                new Type(
+                    builtinType: Type::BUILTIN_TYPE_OBJECT,
+                    class: Clazz::class,
+                    collectionValueType: new Type(
+                        builtinType: Type::BUILTIN_TYPE_OBJECT,
+                        class: Dummy::class,
+                    )
+                ),
+            ],
+        ];
+        yield [
+            'nullableClass',
+            [
+                new Type(
+                    builtinType: Type::BUILTIN_TYPE_OBJECT,
+                    class: Clazz::class,
+                    nullable: true,
+                    collectionValueType: new Type(
+                        builtinType: Type::BUILTIN_TYPE_OBJECT,
+                        class: Dummy::class,
+                    )
+                ),
+            ],
+        ];
+        yield [
+            'basicInterface',
+            [
+                new Type(
+                    builtinType: Type::BUILTIN_TYPE_OBJECT,
+                    class: IFace::class,
+                    collectionValueType: new Type(
+                        builtinType: Type::BUILTIN_TYPE_OBJECT,
+                        class: Dummy::class,
+                    )
+                ),
+            ],
+        ];
+        yield [
+            'nullableInterface',
+            [
+                new Type(
+                    builtinType: Type::BUILTIN_TYPE_OBJECT,
+                    class: IFace::class,
+                    nullable: true,
+                    collectionValueType: new Type(
+                        builtinType: Type::BUILTIN_TYPE_OBJECT,
+                        class: Dummy::class,
+                    )
+                ),
+            ],
+        ];
     }
 }
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyGeneric.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyGeneric.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+interface IFace {}
+
+class Clazz {}
+
+class DummyGeneric
+{
+
+    /**
+     * @var Clazz<Dummy>
+     */
+    public $basicClass;
+
+    /**
+     * @var ?Clazz<Dummy>
+     */
+    public $nullableClass;
+
+    /**
+     * @var IFace<Dummy>
+     */
+    public $basicInterface;
+
+    /**
+     * @var ?IFace<Dummy>
+     */
+    public $nullableInterface;
+
+}

--- a/src/Symfony/Component/PropertyInfo/Util/PhpStanTypeHelper.php
+++ b/src/Symfony/Component/PropertyInfo/Util/PhpStanTypeHelper.php
@@ -128,7 +128,7 @@ final class PhpStanTypeHelper
             $collection = $mainType->isCollection() || \is_a($mainType->getClassName(), \Traversable::class, true) || \is_a($mainType->getClassName(), \ArrayAccess::class, true);
 
             // it's safer to fall back to other extractors if the generic type is too abstract
-            if (!$collection && !class_exists($mainType->getClassName())) {
+            if (!$collection && !class_exists($mainType->getClassName()) && !interface_exists($mainType->getClassName(), false)) {
                 return [];
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Previously, deserializing object with `Interface<T>` property was failing on undefined array key in `PhpStanTypeHelper` (generic `Clazz<T>` works just fine):

```
ErrorException: Undefined array key 0
/app/backend/vendor/symfony/property-info/Util/PhpStanTypeHelper.php:171
/app/backend/vendor/symfony/property-info/Util/PhpStanTypeHelper.php:49
/app/backend/vendor/symfony/property-info/Extractor/PhpStanExtractor.php:130
/app/backend/vendor/symfony/property-info/PropertyInfoExtractor.php:93
/app/backend/vendor/symfony/property-info/PropertyInfoExtractor.php:66
/app/backend/vendor/symfony/property-info/PropertyInfoCacheExtractor.php:102
/app/backend/vendor/symfony/property-info/PropertyInfoCacheExtractor.php:69
/app/backend/vendor/symfony/serializer/Normalizer/AbstractObjectNormalizer.php:669
/app/backend/vendor/symfony/serializer/Normalizer/AbstractObjectNormalizer.php:646
/app/backend/vendor/symfony/serializer/Normalizer/AbstractNormalizer.php:386
/app/backend/vendor/symfony/serializer/Normalizer/AbstractObjectNormalizer.php:243
/app/backend/vendor/symfony/serializer/Normalizer/AbstractObjectNormalizer.php:349
/app/backend/vendor/symfony/serializer/Serializer.php:247
/app/backend/vendor/symfony/serializer/Serializer.php:152
```