### PR TITLE
[Stopwatch] bug #54854  undefined key error when trying to fetch a mis…

### DIFF
--- a/src/Symfony/Component/Stopwatch/Stopwatch.php
+++ b/src/Symfony/Component/Stopwatch/Stopwatch.php
@@ -140,7 +140,7 @@ class Stopwatch implements ResetInterface
      */
     public function getSectionEvents(string $id): array
     {
-        return $this->sections[$id]->getEvents() ?? [];
+        return isset($this->sections[$id]) ? $this->sections[$id]->getEvents() : [];
     }
 
     /**

--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
@@ -187,4 +187,9 @@ class StopwatchTest extends TestCase
 
         $this->assertEquals(new Stopwatch(), $stopwatch);
     }
+
+    public function testShouldReturnEmptyArrayWhenSectionMissing()
+    {
+        $this->assertSame([], (new Stopwatch())->getSectionEvents('missing'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2 
| Bug fix?      | yes
| New feature?  |no 
| Deprecations? |no 
| Issues        | Fix #54854
| License       | MIT

A minor bug was introduced in the related referenced issue which caused an unidentified key exception to trigger when referencing a section that was missing.

Reproduced here, as an example: https://3v4l.org/OFFLB

This MR addresses that and adds a simple test to prevent the same mistake in the future.