### PR TITLE
[DependencyInjection] auto-exclude attributes related to value objects

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -5,6 +5,8 @@ CHANGELOG
 ---
 
  * Make `#[AsTaggedItem]` repeatable
+ * Class attributes `#[AsMessage]` and `#[Entity]` are now automatically excluded as services injection, like `#[Exclude]` does
+ * Bundle creators can now use the `ContainerBuilder::registerAttributeForExclusion()` method for their custom Value Object's attributes
 
 7.2
 ---

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1446,6 +1446,18 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
         return $this->setAlias($type.' $'.$parsedName, $id);
     }
 
+    /** Registers attributes that will exclude classes from service loading
+     *
+     * @template T
+     *
+     * @param class-string<T>[] $attributes
+     */
+    public function registerAttributeForExclusion(array $attributes): void
+    {
+       //TODO: which key in definitions object?
+        $this->definitions['key-foo']->addTag('container.excluded', $attributes);
+    }
+
     /**
      * Returns an array of ChildDefinition[] keyed by interface.
      *

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Utils/ObjectAsMessage.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Utils/ObjectAsMessage.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Utils;
+
+use Symfony\Component\Messenger\Attribute\AsMessage;
+
+#[AsMessage]
+class ObjectAsMessage
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
@@ -42,6 +42,8 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\WithAs
 use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\WithAsAliasInterface;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\WithAsAliasMultiple;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Utils\NotAService;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\Utils\ObjectAsMessage;
+use Symfony\Component\Messenger\Attribute\AsMessage;
 
 class FileLoaderTest extends TestCase
 {
@@ -151,7 +153,7 @@ class FileLoaderTest extends TestCase
      * @testWith [true]
      *           [false]
      */
-    public function testRegisterClassesWithExcludeAttribute(bool $autoconfigure)
+    public function testRegisterClassesWithExcludedAttributes(bool $autoconfigure)
     {
         $container = new ContainerBuilder();
         $loader = new TestFileLoader($container, new FileLocator(self::$fixturesPath.'/Fixtures'));
@@ -163,6 +165,27 @@ class FileLoaderTest extends TestCase
         );
 
         $this->assertSame($autoconfigure, $container->getDefinition(NotAService::class)->hasTag('container.excluded'));
+    }
+
+    /**
+     * @testWith [true]
+     *           [false]
+     */
+    public function testRegisterAttributeAsExcluded(bool $autoconfigure)
+    {
+        $container = new ContainerBuilder();
+        $loader = new TestFileLoader($container, new FileLocator(self::$fixturesPath.'/Fixtures'));
+
+        //TODO: test logic
+        //$container->registerAttributeForExclusion([AsMessage::class]);
+
+        $loader->registerClasses(
+            (new Definition())->setAutoconfigured($autoconfigure),
+            'Symfony\Component\DependencyInjection\Tests\Fixtures\Utils\\',
+            'Utils/*',
+        );
+
+        $this->assertSame($autoconfigure, $container->getDefinition(ObjectAsMessage::class)->hasTag('container.excluded'));
     }
 
     public function testRegisterClassesWithExcludeAsArray()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #59280
| License       | MIT

Hello, this is a draft of a feature that will say to the DI to not create services from classes with attributes:
- #[Exclude]
- #[AsMessage]
- #[Doctrine\Entity]

This is my first PR, and I have a lot of questions:
1. How can I create a test for this without adding unwanted dependencies to the DI composer.json?
2. Would I add some words in CHANGELOG? About how you can get rid of services.App\.exclude entries?
3. Should some words be added in the config component side to, for example, remove the default '../src/Entity/' entry? (`#[AsMessage]` attributes are not mandatory, but `#[ORM\Entity]` will be 99% present over the Entities.
4. Same question for flex and recipes that I don't understand?
5. With string version of the FQCN, are we sure nothing will break if one uses the DI component out of the framework?
6. Some more candidate to be excluded? Traits, Enums, DTOs?