### PR TITLE
[Messenger] customizable logger messages

### DIFF
--- a/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php
@@ -93,7 +93,7 @@ class HandleMessageMiddleware implements MiddlewareInterface
 
                 $handledStamp = HandledStamp::fromDescriptor($handlerDescriptor, $result);
                 $envelope = $envelope->with($handledStamp);
-                $this->logger?->info('Message {class} handled by {handler}', $context + ['handler' => $handledStamp->getHandlerName()]);
+                $this->logHandledMessage($context, $handledStamp);
             } catch (\Throwable $e) {
                 $exceptions[$handlerDescriptor->getName()] = $e;
             }
@@ -117,7 +117,7 @@ class HandleMessageMiddleware implements MiddlewareInterface
                 throw new NoHandlerForMessageException(\sprintf('No handler for message "%s".', $context['class']));
             }
 
-            $this->logger?->info('No handler for message {class}', $context);
+            $this->logNoHandlerMessage($context);
         }
 
         if (\count($exceptions)) {
@@ -150,5 +150,15 @@ class HandleMessageMiddleware implements MiddlewareInterface
         }
 
         return $handler(...$arguments);
+    }
+
+    protected function logHandledMessage(array $context, HandledStamp $handledStamp): void
+    {
+        $this->logger?->info('Message {class} handled by {handler}', $context + ['handler' => $handledStamp->getHandlerName()]);
+    }
+
+    protected function logNoHandlerMessage(array $context): void
+    {
+        $this->logger?->info('No handler for message {class}', $context);
     }
 }

--- a/src/Symfony/Component/Messenger/Worker.php
+++ b/src/Symfony/Component/Messenger/Worker.php
@@ -40,7 +40,6 @@ use Symfony\Component\RateLimiter\LimiterInterface;
  * @author Samuel Roze <samuel.roze@gmail.com>
  * @author Tobias Schultze <http://tobion.de>
  *
- * @final
  */
 class Worker
 {
@@ -227,7 +226,7 @@ class Worker
                     'class' => $message::class,
                     'message_id' => $envelope->last(TransportMessageIdStamp::class)?->getId(),
                 ];
-                $this->logger->info('{class} was handled successfully (acknowledging to transport).', $context);
+                $this->logSuccessfullyHandledMessage($context);
             }
 
             unset($this->keepalives[$envelope->getMessage()]);
@@ -311,5 +310,10 @@ class Worker
     public function getMetadata(): WorkerMetadata
     {
         return $this->metadata;
+    }
+
+    protected function logSuccessfullyHandledMessage(array $context): void
+    {
+        $this->logger->info('{class} was handled successfully (acknowledging to transport).', $context);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

When using Messenger, especially with async transports, you get feedbacks of how your messages are handled in a formatted string, in your logs and on your console:
> `2024-12-27 13:17:28 12:17:28 INFO      [messenger] Message App\Command\Foo handled by App\CommandHandler\Foo::__invoke ["class" => "App\Command\Foo","handler" => "App\CommandHandler\FooHandler::__invoke"]`

That's a good start, but sometimes, you want to customize those messages to align them more with your business logic. That's the purpose of this change, making the strings easily editable.