### PR TITLE
[DependencyInjection] Reset env vars with `kernel.reset`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
@@ -195,6 +195,7 @@ return static function (ContainerConfigurator $container) {
                 tagged_iterator('container.env_var_loader'),
             ])
             ->tag('container.env_var_processor')
+            ->tag('kernel.reset', ['method' => 'reset'])
 
         ->set('slugger', AsciiSlugger::class)
             ->args([

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -291,6 +291,14 @@ class Container implements ContainerInterface, ResetInterface
     }
 
     /**
+     * @internal
+     */
+    public function resetEnvCache(): void
+    {
+        $this->envCache = [];
+    }
+
+    /**
      * Gets all service ids.
      *
      * @return string[]

--- a/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
+++ b/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
@@ -374,5 +374,9 @@ class EnvVarProcessor implements EnvVarProcessorInterface, ResetInterface
     {
         $this->loadedVars = [];
         $this->loaders = $this->originalLoaders;
+
+        if ($this->container instanceof Container) {
+            $this->container->resetEnvCache();
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59128
| License       | MIT


As mentioned in #59128 and https://github.com/symfony/symfony/pull/54666#issuecomment-2479860954 (and proceeding comments), EnvVarProcessor isn't tagged with kernel.reset, hence its reset method is never called in ServicesResetter.

Another issue was that env vars are cached high up in stack (in Container class) and even if EnvVarProcessor's cached env vars are cleared, env var loaders still won't be called as env var loaders are called only for missing env keys.

This PR fixes #59128 by adding the missing tag and also clears "env cache" of Container in `EnvVarProcessor::reset()` method (i.e. whenever env vars of EnvVarProcessor are cleared). This is a safe change and won't break existing apps using symfony messenger.

cc @bendavies
