### PR TITLE
[DoctrineBridge] Fix compatibility to Doctrine persistence 2.5 in Doctrine Bridge 6.4 to avoid Projects stuck on 6.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "ext-xml": "*",
         "friendsofphp/proxy-manager-lts": "^1.0.2",
         "doctrine/event-manager": "^1.2|^2",
-        "doctrine/persistence": "^3.1",
+        "doctrine/persistence": "^2.5|^3.1",
         "twig/twig": "^2.13|^3.0.4",
         "psr/cache": "^2.0|^3.0",
         "psr/clock": "^1.0",

--- a/src/Symfony/Bridge/Doctrine/Tests/DoctrineTestHelper.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DoctrineTestHelper.php
@@ -61,7 +61,10 @@ final class DoctrineTestHelper
         if (class_exists(DefaultSchemaManagerFactory::class)) {
             $config->setSchemaManagerFactory(new DefaultSchemaManagerFactory());
         }
-        $config->setLazyGhostObjectEnabled(true);
+
+        if (!class_exists(\Doctrine\Persistence\Mapping\Driver\AnnotationDriver::class)) { // doctrine/persistence >= 3.0
+            $config->setLazyGhostObjectEnabled(true);
+        }
 
         return $config;
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/Middleware/Debug/MiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Middleware/Debug/MiddlewareTest.php
@@ -55,7 +55,9 @@ class MiddlewareTest extends TestCase
         if (class_exists(DefaultSchemaManagerFactory::class)) {
             $config->setSchemaManagerFactory(new DefaultSchemaManagerFactory());
         }
-        $config->setLazyGhostObjectEnabled(true);
+        if (!class_exists(\Doctrine\Persistence\Mapping\Driver\AnnotationDriver::class)) { // doctrine/persistence >= 3.0
+            $config->setLazyGhostObjectEnabled(true);
+        }
         $this->debugDataHolder = new DebugDataHolder();
         $config->setMiddlewares([new Middleware($this->debugDataHolder, $this->stopwatch)]);
 

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
@@ -44,7 +44,9 @@ class DoctrineExtractorTest extends TestCase
         if (class_exists(DefaultSchemaManagerFactory::class)) {
             $config->setSchemaManagerFactory(new DefaultSchemaManagerFactory());
         }
-        $config->setLazyGhostObjectEnabled(true);
+        if (!class_exists(\Doctrine\Persistence\Mapping\Driver\AnnotationDriver::class)) { // doctrine/persistence >= 3.0
+            $config->setLazyGhostObjectEnabled(true);
+        }
 
         $eventManager = new EventManager();
         $entityManager = new EntityManager(DriverManager::getConnection(['driver' => 'pdo_sqlite'], $config, $eventManager), $config, $eventManager);

--- a/src/Symfony/Bridge/Doctrine/Tests/Security/RememberMe/DoctrineTokenProviderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Security/RememberMe/DoctrineTokenProviderTest.php
@@ -124,7 +124,9 @@ class DoctrineTokenProviderTest extends TestCase
             $config->setSchemaManagerFactory(new DefaultSchemaManagerFactory());
         }
 
-        $config->setLazyGhostObjectEnabled(true);
+        if (!class_exists(\Doctrine\Persistence\Mapping\Driver\AnnotationDriver::class)) { // doctrine/persistence >= 3.0
+            $config->setLazyGhostObjectEnabled(true);
+        }
 
         $connection = DriverManager::getConnection([
             'driver' => 'pdo_sqlite',

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "doctrine/event-manager": "^1.2|^2",
-        "doctrine/persistence": "^3.1",
+        "doctrine/persistence": "^2.5|^3.1",
         "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/polyfill-ctype": "~1.8",
         "symfony/polyfill-mbstring": "~1.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

Doctrine Bridge dropped support of persistence 2 from 6.3 to 6.4 but I could not yet find out why. (https://github.com/symfony/symfony/commit/0d4e2b8dad6b526ed91fa17f9932f3c0642603b8). It making lot of things harder and get projects stuck on 6.3 which can not yet update doctrine/persistence because of some bc breaks (mostly `Bundle:Entity` syntax). It makes also eco system a little bit harder (https://github.com/doctrine/DoctrineBundle/pull/1841, https://github.com/doctrine/DoctrineFixturesBundle/pull/486, https://github.com/sulu/sulu/actions/runs/12050408254/job/34248387939) as with some changes in symfony and doctrine bundles things get downgraded to symfony 5.4 instead keep in 6.3. If there is any easy way to support persistence 2.5 still on 6.4 bridge I think things would get easier.

Want with this PR check what fails on the CI if still allow persistence 2.5.

---

Update: Looks like with a few checkst we could get lowest run on persistence 2.5 which would so make easier projects upgrade to Symfony 6.4 without they have to tackle the persistence update in the same case.