### PR TITLE
[HttpClient] Always set CURLOPT_CUSTOMREQUEST to the correct HTTP method in CurlHttpClient

### DIFF
--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -197,13 +197,12 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
             $curlopts[\CURLOPT_RESOLVE] = $resolve;
         }
 
+        $curlopts[\CURLOPT_CUSTOMREQUEST] = $method;
         if ('POST' === $method) {
             // Use CURLOPT_POST to have browser-like POST-to-GET redirects for 301, 302 and 303
             $curlopts[\CURLOPT_POST] = true;
         } elseif ('HEAD' === $method) {
             $curlopts[\CURLOPT_NOBODY] = true;
-        } else {
-            $curlopts[\CURLOPT_CUSTOMREQUEST] = $method;
         }
 
         if ('\\' !== \DIRECTORY_SEPARATOR && $options['timeout'] < 1) {

--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
@@ -651,4 +651,26 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
 
         $this->assertSame(['abc' => 'def', 'content-type' => 'application/json', 'REQUEST_METHOD' => 'POST'], $response->toArray());
     }
+
+    public function testHeadRequestWithClosureBody()
+    {
+        $p = TestHttpServer::start(8067);
+
+        try {
+            $client = $this->getHttpClient(__FUNCTION__);
+
+            $response = $client->request('HEAD', 'http://localhost:8057/head', [
+                'body' => fn () => '',
+            ]);
+            $headers = $response->getHeaders();
+        } finally {
+            $p->stop();
+        }
+
+        $this->assertArrayHasKey('x-request-vars', $headers);
+
+        $vars = json_decode($headers['x-request-vars'][0], true);
+        $this->assertIsArray($vars);
+        $this->assertSame('HEAD', $vars['REQUEST_METHOD']);
+    }
 }

--- a/src/Symfony/Component/HttpClient/composer.json
+++ b/src/Symfony/Component/HttpClient/composer.json
@@ -25,7 +25,7 @@
         "php": ">=8.1",
         "psr/log": "^1|^2|^3",
         "symfony/deprecation-contracts": "^2.5|^3",
-        "symfony/http-client-contracts": "~3.4.3|^3.5.1",
+        "symfony/http-client-contracts": "~3.4.4|^3.5.2",
         "symfony/service-contracts": "^2.5|^3"
     },
     "require-dev": {

--- a/src/Symfony/Contracts/HttpClient/Test/Fixtures/web/index.php
+++ b/src/Symfony/Contracts/HttpClient/Test/Fixtures/web/index.php
@@ -42,6 +42,7 @@ switch (parse_url($vars['REQUEST_URI'], \PHP_URL_PATH)) {
         exit;
 
     case '/head':
+        header('X-Request-Vars: '.json_encode($vars, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE));
         header('Content-Length: '.strlen($json), true);
         break;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59043
| License       | MIT

Currently, when sending a `HEAD` request and using a closure as the request body using `CurlHttpClient`, a `PUT` request instead of a HEAD request will be sent. This is because `CURLOPT_NOBODY` is set to make a `HEAD` request, but is overwritten by `CURLOPT_UPLOAD`, which is necessary to make curl call `CURLOPT_READFUNCTION`, but also sets the HTTP method to `PUT`.
The solution I am suggesting is to just always set `CURLOPT_CUSTOMREQUEST`, so the correct HTTP method will be used, no matter what other options are added.

This is mainly an issue in the PSR-18 wrapper, since PSR requests always have a request body stream, even if the body is empty. Since #58856, `Psr18Client` always passes a closure as the request body to the underlying HTTP client instead of just reading the entire request body stream into a string, as that made it impossible to upload large files. 

While it would be possible to add an exception to `Psr18Client` to only add the request body if the method used commonly has a body, I think the better solution is to ensure that  `CurlHttpClient` always actually sends the type of request that it is asked to send.
