### PR TITLE
[HttpKernel] [MapQueryString] added key argument to MapQueryString attribute

### DIFF
--- a/src/Symfony/Component/HttpKernel/Attribute/MapQueryString.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/MapQueryString.php
@@ -37,6 +37,7 @@ class MapQueryString extends ValueResolver
         public readonly string|GroupSequence|array|null $validationGroups = null,
         string $resolver = RequestPayloadValueResolver::class,
         public readonly int $validationFailedStatusCode = Response::HTTP_NOT_FOUND,
+        public readonly ?string $key = null,
     ) {
         parent::__construct($resolver);
     }

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.3
+---
+
+ * Add `$key` argument to `#[MapQueryString]` that allows using a specific key for argument resolving
+
 7.2
 ---
 

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
@@ -186,7 +186,7 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
 
     private function mapQueryString(Request $request, ArgumentMetadata $argument, MapQueryString $attribute): ?object
     {
-        if (!($data = $request->query->all()) && ($argument->isNullable() || $argument->hasDefaultValue())) {
+        if (!($data = $request->query->all($attribute->key)) && ($argument->isNullable() || $argument->hasDefaultValue())) {
             return null;
         }
 

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php
@@ -874,6 +874,27 @@ class RequestPayloadValueResolverTest extends TestCase
 
         $this->assertTrue($event->getArguments()[0]->value);
     }
+
+    public function testConfigKeyForQueryString()
+    {
+        $serializer = new Serializer([new ObjectNormalizer()]);
+        $validator = $this->createMock(ValidatorInterface::class);
+        $resolver = new RequestPayloadValueResolver($serializer, $validator);
+
+        $argument = new ArgumentMetadata('filtered', QueryPayload::class, false, false, null, false, [
+            MapQueryString::class => new MapQueryString(key: 'value'),
+        ]);
+        $request = Request::create('/', Request::METHOD_GET, ['value' => ['page' => 1.0]]);
+
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $arguments = $resolver->resolve($request, $argument);
+        $event = new ControllerArgumentsEvent($kernel, function () {}, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $resolver->onKernelControllerArguments($event);
+
+        $this->assertInstanceOf(QueryPayload::class, $event->getArguments()[0]);
+        $this->assertSame(1.0, $event->getArguments()[0]->page);
+    }
 }
 
 class RequestPayload


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | N/A
| License       | MIT


When using `[#MapQueryString]`, the default resolver uses the `$request->query-all()` function but there's currently no way to pass a specific key to this function if needed.  
This PR add a `$key` argument to the `#[MapQueryString]` attribute that will allow to pass a specific key if needed to the default resolver.

**Example :** 
Given the following query : `https://example.org?search[term]=foo&search[category]=bar`, using current `#[MapQueryString]` implementation will resolve an object with only `$search` property.
Change proposed in this PR allows to pass a `key` argument like `#[MapQueryString(key: search)]`. Doing so, the object will be resolved with `$term` and `$category` properties.