### PR TITLE
[JsonEncoder] Add native lazyghost support

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2032,6 +2032,10 @@ class FrameworkExtension extends Extension
         foreach ($config['paths'] as $namespace => $path) {
             $loader->registerClasses($encodableDefinition, $namespace, $path);
         }
+
+        if (\PHP_VERSION_ID >= 80400) {
+            $container->removeDefinition('.json_encoder.cache_warmer.lazy_ghost');
+        }
     }
 
     private function registerPropertyInfoConfiguration(ContainerBuilder $container, PhpFileLoader $loader): void

--- a/src/Symfony/Component/JsonEncoder/CHANGELOG.md
+++ b/src/Symfony/Component/JsonEncoder/CHANGELOG.md
@@ -5,3 +5,4 @@ CHANGELOG
 ---
 
  * Introduce the component as experimental
+ * Add native PHP lazy ghost support

--- a/src/Symfony/Component/JsonEncoder/Decode/PhpAstBuilder.php
+++ b/src/Symfony/Component/JsonEncoder/Decode/PhpAstBuilder.php
@@ -53,8 +53,8 @@ use Symfony\Component\JsonEncoder\Exception\UnexpectedValueException;
 use Symfony\Component\TypeInfo\Type\BackedEnumType;
 use Symfony\Component\TypeInfo\Type\CollectionType;
 use Symfony\Component\TypeInfo\Type\ObjectType;
-use Symfony\Component\TypeInfo\TypeIdentifier;
 use Symfony\Component\TypeInfo\Type\WrappingTypeInterface;
