### PR TITLE
[Uid] Add `@return non-empty-string` annotations to `AbstractUid` and relevant functions

### DIFF
--- a/src/Symfony/Component/Uid/AbstractUid.php
+++ b/src/Symfony/Component/Uid/AbstractUid.php
@@ -85,6 +85,8 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable, HashableIn
 
     /**
      * Returns the identifier as a raw binary string.
+     *
+     * @return non-empty-string
      */
     abstract public function toBinary(): string;
 
@@ -92,6 +94,8 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable, HashableIn
      * Returns the identifier as a base58 case-sensitive string.
      *
      * @example 2AifFTC3zXgZzK5fPrrprL (len=22)
+     *
+     * @return non-empty-string
      */
     public function toBase58(): string
     {
@@ -104,6 +108,8 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable, HashableIn
      * @see https://tools.ietf.org/html/rfc4648#section-6
      *
      * @example 09EJ0S614A9FXVG9C5537Q9ZE1 (len=26)
+     *
+     * @return non-empty-string
      */
     public function toBase32(): string
     {
@@ -127,6 +133,8 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable, HashableIn
      * @see https://datatracker.ietf.org/doc/html/rfc9562/#section-4
      *
      * @example 09748193-048a-4bfb-b825-8528cf74fdc1 (len=36)
+     *
+     * @return non-empty-string
      */
     public function toRfc4122(): string
     {
@@ -143,6 +151,8 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable, HashableIn
      * Returns the identifier as a prefixed hexadecimal case insensitive string.
      *
      * @example 0x09748193048a4bfbb8258528cf74fdc1 (len=34)
+     *
+     * @return non-empty-string
      */
     public function toHex(): string
     {
@@ -161,6 +171,9 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable, HashableIn
         return $this->uid === $other->uid;
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function hash(): string
     {
         return $this->uid;
@@ -171,16 +184,25 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable, HashableIn
         return (\strlen($this->uid) - \strlen($other->uid)) ?: ($this->uid <=> $other->uid);
     }
 
+    /**
+     * @return non-empty-string
+     */
     final public function toString(): string
     {
         return $this->__toString();
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function __toString(): string
     {
         return $this->uid;
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function jsonSerialize(): string
     {
         return $this->uid;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Issue | Fix #59076
| License       | MIT

This Merge Request introduces `@return non-empty-string` annotations to the AbstractUid class and other relevant functions in the Symfony UID component. By explicitly defining the return type as non-empty-string, this change improves type safety and ensures stricter static analysis when working with UIDs.

### Rationale
- Symfony 7.3 has adopted stricter type safety guidelines, including support for non-empty-string in interfaces like UserInterface::getUserIdentifier. Aligning the UID component with these standards improves consistency across the framework.
- Adding these annotations benefits developers by providing enhanced autocompletion and error detection in IDEs and tools like Psalm and PHPStan.

### Changes Made

- Updated PHPDoc comments in AbstractUid and related classes to specify `@return non-empty-string` for methods where applicable.
- Verified all usages of these methods to ensure compatibility with the stricter return type.

### Backward Compatibility

- This change does not affect backward compatibility, as it only updates PHPDoc annotations. The runtime behavior of the methods remains the same.
