### PR TITLE
[Security/Csrf] Trust "Referer" at the same level as "Origin"

### DIFF
--- a/src/Symfony/Component/Security/Csrf/SameOriginCsrfTokenManager.php
+++ b/src/Symfony/Component/Security/Csrf/SameOriginCsrfTokenManager.php
@@ -227,9 +227,21 @@ final class SameOriginCsrfTokenManager implements CsrfTokenManagerInterface
      */
     private function isValidOrigin(Request $request): ?bool
     {
-        $source = $request->headers->get('Origin') ?? $request->headers->get('Referer') ?? 'null';
+        $target = $request->getSchemeAndHttpHost().'/';
+        $source = 'null';
 
-        return 'null' === $source ? null : str_starts_with($source.'/', $request->getSchemeAndHttpHost().'/');
+        foreach (['Origin', 'Referer'] as $header) {
+            if (!$request->headers->has($header)) {
+                continue;
+            }
+            $source = $request->headers->get($header);
+
+            if (str_starts_with($source.'/', $target)) {
+                return true;
+            }
+        }
+
+        return 'null' === $source ? null : false;
     }
 
     /**

--- a/src/Symfony/Component/Security/Csrf/Tests/SameOriginCsrfTokenManagerTest.php
+++ b/src/Symfony/Component/Security/Csrf/Tests/SameOriginCsrfTokenManagerTest.php
@@ -100,6 +100,20 @@ class SameOriginCsrfTokenManagerTest extends TestCase
         $this->assertSame(1 << 8, $request->attributes->get('csrf-token'));
     }
 
+    public function testValidRefererInvalidOrigin()
+    {
+        $request = new Request();
+        $request->headers->set('Origin', 'http://localhost:1234');
+        $request->headers->set('Referer', $request->getSchemeAndHttpHost());
+        $this->requestStack->push($request);
+
+        $token = new CsrfToken('test_token', str_repeat('a', 24));
+
+        $this->logger->expects($this->once())->method('debug')->with('CSRF validation accepted using origin info.');
+        $this->assertTrue($this->csrfTokenManager->isTokenValid($token));
+        $this->assertSame(1 << 8, $request->attributes->get('csrf-token'));
+    }
+
     public function testValidOriginAfterDoubleSubmit()
     {
         $session = $this->createMock(Session::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | https://github.com/symfony/demo/issues/1542
| License       | MIT

As hinted by @GromNaN in https://github.com/symfony/demo/issues/1542#issuecomment-2556634782, there are proxies that mess up with the `Origin` header, but forward a valid `Referer` header. Since both headers have the same level of trust, I'm proposing to trust them both equally. At the moment, `Origin` overrides `Referer`. With this PR, we check both and accept if just `Referer` matches.