### PR TITLE
[Runtime] removing the warning on incorrect `PHP_SAPI` value

### DIFF
--- a/src/Symfony/Component/Runtime/SymfonyRuntime.php
+++ b/src/Symfony/Component/Runtime/SymfonyRuntime.php
@@ -160,10 +160,6 @@ class SymfonyRuntime extends GenericRuntime
         }
 
         if ($application instanceof Application) {
-            if (!\in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
-                echo 'Warning: The console should be invoked via the CLI version of PHP, not the '.\PHP_SAPI.' SAPI'.\PHP_EOL;
-            }
-
             set_time_limit(0);
             $defaultEnv = !isset($this->options['env']) ? ($_SERVER[$this->options['env_var_name']] ?? 'dev') : null;
             $output = $this->output ??= new ConsoleOutput();


### PR DESCRIPTION
As per the comments in the issue I'm proposing a change to remove the check on this specific point as it also in my opinion is not necessary.

| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58729
| License       | MIT

As per the discussion in the referenced issue, hereby a proposal to remove the warning which occurs when running the symfony application using `symfony/runtime` against a PHP_SAPI other than in the allowed list.
