### PR TITLE
[FrameworkBundle] Make uri_signer lazy and improve error when kernel.secret is empty

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -310,10 +310,17 @@ class FrameworkExtension extends Extension
             }
         }
 
+        $emptySecretHint = '"framework.secret" option';
         if (isset($config['secret'])) {
             $container->setParameter('kernel.secret', $config['secret']);
+            $usedEnvs = [];
+            $container->resolveEnvPlaceholders($config['secret'], null, $usedEnvs);
+
+            if ($usedEnvs) {
+                $emptySecretHint = \sprintf('"%s" env var%s', implode('", "', $usedEnvs), 1 === \count($usedEnvs) ? '' : 's');
+            }
         }
-        $container->parameterCannotBeEmpty('kernel.secret', 'A non-empty value for the parameter "kernel.secret" is required. Did you forget to configure the "framework.secret" option?');
+        $container->parameterCannotBeEmpty('kernel.secret', 'A non-empty value for the parameter "kernel.secret" is required. Did you forget to configure the '.$emptySecretHint.'?');
 
         $container->setParameter('kernel.http_method_override', $config['http_method_override']);
         $container->setParameter('kernel.trust_x_sendfile_type_header', $config['trust_x_sendfile_type_header']);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
@@ -157,6 +157,7 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 new Parameter('kernel.secret'),
             ])
+            ->lazy()
         ->alias(UriSigner::class, 'uri_signer')
 
         ->set('config_cache_factory', ResourceCheckerConfigCacheFactory::class)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Some polishing found while delivering The Fast Track workshop at SymfonyCon Vienna ;)

The profiler is currently broken if `APP_SECRET` is empty, and the reason is that the twig extension that provides the `render()` function has a dependency on `uri_signer`. Since this dep is not used by the profiler, this error is a false positive. Making the `uri_signer` service lazy resolves the issue.

Before that, I noticed that the error message was sub-optimal, telling about `framework.secret` being unconfigured, while it was (but the env var was not).