### PR TITLE
[WebProfilerBundle] fix loading of toolbar stylesheet

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/wdt.xml
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/wdt.xml
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing https://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="_wdt_stylesheet" path="/styles.css">
+    <route id="_wdt_stylesheet" path="/styles">
         <default key="_controller">web_profiler.controller.profiler::toolbarStylesheetAction</default>
     </route>
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/ProfilerControllerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/ProfilerControllerTest.php
@@ -152,15 +152,15 @@ class ProfilerControllerTest extends WebTestCase
 
     public function testToolbarStylesheetAction()
     {
-        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
-        $twig = $this->createMock(Environment::class);
-        $profiler = $this->createMock(Profiler::class);
+        $kernel = new WebProfilerBundleKernel();
+        $client = new KernelBrowser($kernel);
 
-        $controller = new ProfilerController($urlGenerator, $profiler, $twig, []);
+        $client->request('GET', '/_wdt/styles');
 
-        $response = $controller->toolbarStylesheetAction();
+        $response = $client->getResponse();
+
         $this->assertSame(200, $response->getStatusCode());
-        $this->assertSame('text/css', $response->headers->get('Content-Type'));
+        $this->assertSame('text/css; charset=UTF-8', $response->headers->get('Content-Type'));
         $this->assertSame('max-age=600, private', $response->headers->get('Cache-Control'));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59045
| License       | MIT

It looks like this PR

- #58287

Caused issues with some configurations:

- #59045

According to the thumb-up emoji on [this comment](https://github.com/symfony/symfony/issues/59045#issuecomment-2510136712) (I don’t have a better measurement of the impact), it affected at least 10 users, with various web servers.

Proposals:

1. do not use the `.css` file extension so that servers do not try to serve an actual file
2. if we consider that the disappearance of the style of the profiler’s toolbar is a breaking change, the `.css` file extension could be added back with Symfony 8.0, with a note to help people upgrade (see the workarounds in the issue)