### PR TITLE
[Security] Hiding userFqcn in RememberMe cookie

### DIFF
--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -3,7 +3,7 @@ CHANGELOG
 
 7.3
 ---
-
+ * Rename property userFqcn to userFqcnHash, remove method getUserFqcn, add method getUserFqcnHash.
  * Add encryption support to `OidcTokenHandler` (JWE)
 
 7.2

--- a/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php
@@ -67,7 +67,7 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
         [$series, $tokenValue] = explode(':', $rememberMeDetails->getValue(), 2);
         $persistentToken = $this->tokenProvider->loadTokenBySeries($series);
 
-        if ($persistentToken->getUserIdentifier() !== $rememberMeDetails->getUserIdentifier() || $persistentToken->getClass() !== $rememberMeDetails->getUserFqcn()) {
+        if ($persistentToken->getUserIdentifier() !== $rememberMeDetails->getUserIdentifier() || !hash_equals(RememberMeDetails::computeUserFqcnHash($persistentToken->getClass()), $rememberMeDetails->getUserFqcnHash())) {
             throw new AuthenticationException('The cookie\'s hash is invalid.');
         }
 
@@ -89,7 +89,7 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
         }
 
         return parent::consumeRememberMeCookie(new RememberMeDetails(
-            $persistentToken->getClass(),
+            RememberMeDetails::computeUserFqcnHash($persistentToken->getClass()),
             $persistentToken->getUserIdentifier(),
             $expires,
             $persistentToken->getLastUsed()->getTimestamp().':'.$series.':'.$tokenValue.':'.$persistentToken->getClass()

--- a/src/Symfony/Component/Security/Http/RememberMe/SignatureRememberMeHandler.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/SignatureRememberMeHandler.php
@@ -47,7 +47,7 @@ final class SignatureRememberMeHandler extends AbstractRememberMeHandler
         $expires = time() + $this->options['lifetime'];
         $value = $this->signatureHasher->computeSignatureHash($user, $expires);
 
-        $details = new RememberMeDetails($user::class, $user->getUserIdentifier(), $expires, $value);
+        $details = new RememberMeDetails(RememberMeDetails::computeUserFqcnHash($user::class), $user->getUserIdentifier(), $expires, $value);
         $this->createCookie($details);
     }
 

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/RememberMeAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/RememberMeAuthenticatorTest.php
@@ -69,7 +69,7 @@ class RememberMeAuthenticatorTest extends TestCase
 
     public function testAuthenticate()
     {
-        $rememberMeDetails = new RememberMeDetails(InMemoryUser::class, 'wouter', 1, 'secret');
+        $rememberMeDetails = new RememberMeDetails(RememberMeDetails::computeUserFqcnHash(InMemoryUser::class), 'wouter', 1, 'secret');
         $request = Request::create('/', 'GET', [], ['_remember_me_cookie' => $rememberMeDetails->toString()]);
         $passport = $this->authenticator->authenticate($request);
 

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentRememberMeHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentRememberMeHandlerTest.php
@@ -63,7 +63,7 @@ class PersistentRememberMeHandlerTest extends TestCase
             ->method('deleteTokenBySeries')
             ->with('series1');
 
-        $this->request->cookies->set('REMEMBERME', (new RememberMeDetails(InMemoryUser::class, 'wouter', 0, 'series1:tokenvalue'))->toString());
+        $this->request->cookies->set('REMEMBERME', (new RememberMeDetails(RememberMeDetails::computeUserFqcnHash(InMemoryUser::class), 'wouter', 0, 'series1:tokenvalue'))->toString());
 
         $this->handler->clearRememberMeCookie();
 
@@ -84,7 +84,7 @@ class PersistentRememberMeHandlerTest extends TestCase
 
         $this->tokenProvider->expects($this->once())->method('updateToken')->with('series1');
 
-        $rememberMeDetails = new RememberMeDetails(InMemoryUser::class, 'wouter', 360, 'series1:tokenvalue');
+        $rememberMeDetails = new RememberMeDetails(RememberMeDetails::computeUserFqcnHash(InMemoryUser::class), 'wouter', 360, 'series1:tokenvalue');
         $this->handler->consumeRememberMeCookie($rememberMeDetails);
 
         // assert that the cookie has been updated with a new base64 encoded token value
@@ -110,7 +110,7 @@ class PersistentRememberMeHandlerTest extends TestCase
             ->willReturn(new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue', new \DateTime('-10 min')))
         ;
 
-        $rememberMeDetails = new RememberMeDetails(InMemoryUser::class, 'jeremy', 360, 'series1:tokenvalue');
+        $rememberMeDetails = new RememberMeDetails(RememberMeDetails::computeUserFqcnHash(InMemoryUser::class), 'jeremy', 360, 'series1:tokenvalue');
 
         $this->expectException(AuthenticationException::class);
         $this->expectExceptionMessage('The cookie\'s hash is invalid.');
@@ -125,7 +125,7 @@ class PersistentRememberMeHandlerTest extends TestCase
             ->willReturn(new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue', new \DateTime('-10 min')))
         ;
 
-        $rememberMeDetails = new RememberMeDetails(InMemoryUser::class, 'wouter', 360, 'series1:tokenvalue:somethingelse');
+        $rememberMeDetails = new RememberMeDetails(RememberMeDetails::computeUserFqcnHash(InMemoryUser::class), 'wouter', 360, 'series1:tokenvalue:somethingelse');
 
         $this->expectException(AuthenticationException::class);
         $this->expectExceptionMessage('This token was already used. The account is possibly compromised.');
@@ -151,7 +151,7 @@ class PersistentRememberMeHandlerTest extends TestCase
             ->willReturn(true)
         ;
 
-        $rememberMeDetails = new RememberMeDetails(InMemoryUser::class, 'wouter', 360, 'series1:oldTokenValue');
+        $rememberMeDetails = new RememberMeDetails(RememberMeDetails::computeUserFqcnHash(InMemoryUser::class), 'wouter', 360, 'series1:oldTokenValue');
         $handler->consumeRememberMeCookie($rememberMeDetails);
 
         $this->assertFalse($this->request->attributes->has(ResponseListener::COOKIE_ATTR_NAME));
@@ -168,7 +168,7 @@ class PersistentRememberMeHandlerTest extends TestCase
 
         $this->expectException(CookieTheftException::class);
 
-        $this->handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, 'series1:tokenvalue'));
+        $this->handler->consumeRememberMeCookie(new RememberMeDetails(RememberMeDetails::computeUserFqcnHash(InMemoryUser::class), 'wouter', 360, 'series1:tokenvalue'));
     }
 
     public function testConsumeRememberMeCookieExpired()
@@ -183,7 +183,7 @@ class PersistentRememberMeHandlerTest extends TestCase
         $this->expectException(AuthenticationException::class);
         $this->expectExceptionMessage('The cookie has expired.');
 
-        $this->handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, 'series1:tokenvalue'));
+        $this->handler->consumeRememberMeCookie(new RememberMeDetails(RememberMeDetails::computeUserFqcnHash(InMemoryUser::class), 'wouter', 360, 'series1:tokenvalue'));
     }
 
     public function testBase64EncodedTokens()
