### PR TITLE
[Security] Deprecate `UserInterface` & `TokenInterface`'s `eraseCredentials()`

### DIFF
--- a/UPGRADE-7.3.md
+++ b/UPGRADE-7.3.md
@@ -6,7 +6,23 @@ backward compatibility breaks. Minor backward compatibility breaks are prefixed 
 `[BC BREAK]`, make sure your code is compatible with these entries before upgrading.
 Read more about this in the [Symfony documentation](https://symfony.com/doc/7.3/setup/upgrade_minor.html).
 
-If you're upgrading from a version below 7.1, follow the [7.2 upgrade guide](UPGRADE-7.2.md) first.
+If you're upgrading from a version below 7.2, follow the [7.2 upgrade guide](UPGRADE-7.2.md) first.
+
+Ldap
+----
+
+ * Deprecate `LdapUser::eraseCredentials()`, use `LdapUser::setPassword(null)` instead
+
+Security
+--------
+
+ * Deprecate `UserInterface::eraseCredentials()` and `TokenInterface::eraseCredentials()`,
+   use a dedicated DTO or erase credentials on your own e.g. upon `AuthenticationTokenCreatedEvent` instead
+
+SecurityBundle
+--------------
+
+ * Deprecate the `erase_credentials` config option, erase credentials on your own e.g. upon `AuthenticationTokenCreatedEvent` instead
 
 Console
 -------
@@ -109,3 +125,4 @@ VarDumper
 
  * Deprecate `ResourceCaster::castCurl()`, `ResourceCaster::castGd()` and `ResourceCaster::castOpensslX509()`
  * Mark all casters as `@internal`
+ * Deprecate the `CompiledClassMetadataFactory` and `CompiledClassMetadataCacheWarmer` classes

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/CacheAttributeListener/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/CacheAttributeListener/config.yml
@@ -10,6 +10,7 @@ services:
         public: true
 
 security:
+    erase_credentials: false
     providers:
         main:
             memory:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Security/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Security/config.yml
@@ -8,6 +8,7 @@ services:
             - container.service_subscriber
 
 security:
+    erase_credentials: false
     providers:
         main:
             memory:

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add `Security::isGrantedForUser()` to test user authorization without relying on the session. For example, users not currently logged in, or while processing a message from a message queue
  * Add encryption support to `OidcTokenHandler` (JWE)
+ * Deprecate the `erase_credentials` config option, erase credentials on your own e.g. upon `AuthenticationTokenCreatedEvent` instead
 
 7.2
 ---

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LdapFactoryTrait.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LdapFactoryTrait.php
@@ -16,6 +16,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Ldap\Security\CheckLdapCredentialsListener;
+use Symfony\Component\Ldap\Security\EraseLdapUserCredentialsListener;
 use Symfony\Component\Ldap\Security\LdapAuthenticator;
 
 /**
@@ -41,6 +42,12 @@ trait LdapFactoryTrait
             ->addTag('kernel.event_subscriber', ['dispatcher' => 'security.event_dispatcher.'.$firewallName])
             ->addArgument(new Reference('security.ldap_locator'))
         ;
+
+        if (class_exists(EraseLdapUserCredentialsListener::class && !$container->getParameter('security.authentication.manager.erase_credentials'))) {
+            $container->setDefinition('security.listener.'.$key.'.'.$firewallName.'erase_ldap_credentials', new Definition(EraseLdapUserCredentialsListener::class))
+                ->addTag('kernel.event_subscriber', ['dispatcher' => 'security.event_dispatcher.'.$firewallName])
+            ;
+        }
 
         $ldapAuthenticatorId = 'security.authenticator.'.$key.'.'.$firewallName;
         $definition = $container->setDefinition($ldapAuthenticatorId, new Definition(LdapAuthenticator::class))

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -135,6 +135,9 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
 
         // set some global scalars
         $container->setParameter('security.access.denied_url', $config['access_denied_url']);
+        if (true === $config['erase_credentials']) {
+            trigger_deprecation('symfony/security-bundle', '7.3', 'Setting the "security.erase_credentials" config option to true is deprecated and won\'t have any effect in 8.0, set it to false instead and use your own erasing logic if needed.');
+        }
         $container->setParameter('security.authentication.manager.erase_credentials', $config['erase_credentials']);
         $container->setParameter('security.authentication.session_strategy.strategy', $config['session_fixation_strategy']);
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Debug/TraceableFirewallListenerTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Debug/TraceableFirewallListenerTest.php
@@ -103,7 +103,9 @@ class TraceableFirewallListenerTest extends TestCase
             [new TraceableAuthenticator($notSupportingAuthenticator), new TraceableAuthenticator($supportingAuthenticator)],
             $tokenStorage,
             $dispatcher,
-            'main'
+            'main',
+            null,
+            false
         );
 
         $listener = new TraceableAuthenticatorManagerListener(new AuthenticatorManagerListener($authenticatorManager));

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSessionDomainConstraintPassTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSessionDomainConstraintPassTest.php
@@ -139,6 +139,7 @@ class AddSessionDomainConstraintPassTest extends TestCase
 
         $config = [
             'security' => [
+                'erase_credentials' => false,
                 'providers' => ['some_provider' => ['id' => 'foo']],
                 'firewalls' => ['some_firewall' => ['security' => false]],
             ],

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/MakeFirewallsEventDispatcherTraceablePassTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/MakeFirewallsEventDispatcherTraceablePassTest.php
@@ -34,6 +34,7 @@ class MakeFirewallsEventDispatcherTraceablePassTest extends TestCase
 
         $this->container->registerExtension(new SecurityExtension());
         $this->container->loadFromExtension('security', [
+            'erase_credentials' => false,
             'firewalls' => ['main' => ['pattern' => '/', 'http_basic' => true]],
         ]);
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/RegisterGlobalSecurityEventListenersPassTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/RegisterGlobalSecurityEventListenersPassTest.php
@@ -56,6 +56,7 @@ class RegisterGlobalSecurityEventListenersPassTest extends TestCase
     public function testEventIsPropagated(string $configuredEvent, string $registeredEvent)
     {
         $this->container->loadFromExtension('security', [
+            'erase_credentials' => false,
             'firewalls' => ['main' => ['pattern' => '/', 'http_basic' => true]],
         ]);
 
@@ -89,6 +90,7 @@ class RegisterGlobalSecurityEventListenersPassTest extends TestCase
     public function testRegisterCustomListener()
     {
         $this->container->loadFromExtension('security', [
+            'erase_credentials' => false,
             'firewalls' => ['main' => ['pattern' => '/', 'http_basic' => true]],
         ]);
 
@@ -109,6 +111,7 @@ class RegisterGlobalSecurityEventListenersPassTest extends TestCase
     public function testRegisterCustomSubscriber()
     {
         $this->container->loadFromExtension('security', [
+            'erase_credentials' => false,
             'firewalls' => ['main' => ['pattern' => '/', 'http_basic' => true]],
         ]);
 
@@ -128,6 +131,7 @@ class RegisterGlobalSecurityEventListenersPassTest extends TestCase
     public function testMultipleFirewalls()
     {
         $this->container->loadFromExtension('security', [
+            'erase_credentials' => false,
             'firewalls' => ['main' => ['pattern' => '/', 'http_basic' => true], 'api' => ['pattern' => '/api', 'http_basic' => true]],
         ]);
 
@@ -157,6 +161,7 @@ class RegisterGlobalSecurityEventListenersPassTest extends TestCase
     public function testListenerAlreadySpecific()
     {
         $this->container->loadFromExtension('security', [
+            'erase_credentials' => false,
             'firewalls' => ['main' => ['pattern' => '/', 'http_basic' => true]],
         ]);
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/access_decision_manager_customized_config.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/access_decision_manager_customized_config.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('security', [
+    'erase_credentials' => false,
     'access_decision_manager' => [
         'allow_if_all_abstain' => true,
         'allow_if_equal_granted_denied' => false,

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/access_decision_manager_default_strategy.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/access_decision_manager_default_strategy.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('security', [
+    'erase_credentials' => false,
     'providers' => [
         'default' => [
             'memory' => [

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/access_decision_manager_service.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/access_decision_manager_service.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('security', [
+    'erase_credentials' => false,
     'access_decision_manager' => [
         'service' => 'app.access_decision_manager',
     ],

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/access_decision_manager_service_and_strategy.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/access_decision_manager_service_and_strategy.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('security', [
+    'erase_credentials' => false,
     'access_decision_manager' => [
         'service' => 'app.access_decision_manager',
         'strategy' => 'affirmative',

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/access_decision_manager_strategy_service.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/access_decision_manager_strategy_service.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('security', [
+    'erase_credentials' => false,
     'access_decision_manager' => [
         'strategy_service' => 'app.custom_access_decision_strategy',
     ],

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/argon2i_hasher.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/argon2i_hasher.php
@@ -3,6 +3,7 @@
 $this->load('container1.php');
 
 $container->loadFromExtension('security', [
+    'erase_credentials' => false,
     'password_hashers' => [
         'JMS\FooBundle\Entity\User7' => [
             'algorithm' => 'argon2i',

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/authenticator_manager.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/authenticator_manager.php
@@ -3,6 +3,7 @@
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\CsrfTokenBadge;
 
 $container->loadFromExtension('security', [
+    'erase_credentials' => false,
     'firewalls' => [
         'main' => [
             'required_badges' => [CsrfTokenBadge::class, 'RememberMeBadge'],

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/bcrypt_hasher.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/bcrypt_hasher.php
@@ -3,6 +3,7 @@
 $this->load('container1.php');
 
 $container->loadFromExtension('security', [
+    'erase_credentials' => false,
     'password_hashers' => [
         'JMS\FooBundle\Entity\User7' => [
             'algorithm' => 'bcrypt',

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('security', [
+    'erase_credentials' => false,
     'password_hashers' => [
         'JMS\FooBundle\Entity\User1' => 'plaintext',
         'JMS\FooBundle\Entity\User2' => [

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/firewall_patterns.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/firewall_patterns.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('security', [
+    'erase_credentials' => false,
     'firewalls' => [
         'no_security' => [
             'pattern' => [

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/firewall_provider.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/firewall_provider.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('security', [
+    'erase_credentials' => false,
     'providers' => [
         'default' => [
             'memory' => $memory = [

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/firewall_undefined_provider.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/firewall_undefined_provider.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('security', [
+    'erase_credentials' => false,
     'providers' => [
         'default' => [
             'memory' => [

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/listener_provider.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/listener_provider.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('security', [
+    'erase_credentials' => false,
     'providers' => [
         'default' => [
             'memory' => [

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/listener_undefined_provider.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/listener_undefined_provider.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('security', [
+    'erase_credentials' => false,
     'providers' => [
         'default' => [
             'memory' => [

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/logout_clear_site_data.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/logout_clear_site_data.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('security', [
+    'erase_credentials' => false,
     'providers' => [
         'default' => ['id' => 'foo'],
     ],

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/merge.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/merge.php
@@ -3,6 +3,7 @@
 $this->load('merge_import.php');
 
 $container->loadFromExtension('security', [
+    'erase_credentials' => false,
     'providers' => [
         'default' => ['id' => 'foo'],
     ],

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/merge_import.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/merge_import.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('security', [
+    'erase_credentials' => false,
     'firewalls' => [
         'main' => [
             'form_login' => [

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/migrating_hasher.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/migrating_hasher.php
@@ -3,6 +3,7 @@
 $this->load('container1.php');
 
 $container->loadFromExtension('security', [
+    'erase_credentials' => false,
     'password_hashers' => [
         'JMS\FooBundle\Entity\User7' => [
             'algorithm' => 'argon2i',

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/no_custom_user_checker.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/no_custom_user_checker.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('security', [
+    'erase_credentials' => false,
     'providers' => [
         'default' => [
             'memory' => [

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/remember_me_options.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/remember_me_options.php
@@ -1,6 +1,7 @@
 <?php
 
 $container->loadFromExtension('security', [
+    'erase_credentials' => false,
     'providers' => [
         'default' => ['id' => 'foo'],
     ],

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/sodium_hasher.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/sodium_hasher.php
@@ -3,6 +3,7 @@
 $this->load('container1.php');
 
 $container->loadFromExtension('security', [
+    'erase_credentials' => false,
     'password_hashers' => [
         'JMS\FooBundle\Entity\User7' => [
             'algorithm' => 'sodium',

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/access_decision_manager_customized_config.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/access_decision_manager_customized_config.xml
@@ -7,7 +7,7 @@
         http://symfony.com/schema/dic/security
         https://symfony.com/schema/dic/security/security-1.0.xsd">
 
-    <config>
+    <config erase-credentials="false">
         <access-decision-manager allow-if-all-abstain="true" allow-if-equal-granted-denied="false" />
 
         <provider name="default">

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/access_decision_manager_default_strategy.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/access_decision_manager_default_strategy.xml
@@ -7,7 +7,7 @@
         http://symfony.com/schema/dic/security
         https://symfony.com/schema/dic/security/security-1.0.xsd">
 
-    <config>
+    <config erase-credentials="false">
         <provider name="default">
             <memory>
                 <user identifier="foo" password="foo" roles="ROLE_USER" />

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/access_decision_manager_service.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/access_decision_manager_service.xml
@@ -7,7 +7,7 @@
         http://symfony.com/schema/dic/security
         https://symfony.com/schema/dic/security/security-1.0.xsd">
 
-    <config>
+    <config erase-credentials="false">
         <access-decision-manager service="app.access_decision_manager" />
 
         <provider name="default">

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/access_decision_manager_service_and_strategy.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/access_decision_manager_service_and_strategy.xml
@@ -7,7 +7,7 @@
         http://symfony.com/schema/dic/security
         https://symfony.com/schema/dic/security/security-1.0.xsd">
 
-    <config>
+    <config erase-credentials="false">
         <access-decision-manager service="app.access_decision_manager" strategy="affirmative" />
 
         <provider name="default">

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/access_decision_manager_strategy_service.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/access_decision_manager_strategy_service.xml
@@ -7,7 +7,7 @@
         http://symfony.com/schema/dic/security
         https://symfony.com/schema/dic/security/security-1.0.xsd">
 
-    <config>
+    <config erase-credentials="false">
         <access-decision-manager strategy-service="app.custom_access_decision_strategy" />
 
         <provider name="default">

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/argon2i_hasher.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/argon2i_hasher.xml
@@ -12,7 +12,7 @@
         <import resource="container1.xml"/>
     </imports>
 
-    <sec:config>
+    <sec:config erase-credentials="false">
         <sec:password_hasher class="JMS\FooBundle\Entity\User7" algorithm="argon2i" memory-cost="256" time-cost="1" />
     </sec:config>
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/authenticator_manager.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/authenticator_manager.xml
@@ -7,7 +7,7 @@
         http://symfony.com/schema/dic/security
         https://symfony.com/schema/dic/security/security-1.0.xsd">
 
-    <config>
+    <config erase-credentials="false">
         <firewall name="main">
             <required-badge>Symfony\Component\Security\Http\Authenticator\Passport\Badge\CsrfTokenBadge</required-badge>
             <required-badge>RememberMeBadge</required-badge>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/bcrypt_hasher.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/bcrypt_hasher.xml
@@ -12,7 +12,7 @@
         <import resource="container1.xml"/>
     </imports>
 
-    <sec:config>
+    <sec:config erase-credentials="false">
         <sec:password_hasher class="JMS\FooBundle\Entity\User7" algorithm="bcrypt" cost="15" />
     </sec:config>
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
@@ -8,7 +8,7 @@
         http://symfony.com/schema/dic/security
         https://symfony.com/schema/dic/security/security-1.0.xsd">
 
-    <config>
+    <config erase-credentials="false">
         <password_hasher class="JMS\FooBundle\Entity\User1" algorithm="plaintext" />
 
         <password_hasher class="JMS\FooBundle\Entity\User2" algorithm="sha1" encode-as-base64="false" iterations="5" />

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/custom_authenticator_under_own_namespace.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/custom_authenticator_under_own_namespace.xml
@@ -8,7 +8,7 @@
         http://symfony.com/schema/dic/security
         https://symfony.com/schema/dic/security/security-1.0.xsd">
 
-    <sec:config>
+    <sec:config erase-credentials="false">
         <sec:firewall name="main">
             <custom xmlns="http://example.com/schema" />
         </sec:firewall>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/custom_authenticator_under_security_namespace.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/custom_authenticator_under_security_namespace.xml
@@ -8,7 +8,7 @@
         http://symfony.com/schema/dic/security
         https://symfony.com/schema/dic/security/security-1.0.xsd">
 
-    <sec:config>
+    <sec:config erase-credentials="false">
         <sec:firewall name="main">
             <sec:custom />
         </sec:firewall>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/custom_provider_under_own_namespace.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/custom_provider_under_own_namespace.xml
@@ -8,7 +8,7 @@
         http://symfony.com/schema/dic/security
         https://symfony.com/schema/dic/security/security-1.0.xsd">
 
-    <sec:config>
+    <sec:config erase-credentials="false">
         <sec:provider name="foo">
             <custom xmlns="http://example.com/schema" />
         </sec:provider>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/custom_provider_under_security_namespace.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/custom_provider_under_security_namespace.xml
@@ -8,7 +8,7 @@
         http://symfony.com/schema/dic/security
         https://symfony.com/schema/dic/security/security-1.0.xsd">
 
-    <sec:config>
+    <sec:config erase-credentials="false">
         <sec:provider name="foo">
             <sec:custom />
         </sec:provider>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/firewall_provider.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/firewall_provider.xml
@@ -8,7 +8,7 @@
         http://symfony.com/schema/dic/security
         https://symfony.com/schema/dic/security/security-1.0.xsd">
 
-    <sec:config>
+    <sec:config erase-credentials="false">
         <sec:providers>
             <sec:provider name="with-dash" id="foo" />
         </sec:providers>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/firewall_undefined_provider.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/firewall_undefined_provider.xml
@@ -8,7 +8,7 @@
         http://symfony.com/schema/dic/security
         https://symfony.com/schema/dic/security/security-1.0.xsd">
 
-    <sec:config>
+    <sec:config erase-credentials="false">
         <sec:providers>
             <sec:provider name="default" id="foo" />
         </sec:providers>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/listener_provider.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/listener_provider.xml
@@ -8,7 +8,7 @@
         http://symfony.com/schema/dic/security
         https://symfony.com/schema/dic/security/security-1.0.xsd">
 
-    <sec:config>
+    <sec:config erase-credentials="false">
         <sec:providers>
             <sec:provider name="default" id="foo" />
         </sec:providers>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/listener_undefined_provider.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/listener_undefined_provider.xml
@@ -8,7 +8,7 @@
         http://symfony.com/schema/dic/security
         https://symfony.com/schema/dic/security/security-1.0.xsd">
 
-    <sec:config>
+    <sec:config erase-credentials="false">
         <sec:providers>
             <sec:provider name="default" id="foo" />
         </sec:providers>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/logout_clear_site_data.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/logout_clear_site_data.xml
@@ -8,7 +8,7 @@
         http://symfony.com/schema/dic/security
         https://symfony.com/schema/dic/security/security-1.0.xsd">
 
-    <config>
+    <config erase-credentials="false">
         <provider name="default" id="foo" />
 
         <firewall name="main" provider="default">

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/merge.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/merge.xml
@@ -12,7 +12,7 @@
         <import resource="merge_import.xml"/>
     </imports>
 
-    <sec:config>
+    <sec:config erase-credentials="false">
         <sec:provider name="default" id="foo" />
 
         <sec:firewall name="main" form-login="false">

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/merge_import.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/merge_import.xml
@@ -8,7 +8,7 @@
         http://symfony.com/schema/dic/security
         https://symfony.com/schema/dic/security/security-1.0.xsd">
 
-    <config>
+    <config erase-credentials="false">
         <firewall name="main">
             <form-login login-path="/login" />
         </firewall>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/migrating_hasher.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/migrating_hasher.xml
@@ -12,7 +12,7 @@
         <import resource="container1.xml"/>
     </imports>
 
-    <sec:config>
+    <sec:config erase-credentials="false">
         <sec:password_hasher class="JMS\FooBundle\Entity\User7" algorithm="argon2i" memory-cost="256" time-cost="1">
             <sec:migrate-from>bcrypt</sec:migrate-from>
         </sec:password_hasher>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/no_custom_user_checker.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/no_custom_user_checker.xml
@@ -7,7 +7,7 @@
         http://symfony.com/schema/dic/security
         https://symfony.com/schema/dic/security/security-1.0.xsd">
 
-    <config>
+    <config erase-credentials="false">
         <provider name="default">
             <memory>
                 <user identifier="foo" password="foo" roles="ROLE_USER" />

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/remember_me_options.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/remember_me_options.xml
@@ -8,7 +8,7 @@
     http://symfony.com/schema/dic/security
     https://symfony.com/schema/dic/security/security-1.0.xsd">
 
-    <sec:config>
+    <sec:config erase-credentials="false">
         <sec:providers>
             <sec:provider name="default" id="foo"/>
         </sec:providers>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/sodium_hasher.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/sodium_hasher.xml
@@ -12,7 +12,7 @@
         <import resource="container1.xml"/>
     </imports>
 
-    <sec:config>
+    <sec:config erase-credentials="false">
         <sec:password_hasher class="JMS\FooBundle\Entity\User7" algorithm="sodium" time-cost="8" memory-cost="131072" />
     </sec:config>
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/access_decision_manager_customized_config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/access_decision_manager_customized_config.yml
@@ -1,4 +1,5 @@
 security:
+    erase_credentials: false
     access_decision_manager:
         allow_if_all_abstain: true
         allow_if_equal_granted_denied: false

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/access_decision_manager_default_strategy.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/access_decision_manager_default_strategy.yml
@@ -1,4 +1,5 @@
 security:
+    erase_credentials: false
     providers:
         default:
             memory:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/access_decision_manager_service.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/access_decision_manager_service.yml
@@ -1,4 +1,5 @@
 security:
+    erase_credentials: false
     access_decision_manager:
         service: app.access_decision_manager
     providers:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/access_decision_manager_service_and_strategy.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/access_decision_manager_service_and_strategy.yml
@@ -1,4 +1,5 @@
 security:
+    erase_credentials: false
     access_decision_manager:
         service: app.access_decision_manager
         strategy: affirmative

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/access_decision_manager_strategy_service.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/access_decision_manager_strategy_service.yml
@@ -1,4 +1,5 @@
 security:
+    erase_credentials: false
     access_decision_manager:
         strategy_service: app.custom_access_decision_strategy
     providers:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/argon2i_hasher.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/argon2i_hasher.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: container1.yml }
 
 security:
+    erase_credentials: false
     password_hashers:
         JMS\FooBundle\Entity\User7:
             algorithm: argon2i

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/authenticator_manager.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/authenticator_manager.yml
@@ -1,4 +1,5 @@
 security:
+    erase_credentials: false
     firewalls:
         main:
             required_badges:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/bcrypt_hasher.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/bcrypt_hasher.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: container1.yml }
 
 security:
+    erase_credentials: false
     password_hashers:
         JMS\FooBundle\Entity\User7:
             algorithm: bcrypt

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
@@ -1,4 +1,5 @@
 security:
+    erase_credentials: false
     password_hashers:
         JMS\FooBundle\Entity\User1: plaintext
         JMS\FooBundle\Entity\User2:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/firewall_patterns.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/firewall_patterns.yml
@@ -1,4 +1,5 @@
 security:
+    erase_credentials: false
     firewalls:
         no_security:
             pattern:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/firewall_provider.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/firewall_provider.yml
@@ -1,4 +1,5 @@
 security:
+    erase_credentials: false
     providers:
         default:
             memory:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/firewall_undefined_provider.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/firewall_undefined_provider.yml
@@ -1,4 +1,5 @@
 security:
+    erase_credentials: false
     providers:
         default:
             memory:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/listener_provider.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/listener_provider.yml
@@ -1,4 +1,5 @@
 security:
+    erase_credentials: false
     providers:
         default:
             memory:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/listener_undefined_provider.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/listener_undefined_provider.yml
@@ -1,4 +1,5 @@
 security:
+    erase_credentials: false
     providers:
         default:
             memory:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/logout_clear_site_data.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/logout_clear_site_data.yml
@@ -1,4 +1,5 @@
 security:
+    erase_credentials: false
     providers:
         default:
             id: foo

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/merge.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/merge.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: merge_import.yml }
 
 security:
+    erase_credentials: false
     providers:
         default: { id: foo }
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/merge_import.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/merge_import.yml
@@ -1,4 +1,5 @@
 security:
+    erase_credentials: false
     firewalls:
         main:
             form_login:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/migrating_hasher.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/migrating_hasher.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: container1.yml }
 
 security:
+    erase_credentials: false
     password_hashers:
         JMS\FooBundle\Entity\User7:
             algorithm: argon2i

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/no_custom_user_checker.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/no_custom_user_checker.yml
@@ -1,4 +1,5 @@
 security:
+    erase_credentials: false
     providers:
         default:
             memory:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/remember_me_options.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/remember_me_options.yml
@@ -1,4 +1,5 @@
 security:
+    erase_credentials: false
     providers:
         default:
             id: foo

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/sodium_hasher.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/sodium_hasher.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: container1.yml }
 
 security:
+    erase_credentials: false
     password_hashers:
         JMS\FooBundle\Entity\User7:
             algorithm: sodium

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -46,6 +46,7 @@ class SecurityExtensionTest extends TestCase
         $container = $this->getRawContainer();
 
         $container->loadFromExtension('security', [
+            'erase_credentials' => false,
             'providers' => [
                 'default' => ['id' => 'foo'],
             ],
@@ -74,6 +75,7 @@ class SecurityExtensionTest extends TestCase
         $extension->addUserProviderFactory(new DummyProvider());
 
         $container->loadFromExtension('security', [
+            'erase_credentials' => false,
             'providers' => [
                 'my_foo' => ['foo' => []],
             ],
@@ -97,6 +99,7 @@ class SecurityExtensionTest extends TestCase
         $container = $this->getRawContainer();
 
         $container->loadFromExtension('security', [
+            'erase_credentials' => false,
             'providers' => [
                 'default' => ['id' => 'foo'],
             ],
@@ -121,6 +124,7 @@ class SecurityExtensionTest extends TestCase
         $container = $this->getRawContainer();
 
         $container->loadFromExtension('security', [
+            'erase_credentials' => false,
             'providers' => [
                 'default' => ['id' => 'foo'],
             ],
@@ -143,6 +147,7 @@ class SecurityExtensionTest extends TestCase
     {
         $container = $this->getRawContainer();
         $container->loadFromExtension('security', [
+            'erase_credentials' => false,
             'providers' => [
                 'first' => ['id' => 'foo'],
                 'second' => ['id' => 'bar'],
@@ -163,6 +168,7 @@ class SecurityExtensionTest extends TestCase
     {
         $container = $this->getRawContainer();
         $container->loadFromExtension('security', [
+            'erase_credentials' => false,
             'providers' => [
                 'first' => ['id' => 'foo'],
                 'second' => ['id' => 'bar'],
@@ -186,6 +192,7 @@ class SecurityExtensionTest extends TestCase
     {
         $container = $this->getRawContainer();
         $container->loadFromExtension('security', [
+            'erase_credentials' => false,
             'providers' => [
                 'first' => ['id' => 'foo'],
                 'second' => ['id' => 'bar'],
@@ -210,6 +217,7 @@ class SecurityExtensionTest extends TestCase
         $rawExpression = "'foo' == 'bar' or 1 in [1, 3, 3]";
 
         $container->loadFromExtension('security', [
+            'erase_credentials' => false,
             'providers' => [
                 'default' => ['id' => 'foo'],
             ],
@@ -253,6 +261,7 @@ class SecurityExtensionTest extends TestCase
         $container->set($requestMatcherId, $requestMatcher);
 
         $container->loadFromExtension('security', [
+            'erase_credentials' => false,
             'providers' => [
                 'default' => ['id' => 'foo'],
             ],
@@ -287,6 +296,7 @@ class SecurityExtensionTest extends TestCase
         $container->set($requestMatcherId, $requestMatcher);
 
         $container->loadFromExtension('security', [
+            'erase_credentials' => false,
             'providers' => [
                 'default' => ['id' => 'foo'],
             ],
@@ -322,6 +332,7 @@ class SecurityExtensionTest extends TestCase
     {
         $container = $this->getRawContainer();
         $container->loadFromExtension('security', [
+            'erase_credentials' => false,
             'providers' => [
                 'default' => ['id' => 'foo'],
             ],
@@ -357,6 +368,7 @@ class SecurityExtensionTest extends TestCase
     {
         $container = $this->getRawContainer();
         $container->loadFromExtension('security', [
+            'erase_credentials' => false,
             'providers' => [
                 'default' => ['id' => 'foo'],
             ],
@@ -392,6 +404,7 @@ class SecurityExtensionTest extends TestCase
     {
         $container = $this->getRawContainer();
         $container->loadFromExtension('security', [
+            'erase_credentials' => false,
             'providers' => [
                 'default' => ['id' => 'foo'],
             ],
@@ -416,6 +429,7 @@ class SecurityExtensionTest extends TestCase
     {
         $container = $this->getRawContainer();
         $container->loadFromExtension('security', [
+            'erase_credentials' => false,
             'providers' => [
                 'default' => ['id' => 'foo'],
             ],
@@ -436,6 +450,7 @@ class SecurityExtensionTest extends TestCase
         $container = $this->getRawContainer();
 
         $container->loadFromExtension('security', [
+            'erase_credentials' => false,
             'providers' => [
                 'default' => ['id' => 'foo'],
             ],
@@ -458,6 +473,7 @@ class SecurityExtensionTest extends TestCase
         $container = $this->getRawContainer();
 
         $container->loadFromExtension('security', [
+            'erase_credentials' => false,
             'providers' => [
                 'first' => ['id' => 'foo'],
                 'second' => ['id' => 'bar'],
@@ -484,6 +500,7 @@ class SecurityExtensionTest extends TestCase
         $container = $this->getRawContainer();
 
         $container->loadFromExtension('security', [
+            'erase_credentials' => false,
             'providers' => [
                 'default' => ['id' => 'foo'],
             ],
@@ -509,6 +526,7 @@ class SecurityExtensionTest extends TestCase
 
         $container->register('custom_remember_me', \stdClass::class);
         $container->loadFromExtension('security', [
+            'erase_credentials' => false,
             'firewalls' => [
                 'default' => [
                     'remember_me' => ['service' => 'custom_remember_me'],
@@ -529,6 +547,7 @@ class SecurityExtensionTest extends TestCase
 
         $container->register('custom_remember_me', \stdClass::class);
         $container->loadFromExtension('security', [
+            'erase_credentials' => false,
             'firewalls' => [
                 'default' => [
                     'remember_me' => ['secret' => 'very'],
@@ -577,6 +596,7 @@ class SecurityExtensionTest extends TestCase
     {
         $container = $this->getRawContainer();
         $container->loadFromExtension('security', [
+            'erase_credentials' => false,
             'providers' => [
                 'first' => ['id' => 'foo'],
                 'second' => ['id' => 'bar'],
@@ -601,6 +621,7 @@ class SecurityExtensionTest extends TestCase
         $container = $this->getRawContainer();
 
         $container->loadFromExtension('security', [
+            'erase_credentials' => false,
             'providers' => [
                 'default' => ['id' => 'foo'],
             ],
@@ -626,6 +647,7 @@ class SecurityExtensionTest extends TestCase
         $container = $this->getRawContainer();
 
         $container->loadFromExtension('security', [
+            'erase_credentials' => false,
             'providers' => [
                 'default' => ['id' => 'foo'],
             ],
@@ -670,6 +692,7 @@ class SecurityExtensionTest extends TestCase
     {
         $container = $this->getRawContainer();
         $container->loadFromExtension('security', [
+            'erase_credentials' => false,
             'providers' => [
                 'first' => ['id' => 'users'],
             ],
@@ -702,6 +725,7 @@ class SecurityExtensionTest extends TestCase
         $container = $this->getRawContainer();
         $container->register(TestAuthenticator::class);
         $container->loadFromExtension('security', [
+            'erase_credentials' => false,
             'providers' => [
                 'first' => ['id' => 'users'],
             ],
@@ -735,6 +759,7 @@ class SecurityExtensionTest extends TestCase
 
         $firewallId = 'stateless_firewall';
         $container->loadFromExtension('security', [
+            'erase_credentials' => false,
             'firewalls' => [
                 $firewallId => [
                     'pattern' => '/.*',
@@ -755,6 +780,7 @@ class SecurityExtensionTest extends TestCase
 
         $firewallId = 'statefull_firewall';
         $container->loadFromExtension('security', [
+            'erase_credentials' => false,
             'firewalls' => [
                 $firewallId => [
                     'pattern' => '/.*',
@@ -778,6 +804,7 @@ class SecurityExtensionTest extends TestCase
         $container->register(TestUserChecker::class);
 
         $container->loadFromExtension('security', [
+            'erase_credentials' => false,
             'firewalls' => [
                 'main' => array_merge([
                     'pattern' => '/.*',
@@ -807,6 +834,7 @@ class SecurityExtensionTest extends TestCase
         $extension->addAuthenticatorFactory(new TestFirewallListenerFactory());
 
         $container->loadFromExtension('security', [
+            'erase_credentials' => false,
             'firewalls' => [
                 'main' => [
                     'custom_listener' => true,
@@ -828,6 +856,7 @@ class SecurityExtensionTest extends TestCase
 
         $firewallId = 'logout_firewall';
         $container->loadFromExtension('security', [
+            'erase_credentials' => false,
             'firewalls' => [
                 $firewallId => [
                     'logout' => [
@@ -850,6 +879,7 @@ class SecurityExtensionTest extends TestCase
 
         $firewallId = 'logout_firewall';
         $container->loadFromExtension('security', [
+            'erase_credentials' => false,
             'firewalls' => [
                 $firewallId => [
                     'logout' => [
@@ -881,6 +911,7 @@ class SecurityExtensionTest extends TestCase
         $container = $this->getRawContainer();
 
         $container->loadFromExtension('security', [
+            'erase_credentials' => false,
             'password_hashers' => [
                 'legacy' => 'md5',
                 'App\User' => [
@@ -914,6 +945,7 @@ class SecurityExtensionTest extends TestCase
 
         $container->register(TestAuthenticator::class);
         $container->loadFromExtension('security', [
+            'erase_credentials' => false,
             'firewalls' => ['main' => ['custom_authenticator' => TestAuthenticator::class]],
         ]);
         $container->compile();

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AbstractTokenCompareRoles/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AbstractTokenCompareRoles/config.yml
@@ -8,6 +8,7 @@ services:
     class: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\SecuredPageBundle\Security\Core\User\ArrayUserProvider
 
 security:
+  erase_credentials: false
   password_hashers:
     \Symfony\Component\Security\Core\User\UserInterface: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_anonymous.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_anonymous.yml
@@ -6,6 +6,7 @@ framework:
     serializer: ~
 
 security:
+    erase_credentials: false
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_body_custom.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_body_custom.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: ./../config/framework.yml }
 
 security:
+    erase_credentials: false
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_body_default.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_body_default.yml
@@ -6,6 +6,7 @@ framework:
     serializer: ~
 
 security:
+    erase_credentials: false
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_cas.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_cas.yml
@@ -6,6 +6,7 @@ framework:
   serializer: ~
 
 security:
+  erase_credentials: false
   password_hashers:
     Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_custom_user_loader.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_custom_user_loader.yml
@@ -6,6 +6,7 @@ framework:
     serializer: ~
 
 security:
+    erase_credentials: false
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_header_custom.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_header_custom.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: ./../config/framework.yml }
 
 security:
+    erase_credentials: false
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_header_default.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_header_default.yml
@@ -6,6 +6,7 @@ framework:
     serializer: ~
 
 security:
+    erase_credentials: false
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_multiple_extractors.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_multiple_extractors.yml
@@ -6,6 +6,7 @@ framework:
     serializer: ~
 
 security:
+    erase_credentials: false
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_no_extractors.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_no_extractors.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: ./../config/framework.yml }
 
 security:
+    erase_credentials: false
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_no_handler.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_no_handler.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: ./../config/framework.yml }
 
 security:
+    erase_credentials: false
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_oidc.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_oidc.yml
@@ -6,6 +6,7 @@ framework:
     serializer: ~
 
 security:
+    erase_credentials: false
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_query_custom.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_query_custom.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: ./../config/framework.yml }
 
 security:
+    erase_credentials: false
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_query_default.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_query_default.yml
@@ -6,6 +6,7 @@ framework:
     serializer: ~
 
 security:
+    erase_credentials: false
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_self_contained_token.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_self_contained_token.yml
@@ -6,6 +6,7 @@ framework:
     serializer: ~
 
 security:
+    erase_credentials: false
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AliasedEvents/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AliasedEvents/config.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: ./../config/framework.yml }
 
 security:
+    erase_credentials: false
     providers:
         dummy:
             memory: ~

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/custom_handlers.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/custom_handlers.yml
@@ -3,6 +3,7 @@ imports:
   - { resource: ./security.yml }
 
 security:
+  erase_credentials: false
   firewalls:
     firewall1:
       pattern: /firewall1

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/firewall_user_provider.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/firewall_user_provider.yml
@@ -3,6 +3,7 @@ imports:
 - { resource: ./security.yml }
 
 security:
+    erase_credentials: false
     firewalls:
         api:
             pattern: /

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/implicit_user_provider.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/implicit_user_provider.yml
@@ -3,6 +3,7 @@ imports:
 - { resource: ./security.yml }
 
 security:
+    erase_credentials: false
     firewalls:
         api:
             pattern: /

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/multiple_firewall_user_provider.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/multiple_firewall_user_provider.yml
@@ -3,6 +3,7 @@ imports:
 - { resource: ./security.yml }
 
 security:
+    erase_credentials: false
     firewalls:
         main:
             pattern: ^/main

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/multiple_firewalls.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/multiple_firewalls.yml
@@ -3,6 +3,7 @@ imports:
 - { resource: ./security.yml }
 
 security:
+    erase_credentials: false
     firewalls:
         firewall1:
             pattern: /firewall1

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/no_user_provider.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/no_user_provider.yml
@@ -6,6 +6,7 @@ services:
         - true
 
 security:
+    erase_credentials: false
     firewalls:
         api:
             pattern: /

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/security.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/security.yml
@@ -1,4 +1,5 @@
 security:
+    erase_credentials: false
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AutowiringTypes/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AutowiringTypes/config.yml
@@ -7,6 +7,7 @@ services:
         class: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AutowiringBundle\AutowiredServices
         autowire: true
 security:
+    erase_credentials: false
     providers:
         dummy:
             memory: ~

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfFormLogin/base_config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfFormLogin/base_config.yml
@@ -15,6 +15,7 @@ services:
             - { name: container.service_subscriber }
 
 security:
+    erase_credentials: false
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfFormLogin/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfFormLogin/config.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: ./base_config.yml }
 
 security:
+    erase_credentials: false
     firewalls:
         default:
             form_login:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfFormLogin/routes_as_path.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfFormLogin/routes_as_path.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: ./config.yml }
 
 security:
+    erase_credentials: false
     firewalls:
         default:
             form_login:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/FirewallEntryPoint/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/FirewallEntryPoint/config.yml
@@ -23,6 +23,7 @@ services:
     logger: { class: Psr\Log\NullLogger }
 
 security:
+    erase_credentials: false
     firewalls:
         secure:
             pattern: ^/secure/

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/FirewallEntryPoint/config_form_login.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/FirewallEntryPoint/config_form_login.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: ./config.yml }
 
 security:
+    erase_credentials: false
     firewalls:
         secure:
             pattern: ^/

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/config.yml
@@ -6,6 +6,7 @@ framework:
     serializer: ~
 
 security:
+    erase_credentials: false
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/custom_handlers.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/custom_handlers.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: ./../config/framework.yml }
 
 security:
+    erase_credentials: false
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/switchuser_stateless.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/switchuser_stateless.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: ./config.yml }
 
 security:
+    erase_credentials: false
     providers:
         in_memory:
             memory:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLoginLdap/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLoginLdap/config.yml
@@ -12,6 +12,7 @@ services:
                     protocol_version: 3
                     referrals: false
 security:
+    erase_credentials: false
     providers:
         ldap:
             ldap:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/LoginLink/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/LoginLink/config.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: ./../config/framework.yml }
 
 security:
+    erase_credentials: false
     providers:
         in_memory:
             memory:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Logout/config_access.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Logout/config_access.yml
@@ -2,6 +2,7 @@ imports:
 - { resource: ./../config/framework.yml }
 
 security:
+    erase_credentials: false
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Logout/config_cookie_clearing.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Logout/config_cookie_clearing.yml
@@ -2,6 +2,7 @@ imports:
 - { resource: ./../config/framework.yml }
 
 security:
+    erase_credentials: false
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Logout/config_csrf_enabled.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Logout/config_csrf_enabled.yml
@@ -2,6 +2,7 @@ imports:
 - { resource: ./../config/framework.yml }
 
 security:
+    erase_credentials: false
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/LogoutWithoutSessionInvalidation/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/LogoutWithoutSessionInvalidation/config.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: ./../config/framework.yml }
 
 security:
+    erase_credentials: false
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/MissingUserProvider/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/MissingUserProvider/config.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: ./../config/framework.yml }
 
 security:
+    erase_credentials: false
     firewalls:
         default:
             http_basic: ~

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMe/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMe/config.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: ./../config/framework.yml }
 
 security:
+    erase_credentials: false
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMe/config_persistent.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMe/config_persistent.yml
@@ -4,6 +4,7 @@ services:
         arguments: ['@kernel']
 
 security:
+    erase_credentials: false
     firewalls:
         default:
             remember_me:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMe/config_session.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMe/config_session.yml
@@ -1,4 +1,5 @@
 security:
+    erase_credentials: false
     firewalls:
         default:
             remember_me:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMe/stateless_config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMe/stateless_config.yml
@@ -9,6 +9,7 @@ framework:
         cookie_samesite: lax
 
 security:
+    erase_credentials: false
     firewalls:
         default:
             stateless: true

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMeCookie/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMeCookie/config.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: ./../config/framework.yml }
 
 security:
+    erase_credentials: false
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/SecurityHelper/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/SecurityHelper/config.yml
@@ -25,6 +25,7 @@ services:
     Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AuthenticatorBundle\ApiAuthenticator: ~
 
 security:
+    erase_credentials: false
     providers:
         main:
             memory:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/SecurityHelper/config_logout_csrf.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/SecurityHelper/config_logout_csrf.yml
@@ -25,6 +25,7 @@ services:
     Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AuthenticatorBundle\ApiAuthenticator: ~
 
 security:
+    erase_credentials: false
     providers:
         main:
             memory:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/base_config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/base_config.yml
@@ -6,6 +6,7 @@ parameters:
     env(APP_IPS): '127.0.0.1, ::1'
 
 security:
+    erase_credentials: false
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/invalid_ip_access_control.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/invalid_ip_access_control.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: ./../config/default.yml }
 
 security:
+    erase_credentials: false
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/localized_form_failure_handler.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/localized_form_failure_handler.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: ./../config/default.yml }
 
 security:
+    erase_credentials: false
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/localized_routes.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/localized_routes.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: ./../config/default.yml }
 
 security:
+    erase_credentials: false
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/localized_routes_with_forward.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/localized_routes_with_forward.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: ./localized_routes.yml }
 
 security:
+    erase_credentials: false
     firewalls:
         default:
             form_login:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/login_throttling.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/login_throttling.yml
@@ -7,6 +7,7 @@ framework:
     rate_limiter: ~
 
 security:
+    erase_credentials: false
     firewalls:
         default:
             login_throttling:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/routes_as_path.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/routes_as_path.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: ./base_config.yml }
 
 security:
+    erase_credentials: false
     firewalls:
         default:
             form_login:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/switchuser.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/switchuser.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: ./base_config.yml }
 
 security:
+    erase_credentials: false
     providers:
         in_memory:
             memory:

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -22,6 +22,7 @@
         "symfony/clock": "^6.4|^7.0",
         "symfony/config": "^6.4|^7.0",
         "symfony/dependency-injection": "^6.4.11|^7.1.4",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/event-dispatcher": "^6.4|^7.0",
         "symfony/http-kernel": "^6.4|^7.0",
         "symfony/http-foundation": "^6.4|^7.0",

--- a/src/Symfony/Component/Ldap/CHANGELOG.md
+++ b/src/Symfony/Component/Ldap/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+7.3
+---
+
+ * Deprecate `LdapUser::eraseCredentials()`, use `LdapUser::setPassword(null)` instead
+ * Add `EraseLdapUserCredentialsListener`
+
 7.2
 ---
 

--- a/src/Symfony/Component/Ldap/Security/EraseLdapUserCredentialsListener.php
+++ b/src/Symfony/Component/Ldap/Security/EraseLdapUserCredentialsListener.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Ldap\Security;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Ldap\Exception\InvalidCredentialsException;
+use Symfony\Component\Ldap\Exception\InvalidSearchCredentialsException;
+use Symfony\Component\Ldap\LdapInterface;
+use Symfony\Component\Security\Core\Event\AuthenticationSuccessEvent;
+use Symfony\Component\Security\Core\Exception\BadCredentialsException;
+use Symfony\Component\Security\Core\Exception\LogicException;
+use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordCredentials;
+use Symfony\Component\Security\Http\Event\AuthenticationTokenCreatedEvent;
+use Symfony\Component\Security\Http\Event\CheckPassportEvent;
+
+/**
+ * Erases credentials from LdapUser instances upon successful authentication.
+ *
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ */
+class EraseLdapUserCredentialsListener implements EventSubscriberInterface
+{
+    public function onAuthenticationSuccess(AuthenticationSuccessEvent $event): void
+    {
+        $user = $event->getAuthenticationToken()->getUser();
+
+        if (!$user instanceof LdapUser) {
+            return;
+        }
+
+        $user->setPassword(null);
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [AuthenticationSuccessEvent::class => ['onAuthenticationSuccess', 256]];
+    }
+}

--- a/src/Symfony/Component/Ldap/Security/LdapUser.php
+++ b/src/Symfony/Component/Ldap/Security/LdapUser.php
@@ -62,6 +62,8 @@ class LdapUser implements UserInterface, PasswordAuthenticatedUserInterface, Equ
 
     public function eraseCredentials(): void
     {
+        trigger_deprecation('symfony/security-core', '7.3', sprintf('The "%s()" method is deprecated and will be removed in 8.0, call "setPassword(null)" instead.', __METHOD__));
+
         $this->password = null;
     }
 
@@ -70,7 +72,7 @@ class LdapUser implements UserInterface, PasswordAuthenticatedUserInterface, Equ
         return $this->extraFields;
     }
 
