### PR TITLE
[JsonEncoder] Add object to normalize method

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/JsonEncoder/RangeNormalizer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/JsonEncoder/RangeNormalizer.php
@@ -21,7 +21,7 @@ use Symfony\Component\TypeInfo\Type\BuiltinType;
  */
 class RangeNormalizer implements NormalizerInterface, DenormalizerInterface
 {
-    public function normalize(mixed $denormalized, array $options = []): string
+    public function normalize(mixed $denormalized, object $object, array $options = []): string
     {
         return $denormalized[0].'..'.$denormalized[1];
     }

--- a/src/Symfony/Component/JsonEncoder/Encode/EncoderGenerator.php
+++ b/src/Symfony/Component/JsonEncoder/Encode/EncoderGenerator.php
@@ -154,7 +154,7 @@ final class EncoderGenerator
                 foreach ($propertyMetadata->getNormalizers() as $normalizer) {
                     if (\is_string($normalizer)) {
                         $normalizerServiceAccessor = new FunctionDataAccessor('get', [new ScalarDataAccessor($normalizer)], new VariableDataAccessor('normalizers'));
-                        $propertyAccessor = new FunctionDataAccessor('normalize', [$propertyAccessor, new VariableDataAccessor('options')], $normalizerServiceAccessor);
+                        $propertyAccessor = new FunctionDataAccessor('normalize', [$propertyAccessor, $accessor, new VariableDataAccessor('options')], $normalizerServiceAccessor);
 
                         continue;
                     }
@@ -168,7 +168,7 @@ final class EncoderGenerator
                     $functionName = !$functionReflection->getClosureScopeClass()
                         ? $functionReflection->getName()
                         : \sprintf('%s::%s', $functionReflection->getClosureScopeClass()->getName(), $functionReflection->getName());
-                    $arguments = $functionReflection->isUserDefined() ? [$propertyAccessor, new VariableDataAccessor('options')] : [$propertyAccessor];
+                    $arguments = $functionReflection->isUserDefined() ? [$propertyAccessor, $accessor, new VariableDataAccessor('options')] : [$propertyAccessor];
 
                     $propertyAccessor = new FunctionDataAccessor($functionName, $arguments);
                 }

--- a/src/Symfony/Component/JsonEncoder/Encode/Normalizer/DateTimeNormalizer.php
+++ b/src/Symfony/Component/JsonEncoder/Encode/Normalizer/DateTimeNormalizer.php
@@ -27,7 +27,7 @@ final class DateTimeNormalizer implements NormalizerInterface
 {
     public const FORMAT_KEY = 'date_time_format';
 
-    public function normalize(mixed $denormalized, array $options = []): string
+    public function normalize(mixed $denormalized, object $object, array $options = []): string
     {
         if (!$denormalized instanceof \DateTimeInterface) {
             throw new InvalidArgumentException('The denormalized data must implement the "\DateTimeInterface".');

--- a/src/Symfony/Component/JsonEncoder/Encode/Normalizer/NormalizerInterface.php
+++ b/src/Symfony/Component/JsonEncoder/Encode/Normalizer/NormalizerInterface.php
@@ -25,7 +25,7 @@ interface NormalizerInterface
     /**
      * @param array<string, mixed> $options
      */
-    public function normalize(mixed $denormalized, array $options = []): mixed;
+    public function normalize(mixed $denormalized, object $object, array $options = []): mixed;
 
     public static function getNormalizedType(): Type;
 }

--- a/src/Symfony/Component/JsonEncoder/Tests/Encode/Normalizer/DateTimeNormalizerTest.php
+++ b/src/Symfony/Component/JsonEncoder/Tests/Encode/Normalizer/DateTimeNormalizerTest.php
@@ -23,12 +23,12 @@ class DateTimeNormalizerTest extends TestCase
 
         $this->assertEquals(
             '2023-07-26T00:00:00+00:00',
-            $normalizer->normalize(new \DateTimeImmutable('2023-07-26', new \DateTimeZone('UTC')), []),
+            $normalizer->normalize(new \DateTimeImmutable('2023-07-26', new \DateTimeZone('UTC')), new \stdClass(), []),
         );
 
         $this->assertEquals(
             '26/07/2023 00:00:00',
-            $normalizer->normalize((new \DateTimeImmutable('2023-07-26', new \DateTimeZone('UTC')))->setTime(0, 0), [DateTimeNormalizer::FORMAT_KEY => 'd/m/Y H:i:s']),
+            $normalizer->normalize((new \DateTimeImmutable('2023-07-26', new \DateTimeZone('UTC')))->setTime(0, 0), new \stdClass(), [DateTimeNormalizer::FORMAT_KEY => 'd/m/Y H:i:s']),
         );
     }
 
@@ -37,6 +37,6 @@ class DateTimeNormalizerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The denormalized data must implement the "\DateTimeInterface".');
 
-        (new DateTimeNormalizer())->normalize(true, []);
+        (new DateTimeNormalizer())->normalize(true, new \stdClass(), []);
     }
 }

