### PR TITLE
[AssetMapper] add support for assets pre-compression

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -33,6 +33,9 @@ jobs:
             mode: low-deps
           - php: '8.3'
           - php: '8.4'
+            # brotli and zstd extensions are optional, when not present the commands will be used instead,
+            # we must test both scenarios
+            extensions: amqp,apcu,brotli,igbinary,intl,mbstring,memcached,redis,relay,zstd
             #mode: experimental
       fail-fast: false
 
@@ -52,6 +55,12 @@ jobs:
           php-version: "${{ matrix.php }}"
           extensions: "${{ matrix.extensions || env.extensions }}"
           tools: flex
+
+      - name: Install optional commands
+        if: matrix.php == '8.4'
+        run: |
+          sudo apt-get update
+          sudo apt-get install zopfli
 
       - name: Configure environment
         run: |

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.3
+---
+
+ * Add support for assets pre-compression
+
 7.2
 ---
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
@@ -17,6 +17,7 @@ use Symfony\Component\AssetMapper\AssetMapperDevServerSubscriber;
 use Symfony\Component\AssetMapper\AssetMapperInterface;
 use Symfony\Component\AssetMapper\AssetMapperRepository;
 use Symfony\Component\AssetMapper\Command\AssetMapperCompileCommand;
+use Symfony\Component\AssetMapper\Command\CompressAssetsCommand;
 use Symfony\Component\AssetMapper\Command\DebugAssetMapperCommand;
 use Symfony\Component\AssetMapper\Command\ImportMapAuditCommand;
 use Symfony\Component\AssetMapper\Command\ImportMapInstallCommand;
@@ -28,6 +29,11 @@ use Symfony\Component\AssetMapper\CompiledAssetMapperConfigReader;
 use Symfony\Component\AssetMapper\Compiler\CssAssetUrlCompiler;
 use Symfony\Component\AssetMapper\Compiler\JavaScriptImportPathCompiler;
 use Symfony\Component\AssetMapper\Compiler\SourceMappingUrlsCompiler;
+use Symfony\Component\AssetMapper\Compressor\BrotliCompressor;
+use Symfony\Component\AssetMapper\Compressor\ChainCompressor;
+use Symfony\Component\AssetMapper\Compressor\CompressorInterface;
+use Symfony\Component\AssetMapper\Compressor\GzipCompressor;
+use Symfony\Component\AssetMapper\Compressor\ZstandardCompressor;
 use Symfony\Component\AssetMapper\Factory\CachedMappedAssetFactory;
 use Symfony\Component\AssetMapper\Factory\MappedAssetFactory;
 use Symfony\Component\AssetMapper\ImportMap\ImportMapAuditor;
@@ -253,6 +259,21 @@ return static function (ContainerConfigurator $container) {
 
         ->set('asset_mapper.importmap.command.outdated', ImportMapOutdatedCommand::class)
             ->args([service('asset_mapper.importmap.update_checker')])
+            ->tag('console.command')
+
+        ->set('asset_mapper.compressor.brotli', BrotliCompressor::class)
+        ->set('asset_mapper.compressor.zstandard', ZstandardCompressor::class)
+        ->set('asset_mapper.compressor.gzip', GzipCompressor::class)
+
+        ->set('asset_mapper.compressor', ChainCompressor::class)
+            ->args([
+                abstract_arg('compressor'),
+                service('logger'),
+            ])
+        ->alias(CompressorInterface::class, 'asset_mapper.compressor')
+
+        ->set('asset_mapper.assets.command.compress', CompressAssetsCommand::class)
+            ->args([service('asset_mapper.compressor')])
             ->tag('console.command')
     ;
 };

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -206,6 +206,7 @@
             <xsd:element name="excluded-pattern" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="extension" type="asset_mapper_extension" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="importmap-script-attribute" type="asset_mapper_attribute" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="precompress" type="asset_mapper_precompress" minOccurs="0" maxOccurs="1" />
         </xsd:sequence>
         <xsd:attribute name="enabled" type="xsd:boolean" />
         <xsd:attribute name="exclude-dotfiles" type="xsd:boolean" />
