### PR TITLE
[Messenger] [Amqp] Allow sendable AmqpStamp for failure routing

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpSenderTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpSenderTest.php
@@ -13,11 +13,14 @@ namespace Symfony\Component\Messenger\Bridge\Amqp\Tests\Transport;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Bridge\Amqp\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpReceivedStamp;
 use Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpSender;
 use Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpStamp;
 use Symfony\Component\Messenger\Bridge\Amqp\Transport\Connection;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\TransportException;
+use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
+use Symfony\Component\Messenger\Stamp\SentToFailureTransportStamp;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
 /**
@@ -43,6 +46,48 @@ class AmqpSenderTest extends TestCase
     public function testItSendsTheEncodedMessageUsingARoutingKey()
     {
         $envelope = (new Envelope(new DummyMessage('Oy')))->with($stamp = new AmqpStamp('rk'));
+        $encoded = ['body' => '...', 'headers' => ['type' => DummyMessage::class]];
+
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->method('encode')->with($envelope)->willReturn($encoded);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())->method('publish')->with($encoded['body'], $encoded['headers'], 0, $stamp);
+
+        $sender = new AmqpSender($connection, $serializer);
+        $sender->send($envelope);
+    }
+
+    public function testItSendsTheEncodedMessageUsingARoutingKeyOnRetry()
+    {
+        $envelope = (new Envelope(new DummyMessage('Oy')))
+            ->with($previousStamp = new AmqpStamp('rk'))
+            ->with(new AmqpReceivedStamp($amqpEnvelope = new \AMQPEnvelope(), 'queueName'))
+            ->with(new RedeliveryStamp(1))
+        ;
+        $encoded = ['body' => '...', 'headers' => ['type' => DummyMessage::class]];
+
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->method('encode')->with($envelope)->willReturn($encoded);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())->method('publish')->with(
+            $encoded['body'],
+            $encoded['headers'],
+            0,
+            AmqpStamp::createFromAmqpEnvelope($amqpEnvelope, $previousStamp, 'queueName')
+        );
+
+        $sender = new AmqpSender($connection, $serializer);
+        $sender->send($envelope);
+    }
+
+    public function testItSendsTheEncodedMessageUsingARoutingKeyOnFailure()
+    {
+        $envelope = (new Envelope(new DummyMessage('Oy')))
+            ->with($stamp = new AmqpStamp('rk'))
+            ->with(new SentToFailureTransportStamp('originalReceiverName'))
+        ;
         $encoded = ['body' => '...', 'headers' => ['type' => DummyMessage::class]];
 
         $serializer = $this->createMock(SerializerInterface::class);

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpStamp.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpStamp.php
@@ -11,13 +11,13 @@
 
 namespace Symfony\Component\Messenger\Bridge\Amqp\Transport;
 
-use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
+use Symfony\Component\Messenger\Stamp\StampInterface;
 
 /**
  * @author Guillaume Gammelin <ggammelin@gmail.com>
  * @author Samuel Roze <samuel.roze@gmail.com>
  */
-final class AmqpStamp implements NonSendableStampInterface
+final class AmqpStamp implements StampInterface
 {
     private bool $isRetryAttempt = false;
 


### PR DESCRIPTION
| Q                       | A
| ---------------| ---
| Branch?            | 7.3 
| Bug fix?            | no
| New feature?   | no
| Deprecations? | no
| Issues               | 
| License             | MIT

This PR allows to route message through failure transport using AMQP routing key. 

**Problem statement:** 
For business purpose, we wanted to route failed message to different queues. This were impossible due to several things : 
- `AmqpStamp` implements `NonSendableStampInterface` so, it's removed on serialization, and we couldn't retrieve it after `SendFailedMessageToFailureTransportListener` sends the envelope to failure transport.
- if a retry occurred, then the `AmqpSender` set the routing to the queue name instead of the initial routing key

**Example**
Here's an example of a messenger configuration that could use it: 
```
framework:
    messenger:
        failure_transport: failure
	
	    transports:
	        failure:
                dsn: '%env(resolve:AMQP_DSN)%/failure_exchange'
                options:
                    queues:
                        failure_queue_1:
                            binding_keys: ['routing_key_1']
                        failure_queue_2:
                            binding_keys: ['routing_key_2']
	        transport_1:
                dsn: '%env(resolve:AMQP_DSN)%/exchange'
                options:
                    queues:
                        queue_1:
                            binding_keys: ['routing_key_1']
	        transport_2:
                dsn: '%env(resolve:AMQP_DSN)%/exchange'
                options:
                    queues:
                        queue_2:
                            binding_keys: ['routing_key_2']
```
This config would create : 
```
exchange
     \____routing_key_1____ queue_1
     \____routing_key_2____ queue_2
failure_exchange
     \____routing_key_1____ failure_queue_1
     \____routing_key_2____ failure_queue_2
```
