### PR TITLE
[Notifier] fix desktop channel bus abstract arg

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2784,7 +2784,7 @@ class FrameworkExtension extends Extension
             $container->removeDefinition('notifier.channel.email');
         }
 
-        foreach (['texter', 'chatter', 'notifier.channel.chat', 'notifier.channel.email', 'notifier.channel.sms', 'notifier.channel.push'] as $serviceId) {
+        foreach (['texter', 'chatter', 'notifier.channel.chat', 'notifier.channel.email', 'notifier.channel.sms', 'notifier.channel.push', 'notifier.channel.desktop'] as $serviceId) {
             if (!$container->hasDefinition($serviceId)) {
                 continue;
             }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier.php
@@ -82,7 +82,10 @@ return static function (ContainerConfigurator $container) {
             ->tag('notifier.channel', ['channel' => 'push'])
 
         ->set('notifier.channel.desktop', DesktopChannel::class)
-            ->args([service('texter.transports'), service('messenger.default_bus')->ignoreOnInvalid()])
+            ->args([
+                service('texter.transports'),
+                abstract_arg('message bus'),
+            ])
             ->tag('notifier.channel', ['channel' => 'desktop'])
 
         ->set('notifier.monolog_handler', NotifierHandler::class)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | none
| License       | MIT

From what I understand the Desktop and Push channels are not configured the same way as the other channels, they don't use the 'message bus' abstract arg which allows the component to disable or selecting message bus through configuration.
So if another message_bus than the default bus is configured inside framework.notifier.message_bus it is ignored for those two. And same if it is set to false inside the configuration.

![image](https://github.com/user-attachments/assets/dd9ecd1b-0edc-4da4-8976-34d6fddefa4c)

