### PR TITLE
[Scheduler] Move properties above `__construct()` method

### DIFF
--- a/src/Symfony/Component/Scheduler/Schedule.php
+++ b/src/Symfony/Component/Scheduler/Schedule.php
@@ -21,17 +21,17 @@ use Symfony\Contracts\Cache\CacheInterface;
 
 final class Schedule implements ScheduleProviderInterface
 {
-    public function __construct(
-        private readonly ?EventDispatcherInterface $dispatcher = null,
-    ) {
-    }
-
     /** @var array<string,RecurringMessage> */
     private array $messages = [];
     private ?LockInterface $lock = null;
     private ?CacheInterface $state = null;
     private bool $shouldRestart = false;
     private bool $onlyLastMissed = false;
+
+    public function __construct(
+        private readonly ?EventDispatcherInterface $dispatcher = null,
+    ) {
+    }
 
     public function with(RecurringMessage $message, RecurringMessage ...$messages): static
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | --
| License       | MIT
