### PR TITLE
[Scheduler] Add `scheduler:task:run` command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
@@ -53,6 +53,7 @@ use Symfony\Component\Messenger\Command\SetupTransportsCommand;
 use Symfony\Component\Messenger\Command\StatsCommand;
 use Symfony\Component\Messenger\Command\StopWorkersCommand;
 use Symfony\Component\Scheduler\Command\DebugCommand as SchedulerDebugCommand;
+use Symfony\Component\Scheduler\Command\RunTaskCommand;
 use Symfony\Component\Serializer\Command\DebugCommand as SerializerDebugCommand;
 use Symfony\Component\Translation\Command\TranslationLintCommand;
 use Symfony\Component\Translation\Command\TranslationPullCommand;
@@ -230,6 +231,16 @@ return static function (ContainerConfigurator $container) {
         ->set('console.command.scheduler_debug', SchedulerDebugCommand::class)
             ->args([
                 tagged_locator('scheduler.schedule_provider', 'name'),
+            ])
+            ->tag('console.command')
+
+        ->set('console.command.scheduler_run_task', RunTaskCommand::class)
+            ->args([
+                tagged_locator('scheduler.schedule_provider', 'name'),
+                service('messenger.bus.default'),
+                service('messenger.receiver_locator'),
+                service('event_dispatcher'),
+                service('logger')->nullOnInvalid(),
             ])
             ->tag('console.command')
 

--- a/src/Symfony/Component/Scheduler/Attribute/AsCronTask.php
+++ b/src/Symfony/Component/Scheduler/Attribute/AsCronTask.php
@@ -30,6 +30,7 @@ class AsCronTask
      * @param string                              $schedule   The name of the schedule responsible for triggering the task
      * @param string|null                         $method     The method to run as the task when the attribute target is a class
      * @param string[]|string|null                $transports One or many transports through which the message scheduling the task will go
+     * @param string|null                         $id         Unique identifier (within the schedule) for the task for manual invocation
      */
     public function __construct(
         public readonly string $expression,
@@ -39,6 +40,7 @@ class AsCronTask
         public readonly string $schedule = 'default',
         public readonly ?string $method = null,
         public readonly array|string|null $transports = null,
+        public readonly ?string $id = null,
     ) {
     }
 }

--- a/src/Symfony/Component/Scheduler/Attribute/AsPeriodicTask.php
+++ b/src/Symfony/Component/Scheduler/Attribute/AsPeriodicTask.php
@@ -31,6 +31,7 @@ class AsPeriodicTask
      * @param string                              $schedule   The name of the schedule responsible for triggering the task
      * @param string|null                         $method     The method to run as the task when the attribute target is a class
      * @param string[]|string|null                $transports One or many transports through which the message scheduling the task will go
+     * @param string|null                         $id         Unique identifier (within the schedule) for the task for manual invocation
      */
     public function __construct(
         public readonly string|int $frequency,
@@ -41,6 +42,7 @@ class AsPeriodicTask
         public readonly string $schedule = 'default',
         public readonly ?string $method = null,
         public readonly array|string|null $transports = null,
+        public readonly ?string $id = null,
     ) {
     }
 }

--- a/src/Symfony/Component/Scheduler/Command/DebugCommand.php
+++ b/src/Symfony/Component/Scheduler/Command/DebugCommand.php
@@ -94,7 +94,7 @@ final class DebugCommand extends Command
                 continue;
             }
             $io->table(
-                ['Trigger', 'Provider', 'Next Run'],
+                ['ID', 'Trigger', 'Provider', 'Next Run'],
                 array_filter(array_map(self::renderRecurringMessage(...), $messages, array_fill(0, \count($messages), $date), array_fill(0, \count($messages), $input->getOption('all')))),
             );
         }
@@ -117,6 +117,6 @@ final class DebugCommand extends Command
         $provider = $recurringMessage->getProvider();
         $description = $provider instanceof \Stringable ? (string) $provider : $provider->getId();
 
-        return [(string) $trigger, $description, $next];
+        return [$recurringMessage->getId(), (string) $trigger, $description, $next];
     }
 }

