### PR TITLE
[HttpFoundation][HttpKernel] Reset request formats after each main request (7.3)

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.3
+---
+
+ * Add `Request::resetFormats()` method to reset the list of supported format to MIME type mappings
+
 7.2
 ---
 

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1731,6 +1731,14 @@ class Request
         return $this->isSafeContentPreferred = AcceptHeader::fromString($this->headers->get('Prefer'))->has('safe');
     }
 
+    /**
+     * Reset the mappings of formats to mime types.
+     */
+    public static function resetFormats(): void
+    {
+        static::$formats = null;
+    }
+
     /*
      * The following methods are derived from code of the Zend Framework (1.10dev - 2010-01-24)
      *

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1732,11 +1732,11 @@ class Request
     }
 
     /**
-     * Reset the mappings of formats to mime types.
+     * Resets the mappings of formats to mime types.
      */
     public static function resetFormats(): void
     {
-        static::$formats = null;
+        static::initializeFormats();
     }
 
     /*

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -31,6 +31,16 @@ class RequestTest extends TestCase
         Request::setTrustedHosts([]);
     }
 
+    public function testResetFormats()
+    {
+        $request = new Request();
+        $request->setFormat('json', ['application/problem+json']);
+        $modifiedRequestFormat = $request->getFormat('application/json');
+        $this->assertNull($modifiedRequestFormat);
+        Request::resetFormats();
+        $this->assertEquals('json', $request->getFormat('application/json'));
+    }
+
     public function testInitialize()
     {
         $request = new Request();

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.3
+---
+
+ * Add call to `Request::resetFormats()` in `Kernel::boot()` to reset the request formats at the start of a new main request.
+
 7.2
 ---
 

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -104,6 +104,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
     {
         if (true === $this->booted) {
             if (!$this->requestStackSize && $this->resetServices) {
+                Request::resetFormats();
                 if ($this->container->has('services_resetter')) {
                     $this->container->get('services_resetter')->reset();
                 }

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -113,6 +113,34 @@ class KernelTest extends TestCase
         $this->assertFileDoesNotExist($legacyContainerDir.'.legacy');
     }
 
+    public function testBootResetsRequestFormatsOnReset()
+    {
+        $request = new Request();
+        $request->setFormat('json', ['application/problem+json']);
+        $modifiedRequestFormat = $request->getFormat('application/json');
+
+        $httpKernelMock = $this->getMockBuilder(HttpKernel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $httpKernelMock
+            ->expects($this->any())
+            ->method('handle')
+            ->with($request);
+
+        $kernel = $this->getKernel(['getHttpKernel']);
+        $kernel->expects($this->any())
+            ->method('getHttpKernel')
+            ->willReturn($httpKernelMock);
+
+        $kernel->handle($request);
+
+        $kernel->boot();
+        $kernel->handle($request);
+        $this->assertNull($modifiedRequestFormat);
+        $this->assertSame('json', $request->getFormat('application/json'));
+    }
+
     public function testBootInitializesBundlesAndContainer()
     {
         $kernel = $this->getKernel(['initializeBundles']);


### PR DESCRIPTION
Add public static method to reset Request format to mime mappings Reset Request format to mime mappings on Kernel boot for each new main request

| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #59036
| License       | MIT

Adds a new public static method to `Request` to reset the mappings of formats to MIME types. Adds a call to this method just before resetting services in `Kernel::boot()`.