-    public function setPassword(#[\SensitiveParameter] string $password): void
+    public function setPassword(#[\SensitiveParameter] ?string $password): void
     {
         $this->password = $password;
     }
@@ -94,5 +96,15 @@ class LdapUser implements UserInterface, PasswordAuthenticatedUserInterface, Equ
         }
 
         return true;
+    }
+
+    public function __serialize(): array
+    {
+        return [$this->entry, $this->identifier, null, $this->roles, $this->extraFields];
+    }
+
+    public function __unserialize(array $data): void
+    {
+        [$this->entry, $this->identifier, $this->password, $this->roles, $this->extraFields] = $data;
     }
 }

--- a/src/Symfony/Component/Ldap/Tests/Security/EraseLdapUserCredentialsListenerTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Security/EraseLdapUserCredentialsListenerTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Ldap\Tests\Security;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Ldap\Adapter\CollectionInterface;
+use Symfony\Component\Ldap\Adapter\QueryInterface;
+use Symfony\Component\Ldap\Entry;
+use Symfony\Component\Ldap\Exception\InvalidCredentialsException;
+use Symfony\Component\Ldap\LdapInterface;
+use Symfony\Component\Ldap\Security\CheckLdapCredentialsListener;
+use Symfony\Component\Ldap\Security\EraseLdapUserCredentialsListener;
+use Symfony\Component\Ldap\Security\LdapBadge;
+use Symfony\Component\Ldap\Security\LdapUser;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Event\AuthenticationSuccessEvent;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Exception\BadCredentialsException;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordCredentials;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+use Symfony\Component\Security\Http\Event\CheckPassportEvent;
+use Symfony\Contracts\Service\ServiceLocatorTrait;
+
+class EraseLdapUserCredentialsListenerTest extends TestCase
+{
+    public function testPasswordIsErasedOnAuthenticationSuccess()
+    {
+        $user = new LdapUser(new Entry(''), 'chalasr', 'password');
+        $listener = new EraseLdapUserCredentialsListener();
+
+        $listener->onAuthenticationSuccess(new AuthenticationSuccessEvent(new UsernamePasswordToken($user, 'main')));
+
+        $this->assertSame(null, $user->getPassword());
+    }
+}

