### PR TITLE
[Semaphore] Add a semaphore store based on locks

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.1
 ---
 
+ * Add support for `lock://` DSN in semaphore configuration to use the Lock component as a semaphore store
  * Add support for configuring JsonStreamer's `default_options`
  * Add project-scoped `flock` and `semaphore` lock store services
  * Add `createFormFlowBuilder` method to `AbstractController` and `ControllerHelper`

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2333,12 +2333,14 @@ class FrameworkExtension extends Extension
 
         foreach ($config['resources'] as $resourceName => $resourceStore) {
             $storeDsn = $container->resolveEnvPlaceholders($resourceStore, null, $usedEnvs);
-            if (!$usedEnvs && !str_contains($resourceStore, '://')) {
-                $resourceStore = new Reference($resourceStore);
-            }
             $storeDefinition = new Definition(SemaphoreStoreInterface::class);
             $storeDefinition->setFactory([SemaphoreStoreFactory::class, 'createStore']);
-            $storeDefinition->setArguments([$resourceStore]);
+            $storeDefinition->setArguments([match (true) {
+                $usedEnvs => $resourceStore,
+                str_starts_with($storeDsn, 'lock://') => new Reference('lock.'.(substr($storeDsn, 7) ?: 'default').'.factory'),
+                !str_contains($resourceStore, '://') => new Reference($resourceStore),
+                default => $resourceStore,
+            }]);
 
             $container->setDefinition($storeDefinitionId = '.semaphore.'.$resourceName.'.store.'.$container->hash($storeDsn), $storeDefinition);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/semaphore_lock.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/semaphore_lock.php
@@ -1,0 +1,6 @@
+<?php
+
+$container->loadFromExtension('framework', [
+    'lock' => 'flock',
+    'semaphore' => 'lock://',
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/semaphore_lock_named.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/semaphore_lock_named.php
@@ -1,0 +1,12 @@
+<?php
+
+$container->loadFromExtension('framework', [
+    'lock' => [
+        'default' => 'flock',
+        'foo' => 'flock',
+    ],
+    'semaphore' => [
+        'default' => 'lock://',
+        'bar' => 'lock://foo',
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/semaphore_lock.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/semaphore_lock.yml
@@ -1,0 +1,3 @@
+framework:
+    lock: flock
+    semaphore: lock://

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/semaphore_lock_named.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/semaphore_lock_named.yml
@@ -1,0 +1,7 @@
+framework:
+    lock:
+        default: flock
+        foo: flock
+    semaphore:
+        default: lock://
+        bar: lock://foo

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -79,6 +79,7 @@ use Symfony\Component\Notifier\ChatterInterface;
 use Symfony\Component\Notifier\TexterInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\Security\Core\AuthenticationEvents;
+use Symfony\Component\Semaphore\Store\StoreFactory as SemaphoreStoreFactory;
 use Symfony\Component\Serializer\DependencyInjection\SerializerPass;
 use Symfony\Component\Serializer\Mapping\Loader\XmlFileLoader;
 use Symfony\Component\Serializer\Mapping\Loader\YamlFileLoader;
@@ -2860,6 +2861,31 @@ abstract class FrameworkExtensionTestCase extends TestCase
         self::assertTrue($container->hasDefinition('semaphore.default.factory'));
         $storeDef = $container->getDefinition($container->getDefinition('semaphore.default.factory')->getArgument(0));
         self::assertEquals(new Reference('my_service'), $storeDef->getArgument(0));
+    }
+
+    public function testSemaphoreWithLock()
+    {
+        $container = $this->createContainerFromFile('semaphore_lock');
+
+        self::assertTrue($container->hasDefinition('semaphore.default.factory'));
+        $storeDef = $container->getDefinition($container->getDefinition('semaphore.default.factory')->getArgument(0));
+        self::assertSame([SemaphoreStoreFactory::class, 'createStore'], $storeDef->getFactory());
+        self::assertEquals(new Reference('lock.default.factory'), $storeDef->getArgument(0));
+    }
+
+    public function testSemaphoreWithNamedLock()
+    {
+        $container = $this->createContainerFromFile('semaphore_lock_named');
+
+        self::assertTrue($container->hasDefinition('semaphore.default.factory'));
+        $storeDef = $container->getDefinition($container->getDefinition('semaphore.default.factory')->getArgument(0));
+        self::assertSame([SemaphoreStoreFactory::class, 'createStore'], $storeDef->getFactory());
+        self::assertEquals(new Reference('lock.default.factory'), $storeDef->getArgument(0));
+
+        self::assertTrue($container->hasDefinition('semaphore.bar.factory'));
+        $storeDef = $container->getDefinition($container->getDefinition('semaphore.bar.factory')->getArgument(0));
+        self::assertSame([SemaphoreStoreFactory::class, 'createStore'], $storeDef->getFactory());
+        self::assertEquals(new Reference('lock.foo.factory'), $storeDef->getArgument(0));
     }
 
     public function testJsonStreamerEnabled()

--- a/src/Symfony/Component/Semaphore/CHANGELOG.md
+++ b/src/Symfony/Component/Semaphore/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.1
 ---
 
+ * Add `LockStore` to use the Lock component as a semaphore store backend
  * Add `SemaphoreKeyNormalizer`
 
 7.4

--- a/src/Symfony/Component/Semaphore/Store/LockStore.php
+++ b/src/Symfony/Component/Semaphore/Store/LockStore.php
@@ -1,0 +1,154 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Semaphore\Store;
+
+use Symfony\Component\Lock\Exception\LockReleasingException;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\LockInterface;
+use Symfony\Component\Semaphore\Exception\SemaphoreAcquiringException;
+use Symfony\Component\Semaphore\Exception\SemaphoreExpiredException;
+use Symfony\Component\Semaphore\Exception\SemaphoreReleasingException;
+use Symfony\Component\Semaphore\Key;
+use Symfony\Component\Semaphore\PersistingStoreInterface;
+
+/**
+ * @author Alexander Schranz <alexander@sulu.io>
+ */
+final class LockStore implements PersistingStoreInterface
+{
+    public function __construct(
+        private readonly LockFactory $lockFactory,
+    ) {
+    }
+
+    public function save(Key $key, float $ttlInSecond): void
+    {
+        if ($this->getExistingLocks($key)) {
+            return;
+        }
+
+        $locks = $this->createLocks($key, $ttlInSecond);
+
+        $key->setState(__CLASS__, $locks);
+        $key->markUnserializable();
+    }
+
+    public function delete(Key $key): void
+    {
+        $this->releaseLocks($this->getExistingLocks($key), $key);
+    }
+
+    public function exists(Key $key): bool
+    {
+        return \count($this->getExistingLocks($key)) >= $key->getWeight();
+    }
+
+    public function putOffExpiration(Key $key, float $ttlInSecond): void
+    {
+        $locks = $this->getExistingLocks($key);
+
+        if (\count($locks) !== $key->getWeight()) {
+            $this->releaseLocks($locks, $key);
+
+            throw new SemaphoreExpiredException($key, 'One or multiple locks were not even acquired.');
+        }
+
+        foreach ($locks as $lock) {
+            $lock->refresh($ttlInSecond);
+
+            if ($lock->isExpired()) {
+                $this->releaseLocks($locks, $key);
+
+                throw new SemaphoreExpiredException($key, 'Failed to refresh one or multiple locks.');
+            }
+        }
+    }
+
+    /**
+     * @param array<LockInterface> $locks
+     */
+    private function releaseLocks(array $locks, Key $key): void
+    {
+        $lockReleasingException = null;
+        foreach ($locks as $lock) {
+            try {
+                $lock->release();
+            } catch (LockReleasingException $e) {
+                $lockReleasingException ??= $e;
+            }
+        }
+
+        $key->removeState(__CLASS__);
+
+        if ($lockReleasingException) {
+            throw new SemaphoreReleasingException($key, $lockReleasingException->getMessage());
+        }
+    }
+
+    /**
+     * @return array<LockInterface>
+     */
+    private function getExistingLocks(Key $key): array
+    {
+        return $key->hasState(__CLASS__) ? $key->getState(__CLASS__) : [];
+    }
+
+    /**
+     * @return array<LockInterface>
+     */
+    private function createLocks(Key $key, float $ttlInSecond): array
+    {
+        $locks = [];
+        $lockName = (string) $key;
+        $limit = $key->getLimit();
+
+        // use a random start point to have a higher chance to catch a free slot directly
+        $startPoint = random_int(0, $limit - 1);
+
+        $previousException = null;
+        try {
+            for ($i = 0; $i < $limit; ++$i) {
+                $index = ($startPoint + $i) % $limit;
+
+                $lock = $this->lockFactory->createLock($lockName.'_'.$index, $ttlInSecond, false);
+                if ($lock->acquire(false)) { // use lock if we can acquire it else try to catch next lock
+                    $locks[] = $lock;
+
+                    if (\count($locks) >= $key->getWeight()) {
+                        break;
+                    }
+
+                    continue;
+                }
+
+                if (\count($locks) + $key->getLimit() - $i < $key->getWeight()) { // no chance to get enough locks
+                    break;
+                }
+            }
+        } catch (\Exception $e) {
+            $previousException = $e;
+        }
+
+        if (\count($locks) === $key->getWeight()) {
+            return $locks;
+        }
+
+        try {
+            // release already acquired locks because not got the amount of locks which were required
+            $this->releaseLocks($locks, $key);
+        } catch (SemaphoreReleasingException) {
+            // ignore releasing exception because we will throw an acquiring exception in the end
+        }
+
+        throw $previousException ?? new SemaphoreAcquiringException($key, 'There were no free locks found');
+    }
+}

--- a/src/Symfony/Component/Semaphore/Store/StoreFactory.php
+++ b/src/Symfony/Component/Semaphore/Store/StoreFactory.php
@@ -11,8 +11,10 @@
 
 namespace Symfony\Component\Semaphore\Store;
 
+use Relay\Cluster as RelayCluster;
 use Relay\Relay;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
+use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Semaphore\Exception\InvalidArgumentException;
 use Symfony\Component\Semaphore\PersistingStoreInterface;
 
@@ -26,8 +28,12 @@ class StoreFactory
     public static function createStore(#[\SensitiveParameter] object|string $connection): PersistingStoreInterface
     {
         switch (true) {
+            case $connection instanceof LockFactory:
+                return new LockStore($connection);
+
             case $connection instanceof \Redis:
             case $connection instanceof Relay:
+            case $connection instanceof RelayCluster:
             case $connection instanceof \RedisArray:
             case $connection instanceof \RedisCluster:
             case $connection instanceof \Predis\ClientInterface:

--- a/src/Symfony/Component/Semaphore/Tests/Store/AbstractStoreTestCase.php
+++ b/src/Symfony/Component/Semaphore/Tests/Store/AbstractStoreTestCase.php
@@ -204,7 +204,6 @@ abstract class AbstractStoreTestCase extends TestCase
         $key1 = new Key(__METHOD__, 4, 2);
 
         $this->expectException(SemaphoreExpiredException::class);
-        $this->expectExceptionMessage('The semaphore "Symfony\Component\Semaphore\Tests\Store\AbstractStoreTestCase::testPutOffExpirationWhenSaveHasNotBeenCalled" has expired: the script returns a positive number.');
 
         $store->putOffExpiration($key1, 20);
     }

--- a/src/Symfony/Component/Semaphore/Tests/Store/LockStoreTest.php
+++ b/src/Symfony/Component/Semaphore/Tests/Store/LockStoreTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Semaphore\Tests\Store;
+
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\Store\FlockStore;
+use Symfony\Component\Semaphore\PersistingStoreInterface;
+use Symfony\Component\Semaphore\Store\LockStore;
+
+class LockStoreTest extends AbstractStoreTestCase
+{
+    public function getStore(): PersistingStoreInterface
+    {
+        $lock = new FlockStore();
+        $factory = new LockFactory($lock);
+
+        return new LockStore($factory);
+    }
+}

--- a/src/Symfony/Component/Semaphore/Tests/Store/StoreFactoryTest.php
+++ b/src/Symfony/Component/Semaphore/Tests/Store/StoreFactoryTest.php
@@ -13,6 +13,9 @@ namespace Symfony\Component\Semaphore\Tests\Store;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\Store\FlockStore;
+use Symfony\Component\Semaphore\Store\LockStore;
 use Symfony\Component\Semaphore\Store\RedisStore;
 use Symfony\Component\Semaphore\Store\StoreFactory;
 
@@ -31,6 +34,7 @@ class StoreFactoryTest extends TestCase
 
     public static function validConnections(): \Generator
     {
+        yield [new LockFactory(new FlockStore()), LockStore::class];
         yield [new \Predis\Client(), RedisStore::class];
 
         if (class_exists(\Redis::class)) {

--- a/src/Symfony/Component/Semaphore/composer.json
+++ b/src/Symfony/Component/Semaphore/composer.json
@@ -25,6 +25,7 @@
     },
     "require-dev": {
         "predis/predis": "^1.1|^2.0",
+        "symfony/lock": "^7.4|^8.0",
         "symfony/serializer": "^6.4|^7.0"
     },
     "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

I really liked the idea of a semaphore component but not have the possibility to use it without Redis it did not get a lot a drive and usage in our projects and we workaround using Locks.

So this idea did come up to have a Semaphore store which can use the existing lock component for it.

@lyrixx @jderusse 


This adds a `LockStore` for the Semaphore component, allowing any Lock component backend (flock, Redis, PDO, etc.) to be used as a semaphore store. This removes the Redis-only limitation that has been holding back adoption of the Semaphore component.

The idea is simple: a semaphore with limit N is implemented by trying to acquire N individual locks (named `{resource}_0` through `{resource}_{N-1}`). A random start point is used to reduce contention.

### Usage

```php
use Symfony\Component\Lock\LockFactory;
use Symfony\Component\Lock\Store\FlockStore;
use Symfony\Component\Semaphore\SemaphoreFactory;
use Symfony\Component\Semaphore\Store\LockStore;

$lockFactory = new LockFactory(new FlockStore());
$store = new LockStore($lockFactory);
$factory = new SemaphoreFactory($store);

$semaphore = $factory->createSemaphore('my-resource', 3);
$semaphore->acquire();
```

### FrameworkBundle integration

```yaml
framework:
    lock: 'flock'
    semaphore: 'lock://'
```

Named lock resources are also supported:

```yaml
framework:
    lock:
        default: 'flock'
        my_locks: '%env(REDIS_DSN)%'
    semaphore:
        default: 'lock://'           # uses lock.default.factory
        other: 'lock://my_locks'     # uses lock.my_locks.factory
```