### PR TITLE
[RemoteEvent][Webhook] Fix `SendgridRequestParser` and `SendgridPayloadConverter`

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/RemoteEvent/SendgridPayloadConverter.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/RemoteEvent/SendgridPayloadConverter.php
@@ -31,7 +31,7 @@ final class SendgridPayloadConverter implements PayloadConverterInterface
                 'deferred' => MailerDeliveryEvent::DEFERRED,
                 'bounce' => MailerDeliveryEvent::BOUNCE,
             };
-            $event = new MailerDeliveryEvent($name, $payload['sg_message_id'], $payload);
+            $event = new MailerDeliveryEvent($name, $payload['sg_message_id'] ?? $payload['sg_event_id'], $payload);
             $event->setReason($payload['reason'] ?? '');
         } else {
             $name = match ($payload['event']) {
@@ -41,7 +41,7 @@ final class SendgridPayloadConverter implements PayloadConverterInterface
                 'spamreport' => MailerEngagementEvent::SPAM,
                 default => throw new ParseException(sprintf('Unsupported event "%s".', $payload['event'])),
             };
-            $event = new MailerEngagementEvent($name, $payload['sg_message_id'], $payload);
+            $event = new MailerEngagementEvent($name, $payload['sg_message_id'] ?? $payload['sg_event_id'], $payload);
         }
 
         if (!$date = \DateTimeImmutable::createFromFormat('U', $payload['timestamp'])) {

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/RemoteEvent/SendgridPayloadConverterTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/RemoteEvent/SendgridPayloadConverterTest.php
@@ -97,4 +97,19 @@ class SendgridPayloadConverterTest extends TestCase
             'email' => 'test@example.com',
         ]);
     }
+
+    public function testAsynchronousBounce()
+    {
+        $converter = new SendgridPayloadConverter();
+
+        $event = $converter->convert([
+            'event' => 'bounce',
+            'sg_event_id' => '123456',
+            'timestamp' => '123456789',
+            'email' => 'test@example.com',
+        ]);
+
+        $this->assertInstanceOf(MailerDeliveryEvent::class, $event);
+        $this->assertSame('123456', $event->getId());
+    }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Webhook/SendgridRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Webhook/SendgridRequestParser.php
@@ -48,7 +48,7 @@ final class SendgridRequestParser extends AbstractRequestParser
             !isset($content[0]['email'])
             || !isset($content[0]['timestamp'])
             || !isset($content[0]['event'])
-            || !isset($content[0]['sg_message_id'])
+            || !isset($content[0]['sg_event_id'])
         ) {
             throw new RejectWebhookException(406, 'Payload is malformed.');
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

According to https://www.twilio.com/docs/sendgrid/for-developers/tracking-events/event#event-objects, not all webhook events contains a `sg_message_id` in the payload. In the case of a delayed or [asynchronous bounce](https://www.twilio.com/docs/sendgrid/ui/sending-email/bounces#asynchronous-bounces), the message ID will be unavailable.

The current implementation rejects the webhook call with "Payload is malformed".
We should use the always present `sg_event_id` instead.

For BC reasons, I did not want to change the id of the RemoteEvent, so I kept `sg_message_id` if present, but fallback to `sg_event_id` instead so that the webhook is not rejected.
