### PR TITLE
[VarDumper] Add casters for object-converted resources

### DIFF
--- a/UPGRADE-7.3.md
+++ b/UPGRADE-7.3.md
@@ -18,3 +18,9 @@ Serializer
 ----------
 
  * Deprecate the `CompiledClassMetadataFactory` and `CompiledClassMetadataCacheWarmer` classes
+
+VarDumper
+---------
+
+ * Deprecate `ResourceCaster::castCurl()`, `ResourceCaster::castGd()` and `ResourceCaster::castOpensslX509()`
+ * Mark all casters as `@internal`

--- a/src/Symfony/Component/VarDumper/CHANGELOG.md
+++ b/src/Symfony/Component/VarDumper/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+7.3
+---
+
+ * Add casters for `Dba\Connection`, `SQLite3Result`, `OpenSSLAsymmetricKey` and `OpenSSLCertificateSigningRequest`
+ * Deprecate `ResourceCaster::castCurl()`, `ResourceCaster::castGd()` and `ResourceCaster::castOpensslX509()`
+ * Mark all casters as `@internal`
+
 7.2
 ---
 

--- a/src/Symfony/Component/VarDumper/Caster/AddressInfoCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/AddressInfoCaster.php
@@ -15,6 +15,8 @@ use Symfony\Component\VarDumper\Cloner\Stub;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @internal since Symfony 7.3
  */
 final class AddressInfoCaster
 {

--- a/src/Symfony/Component/VarDumper/Caster/AmqpCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/AmqpCaster.php
@@ -19,6 +19,8 @@ use Symfony\Component\VarDumper\Cloner\Stub;
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  *
  * @final
+ *
+ * @internal since Symfony 7.3
  */
 class AmqpCaster
 {

--- a/src/Symfony/Component/VarDumper/Caster/Caster.php
+++ b/src/Symfony/Component/VarDumper/Caster/Caster.php
@@ -46,6 +46,8 @@ class Caster
      * Casts objects to arrays and adds the dynamic property prefix.
      *
      * @param bool $hasDebugInfo Whether the __debugInfo method exists on $obj or not
+     *
+     * @internal since Symfony 7.3
      */
     public static function castObject(object $obj, string $class, bool $hasDebugInfo = false, ?string $debugClass = null): array
     {
@@ -162,6 +164,9 @@ class Caster
         return $a;
     }
 
+    /**
+     * @internal since Symfony 7.3
+     */
     public static function castPhpIncompleteClass(\__PHP_Incomplete_Class $c, array $a, Stub $stub, bool $isNested): array
     {
         if (isset($a['__PHP_Incomplete_Class_Name'])) {

--- a/src/Symfony/Component/VarDumper/Caster/CurlCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/CurlCaster.php
@@ -11,24 +11,20 @@
 
 namespace Symfony\Component\VarDumper\Caster;
 
-use ProxyManager\Proxy\ProxyInterface;
 use Symfony\Component\VarDumper\Cloner\Stub;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
  *
- * @final
- *
- * @internal since Symfony 7.3
+ * @internal
  */
-class ProxyManagerCaster
+final class CurlCaster
 {
-    public static function castProxy(ProxyInterface $c, array $a, Stub $stub, bool $isNested): array
+    public static function castCurl(\CurlHandle $h, array $a, Stub $stub, bool $isNested): array
     {
-        if ($parent = get_parent_class($c)) {
-            $stub->class .= ' - '.$parent;
+        foreach (curl_getinfo($h) as $key => $val) {
+            $a[Caster::PREFIX_VIRTUAL.$key] = $val;
         }
-        $stub->class .= '@proxy';
 
         return $a;
     }

--- a/src/Symfony/Component/VarDumper/Caster/DOMCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/DOMCaster.php
@@ -19,6 +19,8 @@ use Symfony\Component\VarDumper\Cloner\Stub;
  * @author Nicolas Grekas <p@tchwork.com>
  *
  * @final
+ *
+ * @internal since Symfony 7.3
  */
 class DOMCaster
 {

--- a/src/Symfony/Component/VarDumper/Caster/DateCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/DateCaster.php
@@ -19,6 +19,8 @@ use Symfony\Component\VarDumper\Cloner\Stub;
  * @author Dany Maillard <danymaillard93b@gmail.com>
  *
  * @final
+ *
+ * @internal since Symfony 7.3
  */
 class DateCaster
 {

--- a/src/Symfony/Component/VarDumper/Caster/DoctrineCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/DoctrineCaster.php
@@ -22,6 +22,8 @@ use Symfony\Component\VarDumper\Cloner\Stub;
  * @author Nicolas Grekas <p@tchwork.com>
  *
  * @final
+ *
+ * @internal since Symfony 7.3
  */
 class DoctrineCaster
 {

--- a/src/Symfony/Component/VarDumper/Caster/ExceptionCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/ExceptionCaster.php
@@ -22,6 +22,8 @@ use Symfony\Component\VarDumper\Exception\ThrowingCasterException;
  * @author Nicolas Grekas <p@tchwork.com>
  *
  * @final
+ *
+ * @internal since Symfony 7.3
  */
 class ExceptionCaster
 {

--- a/src/Symfony/Component/VarDumper/Caster/GdCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/GdCaster.php
@@ -11,24 +11,19 @@
 
 namespace Symfony\Component\VarDumper\Caster;
 
-use ProxyManager\Proxy\ProxyInterface;
 use Symfony\Component\VarDumper\Cloner\Stub;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
  *
- * @final
- *
- * @internal since Symfony 7.3
+ * @internal
  */
-class ProxyManagerCaster
+final class GdCaster
 {
-    public static function castProxy(ProxyInterface $c, array $a, Stub $stub, bool $isNested): array
+    public static function castGd(\GdImage $gd, array $a, Stub $stub, bool $isNested): array
     {
-        if ($parent = get_parent_class($c)) {
-            $stub->class .= ' - '.$parent;
-        }
-        $stub->class .= '@proxy';
+        $a[Caster::PREFIX_VIRTUAL.'size'] = imagesx($gd).'x'.imagesy($gd);
+        $a[Caster::PREFIX_VIRTUAL.'trueColor'] = imageistruecolor($gd);
 
         return $a;
     }

--- a/src/Symfony/Component/VarDumper/Caster/GmpCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/GmpCaster.php
@@ -20,6 +20,8 @@ use Symfony\Component\VarDumper\Cloner\Stub;
  * @author Nicolas Grekas <p@tchwork.com>
  *
  * @final
+ *
+ * @internal since Symfony 7.3
  */
 class GmpCaster
 {

--- a/src/Symfony/Component/VarDumper/Caster/ImagineCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/ImagineCaster.php
@@ -16,6 +16,8 @@ use Symfony\Component\VarDumper\Cloner\Stub;
 
 /**
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ *
+ * @internal since Symfony 7.3
  */
 final class ImagineCaster
 {

--- a/src/Symfony/Component/VarDumper/Caster/IntlCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/IntlCaster.php
@@ -18,6 +18,8 @@ use Symfony\Component\VarDumper\Cloner\Stub;
  * @author Jan Schädlich <jan.schaedlich@sensiolabs.de>
  *
  * @final
+ *
+ * @internal since Symfony 7.3
  */
 class IntlCaster
 {

--- a/src/Symfony/Component/VarDumper/Caster/MemcachedCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/MemcachedCaster.php
@@ -17,6 +17,8 @@ use Symfony\Component\VarDumper\Cloner\Stub;
  * @author Jan Schädlich <jan.schaedlich@sensiolabs.de>
  *
  * @final
+ *
+ * @internal since Symfony 7.3
  */
 class MemcachedCaster
 {

--- a/src/Symfony/Component/VarDumper/Caster/OpenSSLCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/OpenSSLCaster.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Caster;
+
+use Symfony\Component\VarDumper\Cloner\Stub;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ *
+ * @internal
+ */
+final class OpenSSLCaster
+{
+    public static function castOpensslX509(\OpenSSLCertificate $h, array $a, Stub $stub, bool $isNested): array
+    {
+        $stub->cut = -1;
+        $info = openssl_x509_parse($h, false);
+
+        $pin = openssl_pkey_get_public($h);
+        $pin = openssl_pkey_get_details($pin)['key'];
+        $pin = \array_slice(explode("\n", $pin), 1, -2);
+        $pin = base64_decode(implode('', $pin));
+        $pin = base64_encode(hash('sha256', $pin, true));
+
+        $a += [
+            Caster::PREFIX_VIRTUAL.'subject' => new EnumStub(array_intersect_key($info['subject'], ['organizationName' => true, 'commonName' => true])),
+            Caster::PREFIX_VIRTUAL.'issuer' => new EnumStub(array_intersect_key($info['issuer'], ['organizationName' => true, 'commonName' => true])),
+            Caster::PREFIX_VIRTUAL.'expiry' => new ConstStub(date(\DateTimeInterface::ISO8601, $info['validTo_time_t']), $info['validTo_time_t']),
+            Caster::PREFIX_VIRTUAL.'fingerprint' => new EnumStub([
+                'md5' => new ConstStub(wordwrap(strtoupper(openssl_x509_fingerprint($h, 'md5')), 2, ':', true)),
+                'sha1' => new ConstStub(wordwrap(strtoupper(openssl_x509_fingerprint($h, 'sha1')), 2, ':', true)),
+                'sha256' => new ConstStub(wordwrap(strtoupper(openssl_x509_fingerprint($h, 'sha256')), 2, ':', true)),
+                'pin-sha256' => new ConstStub($pin),
+            ]),
+        ];
+
+        return $a;
+    }
+
+    public static function castOpensslAsymmetricKey(\OpenSSLAsymmetricKey $key, array $a, Stub $stub, bool $isNested): array
+    {
+        foreach (openssl_pkey_get_details($key) as $k => $v) {
+            $a[Caster::PREFIX_VIRTUAL.$k] = $v;
+        }
+
+        unset($a[Caster::PREFIX_VIRTUAL.'rsa']); // binary data
+
+        return $a;
+    }
+
+    public static function castOpensslCsr(\OpenSSLCertificateSigningRequest $csr, array $a, Stub $stub, bool $isNested): array
+    {
+        foreach (openssl_csr_get_subject($csr, false) as $k => $v) {
+            $a[Caster::PREFIX_VIRTUAL.$k] = $v;
+        }
+
+        return $a;
+    }
+}

--- a/src/Symfony/Component/VarDumper/Caster/PdoCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/PdoCaster.php
@@ -19,6 +19,8 @@ use Symfony\Component\VarDumper\Cloner\Stub;
  * @author Nicolas Grekas <p@tchwork.com>
  *
  * @final
+ *
+ * @internal since Symfony 7.3
  */
 class PdoCaster
 {

--- a/src/Symfony/Component/VarDumper/Caster/PgSqlCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/PgSqlCaster.php
@@ -19,6 +19,8 @@ use Symfony\Component\VarDumper\Cloner\Stub;
  * @author Nicolas Grekas <p@tchwork.com>
  *
  * @final
+ *
+ * @internal since Symfony 7.3
  */
 class PgSqlCaster
 {

--- a/src/Symfony/Component/VarDumper/Caster/RdKafkaCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/RdKafkaCaster.php
@@ -28,6 +28,8 @@ use Symfony\Component\VarDumper\Cloner\Stub;
  * Casts RdKafka related classes to array representation.
  *
  * @author Romain Neutron <imprec@gmail.com>
+ *
+ * @internal since Symfony 7.3
  */
 class RdKafkaCaster
 {

--- a/src/Symfony/Component/VarDumper/Caster/RedisCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/RedisCaster.php
@@ -20,6 +20,8 @@ use Symfony\Component\VarDumper\Cloner\Stub;
  * @author Nicolas Grekas <p@tchwork.com>
  *
  * @final
+ *
+ * @internal since Symfony 7.3
  */
 class RedisCaster
 {

--- a/src/Symfony/Component/VarDumper/Caster/ReflectionCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/ReflectionCaster.php
@@ -19,6 +19,8 @@ use Symfony\Component\VarDumper\Cloner\Stub;
  * @author Nicolas Grekas <p@tchwork.com>
  *
  * @final
+ *
+ * @internal since Symfony 7.3
  */
 class ReflectionCaster
 {

--- a/src/Symfony/Component/VarDumper/Caster/ResourceCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/ResourceCaster.php
@@ -19,16 +19,31 @@ use Symfony\Component\VarDumper\Cloner\Stub;
  * @author Nicolas Grekas <p@tchwork.com>
  *
  * @final
+ *
+ * @internal since Symfony 7.3
  */
 class ResourceCaster
 {
+    /**
+     * @deprecated since Symfony 7.3
+     */
     public static function castCurl(\CurlHandle $h, array $a, Stub $stub, bool $isNested): array
     {
-        return curl_getinfo($h);
+        trigger_deprecation('symfony/var-dumper', '7.3', 'The "%s()" method is deprecated without replacement.', __METHOD__, CurlCaster::class);
+
+        return CurlCaster::castCurl($h, $a, $stub, $isNested);
     }
 
-    public static function castDba($dba, array $a, Stub $stub, bool $isNested): array
+    /**
+     * @param resource|\Dba\Connection $dba
+     */
+    public static function castDba(mixed $dba, array $a, Stub $stub, bool $isNested): array
     {
+        if (\PHP_VERSION_ID < 80402 && !\is_resource($dba)) {
+            // @see https://github.com/php/php-src/issues/16990
+            return $a;
+        }
+
         $list = dba_list();
         $a['file'] = $list[(int) $dba];
 
@@ -55,37 +70,23 @@ class ResourceCaster
         return @stream_context_get_params($stream) ?: $a;
     }
 
-    public static function castGd($gd, array $a, Stub $stub, bool $isNested): array
+    /**
+     * @deprecated since Symfony 7.3
+     */
+    public static function castGd(\GdImage $gd, array $a, Stub $stub, bool $isNested): array
     {
-        $a['size'] = imagesx($gd).'x'.imagesy($gd);
-        $a['trueColor'] = imageistruecolor($gd);
+        trigger_deprecation('symfony/var-dumper', '7.3', 'The "%s()" method is deprecated without replacement.', __METHOD__, GdCaster::class);
 
-        return $a;
+        return GdCaster::castGd($gd, $a, $stub, $isNested);
     }
 
-    public static function castOpensslX509($h, array $a, Stub $stub, bool $isNested): array
+    /**
+     * @deprecated since Symfony 7.3
+     */
+    public static function castOpensslX509(\OpenSSLCertificate $h, array $a, Stub $stub, bool $isNested): array
     {
-        $stub->cut = -1;
-        $info = openssl_x509_parse($h, false);
+        trigger_deprecation('symfony/var-dumper', '7.3', 'The "%s()" method is deprecated without replacement.', __METHOD__, OpenSSLCaster::class);
 
-        $pin = openssl_pkey_get_public($h);
-        $pin = openssl_pkey_get_details($pin)['key'];
-        $pin = \array_slice(explode("\n", $pin), 1, -2);
-        $pin = base64_decode(implode('', $pin));
-        $pin = base64_encode(hash('sha256', $pin, true));
-
-        $a += [
-            'subject' => new EnumStub(array_intersect_key($info['subject'], ['organizationName' => true, 'commonName' => true])),
-            'issuer' => new EnumStub(array_intersect_key($info['issuer'], ['organizationName' => true, 'commonName' => true])),
-            'expiry' => new ConstStub(date(\DateTimeInterface::ISO8601, $info['validTo_time_t']), $info['validTo_time_t']),
-            'fingerprint' => new EnumStub([
-                'md5' => new ConstStub(wordwrap(strtoupper(openssl_x509_fingerprint($h, 'md5')), 2, ':', true)),
-                'sha1' => new ConstStub(wordwrap(strtoupper(openssl_x509_fingerprint($h, 'sha1')), 2, ':', true)),
-                'sha256' => new ConstStub(wordwrap(strtoupper(openssl_x509_fingerprint($h, 'sha256')), 2, ':', true)),
-                'pin-sha256' => new ConstStub($pin),
-            ]),
-        ];
-
-        return $a;
+        return OpenSSLCaster::castOpensslX509($h, $a, $stub, $isNested);
     }
 }

--- a/src/Symfony/Component/VarDumper/Caster/SplCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/SplCaster.php
@@ -19,6 +19,8 @@ use Symfony\Component\VarDumper\Cloner\Stub;
  * @author Nicolas Grekas <p@tchwork.com>
  *
  * @final
+ *
+ * @internal since Symfony 7.3
  */
 class SplCaster
 {

--- a/src/Symfony/Component/VarDumper/Caster/SqliteCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/SqliteCaster.php
@@ -11,24 +11,21 @@
 
 namespace Symfony\Component\VarDumper\Caster;
 
-use ProxyManager\Proxy\ProxyInterface;
 use Symfony\Component\VarDumper\Cloner\Stub;
 
 /**
- * @author Nicolas Grekas <p@tchwork.com>
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
  *
- * @final
- *
- * @internal since Symfony 7.3
+ * @internal
  */
-class ProxyManagerCaster
+final class SqliteCaster
 {
-    public static function castProxy(ProxyInterface $c, array $a, Stub $stub, bool $isNested): array
+    public static function castSqlite3Result(\SQLite3Result $result, array $a, Stub $stub, bool $isNested): array
     {
-        if ($parent = get_parent_class($c)) {
-            $stub->class .= ' - '.$parent;
+        $numColumns = $result->numColumns();
+        for ($i = 0; $i < $numColumns; ++$i) {
+            $a[Caster::PREFIX_VIRTUAL.'columnNames'][$i] = $result->columnName($i);
         }
-        $stub->class .= '@proxy';
 
         return $a;
     }

--- a/src/Symfony/Component/VarDumper/Caster/StubCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/StubCaster.php
@@ -19,6 +19,8 @@ use Symfony\Component\VarDumper\Cloner\Stub;
  * @author Nicolas Grekas <p@tchwork.com>
  *
  * @final
+ *
+ * @internal since Symfony 7.3
  */
 class StubCaster
 {

--- a/src/Symfony/Component/VarDumper/Caster/SymfonyCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/SymfonyCaster.php
@@ -19,6 +19,8 @@ use Symfony\Component\VarExporter\Internal\LazyObjectState;
 
 /**
  * @final
+ *
+ * @internal since Symfony 7.3
  */
 class SymfonyCaster
 {

--- a/src/Symfony/Component/VarDumper/Caster/UuidCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/UuidCaster.php
@@ -16,6 +16,8 @@ use Symfony\Component\VarDumper\Cloner\Stub;
 
 /**
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ *
+ * @internal since Symfony 7.3
  */
 final class UuidCaster
 {

--- a/src/Symfony/Component/VarDumper/Caster/XmlReaderCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/XmlReaderCaster.php
@@ -19,6 +19,8 @@ use Symfony\Component\VarDumper\Cloner\Stub;
  * @author Baptiste Clavié <clavie.b@gmail.com>
  *
  * @final
+ *
+ * @internal since Symfony 7.3
  */
 class XmlReaderCaster
 {

--- a/src/Symfony/Component/VarDumper/Caster/XmlResourceCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/XmlResourceCaster.php
@@ -19,6 +19,8 @@ use Symfony\Component\VarDumper\Cloner\Stub;
  * @author Nicolas Grekas <p@tchwork.com>
  *
  * @final
+ *
+ * @internal since Symfony 7.3
  */
 class XmlResourceCaster
 {

--- a/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
@@ -177,29 +177,33 @@ abstract class AbstractCloner implements ClonerInterface
 
         'mysqli_driver' => ['Symfony\Component\VarDumper\Caster\MysqliCaster', 'castMysqliDriver'],
 
-        'CurlHandle' => ['Symfony\Component\VarDumper\Caster\ResourceCaster', 'castCurl'],
+        'CurlHandle' => ['Symfony\Component\VarDumper\Caster\CurlCaster', 'castCurl'],
 
+        'Dba\Connection' => ['Symfony\Component\VarDumper\Caster\ResourceCaster', 'castDba'],
         ':dba' => ['Symfony\Component\VarDumper\Caster\ResourceCaster', 'castDba'],
         ':dba persistent' => ['Symfony\Component\VarDumper\Caster\ResourceCaster', 'castDba'],
 
         'GdImage' => ['Symfony\Component\VarDumper\Caster\ResourceCaster', 'castGd'],
-        ':gd' => ['Symfony\Component\VarDumper\Caster\ResourceCaster', 'castGd'],
 
-        ':pgsql large object' => ['Symfony\Component\VarDumper\Caster\PgSqlCaster', 'castLargeObject'],
-        ':pgsql link' => ['Symfony\Component\VarDumper\Caster\PgSqlCaster', 'castLink'],
-        ':pgsql link persistent' => ['Symfony\Component\VarDumper\Caster\PgSqlCaster', 'castLink'],
-        ':pgsql result' => ['Symfony\Component\VarDumper\Caster\PgSqlCaster', 'castResult'],
+        'SQLite3Result' => ['Symfony\Component\VarDumper\Caster\SqliteCaster', 'castSqlite3Result'],
+
+        'PgSql\Lob' => ['Symfony\Component\VarDumper\Caster\PgSqlCaster', 'castLargeObject'],
+        'PgSql\Connection' => ['Symfony\Component\VarDumper\Caster\PgSqlCaster', 'castLink'],
+        'PgSql\Result' => ['Symfony\Component\VarDumper\Caster\PgSqlCaster', 'castResult'],
+
         ':process' => ['Symfony\Component\VarDumper\Caster\ResourceCaster', 'castProcess'],
         ':stream' => ['Symfony\Component\VarDumper\Caster\ResourceCaster', 'castStream'],
 
-        'OpenSSLCertificate' => ['Symfony\Component\VarDumper\Caster\ResourceCaster', 'castOpensslX509'],
-        ':OpenSSL X.509' => ['Symfony\Component\VarDumper\Caster\ResourceCaster', 'castOpensslX509'],
+        'OpenSSLAsymmetricKey' => ['Symfony\Component\VarDumper\Caster\OpenSSLCaster', 'castOpensslAsymmetricKey'],
+        'OpenSSLCertificateSigningRequest' => ['Symfony\Component\VarDumper\Caster\OpenSSLCaster', 'castOpensslCsr'],
+        'OpenSSLCertificate' => ['Symfony\Component\VarDumper\Caster\OpenSSLCaster', 'castOpensslX509'],
 
         ':persistent stream' => ['Symfony\Component\VarDumper\Caster\ResourceCaster', 'castStream'],
         ':stream-context' => ['Symfony\Component\VarDumper\Caster\ResourceCaster', 'castStreamContext'],
 
         'XmlParser' => ['Symfony\Component\VarDumper\Caster\XmlResourceCaster', 'castXml'],
-        ':xml' => ['Symfony\Component\VarDumper\Caster\XmlResourceCaster', 'castXml'],
+
+        'Socket' => ['Symfony\Component\VarDumper\Caster\SocketCaster', 'castSocket'],
 
         'RdKafka' => ['Symfony\Component\VarDumper\Caster\RdKafkaCaster', 'castRdKafka'],
         'RdKafka\Conf' => ['Symfony\Component\VarDumper\Caster\RdKafkaCaster', 'castConf'],

--- a/src/Symfony/Component/VarDumper/Tests/Caster/CurlCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/CurlCasterTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Tests\Caster;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\VarDumper\Test\VarDumperTestTrait;
+
+/**
+ * @requires extension curl
+ */
+class CurlCasterTest extends TestCase
+{
+    use VarDumperTestTrait;
+
+    public function testCastCurl()
+    {
+        $ch = curl_init('http://example.com');
+        curl_setopt($ch, \CURLOPT_RETURNTRANSFER, true);
+        curl_exec($ch);
+
+        $this->assertDumpMatchesFormat(
+            <<<'EODUMP'
+CurlHandle {
+  url: "http://example.com/"
+  content_type: "text/html; charset=UTF-8"
+  http_code: 200%A
+}
+EODUMP, $ch);
+    }
+}

--- a/src/Symfony/Component/VarDumper/Tests/Caster/OpenSSLCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/OpenSSLCasterTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Tests\Caster;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\VarDumper\Test\VarDumperTestTrait;
+
+/**
+ * @requires extension openssl
+ */
+class OpenSSLCasterTest extends TestCase
+{
+    use VarDumperTestTrait;
+
+    public function testAsymmetricKey()
+    {
+        $key = openssl_pkey_new([
+            'private_key_bits' => 1024,
+            'private_key_type' => \OPENSSL_KEYTYPE_RSA,
+        ]);
+
+        if (false === $key) {
+            $this->markTestSkipped('Unable to generate a key pair');
+        }
+
+        $this->assertDumpMatchesFormat(
+            <<<'EODUMP'
+OpenSSLAsymmetricKey {
+  bits: 1024
+  key: """
+    -----BEGIN PUBLIC KEY-----\n
+    %A
+    %A
+    %A
+    %A
+    -----END PUBLIC KEY-----\n
+    """
+  type: 0
+}
+EODUMP, $key);
+    }
+
+    public function testOpensslCsr()
+    {
+        $dn = [
+            'countryName' => 'FR',
+            'stateOrProvinceName' => 'Ile-de-France',
+            'localityName' => 'Paris',
+            'organizationName' => 'Symfony',
+            'organizationalUnitName' => 'Security',
+            'commonName' => 'symfony.com',
+            'emailAddress' => 'test@symfony.com',
+        ];
+        $privkey = openssl_pkey_new();
+        $csr = openssl_csr_new($dn, $privkey);
+
+        if (false === $csr) {
+            $this->markTestSkipped('Unable to generate a CSR');
+        }
+
+        $this->assertDumpMatchesFormat(
+            <<<'EODUMP'
+OpenSSLCertificateSigningRequest {
+  countryName: "FR"
+  stateOrProvinceName: "Ile-de-France"
+  localityName: "Paris"
+  organizationName: "Symfony"
+  organizationalUnitName: "Security"
+  commonName: "symfony.com"
+  emailAddress: "test@symfony.com"
+}
+EODUMP, $csr);
+    }
+}

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ResourceCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ResourceCasterTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Tests\Caster;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\VarDumper\Caster\ResourceCaster;
+use Symfony\Component\VarDumper\Cloner\Stub;
+use Symfony\Component\VarDumper\Test\VarDumperTestTrait;
+
+class ResourceCasterTest extends TestCase
+{
+    use ExpectDeprecationTrait;
+    use VarDumperTestTrait;
+
+    /**
+     * @group legacy
+     *
+     * @requires extension curl
+     */
+    public function testCastCurlIsDeprecated()
+    {
+        $ch = curl_init('http://example.com');
+        curl_setopt($ch, \CURLOPT_RETURNTRANSFER, true);
+        curl_exec($ch);
+
+        $this->expectDeprecation('Since symfony/var-dumper 7.3: The "Symfony\Component\VarDumper\Caster\ResourceCaster::castCurl()" method is deprecated without replacement.');
+
+        ResourceCaster::castCurl($ch, [], new Stub(), false);
+    }
+
+    /**
+     * @group legacy
+     *
+     * @requires extension gd
+     */
+    public function testCastGdIsDeprecated()
+    {
+        $gd = imagecreate(1, 1);
+
+        $this->expectDeprecation('Since symfony/var-dumper 7.3: The "Symfony\Component\VarDumper\Caster\ResourceCaster::castGd()" method is deprecated without replacement.');
+
+        ResourceCaster::castGd($gd, [], new Stub(), false);
+    }
+
+    /**
+     * @requires PHP < 8.4
+     * @requires extension dba
+     */
+    public function testCastDbaPriorToPhp84()
+    {
+        $dba = dba_open(sys_get_temp_dir().'/test.db', 'c');
+
+        $this->assertDumpMatchesFormat(
+            <<<'EODUMP'
+dba resource {
+  file: %s
+}
+EODUMP, $dba);
+    }
+
+    /**
+     * @requires PHP 8.4
+     */
+    public function testCastDba()
+    {
+        if (\PHP_VERSION_ID < 80402) {
+            $this->markTestSkipped('The test cannot be run on PHP 8.4.0 and PHP 8.4.1, see https://github.com/php/php-src/issues/16990');
+        }
+
+        $dba = dba_open(sys_get_temp_dir().'/test.db', 'c');
+
+        $this->assertDumpMatchesFormat(
+            <<<'EODUMP'
+Dba\Connection {
+  +file: %s
+}
+EODUMP, $dba);
+    }
+
+    /**
+     * @requires PHP 8.4
+     */
+    public function testCastDbaOnBuggyPhp84()
+    {
+        if (\PHP_VERSION_ID >= 80402) {
+            $this->markTestSkipped('The test can only be run on PHP 8.4.0 and 8.4.1, see https://github.com/php/php-src/issues/16990');
+        }
+
+        $dba = dba_open(sys_get_temp_dir().'/test.db', 'c');
+
+        $this->assertDumpMatchesFormat(
+            <<<'EODUMP'
+Dba\Connection {
+}
+EODUMP, $dba);
+    }
+}

--- a/src/Symfony/Component/VarDumper/Tests/Caster/SocketCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/SocketCasterTest.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Tests\Caster;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\VarDumper\Test\VarDumperTestTrait;
+
+/**
+ * @requires extension sockets
+ */
+class SocketCasterTest extends TestCase
+{
+    use VarDumperTestTrait;
+
+    /**
+     * @requires PHP 8.3
+     */
+    public function testCastSocket()
+    {
+        $socket = socket_create(\AF_INET, \SOCK_DGRAM, \SOL_UDP);
+        @socket_connect($socket, '127.0.0.1', 80);
+
+        $this->assertDumpMatchesFormat(
+            <<<'EODUMP'
+Socket {
+  uri: "udp://127.0.0.1:%d"
+  timed_out: false
+  blocked: true%A
+}
+EODUMP, $socket);
+    }
+
+    /**
+     * @requires PHP < 8.3
+     */
+    public function testCastSocketPriorToPhp83()
+    {
+        $socket = socket_create(\AF_INET, \SOCK_DGRAM, \SOL_UDP);
+        @socket_connect($socket, '127.0.0.1', 80);
+
+        $this->assertDumpMatchesFormat(
+            <<<'EODUMP'
+Socket {
+  timed_out: false
+  blocked: true
+}
+EODUMP, $socket);
+    }
+
+    /**
+     * @requires PHP 8.3
+     */
+    public function testCastSocketIpV6()
+    {
+        $socket = socket_create(\AF_INET6, \SOCK_STREAM, \SOL_TCP);
+        @socket_connect($socket, '::1', 80);
+
+        $this->assertDumpMatchesFormat(
+            <<<'EODUMP'
+Socket {
+  uri: "tcp://[%A]:%d"
+  timed_out: false
+  blocked: true
+  last_error: SOCKET_ECONNREFUSED
+}
+EODUMP, $socket);
+    }
+
+    /**
+     * @requires PHP < 8.3
+     */
+    public function testCastSocketIpV6PriorToPhp83()
+    {
+        $socket = socket_create(\AF_INET6, \SOCK_STREAM, \SOL_TCP);
+        @socket_connect($socket, '::1', 80);
+
+        $this->assertDumpMatchesFormat(
+            <<<'EODUMP'
+Socket {
+  timed_out: false
+  blocked: true
+  last_error: SOCKET_ECONNREFUSED
+}
+EODUMP, $socket);
+    }
+
+    /**
+     * @requires PHP 8.3
+     */
+    public function testCastUnixSocket()
+    {
+        $socket = socket_create(\AF_UNIX, \SOCK_STREAM, 0);
+        @socket_connect($socket, '/tmp/socket.sock');
+
+        $this->assertDumpMatchesFormat(
+            <<<'EODUMP'
+Socket {
+  uri: "unix://"
+  timed_out: false
+  blocked: true
+  last_error: SOCKET_ENOENT
+}
+EODUMP, $socket);
+    }
+
+    /**
+     * @requires PHP < 8.3
+     */
+    public function testCastUnixSocketPriorToPhp83()
+    {
+        $socket = socket_create(\AF_UNIX, \SOCK_STREAM, 0);
+        @socket_connect($socket, '/tmp/socket.sock');
+
+        $this->assertDumpMatchesFormat(
+            <<<'EODUMP'
+Socket {
+  timed_out: false
+  blocked: true
+  last_error: SOCKET_ENOENT
+}
+EODUMP, $socket);
+    }
+}

--- a/src/Symfony/Component/VarDumper/Tests/Caster/SqliteCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/SqliteCasterTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Tests\Caster;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\VarDumper\Test\VarDumperTestTrait;
+
+/**
+ * @requires extension sqlite3
+ */
+class SqliteCasterTest extends TestCase
+{
+    use VarDumperTestTrait;
+
+    public function testSqlite3Result()
+    {
+        $db = new \SQLite3(':memory:');
+        $db->exec('CREATE TABLE foo (id INTEGER PRIMARY KEY, bar TEXT)');
+        $db->exec('INSERT INTO foo (bar) VALUES ("baz")');
+        $stmt = $db->prepare('SELECT id, bar FROM foo');
+        $result = $stmt->execute();
+
+        $this->assertDumpMatchesFormat(
+            <<<'EODUMP'
+SQLite3Result {
+  columnNames: array:2 [
+    0 => "id"
+    1 => "bar"
+  ]
+}
+EODUMP, $result);
+    }
+}

--- a/src/Symfony/Component/VarDumper/composer.json
+++ b/src/Symfony/Component/VarDumper/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=8.2",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/polyfill-mbstring": "~1.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | -
| License       | MIT

This PR makes up for the backlog of resources transformed into objects in the latest versions of PHP.

✅ Support added (or already existing with an update in `AbstractCloner`):
- ext-curl
    - `CurlMultiHandle`: **no information to gather**
- ext-openssl
  -  `OpenSSLCertificateSigningRequest`
  - `OpenSSLAsymmetricKey`
- ext-finfo
  - **No information to gather**
- ext-sqlite3
	- `Sqlite3Result`
- ext-sockets
	- `Sockets` (to rebase on https://github.com/symfony/symfony/pull/59026)
- ext-pgsql
	- `PgSql\Lob`
	- `PgSql\Connection`
	- `PgSql\Result`

⚠️ Remaining classes I couldn't test/find enough info yet (introduced in PHP 8.4):
- `Odbc\Connection`
- `Odbc\Result`
- `Soap\Url`
- `Soap\Sdl`