### PR TITLE
[Yaml] Fix parsing of unquoted strings in Parser::lexUnquotedString() to ignore spaces

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -1158,7 +1158,7 @@ class Parser
     private function lexUnquotedString(int &$cursor): string
     {
         $offset = $cursor;
-        $cursor += strcspn($this->currentLine, '[]{},: ', $cursor);
+        $cursor += strcspn($this->currentLine, '[]{},:', $cursor);
 
         if ($cursor === $offset) {
             throw new ParseException('Malformed unquoted YAML string.');

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -1710,6 +1710,33 @@ YAML;
         $this->assertSame($expected, $this->parser->parse($yaml));
     }
 
+    /**
+     * @dataProvider wrappedUnquotedStringsProvider
+     */
+    public function testWrappedUnquotedStringWithMultipleSpacesInValue(string $yaml, array $expected)
+    {
+        $this->assertSame($expected, $this->parser->parse($yaml));
+    }
+
+    public static function wrappedUnquotedStringsProvider() {
+        return [
+            'mapping' => [
+                '{ foo: bar  bar, fiz: cat      cat }',
+                [
+                    'foo' => 'bar  bar',
+                    'fiz' => 'cat      cat',
+                ]
+            ],
+            'sequence' => [
+                '[ bar  bar, cat      cat ]',
+                [
+                    'bar  bar',
+                    'cat      cat',
+                ]
+            ],
+        ];
+    }
+
     public function testParseMultiLineUnquotedString()
     {
         $yaml = <<<EOT


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59299
| License       | MIT


I modified the `strcspn()` call in the `lexUnquotedString()` method of the `Parser` class to exclude the space character (' ') from the list of delimiters. This ensures that spaces are no longer considered while parsing unquoted strings.
