### PR TITLE
[Console] Fix tests

### DIFF
--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -79,6 +79,7 @@ class ApplicationTest extends TestCase
             pcntl_signal(\SIGTERM, \SIG_DFL);
             pcntl_signal(\SIGUSR1, \SIG_DFL);
             pcntl_signal(\SIGUSR2, \SIG_DFL);
+            pcntl_signal(\SIGALRM, \SIG_DFL);
         }
     }
 

--- a/src/Symfony/Component/Console/Tests/ConsoleEventsTest.php
+++ b/src/Symfony/Component/Console/Tests/ConsoleEventsTest.php
@@ -39,6 +39,7 @@ class ConsoleEventsTest extends TestCase
             pcntl_signal(\SIGTERM, \SIG_DFL);
             pcntl_signal(\SIGUSR1, \SIG_DFL);
             pcntl_signal(\SIGUSR2, \SIG_DFL);
+            pcntl_signal(\SIGALRM, \SIG_DFL);
         }
     }
 

--- a/src/Symfony/Component/Console/Tests/SignalRegistry/SignalRegistryTest.php
+++ b/src/Symfony/Component/Console/Tests/SignalRegistry/SignalRegistryTest.php
@@ -27,6 +27,7 @@ class SignalRegistryTest extends TestCase
         pcntl_signal(\SIGTERM, \SIG_DFL);
         pcntl_signal(\SIGUSR1, \SIG_DFL);
         pcntl_signal(\SIGUSR2, \SIG_DFL);
+        pcntl_signal(\SIGALRM, \SIG_DFL);
     }
 
     public function testOneCallbackForASignalSignalIsHandled()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The Console test suite was not running correctly since https://github.com/symfony/symfony/pull/53533. 
See unit tests on 7.2/7.3:

<img width="863" alt="Screenshot 2024-12-11 at 04 53 56" src="https://github.com/user-attachments/assets/389281a3-9f62-4984-8d96-5704a123e476">

/cc @theofidry