### PR TITLE
[FrameworkBundle][Translation] fix translation lint compatibility with the `PseudoLocalizationTranslator`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TranslationLintCommandPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TranslationLintCommandPass.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Translation\TranslatorBagInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class TranslationLintCommandPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('console.command.translation_lint') || !$container->has('translator')) {
+            return;
+        }
+
+        $translatorClass = $container->getParameterBag()->resolveValue($container->findDefinition('translator')->getClass());
+
+        if (!is_subclass_of($translatorClass, TranslatorInterface::class) || !is_subclass_of($translatorClass, TranslatorBagInterface::class)) {
+            $container->removeDefinition('console.command.translation_lint');
+        }
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -19,6 +19,7 @@ use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ProfilerPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\RemoveUnusedSessionMarshallingHandlerPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\TestServiceContainerRealRefPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\TestServiceContainerWeakRefPass;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\TranslationLintCommandPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\UnusedTagsPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\VirtualRequestStackPass;
 use Symfony\Component\Cache\Adapter\ApcuAdapter;
@@ -149,6 +150,8 @@ class FrameworkBundle extends Bundle
         $this->addCompilerPassIfExists($container, AddConstraintValidatorsPass::class);
         $this->addCompilerPassIfExists($container, AddValidatorInitializersPass::class);
         $this->addCompilerPassIfExists($container, AddConsoleCommandPass::class, PassConfig::TYPE_BEFORE_REMOVING);
+        // must be registered before the AddConsoleCommandPass
+        $container->addCompilerPass(new TranslationLintCommandPass(), PassConfig::TYPE_BEFORE_REMOVING, 10);
         // must be registered as late as possible to get access to all Twig paths registered in
         // twig.template_iterator definition
         $this->addCompilerPassIfExists($container, TranslatorPass::class, PassConfig::TYPE_BEFORE_OPTIMIZATION, -32);

--- a/src/Symfony/Component/Translation/PseudoLocalizationTranslator.php
+++ b/src/Symfony/Component/Translation/PseudoLocalizationTranslator.php
@@ -11,12 +11,13 @@
 
 namespace Symfony\Component\Translation;
 
+use Symfony\Component\Translation\Exception\LogicException;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * This translator should only be used in a development environment.
  */
-final class PseudoLocalizationTranslator implements TranslatorInterface
+final class PseudoLocalizationTranslator implements TranslatorInterface, TranslatorBagInterface
 {
     private const EXPANSION_CHARACTER = '~';
 
@@ -113,6 +114,24 @@ final class PseudoLocalizationTranslator implements TranslatorInterface
     public function getLocale(): string
     {
         return $this->translator->getLocale();
+    }
+
+    public function getCatalogue(?string $locale = null): MessageCatalogueInterface
+    {
+        if (!$this->translator instanceof TranslatorBagInterface) {
+            throw new LogicException(\sprintf('The "%s()" method cannot be called as the wrapped translator class "%s" does not implement the "%s".', __METHOD__, $this->translator::class, TranslatorBagInterface::class));
+        }
+
+        return $this->translator->getCatalogue($locale);
+    }
+
+    public function getCatalogues(): array
+    {
+        if (!$this->translator instanceof TranslatorBagInterface) {
+            throw new LogicException(\sprintf('The "%s()" method cannot be called as the wrapped translator class "%s" does not implement the "%s".', __METHOD__, $this->translator::class, TranslatorBagInterface::class));
+        }
+
+        return $this->translator->getCatalogues();
     }
 
     private function getParts(string $originalTrans): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59101
| License       | MIT