### PR TITLE
[TypeInfo] Add `accepts` method

### DIFF
--- a/src/Symfony/Component/TypeInfo/CHANGELOG.md
+++ b/src/Symfony/Component/TypeInfo/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.3
+---
+
+ * Add `Type::accepts()` method
+
 7.2
 ---
 

--- a/src/Symfony/Component/TypeInfo/Tests/Type/BackedEnumTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/BackedEnumTypeTest.php
@@ -29,4 +29,12 @@ class BackedEnumTypeTest extends TestCase
     {
         $this->assertSame(DummyBackedEnum::class, (string) new BackedEnumType(DummyBackedEnum::class, Type::int()));
     }
+
+    public function testAccepts()
+    {
+        $type = new BackedEnumType(DummyBackedEnum::class, Type::int());
+
+        $this->assertFalse($type->accepts('string'));
+        $this->assertTrue($type->accepts(DummyBackedEnum::ONE));
+    }
 }

--- a/src/Symfony/Component/TypeInfo/Tests/Type/BuiltinTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/BuiltinTypeTest.php
@@ -39,4 +39,48 @@ class BuiltinTypeTest extends TestCase
         $this->assertTrue((new BuiltinType(TypeIdentifier::MIXED))->isNullable());
         $this->assertFalse((new BuiltinType(TypeIdentifier::INT))->isNullable());
     }
+
+    public function testAccepts()
+    {
+        $this->assertFalse((new BuiltinType(TypeIdentifier::ARRAY))->accepts('string'));
+        $this->assertTrue((new BuiltinType(TypeIdentifier::ARRAY))->accepts([]));
+
+        $this->assertFalse((new BuiltinType(TypeIdentifier::BOOL))->accepts('string'));
+        $this->assertTrue((new BuiltinType(TypeIdentifier::BOOL))->accepts(true));
+
+        $this->assertFalse((new BuiltinType(TypeIdentifier::CALLABLE))->accepts('string'));
+        $this->assertTrue((new BuiltinType(TypeIdentifier::CALLABLE))->accepts('strtoupper'));
+
+        $this->assertFalse((new BuiltinType(TypeIdentifier::FALSE))->accepts('string'));
+        $this->assertTrue((new BuiltinType(TypeIdentifier::FALSE))->accepts(false));
+
+        $this->assertFalse((new BuiltinType(TypeIdentifier::FLOAT))->accepts('string'));
+        $this->assertTrue((new BuiltinType(TypeIdentifier::FLOAT))->accepts(1.23));
+
+        $this->assertFalse((new BuiltinType(TypeIdentifier::INT))->accepts('string'));
+        $this->assertTrue((new BuiltinType(TypeIdentifier::INT))->accepts(123));
+
+        $this->assertFalse((new BuiltinType(TypeIdentifier::ITERABLE))->accepts('string'));
+        $this->assertTrue((new BuiltinType(TypeIdentifier::ITERABLE))->accepts([]));
+
+        $this->assertTrue((new BuiltinType(TypeIdentifier::MIXED))->accepts('string'));
+
+        $this->assertFalse((new BuiltinType(TypeIdentifier::NULL))->accepts('string'));
+        $this->assertTrue((new BuiltinType(TypeIdentifier::NULL))->accepts(null));
+
+        $this->assertFalse((new BuiltinType(TypeIdentifier::OBJECT))->accepts('string'));
+        $this->assertTrue((new BuiltinType(TypeIdentifier::OBJECT))->accepts(new \stdClass()));
+
+        $this->assertFalse((new BuiltinType(TypeIdentifier::RESOURCE))->accepts('string'));
+        $this->assertTrue((new BuiltinType(TypeIdentifier::RESOURCE))->accepts(fopen('php://temp', 'r')));
+
+        $this->assertFalse((new BuiltinType(TypeIdentifier::STRING))->accepts(123));
+        $this->assertTrue((new BuiltinType(TypeIdentifier::STRING))->accepts('string'));
+
+        $this->assertFalse((new BuiltinType(TypeIdentifier::TRUE))->accepts('string'));
+        $this->assertTrue((new BuiltinType(TypeIdentifier::TRUE))->accepts(true));
+
+        $this->assertFalse((new BuiltinType(TypeIdentifier::NEVER))->accepts('string'));
+        $this->assertFalse((new BuiltinType(TypeIdentifier::VOID))->accepts('string'));
+    }
 }