@@ -229,6 +230,16 @@
     <xsd:complexType name="asset_mapper_attribute" mixed="true">
         <xsd:attribute name="key" type="xsd:string" use="required" />
     </xsd:complexType>
+
+    <xsd:complexType name="asset_mapper_precompress">
+        <xsd:sequence>
+            <xsd:element name="format" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="extension" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
+        </xsd:sequence>
+
+        <xsd:attribute name="enabled" type="xsd:boolean" />
+    </xsd:complexType>
+
 
     <xsd:simpleType name="missing-import-mode">
         <xsd:restriction base="xsd:string">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -15,6 +15,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Configuration;
 use Symfony\Bundle\FullStack;
+use Symfony\Component\AssetMapper\Compressor\CompressorInterface;
 use Symfony\Component\Cache\Adapter\DoctrineAdapter;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Definition\Processor;
@@ -141,6 +142,11 @@ class ConfigurationTest extends TestCase
             'vendor_dir' => '%kernel.project_dir%/assets/vendor',
             'importmap_script_attributes' => [],
             'exclude_dotfiles' => true,
+            'precompress' => [
+                'enabled' => false,
+                'formats' => [],
+                'extensions' => interface_exists(CompressorInterface::class) ? CompressorInterface::DEFAULT_EXTENSIONS : [],
+            ],
         ];
 
         $this->assertEquals($defaultConfig, $config['asset_mapper']);
@@ -847,6 +853,11 @@ class ConfigurationTest extends TestCase
                 'vendor_dir' => '%kernel.project_dir%/assets/vendor',
                 'importmap_script_attributes' => [],
                 'exclude_dotfiles' => true,
