### PR TITLE
[HttpClient] Allow using HTTP/3 with the `CurlHttpClient`

### DIFF
--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add IPv6 support to `NativeHttpClient`
+ * Allow using HTTP/3 with the `CurlHttpClient`
 
 7.2
 ---

--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -143,6 +143,8 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
             $curlopts[\CURLOPT_HTTP_VERSION] = \CURL_HTTP_VERSION_1_1;
         } elseif (\defined('CURL_VERSION_HTTP2') && (\CURL_VERSION_HTTP2 & CurlClientState::$curlVersion['features']) && ('https:' === $scheme || 2.0 === (float) $options['http_version'])) {
             $curlopts[\CURLOPT_HTTP_VERSION] = \CURL_HTTP_VERSION_2_0;
+        } elseif (\defined('CURL_VERSION_HTTP3') && (\CURL_VERSION_HTTP3 & CurlClientState::$curlVersion['features']) && 3.0 === (float) $options['http_version']) {
+            $curlopts[\CURLOPT_HTTP_VERSION] = \CURL_HTTP_VERSION_3;
         }
 
         if (isset($options['auth_ntlm'])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #58331
| License       | MIT

Now that PHP 8.4 is out, one can configure curl to use `CURL_HTTP_VERSION_3` (https://github.com/php/php-src/pull/15350).

Since curl HTTP/3 support is still experimental the `http_version` will have to be set to `3` to use this functionality, mimicking [the CLI `--http3` flag](https://curl.se/docs/http3.html#--http3) (meaning curl can fallback to HTTP/2 or HTTP/1.1).