--- a/src/Symfony/Component/Ldap/composer.json
+++ b/src/Symfony/Component/Ldap/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": ">=8.2",
         "ext-ldap": "*",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/options-resolver": "^6.4|^7.0"
     },
     "require-dev": {

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -58,8 +58,15 @@ abstract class AbstractToken implements TokenInterface, \Serializable
         $this->user = $user;
     }
 
+    /**
+     * Removes sensitive information from the token.
+     *
+     * @deprecated since Symfony 7.3
+     */
     public function eraseCredentials(): void
     {
+        trigger_deprecation('symfony/security-core', '7.3', sprintf('The "%s()" method is deprecated and will be removed in 8.0, use a DTO instead or implement your own erasing logic if needed.', __METHOD__));
+
         if ($this->getUser() instanceof UserInterface) {
             $this->getUser()->eraseCredentials();
         }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/NullToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/NullToken.php
@@ -43,6 +43,11 @@ class NullToken implements TokenInterface
         return '';
     }
 
+    /**
+     * Removes sensitive information from the token.
+     *
+     * @deprecated since Symfony 7.3
+     */
     public function eraseCredentials(): void
     {
     }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php
@@ -56,6 +56,9 @@ interface TokenInterface extends \Stringable
 
     /**
      * Removes sensitive information from the token.
+     *
+     * @deprecated since Symfony 7.3, use a dedicated DTO instead or implement your
+     *             own erasing logic instead
      */
     public function eraseCredentials(): void;
 

