### PR TITLE
[BeanstalkMessenger] Round delay to an integer to avoid deprecation warning

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Tests/Transport/ConnectionTest.php
@@ -330,4 +330,25 @@ final class ConnectionTest extends TestCase
 
         $connection->send($body, $headers, $delay);
     }
+
+    public function testSendWithRoundedDelay()
+    {
+        $tube = 'xyz';
+        $body = 'foo';
+        $headers = ['test' => 'bar'];
+        $delay = 920;
+        $expectedDelay = 0;
+
+        $client = $this->createMock(PheanstalkInterface::class);
+        $client->expects($this->once())->method('useTube')->with($tube)->willReturn($client);
+        $client->expects($this->once())->method('put')->with(
+            $this->anything(),
+            $this->anything(),
+            $expectedDelay,
+            $this->anything(),
+        );
+
+        $connection = new Connection(['tube_name' => $tube], $client);
+        $connection->send($body, $headers, $delay);
+    }
 }

--- a/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Transport/Connection.php
@@ -123,7 +123,7 @@ class Connection
             $job = $this->client->useTube($this->tube)->put(
                 $message,
                 PheanstalkInterface::DEFAULT_PRIORITY,
-                $delay / 1000,
+                (int) ($delay / 1000),
                 $this->ttr
             );
         } catch (Exception $exception) {


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | -
| License       | MIT

https://github.com/pheanstalk/pheanstalk/blob/1459f2f62dddfe28902e0584708417dddd79bd70/src/Pheanstalk.php#L223-L228

The `Pheanstalk::put()` method expects the `$delay` parameter to be an integer. However, during the conversion from milliseconds to seconds, it is passed as a float. This triggers a deprecation warning: 'Deprecated: Implicit conversion from float to int loses precision.'
