### PR TITLE
[Finder] Fix using `==` as default operator in `DateComparator`

### DIFF
--- a/src/Symfony/Component/Finder/Comparator/DateComparator.php
+++ b/src/Symfony/Component/Finder/Comparator/DateComparator.php
@@ -36,7 +36,7 @@ class DateComparator extends Comparator
             throw new \InvalidArgumentException(sprintf('"%s" is not a valid date.', $matches[2]));
         }
 
-        $operator = $matches[1] ?? '==';
+        $operator = $matches[1] ?: '==';
         if ('since' === $operator || 'after' === $operator) {
             $operator = '>';
         }

--- a/src/Symfony/Component/Finder/Tests/Comparator/DateComparatorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Comparator/DateComparatorTest.php
@@ -59,6 +59,7 @@ class DateComparatorTest extends TestCase
             ['after 2005-10-10', [strtotime('2005-10-15')], [strtotime('2005-10-09')]],
             ['since 2005-10-10', [strtotime('2005-10-15')], [strtotime('2005-10-09')]],
             ['!= 2005-10-10', [strtotime('2005-10-11')], [strtotime('2005-10-10')]],
+            ['2005-10-10', [strtotime('2005-10-10')], [strtotime('2005-10-11')]],
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59314
| License       | MIT

`$matches` can only contain `null` when passing the [`PREG_UNMATCHED_AS_NULL`](https://www.php.net/manual/en/pcre.constants.php#constant.preg-unmatched-as-null) flag. Since the culprit code line predates PHP 7.2 I made it check for an empty string rather than `null`, as @GlucNAc suggested.