### PR TITLE
[PropertyInfo] Make sure that SerializerExtractor returns null for invalid class metadata

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/SerializerExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/SerializerExtractor.php
@@ -34,7 +34,7 @@ class SerializerExtractor implements PropertyListExtractorInterface
             return null;
         }
 
-        if (!$this->classMetadataFactory->getMetadataFor($class)) {
+        if (!$this->classMetadataFactory->hasMetadataFor($class)) {
             return null;
         }
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/SerializerExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/SerializerExtractorTest.php
@@ -55,4 +55,9 @@ class SerializerExtractorTest extends TestCase
     {
         $this->assertSame(['analyses', 'feet'], $this->extractor->getProperties(AdderRemoverDummy::class, ['serializer_groups' => null]));
     }
+
+    public function testGetPropertiesWithNonExistentClassReturnsNull()
+    {
+        $this->assertSame(null, $this->extractor->getProperties('NonExistent'));
+    }
 }


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT

When we try to call `getProperties` with a classname that doesn't exist, the classMetadataFactory will break.
In this case, this method should return `null` in order to fallback to other instances of `PropertyListExtractorInterface` in case we're accessing this `getProperties` method with `\Symfony\Component\PropertyInfo\PropertyInfoExtractor`.
