### PR TITLE
[HttpKernel] Don't override existing `LoggerInterface` autowiring alias in `LoggerPass`

### DIFF
--- a/src/Symfony/Component/HttpKernel/DependencyInjection/LoggerPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/LoggerPass.php
@@ -30,7 +30,9 @@ class LoggerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        $container->setAlias(LoggerInterface::class, 'logger');
+        if (!$container->has(LoggerInterface::class)) {
+            $container->setAlias(LoggerInterface::class, 'logger');
+        }
 
         if ($container->has('logger')) {
             return;

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/LoggerPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/LoggerPassTest.php
@@ -53,4 +53,15 @@ class LoggerPassTest extends TestCase
         $this->assertSame(Logger::class, $definition->getClass());
         $this->assertFalse($definition->isPublic());
     }
+
+    public function testAutowiringAliasIsPreserved()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.debug', false);
+        $container->setAlias(LoggerInterface::class, 'my_logger');
+
+        (new LoggerPass())->process($container);
+
+        $this->assertSame('my_logger', (string) $container->getAlias(LoggerInterface::class));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Something we missed in #24300

Explicit configuration should always have highest precedence, yet LoggerPass ignores the existing autowiring alias at the moment.