### PR TITLE
[Validator] Validate SVG ratio in Image validator

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.3
+---
+
+ * Add support for ratio checks for SVG files to the `Image` constraint
+
 7.2
 ---
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/test_landscape.svg
+++ b/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/test_landscape.svg
@@ -1,0 +1,2 @@
+<svg viewBox="0 0 500 200" xmlns="http://www.w3.org/2000/svg">
+</svg>

--- a/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/test_landscape_height.svg
+++ b/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/test_landscape_height.svg
@@ -1,0 +1,2 @@
+<svg viewBox="0 0 500 200" xmlns="http://www.w3.org/2000/svg" height="300">
+</svg>

--- a/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/test_landscape_width.svg
+++ b/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/test_landscape_width.svg
@@ -1,0 +1,2 @@
+<svg viewBox="0 0 500 200" xmlns="http://www.w3.org/2000/svg" width="600">
+</svg>

--- a/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/test_landscape_width_height.svg
+++ b/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/test_landscape_width_height.svg
@@ -1,0 +1,2 @@
+<svg viewBox="0 0 500 200" xmlns="http://www.w3.org/2000/svg" width="600" height="300">
+</svg>

--- a/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/test_no_size.svg
+++ b/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/test_no_size.svg
@@ -1,0 +1,2 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+</svg>

--- a/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/test_portrait.svg
+++ b/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/test_portrait.svg
@@ -1,0 +1,2 @@
+<svg viewBox="0 0 200 500" xmlns="http://www.w3.org/2000/svg">
+</svg>

--- a/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/test_square.svg
+++ b/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/test_square.svg
@@ -1,0 +1,2 @@
+<svg viewBox="0 0 500 500" xmlns="http://www.w3.org/2000/svg">
+</svg>

--- a/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
@@ -498,4 +498,140 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
             ]),
         ];
     }
