### PR TITLE
Add @return non-empty-string annotations to AbstractUid and relevant …

### DIFF
--- a/src/Symfony/Component/Uid/AbstractUid.php
+++ b/src/Symfony/Component/Uid/AbstractUid.php
@@ -85,12 +85,15 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable, HashableIn
 
     /**
      * Returns the identifier as a raw binary string.
+     *
+     * @return non-empty-string
      */
     abstract public function toBinary(): string;
 
     /**
      * Returns the identifier as a base58 case-sensitive string.
      *
+     * @return non-empty-string
      * @example 2AifFTC3zXgZzK5fPrrprL (len=22)
      */
     public function toBase58(): string
@@ -103,6 +106,7 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable, HashableIn
      *
      * @see https://tools.ietf.org/html/rfc4648#section-6
      *
+     * @return non-empty-string
      * @example 09EJ0S614A9FXVG9C5537Q9ZE1 (len=26)
      */
     public function toBase32(): string
@@ -126,6 +130,7 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable, HashableIn
      *
      * @see https://datatracker.ietf.org/doc/html/rfc9562/#section-4
      *
+     * @return non-empty-string
      * @example 09748193-048a-4bfb-b825-8528cf74fdc1 (len=36)
      */
     public function toRfc4122(): string
@@ -142,6 +147,7 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable, HashableIn
     /**
      * Returns the identifier as a prefixed hexadecimal case insensitive string.
      *
+     * @return non-empty-string
      * @example 0x09748193048a4bfbb8258528cf74fdc1 (len=34)
      */
     public function toHex(): string
@@ -161,6 +167,9 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable, HashableIn
         return $this->uid === $other->uid;
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function hash(): string
     {
         return $this->uid;
@@ -171,16 +180,25 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable, HashableIn
         return (\strlen($this->uid) - \strlen($other->uid)) ?: ($this->uid <=> $other->uid);
     }
 
+    /**
+     * @return non-empty-string
+     */
     final public function toString(): string
     {
         return $this->__toString();
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function __toString(): string
     {
         return $this->uid;
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function jsonSerialize(): string
     {
         return $this->uid;


### PR DESCRIPTION
…functions

| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT

This Merge Request introduces @return non-empty-string annotations to the AbstractUid class and other relevant functions in the Symfony UID component. By explicitly defining the return type as non-empty-string, this change improves type safety and ensures stricter static analysis when working with UIDs.

### Rationale
- Symfony 7.3 has adopted stricter type safety guidelines, including support for non-empty-string in interfaces like UserInterface::getUserIdentifier. Aligning the UID component with these standards improves consistency across the framework.
- Adding these annotations benefits developers by providing enhanced autocompletion and error detection in IDEs and tools like Psalm and PHPStan.

### Changes Made

- Updated PHPDoc comments in AbstractUid and related classes to specify @return non-empty-string for methods where applicable.
- Verified all usages of these methods to ensure compatibility with the stricter return type.

### Backward Compatibility

- This change does not affect backward compatibility, as it only updates PHPDoc annotations. The runtime behavior of the methods remains the same.



