### PR TITLE
[Routing] fix test method parameter names

### DIFF
--- a/src/Symfony/Component/Routing/Tests/Loader/Psr4DirectoryLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/Psr4DirectoryLoaderTest.php
@@ -110,11 +110,11 @@ class Psr4DirectoryLoaderTest extends TestCase
         return [
             'slash instead of back-slash' => [
                 'namespace' => 'App\Application/Controllers',
-                'exceptionMessage' => 'Namespace "App\Application/Controllers" is not a valid PSR-4 prefix.',
+                'expectedExceptionMessage' => 'Namespace "App\Application/Controllers" is not a valid PSR-4 prefix.',
             ],
             'invalid namespace' => [
                 'namespace' => 'App\Contro llers',
-                'exceptionMessage' => 'Namespace "App\Contro llers" is not a valid PSR-4 prefix.',
+                'expectedExceptionMessage' => 'Namespace "App\Contro llers" is not a valid PSR-4 prefix.',
             ],
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

see https://github.com/symfony/symfony/actions/runs/12353148436/job/34471647973?pr=58370#step:9:3293 for an example of how tests would fail with PHPUnit 11.5 otherwise