### PR TITLE
[Security][SecurityBundle] rename userIsGranted() to isGrantedForUser()

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 7.3
 ---
 
- * Add `Security::userIsGranted()` to test user authorization without relying on the session. For example, users not currently logged in, or while processing a message from a message queue
+ * Add `Security::isGrantedForUser()` to test user authorization without relying on the session. For example, users not currently logged in, or while processing a message from a message queue
 
 7.2
 ---

--- a/src/Symfony/Bundle/SecurityBundle/Security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security.php
@@ -154,10 +154,10 @@ class Security implements AuthorizationCheckerInterface, UserAuthorizationChecke
      *
      * This should be used over isGranted() when checking permissions against a user that is not currently logged in or while in a CLI context.
      */
-    public function userIsGranted(UserInterface $user, mixed $attribute, mixed $subject = null): bool
+    public function isGrantedForUser(UserInterface $user, mixed $attribute, mixed $subject = null): bool
     {
         return $this->container->get('security.user_authorization_checker')
-            ->userIsGranted($user, $attribute, $subject);
+            ->isGrantedForUser($user, $attribute, $subject);
     }
 
     private function getAuthenticator(?string $authenticatorName, string $firewallName): AuthenticatorInterface

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SecurityTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SecurityTest.php
@@ -61,8 +61,8 @@ class SecurityTest extends AbstractWebTestCase
         $security = $container->get('functional_test.security.helper');
         $this->assertTrue($security->isGranted('ROLE_FOO'));
         $this->assertFalse($security->isGranted('ROLE_BAR'));
-        $this->assertTrue($security->userIsGranted($offlineUser, 'ROLE_BAR'));
-        $this->assertFalse($security->userIsGranted($offlineUser, 'ROLE_FOO'));
+        $this->assertTrue($security->isGrantedForUser($offlineUser, 'ROLE_BAR'));
+        $this->assertFalse($security->isGrantedForUser($offlineUser, 'ROLE_FOO'));
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/Authorization/UserAuthorizationChecker.php
+++ b/src/Symfony/Component/Security/Core/Authorization/UserAuthorizationChecker.php
@@ -24,7 +24,7 @@ final class UserAuthorizationChecker implements UserAuthorizationCheckerInterfac
     ) {
     }
 
-    public function userIsGranted(UserInterface $user, mixed $attribute, mixed $subject = null): bool
+    public function isGrantedForUser(UserInterface $user, mixed $attribute, mixed $subject = null): bool
     {
         return $this->accessDecisionManager->decide(new UserAuthorizationCheckerToken($user), [$attribute], $subject);
     }

--- a/src/Symfony/Component/Security/Core/Authorization/UserAuthorizationCheckerInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/UserAuthorizationCheckerInterface.php
@@ -25,5 +25,5 @@ interface UserAuthorizationCheckerInterface
      *
      * @param mixed $attribute A single attribute to vote on (can be of any type, string and instance of Expression are supported by the core)
      */
-    public function userIsGranted(UserInterface $user, mixed $attribute, mixed $subject = null): bool;
+    public function isGrantedForUser(UserInterface $user, mixed $attribute, mixed $subject = null): bool;
 }

--- a/src/Symfony/Component/Security/Core/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Core/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 7.3
 ---
 
- * Add `UserAuthorizationChecker::userIsGranted()` to test user authorization without relying on the session.
+ * Add `UserAuthorizationChecker::isGrantedForUser()` to test user authorization without relying on the session.
    For example, users not currently logged in, or while processing a message from a message queue.
  * Add `OfflineTokenInterface` to mark tokens that do not represent the currently logged-in user
 

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/UserAuthorizationCheckerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/UserAuthorizationCheckerTest.php
@@ -43,7 +43,7 @@ class UserAuthorizationCheckerTest extends TestCase
             ->with($this->callback(fn (UserAuthorizationCheckerToken $token): bool => $user === $token->getUser()), $this->identicalTo(['ROLE_FOO']))
             ->willReturn($decide);
 
-        $this->assertSame($decide, $this->authorizationChecker->userIsGranted($user, 'ROLE_FOO'));
+        $this->assertSame($decide, $this->authorizationChecker->isGrantedForUser($user, 'ROLE_FOO'));
     }
 
     public static function isGrantedProvider(): array
@@ -65,6 +65,6 @@ class UserAuthorizationCheckerTest extends TestCase
             ->method('decide')
             ->with($this->isInstanceOf($token::class), $this->identicalTo([$attribute]))
             ->willReturn(true);
-        $this->assertTrue($this->authorizationChecker->userIsGranted($token->getUser(), $attribute));
+        $this->assertTrue($this->authorizationChecker->isGrantedForUser($token->getUser(), $attribute));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | see https://github.com/symfony/symfony/pull/48142#discussion_r1885376556
| License       | MIT
