### PR TITLE
[TypeInfo] Fix allow creating union with mixed

### DIFF
--- a/src/Symfony/Component/TypeInfo/Tests/TypeFactoryTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeFactoryTest.php
@@ -182,6 +182,7 @@ class TypeFactoryTest extends TestCase
         $this->assertEquals(new UnionType(new BuiltinType(TypeIdentifier::INT), new ObjectType(self::class)), Type::union(Type::int(), Type::object(self::class)));
         $this->assertEquals(new UnionType(new BuiltinType(TypeIdentifier::INT), new BuiltinType(TypeIdentifier::STRING)), Type::union(Type::int(), Type::string(), Type::int()));
         $this->assertEquals(new UnionType(new BuiltinType(TypeIdentifier::INT), new BuiltinType(TypeIdentifier::STRING)), Type::union(Type::int(), Type::union(Type::int(), Type::string())));
+        $this->assertEquals(new BuiltinType(TypeIdentifier::MIXED), Type::union(Type::mixed(), Type::int()));
     }
 
     public function testCreateIntersection()

--- a/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
+++ b/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
@@ -255,9 +255,9 @@ trait TypeFactoryTrait
      *
      * @param list<T> $types
      *
-     * @return UnionType<T>|NullableType<T>
+     * @return UnionType<T>|NullableType<T>|BuiltinType<TypeIdentifier::MIXED>
      */
-    public static function union(Type ...$types): UnionType
+    public static function union(Type ...$types): UnionType|BuiltinType
     {
         /** @var list<T> $unionTypes */
         $unionTypes = [];
@@ -266,6 +266,10 @@ trait TypeFactoryTrait
         $isNullable = fn (Type $type): bool => $type instanceof BuiltinType && TypeIdentifier::NULL === $type->getTypeIdentifier();
 
         foreach ($types as $type) {
+            if ($type instanceof BuiltinType && TypeIdentifier::MIXED === $type->getTypeIdentifier()) {
+                return $type;
+            }
+
             if ($type instanceof UnionType) {
                 foreach ($type->getTypes() as $unionType) {
                     if ($isNullable($type)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59258
| License       | MIT

Make the union factory more relax, returning a `mixed` built-in type whenever a `mixed` is involved in the union type.