--- a/src/Symfony/Component/TypeInfo/Tests/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/CollectionTypeTest.php
@@ -88,4 +88,41 @@ class CollectionTypeTest extends TestCase
         $type = new CollectionType(new GenericType(Type::builtin(TypeIdentifier::ARRAY), Type::string(), Type::bool()));
         $this->assertEquals('array<string,bool>', (string) $type);
     }
+
+    public function testAccepts()
+    {
+        $type = new CollectionType(Type::generic(Type::builtin(TypeIdentifier::ARRAY), Type::string(), Type::bool()));
+
+        $this->assertFalse($type->accepts(new \ArrayObject(['foo' => true, 'bar' => true])));
+
+        $this->assertTrue($type->accepts(['foo' => true, 'bar' => true]));
+        $this->assertFalse($type->accepts(['foo' => true, 'bar' => 123]));
+        $this->assertFalse($type->accepts([1 => true]));
+
+        $type = new CollectionType(Type::generic(Type::builtin(TypeIdentifier::ARRAY), Type::int(), Type::bool()));
+
+        $this->assertTrue($type->accepts([1 => true]));
+        $this->assertFalse($type->accepts(['foo' => true]));
+
+        $type = new CollectionType(Type::generic(Type::builtin(TypeIdentifier::ARRAY), Type::int(), Type::bool()), isList: true);
+
+        $this->assertTrue($type->accepts([0 => true, 1 => false]));
+        $this->assertFalse($type->accepts([0 => true, 2 => false]));
+
+        $type = new CollectionType(Type::generic(Type::builtin(TypeIdentifier::ITERABLE), Type::string(), Type::bool()));
+
+        $this->assertTrue($type->accepts(new \ArrayObject(['foo' => true, 'bar' => true])));
+        $this->assertFalse($type->accepts(new \ArrayObject(['foo' => true, 'bar' => 123])));
+        $this->assertFalse($type->accepts(new \ArrayObject([1 => true])));
+
+        $type = new CollectionType(Type::generic(Type::builtin(TypeIdentifier::ITERABLE), Type::int(), Type::bool()));
+
+        $this->assertTrue($type->accepts(new \ArrayObject([1 => true])));
+        $this->assertFalse($type->accepts(new \ArrayObject(['foo' => true])));
+
+        $type = new CollectionType(Type::generic(Type::builtin(TypeIdentifier::ITERABLE), Type::int(), Type::bool()));
+
+        $this->assertTrue($type->accepts(new \ArrayObject([0 => true, 1 => false])));
+        $this->assertFalse($type->accepts(new \ArrayObject([0 => true, 1 => 'string'])));
+    }
 }

--- a/src/Symfony/Component/TypeInfo/Tests/Type/EnumTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/EnumTypeTest.php
@@ -21,4 +21,12 @@ class EnumTypeTest extends TestCase
     {
         $this->assertSame(DummyEnum::class, (string) new EnumType(DummyEnum::class));
     }
+
+    public function testAccepts()
+    {
+        $type = new EnumType(DummyEnum::class);
+
+        $this->assertFalse($type->accepts('string'));
+        $this->assertTrue($type->accepts(DummyEnum::ONE));
+    }
 }

--- a/src/Symfony/Component/TypeInfo/Tests/Type/GenericTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/GenericTypeTest.php
@@ -45,4 +45,12 @@ class GenericTypeTest extends TestCase
         $type = new GenericType(Type::builtin(TypeIdentifier::ITERABLE), Type::bool());
         $this->assertFalse($type->wrappedTypeIsSatisfiedBy(static fn (Type $t): bool => 'array' === (string) $t));
     }
