### PR TITLE
[Routing] Validate "namespace" (when using `Psr4DirectoryLoader`)

### DIFF
--- a/src/Symfony/Component/Routing/Loader/Psr4DirectoryLoader.php
+++ b/src/Symfony/Component/Routing/Loader/Psr4DirectoryLoader.php
@@ -15,6 +15,7 @@ use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Component\Config\Loader\DirectoryAwareLoaderInterface;
 use Symfony\Component\Config\Loader\Loader;
 use Symfony\Component\Config\Resource\DirectoryResource;
+use Symfony\Component\Routing\Exception\InvalidArgumentException;
 use Symfony\Component\Routing\RouteCollection;
 
 /**
@@ -41,6 +42,10 @@ final class Psr4DirectoryLoader extends Loader implements DirectoryAwareLoaderIn
         $path = $this->locator->locate($resource['path'], $this->currentDirectory);
         if (!is_dir($path)) {
             return new RouteCollection();
+        }
+
+        if (!preg_match('/^(?:[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+\\\)++$/', trim($resource['namespace'], '\\').'\\')) {
+            throw new InvalidArgumentException(\sprintf('Namespace "%s" is not a valid PSR-4 prefix.', $resource['namespace']));
         }
 
         return $this->loadFromDirectory($path, trim($resource['namespace'], '\\'));

--- a/src/Symfony/Component/Routing/Tests/Loader/Psr4DirectoryLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/Psr4DirectoryLoaderTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\DelegatingLoader;
 use Symfony\Component\Config\Loader\LoaderResolver;
+use Symfony\Component\Routing\Exception\InvalidArgumentException;
 use Symfony\Component\Routing\Loader\AttributeClassLoader;
 use Symfony\Component\Routing\Loader\Psr4DirectoryLoader;
 use Symfony\Component\Routing\Route;
@@ -87,6 +88,34 @@ class Psr4DirectoryLoaderTest extends TestCase
             ['\\Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers'],
             ['Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers\\'],
             ['\\Symfony\Component\Routing\Tests\Fixtures\Psr4Controllers\\'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideInvalidPsr4Namespaces
+     */
+    public function testInvalidPsr4Namespace(string $namespace, string $expectedExceptionMessage)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
+        $this->getLoader()->load(
+            ['path' => 'Psr4Controllers', 'namespace' => $namespace],
+            'attribute'
+        );
+    }
+
+    public static function provideInvalidPsr4Namespaces(): array
+    {
+        return [
+            'slash instead of back-slash' => [
+                'namespace' => 'App\Application/Controllers',
+                'exceptionMessage' => 'Namespace "App\Application/Controllers" is not a valid PSR-4 prefix.',
+            ],
+            'invalid namespace' => [
+                'namespace' => 'App\Contro llers',
+                'exceptionMessage' => 'Namespace "App\Contro llers" is not a valid PSR-4 prefix.',
+            ],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

I spend a small amount of time to understand why my controller was inaccessible:

<img width="496" alt="image" src="https://github.com/user-attachments/assets/959188fc-75d3-43db-a4e8-78fc4d140a74" />

With the following configuration:
```yaml
controllers:
    resource:
        path: ../src/Application/Controller/
        namespace: App\Application/Controller
    type: attribute
```

You may have seen that the namespace `App\Application/Controller` is invalid because the presence of `/` instead of `\`. If I correct it, then my controller is accessible.

It means that invalid namespaces are simply ignored without any hints for the user, and I think it can be improved and be more user-friendly :)

This PR add namespace validation, it checks if `/` is found, and if namespace is composed of valid PHP identifiers:  
<img width="759" alt="image" src="https://github.com/user-attachments/assets/ae8d1dc8-f250-4faf-bc07-22aaefc363fd" />
<img width="1011" alt="image" src="https://github.com/user-attachments/assets/7fe97b1e-77be-45ab-b875-b2a67b7501dd" />