+                'precompress' => [
+                    'enabled' => false,
+                    'formats' => [],
+                    'extensions' => interface_exists(CompressorInterface::class) ? CompressorInterface::DEFAULT_EXTENSIONS : [],
+                ],
             ],
             'cache' => [
                 'pools' => [],

--- a/src/Symfony/Component/AssetMapper/CHANGELOG.md
+++ b/src/Symfony/Component/AssetMapper/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.3
+---
+
+ * Add support for pre-compressing assets with Brotli, Zstandard, Zopfli, and gzip
+
 7.2
 ---
 

--- a/src/Symfony/Component/AssetMapper/Command/CompressAssetsCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/CompressAssetsCommand.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AssetMapper\Command;
+
+use Symfony\Component\AssetMapper\Compressor\CompressorInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Pre-compresses files to serve through a web server.
+ *
+ * @author Kévin Dunglas <kevin@dunglas.dev>
+ */
+#[AsCommand(name: 'assets:compress', description: 'Pre-compresses files to serve through a web server')]
+final class CompressAssetsCommand extends Command
+{
+    public function __construct(
+        private readonly CompressorInterface $compressor,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('paths', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'The files to compress')
+            ->setHelp(<<<'EOT'
+The <info>%command.name%</info> command compresses the given file in Brotli, Zstandard and gzip formats.
+This is especially useful to serve pre-compressed files through a web server.
+
+The existing file will be kept. The compressed files will be created in the same directory.
+The extension of the compression format will be appended to the original file name.
+EOT
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $paths = $input->getArgument('paths');
+        foreach ($paths as $path) {
+            $this->compressor->compress($path);
+        }
+
+        $io->success(\sprintf('File%s compressed successfully.', \count($paths) > 1 ? 's' : ''));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Symfony/Component/AssetMapper/Compressor/BrotliCompressor.php
+++ b/src/Symfony/Component/AssetMapper/Compressor/BrotliCompressor.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AssetMapper\Compressor;
+
+use Symfony\Component\Process\Process;
+
+/**
+ * Compresses a file using Brotli.
+ *
+ * @author Kévin Dunglas <kevin@dunglas.dev>
+ */
+final class BrotliCompressor implements SupportedCompressorInterface
+{
+    use CompressorTrait;
+
+    private const WRAPPER = 'compress.brotli';
+    private const COMMAND = 'brotli';
+    private const PHP_EXTENSION = 'brotli';
+    private const FILE_EXTENSION = 'br';
+
+    public function __construct(
+        ?string $executable = null,
+    ) {
+        $this->executable = $executable;
+    }
+
+    /**
+     * @return resource
+     */
+    private function createStreamContext()
+    {
+        return stream_context_create(['brotli' => ['level' => BROTLI_COMPRESS_LEVEL_MAX]]);
+    }
+
+    private function compressWithBinary(string $path): void
+    {
+        (new Process([$this->executable, '--best', '--force', "--output=$path.".self::FILE_EXTENSION, '--', $path]))->mustRun();
+    }
+}

--- a/src/Symfony/Component/AssetMapper/Compressor/ChainCompressor.php
+++ b/src/Symfony/Component/AssetMapper/Compressor/ChainCompressor.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AssetMapper\Compressor;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * Calls multiple compressors in a chain.
+ *
+ * @author Kévin Dunglas <kevin@dunglas.dev>
+ */
+final class ChainCompressor implements CompressorInterface
+{
+    /**
+     * @param CompressorInterface[] $compressors
+     */
+    public function __construct(
+        private ?array $compressors = null,
+        private readonly ?LoggerInterface $logger = null,
+    ) {
+    }
+
+    public function compress(string $path): void
+    {
+        if (null === $this->compressors) {
+            $this->compressors = [];
+            foreach ([new BrotliCompressor(), new ZstandardCompressor(), new GzipCompressor()] as $compressor) {
+                $unsupportedReason = $compressor->getUnsupportedReason();
+                if (null === $unsupportedReason) {
+                    $this->compressors[] = $compressor;
+                } else {
+                    $this->logger?->warning($unsupportedReason);
+                }
+            }
+        }
+
+        foreach ($this->compressors as $compressor) {
+            $compressor->compress($path);
+        }
+    }
+}

--- a/src/Symfony/Component/AssetMapper/Compressor/CompressorInterface.php
+++ b/src/Symfony/Component/AssetMapper/Compressor/CompressorInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AssetMapper\Compressor;
+
+/**
+ * Compresses a file.
+ *
+ * @author Kévin Dunglas <kevin@dunglas.dev>
+ */
+interface CompressorInterface
+{
+    // Loosely based on https://caddyserver.com/docs/caddyfile/directives/encode#match
+    public const DEFAULT_EXTENSIONS = [
+        'css',
+        'cur',
+        'eot',
+        'html',
+        'js',
+        'json',
+        'md',
+        'otc',
+        'otf',
+        'proto',
+        'rss',
+        'rtf',
+        'svg',
+        'ttc',
+        'ttf',
+        'txt',
+        'wasm',
+        'xml',
+    ];
+
+    public function compress(string $path): void;
+}

--- a/src/Symfony/Component/AssetMapper/Compressor/CompressorTrait.php
+++ b/src/Symfony/Component/AssetMapper/Compressor/CompressorTrait.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AssetMapper\Compressor;
+
+use Symfony\Component\Process\ExecutableFinder;
+use Symfony\Component\Process\Process;
+
+/**
+ * @internal
+ *
+ * @author Kévin Dunglas <kevin@dunglas.dev>
+ */
+trait CompressorTrait
+{
+    private ?\Closure $method = null;
+    private ?string $executable = null;
+    /**
+     * @var ?resource
+     */
+    private $streamContext;
+    private ?string $unsupportedReason = null;
+
+    private function initialize(): void
+    {
+        if ('' !== self::WRAPPER && \in_array(self::WRAPPER, stream_get_wrappers(), true)) {
+            $this->method = $this->compressWithExtension(...);
+
+            return;
+        }
+
+        if (!class_exists(Process::class)) {
+            if ('' === self::WRAPPER) {
+                $this->unsupportedReason = \sprintf('%s compression is unsupported. Run "composer require symfony/process" and install the "%s" command.', self::COMMAND, self::COMMAND);
+            } else {
+                $this->unsupportedReason = \sprintf('%s compression is unsupported. Install the "%s" extension or run "composer require symfony/process" and install the "%s" command.', self::COMMAND, self::PHP_EXTENSION, self::COMMAND);
+            }
+
+            return;
+        }
+
+        if (null === $this->executable) {
+            $executableFinder = new ExecutableFinder();
+            $this->executable = $executableFinder->find(self::COMMAND);
+
+            if (null === $this->executable) {
+                if (self::WRAPPER === '') {
+                    $this->unsupportedReason = \sprintf('%s compression is unsupported. Install the "%s" command.', self::COMMAND, self::COMMAND);
+                } else {
+                    $this->unsupportedReason = \sprintf('%s compression is unsupported. Install the "%s" extension or the "%s" command.', self::COMMAND, self::PHP_EXTENSION, self::COMMAND);
+                }
+
+                return;
+            }
+        }
+
+        $this->method = $this->compressWithBinary(...);
+    }
+
+    public function compress(string $path): void
+    {
+        if (null === $this->method && null === $this->unsupportedReason) {
+            $this->initialize();
+        }
+        if (null !== $this->unsupportedReason) {
+            throw new \RuntimeException($this->unsupportedReason);
+        }
+
+        ($this->method)($path);
+    }
+
+    public function getUnsupportedReason(): ?string
+    {
+        if (null !== $this->method) {
+            return null;
+        }
+
+        $this->initialize();
+
+        return $this->unsupportedReason;
+    }
+
+    abstract private function compressWithBinary(string $path): void;
+
+    /**
+     * @return resource
+     */
+    abstract private function createStreamContext();
+
+    private function compressWithExtension(string $path): void
+    {
+        if (null === $this->streamContext) {
+            $this->streamContext = $this->createStreamContext();
+        }
+
+        if (!copy($path, \sprintf('%s://%s.%s', self::WRAPPER, $path, self::FILE_EXTENSION), $this->streamContext)) {
+            throw new \RuntimeException(\sprintf('The compressed file "%s.%s" could not be written.', $path, self::FILE_EXTENSION));
+        }
+    }
+}

--- a/src/Symfony/Component/AssetMapper/Compressor/GzipCompressor.php
+++ b/src/Symfony/Component/AssetMapper/Compressor/GzipCompressor.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AssetMapper\Compressor;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Process\Process;
+
+/**
+ * Compresses a file using zopfli if possible, or fallback on gzip.
+ *
+ * @author Kévin Dunglas <kevin@dunglas.dev>
+ */
+final class GzipCompressor implements SupportedCompressorInterface
+{
+    use CompressorTrait {
+        compress as baseCompress;
+    }
+
+    private const WRAPPER = 'compress.zlib';
+    private const COMMAND = 'gzip';
+    private const PHP_EXTENSION = 'zlib';
+    private const FILE_EXTENSION = 'gz';
+
+    public function __construct(
+        private readonly ZopfliCompressor $zopfliCompressor = new ZopfliCompressor(),
+        ?string $executable = null,
+        private ?LoggerInterface $logger = null,
+    ) {
+        $this->executable = $executable;
+    }
+
+    public function compress(string $path): void
+    {
+        if (null === $reason = $this->zopfliCompressor->getUnsupportedReason()) {
+            $this->zopfliCompressor->compress($path);
+
+            return;
+        } else {
+            $this->logger?->warning($reason);
+        }
+
+        $this->baseCompress($path);
+    }
+
+    /**
+     * @return resource
+     */
+    private function createStreamContext()
+    {
+        return stream_context_create(['zlib' => ['level' => 9]]);
+    }
+
+    private function compressWithBinary(string $path): void
+    {
+        (new Process([$this->executable, '--best', '--force', '--keep', '--', $path]))->mustRun();
+    }
+}

--- a/src/Symfony/Component/AssetMapper/Compressor/SupportedCompressorInterface.php
+++ b/src/Symfony/Component/AssetMapper/Compressor/SupportedCompressorInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AssetMapper\Compressor;
+
+/**
+ * @internal
+ *
+ * @author Kévin Dunglas <kevin@dunglas.dev>
+ */
+interface SupportedCompressorInterface extends CompressorInterface
+{
+    /**
+     * Returns null if the compressor is supported, or the reason why the compressor it is not.
+     */
+    public function getUnsupportedReason(): ?string;
+}

--- a/src/Symfony/Component/AssetMapper/Compressor/ZopfliCompressor.php
+++ b/src/Symfony/Component/AssetMapper/Compressor/ZopfliCompressor.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AssetMapper\Compressor;
+
+use Symfony\Component\Process\Process;
+
+/**
+ * Compresses a file using zopfli.
+ *
+ * @author Kévin Dunglas <kevin@dunglas.dev>
+ */
+final class ZopfliCompressor implements SupportedCompressorInterface
+{
+    use CompressorTrait;
+
+    private const WRAPPER = ''; // not supported yet https://github.com/kjdev/php-ext-zopfli/issues/23
+    private const COMMAND = 'zopfli';
+    private const PHP_EXTENSION = '';
+    private const FILE_EXTENSION = 'gz';
+
+    public function __construct(
+        ?string $executable = null,
+    ) {
+        $this->executable = $executable;
+    }
+
+    private function compressWithBinary(string $path): void
+    {
+        (new Process([$this->executable, '--', $path]))->mustRun();
+    }
+
+    private function createStreamContext()
+    {
+        throw new \BadMethodCallException('Extension is not supported yet.');
+    }
+}

--- a/src/Symfony/Component/AssetMapper/Compressor/ZstandardCompressor.php
+++ b/src/Symfony/Component/AssetMapper/Compressor/ZstandardCompressor.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AssetMapper\Compressor;
+
+use Symfony\Component\Process\Process;
+
+/**
+ * Compresses a file using Zstandard.
+ *
+ * @author Kévin Dunglas <kevin@dunglas.dev>
+ */
+final class ZstandardCompressor implements SupportedCompressorInterface
+{
+    use CompressorTrait;
+
+    private const WRAPPER = 'compress.zstd';
+    private const COMMAND = 'zstd';
+    private const PHP_EXTENSION = 'zstd';
+    private const FILE_EXTENSION = 'zst';
+
+    public function __construct(
+        ?string $executable = null,
+    ) {
+        $this->executable = $executable;
+    }
+
+    /**
+     * @return resource
+     */
+    private function createStreamContext()
+    {
+        return stream_context_create(['zstd' => ['level' => ZSTD_COMPRESS_LEVEL_MAX]]);
+    }
+
+    private function compressWithBinary(string $path): void
+    {
+        (new Process([$this->executable, '-19', '--force', '-o', "$path.".self::FILE_EXTENSION, '--', $path]))->mustRun();
+    }
+}

--- a/src/Symfony/Component/AssetMapper/Tests/Compressor/BrotliCompressorTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Compressor/BrotliCompressorTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AssetMapper\Tests\Compressor;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\AssetMapper\Compressor\BrotliCompressor;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @author Kévin Dunglas <kevin@dunglas.dev>
+ */
+class BrotliCompressorTest extends TestCase
+{
+    private const WRITABLE_ROOT = __DIR__.'/../Fixtures/brotli_compressor_filesystem';
+
+    private Filesystem $filesystem;
+
+    protected function setUp(): void
+    {
+        if (null !== $reason = (new BrotliCompressor())->getUnsupportedReason()) {
+            $this->markTestSkipped($reason);
+        }
+
+        $this->filesystem = new Filesystem();
+        if (!file_exists(self::WRITABLE_ROOT)) {
+            $this->filesystem->mkdir(self::WRITABLE_ROOT);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove(self::WRITABLE_ROOT);
+    }
+
+    public function testCompress()
+    {
+        $this->filesystem->dumpFile(self::WRITABLE_ROOT.'/foo/bar.js', 'foobar');
+
+        (new BrotliCompressor())->compress(self::WRITABLE_ROOT.'/foo/bar.js');
+
+        $this->assertFileExists(self::WRITABLE_ROOT.'/foo/bar.js.br');
+    }
+}

--- a/src/Symfony/Component/AssetMapper/Tests/Compressor/ChainCompressorTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Compressor/ChainCompressorTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AssetMapper\Tests\Compressor;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\AssetMapper\Compressor\BrotliCompressor;
+use Symfony\Component\AssetMapper\Compressor\ChainCompressor;
+use Symfony\Component\AssetMapper\Compressor\ZstandardCompressor;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @author Kévin Dunglas <kevin@dunglas.dev>
+ */
+class ChainCompressorTest extends TestCase
+{
+    private const WRITABLE_ROOT = __DIR__.'/../Fixtures/chain_compressor_filesystem';
+
+    private Filesystem $filesystem;
+
+    protected function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+        if (!file_exists(self::WRITABLE_ROOT)) {
+            $this->filesystem->mkdir(self::WRITABLE_ROOT);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove(self::WRITABLE_ROOT);
+    }
+
+    public function testCompress()
+    {
+        $extensions = ['gz'];
+        if (null === (new BrotliCompressor())->getUnsupportedReason()) {
+            $extensions[] = 'br';
+        }
+        if (null === (new ZstandardCompressor())->getUnsupportedReason()) {
+            $extensions[] = 'zst';
+        }
+
+        $this->filesystem->dumpFile(self::WRITABLE_ROOT.'/foo/bar.js', 'foobar');
+
+        (new ChainCompressor())->compress(self::WRITABLE_ROOT.'/foo/bar.js');
+
+        foreach ($extensions as $extension) {
+            $this->assertFileExists(self::WRITABLE_ROOT.'/foo/bar.js.'.$extension);
+        }
+    }
+}

--- a/src/Symfony/Component/AssetMapper/Tests/Compressor/GzipCompressorTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Compressor/GzipCompressorTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AssetMapper\Tests\Compressor;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\AssetMapper\Compressor\GzipCompressor;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @author Kévin Dunglas <kevin@dunglas.dev>
+ */
+class GzipCompressorTest extends TestCase
+{
+    private const WRITABLE_ROOT = __DIR__.'/../Fixtures/gzip_compressor_filesystem';
+
+    private Filesystem $filesystem;
+
+    protected function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+        if (!file_exists(self::WRITABLE_ROOT)) {
+            $this->filesystem->mkdir(self::WRITABLE_ROOT);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove(self::WRITABLE_ROOT);
+    }
+
+    public function testCompress()
+    {
+        $this->filesystem->dumpFile(self::WRITABLE_ROOT.'/foo/bar.js', 'foobar');
+
+        (new GzipCompressor())->compress(self::WRITABLE_ROOT.'/foo/bar.js');
+
+        $this->assertFileExists(self::WRITABLE_ROOT.'/foo/bar.js.gz');
+    }
+}

--- a/src/Symfony/Component/AssetMapper/Tests/Compressor/ZstandardCompressorTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Compressor/ZstandardCompressorTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AssetMapper\Tests\Compressor;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\AssetMapper\Compressor\ZstandardCompressor;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @author Kévin Dunglas <kevin@dunglas.dev>
+ */
+class ZstandardCompressorTest extends TestCase
+{
+    private const WRITABLE_ROOT = __DIR__.'/../Fixtures/zstandard_compressor_filesystem';
+
+    private Filesystem $filesystem;
+
+    protected function setUp(): void
+    {
+        if (null !== $reason = (new ZstandardCompressor())->getUnsupportedReason()) {
+            $this->markTestSkipped($reason);
+        }
+
+        $this->filesystem = new Filesystem();
+        if (!file_exists(self::WRITABLE_ROOT)) {
+            $this->filesystem->mkdir(self::WRITABLE_ROOT);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove(self::WRITABLE_ROOT);
+    }
+
+    public function testCompress()
+    {
+        $this->filesystem->dumpFile(self::WRITABLE_ROOT.'/foo/bar.js', 'foobar');
+
+        (new ZstandardCompressor())->compress(self::WRITABLE_ROOT.'/foo/bar.js');
+
+        $this->assertFileExists(self::WRITABLE_ROOT.'/foo/bar.js.zst');
+    }
+}

--- a/src/Symfony/Component/AssetMapper/Tests/Path/LocalPublicAssetsFilesystemTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Path/LocalPublicAssetsFilesystemTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\AssetMapper\Tests\Path;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\AssetMapper\Compressor\GzipCompressor;
 use Symfony\Component\AssetMapper\Path\LocalPublicAssetsFilesystem;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -51,5 +52,21 @@ class LocalPublicAssetsFilesystemTest extends TestCase
         $filesystem->copy(__DIR__.'/../Fixtures/importmaps/assets/pizza/index.js', 'foo/bar.js');
         $this->assertFileExists(self::$writableRoot.'/foo/bar.js');
         $this->assertSame("console.log('pizza/index.js');", trim($this->filesystem->readFile(self::$writableRoot.'/foo/bar.js')));
+    }
+
+    public function testCompress()
+    {
+        $filesystem = new LocalPublicAssetsFilesystem(self::$writableRoot, new GzipCompressor(), ['js']);
+        $filesystem->write('foo/baz/bar.js', 'foobar');
+
+        $this->assertFileExists(self::$writableRoot.'/foo/baz/bar.js');
+        $this->assertSame('foobar', $this->filesystem->readFile(self::$writableRoot.'/foo/baz/bar.js'));
+
+        $this->assertFileExists(self::$writableRoot.'/foo/baz/bar.js.gz');
+        $this->assertSame('foobar', gzdecode($this->filesystem->readFile(self::$writableRoot.'/foo/baz/bar.js.gz')));
+
+        $filesystem->write('foo/baz/bar.css', 'foobar');
+        $this->assertFileExists(self::$writableRoot.'/foo/baz/bar.css');
+        $this->assertFileDoesNotExist(self::$writableRoot.'/foo/baz/bar.css.gz');
     }
 }

--- a/src/Symfony/Component/AssetMapper/composer.json
+++ b/src/Symfony/Component/AssetMapper/composer.json
@@ -31,6 +31,7 @@
         "symfony/framework-bundle": "^6.4|^7.0",
         "symfony/http-foundation": "^6.4|^7.0",
         "symfony/http-kernel": "^6.4|^7.0",
+        "symfony/process": "^6.4|^7.0",
         "symfony/web-link": "^6.4|^7.0"
     },
     "conflict": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | n/a
| License       | MIT

Adds support for assets and files precompression using Zstandard, Brotli, and gzip (this will be part of [my talk at SymfonyCon next week](https://live.symfony.com/2024-vienna-con/schedule#http-compression-in-symfony-apps)).

When calling `bin/console asset-map:compile` and if the new option `asset_mapper.precompress` is enabled, all files matching the configured extensions will be compressed in Brotli, Zstandard, and gzip (zopfli when available) at maximal compression (defaults to the list supported by Caddy and Cloudflare). The PHP extension is used if available, otherwise the Unix command is used as a fallback.

The compressed files are created with the same name as the original asset but with the `.br`, `.zst`, or `.gz` extension appended.
This allows native compatibility with web servers supporting precompression such as [Caddy and FrankenPHP](https://caddyserver.com/docs/caddyfile/directives/file_server#precompressed) or [NGINX with the Brotli module](https://github.com/google/ngx_brotli).
Apache can also use these files but will require [some extra config](https://stackoverflow.com/questions/16883241/how-to-host-static-content-pre-compressed-in-apache).

This PR also adds an `assets:compress` command that can be used to compress files not managed by AssetMapper (e.g. `robots.txt`).

Finally, the new `asset_mapper.compressor` service can be used to precompress files uploaded by the user (among various other use cases).

TODO:

* [x] add tests