### PR TITLE
[DependencyInjection] Bootstrap-function-declarations

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -54,7 +54,16 @@ jobs:
           # @see https://github.com/vimeo/psalm/issues/7520
           sed -i 's/Uuid&/Uuid|/' src/Symfony/Component/Uid/Factory/TimeBasedUuidFactory.php
           sed -i 's/Interface&/Interface|/' src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MigratingSessionHandler.php
+          # TODO: Remove after merge
+          if [ ! -f src/Symfony/Component/DependencyInjection/Loader/Configurator/functions.php ]; then
+              NEED_TO_REMOVE=1
+              echo '<?php' > src/Symfony/Component/DependencyInjection/Loader/Configurator/functions.php
+          fi
           ./vendor/bin/psalm.phar --set-baseline=.github/psalm/psalm.baseline.xml --no-progress
+          # TODO: Remove after merge
+          if [ "$NEED_TO_REMOVE" -eq 1 ]; then
+              rm src/Symfony/Component/DependencyInjection/Loader/Configurator/functions.php
+          fi
           git checkout -m FETCH_HEAD
 
       - name: Psalm

--- a/composer.json
+++ b/composer.json
@@ -192,6 +192,7 @@
             "Symfony\\Runtime\\Symfony\\Component\\": "src/Symfony/Component/Runtime/Internal/"
         },
         "files": [
+            "src/Symfony/Component/DependencyInjection/Loader/Configurator/functions.php",
             "src/Symfony/Component/String/Resources/functions.php"
         ],
         "classmap": [

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.3
+---
+
+* Moved functions in Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator to be bootstrapped by Composer
+
 7.2
 ---
 

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 7.3
 ---
 
-* Moved functions in Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator to be bootstrapped by Composer
+ * Moved functions in Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator to be bootstrapped by Composer
 
 7.2
 ---

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
@@ -11,18 +11,11 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-use Symfony\Component\Config\Loader\ParamConfigurator;
-use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
-use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
-use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
-use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Loader\UndefinedExtensionHandler;
-use Symfony\Component\ExpressionLanguage\Expression;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
@@ -93,108 +86,4 @@ class ContainerConfigurator extends AbstractConfigurator
 
         return $clone;
     }
