### PR TITLE
[TypeInfo] Fix add phpstan/phpdoc-parser conflict

### DIFF
--- a/src/Symfony/Component/TypeInfo/composer.json
+++ b/src/Symfony/Component/TypeInfo/composer.json
@@ -31,6 +31,9 @@
     "require-dev": {
         "phpstan/phpdoc-parser": "^1.0|^2.0"
     },
+    "conflict": {
+        "phpstan/phpdoc-parser": "<1.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\TypeInfo\\": "" },
         "exclude-from-classmap": [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Re-add `phpstan/phpdoc-parser` conflict as it's located in the `required-dev` section (and not the `require` section)