### PR TITLE
[Security] Sync Security\ExpressionLanguage constructor with parent

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ExpressionLanguage.php
+++ b/src/Symfony/Component/DependencyInjection/ExpressionLanguage.php
@@ -27,8 +27,12 @@ if (!class_exists(BaseExpressionLanguage::class)) {
  */
 class ExpressionLanguage extends BaseExpressionLanguage
 {
-    public function __construct(?CacheItemPoolInterface $cache = null, array $providers = [], ?callable $serviceCompiler = null, ?\Closure $getEnv = null)
+    public function __construct(?CacheItemPoolInterface $cache = null, iterable $providers = [], ?callable $serviceCompiler = null, ?\Closure $getEnv = null)
     {
+        if (!\is_array($providers)) {
+            $providers = iterator_to_array($providers, false);
+        }
+
         // prepend the default provider to let users override it easily
         array_unshift($providers, new ExpressionLanguageProvider($serviceCompiler, $getEnv));
 

--- a/src/Symfony/Component/Security/Core/Authorization/ExpressionLanguage.php
+++ b/src/Symfony/Component/Security/Core/Authorization/ExpressionLanguage.php
@@ -29,8 +29,12 @@ if (!class_exists(BaseExpressionLanguage::class)) {
      */
     class ExpressionLanguage extends BaseExpressionLanguage
     {
-        public function __construct(?CacheItemPoolInterface $cache = null, array $providers = [])
+        public function __construct(?CacheItemPoolInterface $cache = null, iterable $providers = [])
         {
+            if (!\is_array($providers)) {
+                $providers = iterator_to_array($providers, false);
+            }
+
             // prepend the default provider to let users override it easily
             array_unshift($providers, new ExpressionLanguageProvider());
 


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? |no
| Issues        | -
| License       | MIT

change typehint array -> iterable in `\Symfony\Component\Security\Core\Authorization\ExpressionLanguage::__construct`
