### PR TITLE
[WebProfilerBundle] fix: white-space in highlighted code

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/open.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/open.css.twig
@@ -40,6 +40,7 @@
 #source .source-content ol li {
     margin: 0 0 2px 0;
     padding-left: 5px;
+    white-space: preserve nowrap;
 }
 #source .source-content ol li::marker {
     color: var(--color-muted);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

fixing the whitespace handling in highlighted code.
might it's like this for a while now or maybe just with newer php version ¯\_(ツ)_/¯

**before:**
![image](https://github.com/user-attachments/assets/9dfe5279-a652-4721-8d95-3f99cae6456c)

**after:**
![image](https://github.com/user-attachments/assets/4b42c14e-18af-48aa-9413-346a92c2ca87)
