### PR TITLE
[HttpClient] Fix a typo in NoPrivateNetworkHttpClient

### DIFF
--- a/src/Symfony/Component/HttpClient/NoPrivateNetworkHttpClient.php
+++ b/src/Symfony/Component/HttpClient/NoPrivateNetworkHttpClient.php
@@ -138,7 +138,7 @@ final class NoPrivateNetworkHttpClient implements HttpClientInterface, LoggerAwa
                     $filterContentHeaders = static function ($h) {
                         return 0 !== stripos($h, 'Content-Length:') && 0 !== stripos($h, 'Content-Type:') && 0 !== stripos($h, 'Transfer-Encoding:');
                     };
-                    $options['header'] = array_filter($options['header'], $filterContentHeaders);
+                    $options['headers'] = array_filter($options['headers'], $filterContentHeaders);
                     $redirectHeaders['no_auth'] = array_filter($redirectHeaders['no_auth'], $filterContentHeaders);
                     $redirectHeaders['with_auth'] = array_filter($redirectHeaders['with_auth'], $filterContentHeaders);
                 }

--- a/src/Symfony/Component/HttpClient/Tests/NoPrivateNetworkHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/NoPrivateNetworkHttpClientTest.php
@@ -173,6 +173,27 @@ class NoPrivateNetworkHttpClientTest extends TestCase
         $client->request('GET', $url, ['on_progress' => $customCallback]);
     }
 
+    public function testHeadersArePassedOnRedirect()
+    {
+        $ipAddr = '104.26.14.6';
+        $url = sprintf('http://%s/', $ipAddr);
+        $content = 'foo';
+
+        $callback = function ($method, $url, $options) use ($content): MockResponse {
+            $this->assertArrayHasKey('headers', $options);
+            $this->assertNotContains('content-type: application/json', $options['headers']);
+            $this->assertContains('foo: bar', $options['headers']);
+            return new MockResponse($content);
+        };
+        $responses = [
+            new MockResponse('', ['http_code' => 302, 'redirect_url' => 'http://104.26.14.7']),
+            $callback,
+        ];
+        $client = new NoPrivateNetworkHttpClient(new MockHttpClient($responses));
+        $response = $client->request('POST', $url, ['headers' => ['foo' => 'bar', 'content-type' => 'application/json']]);
+        $this->assertEquals($content, $response->getContent());
+    }
+
     private function getMockHttpClient(string $ipAddr, string $content)
     {
         return new MockHttpClient(new MockResponse($content, ['primary_ip' => $ipAddr]));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59244
| License       | MIT

Fix a typo in NoPrivateNetworkHttpClient that may cause `Undefined array key` error if server returns redirect response to a POST request.