### PR TITLE
[TypeInfo] Fix PHPDoc resolving of union with mixed

### DIFF
--- a/src/Symfony/Component/TypeInfo/Tests/TypeResolver/StringTypeResolverTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeResolver/StringTypeResolverTest.php
@@ -155,6 +155,8 @@ class StringTypeResolverTest extends TestCase
 
         // union
         yield [Type::union(Type::int(), Type::string()), 'int|string'];
+        yield [Type::mixed(), 'int|mixed'];
+        yield [Type::mixed(), 'mixed|int'];
 
         // intersection
         yield [Type::intersection(Type::object(\DateTime::class), Type::object(\Stringable::class)), \DateTime::class.'&'.\Stringable::class];

--- a/src/Symfony/Component/TypeInfo/TypeResolver/StringTypeResolver.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/StringTypeResolver.php
@@ -223,7 +223,19 @@ final class StringTypeResolver implements TypeResolverInterface
         }
 
         if ($node instanceof UnionTypeNode) {
-            return Type::union(...array_map(fn (TypeNode $t): Type => $this->getTypeFromNode($t, $typeContext), $node->types));
+            $types = [];
+
+            foreach ($node->types as $nodeType) {
+                $type = $this->getTypeFromNode($nodeType, $typeContext);
+
+                if ($type instanceof BuiltinType && TypeIdentifier::MIXED === $type->getTypeIdentifier()) {
+                    return Type::mixed();
+                }
+
+                $types[] = $type;
+            }
+
+            return Type::union(...$types);
         }
 
         if ($node instanceof IntersectionTypeNode) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59258, Fix #59223
| License       | MIT

Resolve "invalid" union PHPDoc with `mixed` standalone type as `mixed` type.