### PR TITLE
[Messenger] ensure exception on rollback does not hide previous exception

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Messenger/DoctrineTransactionMiddleware.php
+++ b/src/Symfony/Bridge/Doctrine/Messenger/DoctrineTransactionMiddleware.php
@@ -27,15 +27,17 @@ class DoctrineTransactionMiddleware extends AbstractDoctrineMiddleware
     protected function handleForManager(EntityManagerInterface $entityManager, Envelope $envelope, StackInterface $stack): Envelope
     {
         $entityManager->getConnection()->beginTransaction();
+
+        $success = false;
         try {
             $envelope = $stack->next()->handle($envelope, $stack);
             $entityManager->flush();
             $entityManager->getConnection()->commit();
 
+            $success = true;
+
             return $envelope;
         } catch (\Throwable $exception) {
-            $entityManager->getConnection()->rollBack();
-
             if ($exception instanceof HandlerFailedException) {
                 // Remove all HandledStamp from the envelope so the retry will execute all handlers again.
                 // When a handler fails, the queries of allegedly successful previous handlers just got rolled back.
@@ -43,6 +45,12 @@ class DoctrineTransactionMiddleware extends AbstractDoctrineMiddleware
             }
 
             throw $exception;
+        } finally {
+            $connection = $entityManager->getConnection();
+
+            if (!$success && $connection->isTransactionActive()) {
+                $connection->rollBack();
+            }
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Hello,

this is kinda related to https://github.com/doctrine/orm/issues/11230 and https://github.com/doctrine/orm/pull/11646

I propose to use the same logic in `DoctrineTransactionMiddleware` than in https://github.com/doctrine/orm/pull/11646 towards rollback: currently if an error occurs in the rollback (for example, the infamous `SAVEPOINT DOCTRINE_2 does not exist`), the previous error is hidden, because the error should not occur in the `catch`.

ping @ro0NL 

_EDIt: failure in CI is unrelated to this PR_