### PR TITLE
[Form] do not render hidden CSRF token forms with autocomplete set to off

### DIFF
--- a/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
@@ -76,7 +76,7 @@ class FormTypeCsrfExtension extends AbstractTypeExtension
             $csrfForm = $factory->createNamed($options['csrf_field_name'], HiddenType::class, $data, [
                 'block_prefix' => 'csrf_token',
                 'mapped' => false,
-                'attr' => $this->fieldAttr + ['autocomplete' => 'off'],
+                'attr' => $this->fieldAttr,
             ]);
 
             $view->children[$options['csrf_field_name']] = $csrfForm->createView($view);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59294
| License       | MIT