+
+    public function testAccepts()
+    {
+        $type = new GenericType(Type::object(self::class), Type::string());
+
+        $this->assertFalse($type->accepts('string'));
+        $this->assertTrue($type->accepts($this));
+    }
 }

--- a/src/Symfony/Component/TypeInfo/Tests/Type/IntersectionTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/IntersectionTypeTest.php
@@ -77,4 +77,22 @@ class IntersectionTypeTest extends TestCase
         $type = new IntersectionType(Type::object(\DateTime::class), Type::object(\Iterator::class), Type::object(\Stringable::class));
         $this->assertSame(\sprintf('%s&%s&%s', \DateTime::class, \Iterator::class, \Stringable::class), (string) $type);
     }
+
+    public function testAccepts()
+    {
+        $type = new IntersectionType(Type::object(\Traversable::class), Type::object(\Countable::class));
+
+        $traversableAndCountable = new \ArrayObject();
+
+        $countable = new class implements \Countable {
+            public function count(): int
+            {
+                return 1;
+            }
+        };
+
+        $this->assertFalse($type->accepts('string'));
+        $this->assertFalse($type->accepts($countable));
+        $this->assertTrue($type->accepts($traversableAndCountable));
+    }
 }

--- a/src/Symfony/Component/TypeInfo/Tests/Type/NullableTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/NullableTypeTest.php
@@ -41,4 +41,13 @@ class NullableTypeTest extends TestCase
         $type = new NullableType(Type::string());
         $this->assertFalse($type->wrappedTypeIsSatisfiedBy(static fn (Type $t): bool => 'int' === (string) $t));
     }
+
+    public function testAccepts()
+    {
+        $type = new NullableType(Type::int());
+
+        $this->assertFalse($type->accepts('string'));
+        $this->assertTrue($type->accepts(123));
+        $this->assertTrue($type->accepts(null));
+    }
 }

--- a/src/Symfony/Component/TypeInfo/Tests/Type/ObjectTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/ObjectTypeTest.php
@@ -35,4 +35,12 @@ class ObjectTypeTest extends TestCase
 
         $this->assertTrue((new ObjectType(self::class))->isIdentifiedBy('array', 'object'));
     }
+
+    public function testAccepts()
+    {
+        $this->assertFalse((new ObjectType(self::class))->accepts('string'));
+        $this->assertFalse((new ObjectType(self::class))->accepts(new \stdClass()));
+        $this->assertTrue((new ObjectType(parent::class))->accepts($this));
+        $this->assertTrue((new ObjectType(self::class))->accepts($this));
+    }
 }

--- a/src/Symfony/Component/TypeInfo/Tests/Type/TemplateTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/TemplateTypeTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Tests\Type;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\TypeInfo\Type\BuiltinType;
+use Symfony\Component\TypeInfo\Type\TemplateType;
+use Symfony\Component\TypeInfo\TypeIdentifier;
+
+class TemplateTypeTest extends TestCase
+{
+    public function testAccepts()
+    {
+        $this->assertFalse((new TemplateType('T', new BuiltinType(TypeIdentifier::BOOL)))->accepts('string'));
+        $this->assertTrue((new TemplateType('T', new BuiltinType(TypeIdentifier::BOOL)))->accepts(true));
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Tests/Type/UnionTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/UnionTypeTest.php
@@ -85,4 +85,13 @@ class UnionTypeTest extends TestCase
         $type = new UnionType(Type::int(), Type::string(), Type::intersection(Type::object(\DateTime::class), Type::object(\Iterator::class)));
         $this->assertSame(\sprintf('(%s&%s)|int|string', \DateTime::class, \Iterator::class), (string) $type);
     }
+
+    public function testAccepts()
+    {
+        $type = new UnionType(Type::int(), Type::bool());
+
+        $this->assertFalse($type->accepts('string'));
+        $this->assertTrue($type->accepts(123));
+        $this->assertTrue($type->accepts(false));
+    }
 }

