### PR TITLE
[HttpFoundation] Fixed `IpUtils::anonymize` exception when using IPv6 link-local addresses with RFC4007 scoping

### DIFF
--- a/src/Symfony/Component/HttpFoundation/IpUtils.php
+++ b/src/Symfony/Component/HttpFoundation/IpUtils.php
@@ -182,6 +182,16 @@ class IpUtils
      */
     public static function anonymize(string $ip): string
     {
+        /**
+         * If the IP contains a % symbol, then it is a local-link address with scoping according to RFC 4007
+         * In that case, we only care about the part before the % symbol, as the following functions, can only work with
+         * the IP address itself. As the scope can leak information (containing interface name), we do not want to
+         * include it in our anonymized IP data.
+         */
+        if (str_contains($ip, '%')) {
+            $ip = substr($ip, 0, strpos($ip, '%'));
+        }
+
         $wrappedIPv6 = false;
         if (str_starts_with($ip, '[') && str_ends_with($ip, ']')) {
             $wrappedIPv6 = true;

--- a/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
@@ -147,6 +147,7 @@ class IpUtilsTest extends TestCase
             ['[2a01:198::3]', '[2a01:198::]'],
             ['::ffff:123.234.235.236', '::ffff:123.234.235.0'], // IPv4-mapped IPv6 addresses
             ['::123.234.235.236', '::123.234.235.0'], // deprecated IPv4-compatible IPv6 address
+            ['fe80::1fc4:15d8:78db:2319%enp4s0', 'fe80::'], // IPv6 link-local with RFC4007 scoping
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | See below
| License       | MIT

When accessing a web server via an IPv6 link-local address, it is possible to get a `REMOTE_ADDR` like `fe80::1fc4:15d8:78db:2319%enp4s0`, which is then subsequently also returned by Request::getClientIp().
This `%` suffix is IPv6 scoping according to [RFC4007](https://datatracker.ietf.org/doc/html/rfc4007), as the link-local addresses are network interface dependent, and are important to uniquely identify a device in the network.

PHP and Symfony Request consider this format valid (or at least do not touch it). However, IPUtils::anonymize break when getting such a (valid) IP and throws an exception as the `inet_ntop` function cannot handle that format and returns false.

This PR fixes that by just stripping away the scoping suffix, before passing the IP to that function. I think the interface information is not important on the anonymized IP (as we want to lose the uniqueness anyway) and it might contain the interface name, which one could consider as somewhat sensitive information, that should not be leaked to end users.