### PR TITLE
Use `spl_object_id()` instead of `spl_object_hash()`

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
@@ -233,10 +233,10 @@ class LoggerDataCollector extends DataCollector implements LateDataCollectorInte
             $exception = $log['context']['exception'];
 
             if ($exception instanceof SilencedErrorContext) {
-                if (isset($silencedLogs[$h = spl_object_hash($exception)])) {
+                if (isset($silencedLogs[$id = spl_object_id($exception)])) {
                     continue;
                 }
-                $silencedLogs[$h] = true;
+                $silencedLogs[$id] = true;
 
                 if (!isset($sanitizedLogs[$message])) {
                     $sanitizedLogs[$message] = $log + [
@@ -312,10 +312,10 @@ class LoggerDataCollector extends DataCollector implements LateDataCollectorInte
             if ($this->isSilencedOrDeprecationErrorLog($log)) {
                 $exception = $log['context']['exception'];
                 if ($exception instanceof SilencedErrorContext) {
-                    if (isset($silencedLogs[$h = spl_object_hash($exception)])) {
+                    if (isset($silencedLogs[$id = spl_object_id($exception)])) {
                         continue;
                     }
-                    $silencedLogs[$h] = true;
+                    $silencedLogs[$id] = true;
                     $count['scream_count'] += $exception->count;
                 } else {
                     ++$count['deprecation_count'];

--- a/src/Symfony/Component/Lock/Tests/LockTest.php
+++ b/src/Symfony/Component/Lock/Tests/LockTest.php
@@ -476,18 +476,18 @@ class LockTest extends TestCase
             public function save(Key $key): void
             {
                 $key->reduceLifetime($this->initialTtl);
-                $this->keys[spl_object_hash($key)] = $key;
+                $this->keys[spl_object_id($key)] = $key;
                 $this->checkNotExpired($key);
             }
 
             public function delete(Key $key): void
             {
-                unset($this->keys[spl_object_hash($key)]);
+                unset($this->keys[spl_object_id($key)]);
             }
 
             public function exists(Key $key): bool
             {
-                return isset($this->keys[spl_object_hash($key)]);
+                return isset($this->keys[spl_object_id($key)]);
             }
 
             public function putOffExpiration(Key $key, $ttl): void
@@ -520,18 +520,18 @@ class LockTest extends TestCase
             public function save(Key $key): void
             {
                 $key->reduceLifetime($this->initialTtl);
-                $this->keys[spl_object_hash($key)] = $key;
+                $this->keys[spl_object_id($key)] = $key;
                 $this->checkNotExpired($key);
             }
 
             public function delete(Key $key): void
             {
-                unset($this->keys[spl_object_hash($key)]);
+                unset($this->keys[spl_object_id($key)]);
             }
 
             public function exists(Key $key): bool
             {
-                return isset($this->keys[spl_object_hash($key)]);
+                return isset($this->keys[spl_object_id($key)]);
             }
 
             public function putOffExpiration(Key $key, $ttl): void

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -164,19 +164,19 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
      */
     protected function isCircularReference(object $object, array &$context): bool
     {
-        $objectHash = spl_object_hash($object);
+        $objectId = spl_object_id($object);
 
         $circularReferenceLimit = $context[self::CIRCULAR_REFERENCE_LIMIT] ?? $this->defaultContext[self::CIRCULAR_REFERENCE_LIMIT];
-        if (isset($context[self::CIRCULAR_REFERENCE_LIMIT_COUNTERS][$objectHash])) {
-            if ($context[self::CIRCULAR_REFERENCE_LIMIT_COUNTERS][$objectHash] >= $circularReferenceLimit) {
-                unset($context[self::CIRCULAR_REFERENCE_LIMIT_COUNTERS][$objectHash]);
+        if (isset($context[self::CIRCULAR_REFERENCE_LIMIT_COUNTERS][$objectId])) {
+            if ($context[self::CIRCULAR_REFERENCE_LIMIT_COUNTERS][$objectId] >= $circularReferenceLimit) {
+                unset($context[self::CIRCULAR_REFERENCE_LIMIT_COUNTERS][$objectId]);
 
                 return true;
             }
 
-            ++$context[self::CIRCULAR_REFERENCE_LIMIT_COUNTERS][$objectHash];
+            ++$context[self::CIRCULAR_REFERENCE_LIMIT_COUNTERS][$objectId];
         } else {
-            $context[self::CIRCULAR_REFERENCE_LIMIT_COUNTERS][$objectHash] = 1;
+            $context[self::CIRCULAR_REFERENCE_LIMIT_COUNTERS][$objectId] = 1;
         }
 
         return false;

--- a/src/Symfony/Component/Validator/Tests/Fixtures/FakeMetadataFactory.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/FakeMetadataFactory.php
@@ -21,10 +21,10 @@ class FakeMetadataFactory implements MetadataFactoryInterface
 
     public function getMetadataFor($class): MetadataInterface
     {
-        $hash = null;
+        $objectId = null;
 
         if (\is_object($class)) {
-            $hash = spl_object_hash($class);
+            $objectId = spl_object_id($class);
             $class = $class::class;
         }
 
@@ -33,8 +33,8 @@ class FakeMetadataFactory implements MetadataFactoryInterface
         }
 
         if (!isset($this->metadatas[$class])) {
-            if (isset($this->metadatas[$hash])) {
-                return $this->metadatas[$hash];
+            if (isset($this->metadatas[$objectId])) {
+                return $this->metadatas[$objectId];
             }
 
             throw new NoSuchMetadataException(sprintf('No metadata for "%s"', $class));
@@ -45,10 +45,10 @@ class FakeMetadataFactory implements MetadataFactoryInterface
 
     public function hasMetadataFor($class): bool
     {
-        $hash = null;
+        $objectId = null;
 
         if (\is_object($class)) {
-            $hash = spl_object_hash($class);
+            $objectId = spl_object_id($class);
             $class = $class::class;
         }
 
@@ -56,7 +56,7 @@ class FakeMetadataFactory implements MetadataFactoryInterface
             return false;
         }
 
-        return isset($this->metadatas[$class]) || isset($this->metadatas[$hash]);
+        return isset($this->metadatas[$class]) || isset($this->metadatas[$objectId]);
     }
 
     public function addMetadata($metadata)
@@ -66,7 +66,7 @@ class FakeMetadataFactory implements MetadataFactoryInterface
 
     public function addMetadataForValue($value, MetadataInterface $metadata)
     {
-        $key = \is_object($value) ? spl_object_hash($value) : $value;
+        $key = \is_object($value) ? spl_object_id($value) : $value;
         $this->metadatas[$key] = $metadata;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Small performance tweak.