### PR TITLE
[DependencyInjection] Support `@>` as a shorthand for `!service_closure` in `YamlFileLoader`

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Make `#[AsTaggedItem]` repeatable
+ * Support `@>` as a shorthand for `!service_closure` in yaml files
 
 7.2
 ---

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -923,6 +923,11 @@ class YamlFileLoader extends FileLoader
 
             return new Expression(substr($value, 2));
         } elseif (\is_string($value) && str_starts_with($value, '@')) {
+            if (str_starts_with($value, '@>')) {
+                $argument = $this->resolveServices(substr_replace($value, '', 1, 1), $file, $isParameter);
+
+                return new ServiceClosureArgument($argument);
+            }
             if (str_starts_with($value, '@@')) {
                 $value = substr($value, 1);
                 $invalidBehavior = null;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_short_service_closure.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_short_service_closure.yml
@@ -1,0 +1,8 @@
+services:
+    service_container:
+        class: Symfony\Component\DependencyInjection\ContainerInterface
+        public: true
+        synthetic: true
+    foo:
+        class: Foo
+        arguments: ['@>bar']

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -466,6 +466,15 @@ class YamlFileLoaderTest extends TestCase
         $this->assertEquals(new ServiceClosureArgument(new Reference('bar', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)), $container->getDefinition('foo')->getArgument(0));
     }
 
+    public function testParseShortServiceClosure()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('services_with_short_service_closure.yml');
+
+        $this->assertEquals(new ServiceClosureArgument(new Reference('bar')), $container->getDefinition('foo')->getArgument(0));
+    }
+
     public function testNameOnlyTagsAreAllowedAsString()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #59255 
| License       | MIT

