### PR TITLE
[ErrorHandler] Fix error message in test with PHP 8.5

### DIFF
--- a/src/Symfony/Component/ErrorHandler/Tests/phpt/fatal_with_nested_handlers.phpt
+++ b/src/Symfony/Component/ErrorHandler/Tests/phpt/fatal_with_nested_handlers.phpt
@@ -24,7 +24,7 @@ var_dump([
 $eHandler[0]->setExceptionHandler('print_r');
 
 if (true) {
-    class Broken implements \JsonSerializable
+    class Broken implements \Iterator
     {
     }
 }
@@ -37,14 +37,14 @@ array(1) {
 }
 object(Symfony\Component\ErrorHandler\Error\FatalError)#%d (%d) {
   ["message":protected]=>
-  string(186) "Error: Class Symfony\Component\ErrorHandler\Broken contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (JsonSerializable::jsonSerialize)"
+  string(209) "Error: Class Symfony\Component\ErrorHandler\Broken contains 5 abstract methods and must therefore be declared abstract or implement the remaining methods (Iterator::current, Iterator::next, Iterator::key, ...)"
 %a
   ["error":"Symfony\Component\ErrorHandler\Error\FatalError":private]=>
   array(4) {
     ["type"]=>
     int(1)
     ["message"]=>
-    string(179) "Class Symfony\Component\ErrorHandler\Broken contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (JsonSerializable::jsonSerialize)"
+    string(202) "Class Symfony\Component\ErrorHandler\Broken contains 5 abstract methods and must therefore be declared abstract or implement the remaining methods (Iterator::current, Iterator::next, Iterator::key, ...)"
     ["file"]=>
     string(%d) "%s"
     ["line"]=>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

PHP 8.5 singularize `methods` in an error message used in a test. To avoid having two test cases to maintain, let's just modify the broken class so there's always more than one method to be implemented.