+use Symfony\Component\TypeInfo\TypeIdentifier;
 
 /**
  * Builds a PHP syntax tree that decodes JSON.
@@ -445,21 +445,8 @@ final class PhpAstBuilder
                     );
 
                 $streamPropertiesValuesStmts[] = new MatchArm([$this->builder->val($encodedName)], new Assign(
-                    new ArrayDimFetch($this->builder->var('properties'), $this->builder->val($property['name'])),
-                    new Closure([
-                        'static' => true,
-                        'uses' => [
-                            new ClosureUse($this->builder->var('stream')),
-                            new ClosureUse($this->builder->var('v')),
-                            new ClosureUse($this->builder->var('options')),
-                            new ClosureUse($this->builder->var('denormalizers')),
-                            new ClosureUse($this->builder->var('instantiator')),
-                            new ClosureUse($this->builder->var('providers'), byRef: true),
-                        ],
-                        'stmts' => [
-                            new Return_($property['accessor'](new PhpExprDataAccessor($propertyValueStmt))->toPhpExpr()),
-                        ],
-                    ]),
+                    $this->builder->propertyFetch($this->builder->var('object'), $property['name']),
+                    $property['accessor'](new PhpExprDataAccessor($propertyValueStmt))->toPhpExpr(),
                 ));
             } else {
                 $propertyValueStmt = $this->nodeOnlyNeedsDecode($property['value'], $decodeFromStream)
@@ -494,17 +481,29 @@ final class PhpAstBuilder
 
         if ($decodeFromStream) {
             $instantiateStmts = [
-                new Expression(new Assign($this->builder->var('properties'), new Array_([], ['kind' => Array_::KIND_SHORT]))),
-                new Foreach_($this->builder->var('data'), $this->builder->var('v'), [
-                    'keyVar' => $this->builder->var('k'),
-                    'stmts' => [new Expression(new Match_(
-                        $this->builder->var('k'),
-                        [...$streamPropertiesValuesStmts, new MatchArm(null, $this->builder->val(null))],
-                    ))],
-                ]),
                 new Return_($this->builder->methodCall($this->builder->var('instantiator'), 'instantiate', [
                     new ClassConstFetch(new FullyQualified($node->getType()->getClassName()), 'class'),
-                    $this->builder->var('properties'),
+                    new Closure([
+                        'static' => true,
+                        'params' => [new Param($this->builder->var('object'))],
+                        'uses' => [
+                            new ClosureUse($this->builder->var('stream')),
+                            new ClosureUse($this->builder->var('data')),
+                            new ClosureUse($this->builder->var('options')),
+                            new ClosureUse($this->builder->var('denormalizers')),
+                            new ClosureUse($this->builder->var('instantiator')),
+                            new ClosureUse($this->builder->var('providers'), byRef: true),
+                        ],
+                        'stmts' => [
+                            new Foreach_($this->builder->var('data'), $this->builder->var('v'), [
+                                'keyVar' => $this->builder->var('k'),
+                                'stmts' => [new Expression(new Match_(
+                                    $this->builder->var('k'),
+                                    [...$streamPropertiesValuesStmts, new MatchArm(null, $this->builder->val(null))],
+                                ))],
+                            ]),
+                        ],
+                    ]),
                 ])),
             ];
         } else {

--- a/src/Symfony/Component/JsonEncoder/Encode/PhpAstBuilder.php
+++ b/src/Symfony/Component/JsonEncoder/Encode/PhpAstBuilder.php
@@ -45,8 +45,8 @@ use Symfony\Component\JsonEncoder\Exception\LogicException;
 use Symfony\Component\JsonEncoder\Exception\RuntimeException;
 use Symfony\Component\JsonEncoder\Exception\UnexpectedValueException;
 use Symfony\Component\TypeInfo\Type\ObjectType;
-use Symfony\Component\TypeInfo\TypeIdentifier;
 use Symfony\Component\TypeInfo\Type\WrappingTypeInterface;
+use Symfony\Component\TypeInfo\TypeIdentifier;
 
 /**
  * Builds a PHP syntax tree that encodes data to JSON.

--- a/src/Symfony/Component/JsonEncoder/Mapping/GenericTypePropertyMetadataLoader.php
+++ b/src/Symfony/Component/JsonEncoder/Mapping/GenericTypePropertyMetadataLoader.php
@@ -18,8 +18,8 @@ use Symfony\Component\TypeInfo\Type\GenericType;
 use Symfony\Component\TypeInfo\Type\IntersectionType;
 use Symfony\Component\TypeInfo\Type\ObjectType;
 use Symfony\Component\TypeInfo\Type\UnionType;
-use Symfony\Component\TypeInfo\TypeContext\TypeContextFactory;
 use Symfony\Component\TypeInfo\Type\WrappingTypeInterface;
+use Symfony\Component\TypeInfo\TypeContext\TypeContextFactory;
 
 /**
  * Enhances properties encoding/decoding metadata based on properties' generic type.

--- a/src/Symfony/Component/JsonEncoder/Tests/Fixtures/decoder/nullable_object.stream.php
+++ b/src/Symfony/Component/JsonEncoder/Tests/Fixtures/decoder/nullable_object.stream.php
@@ -3,19 +3,15 @@
 return static function (mixed $stream, \Psr\Container\ContainerInterface $denormalizers, \Symfony\Component\JsonEncoder\Decode\LazyInstantiator $instantiator, array $options): mixed {
     $providers['Symfony\Component\JsonEncoder\Tests\Fixtures\Model\ClassicDummy'] = static function ($stream, $offset, $length) use ($options, $denormalizers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonEncoder\Decode\Splitter::splitDict($stream, $offset, $length);
-        $properties = [];
-        foreach ($data as $k => $v) {
-            match ($k) {
-                'id' => $properties['id'] = static function () use ($stream, $v, $options, $denormalizers, $instantiator, &$providers) {
-                    return \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]);
-                },
-                'name' => $properties['name'] = static function () use ($stream, $v, $options, $denormalizers, $instantiator, &$providers) {
-                    return \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]);
-                },
-                default => null,
-            };
-        }
-        return $instantiator->instantiate(\Symfony\Component\JsonEncoder\Tests\Fixtures\Model\ClassicDummy::class, $properties);
+        return $instantiator->instantiate(\Symfony\Component\JsonEncoder\Tests\Fixtures\Model\ClassicDummy::class, static function ($object) use ($stream, $data, $options, $denormalizers, $instantiator, &$providers) {
+            foreach ($data as $k => $v) {
+                match ($k) {
+                    'id' => $object->id = \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]),
+                    'name' => $object->name = \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]),
+                    default => null,
+                };
+            }
+        });
     };
     $providers['Symfony\Component\JsonEncoder\Tests\Fixtures\Model\ClassicDummy|null'] = static function ($stream, $offset, $length) use ($options, $denormalizers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $offset, $length);

--- a/src/Symfony/Component/JsonEncoder/Tests/Fixtures/decoder/nullable_object_dict.stream.php
+++ b/src/Symfony/Component/JsonEncoder/Tests/Fixtures/decoder/nullable_object_dict.stream.php
@@ -12,19 +12,15 @@ return static function (mixed $stream, \Psr\Container\ContainerInterface $denorm
     };
     $providers['Symfony\Component\JsonEncoder\Tests\Fixtures\Model\ClassicDummy'] = static function ($stream, $offset, $length) use ($options, $denormalizers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonEncoder\Decode\Splitter::splitDict($stream, $offset, $length);
-        $properties = [];
-        foreach ($data as $k => $v) {
-            match ($k) {
-                'id' => $properties['id'] = static function () use ($stream, $v, $options, $denormalizers, $instantiator, &$providers) {
-                    return \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]);
-                },
-                'name' => $properties['name'] = static function () use ($stream, $v, $options, $denormalizers, $instantiator, &$providers) {
-                    return \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]);
-                },
-                default => null,
-            };
-        }
-        return $instantiator->instantiate(\Symfony\Component\JsonEncoder\Tests\Fixtures\Model\ClassicDummy::class, $properties);
+        return $instantiator->instantiate(\Symfony\Component\JsonEncoder\Tests\Fixtures\Model\ClassicDummy::class, static function ($object) use ($stream, $data, $options, $denormalizers, $instantiator, &$providers) {
+            foreach ($data as $k => $v) {
+                match ($k) {
+                    'id' => $object->id = \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]),
+                    'name' => $object->name = \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]),
+                    default => null,
+                };
+            }
+        });
     };
     $providers['array<string,Symfony\Component\JsonEncoder\Tests\Fixtures\Model\ClassicDummy>|null'] = static function ($stream, $offset, $length) use ($options, $denormalizers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $offset, $length);

--- a/src/Symfony/Component/JsonEncoder/Tests/Fixtures/decoder/nullable_object_list.stream.php
+++ b/src/Symfony/Component/JsonEncoder/Tests/Fixtures/decoder/nullable_object_list.stream.php
@@ -12,19 +12,15 @@ return static function (mixed $stream, \Psr\Container\ContainerInterface $denorm
     };
     $providers['Symfony\Component\JsonEncoder\Tests\Fixtures\Model\ClassicDummy'] = static function ($stream, $offset, $length) use ($options, $denormalizers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonEncoder\Decode\Splitter::splitDict($stream, $offset, $length);
-        $properties = [];
-        foreach ($data as $k => $v) {
-            match ($k) {
-                'id' => $properties['id'] = static function () use ($stream, $v, $options, $denormalizers, $instantiator, &$providers) {
-                    return \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]);
-                },
-                'name' => $properties['name'] = static function () use ($stream, $v, $options, $denormalizers, $instantiator, &$providers) {
-                    return \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]);
-                },
-                default => null,
-            };
-        }
-        return $instantiator->instantiate(\Symfony\Component\JsonEncoder\Tests\Fixtures\Model\ClassicDummy::class, $properties);
+        return $instantiator->instantiate(\Symfony\Component\JsonEncoder\Tests\Fixtures\Model\ClassicDummy::class, static function ($object) use ($stream, $data, $options, $denormalizers, $instantiator, &$providers) {
+            foreach ($data as $k => $v) {
+                match ($k) {
+                    'id' => $object->id = \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]),
+                    'name' => $object->name = \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]),
+                    default => null,
+                };
+            }
+        });
     };
     $providers['array<int,Symfony\Component\JsonEncoder\Tests\Fixtures\Model\ClassicDummy>|null'] = static function ($stream, $offset, $length) use ($options, $denormalizers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $offset, $length);

--- a/src/Symfony/Component/JsonEncoder/Tests/Fixtures/decoder/object.stream.php
+++ b/src/Symfony/Component/JsonEncoder/Tests/Fixtures/decoder/object.stream.php
@@ -3,19 +3,15 @@
 return static function (mixed $stream, \Psr\Container\ContainerInterface $denormalizers, \Symfony\Component\JsonEncoder\Decode\LazyInstantiator $instantiator, array $options): mixed {
     $providers['Symfony\Component\JsonEncoder\Tests\Fixtures\Model\ClassicDummy'] = static function ($stream, $offset, $length) use ($options, $denormalizers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonEncoder\Decode\Splitter::splitDict($stream, $offset, $length);
-        $properties = [];
-        foreach ($data as $k => $v) {
-            match ($k) {
-                'id' => $properties['id'] = static function () use ($stream, $v, $options, $denormalizers, $instantiator, &$providers) {
-                    return \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]);
-                },
-                'name' => $properties['name'] = static function () use ($stream, $v, $options, $denormalizers, $instantiator, &$providers) {
-                    return \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]);
-                },
-                default => null,
-            };
-        }
-        return $instantiator->instantiate(\Symfony\Component\JsonEncoder\Tests\Fixtures\Model\ClassicDummy::class, $properties);
+        return $instantiator->instantiate(\Symfony\Component\JsonEncoder\Tests\Fixtures\Model\ClassicDummy::class, static function ($object) use ($stream, $data, $options, $denormalizers, $instantiator, &$providers) {
+            foreach ($data as $k => $v) {
+                match ($k) {
+                    'id' => $object->id = \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]),
+                    'name' => $object->name = \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]),
+                    default => null,
+                };
+            }
+        });
     };
     return $providers['Symfony\Component\JsonEncoder\Tests\Fixtures\Model\ClassicDummy']($stream, 0, null);
 };

--- a/src/Symfony/Component/JsonEncoder/Tests/Fixtures/decoder/object_dict.stream.php
+++ b/src/Symfony/Component/JsonEncoder/Tests/Fixtures/decoder/object_dict.stream.php
@@ -12,19 +12,15 @@ return static function (mixed $stream, \Psr\Container\ContainerInterface $denorm
     };
     $providers['Symfony\Component\JsonEncoder\Tests\Fixtures\Model\ClassicDummy'] = static function ($stream, $offset, $length) use ($options, $denormalizers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonEncoder\Decode\Splitter::splitDict($stream, $offset, $length);
-        $properties = [];
-        foreach ($data as $k => $v) {
-            match ($k) {
-                'id' => $properties['id'] = static function () use ($stream, $v, $options, $denormalizers, $instantiator, &$providers) {
-                    return \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]);
-                },
-                'name' => $properties['name'] = static function () use ($stream, $v, $options, $denormalizers, $instantiator, &$providers) {
-                    return \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]);
-                },
-                default => null,
-            };
-        }
-        return $instantiator->instantiate(\Symfony\Component\JsonEncoder\Tests\Fixtures\Model\ClassicDummy::class, $properties);
+        return $instantiator->instantiate(\Symfony\Component\JsonEncoder\Tests\Fixtures\Model\ClassicDummy::class, static function ($object) use ($stream, $data, $options, $denormalizers, $instantiator, &$providers) {
+            foreach ($data as $k => $v) {
+                match ($k) {
+                    'id' => $object->id = \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]),
+                    'name' => $object->name = \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]),
+                    default => null,
+                };
+            }
+        });
     };
     return $providers['array<string,Symfony\Component\JsonEncoder\Tests\Fixtures\Model\ClassicDummy>']($stream, 0, null);
 };

--- a/src/Symfony/Component/JsonEncoder/Tests/Fixtures/decoder/object_in_object.stream.php
+++ b/src/Symfony/Component/JsonEncoder/Tests/Fixtures/decoder/object_in_object.stream.php
@@ -3,54 +3,40 @@
 return static function (mixed $stream, \Psr\Container\ContainerInterface $denormalizers, \Symfony\Component\JsonEncoder\Decode\LazyInstantiator $instantiator, array $options): mixed {
     $providers['Symfony\Component\JsonEncoder\Tests\Fixtures\Model\DummyWithOtherDummies'] = static function ($stream, $offset, $length) use ($options, $denormalizers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonEncoder\Decode\Splitter::splitDict($stream, $offset, $length);
-        $properties = [];
-        foreach ($data as $k => $v) {
-            match ($k) {
-                'name' => $properties['name'] = static function () use ($stream, $v, $options, $denormalizers, $instantiator, &$providers) {
-                    return \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]);
-                },
-                'otherDummyOne' => $properties['otherDummyOne'] = static function () use ($stream, $v, $options, $denormalizers, $instantiator, &$providers) {
-                    return $providers['Symfony\Component\JsonEncoder\Tests\Fixtures\Model\DummyWithNameAttributes']($stream, $v[0], $v[1]);
-                },
-                'otherDummyTwo' => $properties['otherDummyTwo'] = static function () use ($stream, $v, $options, $denormalizers, $instantiator, &$providers) {
-                    return $providers['Symfony\Component\JsonEncoder\Tests\Fixtures\Model\ClassicDummy']($stream, $v[0], $v[1]);
-                },
-                default => null,
-            };
-        }
-        return $instantiator->instantiate(\Symfony\Component\JsonEncoder\Tests\Fixtures\Model\DummyWithOtherDummies::class, $properties);
+        return $instantiator->instantiate(\Symfony\Component\JsonEncoder\Tests\Fixtures\Model\DummyWithOtherDummies::class, static function ($object) use ($stream, $data, $options, $denormalizers, $instantiator, &$providers) {
+            foreach ($data as $k => $v) {
+                match ($k) {
+                    'name' => $object->name = \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]),
+                    'otherDummyOne' => $object->otherDummyOne = $providers['Symfony\Component\JsonEncoder\Tests\Fixtures\Model\DummyWithNameAttributes']($stream, $v[0], $v[1]),
+                    'otherDummyTwo' => $object->otherDummyTwo = $providers['Symfony\Component\JsonEncoder\Tests\Fixtures\Model\ClassicDummy']($stream, $v[0], $v[1]),
+                    default => null,
+                };
+            }
+        });
     };
     $providers['Symfony\Component\JsonEncoder\Tests\Fixtures\Model\DummyWithNameAttributes'] = static function ($stream, $offset, $length) use ($options, $denormalizers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonEncoder\Decode\Splitter::splitDict($stream, $offset, $length);
-        $properties = [];
-        foreach ($data as $k => $v) {
-            match ($k) {
-                '@id' => $properties['id'] = static function () use ($stream, $v, $options, $denormalizers, $instantiator, &$providers) {
-                    return \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]);
-                },
-                'name' => $properties['name'] = static function () use ($stream, $v, $options, $denormalizers, $instantiator, &$providers) {
-                    return \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]);
-                },
-                default => null,
-            };
-        }
-        return $instantiator->instantiate(\Symfony\Component\JsonEncoder\Tests\Fixtures\Model\DummyWithNameAttributes::class, $properties);
+        return $instantiator->instantiate(\Symfony\Component\JsonEncoder\Tests\Fixtures\Model\DummyWithNameAttributes::class, static function ($object) use ($stream, $data, $options, $denormalizers, $instantiator, &$providers) {
+            foreach ($data as $k => $v) {
+                match ($k) {
+                    '@id' => $object->id = \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]),
+                    'name' => $object->name = \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]),
+                    default => null,
+                };
+            }
+        });
     };
     $providers['Symfony\Component\JsonEncoder\Tests\Fixtures\Model\ClassicDummy'] = static function ($stream, $offset, $length) use ($options, $denormalizers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonEncoder\Decode\Splitter::splitDict($stream, $offset, $length);
-        $properties = [];
-        foreach ($data as $k => $v) {
-            match ($k) {
-                'id' => $properties['id'] = static function () use ($stream, $v, $options, $denormalizers, $instantiator, &$providers) {
-                    return \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]);
-                },
-                'name' => $properties['name'] = static function () use ($stream, $v, $options, $denormalizers, $instantiator, &$providers) {
-                    return \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]);
-                },
-                default => null,
-            };
-        }
-        return $instantiator->instantiate(\Symfony\Component\JsonEncoder\Tests\Fixtures\Model\ClassicDummy::class, $properties);
+        return $instantiator->instantiate(\Symfony\Component\JsonEncoder\Tests\Fixtures\Model\ClassicDummy::class, static function ($object) use ($stream, $data, $options, $denormalizers, $instantiator, &$providers) {
+            foreach ($data as $k => $v) {
+                match ($k) {
+                    'id' => $object->id = \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]),
+                    'name' => $object->name = \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]),
+                    default => null,
+                };
+            }
+        });
     };
     return $providers['Symfony\Component\JsonEncoder\Tests\Fixtures\Model\DummyWithOtherDummies']($stream, 0, null);
 };

--- a/src/Symfony/Component/JsonEncoder/Tests/Fixtures/decoder/object_list.stream.php
+++ b/src/Symfony/Component/JsonEncoder/Tests/Fixtures/decoder/object_list.stream.php
@@ -12,19 +12,15 @@ return static function (mixed $stream, \Psr\Container\ContainerInterface $denorm
     };
     $providers['Symfony\Component\JsonEncoder\Tests\Fixtures\Model\ClassicDummy'] = static function ($stream, $offset, $length) use ($options, $denormalizers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonEncoder\Decode\Splitter::splitDict($stream, $offset, $length);
-        $properties = [];
-        foreach ($data as $k => $v) {
-            match ($k) {
-                'id' => $properties['id'] = static function () use ($stream, $v, $options, $denormalizers, $instantiator, &$providers) {
-                    return \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]);
-                },
-                'name' => $properties['name'] = static function () use ($stream, $v, $options, $denormalizers, $instantiator, &$providers) {
-                    return \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]);
-                },
-                default => null,
-            };
-        }
-        return $instantiator->instantiate(\Symfony\Component\JsonEncoder\Tests\Fixtures\Model\ClassicDummy::class, $properties);
+        return $instantiator->instantiate(\Symfony\Component\JsonEncoder\Tests\Fixtures\Model\ClassicDummy::class, static function ($object) use ($stream, $data, $options, $denormalizers, $instantiator, &$providers) {
+            foreach ($data as $k => $v) {
+                match ($k) {
+                    'id' => $object->id = \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]),
+                    'name' => $object->name = \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]),
+                    default => null,
+                };
+            }
+        });
     };
     return $providers['array<int,Symfony\Component\JsonEncoder\Tests\Fixtures\Model\ClassicDummy>']($stream, 0, null);
 };

--- a/src/Symfony/Component/JsonEncoder/Tests/Fixtures/decoder/object_with_denormalizer.stream.php
+++ b/src/Symfony/Component/JsonEncoder/Tests/Fixtures/decoder/object_with_denormalizer.stream.php
@@ -3,25 +3,17 @@
 return static function (mixed $stream, \Psr\Container\ContainerInterface $denormalizers, \Symfony\Component\JsonEncoder\Decode\LazyInstantiator $instantiator, array $options): mixed {
     $providers['Symfony\Component\JsonEncoder\Tests\Fixtures\Model\DummyWithNormalizerAttributes'] = static function ($stream, $offset, $length) use ($options, $denormalizers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonEncoder\Decode\Splitter::splitDict($stream, $offset, $length);
-        $properties = [];
-        foreach ($data as $k => $v) {
-            match ($k) {
-                'id' => $properties['id'] = static function () use ($stream, $v, $options, $denormalizers, $instantiator, &$providers) {
-                    return $denormalizers->get('Symfony\Component\JsonEncoder\Tests\Fixtures\Denormalizer\DivideStringAndCastToIntDenormalizer')->denormalize(\Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]), $options);
-                },
-                'active' => $properties['active'] = static function () use ($stream, $v, $options, $denormalizers, $instantiator, &$providers) {
-                    return $denormalizers->get('Symfony\Component\JsonEncoder\Tests\Fixtures\Denormalizer\BooleanStringDenormalizer')->denormalize(\Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]), $options);
-                },
-                'name' => $properties['name'] = static function () use ($stream, $v, $options, $denormalizers, $instantiator, &$providers) {
-                    return strtoupper(\Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]));
-                },
-                'range' => $properties['range'] = static function () use ($stream, $v, $options, $denormalizers, $instantiator, &$providers) {
-                    return Symfony\Component\JsonEncoder\Tests\Fixtures\Model\DummyWithNormalizerAttributes::explodeRange(\Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]), $options);
-                },
-                default => null,
-            };
-        }
-        return $instantiator->instantiate(\Symfony\Component\JsonEncoder\Tests\Fixtures\Model\DummyWithNormalizerAttributes::class, $properties);
+        return $instantiator->instantiate(\Symfony\Component\JsonEncoder\Tests\Fixtures\Model\DummyWithNormalizerAttributes::class, static function ($object) use ($stream, $data, $options, $denormalizers, $instantiator, &$providers) {
+            foreach ($data as $k => $v) {
+                match ($k) {
+                    'id' => $object->id = $denormalizers->get('Symfony\Component\JsonEncoder\Tests\Fixtures\Denormalizer\DivideStringAndCastToIntDenormalizer')->denormalize(\Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]), $options),
+                    'active' => $object->active = $denormalizers->get('Symfony\Component\JsonEncoder\Tests\Fixtures\Denormalizer\BooleanStringDenormalizer')->denormalize(\Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]), $options),
+                    'name' => $object->name = strtoupper(\Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1])),
+                    'range' => $object->range = Symfony\Component\JsonEncoder\Tests\Fixtures\Model\DummyWithNormalizerAttributes::explodeRange(\Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]), $options),
+                    default => null,
+                };
+            }
+        });
     };
     return $providers['Symfony\Component\JsonEncoder\Tests\Fixtures\Model\DummyWithNormalizerAttributes']($stream, 0, null);
 };

--- a/src/Symfony/Component/JsonEncoder/Tests/Fixtures/decoder/object_with_nullable_properties.stream.php
+++ b/src/Symfony/Component/JsonEncoder/Tests/Fixtures/decoder/object_with_nullable_properties.stream.php
@@ -3,19 +3,15 @@
 return static function (mixed $stream, \Psr\Container\ContainerInterface $denormalizers, \Symfony\Component\JsonEncoder\Decode\LazyInstantiator $instantiator, array $options): mixed {
     $providers['Symfony\Component\JsonEncoder\Tests\Fixtures\Model\DummyWithNullableProperties'] = static function ($stream, $offset, $length) use ($options, $denormalizers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonEncoder\Decode\Splitter::splitDict($stream, $offset, $length);
-        $properties = [];
-        foreach ($data as $k => $v) {
-            match ($k) {
-                'name' => $properties['name'] = static function () use ($stream, $v, $options, $denormalizers, $instantiator, &$providers) {
-                    return \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]);
-                },
-                'enum' => $properties['enum'] = static function () use ($stream, $v, $options, $denormalizers, $instantiator, &$providers) {
-                    return $providers['Symfony\Component\JsonEncoder\Tests\Fixtures\Enum\DummyBackedEnum|null']($stream, $v[0], $v[1]);
-                },
-                default => null,
-            };
-        }
-        return $instantiator->instantiate(\Symfony\Component\JsonEncoder\Tests\Fixtures\Model\DummyWithNullableProperties::class, $properties);
+        return $instantiator->instantiate(\Symfony\Component\JsonEncoder\Tests\Fixtures\Model\DummyWithNullableProperties::class, static function ($object) use ($stream, $data, $options, $denormalizers, $instantiator, &$providers) {
+            foreach ($data as $k => $v) {
+                match ($k) {
+                    'name' => $object->name = \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]),
+                    'enum' => $object->enum = $providers['Symfony\Component\JsonEncoder\Tests\Fixtures\Enum\DummyBackedEnum|null']($stream, $v[0], $v[1]),
+                    default => null,
+                };
+            }
+        });
     };
     $providers['Symfony\Component\JsonEncoder\Tests\Fixtures\Enum\DummyBackedEnum'] = static function ($stream, $offset, $length) {
         return \Symfony\Component\JsonEncoder\Tests\Fixtures\Enum\DummyBackedEnum::from(\Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $offset, $length));

--- a/src/Symfony/Component/JsonEncoder/Tests/Fixtures/decoder/union.stream.php
+++ b/src/Symfony/Component/JsonEncoder/Tests/Fixtures/decoder/union.stream.php
@@ -15,19 +15,15 @@ return static function (mixed $stream, \Psr\Container\ContainerInterface $denorm
     };
     $providers['Symfony\Component\JsonEncoder\Tests\Fixtures\Model\DummyWithNameAttributes'] = static function ($stream, $offset, $length) use ($options, $denormalizers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonEncoder\Decode\Splitter::splitDict($stream, $offset, $length);
-        $properties = [];
-        foreach ($data as $k => $v) {
-            match ($k) {
-                '@id' => $properties['id'] = static function () use ($stream, $v, $options, $denormalizers, $instantiator, &$providers) {
-                    return \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]);
-                },
-                'name' => $properties['name'] = static function () use ($stream, $v, $options, $denormalizers, $instantiator, &$providers) {
-                    return \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]);
-                },
-                default => null,
-            };
-        }
-        return $instantiator->instantiate(\Symfony\Component\JsonEncoder\Tests\Fixtures\Model\DummyWithNameAttributes::class, $properties);
+        return $instantiator->instantiate(\Symfony\Component\JsonEncoder\Tests\Fixtures\Model\DummyWithNameAttributes::class, static function ($object) use ($stream, $data, $options, $denormalizers, $instantiator, &$providers) {
+            foreach ($data as $k => $v) {
+                match ($k) {
+                    '@id' => $object->id = \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]),
+                    'name' => $object->name = \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]),
+                    default => null,
+                };
+            }
+        });
     };
     $providers['Symfony\Component\JsonEncoder\Tests\Fixtures\Model\DummyWithNameAttributes|array<int,Symfony\Component\JsonEncoder\Tests\Fixtures\Enum\DummyBackedEnum>|int'] = static function ($stream, $offset, $length) use ($options, $denormalizers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $offset, $length);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

- Add support for native lazy ghost if available.
- Improve var exporter lazy ghost usage, as it's not possible anymore to initialize a single property and letting the rest uninitialized.

The object part of a stream generated decoder changed from:
```php
$data = \Symfony\Component\JsonEncoder\Decode\Splitter::splitDict($stream, $offset, $length);
$properties = [];
foreach ($data as $k => $v) {
    match ($k) {
        'id' => $properties['id'] = static function () use ($stream, $v, $options, $denormalizers, $instantiator, &$providers) {
            return \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]);
        },
        'name' => $properties['name'] = static function () use ($stream, $v, $options, $denormalizers, $instantiator, &$providers) {
            return \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]);
        },
        default => null,
    };
}
return $instantiator->instantiate(\Symfony\Component\JsonEncoder\Tests\Fixtures\Model\ClassicDummy::class, $properties);
```

to:
```php
$data = \Symfony\Component\JsonEncoder\Decode\Splitter::splitDict($stream, $offset, $length);
return $instantiator->instantiate(\Symfony\Component\JsonEncoder\Tests\Fixtures\Model\ClassicDummy::class, static function ($object) use ($stream, $data, $options, $denormalizers, $instantiator, &$providers) {
    foreach ($data as $k => $v) {
        match ($k) {
            'id' => $object->id = \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]),
            'name' => $object->name = \Symfony\Component\JsonEncoder\Decode\NativeDecoder::decodeStream($stream, $v[0], $v[1]),
            default => null,
        };
    }
});
```
