### PR TITLE
[Mailer] fix NativeTransportFactoryTest

### DIFF
--- a/src/Symfony/Component/Mailer/Transport/NativeTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Transport/NativeTransportFactory.php
@@ -29,7 +29,7 @@ final class NativeTransportFactory extends AbstractTransportFactory
             throw new UnsupportedSchemeException($dsn, 'native', $this->getSupportedSchemes());
         }
 
-        if ($sendMailPath = \ini_get('sendmail_path')) {
+        if ($sendMailPath = ini_get('sendmail_path')) {
             return new SendmailTransport($sendMailPath, $this->dispatcher, $this->logger);
         }
 
@@ -39,8 +39,8 @@ final class NativeTransportFactory extends AbstractTransportFactory
 
         // Only for windows hosts; at this point non-windows
         // host have already thrown an exception or returned a transport
-        $host = \ini_get('SMTP');
-        $port = (int) \ini_get('smtp_port');
+        $host = ini_get('SMTP');
+        $port = (int) ini_get('smtp_port');
 
         if (!$host || !$port) {
             throw new TransportException('smtp or smtp_port is not configured in php.ini.');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

This is required as the `ini_set()` function is overwritten in the test to simulate a not-configured `sendmail_path` option.

This partially reverts #59173. Even if this violates our coding standards we have to keep it this way until we find another solution for the test.