@@ -196,7 +196,7 @@ class PersistentRememberMeHandlerTest extends TestCase
 
         $this->tokenProvider->expects($this->once())->method('updateToken')->with('series1');
 
-        $rememberMeDetails = new RememberMeDetails(InMemoryUser::class, 'wouter', 360, 'series1:tokenvalue');
+        $rememberMeDetails = new RememberMeDetails(RememberMeDetails::computeUserFqcnHash(InMemoryUser::class), 'wouter', 360, 'series1:tokenvalue');
         $rememberMeDetails = RememberMeDetails::fromRawCookie(base64_encode($rememberMeDetails->toString()));
         $this->handler->consumeRememberMeCookie($rememberMeDetails);
     }

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/SignatureRememberMeHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/SignatureRememberMeHandlerTest.php
@@ -57,7 +57,7 @@ class SignatureRememberMeHandlerTest extends TestCase
 
         /** @var Cookie $cookie */
         $cookie = $this->request->attributes->get(ResponseListener::COOKIE_ATTR_NAME);
-        $this->assertEquals(strtr(InMemoryUser::class, '\\', '.').':d291dGVy:'.$expire.':'.$signature, $cookie->getValue());
+        $this->assertEquals(RememberMeDetails::computeUserFqcnHash(InMemoryUser::class).':d291dGVy:'.$expire.':'.$signature, $cookie->getValue());
     }
 
     public function testClearRememberMeCookie()
