### PR TITLE
[AssetMapper] Fix missing return type

### DIFF
--- a/src/Symfony/Component/AssetMapper/Compressor/ZopfliCompressor.php
+++ b/src/Symfony/Component/AssetMapper/Compressor/ZopfliCompressor.php
@@ -38,6 +38,9 @@ final class ZopfliCompressor implements SupportedCompressorInterface
         (new Process([$this->executable, '--', $path]))->mustRun();
     }
 
+    /**
+     * @return resource
+     */
     private function createStreamContext()
     {
         throw new \BadMethodCallException('Extension is not supported yet.');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

A return type is missing: https://github.com/symfony/symfony/actions/runs/12199796735/job/34034462666. `@return resource` is added to match other implementations of `SupportedCompressorInterface`.