--- a/src/Symfony/Component/Security/Core/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Core/CHANGELOG.md
@@ -7,6 +7,8 @@ CHANGELOG
  * Add `UserAuthorizationChecker::isGrantedForUser()` to test user authorization without relying on the session.
    For example, users not currently logged in, or while processing a message from a message queue.
  * Add `OfflineTokenInterface` to mark tokens that do not represent the currently logged-in user
+ * Deprecate `UserInterface::eraseCredentials()` and `TokenInterface::eraseCredentials()`,
+   use a dedicated DTO or erase credentials on your own e.g. upon `AuthenticationTokenCreatedEvent` instead
 
 7.2
 ---

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/AbstractTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/AbstractTokenTest.php
@@ -12,12 +12,15 @@
 namespace Symfony\Component\Security\Core\Tests\Authentication\Token;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
 use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 class AbstractTokenTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     /**
      * @dataProvider provideUsers
      */
@@ -33,6 +36,9 @@ class AbstractTokenTest extends TestCase
         yield [new InMemoryUser('fabien', null), 'fabien'];
     }
 
+    /**
+     * @group legacy
+     */
     public function testEraseCredentials()
     {
         $token = new ConcreteToken(['ROLE_FOO']);
@@ -40,6 +46,7 @@ class AbstractTokenTest extends TestCase
         $user = $this->createMock(UserInterface::class);
         $user->expects($this->once())->method('eraseCredentials');
         $token->setUser($user);
+        $this->expectDeprecation('The Symfony\Component\Security\Core\User\UserInterface::eraseCredentials method is deprecated (since Symfony 7.3, use a dedicated DTO instead or implement your own erasing logic instead).');
 
         $token->eraseCredentials();
     }

