### PR TITLE
[HttpClient] Test POST to GET redirects

### DIFF
--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
@@ -673,4 +673,26 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
         $this->assertIsArray($vars);
         $this->assertSame('HEAD', $vars['REQUEST_METHOD']);
     }
+
+    /**
+     * @testWith [301]
+     *           [302]
+     *           [303]
+     */
+    public function testPostToGetRedirect(int $status)
+    {
+        $p = TestHttpServer::start(8067);
+
+        try {
+            $client = $this->getHttpClient(__FUNCTION__);
+
+            $response = $client->request('POST', 'http://localhost:8057/custom?status=' . $status . '&headers[]=Location%3A%20%2F');
+            $body = $response->toArray();
+        } finally {
+            $p->stop();
+        }
+
+        $this->assertSame('GET', $body['REQUEST_METHOD']);
+        $this->assertSame('/', $body['REQUEST_URI']);
+    }
 }

--- a/src/Symfony/Contracts/HttpClient/Test/Fixtures/web/index.php
+++ b/src/Symfony/Contracts/HttpClient/Test/Fixtures/web/index.php
@@ -199,6 +199,16 @@ switch (parse_url($vars['REQUEST_URI'], \PHP_URL_PATH)) {
         ]);
 
         exit;
+
+    case '/custom':
+        if (isset($_GET['status'])) {
+            http_response_code((int) $_GET['status']);
+        }
+        if (isset($_GET['headers']) && is_array($_GET['headers'])) {
+            foreach ($_GET['headers'] as $header) {
+                header($header);
+            }
+        }
 }
 
 header('Content-Type: application/json', true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | idk
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

In a discussion in #59062 after that pull request was already merged, it was suggested that the changes of that pull request might break POST-to-GET redirects. While it turned out that they do not because of how Symfony handles redirects, but I thought it might be a good idea to just test this.