### PR TITLE
[Security] Use the session only if it is started when using `SameOriginCsrfTokenManager`

### DIFF
--- a/src/Symfony/Component/Security/Csrf/SameOriginCsrfTokenManager.php
+++ b/src/Symfony/Component/Security/Csrf/SameOriginCsrfTokenManager.php
@@ -207,9 +207,17 @@ final class SameOriginCsrfTokenManager implements CsrfTokenManagerInterface
 
     public function persistStrategy(Request $request): void
     {
-        if ($request->hasSession(true) && $request->attributes->has($this->cookieName)) {
-            $request->getSession()->set($this->cookieName, $request->attributes->get($this->cookieName));
+        if (!$request->attributes->has($this->cookieName)
+            || !$request->hasSession(true)
+            || !($session = $request->getSession())->isStarted()
+        ) {
+            return;
         }
+
+        $usageIndexValue = $session instanceof Session ? $usageIndexReference = &$session->getUsageIndex() : 0;
+        $usageIndexReference = \PHP_INT_MIN;
+        $session->set($this->cookieName, $request->attributes->get($this->cookieName));
+        $usageIndexReference = $usageIndexValue;
     }
 
     public function onKernelResponse(ResponseEvent $event): void

--- a/src/Symfony/Component/Security/Csrf/Tests/SameOriginCsrfTokenManagerTest.php
+++ b/src/Symfony/Component/Security/Csrf/Tests/SameOriginCsrfTokenManagerTest.php
@@ -207,14 +207,29 @@ class SameOriginCsrfTokenManagerTest extends TestCase
         $this->assertTrue($response->headers->has('Set-Cookie'));
     }
 
-    public function testPersistStrategyWithSession()
+    public function testPersistStrategyWithStartedSession()
     {
         $session = $this->createMock(Session::class);
+        $session->method('isStarted')->willReturn(true);
+
         $request = new Request();
         $request->setSession($session);
         $request->attributes->set('csrf-token', 2 << 8);
 
         $session->expects($this->once())->method('set')->with('csrf-token', 2 << 8);
+
+        $this->csrfTokenManager->persistStrategy($request);
+    }
+
+    public function testPersistStrategyWithSessionNotStarted()
+    {
+        $session = $this->createMock(Session::class);
+
+        $request = new Request();
+        $request->setSession($session);
+        $request->attributes->set('csrf-token', 2 << 8);
+
+        $session->expects($this->never())->method('set');
 
         $this->csrfTokenManager->persistStrategy($request);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59092
| License       | MIT

If I understand well, the `SameOriginCsrfTokenManager` has been created to provide a stateless way of creating CSRF tokens and therefore allow pages with CSRF tokens to be cached.

When using `Symfony\Component\Security\Csrf\SameOriginCsrfTokenManager`, I think an additionnal check must be done to ensure that the session is started in addition to verifying that it exists. If not, the CSRF strategy used will be persisted everytime in the session and the stateless check (used with the `#[Route]` attribute parameter) will therefore never pass.