@@ -77,21 +77,21 @@ class SignatureRememberMeHandlerTest extends TestCase
         $signature = $this->signatureHasher->computeSignatureHash($user, $expire = time() + 3600);
         $this->userProvider->createUser(new InMemoryUser('wouter', null));
 
-        $rememberMeDetails = new RememberMeDetails(InMemoryUser::class, 'wouter', $expire, $signature);
+        $rememberMeDetails = new RememberMeDetails(RememberMeDetails::computeUserFqcnHash(InMemoryUser::class), 'wouter', $expire, $signature);
         $this->handler->consumeRememberMeCookie($rememberMeDetails);
 
         $this->assertTrue($this->request->attributes->has(ResponseListener::COOKIE_ATTR_NAME));
 
         /** @var Cookie $cookie */
         $cookie = $this->request->attributes->get(ResponseListener::COOKIE_ATTR_NAME);
-        $this->assertNotEquals((new RememberMeDetails(InMemoryUser::class, 'wouter', $expire, $signature))->toString(), $cookie->getValue());
+        $this->assertNotEquals((new RememberMeDetails(RememberMeDetails::computeUserFqcnHash(InMemoryUser::class), 'wouter', $expire, $signature))->toString(), $cookie->getValue());
     }
 
     public function testConsumeRememberMeCookieInvalidHash()
     {
         $this->expectException(AuthenticationException::class);
         $this->expectExceptionMessage('The cookie\'s hash is invalid.');
-        $this->handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', time() + 600, 'badsignature'));
+        $this->handler->consumeRememberMeCookie(new RememberMeDetails(RememberMeDetails::computeUserFqcnHash(InMemoryUser::class), 'wouter', time() + 600, 'badsignature'));
     }
 
     public function testConsumeRememberMeCookieExpired()
@@ -101,6 +101,6 @@ class SignatureRememberMeHandlerTest extends TestCase
 
         $this->expectException(AuthenticationException::class);
         $this->expectExceptionMessage('The cookie has expired.');
-        $this->handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, $signature));
+        $this->handler->consumeRememberMeCookie(new RememberMeDetails(RememberMeDetails::computeUserFqcnHash(InMemoryUser::class), 'wouter', 360, $signature));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3 
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #42349
| License       | MIT

In the current implementation, RememberMeDetails stores the userFqcn field, which exposes the class name of the user. This can potentially lead to information leakage about the application's internal structure.

This PR replaces the storage of userFqcn with its hash. By doing so, the implementation details of the application remain protected.

This change is **not backward compatible** for the following reasons:
1. Data stored using the old format (with userFqcn) will no longer be compatible with the new implementation.
2. The getUserFqcn method will be replaced

If this approach is acceptable, I will adjust the implementation to ensure compatibility by:

1. Deprecating the getUserFqcn method.
2. Introducing a new method (e.g., getUserFqcnHash) to handle the hashed value while maintaining support for the old userFqcn field during a transition period.

Let me know if this approach works for you, and I will update the PR and fix tests.