### PR TITLE
[PropertyInfo] bump lowest required TypeInfo component version

### DIFF
--- a/src/Symfony/Component/PropertyInfo/composer.json
+++ b/src/Symfony/Component/PropertyInfo/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "php": ">=8.2",
         "symfony/string": "^6.4|^7.0",
-        "symfony/type-info": "^7.1"
+        "symfony/type-info": "~7.1.9|^7.2.2"
     },
     "require-dev": {
         "symfony/serializer": "^6.4|^7.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

we need #59066 so that the test fixes from #59156 are also having an effect on the low deps job