### PR TITLE
[Messenger] Implement `KeepaliveReceiverInterface` in Redis bridge

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Redis/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.3
+---
+
+ * Implement the `KeepaliveReceiverInterface` to enable asynchronously notifying Redis that the job is still being processed, in order to avoid timeouts
+
 6.3
 ---
 

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisReceiverTest.php
@@ -16,7 +16,9 @@ use Symfony\Component\Messenger\Bridge\Redis\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Bridge\Redis\Tests\Fixtures\ExternalMessage;
 use Symfony\Component\Messenger\Bridge\Redis\Tests\Fixtures\ExternalMessageSerializer;
 use Symfony\Component\Messenger\Bridge\Redis\Transport\Connection;
+use Symfony\Component\Messenger\Bridge\Redis\Transport\RedisReceivedStamp;
 use Symfony\Component\Messenger\Bridge\Redis\Transport\RedisReceiver;
+use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 use Symfony\Component\Messenger\Transport\Serialization\Serializer;
@@ -125,5 +127,16 @@ class RedisReceiverTest extends TestCase
                 ],
             ],
         ];
+    }
+
+    public function testKeepalive()
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())->method('keepalive')->with('redisid-123');
+
+        $receiver = new RedisReceiver($connection, new Serializer(
+            new SerializerComponent\Serializer([new ObjectNormalizer()], ['json' => new JsonEncoder()])
+        ));
+        $receiver->keepalive(new Envelope(new DummyMessage('foo'), [new RedisReceivedStamp('redisid-123')]));
     }
 }

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisTransportTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisTransportTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Messenger\Bridge\Redis\Tests\Transport;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Bridge\Redis\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Bridge\Redis\Transport\Connection;
+use Symfony\Component\Messenger\Bridge\Redis\Transport\RedisReceivedStamp;
 use Symfony\Component\Messenger\Bridge\Redis\Transport\RedisTransport;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
@@ -52,6 +53,18 @@ class RedisTransportTest extends TestCase
 
         $envelopes = $transport->get();
         $this->assertSame($decodedMessage, $envelopes[0]->getMessage());
+    }
+
+    public function testKeepalive()
+    {
+        $transport = $this->getTransport(
+            null,
+            $connection = $this->createMock(Connection::class),
+        );
+
+        $connection->expects($this->once())->method('keepalive')->with('redisid-123');
+
+        $transport->keepalive(new Envelope(new DummyMessage('foo'), [new RedisReceivedStamp('redisid-123')]));
     }
 
     private function getTransport(?SerializerInterface $serializer = null, ?Connection $connection = null): RedisTransport

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisReceiver.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisReceiver.php
@@ -15,8 +15,8 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\LogicException;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
 use Symfony\Component\Messenger\Exception\TransportException;
+use Symfony\Component\Messenger\Transport\Receiver\KeepaliveReceiverInterface;
 use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
-use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
@@ -24,7 +24,7 @@ use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
  * @author Alexander Schranz <alexander@sulu.io>
  * @author Antoine Bluchet <soyuka@gmail.com>
  */
-class RedisReceiver implements ReceiverInterface, MessageCountAwareInterface
+class RedisReceiver implements KeepaliveReceiverInterface, MessageCountAwareInterface
 {
     private SerializerInterface $serializer;
 
@@ -87,6 +87,11 @@ class RedisReceiver implements ReceiverInterface, MessageCountAwareInterface
     public function reject(Envelope $envelope): void
     {
         $this->connection->reject($this->findRedisReceivedStamp($envelope)->getId());
+    }
+
+    public function keepalive(Envelope $envelope, ?int $seconds = null): void
+    {
+        $this->connection->keepalive($this->findRedisReceivedStamp($envelope)->getId(), $seconds);
     }
 
     public function getMessageCount(): int

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisTransport.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisTransport.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Messenger\Bridge\Redis\Transport;
 
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Transport\Receiver\KeepaliveReceiverInterface;
 use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
@@ -22,7 +23,7 @@ use Symfony\Component\Messenger\Transport\TransportInterface;
  * @author Alexander Schranz <alexander@sulu.io>
  * @author Antoine Bluchet <soyuka@gmail.com>
  */
-class RedisTransport implements TransportInterface, SetupableTransportInterface, MessageCountAwareInterface
+class RedisTransport implements TransportInterface, KeepaliveReceiverInterface, SetupableTransportInterface, MessageCountAwareInterface
 {
     private SerializerInterface $serializer;
     private RedisReceiver $receiver;
@@ -48,6 +49,11 @@ class RedisTransport implements TransportInterface, SetupableTransportInterface,
     public function reject(Envelope $envelope): void
     {
         $this->getReceiver()->reject($envelope);
+    }
+
+    public function keepalive(Envelope $envelope, ?int $seconds = null): void
+    {
+        $this->getReceiver()->keepalive($envelope, $seconds);
     }
 
     public function send(Envelope $envelope): Envelope

--- a/src/Symfony/Component/Messenger/Bridge/Redis/composer.json
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.2",
         "ext-redis": "*",
-        "symfony/messenger": "^6.4|^7.0"
+        "symfony/messenger": "^7.2"
     },
     "require-dev": {
         "symfony/property-access": "^6.4|^7.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Implements the `KeepaliveReceiverInterface` in the Redis bridge.