### PR TITLE
[TypeInfo] Add `TypeFactoryTrait::fromValue` method

### DIFF
--- a/src/Symfony/Component/TypeInfo/CHANGELOG.md
+++ b/src/Symfony/Component/TypeInfo/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `Type::accepts()` method
+ * Add `TypeFactoryTrait::fromValue()` method
 
 7.2
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

Add `TypeFactoryTrait::fromValue` method that will create a `Type` instance from a given value as precisely as possible.