### PR TITLE
[Lock] Fix predis command error checking

### DIFF
--- a/src/Symfony/Component/Lock/Tests/Store/CombinedStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/CombinedStoreTest.php
@@ -39,7 +39,10 @@ class CombinedStoreTest extends AbstractStoreTestCase
 
     public function getStore(): PersistingStoreInterface
     {
-        $redis = new \Predis\Client(array_combine(['host', 'port'], explode(':', getenv('REDIS_HOST')) + [1 => 6379]));
+        $redis = new \Predis\Client(
+            array_combine(['host', 'port'], explode(':', getenv('REDIS_HOST')) + [1 => 6379]),
+            ['exceptions' => false],
+        );
 
         try {
             $redis->connect();

--- a/src/Symfony/Component/Lock/Tests/Store/PredisStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/PredisStoreTest.php
@@ -20,7 +20,10 @@ class PredisStoreTest extends AbstractRedisStoreTestCase
 {
     public static function setUpBeforeClass(): void
     {
-        $redis = new \Predis\Client(array_combine(['host', 'port'], explode(':', getenv('REDIS_HOST')) + [1 => null]));
+        $redis = new \Predis\Client(
+            array_combine(['host', 'port'], explode(':', getenv('REDIS_HOST')) + [1 => null]),
+            ['exceptions' => false],
+        );
         try {
             $redis->connect();
         } catch (\Exception $e) {
@@ -30,7 +33,10 @@ class PredisStoreTest extends AbstractRedisStoreTestCase
 
     protected function getRedisConnection(): \Predis\Client
     {
-        $redis = new \Predis\Client(array_combine(['host', 'port'], explode(':', getenv('REDIS_HOST')) + [1 => null]));
+        $redis = new \Predis\Client(
+            array_combine(['host', 'port'], explode(':', getenv('REDIS_HOST')) + [1 => null]),
+            ['exceptions' => false],
+        );
         $redis->connect();
 
         return $redis;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #59087
| License       | MIT

We seem to have had an incompatibility with how Predis clients are initialized (`'exceptions' => false`) and the implementation of RedisStore, which only surfaced now due to the recent EVAL -> EVALSHA changes.

According to https://github.com/symfony/symfony/blob/7.2/src/Symfony/Component/Cache/Traits/RedisTrait.php#L65 and 
https://github.com/symfony/symfony/blob/7.2/src/Symfony/Component/Cache/Traits/RedisTrait.php#L419 , the Predis client is always initialized with exceptions disabled; it returns Error objects instead.

This PR fixes the tests to replicate this behaviour and the implementation.

An small additional change was made regarding error checking, to ensure the initial `evalSha` does not fail with anything else besides the expected `NOSCRIPT` error.
