### PR TITLE
[FrameworkBundle] Add `symfony/json-encoder` to dev requirements

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HtmlSanitizer\HtmlSanitizer;
 use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\JsonEncoder\JsonEncoder;
 use Symfony\Component\Lock\Store\SemaphoreStore;
 use Symfony\Component\Mailer\Mailer;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -971,7 +972,7 @@ class ConfigurationTest extends TestCase
                 'enabled' => !class_exists(FullStack::class) && class_exists(RemoteEvent::class),
             ],
             'json_encoder' => [
-                'enabled' => false,
+                'enabled' => !class_exists(FullStack::class) && class_exists(JsonEncoder::class),
                 'paths' => [],
             ],
         ];

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -69,6 +69,7 @@
         "symfony/workflow": "^6.4|^7.0",
         "symfony/yaml": "^6.4|^7.0",
         "symfony/property-info": "^6.4|^7.0",
+        "symfony/json-encoder": "^7.3",
         "symfony/uid": "^6.4|^7.0",
         "symfony/web-link": "^6.4|^7.0",
         "symfony/webhook": "^7.2",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This fixes most errors on low-deps (from about 60 to 7), but a few are remaining because of some invalid service definition which certainly has another root cause. They may be addressed in a follow-up PR. Maybe do you have an idea @mtarld?