--- a/src/Symfony/Component/TypeInfo/Type.php
+++ b/src/Symfony/Component/TypeInfo/Type.php
@@ -56,4 +56,24 @@ abstract class Type implements \Stringable
     {
         return false;
     }
+
+    /**
+     * Tells if the type (or one of its wrapped/composed parts) accepts the given $value.
+     */
+    public function accepts(mixed $value): bool
+    {
+        $specification = static function (Type $type) use (&$specification, $value): bool {
+            if ($type instanceof WrappingTypeInterface) {
+                return $type->wrappedTypeIsSatisfiedBy($specification);
+            }
+
+            if ($type instanceof CompositeTypeInterface) {
+                return $type->composedTypesAreSatisfiedBy($specification);
+            }
+
+            return $type->accepts($value);
+        };
+
+        return $this->isSatisfiedBy($specification);
+    }
 }

--- a/src/Symfony/Component/TypeInfo/Type/BuiltinType.php
+++ b/src/Symfony/Component/TypeInfo/Type/BuiltinType.php
@@ -62,6 +62,26 @@ final class BuiltinType extends Type
         return \in_array($this->typeIdentifier, [TypeIdentifier::NULL, TypeIdentifier::MIXED]);
     }
 
+    public function accepts(mixed $value): bool
+    {
+        return match ($this->typeIdentifier) {
+            TypeIdentifier::ARRAY => \is_array($value),
+            TypeIdentifier::BOOL => \is_bool($value),
+            TypeIdentifier::CALLABLE => \is_callable($value),
+            TypeIdentifier::FALSE => false === $value,
+            TypeIdentifier::FLOAT => \is_float($value),
+            TypeIdentifier::INT => \is_int($value),
+            TypeIdentifier::ITERABLE => is_iterable($value),
+            TypeIdentifier::MIXED => true,
+            TypeIdentifier::NULL => null === $value,
+            TypeIdentifier::OBJECT => \is_object($value),
+            TypeIdentifier::RESOURCE => \is_resource($value),
+            TypeIdentifier::STRING => \is_string($value),
+            TypeIdentifier::TRUE => true === $value,
+            default => false,
+        };
+    }
+
     public function __toString(): string
     {
         return $this->typeIdentifier->value;

--- a/src/Symfony/Component/TypeInfo/Type/CollectionType.php
+++ b/src/Symfony/Component/TypeInfo/Type/CollectionType.php
@@ -92,6 +92,31 @@ final class CollectionType extends Type implements WrappingTypeInterface
         return $this->getWrappedType()->isSatisfiedBy($specification);
     }
 
+    public function accepts(mixed $value): bool
+    {
+        if (!parent::accepts($value)) {
+            return false;
+        }
+
+        if ($this->isList() && (!\is_array($value) || !array_is_list($value))) {
+            return false;
+        }
+
+        $keyType = $this->getCollectionKeyType();
+        $valueType = $this->getCollectionValueType();
+
+        if (is_iterable($value)) {
+            foreach ($value as $k => $v) {
+                // key or value do not match
+                if (!$keyType->accepts($k) || !$valueType->accepts($v)) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
     public function __toString(): string
     {
         return (string) $this->type;

--- a/src/Symfony/Component/TypeInfo/Type/NullableType.php
+++ b/src/Symfony/Component/TypeInfo/Type/NullableType.php
@@ -59,4 +59,9 @@ final class NullableType extends UnionType implements WrappingTypeInterface
     {
         return true;
     }
+
+    public function accepts(mixed $value): bool
+    {
+        return null === $value || parent::accepts($value);
+    }
 }

--- a/src/Symfony/Component/TypeInfo/Type/ObjectType.php
+++ b/src/Symfony/Component/TypeInfo/Type/ObjectType.php
@@ -66,6 +66,11 @@ class ObjectType extends Type
         return false;
     }
 
+    public function accepts(mixed $value): bool
+    {
+        return $value instanceof $this->className;
+    }
+
     public function __toString(): string
     {
         return $this->className;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

Add `Type::accepts($value)` method, which returns `true` whether a given value matches the current type.