### PR TITLE
[TypeInfo] Remove useless dependencies and conflicts

### DIFF
--- a/src/Symfony/Component/TypeInfo/composer.json
+++ b/src/Symfony/Component/TypeInfo/composer.json
@@ -29,12 +29,7 @@
         "psr/container": "^1.1|^2.0"
     },
     "require-dev": {
-        "phpstan/phpdoc-parser": "^1.0|^2.0",
-        "symfony/dependency-injection": "^6.4|^7.0"
-    },
-    "conflict": {
-        "phpstan/phpdoc-parser": "<1.0",
-        "symfony/dependency-injection": "<6.4"
+        "phpstan/phpdoc-parser": "^1.0|^2.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\TypeInfo\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

- Remove `symfony/dependency-injection` dev dependency as it's not required anymore.
- Remove useless conflict definition.