### PR TITLE
[Mailer] [sendgrid-mailer] Fix null check on region

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridSmtpTransport.php
@@ -22,7 +22,7 @@ class SendgridSmtpTransport extends EsmtpTransport
 {
     public function __construct(#[\SensitiveParameter] string $key, ?EventDispatcherInterface $dispatcher = null, ?LoggerInterface $logger = null, private ?string $region = null)
     {
-        parent::__construct('null' !== $region ? \sprintf('smtp.%s.sendgrid.net', $region) : 'smtp.sendgrid.net', 465, true, $dispatcher, $logger);
+        parent::__construct(null !== $region ? \sprintf('smtp.%s.sendgrid.net', $region) : 'smtp.sendgrid.net', 465, true, $dispatcher, $logger);
 
         $this->setUsername('apikey');
         $this->setPassword($key);


### PR DESCRIPTION
Fix region null check

| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Issue : 
Nullable check on region is wrong.
