### PR TITLE
[Validator] [Component]  [PasswordStrengthValidator] Fix invalid code making custom password strength estimators not working

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/PasswordStrengthValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/PasswordStrengthValidator.php
@@ -39,7 +39,11 @@ final class PasswordStrengthValidator extends ConstraintValidator
         if (!\is_string($value) && !$value instanceof \Stringable) {
             throw new UnexpectedValueException($value, 'string');
         }
-        $passwordStrengthEstimator = $this->passwordStrengthEstimator ?? self::estimateStrength(...);
+
+        $passwordStrengthEstimator = $this->passwordStrengthEstimator ?
+            ($this->passwordStrengthEstimator)() :
+            self::estimateStrength(...);
+
         $strength = $passwordStrengthEstimator((string) $value);
 
         if ($strength < $constraint->minScore) {


### PR DESCRIPTION
 Fix invalid code making custom password strength estimators not working

| Q             | A
| ------------- | ---
| Branch?       | 7.3 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59235
| License       | MIT

See issue #59235 59235

Custom Password Strength Estimator not working when following the official guide, section Customizing the Password Strength Estimation:
https://symfony.com/doc/current/reference/constraints/PasswordStrength.html#customizing-the-password-strength-estimation

Results in error:
```
"Notice: Object of class App\\Validator\\CustomPasswordStrengthEstimator could not be converted to int"
```