### PR TITLE
[Serializer] Deprecate the `CompiledClassMetadataFactory`

### DIFF
--- a/UPGRADE-7.3.md
+++ b/UPGRADE-7.3.md
@@ -1,0 +1,14 @@
+UPGRADE FROM 7.2 to 7.3
+=======================
+
+Symfony 7.3 is a minor release. According to the Symfony release process, there should be no significant
+backward compatibility breaks. Minor backward compatibility breaks are prefixed in this document with
+`[BC BREAK]`, make sure your code is compatible with these entries before upgrading.
+Read more about this in the [Symfony documentation](https://symfony.com/doc/7.3/setup/upgrade_minor.html).
+
+If you're upgrading from a version below 7.1, follow the [7.2 upgrade guide](UPGRADE-7.2.md) first.
+
+Serializer
+----------
+
+ * Deprecate the `CompiledClassMetadataFactory` and `CompiledClassMetadataCacheWarmer` classes

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.3
+---
+
+ * Deprecate the `CompiledClassMetadataFactory` and `CompiledClassMetadataCacheWarmer` classes
+
 7.2
 ---
 

--- a/src/Symfony/Component/Serializer/CacheWarmer/CompiledClassMetadataCacheWarmer.php
+++ b/src/Symfony/Component/Serializer/CacheWarmer/CompiledClassMetadataCacheWarmer.php
@@ -16,8 +16,12 @@ use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryCompiler;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 
+trigger_deprecation('symfony/serializer', '7.3', 'The "%s" class is deprecated.', CompiledClassMetadataCacheWarmer::class);
+
 /**
  * @author Fabien Bourigault <bourigaultfabien@gmail.com>
+ *
+ * @deprecated since Symfony 7.3
  */
 final class CompiledClassMetadataCacheWarmer implements CacheWarmerInterface
 {

--- a/src/Symfony/Component/Serializer/Mapping/Factory/CompiledClassMetadataFactory.php
+++ b/src/Symfony/Component/Serializer/Mapping/Factory/CompiledClassMetadataFactory.php
@@ -16,8 +16,12 @@ use Symfony\Component\Serializer\Mapping\ClassDiscriminatorMapping;
 use Symfony\Component\Serializer\Mapping\ClassMetadata;
 use Symfony\Component\Serializer\Mapping\ClassMetadataInterface;
 
+trigger_deprecation('symfony/serializer', '7.3', 'The "%s" class is deprecated.', CompiledClassMetadataFactory::class);
+
 /**
  * @author Fabien Bourigault <bourigaultfabien@gmail.com>
+ *
+ * @deprecated since Symfony 7.3
  */
 final class CompiledClassMetadataFactory implements ClassMetadataFactoryInterface
 {

--- a/src/Symfony/Component/Serializer/Tests/CacheWarmer/CompiledClassMetadataCacheWarmerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/CacheWarmer/CompiledClassMetadataCacheWarmerTest.php
@@ -18,6 +18,9 @@ use Symfony\Component\Serializer\CacheWarmer\CompiledClassMetadataCacheWarmer;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryCompiler;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 
+/**
+ * @group legacy
+ */
 final class CompiledClassMetadataCacheWarmerTest extends TestCase
 {
     public function testItImplementsCacheWarmerInterface()

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Factory/CompiledClassMetadataFactoryTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Factory/CompiledClassMetadataFactoryTest.php
@@ -21,6 +21,8 @@ use Symfony\Component\Serializer\Tests\Fixtures\Dummy;
 
 /**
  * @author Fabien Bourigault <bourigaultfabien@gmail.com>
+ *
+ * @group legacy
  */
 final class CompiledClassMetadataFactoryTest extends TestCase
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | Fix #57552
| License       | MIT

Deprecate the `CompiledClassMetadataFactory` and `CompiledClassMetadataCacheWarmer` classes as they're not used in the codebase and not meant to be used in the future (see #57552). 