### PR TITLE
[TypeInfo] Make `Type::nullable` method no-op on every nullable type

### DIFF
--- a/src/Symfony/Component/TypeInfo/Tests/TypeFactoryTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeFactoryTest.php
@@ -195,6 +195,7 @@ class TypeFactoryTest extends TestCase
     {
         $this->assertEquals(new NullableType(new BuiltinType(TypeIdentifier::INT)), Type::nullable(Type::int()));
         $this->assertEquals(new NullableType(new BuiltinType(TypeIdentifier::INT)), Type::nullable(Type::nullable(Type::int())));
+        $this->assertEquals(new BuiltinType(TypeIdentifier::MIXED), Type::nullable(Type::mixed()));
 
         $this->assertEquals(
             new NullableType(new UnionType(new BuiltinType(TypeIdentifier::INT), new BuiltinType(TypeIdentifier::STRING))),

--- a/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
+++ b/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
@@ -330,11 +330,11 @@ trait TypeFactoryTrait
      *
      * @param T $type
      *
-     * @return ($type is NullableType ? T : NullableType<T>)
+     * @return T|NullableType<T>
      */
-    public static function nullable(Type $type): NullableType
+    public static function nullable(Type $type): Type
     {
-        if ($type instanceof NullableType) {
+        if ($type->isNullable()) {
             return $type;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #59137
| License       | MIT

Make `Type::nullable` method no-op on every nullable type, not only on `NullableType` types.