--- a/src/Symfony/Component/Security/Core/Tests/User/InMemoryUserTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/InMemoryUserTest.php
@@ -53,6 +53,9 @@ class InMemoryUserTest extends TestCase
         $this->assertFalse($user->isEnabled());
     }
 
+    /**
+     * @group legacy
+     */
     public function testEraseCredentials()
     {
         $user = new InMemoryUser('fabien', 'superpass');

--- a/src/Symfony/Component/Security/Core/User/InMemoryUser.php
+++ b/src/Symfony/Component/Security/Core/User/InMemoryUser.php
@@ -76,6 +76,7 @@ final class InMemoryUser implements UserInterface, PasswordAuthenticatedUserInte
 
     public function eraseCredentials(): void
     {
+        trigger_deprecation('symfony/security-core', '7.3', sprintf('The "%s()" method is deprecated and will be removed in 8.0, use a DTO instead or implement your own erasing logic if needed.', __METHOD__));
     }
 
     public function isEqualTo(UserInterface $user): bool

--- a/src/Symfony/Component/Security/Core/User/UserInterface.php
+++ b/src/Symfony/Component/Security/Core/User/UserInterface.php
@@ -47,17 +47,21 @@ interface UserInterface
     public function getRoles(): array;
 
     /**
-     * Removes sensitive data from the user.
-     *
-     * This is important if, at any given point, sensitive information like
-     * the plain-text password is stored on this object.
-     */
-    public function eraseCredentials(): void;
-
-    /**
      * Returns the identifier for this user (e.g. username or email address).
      *
      * @return non-empty-string
      */
     public function getUserIdentifier(): string;
+
+    /**
+     * Removes sensitive data from the user.
+     *
+     * This is important if, at any given point, sensitive information like
+     * the plain-text password is stored on this object.
+     *
+     * @deprecated since Symfony 7.3, use a dedicated DTO instead or implement your
+     *             own erasing logic instead
+     */
+    public function eraseCredentials(): void;
+
 }

