### PR TITLE
[Mailer] Fix Sendmail memory leak

### DIFF
--- a/src/Symfony/Component/Mailer/Transport/SendmailTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/SendmailTransport.php
@@ -114,7 +114,7 @@ class SendmailTransport extends AbstractTransport
         $this->stream->setCommand($command);
         $this->stream->initialize();
         foreach ($chunks as $chunk) {
-            $this->stream->write($chunk);
+            $this->stream->write($chunk, false);
         }
         $this->stream->flush();
         $this->stream->terminate();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? |no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #50486 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

Previous PR: https://github.com/symfony/symfony/pull/59239

Fixes issue #50486 (Sendmail transport runs out of memory).
- I have removed unrelated changes that somehow got in the previous attempt of pull request because of wrong base version.
- As for the "metrics about the memory leak itself" - it is in the issue 50486. When write(), which is defined in vendor/symfony/mailer/Transport/Smtp/Stream/AbstractStream.php, is called without $debug parameter, it's true by default, and $this->debug gets appended all the email body data incrementally.
  So for example if you have loop sending personalized emails to 200,000 subscribers 20 kB each, $this->debug becomes 4 GB, plus overhead, and the script runs out of resources.
  The fix eliminates the problem.
<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
