### PR TITLE
[AssetMapper] Adding 'Everything up to date' message

### DIFF
--- a/src/Symfony/Component/AssetMapper/Command/ImportMapOutdatedCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/ImportMapOutdatedCommand.php
@@ -76,6 +76,12 @@ EOT
         $packagesUpdateInfos = $this->updateChecker->getAvailableUpdates($packages);
         $packagesUpdateInfos = array_filter($packagesUpdateInfos, fn ($packageUpdateInfo) => $packageUpdateInfo->hasUpdate());
         if (0 === \count($packagesUpdateInfos)) {
+            if ('json' === $input->getOption('format')) {
+                $io->writeln('[]');
+            } else {
+                $io->writeln('No updates found.');
+            }
+
             return Command::SUCCESS;
         }
 

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapOutdatedCommandTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapOutdatedCommandTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AssetMapper\Tests\ImportMap;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\AssetMapper\Command\ImportMapOutdatedCommand;
+use Symfony\Component\AssetMapper\ImportMap\ImportMapUpdateChecker;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class ImportMapOutdatedCommandTest extends TestCase
+{
+    /**
+     * @dataProvider provideNoOutdatedPackageCases
+     */
+    public function testCommandWhenNoOutdatedPackages(string $display, ?string $format = null)
+    {
+        $updateChecker = $this->createMock(ImportMapUpdateChecker::class);
+        $command = new ImportMapOutdatedCommand($updateChecker);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(\is_string($format) ? ['--format' => $format] : []);
+
+        $commandTester->assertCommandIsSuccessful();
+        $this->assertEquals($display, trim($commandTester->getDisplay(true)));
+    }
+
+    /**
+     * @return iterable<array{string, string|null}>
+     */
+    public static function provideNoOutdatedPackageCases(): iterable
+    {
+        yield 'default' => ['No updates found.', null];
+        yield 'txt' => ['No updates found.', 'txt'];
+        yield 'json' => ['[]', 'json'];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | not really
| Deprecations? | no
| Issues        | 
| License       | MIT

Adding friendly message for `php bin/console importmap:outdated` if no updates are found.
Wording is taken from `composer outdated`
