### PR TITLE
[Yaml] Add compact nested mapping support to `Dumper`

### DIFF
--- a/src/Symfony/Component/Yaml/CHANGELOG.md
+++ b/src/Symfony/Component/Yaml/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.3
+---
+
+ * Add compact nested mapping support by using the `Yaml::DUMP_COMPACT_NESTED_MAPPING` flag
+
 7.2
 ---
 

--- a/src/Symfony/Component/Yaml/Dumper.php
+++ b/src/Symfony/Component/Yaml/Dumper.php
@@ -65,6 +65,7 @@ class Dumper
             $output .= $this->dumpTaggedValue($input, $inline, $indent, $flags, $prefix, $nestingLevel);
         } else {
             $dumpAsMap = Inline::isHash($input);
+            $compactNestedMapping = Yaml::DUMP_COMPACT_NESTED_MAPPING & $flags && !$dumpAsMap;
 
             foreach ($input as $key => $value) {
                 if ('' !== $output && "\n" !== $output[-1]) {
@@ -134,8 +135,8 @@ class Dumper
                 $output .= \sprintf('%s%s%s%s',
                     $prefix,
                     $dumpAsMap ? Inline::dump($key, $flags).':' : '-',
-                    $willBeInlined ? ' ' : "\n",
-                    $this->doDump($value, $inline - 1, $willBeInlined ? 0 : $indent + $this->indentation, $flags, $nestingLevel + 1)
+                    $willBeInlined || ($compactNestedMapping && \is_array($value)) ? ' ' : "\n",
+                    $compactNestedMapping && \is_array($value) ? substr($this->doDump($value, $inline - 1, $indent + 2, $flags, $nestingLevel + 1), $indent + 2) : $this->doDump($value, $inline - 1, $willBeInlined ? 0 : $indent + $this->indentation, $flags, $nestingLevel + 1)
                 ).($willBeInlined ? "\n" : '');
             }
         }

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -1061,6 +1061,97 @@ YAML;
         ];
     }
 
+    public static function getDumpCompactNestedMapping()
+    {
+        $data = [
+            'planets' => [
+                [
+                    'name' => 'Mercury',
+                    'distance' => 57910000,
+                    'properties' => [
+                        ['name' => 'size', 'value' => 4879],
+                        ['name' => 'moons', 'value' => 0],
+                        [[[]]],
+                    ],
+                ],
+                [
+                    'name' => 'Jupiter',
+                    'distance' => 778500000,
+                    'properties' => [
+                        ['name' => 'size', 'value' => 139820],
+                        ['name' => 'moons', 'value' => 79],
+                        [[]],
+                    ],
+                ],
+            ],
+        ];
+        $expected = <<<YAML
+planets:
+\t- name: Mercury
+\t  distance: 57910000
+\t  properties:
+\t\t  - name: size
+\t\t    value: 4879
+\t\t  - name: moons
+\t\t    value: 0
+\t\t  - - - {  }
+\t- name: Jupiter
+\t  distance: 778500000
+\t  properties:
+\t\t  - name: size
+\t\t    value: 139820
+\t\t  - name: moons
+\t\t    value: 79
+\t\t  - - {  }
+
+YAML;
+
+        for ($indentation = 1; $indentation < 5; ++$indentation) {
+            yield \sprintf('Compact nested mapping %d', $indentation) => [
+                $data,
+                strtr($expected, ["\t" => str_repeat(' ', $indentation)]),
+                $indentation,
+            ];
+        }
+
+        $indentation = 2;
+        $inline = 4;
+        $expected = <<<YAML
+planets:
+  - name: Mercury
+    distance: 57910000
+    properties:
+      - { name: size, value: 4879 }
+      - { name: moons, value: 0 }
+      - [[{  }]]
+  - name: Jupiter
+    distance: 778500000
+    properties:
+      - { name: size, value: 139820 }
+      - { name: moons, value: 79 }
+      - [{  }]
+
+YAML;
+
+        yield \sprintf('Compact nested mapping %d and inline %d', $indentation, $inline) => [
+            $data,
+            $expected,
+            $indentation,
+            $inline,
+        ];
+    }
+
+    /**
+     * @dataProvider getDumpCompactNestedMapping
+     */
+    public function testDumpCompactNestedMapping(array $data, string $expected, int $indentation, int $inline = 10)
+    {
+        $dumper = new Dumper($indentation);
+        $actual = $dumper->dump($data, $inline, 0, Yaml::DUMP_COMPACT_NESTED_MAPPING);
+        $this->assertSame($expected, $actual);
+        $this->assertSameData($data, $this->parser->parse($actual));
+    }
+
     private function assertSameData($expected, $actual)
     {
         $this->assertEquals($expected, $actual);

--- a/src/Symfony/Component/Yaml/Yaml.php
+++ b/src/Symfony/Component/Yaml/Yaml.php
@@ -36,6 +36,7 @@ class Yaml
     public const DUMP_NULL_AS_TILDE = 2048;
     public const DUMP_NUMERIC_KEY_AS_STRING = 4096;
     public const DUMP_NULL_AS_EMPTY = 8192;
+    public const DUMP_COMPACT_NESTED_MAPPING = 16384;
 
     /**
      * Parses a YAML file into a PHP value.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Feature allow to decrease count of lines in YAML output using list hash start line also as hash dump first line.

Original output
```yaml
planets:
  -
    name: Mercury
    distance: 57910000
  -
    name: Jupiter
    distance: 778500000
```

 With `Yaml::DUMP_COMPACT_NESTED_MAPPING` flag enabled.
```yaml
planets:
  - name: Mercury
    distance: 57910000
  - name: Jupiter
    distance: 778500000
```

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

