### PR TITLE
[HttpFoundation] Define PHPDoc type for `Response::$statusTexts`

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -121,6 +121,8 @@ class Response
      * (last updated 2021-10-01).
      *
      * Unless otherwise noted, the status code is defined in RFC2616.
+     *
+     * @var array<int, string>
      */
     public static array $statusTexts = [
         100 => 'Continue',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  |no
| Deprecations? | no
| Issues        | none
| License       | MIT

As `Symfony\Component\HttpFoundation\Response::$statusTexts` is public, it can be used by every projects. Some of them can use strict type analysis like PSALM or PHPStan...

It is always useful, and for some of them mandatory to have a proper array typing to use this variable.