--- a/src/Symfony/Component/Scheduler/Command/RunTaskCommand.php
+++ b/src/Symfony/Component/Scheduler/Command/RunTaskCommand.php
@@ -1,0 +1,133 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Scheduler\Command;
+
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\WorkerMessageReceivedEvent;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Transport\Receiver\SingleMessageReceiver;
+use Symfony\Component\Messenger\Worker;
+use Symfony\Component\Scheduler\Generator\MessageContext;
+use Symfony\Component\Scheduler\ScheduleProviderInterface;
+use Symfony\Contracts\Service\ServiceProviderInterface;
+
+/**
+ * Command to run a task immediately
+ *
+ * @author valtzu <valtzu@gmail.com>
+ */
+#[AsCommand(name: 'scheduler:task:run', description: 'Run single scheduler task now')]
+final class RunTaskCommand extends Command
+{
+    private array $scheduleNames;
+
+    public function __construct(
+        private readonly ServiceProviderInterface $schedules,
+        private readonly MessageBusInterface $messageBus,
+        private readonly ContainerInterface $receiverLocator,
+        private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly ?LoggerInterface $logger = null,
+    ) {
+        $this->scheduleNames = array_keys($this->schedules->getProvidedServices());
+
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('task', InputArgument::REQUIRED, 'The ID of the task to run')
+            ->addOption('schedule', 's', InputOption::VALUE_REQUIRED, \sprintf('The schedule name (one of "%s")', implode('", "', $this->scheduleNames)), 'default', $this->scheduleNames)
+            ->setHelp(<<<'EOF'
+                The <info>%command.name%</info> runs or dispatches a single scheduled task, ignoring its schedule:
+
+                  <info>php %command.full_name% example_task_id</info>
+
+                Or for a specific schedule:
+
+                  <info>php %command.full_name% --schedule=default example_task_id</info>
+
+                EOF
+            )
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $name = $input->getOption('schedule');
+
+        if (!$this->schedules->has($name)) {
+            $io->error(\sprintf('Schedule %s not found.', $name));
+
+            return 2;
+        }
+
+        /** @var ScheduleProviderInterface $schedule */
+        $schedule = $this->schedules->get($name);
+        if (!$messages = $schedule->getSchedule()->getRecurringMessages()) {
+            $io->warning(\sprintf('No recurring messages found for schedule "%s".', $name));
+
+            return 3;
+        }
+
+        $id = $input->getArgument('task');
+        $found = false;
+        foreach ($messages as $recurringMessage) {
+            if ($recurringMessage->getId() !== $id) {
+                continue;
+            }
+
+            $provider = $recurringMessage->getProvider();
+            $description = ($provider instanceof \Stringable ? (string)$provider : $provider->getId());
+            $context = new MessageContext($name, $recurringMessage->getId(), $recurringMessage->getTrigger(), new \DateTimeImmutable());
+            $io->info(\sprintf('Running task "%s"', $description));
+
+            foreach ($provider->getMessages($context) as $message) {
+                $found = true;
+                $singleReceiver = new SingleMessageReceiver($this->receiverLocator->get('scheduler_' . $name), Envelope::wrap($message));
+                $worker = new Worker(
+                    [$name => $singleReceiver],
+                    $this->messageBus,
+                    $this->eventDispatcher,
+                    $this->logger,
+                );
+
+                $this->eventDispatcher->addListener(WorkerMessageReceivedEvent::class, $listener = $worker->stop(...));
+                try {
+                    $worker->run();
+                } finally {
+                    $this->eventDispatcher->removeListener(WorkerMessageReceivedEvent::class, $listener);
+                }
+            }
+        }
+
+        if (!$found) {
+            $io->error(\sprintf('No task with ID "%s" found in schedule "%s".', $id, $name));
+            return 3;
+        }
+
+        $io->success('Task finished successfully.');
+
+        return 0;
+    }
+}