--- a/src/Symfony/Component/JsonEncoder/Tests/Fixtures/Normalizer/BooleanStringNormalizer.php
+++ b/src/Symfony/Component/JsonEncoder/Tests/Fixtures/Normalizer/BooleanStringNormalizer.php
@@ -7,7 +7,7 @@ use Symfony\Component\TypeInfo\Type;
 
 final class BooleanStringNormalizer implements NormalizerInterface
 {
-    public function normalize(mixed $data, array $options = []): mixed
+    public function normalize(mixed $data, object $object, array $options = []): mixed
     {
         return $data ? 'true' : 'false';
     }

--- a/src/Symfony/Component/JsonEncoder/Tests/Fixtures/Normalizer/DoubleIntAndCastToStringNormalizer.php
+++ b/src/Symfony/Component/JsonEncoder/Tests/Fixtures/Normalizer/DoubleIntAndCastToStringNormalizer.php
@@ -7,7 +7,7 @@ use Symfony\Component\TypeInfo\Type;
 
 final class DoubleIntAndCastToStringNormalizer implements NormalizerInterface
 {
-    public function normalize(mixed $data, array $options = []): mixed
+    public function normalize(mixed $data, object $object, array $options = []): mixed
     {
         return (string) (2 * $options['scale'] * $data);
     }

--- a/src/Symfony/Component/JsonEncoder/Tests/Fixtures/encoder/object_with_normalizer.php
+++ b/src/Symfony/Component/JsonEncoder/Tests/Fixtures/encoder/object_with_normalizer.php
@@ -2,12 +2,12 @@
 
 return static function (mixed $data, \Psr\Container\ContainerInterface $normalizers, array $options): \Traversable {
     yield '{"id":';
-    yield \json_encode($normalizers->get('Symfony\Component\JsonEncoder\Tests\Fixtures\Normalizer\DoubleIntAndCastToStringNormalizer')->normalize($data->id, $options));
+    yield \json_encode($normalizers->get('Symfony\Component\JsonEncoder\Tests\Fixtures\Normalizer\DoubleIntAndCastToStringNormalizer')->normalize($data->id, $data, $options));
     yield ',"active":';
-    yield \json_encode($normalizers->get('Symfony\Component\JsonEncoder\Tests\Fixtures\Normalizer\BooleanStringNormalizer')->normalize($data->active, $options));
+    yield \json_encode($normalizers->get('Symfony\Component\JsonEncoder\Tests\Fixtures\Normalizer\BooleanStringNormalizer')->normalize($data->active, $data, $options));
     yield ',"name":';
     yield \json_encode(strtolower($data->name));
     yield ',"range":';
-    yield \json_encode(Symfony\Component\JsonEncoder\Tests\Fixtures\Model\DummyWithNormalizerAttributes::concatRange($data->range, $options));
+    yield \json_encode(Symfony\Component\JsonEncoder\Tests\Fixtures\Model\DummyWithNormalizerAttributes::concatRange($data->range, $data, $options));
     yield '}';
 };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

When normalizing a property, the whole object is sometimes useful.

For example, in API Platform if we want to convert resource ID to an IRI, we'll have to use https://github.com/api-platform/core/blob/main/src/Metadata/IriConverterInterface.php#L46 which needs the whole resource to gather some data and create the IRI.