--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
@@ -59,6 +59,9 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
         private bool $hideUserNotFoundExceptions = true,
         private array $requiredBadges = [],
     ) {
+        if ($eraseCredentials) {
+            trigger_deprecation('symfony/security-http', '7.3', sprintf('Passing true as "$eraseCredentials" argument to "%s::__construct()" is deprecated and won\'t have any effect in 8.0, pass "false" instead and use your own erasing logic if needed.', __CLASS__));
+        }
     }
 
     /**
@@ -198,6 +201,7 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
             // announce the authentication token
             $authenticatedToken = $this->eventDispatcher->dispatch(new AuthenticationTokenCreatedEvent($authenticatedToken, $passport))->getAuthenticatedToken();
 
+            // @deprecated since Symfony 7.3, remove the if statement in 8.0
             if (true === $this->eraseCredentials) {
                 $authenticatedToken->eraseCredentials();
             }

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -5,6 +5,8 @@ CHANGELOG
 ---
 
  * Add encryption support to `OidcTokenHandler` (JWE)
+ * Deprecate passing `true` for the `$eraseCredentials` parameter of `AuthenticatorManager::__construct()`, erase credentials
+  on your own e.g. upon `AuthenticationTokenCreatedEvent` instead. Passing it won't thave any effect in 8.0.
 
 7.2
 ---

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/AuthenticatorManagerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/AuthenticatorManagerTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\AbstractLogger;
 use Psr\Log\LoggerInterface;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -38,6 +39,8 @@ use Symfony\Component\Security\Http\Tests\Fixtures\DummySupportsAuthenticator;
 
 class AuthenticatorManagerTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     private MockObject&TokenStorageInterface $tokenStorage;
     private EventDispatcher $eventDispatcher;
     private Request $request;
@@ -161,7 +164,7 @@ class AuthenticatorManagerTest extends TestCase
 
         $authenticator->expects($this->once())->method('onAuthenticationFailure')->with($this->anything(), $this->callback(fn ($exception) => 'Authentication failed; Some badges marked as required by the firewall config are not available on the passport: "'.CsrfTokenBadge::class.'".' === $exception->getMessage()));
 
-        $manager = $this->createManager([$authenticator], 'main', true, [CsrfTokenBadge::class]);
+        $manager = $this->createManager([$authenticator], 'main', false, [CsrfTokenBadge::class]);
         $manager->authenticateRequest($this->request);
     }
 
@@ -177,11 +180,12 @@ class AuthenticatorManagerTest extends TestCase
 
         $authenticator->expects($this->once())->method('onAuthenticationSuccess');
 
-        $manager = $this->createManager([$authenticator], 'main', true, [CsrfTokenBadge::class]);
+        $manager = $this->createManager([$authenticator], 'main', false, [CsrfTokenBadge::class]);
         $manager->authenticateRequest($this->request);
     }
 
     /**
+     * @group legacy
      * @dataProvider provideEraseCredentialsData
      */
     public function testEraseCredentials($eraseCredentials)