--- a/src/Symfony/Component/Scheduler/DependencyInjection/AddScheduleMessengerPass.php
+++ b/src/Symfony/Component/Scheduler/DependencyInjection/AddScheduleMessengerPass.php
@@ -66,6 +66,7 @@ class AddScheduleMessengerPass implements CompilerPassInterface
 
                 $taskArguments = [
                     '$message' => $message,
+                    '$id' => $tagAttributes['id'] ?? null,
                 ] + array_filter(match ($tagAttributes['trigger'] ?? throw new InvalidArgumentException(\sprintf('Tag "scheduler.task" is missing attribute "trigger" on service "%s".', $serviceId))) {
                     'every' => [
                         '$frequency' => $tagAttributes['frequency'] ?? throw new InvalidArgumentException(\sprintf('Tag "scheduler.task" is missing attribute "frequency" on service "%s".', $serviceId)),

--- a/src/Symfony/Component/Scheduler/RecurringMessage.php
+++ b/src/Symfony/Component/Scheduler/RecurringMessage.php
@@ -22,11 +22,10 @@ use Symfony\Component\Scheduler\Trigger\TriggerInterface;
 
 final class RecurringMessage implements MessageProviderInterface
 {
-    private string $id;
-
     private function __construct(
         private readonly TriggerInterface $trigger,
         private readonly MessageProviderInterface $provider,
+        private ?string $id = null,
     ) {
     }
 
@@ -45,34 +44,34 @@ final class RecurringMessage implements MessageProviderInterface
      * @see https://en.wikipedia.org/wiki/ISO_8601#Durations
      * @see https://php.net/datetime.formats#datetime.formats.relative
      */
-    public static function every(string|int|\DateInterval $frequency, object $message, string|\DateTimeImmutable|null $from = null, string|\DateTimeImmutable $until = new \DateTimeImmutable('3000-01-01')): self
+    public static function every(string|int|\DateInterval $frequency, object $message, string|\DateTimeImmutable|null $from = null, string|\DateTimeImmutable $until = new \DateTimeImmutable('3000-01-01'), ?string $id = null): self
     {
-        return self::trigger(new PeriodicalTrigger($frequency, $from, $until), $message);
+        return self::trigger(new PeriodicalTrigger($frequency, $from, $until), $message, $id);
     }
 
     /**
      * @param MessageProviderInterface|object $message A message provider that yields messages or a static message that will be dispatched on every trigger
      */
-    public static function cron(string $expression, object $message, \DateTimeZone|string|null $timezone = null): self
+    public static function cron(string $expression, object $message, \DateTimeZone|string|null $timezone = null, ?string $id = null): self
     {
         if (!str_contains($expression, '#')) {
-            return self::trigger(CronExpressionTrigger::fromSpec($expression, null, $timezone), $message);
+            return self::trigger(CronExpressionTrigger::fromSpec($expression, null, $timezone), $message, $id);
         }
 
         if (!$message instanceof \Stringable) {
             throw new InvalidArgumentException('A message must be stringable to use "hashed" cron expressions.');
         }
 
-        return self::trigger(CronExpressionTrigger::fromSpec($expression, (string) $message, $timezone), $message);
+        return self::trigger(CronExpressionTrigger::fromSpec($expression, (string) $message, $timezone), $message, $id);
     }
 
     /**
      * @param MessageProviderInterface|object $message A message provider that yields messages or a static message that will be dispatched on every trigger
      */
-    public static function trigger(TriggerInterface $trigger, object $message): self
+    public static function trigger(TriggerInterface $trigger, object $message, ?string $id = null): self
     {
         if ($message instanceof MessageProviderInterface) {
-            return new self($trigger, $message);
+            return new self($trigger, $message, $id);
         }
 
         $description = $message::class;
@@ -83,12 +82,12 @@ final class RecurringMessage implements MessageProviderInterface
             }
         }
 
-        return new self($trigger, new StaticMessageProvider([$message], strtr(substr(base64_encode(hash('xxh128', serialize($message), true)), 0, 7), '/+', '._'), $description));
+        return new self($trigger, new StaticMessageProvider([$message], strtr(substr(base64_encode(hash('xxh128', serialize($message), true)), 0, 7), '/+', '._'), $description), $id);
     }
 
     public function withJitter(int $maxSeconds = 60): self
     {
-        return new self(new JitterTrigger($this->trigger, $maxSeconds), $this->provider);
+        return new self(new JitterTrigger($this->trigger, $maxSeconds), $this->provider, $this->id);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #58973
| License       | MIT

Alternate solution to #58974. This solution should work with any type of schedules and messages.

#### What is done here

##### 1) add possibility to set id on tasks

_(This could be done in separate PR with nr. 2)_

```php
#[AsPeriodicTask(frequency: 5, arguments: ['Hello from periodic trigger'], id: 'business_logic')]
```

##### 2 ) Show IDs in `debug:scheduler` output

```bash
$ bin/console debug:scheduler

Scheduler
=========

default
-------

 ---------------- ---------------------------------------- --------------------------------------------------------------------------------------------------- --------------------------------- 
  ID               Trigger                                  Provider                                                                                            Next Run                         
 ---------------- ---------------------------------------- --------------------------------------------------------------------------------------------------- --------------------------------- 
  business_logic   every 5 seconds with 0-1 second jitter   Symfony\Component\Scheduler\Messenger\ServiceCallMessage (@App\BusinessLogic)                       Tue, 03 Dec 2024 18:40:57 +0000  
  084254e4         0 9-17 * * *                             Symfony\Component\Messenger\Message\RedispatchMessage (@some_other_service::someMethod via async)   Wed, 04 Dec 2024 09:00:00 +0000  
  b90182f5         0 20-23 * * *                            Symfony\Component\Scheduler\Messenger\ServiceCallMessage (@some_other_service::someOtherMethod)     Tue, 03 Dec 2024 20:00:00 +0000  
 ---------------- ---------------------------------------- --------------------------------------------------------------------------------------------------- --------------------------------- 

```

##### 3) Add a command `scheduler:task:run` to run a single task

```bash
$ bin/console scheduler:task:run business_logic

                                                                                                                        
 [INFO] Running task "Symfony\Component\Scheduler\Messenger\ServiceCallMessage (@App\BusinessLogic)"                    
                                                                                                                        

[alert] [2024-12-03T18:42:56+00:00] Hello from periodic trigger
                                                                                                                        
 [OK] Task finished successfully.                                                                                       
                                                                                                                        
```

#### Other thoughts

In general, I'm not sure if this feature should exists since it is kind of an alternative way to define console commands – it'd be cool if we could use `#[AsCommand('business_logic')]` on any method / invokable class instead.


#### Todo:
1. tests (help is welcome)
2. changelog