### PR TITLE
[Scheduler] Fix optional `$count` variable in `testGetNextRunDates`

### DIFF
--- a/src/Symfony/Component/Scheduler/Tests/Trigger/PeriodicalTriggerTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Trigger/PeriodicalTriggerTest.php
@@ -108,9 +108,9 @@ class PeriodicalTriggerTest extends TestCase
     /**
      * @dataProvider providerGetNextRunDates
      */
-    public function testGetNextRunDates(\DateTimeImmutable $from, TriggerInterface $trigger, array $expected, int $count = 0)
+    public function testGetNextRunDates(\DateTimeImmutable $from, TriggerInterface $trigger, array $expected, int $count)
     {
-        $this->assertEquals($expected, $this->getNextRunDates($from, $trigger, $count ?? \count($expected)));
+        $this->assertEquals($expected, $this->getNextRunDates($from, $trigger, $count));
     }
 
     public static function providerGetNextRunDates(): iterable


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes (in tests)
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Fixes a weird side effect of the optional `$count` variable in `testGetNextRunDates`, because it uses the Null Coalescing Operator it was always expecting 0 iterations if not passing a value from the provider.

It doesn't need to be optional because it's always passed from the provider so we could just make it a required variable.