### PR TITLE
[HttpKernel] Add a `noStore` argument to the `#` attribute

### DIFF
--- a/src/Symfony/Component/HttpKernel/Attribute/Cache.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/Cache.php
@@ -102,6 +102,18 @@ final class Cache
          * It can be expressed in seconds or with a relative time format (1 day, 2 weeks, ...).
          */
         public int|string|null $staleIfError = null,
+
+        /**
+         * Add the "no-store" Cache-Control directive when set to true.
+         *
+         * This directive indicates that no part of the response can be cached
+         * in any cache (not in a shared cache, nor in a private cache).
+         *
+         * Supersedes the "$public" and "$smaxage" values.
+         *
+         * @see https://datatracker.ietf.org/doc/html/rfc7234#section-5.2.2.3
+         */
+        public ?bool $noStore = null,
     ) {
     }
 }

--- a/src/Symfony/Component/HttpKernel/EventListener/CacheAttributeListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/CacheAttributeListener.php
@@ -163,6 +163,15 @@ class CacheAttributeListener implements EventSubscriberInterface
             if (false === $cache->public) {
                 $response->setPrivate();
             }
+
+            if (true === $cache->noStore) {
+                $response->setPrivate();
+                $response->headers->addCacheControlDirective('no-store');
+            }
+
+            if (false === $cache->noStore) {
+                $response->headers->removeCacheControlDirective('no-store');
+            }
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #...
| License       | MIT

This PR introduces a `noStore` argument to the `#[Cache]` attribute, allowing controllers to easily set the [no-store](https://datatracker.ietf.org/doc/html/rfc7234#section-5.2.2.3) directive.

```php
use Symfony\Component\HttpKernel\Attribute\Cache;

#[Cache(noStore: true)]
final class MyController
{
    public function __invoke(): Response
    {
        // This response will NOT be stored in ANY cache
        
```

When set to `true`, it also supersedes the `public` / `private` value.

---

I recently encountered issues with the back-forward cache ([bfcache](https://web.dev/articles/bfcache)), a browser feature that stores entire pages in memory to make navigating back and forth faster. It can cause problems when pages rely on JavaScript initialization, dynamic content, or state-changing resources. For example, an edit form might reappear after submission just by hitting “Back” (even after a redirection), with no HTTP request being triggered—leading to unexpected behavior and frustrating the user.

Standard cache headers like `Cache-Control: no-cache` don’t stop this behavior. The _**only**_ reliable way to disable the bfcache across all major browsers is by using the `no-store` directive.

```php
use Symfony\Component\HttpKernel\Attribute\Cache;

final class MyController
{
    #[Cache(public: false)]
    public function private(): Response
    {
        // ❌ This page can (and probably will) be cached in the browser bfc
    }
    
    #[Cache(noStore: true)]
    public function notStored(): Response
    {
        // ✅ This page will NOT be cached -- not even in the browser bfc
    }
}
```

The [HTTP cache documentation](https://symfony.com/doc/current/http_cache.html) states that all options available for the `Response::setCache()` method can also be used with the `#[Cache]` attribute. However, the `no-store` option is currently missing.

> [!NOTE]
> This is a very "raw" implementation.. not sure about it or potential consequences I might not have considered... but I wanted to start the discussion :) 

---

**Resources:**

* [Understanding bfcache (web.dev)](https://web.dev/articles/bfcache)
* [Minimizing the impact of no-store on bfcache (web.dev)](https://web.dev/articles/bfcache#minimize-no-store)
* [MDN Glossary: bfcache](https://developer.mozilla.org/en-US/docs/Glossary/bfcache)
* [RFC7234 - Storing Responses in Caches](https://datatracker.ietf.org/doc/html/rfc7234#section-3)
* [RFC7234 - no-store](https://datatracker.ietf.org/doc/html/rfc7234#section-5.2.2.3)