### PR TITLE
[TwigBridge] Deprecate passing `$field` argument to `is_granted()`

### DIFF
--- a/UPGRADE-7.3.md
+++ b/UPGRADE-7.3.md
@@ -1,0 +1,21 @@
+UPGRADE FROM 7.2 to 7.3
+=======================
+
+Symfony 7.3 is a minor release. According to the Symfony release process, there should be no significant
+backward compatibility breaks. Minor backward compatibility breaks are prefixed in this document with
+`[BC BREAK]`, make sure your code is compatible with these entries before upgrading.
+Read more about this in the [Symfony documentation](https://symfony.com/doc/7.3/setup/upgrade_minor.html).
+
+If you're upgrading from a version below 7.2, follow the [7.2 upgrade guide](UPGRADE-7.2.md) first.
+
+Table of Contents
+-----------------
+
+Bridges
+
+ * [TwigBridge](#TwigBridge)
+
+TwigBridge
+----------
+
+ * The "$field" parameter of the `is_granted` Twig function is deprecated.

--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `is_granted_for_user()` Twig function
+ * Deprecate passing a third argument to the `is_granted()` Twig function
 
 7.2
 ---

--- a/src/Symfony/Bridge/Twig/Extension/SecurityExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/SecurityExtension.php
@@ -53,14 +53,10 @@ final class SecurityExtension extends AbstractExtension
         }
     }
 
-    public function isGrantedForUser(UserInterface $user, mixed $attribute, mixed $subject = null, ?string $field = null): bool
+    public function isGrantedForUser(UserInterface $user, mixed $attribute, mixed $subject = null): bool
     {
         if (!$this->userSecurityChecker) {
             throw new \LogicException(\sprintf('An instance of "%s" must be provided to use "%s()".', UserAuthorizationCheckerInterface::class, __METHOD__));
-        }
-
-        if ($field) {
-            $subject = new FieldVote($subject, $field);
         }
 
         return $this->userSecurityChecker->isGrantedForUser($user, $attribute, $subject);

--- a/src/Symfony/Bridge/Twig/Extension/SecurityExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/SecurityExtension.php
@@ -41,6 +41,8 @@ final class SecurityExtension extends AbstractExtension
         }
 
         if (null !== $field) {
+            trigger_deprecation('symfony/twig-bridge', '7.3', 'Passing a "field" argument to the "is_granted" Twig function is deprecated. It will be removed in version 8.0.');
+
             $object = new FieldVote($object, $field);
         }
 

--- a/src/Symfony/Bridge/Twig/Extension/SecurityExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/SecurityExtension.php
@@ -41,7 +41,7 @@ final class SecurityExtension extends AbstractExtension
         }
 
         if (null !== $field) {
-            trigger_deprecation('symfony/twig-bridge', '7.3', 'Passing a "field" argument to the "is_granted" Twig function is deprecated. It will be removed in version 8.0.');
+            trigger_deprecation('symfony/twig-bridge', '7.3', 'Passing the "$field" argument to the "is_granted" Twig function is deprecated and will be removed in version 8.0.');
 
             $object = new FieldVote($object, $field);
         }

--- a/src/Symfony/Bridge/Twig/Extension/SecurityExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/SecurityExtension.php
@@ -41,7 +41,7 @@ final class SecurityExtension extends AbstractExtension
         }
 
         if (null !== $field) {
-            trigger_deprecation('symfony/twig-bridge', '7.3', 'Passing the "$field" argument to the "is_granted" Twig function is deprecated and will be removed in version 8.0.');
+            trigger_deprecation('symfony/twig-bridge', '7.3', 'The "$field" parameter of the "is_granted" Twig function is deprecated and will be removed in version 8.0.');
 
             $object = new FieldVote($object, $field);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      |  no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | yes
| Issues        | Fix #... 
| License       | MIT


This PR deprecates the `$field` argument of the [`is_granted`](https://github.com/symfony/symfony/blob/78f4d9a1059725384ce563c4e1696b8e66c6983a/src/Symfony/Bridge/Twig/Extension/SecurityExtension.php#L37) Twig function, and removes it from the just-added is_user_granted function.

It seems that passing a third argument "field" is a feature made/kept for the [AclBundle](https://github.com/symfony/acl-bundle). 

The Symfony [documentation](https://symfony.com/doc/current/reference/twig_reference.html#is-granted) states:
> Optionally, an object can be passed to be used by the voter. More information can be found in Security.

But in the [linked security page](https://symfony.com/doc/current/security.html#security-template), no mention is made about it.

The last version of the [documentation about ACL](https://symfony.com/doc/3.x/security/acl_advanced.html) writes
> ACL support was deprecated in Symfony 3.4 and will be removed in 4.0. Install the Symfony ACL bundle if you want to keep using ACL.

This feature is, **afaik**, not available in the rest of the similar security tools/helpers (_IsGranted_ attribute, _is_granted_ function in expression language, ...)

Finally, passing an value here will throw an error as the FieldVote class cannot be used without installing the AclBundle (something not documented that can lead to very frustating DX).

...

I may not have all context/history here, so please don't bite :)