### PR TITLE
[HttpClient] allow to use unix socket when using amphp http client

### DIFF
--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.3
+--
+
+* Allow `AmphpHttpClient` with amphp/http-client v5 to use unix socket
+
 7.2
 ---
 

--- a/src/Symfony/Component/HttpClient/Internal/AmpListenerV5.php
+++ b/src/Symfony/Component/HttpClient/Internal/AmpListenerV5.php
@@ -18,6 +18,7 @@ use Amp\Http\Client\EventListener;
 use Amp\Http\Client\NetworkInterceptor;
 use Amp\Http\Client\Request;
 use Amp\Http\Client\Response;
+use Amp\Socket\UnixAddress;
 use Symfony\Component\HttpClient\Exception\TransportException;
 
 /**
@@ -66,14 +67,19 @@ class AmpListenerV5 implements EventListener
 
     public function requestHeaderStart(Request $request, Stream $stream): void
     {
-        $host = $stream->getRemoteAddress()->getAddress();
+        if ($stream->getRemoteAddress() instanceof UnixAddress) {
+            $host = $stream->getRemoteAddress()->toString();
+        } else {
+            $host = $stream->getRemoteAddress()->getAddress();
+            $this->info['primary_port'] = $stream->getRemoteAddress()->getPort();
+        }
+
         $this->info['primary_ip'] = $host;
 
         if (str_contains($host, ':')) {
             $host = '['.$host.']';
         }
 
-        $this->info['primary_port'] = $stream->getRemoteAddress()->getPort();
         $this->info['pretransfer_time'] = microtime(true) - $this->info['start_time'];
         $this->info['debug'] .= \sprintf("* Connected to %s (%s) port %d\n", $request->getUri()->getHost(), $host, $this->info['primary_port']);
 

--- a/src/Symfony/Component/HttpClient/Internal/AmpListenerV5.php
+++ b/src/Symfony/Component/HttpClient/Internal/AmpListenerV5.php
@@ -18,8 +18,11 @@ use Amp\Http\Client\EventListener;
 use Amp\Http\Client\NetworkInterceptor;
 use Amp\Http\Client\Request;
 use Amp\Http\Client\Response;
-use Amp\Socket\UnixAddress;
 use Symfony\Component\HttpClient\Exception\TransportException;
+
+if (\PHP_VERSION_ID < 80400 || !class_exists('Amp\Socket\UnixAddress')) {
+    throw new \LogicException('Using "Symfony\Component\HttpClient\AmpHttpClient" with amphp/http-client >= 5 requires PHP >= 8.4.');
+}
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
@@ -67,7 +70,8 @@ class AmpListenerV5 implements EventListener
 
     public function requestHeaderStart(Request $request, Stream $stream): void
     {
-        if ($stream->getRemoteAddress() instanceof UnixAddress) {
+        $unixSocketClass = 'Amp\Socket\UnixAddress';
+        if ($stream->getRemoteAddress() instanceof $unixSocketClass) {
             $host = $stream->getRemoteAddress()->toString();
         } else {
             $host = $stream->getRemoteAddress()->getAddress();

--- a/src/Symfony/Component/HttpClient/Tests/AmpHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/AmpHttpClientTest.php
@@ -11,8 +11,14 @@
 
 namespace Symfony\Component\HttpClient\Tests;
 
+use Amp\Http\Client\Connection\DefaultConnectionFactory;
+use Amp\Http\Client\Connection\UnlimitedConnectionPool;
+use Amp\Http\Client\HttpClientBuilder;
+use Amp\Socket\StaticSocketConnector;
 use Symfony\Component\HttpClient\AmpHttpClient;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+use function Amp\Socket\socketConnector;
 
 /**
  * @group dns-sensitive
@@ -22,6 +28,29 @@ class AmpHttpClientTest extends HttpClientTestCase
     protected function getHttpClient(string $testCase): HttpClientInterface
     {
         return new AmpHttpClient(['verify_peer' => false, 'verify_host' => false, 'timeout' => 5]);
+    }
+
+    public function testUnixSocket()
+    {
+        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+            $this->markTestSkipped('Unix sockets are not supported on Windows.');
+        }
+
+        $client = new AmpHttpClient(clientConfigurator: function() {
+            $connector = new StaticSocketConnector("unix:///var/run/docker.sock", socketConnector());
+
+            return (new HttpClientBuilder)
+                ->usingPool(new UnlimitedConnectionPool(new DefaultConnectionFactory($connector)))
+                ->build();
+        });
+
+        $client = $client->withOptions(['base_uri' => 'http://docker']);
+
+        $response = $client->request('GET', '/info');
+
+        $this->assertSame(200, $response->getStatusCode());
+        $content = json_decode($response->getContent(), true);
+        $this->assertNotEmpty($content['ID']);
     }
 
     public function testProxy()

--- a/src/Symfony/Component/HttpClient/Tests/AmpHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/AmpHttpClientTest.php
@@ -32,17 +32,15 @@ class AmpHttpClientTest extends HttpClientTestCase
 
     public function testUnixSocket()
     {
-        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+        if (\PHP_VERSION_ID < 80400) {
+            $this->markTestSkipped('Unix sockets only support PHP >= 8.4.');
+        }
+
+        if (strtoupper(substr(\PHP_OS, 0, 3)) === 'WIN') {
             $this->markTestSkipped('Unix sockets are not supported on Windows.');
         }
 
-        $client = new AmpHttpClient(clientConfigurator: function() {
-            $connector = new StaticSocketConnector("unix:///var/run/docker.sock", socketConnector());
-
-            return (new HttpClientBuilder)
-                ->usingPool(new UnlimitedConnectionPool(new DefaultConnectionFactory($connector)))
-                ->build();
-        });
+        $client = new AmpHttpClient(['bindto' => '/var/run/docker.sock']);
 
         $client = $client->withOptions(['base_uri' => 'http://docker']);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Allow HttpClient to interact with unix socket when using amphp/http-client v5

```php
$client = new AmpHttpClient(clientConfigurator: function() {
    $connector = new StaticSocketConnector("unix:///var/run/docker.sock", socketConnector());

    return (new HttpClientBuilder)
        ->usingPool(new UnlimitedConnectionPool(new DefaultConnectionFactory($connector)))
        ->build();
});

$client = $client->withOptions(['base_uri' => 'http://docker']);

$response = $client->request('GET', '/info');
```