@@ -194,6 +198,10 @@ class AuthenticatorManagerTest extends TestCase
         $authenticator->expects($this->any())->method('createToken')->willReturn($this->token);
 
         $this->token->expects($eraseCredentials ? $this->once() : $this->never())->method('eraseCredentials');
+
+        if ($eraseCredentials) {
+            $this->expectDeprecation('Since symfony/security-http 7.3: Passing true as "$eraseCredentials" argument to "Symfony\Component\Security\Http\Authentication\AuthenticatorManager::__construct()" is deprecated and won\'t have any effect in 8.0, pass "false" instead and use your own erasing logic if needed.');
+        }
 
         $manager = $this->createManager([$authenticator], 'main', $eraseCredentials);
         $manager->authenticateRequest($this->request);
@@ -365,7 +373,7 @@ class AuthenticatorManagerTest extends TestCase
             }
         };
 
-        $manager = $this->createManager([$authenticator], 'main', true, [], $logger);
+        $manager = $this->createManager([$authenticator], 'main', false, [], $logger);
         $response = $manager->authenticateRequest($this->request);
         $this->assertSame($this->response, $response);
         $this->assertStringContainsString($authenticator::class, $logger->logContexts[0]['authenticator']);
@@ -384,7 +392,7 @@ class AuthenticatorManagerTest extends TestCase
         return new DummySupportsAuthenticator($supports);
     }
 
-    private function createManager($authenticators, $firewallName = 'main', $eraseCredentials = true, array $requiredBadges = [], ?LoggerInterface $logger = null)
+    private function createManager($authenticators, $firewallName = 'main', $eraseCredentials = false, array $requiredBadges = [], ?LoggerInterface $logger = null)
     {
         return new AuthenticatorManager($authenticators, $this->tokenStorage, $this->eventDispatcher, $firewallName, $logger, $eraseCredentials, true, $requiredBadges);
     }

--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -22,7 +22,7 @@
         "symfony/http-kernel": "^6.4|^7.0",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/property-access": "^6.4|^7.0",
-        "symfony/security-core": "^7.2",
+        "symfony/security-core": "^7.3",
         "symfony/service-contracts": "^2.5|^3"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | Fix https://github.com/symfony/symfony/issues/57842
| License       | MIT

Better avoid storing plain credentials on the security user object itself. Core no longer needs to handle this behavior to me.