### PR TITLE
Release v6.4.16

### DIFF
--- a/CHANGELOG-6.4.md
+++ b/CHANGELOG-6.4.md
@@ -7,6 +7,37 @@ in 6.4 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v6.4.0...v6.4.1
 
+* 6.4.16 (2024-11-27)
+
+ * bug #59013 [HttpClient] Fix checking for private IPs before connecting (nicolas-grekas)
+ * bug #58562 [HttpClient] Close gracefull when the server closes the connection abruptly (discordier)
+ * bug #59007 [Dotenv] read runtime config from composer.json in debug dotenv command (xabbuh)
+ * bug #58963 [PropertyInfo] Fix write visibility for Asymmetric Visibility and Virtual Properties (xabbuh, pan93412)
+ * bug #58983 [Translation] [Bridge][Lokalise] Fix empty keys array in PUT, DELETE requests causing Lokalise API error (DominicLuidold)
+ * bug #58956 [DoctrineBridge] Fix `Connection::createSchemaManager()` for Doctrine DBAL v2 (neodevcode)
+ * bug #58959 [PropertyInfo] consider write property visibility to decide whether a property is writable (xabbuh)
+ * bug #58964 [TwigBridge] do not add child nodes to EmptyNode instances (xabbuh)
+ * bug #58952 [Cache] silence warnings issued by Redis Sentinel on connection issues (xabbuh)
+ * bug #58859 [AssetMapper] ignore missing directory in `isVendor()` (alexislefebvre)
+ * bug #58917 [OptionsResolver] Allow Union/Intersection Types in Resolved Closures (zanbaldwin)
+ * bug #58822 [DependencyInjection] Fix checking for interfaces in ContainerBuilder::getReflectionClass() (donquixote)
+ * bug #58865 Dynamically fix compatibility with doctrine/data-fixtures v2 (greg0ire)
+ * bug #58921 [HttpKernel] Ensure `HttpCache::getTraceKey()` does not throw exception (lyrixx)
+ * bug #58908 [DoctrineBridge] don't call `EntityManager::initializeObject()` with scalar values (xabbuh)
+ * bug #58938 [Cache] make RelayProxyTrait compatible with relay extension 0.9.0 (xabbuh)
+ * bug #58924 [HttpClient] Fix empty hosts in option "resolve" (nicolas-grekas)
+ * bug #58915 [HttpClient] Fix option "resolve" with IPv6 addresses (nicolas-grekas)
+ * bug #58919 [WebProfilerBundle] Twig deprecations (mazodude)
+ * bug #58914 [HttpClient] Fix option "bindto" with IPv6 addresses (nicolas-grekas)
+ * bug #58875 [HttpClient] Removed body size limit (Carl Julian Sauter)
+ * bug #58862 [Notifier] Fix GoIpTransport (nicolas-grekas)
+ * bug #58860 [HttpClient] Fix catching some invalid Location headers (nicolas-grekas)
+ * bug #58836 Work around `parse_url()` bug (bis) (nicolas-grekas)
+ * bug #58818 [Messenger] silence PHP warnings issued by `Redis::connect()` (xabbuh)
+ * bug #58828 [PhpUnitBridge] fix dumping tests to skip with data providers (xabbuh)
+ * bug #58842 [Routing] Fix: lost priority when defining hosts in configuration (BeBlood)
+ * bug #58850 [HttpClient] fix PHP 7.2 compatibility (xabbuh)
+
 * 6.4.15 (2024-11-13)
 
  * security #cve-2024-50342 [HttpClient] Resolve hostnames in NoPrivateNetworkHttpClient (nicolas-grekas)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -76,12 +76,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     private static array $freshCache = [];
 
-    public const VERSION = '6.4.16-DEV';
+    public const VERSION = '6.4.16';
     public const VERSION_ID = 60416;
     public const MAJOR_VERSION = 6;
     public const MINOR_VERSION = 4;
     public const RELEASE_VERSION = 16;
-    public const EXTRA_VERSION = 'DEV';
+    public const EXTRA_VERSION = '';
 
     public const END_OF_MAINTENANCE = '11/2026';
     public const END_OF_LIFE = '11/2027';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v6.4.15...v6.4.16)

 * bug #59013 [HttpClient] Fix checking for private IPs before connecting (@nicolas-grekas)
 * bug #58562 [HttpClient] Close gracefull when the server closes the connection abruptly (@discordier)
 * bug #59007 [Dotenv] read runtime config from composer.json in debug dotenv command (@xabbuh)
 * bug #58963 [PropertyInfo] Fix write visibility for Asymmetric Visibility and Virtual Properties (@xabbuh, @pan93412)
 * bug #58983 [Translation] [Bridge][Lokalise] Fix empty keys array in PUT, DELETE requests causing Lokalise API error (@DominicLuidold)
 * bug #58956 [DoctrineBridge] Fix `Connection::createSchemaManager()` for Doctrine DBAL v2 (@neodevcode)
 * bug #58959 [PropertyInfo] consider write property visibility to decide whether a property is writable (@xabbuh)
 * bug #58964 [TwigBridge] do not add child nodes to EmptyNode instances (@xabbuh)
 * bug #58952 [Cache] silence warnings issued by Redis Sentinel on connection issues (@xabbuh)
 * bug #58859 [AssetMapper] ignore missing directory in `isVendor()` (@alexislefebvre)
 * bug #58917 [OptionsResolver] Allow Union/Intersection Types in Resolved Closures (@zanbaldwin)
 * bug #58822 [DependencyInjection] Fix checking for interfaces in ContainerBuilder::getReflectionClass() (@donquixote)
 * bug #58865 Dynamically fix compatibility with doctrine/data-fixtures v2 (@greg0ire)
 * bug #58921 [HttpKernel] Ensure `HttpCache::getTraceKey()` does not throw exception (@lyrixx)
 * bug #58908 [DoctrineBridge] don't call `EntityManager::initializeObject()` with scalar values (@xabbuh)
 * bug #58938 [Cache] make RelayProxyTrait compatible with relay extension 0.9.0 (@xabbuh)
 * bug #58924 [HttpClient] Fix empty hosts in option "resolve" (@nicolas-grekas)
 * bug #58915 [HttpClient] Fix option "resolve" with IPv6 addresses (@nicolas-grekas)
 * bug #58919 [WebProfilerBundle] Twig deprecations (@mazodude)
 * bug #58914 [HttpClient] Fix option "bindto" with IPv6 addresses (@nicolas-grekas)
 * bug #58875 [HttpClient] Removed body size limit (Carl Julian Sauter)
 * bug #58862 [Notifier] Fix GoIpTransport (@nicolas-grekas)
 * bug #58860 [HttpClient] Fix catching some invalid Location headers (@nicolas-grekas)
 * bug #58836 Work around `parse_url()` bug (bis) (@nicolas-grekas)
 * bug #58818 [Messenger] silence PHP warnings issued by `Redis::connect()` (@xabbuh)
 * bug #58828 [PhpUnitBridge] fix dumping tests to skip with data providers (@xabbuh)
 * bug #58842 [Routing] Fix: lost priority when defining hosts in configuration (@BeBlood)
 * bug #58850 [HttpClient] fix PHP 7.2 compatibility (@xabbuh)
