### PR TITLE
[Serializer] Fix exception thrown by `YamlEncoder`

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/YamlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/YamlEncoder.php
@@ -11,8 +11,10 @@
 
 namespace Symfony\Component\Serializer\Encoder;
 
+use Symfony\Component\Serializer\Exception\NotEncodableValueException;
 use Symfony\Component\Serializer\Exception\RuntimeException;
 use Symfony\Component\Yaml\Dumper;
+use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Parser;
 use Symfony\Component\Yaml\Yaml;
 
@@ -85,7 +87,11 @@ class YamlEncoder implements EncoderInterface, DecoderInterface
     {
         $context = array_merge($this->defaultContext, $context);
 
-        return $this->parser->parse($data, $context[self::YAML_FLAGS]);
+        try {
+            return $this->parser->parse($data, $context[self::YAML_FLAGS]);
+        } catch (ParseException $e) {
+            throw new NotEncodableValueException($e->getMessage(), $e->getCode(), $e);
+        }
     }
 
     public function supportsDecoding(string $format): bool

--- a/src/Symfony/Component/Serializer/Tests/Encoder/YamlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/YamlEncoderTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Serializer\Tests\Encoder;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Encoder\YamlEncoder;
+use Symfony\Component\Serializer\Exception\NotEncodableValueException;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -80,5 +81,13 @@ END;
         $this->assertEquals('  { foo: null }', $encoder->encode(['foo' => $obj], 'yaml', [YamlEncoder::YAML_INLINE => 0, YamlEncoder::YAML_INDENT => 2, YamlEncoder::YAML_FLAGS => 0]));
         $this->assertEquals(['foo' => $obj], $encoder->decode("foo: !php/object 'O:8:\"stdClass\":1:{s:3:\"bar\";i:2;}'", 'yaml'));
         $this->assertEquals(['foo' => null], $encoder->decode("foo: !php/object 'O:8:\"stdClass\":1:{s:3:\"bar\";i:2;}'", 'yaml', [YamlEncoder::YAML_FLAGS => 0]));
+    }
+
+    public function testInvalidYaml()
+    {
+        $encoder = new YamlEncoder();
+
+        $this->expectException(NotEncodableValueException::class);
+        $encoder->decode("\t", 'yaml');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix the example given https://github.com/symfony/symfony/pull/59306#issuecomment-2564832423
| License       | MIT

DecoderInterface::decode is supposed to throw scoped exception cf https://github.com/symfony/symfony/blob/4078cb1642332cf5bbd45f5118edf766580cfb1e/src/Symfony/Component/Serializer/Encoder/DecoderInterface.php#L33-L35

but the YamlEncoder::decode could throw ParseException.
Others similar Encoder, like XmlEncoder or JsonEncoder are throwing NotEncodableValue so I did the same cf example
https://github.com/symfony/symfony/blob/da155534524f0d9c501023d10bb423fce4cd4482/src/Symfony/Component/Serializer/Encoder/JsonEncode.php#L41-L45