### PR TITLE
[Messenger] [WIP][Keepalive] keepaliveInterval from KeepaliveReceiverInterface

### DIFF
--- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
@@ -250,6 +250,10 @@ EOF
             $options['queues'] = $queues;
         }
 
+        if (!$this->getApplication()->getAlarmInterval() && $keepAliveInterval = $this->worker->keepaliveInterval()) {
+            $this->getApplication()->setAlarmInterval($keepAliveInterval);
+        }
+
         try {
             $this->worker->run($options);
         } finally {

--- a/src/Symfony/Component/Messenger/Command/FailedMessagesRetryCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesRetryCommand.php
@@ -250,10 +250,16 @@ EOF
             $this->logger
         );
 
+        $currentKeepaliveInterval = $this->getApplication()->getAlarmInterval();
+        if (!$currentKeepaliveInterval && $keepAliveInterval = $this->worker->keepaliveInterval()) {
+            $this->getApplication()->setAlarmInterval($keepAliveInterval);
+        }
+
         try {
             $this->worker->run();
         } finally {
             $this->worker = null;
+            $this->getApplication()->setAlarmInterval($currentKeepaliveInterval);
             $this->eventDispatcher->removeListener(WorkerMessageReceivedEvent::class, $listener);
         }
 

--- a/src/Symfony/Component/Messenger/Transport/Receiver/KeepaliveReceiverInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/Receiver/KeepaliveReceiverInterface.php
@@ -14,6 +14,9 @@ namespace Symfony\Component\Messenger\Transport\Receiver;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\TransportException;
 
+/**
+ * @method int|null getKeepaliveInterval() Interval to schedule a SIGALRM signal in seconds.
+ */
 interface KeepaliveReceiverInterface extends ReceiverInterface
 {
     /**

--- a/src/Symfony/Component/Messenger/Worker.php
+++ b/src/Symfony/Component/Messenger/Worker.php
@@ -308,6 +308,23 @@ class Worker
         }
     }
 
+    public function keepaliveInterval(): ?int
+    {
+        $minSeconds = null;
+        foreach ($this->receivers as $receiver) {
+            if (!$receiver instanceof KeepaliveReceiverInterface || !method_exists($receiver, 'getKeepaliveInterval')) {
+                continue;
+            }
+
+            $keepaliveInterval = $receiver->getKeepaliveInterval();
+            if ($keepaliveInterval && $keepaliveInterval > 0) {
+                $minSeconds = min($minSeconds ?? $keepaliveInterval, $keepaliveInterval);
+            }
+        }
+
+        return $minSeconds;
+    }
+
     public function getMetadata(): WorkerMetadata
     {
         return $this->metadata;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

TODO:
- [ ] write PR description
- [ ] fix tests
- [ ] write tests
- [ ] update CHANGELOG.md
- [ ] submit changes to the documentation

---

### Allow to retrieve alarm interval by receiver next to command option

For now we have to pass `--keepalive` option to ConsumeMessagesCommand and FailedMessagesRetryCommand to set alarm interval for application. But \AMQPQueue and amqp transport has `heartbeat` option. Will be nice to allow manage the keepalive interval by receiver so we can use this option and adjust alarm interval automatically by transport (maybe I will make another PR for AmqpTransport, I am working on this).

To achieve this I propose to use (new in 7.2) interface KeepaliveReceiverInterface and get keepalive interval from it. If  `--keepalive` option was already been passed by command  we shouldn't change it. Command option should be more important.

(this is my first PR in Symfony, so if I need to do anything more for now, please let me know)

<!--
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->
