### PR TITLE
[HttpFoundation] Avoid mime type guess with temp files in `BinaryFileResponse`

### DIFF
--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -189,7 +189,12 @@ class BinaryFileResponse extends Response
         }
 
         if (!$this->headers->has('Content-Type')) {
-            $this->headers->set('Content-Type', $this->file->getMimeType() ?: 'application/octet-stream');
+            $mimeType = null;
+            if (!$this->tempFileObject) {
+                $mimeType = $this->file->getMimeType();
+            }
+
+            $this->headers->set('Content-Type', $mimeType ?: 'application/octet-stream');
         }
 
         parent::prepare($request);

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -458,4 +458,15 @@ class BinaryFileResponseTest extends ResponseTestCase
         $string = ob_get_clean();
         $this->assertSame('foo,bar', $string);
     }
+
+    public function testCreateFromTemporaryFileWithoutMimeType()
+    {
+        $file = new \SplTempFileObject();
+        $file->fwrite('foo,bar');
+
+        $response = new BinaryFileResponse($file);
+        $response->prepare(new Request());
+
+        $this->assertSame('application/octet-stream', $response->headers->get('Content-Type'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When using `SplTempFileObject` with `BinaryFileResponse`, the MIME type guesser cannot be used on the `php://temp` stream. The mime type should be passed manually to the `Content-Type` header.

Currently, if the content type header is not provided when passing a `SplTempFileObject` to `BinaryFileResponse`, the MIME type guesser throws an exception.