### PR TITLE
[HttpClient] Fix checking for private IPs before connecting

### DIFF
--- a/src/Symfony/Component/HttpClient/NativeHttpClient.php
+++ b/src/Symfony/Component/HttpClient/NativeHttpClient.php
@@ -141,22 +141,13 @@ final class NativeHttpClient implements HttpClientInterface, LoggerAwareInterfac
             // Memoize the last progress to ease calling the callback periodically when no network transfer happens
             $lastProgress = [0, 0];
             $maxDuration = 0 < $options['max_duration'] ? $options['max_duration'] : \INF;
-            $multi = $this->multi;
-            $resolve = static function (string $host, ?string $ip = null) use ($multi): ?string {
-                if (null !== $ip) {
-                    $multi->dnsCache[$host] = $ip;
-                }
-
-                return $multi->dnsCache[$host] ?? null;
-            };
-            $onProgress = static function (...$progress) use ($onProgress, &$lastProgress, &$info, $maxDuration, $resolve) {
+            $onProgress = static function (...$progress) use ($onProgress, &$lastProgress, &$info, $maxDuration) {
                 if ($info['total_time'] >= $maxDuration) {
                     throw new TransportException(sprintf('Max duration was reached for "%s".', implode('', $info['url'])));
                 }
 
                 $progressInfo = $info;
                 $progressInfo['url'] = implode('', $info['url']);
-                $progressInfo['resolve'] = $resolve;
                 unset($progressInfo['size_body']);
 
                 if ($progress && -1 === $progress[0]) {

--- a/src/Symfony/Component/HttpClient/NoPrivateNetworkHttpClient.php
+++ b/src/Symfony/Component/HttpClient/NoPrivateNetworkHttpClient.php
@@ -13,9 +13,11 @@ namespace Symfony\Component\HttpClient;
 
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\HttpClient\Exception\InvalidArgumentException;
 use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Component\HttpClient\Response\AsyncContext;
+use Symfony\Component\HttpClient\Response\AsyncResponse;
 use Symfony\Component\HttpFoundation\IpUtils;
+use Symfony\Contracts\HttpClient\ChunkInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 use Symfony\Contracts\HttpClient\ResponseStreamInterface;
@@ -25,10 +27,12 @@ use Symfony\Contracts\Service\ResetInterface;
  * Decorator that blocks requests to private networks by default.
  *
  * @author Hallison Boaventura <hallisonboaventura@gmail.com>
+ * @author Nicolas Grekas <p@tchwork.com>
  */
 final class NoPrivateNetworkHttpClient implements HttpClientInterface, LoggerAwareInterface, ResetInterface
 {
     use HttpClientTrait;
+    use AsyncDecoratorTrait;
 
     private const PRIVATE_SUBNETS = [
         '127.0.0.0/8',
@@ -45,11 +49,14 @@ final class NoPrivateNetworkHttpClient implements HttpClientInterface, LoggerAwa
         '::/128',
     ];
 
+    private $defaultOptions = self::OPTIONS_DEFAULTS;
     private $client;
     private $subnets;
+    private $ipFlags;
+    private $dnsCache;
 
     /**
-     * @param string|array|null $subnets String or array of subnets using CIDR notation that will be used by IpUtils.
+     * @param string|array|null $subnets String or array of subnets using CIDR notation that should be considered private.
      *                                   If null is passed, the standard private subnets will be used.
      */
     public function __construct(HttpClientInterface $client, $subnets = null)
@@ -62,8 +69,23 @@ final class NoPrivateNetworkHttpClient implements HttpClientInterface, LoggerAwa
             throw new \LogicException(sprintf('You cannot use "%s" if the HttpFoundation component is not installed. Try running "composer require symfony/http-foundation".', __CLASS__));
         }
 
+        if (null === $subnets) {
+            $ipFlags = \FILTER_FLAG_IPV4 | \FILTER_FLAG_IPV6;
+        } else {
+            $ipFlags = 0;
+            foreach ((array) $subnets as $subnet) {
+                $ipFlags |= str_contains($subnet, ':') ? \FILTER_FLAG_IPV6 : \FILTER_FLAG_IPV4;
+            }
+        }
+
+        if (!\defined('STREAM_PF_INET6')) {
+            $ipFlags &= ~\FILTER_FLAG_IPV6;
+        }
+
         $this->client = $client;
-        $this->subnets = $subnets;
+        $this->subnets = null !== $subnets ? (array) $subnets : null;
+        $this->ipFlags = $ipFlags;
+        $this->dnsCache = new \ArrayObject();
     }
 
     /**
@@ -71,47 +93,89 @@ final class NoPrivateNetworkHttpClient implements HttpClientInterface, LoggerAwa
      */
     public function request(string $method, string $url, array $options = []): ResponseInterface
     {
-        $onProgress = $options['on_progress'] ?? null;
-        if (null !== $onProgress && !\is_callable($onProgress)) {
-            throw new InvalidArgumentException(sprintf('Option "on_progress" must be callable, "%s" given.', get_debug_type($onProgress)));
+        [$url, $options] = self::prepareRequest($method, $url, $options, $this->defaultOptions, true);
+
+        $redirectHeaders = parse_url($url['authority']);
+        $host = $redirectHeaders['host'];
+        $url = implode('', $url);
+        $dnsCache = $this->dnsCache;
+
+        $ip = self::dnsResolve($dnsCache, $host, $this->ipFlags, $options);
+        self::ipCheck($ip, $this->subnets, $this->ipFlags, $host, $url);
+
+        if (0 < $maxRedirects = $options['max_redirects']) {
+            $options['max_redirects'] = 0;
+            $redirectHeaders['with_auth'] = $redirectHeaders['no_auth'] = $options['headers'];
+
+            if (isset($options['normalized_headers']['host']) || isset($options['normalized_headers']['authorization']) || isset($options['normalized_headers']['cookie'])) {
+                $redirectHeaders['no_auth'] = array_filter($redirectHeaders['no_auth'], static function ($h) {
+                    return 0 !== stripos($h, 'Host:') && 0 !== stripos($h, 'Authorization:') && 0 !== stripos($h, 'Cookie:');
+                });
+            }
         }
 
+        $onProgress = $options['on_progress'] ?? null;
         $subnets = $this->subnets;
-        $lastUrl = '';
+        $ipFlags = $this->ipFlags;
         $lastPrimaryIp = '';
 
-        $options['on_progress'] = function (int $dlNow, int $dlSize, array $info) use ($onProgress, $subnets, &$lastUrl, &$lastPrimaryIp): void {
-            if ($info['url'] !== $lastUrl) {
-                $host = parse_url($info['url'], PHP_URL_HOST) ?: '';
-                $resolve = $info['resolve'] ?? static function () { return null; };
-
-                if (($ip = trim($host, '[]'))
-                    && !filter_var($ip, \FILTER_VALIDATE_IP)
-                    && !($ip = $resolve($host))
-                    && $ip = @(gethostbynamel($host)[0] ?? dns_get_record($host, \DNS_AAAA)[0]['ipv6'] ?? null)
-                ) {
-                    $resolve($host, $ip);
-                }
-
-                if ($ip && IpUtils::checkIp($ip, $subnets ?? self::PRIVATE_SUBNETS)) {
-                    throw new TransportException(sprintf('Host "%s" is blocked for "%s".', $host, $info['url']));
-                }
-
-                $lastUrl = $info['url'];
-            }
-
-            if ($info['primary_ip'] !== $lastPrimaryIp) {
-                if ($info['primary_ip'] && IpUtils::checkIp($info['primary_ip'], $subnets ?? self::PRIVATE_SUBNETS)) {
-                    throw new TransportException(sprintf('IP "%s" is blocked for "%s".', $info['primary_ip'], $info['url']));
-                }
-
+        $options['on_progress'] = static function (int $dlNow, int $dlSize, array $info) use ($onProgress, $subnets, $ipFlags, &$lastPrimaryIp): void {
+            if (($info['primary_ip'] ?? '') !== $lastPrimaryIp) {
+                self::ipCheck($info['primary_ip'], $subnets, $ipFlags, null, $info['url']);
                 $lastPrimaryIp = $info['primary_ip'];
             }
 
             null !== $onProgress && $onProgress($dlNow, $dlSize, $info);
         };
 
-        return $this->client->request($method, $url, $options);
+        return new AsyncResponse($this->client, $method, $url, $options, static function (ChunkInterface $chunk, AsyncContext $context) use (&$method, &$options, $maxRedirects, &$redirectHeaders, $subnets, $ipFlags, $dnsCache): \Generator {
+            if (null !== $chunk->getError() || $chunk->isTimeout() || !$chunk->isFirst()) {
+                yield $chunk;
+
+                return;
+            }
+
+            $statusCode = $context->getStatusCode();
+
+            if ($statusCode < 300 || 400 <= $statusCode || null === $url = $context->getInfo('redirect_url')) {
+                $context->passthru();
+
+                yield $chunk;
+
+                return;
+            }
+
+            $host = parse_url($url, \PHP_URL_HOST);
+            $ip = self::dnsResolve($dnsCache, $host, $ipFlags, $options);
+            self::ipCheck($ip, $subnets, $ipFlags, $host, $url);
+
+            // Do like curl and browsers: turn POST to GET on 301, 302 and 303
+            if (303 === $statusCode || 'POST' === $method && \in_array($statusCode, [301, 302], true)) {
+                $method = 'HEAD' === $method ? 'HEAD' : 'GET';
+                unset($options['body'], $options['json']);
+
+                if (isset($options['normalized_headers']['content-length']) || isset($options['normalized_headers']['content-type']) || isset($options['normalized_headers']['transfer-encoding'])) {
+                    $filterContentHeaders = static function ($h) {
+                        return 0 !== stripos($h, 'Content-Length:') && 0 !== stripos($h, 'Content-Type:') && 0 !== stripos($h, 'Transfer-Encoding:');
+                    };
+                    $options['header'] = array_filter($options['header'], $filterContentHeaders);
+                    $redirectHeaders['no_auth'] = array_filter($redirectHeaders['no_auth'], $filterContentHeaders);
+                    $redirectHeaders['with_auth'] = array_filter($redirectHeaders['with_auth'], $filterContentHeaders);
+                }
+            }
+
+            // Authorization and Cookie headers MUST NOT follow except for the initial host name
+            $options['headers'] = $redirectHeaders['host'] === $host ? $redirectHeaders['with_auth'] : $redirectHeaders['no_auth'];
+
+            static $redirectCount = 0;
+            $context->setInfo('redirect_count', ++$redirectCount);
+
+            $context->replaceRequest($method, $url, $options);
+
+            if ($redirectCount >= $maxRedirects) {
+                $context->passthru();
+            }
+        });
     }
 
     /**
@@ -139,14 +203,73 @@ final class NoPrivateNetworkHttpClient implements HttpClientInterface, LoggerAwa
     {
         $clone = clone $this;
         $clone->client = $this->client->withOptions($options);
+        $clone->defaultOptions = self::mergeDefaultOptions($options, $this->defaultOptions);
 
         return $clone;
     }
 
     public function reset()
     {
+        $this->dnsCache->exchangeArray([]);
+
         if ($this->client instanceof ResetInterface) {
             $this->client->reset();
         }
+    }
+
+    private static function dnsResolve(\ArrayObject $dnsCache, string $host, int $ipFlags, array &$options): string
+    {
+        if ($ip = filter_var(trim($host, '[]'), \FILTER_VALIDATE_IP) ?: $options['resolve'][$host] ?? false) {
+            return $ip;
+        }
+
+        if ($dnsCache->offsetExists($host)) {
+            return $dnsCache[$host];
+        }
+
+        if ((\FILTER_FLAG_IPV4 & $ipFlags) && $ip = gethostbynamel($host)) {
+            return $options['resolve'][$host] = $dnsCache[$host] = $ip[0];
+        }
+
+        if (!(\FILTER_FLAG_IPV6 & $ipFlags)) {
+            return $host;
+        }
+
+        if ($ip = dns_get_record($host, \DNS_AAAA)) {
+            $ip = $ip[0]['ipv6'];
+        } elseif (extension_loaded('sockets')) {
+            if (!$info = socket_addrinfo_lookup($host, 0, ['ai_socktype' => \SOCK_STREAM, 'ai_family' => \AF_INET6])) {
+                return $host;
+            }
+
+            $ip = socket_addrinfo_explain($info[0])['ai_addr']['sin6_addr'];
+        } elseif ('localhost' === $host || 'localhost.' === $host) {
+            $ip = '::1';
+        } else {
+            return $host;
+        }
+
+        return $options['resolve'][$host] = $dnsCache[$host] = $ip;
+    }
+
+    private static function ipCheck(string $ip, ?array $subnets, int $ipFlags, ?string $host, string $url): void
+    {
+        if (null === $subnets) {
+            // Quick check, but not reliable enough, see https://github.com/php/php-src/issues/16944
+            $ipFlags |= \FILTER_FLAG_NO_PRIV_RANGE | \FILTER_FLAG_NO_RES_RANGE;
+        }
+
+        if (false !== filter_var($ip, \FILTER_VALIDATE_IP, $ipFlags) && !IpUtils::checkIp($ip, $subnets ?? self::PRIVATE_SUBNETS)) {
+            return;
+        }
+
+        if (null !== $host) {
+            $type = 'Host';
+        } else {
+            $host = $ip;
+            $type = 'IP';
+        }
+
+        throw new TransportException($type.\sprintf(' "%s" is blocked for "%s".', $host, $url));
     }
 }

--- a/src/Symfony/Component/HttpClient/Response/AmpResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/AmpResponse.php
@@ -89,17 +89,9 @@ final class AmpResponse implements ResponseInterface, StreamableInterface
         $info['max_duration'] = $options['max_duration'];
         $info['debug'] = '';
 
-        $resolve = static function (string $host, ?string $ip = null) use ($multi): ?string {
-            if (null !== $ip) {
-                $multi->dnsCache[$host] = $ip;
-            }
-
-            return $multi->dnsCache[$host] ?? null;
-        };
         $onProgress = $options['on_progress'] ?? static function () {};
-        $onProgress = $this->onProgress = static function () use (&$info, $onProgress, $resolve) {
+        $onProgress = $this->onProgress = static function () use (&$info, $onProgress) {
             $info['total_time'] = microtime(true) - $info['start_time'];
-            $info['resolve'] = $resolve;
             $onProgress((int) $info['size_download'], ((int) (1 + $info['download_content_length']) ?: 1) - 1, (array) $info);
         };
 

--- a/src/Symfony/Component/HttpClient/Response/CurlResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/CurlResponse.php
@@ -115,20 +115,13 @@ final class CurlResponse implements ResponseInterface, StreamableInterface
         curl_pause($ch, \CURLPAUSE_CONT);
 
         if ($onProgress = $options['on_progress']) {
-            $resolve = static function (string $host, ?string $ip = null) use ($multi): ?string {
-                if (null !== $ip) {
-                    $multi->dnsCache->hostnames[$host] = $ip;
-                }
-
-                return $multi->dnsCache->hostnames[$host] ?? null;
-            };
             $url = isset($info['url']) ? ['url' => $info['url']] : [];
             curl_setopt($ch, \CURLOPT_NOPROGRESS, false);
-            curl_setopt($ch, \CURLOPT_PROGRESSFUNCTION, static function ($ch, $dlSize, $dlNow) use ($onProgress, &$info, $url, $multi, $debugBuffer, $resolve) {
+            curl_setopt($ch, \CURLOPT_PROGRESSFUNCTION, static function ($ch, $dlSize, $dlNow) use ($onProgress, &$info, $url, $multi, $debugBuffer) {
                 try {
                     rewind($debugBuffer);
                     $debug = ['debug' => stream_get_contents($debugBuffer)];
-                    $onProgress($dlNow, $dlSize, $url + curl_getinfo($ch) + $info + $debug + ['resolve' => $resolve]);
+                    $onProgress($dlNow, $dlSize, $url + curl_getinfo($ch) + $info + $debug);
                 } catch (\Throwable $e) {
                     $multi->handlesActivity[(int) $ch][] = null;
                     $multi->handlesActivity[(int) $ch][] = $e;

--- a/src/Symfony/Component/HttpClient/Tests/AmpHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/AmpHttpClientTest.php
@@ -14,6 +14,9 @@ namespace Symfony\Component\HttpClient\Tests;
 use Symfony\Component\HttpClient\AmpHttpClient;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
+/**
+ * @group dns-sensitive
+ */
 class AmpHttpClientTest extends HttpClientTestCase
 {
     protected function getHttpClient(string $testCase): HttpClientInterface

--- a/src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php
@@ -17,6 +17,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * @requires extension curl
+ * @group dns-sensitive
  */
 class CurlHttpClientTest extends HttpClientTestCase
 {

--- a/src/Symfony/Component/HttpClient/Tests/NativeHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/NativeHttpClientTest.php
@@ -14,6 +14,9 @@ namespace Symfony\Component\HttpClient\Tests;
 use Symfony\Component\HttpClient\NativeHttpClient;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
+/**
+ * @group dns-sensitive
+ */
 class NativeHttpClientTest extends HttpClientTestCase
 {
     protected function getHttpClient(string $testCase): HttpClientInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The patch for [CVE-2024-50342](https://symfony.com/blog/cve-2024-50342-internal-address-and-port-enumeration-allowed-by-noprivatenetworkhttpclient) isn't enough.

As reported by @cs278:
> A DNS name which presents multiple A records can be used to bypass the new fix due to a TOCTOU
condition where the decorator is performing the DNS lookup but curl is then performing its own
DNS query and getting a private IP address.

In addition:
> A DNS record which presents a public A record and a private AAAA record can be used to workaround
the protection measures if certain conditions are present

As a first reminder, NoPrivateNetworkHttpClient DOES prevent requests to unwanted servers, but it doesn't prevent connecting to them, allowing to use timings to scan private network topologies.

As a second reminder, [according to our security policy](https://symfony.com/doc/current/contributing/code/security.html#reporting-a-security-issue), we shouldn't have considered this as a security issue in the first place, but as a security hardening that could be handled without a CVE. Yet we did so we're going to update the already published CVE/advisory/blog post after this PR.

This patch rewrites `NoPrivateNetworkHttpClient` to make it responsible for resolving DNS and following redirections. I tried using `CURLOPT_RESOLVE` instead, but this setting is ignored during a curl transaction apparently so we have no other choices.

In addition, the decorator will refuse to connect to IPv6/IPv4 hosts if the configured `$subnets` doesn't block any IPs for the corresponding version of the protocol.

Because the DNS check is made earlier, the decorator now also rejects relative URLs when the base URI is unknown to it.
