### PR TITLE
[TypeInfo] Fix resolve enum in string type resolver

### DIFF
--- a/src/Symfony/Component/TypeInfo/Tests/TypeResolver/StringTypeResolverTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeResolver/StringTypeResolverTest.php
@@ -16,7 +16,9 @@ use Symfony\Component\TypeInfo\Exception\InvalidArgumentException;
 use Symfony\Component\TypeInfo\Exception\UnsupportedException;
 use Symfony\Component\TypeInfo\Tests\Fixtures\AbstractDummy;
 use Symfony\Component\TypeInfo\Tests\Fixtures\Dummy;
+use Symfony\Component\TypeInfo\Tests\Fixtures\DummyBackedEnum;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyCollection;
+use Symfony\Component\TypeInfo\Tests\Fixtures\DummyEnum;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithTemplates;
 use Symfony\Component\TypeInfo\Type;
 use Symfony\Component\TypeInfo\TypeContext\TypeContext;
@@ -138,6 +140,8 @@ class StringTypeResolverTest extends TestCase
         yield [Type::object(Dummy::class), 'static', $typeContextFactory->createFromClassName(Dummy::class, AbstractDummy::class)];
         yield [Type::object(AbstractDummy::class), 'parent', $typeContextFactory->createFromClassName(Dummy::class)];
         yield [Type::object(Dummy::class), 'Dummy', $typeContextFactory->createFromClassName(Dummy::class)];
+        yield [Type::enum(DummyEnum::class), 'DummyEnum', $typeContextFactory->createFromClassName(DummyEnum::class)];
+        yield [Type::enum(DummyBackedEnum::class), 'DummyBackedEnum', $typeContextFactory->createFromClassName(DummyBackedEnum::class)];
         yield [Type::template('T', Type::union(Type::int(), Type::string())), 'T', $typeContextFactory->createFromClassName(DummyWithTemplates::class)];
         yield [Type::template('V'), 'V', $typeContextFactory->createFromReflection(new \ReflectionMethod(DummyWithTemplates::class, 'getPrice'))];
 

--- a/src/Symfony/Component/TypeInfo/TypeResolver/ReflectionTypeResolver.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/ReflectionTypeResolver.php
@@ -27,11 +27,6 @@ use Symfony\Component\TypeInfo\TypeIdentifier;
  */
 final class ReflectionTypeResolver implements TypeResolverInterface
 {
-    /**
-     * @var array<class-string, \ReflectionEnum>
-     */
-    private static array $reflectionEnumCache = [];
-
     public function resolve(mixed $subject, ?TypeContext $typeContext = null): Type
     {
         if ($subject instanceof \ReflectionUnionType) {
@@ -83,11 +78,7 @@ final class ReflectionTypeResolver implements TypeResolverInterface
             default => $identifier,
         };
 
-        if (is_subclass_of($className, \BackedEnum::class)) {
-            $reflectionEnum = (self::$reflectionEnumCache[$className] ??= new \ReflectionEnum($className));
-            $backingType = $this->resolve($reflectionEnum->getBackingType(), $typeContext);
-            $type = Type::enum($className, $backingType);
-        } elseif (is_subclass_of($className, \UnitEnum::class)) {
+        if (is_subclass_of($className, \UnitEnum::class)) {
             $type = Type::enum($className);
         } else {
             $type = Type::object($className);

--- a/src/Symfony/Component/TypeInfo/TypeResolver/StringTypeResolver.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/StringTypeResolver.php
@@ -243,14 +243,16 @@ final class StringTypeResolver implements TypeResolverInterface
                 try {
                     new \ReflectionClass($className);
                     self::$classExistCache[$className] = true;
-
-                    return Type::object($className);
                 } catch (\Throwable) {
                 }
             }
         }
 
         if (self::$classExistCache[$className]) {
+            if (is_subclass_of($className, \UnitEnum::class)) {
+                return Type::enum($className);
+            }
+
             return Type::object($className);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        |  ~
| License       | MIT

Enum types are not handled correctly in the `StringTypeResolver`. They are always wrongly classified as `object`.

```php
enum Status: string {
  case Pending = 'pending';
  case Closed = 'closed';
}

class Dto {
  /**
    * @var list<Status>
    */
  public array $statusList;
}

$reflection = new ReflectionProperty(Dto::class, 'statusList');
$type TypeResolver::create()->resolve($reflection);

$type instanceof BackedEnumType; // false -> should be true
```
