### PR TITLE
WIP: support for targeted cache control

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CacheControl.php
+++ b/src/Symfony/Component/HttpFoundation/CacheControl.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation;
+
+/**
+ * CacheControl is a container for HTTP cache instructions.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+final class CacheControl
+{
+    /**
+     * @var array<string, string|bool>
+     */
+    private array $directives = [];
+
+    public function __construct(array $directives = [])
+    {
+        $this->directives = $directives;
+    }
+
+    public static function fromHeader(string $header): self
+    {
+        return new self(self::parseCacheControl($header));
+    }
+
+    public function empty(): bool
+    {
+        return 0 === \count($this->directives);
+    }
+
+    public function all(): array
+    {
+        return $this->directives;
+    }
+
+    /**
+     * Add or replace many Cache-Control directives.
+     *
+     * @param array<string, bool|string> $directives
+     */
+    public function addCacheControlDirectives(array $directives): void
+    {
+        foreach ($directives as $key => $value) {
+            $this->addCacheControlDirective($key, $value);
+        }
+    }
+
+    /**
+     * Add or replace a Cache-Control directive.
+     */
+    public function addCacheControlDirective(string $key, bool|string $value = true): void
+    {
+        $this->directives[$key] = $value;
+    }
+
+    /**
+     * Returns true if the Cache-Control directive is defined.
+     */
+    public function hasCacheControlDirective(string $key): bool
+    {
+        return \array_key_exists($key, $this->directives);
+    }
+
+    /**
+     * Returns a Cache-Control directive value by name.
+     */
+    public function getCacheControlDirective(string $key): bool|string|null
+    {
+        return $this->directives[$key] ?? null;
+    }
+
+    /**
+     * Removes a Cache-Control directive.
+     */
+    public function removeCacheControlDirective(string $key): void
+    {
+        unset($this->directives[$key]);
+    }
+
+    public function getCacheControlHeader(): string
+    {
+        ksort($this->directives);
+
+        return HeaderUtils::toString($this->directives, ',');
+    }
+
+    /**
+     * Parses a Cache-Control HTTP header.
+     */
+    public static function parseCacheControl(string $header): array
+    {
+        $parts = HeaderUtils::split($header, ',=');
+
+        return HeaderUtils::combine($parts);
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/HeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderBag.php
@@ -20,6 +20,7 @@ namespace Symfony\Component\HttpFoundation;
  */
 class HeaderBag implements \IteratorAggregate, \Countable, \Stringable
 {
+    public const DEFAULT_CACHE_CONTROL_TARGET = '';
     protected const UPPER = '_ABCDEFGHIJKLMNOPQRSTUVWXYZ';
     protected const LOWER = '-abcdefghijklmnopqrstuvwxyz';
 
@@ -27,7 +28,13 @@ class HeaderBag implements \IteratorAggregate, \Countable, \Stringable
      * @var array<string, list<string|null>>
      */
     protected array $headers = [];
-    protected array $cacheControl = [];
+
+    /**
+     * Map of target to cache control instructions.
+     *
+     * @var array<string, CacheControl>
+     */
+    protected array $cacheControls = [];
 
     public function __construct(array $headers = [])
     {
@@ -68,10 +75,21 @@ class HeaderBag implements \IteratorAggregate, \Countable, \Stringable
     public function all(?string $key = null): array
     {
         if (null !== $key) {
-            return $this->headers[strtr($key, self::UPPER, self::LOWER)] ?? [];
+            $uniqueKey = strtr($key, self::UPPER, self::LOWER);
+            if (str_ends_with($uniqueKey, 'cache-control')) {
+                return [$this->getCacheControl($this->extractCacheControlTarget($key))->getCacheControlHeader()];
+            }
+
+            return $this->headers[$uniqueKey] ?? [];
         }
 
-        return $this->headers;
+        $headers = $this->headers;
+        // edge case: what if extending class directly changed Cache-Control in the $headers array?
+        foreach ($this->cacheControls as $target => $cacheControl) {
+            $headers[self::DEFAULT_CACHE_CONTROL_TARGET === $target ? 'cache-control' : $target.'-cache-control'] = [$cacheControl->getCacheControlHeader()];
+        }
+
+        return $headers;
     }
 
     /**
@@ -89,6 +107,7 @@ class HeaderBag implements \IteratorAggregate, \Countable, \Stringable
      */
     public function replace(array $headers = []): void
     {
+        $this->cacheControls = [];
         $this->headers = [];
         $this->add($headers);
     }
@@ -129,27 +148,43 @@ class HeaderBag implements \IteratorAggregate, \Countable, \Stringable
      */
     public function set(string $key, string|array|null $values, bool $replace = true): void
     {
-        $key = strtr($key, self::UPPER, self::LOWER);
+        $uniqueKey = strtr($key, self::UPPER, self::LOWER);
+
+        if (str_ends_with($uniqueKey, 'cache-control')) {
+            $this->setCacheControlFromHeader($key, $values, $replace);
+
+            return;
+        }
 
         if (\is_array($values)) {
             $values = array_values($values);
 
-            if (true === $replace || !isset($this->headers[$key])) {
-                $this->headers[$key] = $values;
+            if (true === $replace || !isset($this->headers[$uniqueKey])) {
+                $this->headers[$uniqueKey] = $values;
             } else {
-                $this->headers[$key] = array_merge($this->headers[$key], $values);
+                $this->headers[$uniqueKey] = array_merge($this->headers[$uniqueKey], $values);
             }
         } else {
-            if (true === $replace || !isset($this->headers[$key])) {
-                $this->headers[$key] = [$values];
+            if (true === $replace || !isset($this->headers[$uniqueKey])) {
+                $this->headers[$uniqueKey] = [$values];
             } else {
-                $this->headers[$key][] = $values;
+                $this->headers[$uniqueKey][] = $values;
             }
         }
+    }
 
-        if ('cache-control' === $key) {
-            $this->cacheControl = $this->parseCacheControl(implode(', ', $this->headers[$key]));
+    private function setCacheControlFromHeader(string $key, string|array|null $values, bool $replace = true): void
+    {
+        if (\is_array($values)) {
+            $values = implode(', ', $values);
         }
+        $target = $this->extractCacheControlTarget($key);
+        if ($replace) {
+            $this->cacheControls[$target] = CacheControl::fromHeader($values);
+
+            return;
+        }
+        $this->getCacheControl($target)->addCacheControlDirectives(CacheControl::parseCacheControl($values));
     }
 
     /**
@@ -173,12 +208,12 @@ class HeaderBag implements \IteratorAggregate, \Countable, \Stringable
      */
     public function remove(string $key): void
     {
-        $key = strtr($key, self::UPPER, self::LOWER);
+        $uniqueKey = strtr($key, self::UPPER, self::LOWER);
 
-        unset($this->headers[$key]);
+        unset($this->headers[$uniqueKey]);
 
-        if ('cache-control' === $key) {
-            $this->cacheControl = [];
+        if (str_ends_with($uniqueKey, 'cache-control')) {
+            $this->removeCacheControl($this->extractCacheControlTarget($key));
         }
     }
 
@@ -201,29 +236,56 @@ class HeaderBag implements \IteratorAggregate, \Countable, \Stringable
     }
 
     /**
+     * Get the default or a targeted cache control instruction set.
+     *
+     * If the set did not exist yet, it is created.
+     */
+    public function getCacheControl(string $target = self::DEFAULT_CACHE_CONTROL_TARGET): CacheControl
+    {
+        // TODO do we need to lowercase the targets as well, and track the desired case as we do for the headers in ResponseHeaderBag
+        if (!\array_key_exists($target, $this->cacheControls)) {
+            $this->cacheControls[$target] = new CacheControl();
+        }
+
+        return $this->cacheControls[$target];
+    }
+
+    /**
+     * Remove cache control settings.
+     */
+    public function removeCacheControl(string $target = self::DEFAULT_CACHE_CONTROL_TARGET): void
+    {
+        unset($this->cacheControls[$target]);
+    }
+
+    /**
      * Adds a custom Cache-Control directive.
+     *
+     * @deprecated Use getCacheControl()->addCacheControlDirective instead
      */
     public function addCacheControlDirective(string $key, bool|string $value = true): void
     {
-        $this->cacheControl[$key] = $value;
-
-        $this->set('Cache-Control', $this->getCacheControlHeader());
+        $this->getCacheControl()->addCacheControlDirective($key, $value);
     }
 
     /**
      * Returns true if the Cache-Control directive is defined.
+     *
+     * @deprecated Use getCacheControl()->hasCacheControlDirective instead
      */
     public function hasCacheControlDirective(string $key): bool
     {
-        return \array_key_exists($key, $this->cacheControl);
+        return $this->getCacheControl()->hasCacheControlDirective($key);
     }
 
     /**
      * Returns a Cache-Control directive value by name.
+     *
+     * @deprecated Use getCacheControl()->getCacheControlDirective instead
      */
     public function getCacheControlDirective(string $key): bool|string|null
     {
-        return $this->cacheControl[$key] ?? null;
+        return $this->getCacheControl()->getCacheControlDirective($key);
     }
 
     /**
@@ -231,9 +293,7 @@ class HeaderBag implements \IteratorAggregate, \Countable, \Stringable
      */
     public function removeCacheControlDirective(string $key): void
     {
-        unset($this->cacheControl[$key]);
-
-        $this->set('Cache-Control', $this->getCacheControlHeader());
+        $this->getCacheControl()->removeCacheControlDirective($key);
     }
 
     /**
@@ -254,20 +314,35 @@ class HeaderBag implements \IteratorAggregate, \Countable, \Stringable
         return \count($this->headers);
     }
 
+    /**
+     * @deprecated Use getCacheControl()->getCacheControlHeader instead
+     */
     protected function getCacheControlHeader(): string
     {
-        ksort($this->cacheControl);
-
-        return HeaderUtils::toString($this->cacheControl, ',');
+        return $this->getCacheControl()->getCacheControlHeader();
     }
 
     /**
      * Parses a Cache-Control HTTP header.
+     *
+     * @deprecated Use CacheControl::fromHeader instead
      */
     protected function parseCacheControl(string $header): array
     {
         $parts = HeaderUtils::split($header, ',=');
 
         return HeaderUtils::combine($parts);
+    }
+
+    /**
+     * Get the cache-control target from the header name.
+     */
+    private function extractCacheControlTarget(string $headerName): string
+    {
+        if ('cache-control' === strtolower($headerName)) {
+            return self::DEFAULT_CACHE_CONTROL_TARGET;
+        }
+
+        return substr($headerName, 0, -\strlen('-cache-control'));
     }
 }

--- a/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
@@ -24,7 +24,6 @@ class ResponseHeaderBag extends HeaderBag
     public const DISPOSITION_ATTACHMENT = 'attachment';
     public const DISPOSITION_INLINE = 'inline';
 
-    protected array $computedCacheControl = [];
     protected array $cookies = [];
     protected array $headerNames = [];
 
@@ -32,9 +31,8 @@ class ResponseHeaderBag extends HeaderBag
     {
         parent::__construct($headers);
 
-        if (!isset($this->headers['cache-control'])) {
-            $this->set('Cache-Control', '');
-        }
+        // ensure that an empty default cache control object is initialized
+        $this->getCacheControl();
 
         /* RFC2616 - 14.18 says all Responses need to have a Date */
         if (!isset($this->headers['date'])) {
@@ -50,6 +48,15 @@ class ResponseHeaderBag extends HeaderBag
         $headers = [];
         foreach ($this->all() as $name => $value) {
             $headers[$this->headerNames[$name] ?? $name] = $value;
+        }
+        foreach ($this->cacheControls as $target => $cacheControl) {
+            if (self::DEFAULT_CACHE_CONTROL_TARGET === $target) {
+                unset($headers['cache-control']);
+                $headers['Cache-Control'] = [$this->computeCacheControl()->getCacheControlHeader()];
+            } else {
+                unset($headers[$target.'-cache-control']);
+                $headers[$target.'-Cache-Control'] = [$cacheControl->getCacheControlHeader()];
+            }
         }
 
         return $headers;
@@ -71,9 +78,8 @@ class ResponseHeaderBag extends HeaderBag
 
         parent::replace($headers);
 
-        if (!isset($this->headers['cache-control'])) {
-            $this->set('Cache-Control', '');
-        }
+        // ensure that an empty default cache control object is initialized
+        $this->getCacheControl();
 
         if (!isset($this->headers['date'])) {
             $this->initDate();
@@ -87,11 +93,18 @@ class ResponseHeaderBag extends HeaderBag
         if (null !== $key) {
             $key = strtr($key, self::UPPER, self::LOWER);
 
-            return 'set-cookie' !== $key ? $headers[$key] ?? [] : array_map('strval', $this->getCookies());
+            return match ($key) {
+                'set-cookie' => array_map('strval', $this->getCookies()),
+                'cache-control' => [$this->computeCacheControl()->getCacheControlHeader()],
+                default => $headers[$key] ?? [],
+            };
         }
 
         foreach ($this->getCookies() as $cookie) {
             $headers['set-cookie'][] = (string) $cookie;
+        }
+        if (\array_key_exists(self::DEFAULT_CACHE_CONTROL_TARGET, $this->cacheControls)) {
+            $headers['cache-control'] = [$this->computeCacheControl()->getCacheControlHeader()];
         }
 
         return $headers;
@@ -116,13 +129,6 @@ class ResponseHeaderBag extends HeaderBag
         $this->headerNames[$uniqueKey] = $key;
 
         parent::set($key, $values, $replace);
-
-        // ensure the cache-control header has sensible defaults
-        if (\in_array($uniqueKey, ['cache-control', 'etag', 'last-modified', 'expires'], true) && '' !== $computed = $this->computeCacheControlValue()) {
-            $this->headers['cache-control'] = [$computed];
-            $this->headerNames['cache-control'] = 'Cache-Control';
-            $this->computedCacheControl = $this->parseCacheControl($computed);
-        }
     }
 
     public function remove(string $key): void
@@ -138,23 +144,25 @@ class ResponseHeaderBag extends HeaderBag
 
         parent::remove($key);
 
-        if ('cache-control' === $uniqueKey) {
-            $this->computedCacheControl = [];
-        }
-
         if ('date' === $uniqueKey) {
             $this->initDate();
         }
     }
 
+    /**
+     * @deprecated use computeCacheControl()->hasCacheControlDirective instead)
+     */
     public function hasCacheControlDirective(string $key): bool
     {
-        return \array_key_exists($key, $this->computedCacheControl);
+        return $this->computeCacheControl()->hasCacheControlDirective($key);
     }
 
+    /**
+     * @deprecated use computeCacheControl()->getCacheControlDirective instead)
+     */
     public function getCacheControlDirective(string $key): bool|string|null
     {
-        return $this->computedCacheControl[$key] ?? null;
+        return $this->computeCacheControl()->getCacheControlDirective($key);
     }
 
     public function setCookie(Cookie $cookie): void
@@ -221,7 +229,7 @@ class ResponseHeaderBag extends HeaderBag
      */
     public function clearCookie(string $name, ?string $path = '/', ?string $domain = null, bool $secure = false, bool $httpOnly = true, ?string $sameSite = null /* , bool $partitioned = false */): void
     {
-        $partitioned = 6 < \func_num_args() ? \func_get_arg(6) : false;
+        $partitioned = 6 < \func_num_args() ? func_get_arg(6) : false;
 
         $this->setCookie(new Cookie($name, null, 1, $path, $domain, $secure, $httpOnly, false, $sameSite, $partitioned));
     }
@@ -240,28 +248,33 @@ class ResponseHeaderBag extends HeaderBag
      * This considers several other headers and calculates or modifies the
      * cache-control header to a sensible, conservative value.
      */
-    protected function computeCacheControlValue(): string
+    protected function computeCacheControl(): CacheControl
     {
-        if (!$this->cacheControl) {
-            if ($this->has('Last-Modified') || $this->has('Expires')) {
-                return 'private, must-revalidate'; // allows for heuristic expiration (RFC 7234 Section 4.2.2) in the case of "Last-Modified"
+        if (!\array_key_exists(self::DEFAULT_CACHE_CONTROL_TARGET, $this->cacheControls)) {
+            // cache control explicitly removed
+            return new CacheControl();
+        }
+        $cacheControl = $this->getCacheControl();
+        if ($cacheControl->empty()) {
+            if (\array_key_exists('last-modified', $this->headers) || \array_key_exists('expires', $this->headers)) {
+                return new CacheControl(['private' => true, 'must-revalidate' => true]); // allows for heuristic expiration (RFC 7234 Section 4.2.2) in the case of "Last-Modified"
             }
 
             // conservative by default
-            return 'no-cache, private';
+            return new CacheControl(['no-cache' => true, 'private' => true]);
         }
 
-        $header = $this->getCacheControlHeader();
-        if (isset($this->cacheControl['public']) || isset($this->cacheControl['private'])) {
-            return $header;
+        if ($cacheControl->hasCacheControlDirective('public') || $cacheControl->hasCacheControlDirective('private')) {
+            return $cacheControl; // do we need to clone? i think not
         }
 
         // public if s-maxage is defined, private otherwise
-        if (!isset($this->cacheControl['s-maxage'])) {
-            return $header.', private';
+        if (!$cacheControl->hasCacheControlDirective('s-maxage')) {
+            $cacheControl = clone $cacheControl;
+            $cacheControl->addCacheControlDirective('private');
         }
 
-        return $header;
+        return $cacheControl;
     }
 
     private function initDate(): void

--- a/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/cookie_raw_urlencode.expected
+++ b/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/cookie_raw_urlencode.expected
@@ -2,8 +2,8 @@
 Array
 (
     [0] => Content-Type: text/plain; charset=utf-8
-    [1] => Cache-Control: no-cache, private
-    [2] => Date: Sat, 12 Nov 1955 20:04:00 GMT
+    [1] => Date: Sat, 12 Nov 1955 20:04:00 GMT
+    [2] => Cache-Control: no-cache, private
     [3] => Set-Cookie: ?*():@&+$/%#[]=?*():@&+$/%#[]; path=/
     [4] => Set-Cookie: ?*():@&+$/%#[]=?*():@&+$/%#[]; path=/
 )

--- a/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/cookie_samesite_lax.expected
+++ b/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/cookie_samesite_lax.expected
@@ -2,8 +2,8 @@
 Array
 (
     [0] => Content-Type: text/plain; charset=utf-8
-    [1] => Cache-Control: no-cache, private
-    [2] => Date: Sat, 12 Nov 1955 20:04:00 GMT
+    [1] => Date: Sat, 12 Nov 1955 20:04:00 GMT
+    [2] => Cache-Control: no-cache, private
     [3] => Set-Cookie: CookieSamesiteLaxTest=LaxValue; path=/; httponly; samesite=lax
 )
 shutdown

--- a/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/cookie_samesite_strict.expected
+++ b/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/cookie_samesite_strict.expected
@@ -2,8 +2,8 @@
 Array
 (
     [0] => Content-Type: text/plain; charset=utf-8
-    [1] => Cache-Control: no-cache, private
-    [2] => Date: Sat, 12 Nov 1955 20:04:00 GMT
+    [1] => Date: Sat, 12 Nov 1955 20:04:00 GMT
+    [2] => Cache-Control: no-cache, private
     [3] => Set-Cookie: CookieSamesiteStrictTest=StrictValue; path=/; httponly; samesite=strict
 )
 shutdown

--- a/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/cookie_urlencode.expected
+++ b/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/cookie_urlencode.expected
@@ -2,8 +2,8 @@
 Array
 (
     [0] => Content-Type: text/plain; charset=utf-8
-    [1] => Cache-Control: no-cache, private
-    [2] => Date: Sat, 12 Nov 1955 20:04:00 GMT
+    [1] => Date: Sat, 12 Nov 1955 20:04:00 GMT
+    [2] => Cache-Control: no-cache, private
     [3] => Set-Cookie: %3D%2C%3B%20%09%0D%0A%0B%0C=%3D%2C%3B%20%09%0D%0A%0B%0C; path=/
     [4] => Set-Cookie: ?*():@&+$/%#[]=%3F%2A%28%29%3A%40%26%2B%24%2F%25%23%5B%5D; path=/
     [5] => Set-Cookie: ?*():@&+$/%#[]=%3F%2A%28%29%3A%40%26%2B%24%2F%25%23%5B%5D; path=/

--- a/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/deleted_cookie.expected
+++ b/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/deleted_cookie.expected
@@ -3,9 +3,9 @@ Array
 (
     [0] => Content-Type: text/plain; charset=utf-8
     [1] => Cache-Control: max-age=0, private, must-revalidate
-    [2] => Cache-Control: max-age=0, must-revalidate, private
-    [3] => Date: Sat, 12 Nov 1955 20:04:00 GMT
-    [4] => Expires: %s, %d %s %d %d:%d:%d GMT
+    [2] => Date: Sat, 12 Nov 1955 20:04:00 GMT
+    [3] => Expires: %s, %d %s %d %d:%d:%d GMT
+    [4] => Cache-Control: max-age=0, must-revalidate, private
     [5] => Set-Cookie: PHPSESSID=deleted; expires=%s, %d %s %d %d:%d:%d GMT; Max-Age=%d; %s
 )
 shutdown

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseHeaderBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseHeaderBagTest.php
@@ -57,7 +57,7 @@ class ResponseHeaderBagTest extends TestCase
         $this->assertFalse($bag->hasCacheControlDirective('max-age'));
 
         $bag = new ResponseHeaderBag(['Expires' => 'Wed, 16 Feb 2011 14:17:43 GMT']);
-        $this->assertEquals('private, must-revalidate', $bag->get('Cache-Control'));
+        $this->assertEquals('must-revalidate, private', $bag->get('Cache-Control'));
 
         $bag = new ResponseHeaderBag([
             'Expires' => 'Wed, 16 Feb 2011 14:17:43 GMT',
@@ -66,10 +66,10 @@ class ResponseHeaderBagTest extends TestCase
         $this->assertEquals('max-age=3600, private', $bag->get('Cache-Control'));
 
         $bag = new ResponseHeaderBag(['Last-Modified' => 'abcde']);
-        $this->assertEquals('private, must-revalidate', $bag->get('Cache-Control'));
+        $this->assertEquals('must-revalidate, private', $bag->get('Cache-Control'));
 
         $bag = new ResponseHeaderBag(['Etag' => 'abcde', 'Last-Modified' => 'abcde']);
-        $this->assertEquals('private, must-revalidate', $bag->get('Cache-Control'));
+        $this->assertEquals('must-revalidate, private', $bag->get('Cache-Control'));
 
         $bag = new ResponseHeaderBag(['cache-control' => 'max-age=100']);
         $this->assertEquals('max-age=100, private', $bag->get('Cache-Control'));
@@ -85,7 +85,7 @@ class ResponseHeaderBagTest extends TestCase
 
         $bag = new ResponseHeaderBag();
         $bag->set('Last-Modified', 'abcde');
-        $this->assertEquals('private, must-revalidate', $bag->get('Cache-Control'));
+        $this->assertEquals('must-revalidate, private', $bag->get('Cache-Control'));
 
         $bag = new ResponseHeaderBag();
         $bag->set('Cache-Control', ['public', 'must-revalidate']);

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
@@ -379,7 +379,7 @@ class ResponseTest extends ResponseTestCase
         $response->setStaleIfError(86400);
 
         $cacheControl = $response->headers->get('Cache-Control');
-        $this->assertEquals('stale-if-error=86400, private', $cacheControl);
+        $this->assertEquals('private, stale-if-error=86400', $cacheControl);
     }
 
     public function testSetStaleWhileRevalidateWithoutSharedMaxAge()
@@ -388,7 +388,7 @@ class ResponseTest extends ResponseTestCase
         $response->setStaleWhileRevalidate(300);
 
         $cacheControl = $response->headers->get('Cache-Control');
-        $this->assertEquals('stale-while-revalidate=300, private', $cacheControl);
+        $this->assertEquals('private, stale-while-revalidate=300', $cacheControl);
     }
 
     public function testIsPrivate()


### PR DESCRIPTION
https://datatracker.ietf.org/doc/rfc9213/ defines additional headers to target cache-control to specific reverse proxies. this PR refactors the header bag:

* extract cache control handling into separate class
* support having additional targets with cache control

| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | Fix #47288
| License       | MIT

This is the current work in progress for targeted cache control. 

TODO
* double check if tests cover all cases (setting cache-control to `''` or `null` for example)
* separate MR to add some unit tests for extending the header bag and manipulating the protected `HeaderBag::$cacheControl` array (that array should have been private, but as it is not, we need to provide BC)
* add BC for the removed $cacheControl (with `__get` / `__set`)
* Update CHANGELOG and UPGRADE documents with instructions
* Documentation PR to adjust examples, and document targeted cache control

#SymfonyHackday