### PR TITLE
[DependencyInjection] Make `#[AsTaggedItem]` repeatable

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/AsTaggedItem.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/AsTaggedItem.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\DependencyInjection\Attribute;
  *
  * @author Nicolas Grekas <p@tchwork.com>
  */
-#[\Attribute(\Attribute::TARGET_CLASS)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 class AsTaggedItem
 {
     /**

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.3
+---
+
+ * Make `#[AsTaggedItem]` repeatable
+
 7.2
 ---
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
@@ -92,6 +92,21 @@ trait PriorityTaggedServiceTrait
 
                 $services[] = [$priority, ++$i, $index, $serviceId, $class];
             }
+
+            if ($class) {
+                $attributes = (new \ReflectionClass($class))->getAttributes(AsTaggedItem::class);
+                $attributeCount = \count($attributes);
+
+                foreach ($attributes as $attribute) {
+                    $instance = $attribute->newInstance();
+
+                    if (!$instance->index && 1 < $attributeCount) {
+                        throw new InvalidArgumentException(\sprintf('Attribute "%s" on class "%s" cannot have an empty index when repeated.', AsTaggedItem::class, $class));
+                    }
+
+                    $services[] = [$instance->priority ?? 0, ++$i, $instance->index ?? $serviceId, $serviceId, $class];
+                }
+            }
         }
 
         uasort($services, static fn ($a, $b) => $b[0] <=> $a[0] ?: $a[1] <=> $b[1]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #59085
| License       | MIT

Allow to repeat the `AsTaggedItem` attribute:

```php
#[AsTaggedItem(index: 'multi_hello_1', priority: 1)]
#[AsTaggedItem(index: 'multi_hello_2', priority: 2)]
class MultiTagHelloNamedService
{
}
```