### PR TITLE
[AssetMapper] add leading slash to public prefix

### DIFF
--- a/src/Symfony/Component/AssetMapper/AssetMapperDevServerSubscriber.php
+++ b/src/Symfony/Component/AssetMapper/AssetMapperDevServerSubscriber.php
@@ -109,7 +109,7 @@ final class AssetMapperDevServerSubscriber implements EventSubscriberInterface
         private readonly ?CacheItemPoolInterface $cacheMapCache = null,
         private readonly ?Profiler $profiler = null,
     ) {
-        $this->publicPrefix = rtrim($publicPrefix, '/').'/';
+        $this->publicPrefix = '/'.trim($publicPrefix, '/').'/';
         $this->extensionsMap = array_merge(self::EXTENSIONS_MAP, $extensionsMap);
     }
 

--- a/src/Symfony/Component/AssetMapper/Path/PublicAssetsPathResolver.php
+++ b/src/Symfony/Component/AssetMapper/Path/PublicAssetsPathResolver.php
@@ -18,8 +18,8 @@ class PublicAssetsPathResolver implements PublicAssetsPathResolverInterface
     public function __construct(
         string $publicPrefix = '/assets/',
     ) {
-        // ensure that the public prefix always ends with a single slash
-        $this->publicPrefix = rtrim($publicPrefix, '/').'/';
+        // ensure that the public prefix always starts and ends with a single slash
+        $this->publicPrefix = '/'.trim($publicPrefix, '/').'/';
     }
 
     public function resolvePublicPath(string $logicalPath): string

--- a/src/Symfony/Component/AssetMapper/Tests/Fixtures/AssetMapperTestAppKernel.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Fixtures/AssetMapperTestAppKernel.php
@@ -44,6 +44,7 @@ class AssetMapperTestAppKernel extends Kernel
                 'assets' => null,
                 'asset_mapper' => [
                     'paths' => ['dir1', 'dir2', 'non_ascii', 'assets'],
+                    'public_prefix' => 'assets'
                 ],
                 'test' => true,
             ]);

--- a/src/Symfony/Component/AssetMapper/Tests/Path/PublicAssetsPathResolverTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Path/PublicAssetsPathResolverTest.php
@@ -26,7 +26,7 @@ class PublicAssetsPathResolverTest extends TestCase
         $this->assertSame('/assets-prefix/foo/bar', $resolver->resolvePublicPath('foo/bar'));
 
         $resolver = new PublicAssetsPathResolver(
-            '/assets-prefix', // The trailing slash should be added automatically
+            'assets-prefix', // The leading and trailing slash should be added automatically
         );
         $this->assertSame('/assets-prefix/', $resolver->resolvePublicPath(''));
         $this->assertSame('/assets-prefix/foo/bar', $resolver->resolvePublicPath('/foo/bar'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no 
| Issues        | -
| License       | MIT

```yaml
framework:
    asset_mapper:
        public_prefix: custom/path
```

i added above config to make `asset-map:compile` command create all files in that directory but i was not aware if that value should start with a `/` and make the page not load properly, so if the `/` is required then we can add it by default instead