### PR TITLE
Add CI job for PHP 8.5

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -33,6 +33,7 @@ jobs:
             mode: low-deps
           - php: '8.3'
           - php: '8.4'
+          - php: '8.5'
             #mode: experimental
       fail-fast: false
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Enables PHP 8.5 nightlies on the CI.

What motivated this early addition is the continuous effort of converting resources to actual classes. PHP 8.5 already embeds features like https://wiki.php.net/rfc/directory-opaque-object, which could already be handled in PRs such as #59035.

Also we'll be able to fix future deprecations as soon as they appear during the next year.