### PR TITLE
[Form] Allow integer for the `calendar` option of `DateType`

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -313,7 +313,7 @@ class DateType extends AbstractType
         $resolver->setAllowedTypes('months', 'array');
         $resolver->setAllowedTypes('days', 'array');
         $resolver->setAllowedTypes('input_format', 'string');
-        $resolver->setAllowedTypes('calendar', ['null', \IntlCalendar::class]);
+        $resolver->setAllowedTypes('calendar', ['null', 'int', \IntlCalendar::class]);
 
         $resolver->setInfo('calendar', 'The calendar to use for formatting and parsing the date. The value should be an instance of \IntlCalendar. By default, the Gregorian calendar with the default locale is used.');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Underlying mechanisms support integers for the calendar, so integers should be allowed in the form type option.

Spotted by @stof in https://github.com/symfony/symfony/pull/57960#discussion_r1860505553
