### PR TITLE
[TypeInfo] Prevent creation of composite with only same types

### DIFF
--- a/UPGRADE-7.3.md
+++ b/UPGRADE-7.3.md
@@ -1,0 +1,14 @@
+UPGRADE FROM 7.2 to 7.3
+=======================
+
+Symfony 7.3 is a minor release. According to the Symfony release process, there should be no significant
+backward compatibility breaks. Minor backward compatibility breaks are prefixed in this document with
+`[BC BREAK]`, make sure your code is compatible with these entries before upgrading.
+Read more about this in the [Symfony documentation](https://symfony.com/doc/7.3/setup/upgrade_minor.html).
+
+If you're upgrading from a version below 7.2, follow the [7.2 upgrade guide](UPGRADE-7.2.md) first.
+
+TypeInfo
+--------
+
+ * Deprecate creation of `UnionType` and `IntersectionType` with only same types

--- a/src/Symfony/Component/TypeInfo/CHANGELOG.md
+++ b/src/Symfony/Component/TypeInfo/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.3
+---
+
+ * Deprecate creation of `UnionType` and `IntersectionType` with only same types
+
 7.2
 ---
 

--- a/src/Symfony/Component/TypeInfo/Tests/Type/IntersectionTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/IntersectionTypeTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\TypeInfo\Tests\Type;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectUserDeprecationMessageTrait;
 use Symfony\Component\TypeInfo\Exception\InvalidArgumentException;
 use Symfony\Component\TypeInfo\Type;
 use Symfony\Component\TypeInfo\Type\IntersectionType;
@@ -20,10 +21,21 @@ use Symfony\Component\TypeInfo\Type\UnionType;
 
 class IntersectionTypeTest extends TestCase
 {
+    use ExpectUserDeprecationMessageTrait;
+
     public function testCannotCreateWithOnlyOneType()
     {
         $this->expectException(InvalidArgumentException::class);
         new IntersectionType(Type::object(\DateTime::class));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testCannotCreateWithOnlySameTypes()
+    {
+        $this->expectUserDeprecationMessage('Since symfony/type-info 7.3: Creating a "Symfony\Component\TypeInfo\Type\IntersectionType" with only same types is deprecated and will throw a "Symfony\Component\TypeInfo\Exception\InvalidArgumentException" exception in 8.0.');
+        new IntersectionType(Type::object(\DateTime::class), Type::object(\DateTime::class));
     }
 
     public function testCannotCreateWithUnionTypePart()

--- a/src/Symfony/Component/TypeInfo/Tests/Type/UnionTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/UnionTypeTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\TypeInfo\Tests\Type;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectUserDeprecationMessageTrait;
 use Symfony\Component\TypeInfo\Exception\InvalidArgumentException;
 use Symfony\Component\TypeInfo\Type;
 use Symfony\Component\TypeInfo\Type\BuiltinType;
@@ -20,10 +21,21 @@ use Symfony\Component\TypeInfo\Type\UnionType;
 
 class UnionTypeTest extends TestCase
 {
+    use ExpectUserDeprecationMessageTrait;
+
     public function testCannotCreateWithOnlyOneType()
     {
         $this->expectException(InvalidArgumentException::class);
         new UnionType(Type::int());
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testCannotCreateWithOnlySameTypes()
+    {
+        $this->expectUserDeprecationMessage('Since symfony/type-info 7.3: Creating a "Symfony\Component\TypeInfo\Type\UnionType" with only same types is deprecated and will throw a "Symfony\Component\TypeInfo\Exception\InvalidArgumentException" exception in 8.0.');
+        new UnionType(Type::int(), Type::int());
     }
 
     public function testCannotCreateWithUnionTypePart()

--- a/src/Symfony/Component/TypeInfo/Type/IntersectionType.php
+++ b/src/Symfony/Component/TypeInfo/Type/IntersectionType.php
@@ -54,6 +54,10 @@ final class IntersectionType extends Type implements CompositeTypeInterface
 
         usort($types, fn (Type $a, Type $b): int => (string) $a <=> (string) $b);
         $this->types = array_values(array_unique($types));
+
+        if (\count($this->types) < 2) {
+            trigger_deprecation('symfony/type-info', '7.3', 'Creating a "%s" with only same types is deprecated and will throw a "%s" exception in 8.0.', self::class, InvalidArgumentException::class);
+        }
     }
 
     /**

--- a/src/Symfony/Component/TypeInfo/Type/UnionType.php
+++ b/src/Symfony/Component/TypeInfo/Type/UnionType.php
@@ -58,6 +58,10 @@ class UnionType extends Type implements CompositeTypeInterface
         usort($types, fn (Type $a, Type $b): int => (string) $a <=> (string) $b);
         $this->types = array_values(array_unique($types));
 
+        if (\count($this->types) < 2) {
+            trigger_deprecation('symfony/type-info', '7.3', 'Creating a "%s" with only same types is deprecated and will throw a "%s" exception in 8.0.', self::class, InvalidArgumentException::class);
+        }
+
         $builtinTypesIdentifiers = array_map(
             fn (BuiltinType $t): TypeIdentifier => $t->getTypeIdentifier(),
             array_filter($this->types, fn (Type $t): bool => $t instanceof BuiltinType),

--- a/src/Symfony/Component/TypeInfo/composer.json
+++ b/src/Symfony/Component/TypeInfo/composer.json
@@ -26,7 +26,8 @@
     ],
     "require": {
         "php": ">=8.2",
-        "psr/container": "^1.1|^2.0"
+        "psr/container": "^1.1|^2.0",
+        "symfony/deprecation-contracts": "^2.5|^3"
     },
     "require-dev": {
         "phpstan/phpdoc-parser": "^1.0|^2.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | 
| License       | MIT

Prevent creation of composite with only same types, such as `Type::union(Type::string(), Type::string())`.
This was possible before, and created an inconsistent union type.

I didn't treat that as a bug fix because it'll cause BC breaks. But this can be discussed.