### PR TITLE
[Mailer] When using Sendgrid with SMTP and no region, host is built incorrectly

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridSmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridSmtpTransportTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\Sendgrid\Tests\Transport;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\Bridge\Sendgrid\Transport\SendgridSmtpTransport;
+
+class SendgridSmtpTransportTest extends TestCase
+{
+    /**
+     * @dataProvider getTransportData
+     */
+    public function testToString(SendgridSmtpTransport $transport, string $expected)
+    {
+        $this->assertSame($expected, (string) $transport);
+    }
+
+    public static function getTransportData()
+    {
+        return [
+            [
+                new SendgridSmtpTransport('KEY'),
+                'smtps://smtp.sendgrid.net',
+            ],
+            [
+                new SendgridSmtpTransport('KEY', null, null, 'eu'),
+                'smtps://smtp.eu.sendgrid.net',
+            ],
+        ];
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridSmtpTransport.php
@@ -22,7 +22,7 @@ class SendgridSmtpTransport extends EsmtpTransport
 {
     public function __construct(#[\SensitiveParameter] string $key, ?EventDispatcherInterface $dispatcher = null, ?LoggerInterface $logger = null, private ?string $region = null)
     {
-        parent::__construct('null' !== $region ? \sprintf('smtp.%s.sendgrid.net', $region) : 'smtp.sendgrid.net', 465, true, $dispatcher, $logger);
+        parent::__construct(null !== $region ? \sprintf('smtp.%s.sendgrid.net', $region) : 'smtp.sendgrid.net', 465, true, $dispatcher, $logger);
 
         $this->setUsername('apikey');
         $this->setPassword($key);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

When using Sendgrid with SMTP and no region, host is built incorrectly. This bug basically breaks sending emails via SMTP with Sengrid if there is no region configured.

Added failing test with current code:

![image](https://github.com/user-attachments/assets/c4bfa4ef-b868-427f-8470-f5b318171e08)

After fix:

![image](https://github.com/user-attachments/assets/fbda5a59-5cfc-409a-bab1-48c9f35091b0)

