### PR TITLE
[Mime] Fix wrong PHPDoc in `FormDataPart` constructor

### DIFF
--- a/src/Symfony/Component/Mime/Part/Multipart/FormDataPart.php
+++ b/src/Symfony/Component/Mime/Part/Multipart/FormDataPart.php
@@ -26,7 +26,7 @@ final class FormDataPart extends AbstractMultipartPart
     private array $fields = [];
 
     /**
-     * @param array<string|array|DataPart> $fields
+     * @param array<string|array|TextPart> $fields
      */
     public function __construct(array $fields = [])
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | - <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

I believe the PHPDoc is wrong.

As far as I understand, the `FormDataPart` expects instances of `TextPart`:

```php
if (!\is_string($item) && !$item instanceof TextPart) {
    throw new InvalidArgumentException(sprintf('The value of the form field "%s" can only be a string, an array, or an instance of TextPart, "%s" given.', $fieldName, get_debug_type($item)));
}
```
https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/Mime/Part/Multipart/FormDataPart.php#L74

The following code is rejected by PHPStan while it works:

```php
final readonly class Foo
{
    public function bar(): void
    {
        new FormDataPart([
            new TextPart('baz'),
        ]);
    }
}
```

```shell
 ------ ------------------------------------------------------------------------------------------------------------------- 
  Line   src/Foo.php                                                                                     
 ------ ------------------------------------------------------------------------------------------------------------------- 
  14     Parameter #1 $fields of class Symfony\Component\Mime\Part\Multipart\FormDataPart constructor expects               
         array<array|string|Symfony\Component\Mime\Part\DataPart>, array<int, Symfony\Component\Mime\Part\TextPart> given.  
 ------ ------------------------------------------------------------------------------------------------------------------- 
```

(cc @B-Galati)