### PR TITLE
[PropertyInfo] Remove `@internal` from `PropertyReadInfo` and `PropertyWriteInfo`

### DIFF
--- a/src/Symfony/Component/PropertyInfo/PropertyReadInfo.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyReadInfo.php
@@ -15,8 +15,6 @@ namespace Symfony\Component\PropertyInfo;
  * The property read info tells how a property can be read.
  *
  * @author Joel Wurtz <jwurtz@jolicode.com>
- *
- * @internal
  */
 final class PropertyReadInfo
 {

--- a/src/Symfony/Component/PropertyInfo/PropertyWriteInfo.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyWriteInfo.php
@@ -15,8 +15,6 @@ namespace Symfony\Component\PropertyInfo;
  * The write mutator defines how a property can be written.
  *
  * @author Joel Wurtz <jwurtz@jolicode.com>
- *
- * @internal
  */
 final class PropertyWriteInfo
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | [Fix #58988](https://github.com/symfony/symfony/issues/58988)
| License       | MIT
