### PR TITLE
[PropertyAccess] Fix compatibility with PHP 8.4 asymmetric visibility

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -640,15 +640,22 @@ class PropertyAccessor implements PropertyAccessorInterface
      */
     private function isPropertyWritable(object $object, string $property): bool
     {
-        $mutatorForArray = $this->getWriteInfo($object::class, $property, []);
+        if ($object instanceof \stdClass && property_exists($object, $property)) {
+            return true;
+        }
 
-        if (PropertyWriteInfo::TYPE_NONE !== $mutatorForArray->getType() || ($object instanceof \stdClass && property_exists($object, $property))) {
+        $mutatorForArray = $this->getWriteInfo($object::class, $property, []);
+        if (PropertyWriteInfo::TYPE_PROPERTY === $mutatorForArray->getType()) {
+            return $mutatorForArray->getVisibility() === 'public';
+        }
+
+        if (PropertyWriteInfo::TYPE_NONE !== $mutatorForArray->getType()) {
             return true;
         }
 
         $mutator = $this->getWriteInfo($object::class, $property, '');
 
-        return PropertyWriteInfo::TYPE_NONE !== $mutator->getType() || ($object instanceof \stdClass && property_exists($object, $property));
+        return PropertyWriteInfo::TYPE_NONE !== $mutator->getType();
     }
 
     /**

--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/AsymmetricVisibility.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/AsymmetricVisibility.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyAccess\Tests\Fixtures;
+
+class AsymmetricVisibility
+{
+    public public(set) mixed $publicPublic = null;
+    public protected(set) mixed $publicProtected = null;
+    public private(set) mixed $publicPrivate = null;
+    private private(set) mixed $privatePrivate = null;
+    public bool $virtualNoSetHook { get => true; }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59183
| License       | MIT

Fix compatibility with PHP 8.4 asymmetric visibility by looking if the setter hook is public.