### PR TITLE
[Cache] Update PhpFilesAdapter.php, remove goto statement

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/PhpFilesAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/PhpFilesAdapter.php
@@ -104,65 +104,65 @@ class PhpFilesAdapter extends AbstractAdapter implements PruneableInterface
         }
         $values = [];
 
-        begin:
-        $getExpiry = false;
+        while (true) {
+            $getExpiry = false;
 
-        foreach ($ids as $id) {
-            if (null === $value = $this->values[$id] ?? null) {
-                $missingIds[] = $id;
-            } elseif ('N;' === $value) {
-                $values[$id] = null;
-            } elseif (!\is_object($value)) {
-                $values[$id] = $value;
-            } elseif (!$value instanceof LazyValue) {
-                $values[$id] = $value();
-            } elseif (false === $values[$id] = include $value->file) {
-                unset($values[$id], $this->values[$id]);
-                $missingIds[] = $id;
-            }
-            if (!$this->appendOnly) {
-                unset($this->values[$id]);
-            }
-        }
-
-        if (!$missingIds) {
-            return $values;
-        }
-
-        set_error_handler($this->includeHandler);
-        try {
-            $getExpiry = true;
-
-            foreach ($missingIds as $k => $id) {
-                try {
-                    $file = $this->files[$id] ??= $this->getFile($id);
-
-                    if (isset(self::$valuesCache[$file])) {
-                        [$expiresAt, $this->values[$id]] = self::$valuesCache[$file];
-                    } elseif (\is_array($expiresAt = include $file)) {
-                        if ($this->appendOnly) {
-                            self::$valuesCache[$file] = $expiresAt;
-                        }
-
-                        [$expiresAt, $this->values[$id]] = $expiresAt;
-                    } elseif ($now < $expiresAt) {
-                        $this->values[$id] = new LazyValue($file);
-                    }
-
-                    if ($now >= $expiresAt) {
-                        unset($this->values[$id], $missingIds[$k], self::$valuesCache[$file]);
-                    }
-                } catch (\ErrorException $e) {
-                    unset($missingIds[$k]);
+            foreach ($ids as $id) {
+                if (null === $value = $this->values[$id] ?? null) {
+                    $missingIds[] = $id;
+                } elseif ('N;' === $value) {
+                    $values[$id] = null;
+                } elseif (!\is_object($value)) {
+                    $values[$id] = $value;
+                } elseif (!$value instanceof LazyValue) {
+                    $values[$id] = $value();
+                } elseif (false === $values[$id] = include $value->file) {
+                    unset($values[$id], $this->values[$id]);
+                    $missingIds[] = $id;
+                }
+                if (!$this->appendOnly) {
+                    unset($this->values[$id]);
                 }
             }
-        } finally {
-            restore_error_handler();
-        }
 
-        $ids = $missingIds;
-        $missingIds = [];
-        goto begin;
+            if (!$missingIds) {
+                return $values;
+            }
+
+            set_error_handler($this->includeHandler);
+            try {
+                $getExpiry = true;
+
+                foreach ($missingIds as $k => $id) {
+                    try {
+                        $file = $this->files[$id] ??= $this->getFile($id);
+
+                        if (isset(self::$valuesCache[$file])) {
+                            [$expiresAt, $this->values[$id]] = self::$valuesCache[$file];
+                        } elseif (\is_array($expiresAt = include $file)) {
+                            if ($this->appendOnly) {
+                                self::$valuesCache[$file] = $expiresAt;
+                            }
+
+                            [$expiresAt, $this->values[$id]] = $expiresAt;
+                        } elseif ($now < $expiresAt) {
+                            $this->values[$id] = new LazyValue($file);
+                        }
+
+                        if ($now >= $expiresAt) {
+                            unset($this->values[$id], $missingIds[$k], self::$valuesCache[$file]);
+                        }
+                    } catch (\ErrorException $e) {
+                        unset($missingIds[$k]);
+                    }
+                }
+            } finally {
+                restore_error_handler();
+            }
+
+            $ids = $missingIds;
+            $missingIds = [];
+        }
     }
 
     protected function doHave(string $id): bool


### PR DESCRIPTION
The goto statement can make the code's flow difficult to follow. PHP code is typically expected to have a more linear and understandable structure. For example, when using goto, it can jump from one part of the code to another in a non - sequential manner. This can lead to confusion for developers who are trying to understand the program's logic, especially in larger codebases.

| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? |no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