+
+    /** @dataProvider provideSvgWithViolation */
+    public function testSvgWithViolation(string $image, Image $constraint, string $violation, array $parameters = [])
+    {
+        $this->validator->validate($image, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setCode($violation)
+            ->setParameters($parameters)
+            ->assertRaised();
+    }
+
+    public static function provideSvgWithViolation(): iterable
+    {
+        yield 'No size svg' => [
+            __DIR__.'/Fixtures/test_no_size.svg',
+            new Image(allowLandscape: false, sizeNotDetectedMessage: 'myMessage'),
+            Image::SIZE_NOT_DETECTED_ERROR,
+        ];
+
+        yield 'Landscape SVG not allowed' => [
+            __DIR__.'/Fixtures/test_landscape.svg',
+            new Image(allowLandscape: false, allowLandscapeMessage: 'myMessage'),
+            Image::LANDSCAPE_NOT_ALLOWED_ERROR,
+            [
+                '{{ width }}' => 500,
+                '{{ height }}' => 200,
+            ],
+        ];
+
+        yield 'Portrait SVG not allowed' => [
+            __DIR__.'/Fixtures/test_portrait.svg',
+            new Image(allowPortrait: false, allowPortraitMessage: 'myMessage'),
+            Image::PORTRAIT_NOT_ALLOWED_ERROR,
+            [
+                '{{ width }}' => 200,
+                '{{ height }}' => 500,
+            ],
+        ];
+
+        yield 'Square SVG not allowed' => [
+            __DIR__.'/Fixtures/test_square.svg',
+            new Image(allowSquare: false, allowSquareMessage: 'myMessage'),
+            Image::SQUARE_NOT_ALLOWED_ERROR,
+            [
+                '{{ width }}' => 500,
+                '{{ height }}' => 500,
+            ],
+        ];
+
+        yield 'Landscape with width attribute SVG allowed' => [
+            __DIR__.'/Fixtures/test_landscape_width.svg',
+            new Image(allowLandscape: false, allowLandscapeMessage: 'myMessage'),
+            Image::LANDSCAPE_NOT_ALLOWED_ERROR,
+            [
+                '{{ width }}' => 600,
+                '{{ height }}' => 200,
+            ],
+        ];
+
+        yield 'Landscape with height attribute SVG not allowed' => [
+            __DIR__.'/Fixtures/test_landscape_height.svg',
+            new Image(allowLandscape: false, allowLandscapeMessage: 'myMessage'),
+            Image::LANDSCAPE_NOT_ALLOWED_ERROR,
+            [
+                '{{ width }}' => 500,
+                '{{ height }}' => 300,
+            ],
+        ];
+
+        yield 'Landscape with width and height attribute SVG not allowed' => [
+            __DIR__.'/Fixtures/test_landscape_width_height.svg',
+            new Image(allowLandscape: false, allowLandscapeMessage: 'myMessage'),
+            Image::LANDSCAPE_NOT_ALLOWED_ERROR,
+            [
+                '{{ width }}' => 600,
+                '{{ height }}' => 300,
+            ],
+        ];
+
+        yield 'SVG Min ratio 2' => [
+            __DIR__.'/Fixtures/test_square.svg',
+            new Image(minRatio: 2, minRatioMessage: 'myMessage'),
+            Image::RATIO_TOO_SMALL_ERROR,
+            [
+                '{{ ratio }}' => '1',
+                '{{ min_ratio }}' => '2',
+            ],
+        ];
+
+        yield 'SVG Min ratio 0.5' => [
+            __DIR__.'/Fixtures/test_square.svg',
+            new Image(maxRatio: 0.5, maxRatioMessage: 'myMessage'),
+            Image::RATIO_TOO_BIG_ERROR,
+            [
+                '{{ ratio }}' => '1',
+                '{{ max_ratio }}' => '0.5',
+            ],
+        ];
+    }
+
+    /** @dataProvider provideSvgWithoutViolation */
+    public function testSvgWithoutViolation(string $image, Image $constraint)
+    {
+        $this->validator->validate($image, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public static function provideSvgWithoutViolation(): iterable
+    {
+        yield 'Landscape SVG allowed' => [
+            __DIR__.'/Fixtures/test_landscape.svg',
+            new Image(allowLandscape: true, allowLandscapeMessage: 'myMessage'),
+        ];
+
+        yield 'Portrait SVG allowed' => [
+            __DIR__.'/Fixtures/test_portrait.svg',
+            new Image(allowPortrait: true, allowPortraitMessage: 'myMessage'),
+        ];
+
+        yield 'Square SVG allowed' => [
+            __DIR__.'/Fixtures/test_square.svg',
+            new Image(allowSquare: true, allowSquareMessage: 'myMessage'),
+        ];
+
+        yield 'SVG Min ratio 1' => [
+            __DIR__.'/Fixtures/test_square.svg',
+            new Image(minRatio: 1, minRatioMessage: 'myMessage'),
+        ];
+
+        yield 'SVG Max ratio 1' => [
+            __DIR__.'/Fixtures/test_square.svg',
+            new Image(maxRatio: 1, maxRatioMessage: 'myMessage'),
+        ];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #45269
| License       | MIT

Implement ratio check for SVG images. Checking SGV size is not relevant as a SVG image can be enlarged without loss, but ratio can be important to check.

Currently, the validator add a violation with `SIZE_NOT_DETECTED_ERROR` in case of SVG image.

SVG size is guessed from viewbox, width and height attributes. Viewbox will provides default size, width and height can override viewbox size if they are number. Width and height as percentage are ignored as the final size will depend on the container.

I use `preg_match` instead of `\DomDocument` or `simplexml` functions to extract viewBox, width and height in order to avoid new dependencies on `ext-dom` or `ext-simplexml`.

In case of SVG, `minWidth`, `maxWidth`, `minHeight`, `maxHeight`, `minPixels` and `maxPixels` are ignored because not relevant. Only `maxRatio`, `minRatio`, `allowSquare`, `allowLandscape` and `allowPortrait` can generate violations, like suggested in the comments of the abandoned #45486.






