### PR TITLE
[AssetMapper] Fix JavaScript compiler creates self-referencing imports

### DIFF
--- a/src/Symfony/Component/AssetMapper/Compiler/JavaScriptImportPathCompiler.php
+++ b/src/Symfony/Component/AssetMapper/Compiler/JavaScriptImportPathCompiler.php
@@ -92,6 +92,11 @@ final class JavaScriptImportPathCompiler implements AssetCompilerInterface
                 return $fullImportString;
             }
 
+            // Ignore self-referencing import
+            if ($dependentAsset->logicalPath === $asset->logicalPath) {
+                return $fullImportString;
+            }
+
             // List as a JavaScript import.
             // This will cause the asset to be included in the importmap (for relative imports)
             // and will be used to generate the preloads in the importmap.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #59289
| License       | MIT

Ignore self-referencing imports to avoid creating circular dependencies (and infinite parsing)