-}
-
-/**
- * Creates a parameter.
- */
-function param(string $name): ParamConfigurator
-{
-    return new ParamConfigurator($name);
-}
-
-/**
- * Creates a reference to a service.
- */
-function service(string $serviceId): ReferenceConfigurator
-{
-    return new ReferenceConfigurator($serviceId);
-}
-
-/**
- * Creates an inline service.
- */
-function inline_service(?string $class = null): InlineServiceConfigurator
-{
-    return new InlineServiceConfigurator(new Definition($class));
-}
-
-/**
- * Creates a service locator.
- *
- * @param array<ReferenceConfigurator|InlineServiceConfigurator> $values
- */
-function service_locator(array $values): ServiceLocatorArgument
-{
-    $values = AbstractConfigurator::processValue($values, true);
-
-    return new ServiceLocatorArgument($values);
-}
-
-/**
- * Creates a lazy iterator.
- *
- * @param ReferenceConfigurator[] $values
- */
-function iterator(array $values): IteratorArgument
-{
-    return new IteratorArgument(AbstractConfigurator::processValue($values, true));
-}
-
-/**
- * Creates a lazy iterator by tag name.
- */
-function tagged_iterator(string $tag, ?string $indexAttribute = null, ?string $defaultIndexMethod = null, ?string $defaultPriorityMethod = null, string|array $exclude = [], bool $excludeSelf = true): TaggedIteratorArgument
-{
-    return new TaggedIteratorArgument($tag, $indexAttribute, $defaultIndexMethod, false, $defaultPriorityMethod, (array) $exclude, $excludeSelf);
-}
-
-/**
- * Creates a service locator by tag name.
- */
-function tagged_locator(string $tag, ?string $indexAttribute = null, ?string $defaultIndexMethod = null, ?string $defaultPriorityMethod = null, string|array $exclude = [], bool $excludeSelf = true): ServiceLocatorArgument
-{
-    return new ServiceLocatorArgument(new TaggedIteratorArgument($tag, $indexAttribute, $defaultIndexMethod, true, $defaultPriorityMethod, (array) $exclude, $excludeSelf));
-}
-
-/**
- * Creates an expression.
- */
-function expr(string $expression): Expression
-{
-    return new Expression($expression);
-}
-
-/**
- * Creates an abstract argument.
- */
-function abstract_arg(string $description): AbstractArgument
-{
-    return new AbstractArgument($description);
-}
-
-/**
- * Creates an environment variable reference.
- */
-function env(string $name): EnvConfigurator
-{
-    return new EnvConfigurator($name);
-}
-
-/**
- * Creates a closure service reference.
- */
-function service_closure(string $serviceId): ClosureReferenceConfigurator
-{
-    return new ClosureReferenceConfigurator($serviceId);
-}
-
-/**
- * Creates a closure.
- */
-function closure(string|array|ReferenceConfigurator|Expression $callable): InlineServiceConfigurator
-{
-    return (new InlineServiceConfigurator(new Definition('Closure')))
-        ->factory(['Closure', 'fromCallable'])
-        ->args([$callable]);
 }

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/functions.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/functions.php
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Component\Config\Loader\ParamConfigurator;
+use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
+use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
+use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\ExpressionLanguage\Expression;
+
+/**
+ * Creates a parameter.
+ */
+function param(string $name): ParamConfigurator
+{
+    return new ParamConfigurator($name);
+}
+
+/**
+ * Creates a reference to a service.
+ */
+function service(string $serviceId): ReferenceConfigurator
+{
+    return new ReferenceConfigurator($serviceId);
+}
+
+/**
+ * Creates an inline service.
+ */
+function inline_service(?string $class = null): InlineServiceConfigurator
+{
+    return new InlineServiceConfigurator(new Definition($class));
+}
+
+/**
+ * Creates a service locator.
+ *
+ * @param array<ReferenceConfigurator|InlineServiceConfigurator> $values
+ */
+function service_locator(array $values): ServiceLocatorArgument
+{
+    $values = AbstractConfigurator::processValue($values, true);
+
+    return new ServiceLocatorArgument($values);
+}
+
+/**
+ * Creates a lazy iterator.
+ *
+ * @param ReferenceConfigurator[] $values
+ */
+function iterator(array $values): IteratorArgument
+{
+    return new IteratorArgument(AbstractConfigurator::processValue($values, true));
+}
+
+/**
+ * Creates a lazy iterator by tag name.
+ */
+function tagged_iterator(string $tag, ?string $indexAttribute = null, ?string $defaultIndexMethod = null, ?string $defaultPriorityMethod = null, string|array $exclude = [], bool $excludeSelf = true): TaggedIteratorArgument
+{
+    return new TaggedIteratorArgument($tag, $indexAttribute, $defaultIndexMethod, false, $defaultPriorityMethod, (array) $exclude, $excludeSelf);
+}
+
+/**
+ * Creates a service locator by tag name.
+ */
+function tagged_locator(string $tag, ?string $indexAttribute = null, ?string $defaultIndexMethod = null, ?string $defaultPriorityMethod = null, string|array $exclude = [], bool $excludeSelf = true): ServiceLocatorArgument
+{
+    return new ServiceLocatorArgument(new TaggedIteratorArgument($tag, $indexAttribute, $defaultIndexMethod, true, $defaultPriorityMethod, (array) $exclude, $excludeSelf));
+}
+
+/**
+ * Creates an expression.
+ */
+function expr(string $expression): Expression
+{
+    return new Expression($expression);
+}
+
+/**
+ * Creates an abstract argument.
+ */
+function abstract_arg(string $description): AbstractArgument
+{
+    return new AbstractArgument($description);
+}
+
+/**
+ * Creates an environment variable reference.
+ */
+function env(string $name): EnvConfigurator
+{
+    return new EnvConfigurator($name);
+}
+
+/**
+ * Creates a closure service reference.
+ */
+function service_closure(string $serviceId): ClosureReferenceConfigurator
+{
+    return new ClosureReferenceConfigurator($serviceId);
+}
+
+/**
+ * Creates a closure.
+ */
+function closure(string|array|ReferenceConfigurator|Expression $callable): InlineServiceConfigurator
+{
+    return (new InlineServiceConfigurator(new Definition('Closure')))
+        ->factory(['Closure', 'fromCallable'])
+        ->args([$callable]);
+}

--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -39,6 +39,9 @@
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\DependencyInjection\\": "" },
+        "files": [
+            "Loader/Configurator/functions.php"
+        ],
         "exclude-from-classmap": [
             "/Tests/"
         ]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Because these functions are not being bootstrapped by Composer, static analysis tools like Psalm and PHPStan require special configuration to understand these function exist. For example, in PHPStan you are required to add the following to your configuration:
```yaml
scanFiles:
    - vendor/symfony/dependency-injection/Loader/Configurator/ContainerConfigurator.php
```

To the best of my knowledge, there is no reason to not bootstrap these functions. If there is, we should add a comment explaining why in `ContainerConfigurator.php`.
