### PR TITLE
[PropertyInfo] Gather data from property hooks in ReflectionExtractor

### DIFF
--- a/src/Symfony/Component/PropertyInfo/CHANGELOG.md
+++ b/src/Symfony/Component/PropertyInfo/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Allow defining accessors and mutators via a `#[WithAccessors]` attribute
+ * Gather data from property hooks in ReflectionExtractor
  * Add `PropertyNameExtractorInterface` and `getPropertyName()` to enable property name extraction from an accessor or mutator
 
 8.1

--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -389,12 +389,12 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyNam
             return new PropertyReadInfo(PropertyReadInfo::TYPE_METHOD, $getsetter, $this->getReadVisibilityForMethod($m), $m->isStatic(), false);
         }
 
-        if ($allowMagicGet && $reflClass->hasMethod('__get') && (($r = $reflClass->getMethod('__get'))->getModifiers() & $this->methodReflectionFlags)) {
-            return new PropertyReadInfo(PropertyReadInfo::TYPE_PROPERTY, $property, PropertyReadInfo::VISIBILITY_PUBLIC, false, $r->returnsReference());
+        if ($hasProperty && (($r = $reflClass->getProperty($property))->getModifiers() & $this->propertyReflectionFlags)) {
+            return new PropertyReadInfo(PropertyReadInfo::TYPE_PROPERTY, $property, $this->getReadVisibilityForProperty($r), $r->isStatic(), true, $this->propertyHasHook($r, 'get'), $this->propertyIsVirtual($r));
         }
 
-        if ($hasProperty && (($r = $reflClass->getProperty($property))->getModifiers() & $this->propertyReflectionFlags)) {
-            return new PropertyReadInfo(PropertyReadInfo::TYPE_PROPERTY, $property, $this->getReadVisibilityForProperty($r), $r->isStatic(), true);
+        if ($allowMagicGet && $reflClass->hasMethod('__get') && (($r = $reflClass->getMethod('__get'))->getModifiers() & $this->methodReflectionFlags)) {
+            return new PropertyReadInfo(PropertyReadInfo::TYPE_PROPERTY, $property, PropertyReadInfo::VISIBILITY_PUBLIC, false, $r->returnsReference(), false, false);
         }
 
         if ($allowMagicCall && $reflClass->hasMethod('__call') && ($reflClass->getMethod('__call')->getModifiers() & $this->methodReflectionFlags)) {
@@ -532,7 +532,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyNam
         if ($reflClass->hasProperty($property) && ($reflClass->getProperty($property)->getModifiers() & $this->propertyReflectionFlags)) {
             $reflProperty = $reflClass->getProperty($property);
             if (!$reflProperty->isReadOnly()) {
-                return new PropertyWriteInfo(PropertyWriteInfo::TYPE_PROPERTY, $property, $this->getWriteVisibilityForProperty($reflProperty), $reflProperty->isStatic());
+                return new PropertyWriteInfo(PropertyWriteInfo::TYPE_PROPERTY, $property, $this->getWriteVisibilityForProperty($reflProperty), $reflProperty->isStatic(), $this->propertyHasHook($reflProperty, 'set'));
             }
 
             $errors[] = [\sprintf('The property "%s" in class "%s" is a promoted readonly property.', $property, $reflClass->getName())];
@@ -542,7 +542,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyNam
         if ($allowMagicSet) {
             [$accessible, $methodAccessibleErrors] = $this->isMethodAccessible($reflClass, '__set', 2);
             if ($accessible) {
-                return new PropertyWriteInfo(PropertyWriteInfo::TYPE_PROPERTY, $property, PropertyWriteInfo::VISIBILITY_PUBLIC, false);
+                return new PropertyWriteInfo(PropertyWriteInfo::TYPE_PROPERTY, $property, PropertyWriteInfo::VISIBILITY_PUBLIC, false, false);
             }
 
             $errors[] = $methodAccessibleErrors;
@@ -816,6 +816,16 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyNam
         }
 
         return [false, $errors];
+    }
+
+    private function propertyHasHook(\ReflectionProperty $property, string $hookType): bool
+    {
+        return $property->hasHook(\PropertyHookType::from($hookType));
+    }
+
+    private function propertyIsVirtual(\ReflectionProperty $property): bool
+    {
+        return $property->isVirtual();
     }
 
     /**

--- a/src/Symfony/Component/PropertyInfo/PropertyReadInfo.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyReadInfo.php
@@ -31,6 +31,8 @@ final class PropertyReadInfo
         private readonly string $visibility,
         private readonly bool $static,
         private readonly bool $byRef,
+        private readonly ?bool $hasHook = null,
+        private readonly ?bool $isVirtual = null,
     ) {
     }
 
@@ -66,5 +68,15 @@ final class PropertyReadInfo
     public function canBeReference(): bool
     {
         return $this->byRef;
+    }
+
+    public function hasHook(): ?bool
+    {
+        return $this->hasHook;
+    }
+
+    public function isVirtual(): ?bool
+    {
+        return $this->isVirtual;
     }
 }

--- a/src/Symfony/Component/PropertyInfo/PropertyWriteInfo.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyWriteInfo.php
@@ -37,6 +37,7 @@ final class PropertyWriteInfo
         private readonly ?string $name = null,
         private readonly ?string $visibility = null,
         private readonly ?bool $static = null,
+        private readonly ?bool $hasHook = null,
     ) {
     }
 
@@ -113,5 +114,10 @@ final class PropertyWriteInfo
     public function hasErrors(): bool
     {
         return (bool) \count($this->errors);
+    }
+
+    public function hasHook(): ?bool
+    {
+        return $this->hasHook;
     }
 }

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\PropertyInfo\Tests\Extractor;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Exception\MappingException;
@@ -26,6 +27,7 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyWithAccessorWithoutProperty;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyWithHasser;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\FalseAccessorDummy;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\HookedProperties;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\MultiParameterAdderDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\MultiParameterAdderParentDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\MultiParameterAdderValue;
@@ -750,10 +752,20 @@ class ReflectionExtractorTest extends TestCase
     public function testVirtualProperties()
     {
         $this->assertTrue($this->extractor->isReadable(VirtualProperties::class, 'virtualNoSetHook'));
+        $this->assertTrue($this->extractor->getReadInfo(VirtualProperties::class, 'virtualNoSetHook')->isVirtual());
+        $this->assertTrue($this->extractor->getReadInfo(VirtualProperties::class, 'virtualNoSetHook')->hasHook());
         $this->assertTrue($this->extractor->isReadable(VirtualProperties::class, 'virtualSetHookOnly'));
+        $this->assertFalse($this->extractor->getReadInfo(VirtualProperties::class, 'virtualSetHookOnly')->isVirtual());
+        $this->assertFalse($this->extractor->getReadInfo(VirtualProperties::class, 'virtualSetHookOnly')->hasHook());
+        $this->assertTrue($this->extractor->isReadable(VirtualProperties::class, 'virtualSetOnly'));
+        $this->assertTrue($this->extractor->getReadInfo(VirtualProperties::class, 'virtualSetOnly')->isVirtual());
+        $this->assertFalse($this->extractor->getReadInfo(VirtualProperties::class, 'virtualSetOnly')->hasHook());
         $this->assertTrue($this->extractor->isReadable(VirtualProperties::class, 'virtualHook'));
+        $this->assertFalse($this->extractor->getReadInfo(VirtualProperties::class, 'virtualHook')->isVirtual());
+        $this->assertTrue($this->extractor->getReadInfo(VirtualProperties::class, 'virtualHook')->hasHook());
         $this->assertFalse($this->extractor->isWritable(VirtualProperties::class, 'virtualNoSetHook'));
         $this->assertTrue($this->extractor->isWritable(VirtualProperties::class, 'virtualSetHookOnly'));
+        $this->assertTrue($this->extractor->isWritable(VirtualProperties::class, 'virtualSetOnly'));
         $this->assertTrue($this->extractor->isWritable(VirtualProperties::class, 'virtualHook'));
     }
 
@@ -795,6 +807,20 @@ class ReflectionExtractorTest extends TestCase
         $this->assertSame(PropertyWriteInfo::TYPE_PROPERTY, $writeMutator->getType());
         $this->assertSame($readVisibility, $readMutator->getVisibility());
         $this->assertSame($writeVisibility, $writeMutator->getVisibility());
+    }
+
+    #[RequiresPhp('>=8.4.0')]
+    public function testHookedProperties()
+    {
+        $this->assertTrue($this->extractor->getReadInfo(HookedProperties::class, 'hookGetOnly')->hasHook());
+        $this->assertFalse($this->extractor->getReadInfo(HookedProperties::class, 'hookGetOnly')->isVirtual());
+        $this->assertFalse($this->extractor->getWriteInfo(HookedProperties::class, 'hookGetOnly')->hasHook());
+        $this->assertFalse($this->extractor->getReadInfo(HookedProperties::class, 'hookSetOnly')->hasHook());
+        $this->assertFalse($this->extractor->getReadInfo(HookedProperties::class, 'hookSetOnly')->isVirtual());
+        $this->assertTrue($this->extractor->getWriteInfo(HookedProperties::class, 'hookSetOnly')->hasHook());
+        $this->assertTrue($this->extractor->getReadInfo(HookedProperties::class, 'hookBoth')->hasHook());
+        $this->assertFalse($this->extractor->getReadInfo(HookedProperties::class, 'hookBoth')->isVirtual());
+        $this->assertTrue($this->extractor->getWriteInfo(HookedProperties::class, 'hookBoth')->hasHook());
     }
 
     public static function provideAsymmetricVisibilityMutator(): iterable

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/HookedProperties.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/HookedProperties.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+  * This file is part of the Symfony package.
+  *
+  * (c) Fabien Potencier <fabien@symfony.com>
+  *
+  * For the full copyright and license information, please view the LICENSE
+  * file that was distributed with this source code.
+  */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+class HookedProperties
+{
+    public string $hookGetOnly {
+        get => $this->hookGetOnly . ' (hooked on get)';
+    }
+    public string $hookSetOnly {
+        set(string $value) {
+            $this->hookSetOnly = $value . ' (hooked on set)';
+        }
+    }
+    public string $hookBoth {
+        get => $this->hookBoth . ' (hooked on get)';
+        set(string $value) {
+            $this->hookBoth = $value . ' (hooked on set)';
+        }
+    }
+}

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/VirtualProperties.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/VirtualProperties.php
@@ -15,6 +15,7 @@ class VirtualProperties
 {
     public bool $virtualNoSetHook { get => true; }
     public bool $virtualSetHookOnly { set => $value; }
+    public bool $virtualSetOnly { set (bool $value) { } }
     public bool $virtualHook { get => true; set => $value; }
     public string $expandedSetterType {
         set (string|null $value) => $value ?? 'default';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

`ReflectionExtractor` now reports whether a property is backed by hooks, so consumers can tell a hooked property from a plain one without reflecting themselves.

Three additions to the metadata it returns:

* `PropertyReadInfo::hasHook()` and `PropertyWriteInfo::hasHook()` tell whether the access goes through a `get` or `set` hook;
* `PropertyReadInfo::isVirtual()` tells whether the property is virtual, that is, has hooks but no backing value.

```php
class Person
{
    public string $plain = 'x';
    public string $fullName { get => $this->first.' '.$this->last; }
    public string $guarded { get => $this->last; set => $this->last = strtoupper($value); }
}
```

```
             read                            write
plain        hasHook=false isVirtual=false   hasHook=false
fullName     hasHook=true  isVirtual=true    hasHook=false
guarded      hasHook=true  isVirtual=false   hasHook=true
```

The values mirror `ReflectionProperty::hasHooks()` and `ReflectionProperty::isVirtual()`, so a property whose hooks only touch another property, like `guarded` above, is hooked but not virtual, exactly as PHP reports it.

Both methods return `?bool`. `ReflectionExtractor` always fills them in, but the constructor arguments default to `null`, so an info object built by another extractor reports `null` rather than a wrong `false`. The new arguments come last in `PropertyReadInfo::__construct()` and `PropertyWriteInfo::__construct()`, so existing positional calls keep working.

This is metadata only. Nothing here reads or writes a backing value, and the way PropertyAccess reaches properties is unchanged.

An earlier revision also added a PropertyAccess option to bypass hooks. @stof voted -1 on it, since PropertyAccess has always gone through the public API of a class and never through Reflection for state, and @OskarStark had suggested splitting the two halves. That half is dropped and only the PropertyInfo metadata is kept.

Documentation should cover: `hasHook()` on both info classes, `isVirtual()` on the read one, and that virtual properties report a hook with no backing value.
