### PR TITLE
[Serializer] Add template parameter to avoid necessity to assert data in normalize

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
@@ -18,13 +18,15 @@ use Symfony\Component\Serializer\Exception\LogicException;
 
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * @template TData
  */
 interface NormalizerInterface
 {
     /**
      * Normalizes data into a set of arrays/scalars.
      *
-     * @param mixed       $data    Data to normalize
+     * @param TData       $data    Data to normalize
      * @param string|null $format  Format the normalization result will be encoded as
      * @param array       $context Context options for the normalizer
      *
@@ -41,8 +43,8 @@ interface NormalizerInterface
     /**
      * Checks whether the given class is supported for normalization by this normalizer.
      *
-     * @param mixed       $data   Data to normalize
-     * @param string|null $format The format being (de-)serialized from or into
+     * @param TData|mixed   $data   Data to normalize
+     * @param string|null   $format The format being (de-)serialized from or into
      */
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | TBH I am not sure about this one 😅
| Bug fix?      | Also not sure...
| New feature?  | no
| Deprecations? | maybe
| Issues        | Didn't create one, since the code change is minimal anyway
| License       | MIT

In a project I am working on we are using quite some value objects, and I also want to normalize some of them. Instead of repeating the serialization part for every object, I like to create a separate `ValueObjectNormalizer` (whereby I use `ValueObject` as a placeholder here and in the below code).

We are also using PHPStan with its highest level, and then there are some "issues" with that. The problem is that I always have to add a call to `assert` in the `normalize` function, since the `$data` variable is typed as mixed, and whatever I am doing with the passed data PHPStan won't like. This looks something like this:

```php
<?php

namespace App\Serializer;

use App\Domain\ValueObject;
use Symfony\Component\Serializer\Normalizer\NormalizerInterface;

final class ValueObjectNormalizer implements NormalizerInterface
{
	public function normalize(mixed $object, null|string $format = null, array $context = []): string
	{
		\assert($object instanceof ValueObject);

		return $object->someValueObjectProperty;
	}

	public function supportsNormalization(mixed $data, null|string $format = null, array $context = []): bool
	{
		return $data instanceof ValueObject;
	}

	public function getSupportedTypes(null|string $format): array
	{
		return [
			ValueObject::class => true,
		];
	}
}
```

With the change being introduced in this PR, it would be possible to make use of generics in order to avoid this `assert` call, which I think is a bit nicer.

```php
<?php

declare(strict_types=1);

namespace App\Serializer;

use App\Domain\ValueObject;
use Symfony\Component\Serializer\Normalizer\NormalizerInterface;

/**
 * @implements NormalizerInterface<ValueObject>
 */
final class ValueObjectNormalizer implements NormalizerInterface
{
	public function normalize(mixed $object, null|string $format = null, array $context = []): string
	{
		return $object->someValueObjectProperty;
	}

	public function supportsNormalization(mixed $data, null|string $format = null, array $context = []): bool
	{
		return $data instanceof ValueObject;
	}

	public function getSupportedTypes(null|string $format): array
	{
		return [
			ValueObject::class => true,
		];
	}
}
```

What do you think about this? I am also not sure in which branch such a change would have to go, and I am also not sure if you consider this a breaking change.