### PR TITLE
[HttpClient] fix amphp http client v5 unix socket

### DIFF
--- a/src/Symfony/Component/HttpClient/Internal/AmpClientStateV5.php
+++ b/src/Symfony/Component/HttpClient/Internal/AmpClientStateV5.php
@@ -28,6 +28,7 @@ use Amp\Socket\Certificate;
 use Amp\Socket\ClientTlsContext;
 use Amp\Socket\ConnectContext;
 use Amp\Socket\DnsSocketConnector;
+use Amp\Socket\InternetAddress;
 use Amp\Socket\Socket;
 use Amp\Socket\SocketAddress;
 use Amp\Socket\SocketConnector;
@@ -160,7 +161,7 @@ final class AmpClientStateV5 extends ClientState
 
         if ($options['proxy']) {
             $proxyUrl = parse_url($options['proxy']['url']);
-            $proxySocket = new SocketAddress($proxyUrl['host'], $proxyUrl['port']);
+            $proxySocket = new InternetAddress($proxyUrl['host'], $proxyUrl['port']);
             $proxyHeaders = $options['proxy']['auth'] ? ['Proxy-Authorization' => $options['proxy']['auth']] : [];
 
             if ('ssl' === $proxyUrl['scheme']) {

--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
@@ -700,4 +700,24 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
         $this->assertSame('GET', $body['REQUEST_METHOD']);
         $this->assertSame('/', $body['REQUEST_URI']);
     }
+
+    public function testUnixSocket()
+    {
+        if (!file_exists('/var/run/docker.sock')) {
+            $this->markTestSkipped('Docker socket not found.');
+        }
+
+        $client = $this->getHttpClient(__FUNCTION__)
+            ->withOptions([
+                'base_uri' => 'http://docker',
+                'bindto' => '/run/docker.sock',
+            ]);
+
+        $response = $client->request('GET', '/info');
+
+        $this->assertSame(200, $response->getStatusCode());
+
+        $info = $response->getInfo();
+        $this->assertSame('/run/docker.sock', $info['primary_ip']);
+    }
 }

--- a/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
@@ -505,6 +505,11 @@ class MockHttpClientTest extends HttpClientTestCase
         $this->markTestSkipped('MockHttpClient doesn\'t support HTTP/2 PUSH.');
     }
 
+    public function testUnixSocket()
+    {
+        $this->markTestSkipped('MockHttpClient doesn\'t support binding to unix sockets.');
+    }
+
     public function testChangeResponseFactory()
     {
         /* @var MockHttpClient $client */

--- a/src/Symfony/Component/HttpClient/Tests/NativeHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/NativeHttpClientTest.php
@@ -48,4 +48,9 @@ class NativeHttpClientTest extends HttpClientTestCase
     {
         $this->markTestSkipped('NativeHttpClient doesn\'t support HTTP/2.');
     }
+
+    public function testUnixSocket()
+    {
+        $this->markTestSkipped('NativeHttpClient doesn\'t support binding to unix sockets.');
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Fix unix socket connection when using `amphp/http-client` v5

@nicolas-grekas 
