### PR TITLE
[Doctrine][Messenger] Prevents multiple TransportMessageIdStamp being stored in envelope

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineReceiver.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineReceiver.php
@@ -141,10 +141,12 @@ class DoctrineReceiver implements ListableReceiverInterface, MessageCountAwareIn
             throw $exception;
         }
 
-        return $envelope->with(
-            new DoctrineReceivedStamp($data['id']),
-            new TransportMessageIdStamp($data['id'])
-        );
+        return $envelope
+            ->withoutAll(TransportMessageIdStamp::class)
+            ->with(
+                new DoctrineReceivedStamp($data['id']),
+                new TransportMessageIdStamp($data['id'])
+            );
     }
 
     private function withRetryableExceptionRetry(callable $callable): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #49637
| License       | MIT

- Multiple TransportMessageIdStamps can heavily increase message size on multiple retries, to prevent that when message is fetched existing TransportMessageIdStamps are discarded before new one is added.
- Replaces static calls to \PHPUnit\Framework\TestCase::expectException in DoctrineReceiverTest test with instance calls.
