### PR TITLE
[Validator] Allow Unique constraint validation on all elements

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -5,59 +5,12 @@ CHANGELOG
 ---
 
  * Deprecate defining custom constraints not supporting named arguments
-
-   Before:
-
-   ```php
-   use Symfony\Component\Validator\Constraint;
-
-   class CustomConstraint extends Constraint
-   {
-       public function __construct(array $options)
-       {
-           // ...
-       }
-   }
-   ```
-
-   After:
-
-   ```php
-   use Symfony\Component\Validator\Attribute\HasNamedArguments;
-   use Symfony\Component\Validator\Constraint;
-
-   class CustomConstraint extends Constraint
-   {
-       #[HasNamedArguments]
-       public function __construct($option1, $option2, $groups, $payload)
-       {
-           // ...
-       }
-   }
-   ```
  * Deprecate passing an array of options to the constructors of the constraint classes, pass each option as a dedicated argument instead
-
-   Before:
-
-   ```php
-   new NotNull([
-       'groups' => ['foo', 'bar'],
-       'message' => 'a custom constraint violation message',
-   ])
-   ```
-
-   After:
-
-   ```php
-   new NotNull(
-       groups: ['foo', 'bar'],
-       message: 'a custom constraint violation message',
-   )
-   ```
  * Add support for ratio checks for SVG files to the `Image` constraint
  * Add the `Slug` constraint
  * Add support for the `otherwise` option in the `When` constraint
  * Add support for multiple fields containing nested constraints in `Composite` constraints
+ * Add the `stopOnFirstError` option to the `Unique` constraint to validate all elements
 
 7.2
 ---

--- a/src/Symfony/Component/Validator/Constraints/Unique.php
+++ b/src/Symfony/Component/Validator/Constraints/Unique.php
@@ -27,6 +27,7 @@ class Unique extends Constraint
 
     public array|string $fields = [];
     public ?string $errorPath = null;
+    public bool $stopOnFirstError = true;
 
     protected const ERROR_NAMES = [
         self::IS_NOT_UNIQUE => 'IS_NOT_UNIQUE',
@@ -50,6 +51,7 @@ class Unique extends Constraint
         mixed $payload = null,
         array|string|null $fields = null,
         ?string $errorPath = null,
+        ?bool $stopOnFirstError = null,
     ) {
         if (\is_array($options)) {
             trigger_deprecation('symfony/validator', '7.3', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
@@ -61,6 +63,7 @@ class Unique extends Constraint
         $this->normalizer = $normalizer ?? $this->normalizer;
         $this->fields = $fields ?? $this->fields;
         $this->errorPath = $errorPath ?? $this->errorPath;
+        $this->stopOnFirstError = $stopOnFirstError ?? $this->stopOnFirstError;
 
         if (null !== $this->normalizer && !\is_callable($this->normalizer)) {
             throw new InvalidArgumentException(\sprintf('The "normalizer" option must be a valid callable ("%s" given).', get_debug_type($this->normalizer)));

--- a/src/Symfony/Component/Validator/Constraints/UniqueValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UniqueValidator.php
@@ -46,20 +46,24 @@ class UniqueValidator extends ConstraintValidator
                 continue;
             }
 
-            if (\in_array($element, $collectionElements, true)) {
-                $violationBuilder = $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($element))
-                    ->setCode(Unique::IS_NOT_UNIQUE);
+            if (!\in_array($element, $collectionElements, true)) {
+                $collectionElements[] = $element;
+                continue;
+            }
 
-                if (null !== $constraint->errorPath) {
-                    $violationBuilder->atPath("[$index].{$constraint->errorPath}");
-                }
+            $violationBuilder = $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($element))
+                ->setCode(Unique::IS_NOT_UNIQUE);
 
-                $violationBuilder->addViolation();
+            if (!$constraint->stopOnFirstError || null !== $constraint->errorPath) {
+                $violationBuilder->atPath("[$index]".(null !== $constraint->errorPath ? ".{$constraint->errorPath}" : ''));
+            }
 
+            $violationBuilder->addViolation();
+
+            if ($constraint->stopOnFirstError) {
                 return;
             }
-            $collectionElements[] = $element;
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        |  
| License       | MIT

Sometimes it could be useful to assert that every elements of a collection is not duplicated.  This PR adds a `multipleErrors` option to the Unique constraint to avoid stopping at the first violation. 

Its value is `false` by default to avoid BC breaks:
```php
$violations = $this->validator->validate(
    ['a1', 'a2', 'a1', 'a1', 'a2'],
    new Unique(),
);
// 1 violation on [2]
```

Now
```php
$violations = $this->validator->validate(
    ['a1', 'a2', 'a1', 'a1', 'a2'],
    new Unique(multipleErrors: true),
);
// 3 violations on [2], [3] and [4]
```