### PR TITLE
[Yaml] fix inline notation with inline comment

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -1206,7 +1206,7 @@ class Parser
                         $value .= $this->currentLine[$cursor];
                         ++$cursor;
 
-                        if ($consumeUntilEol && isset($this->currentLine[$cursor]) && (strspn($this->currentLine, ' ', $cursor) + $cursor) < strlen($this->currentLine)) {
+                        if ($consumeUntilEol && isset($this->currentLine[$cursor]) && ($whitespaces = strspn($this->currentLine, ' ', $cursor) + $cursor) < strlen($this->currentLine) && '#' !== $this->currentLine[$whitespaces]) {
                             throw new ParseException(sprintf('Unexpected token "%s".', trim(substr($this->currentLine, $cursor))));
                         }
 

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -2162,6 +2162,19 @@ map: {key: "value", a: "b"}
 param: "some"
 YAML
             ],
+            'mixed mapping with inline notation on one line with a comment' => [
+                [
+                    'map' => [
+                        'key' => 'value',
+                        'a' => 'b',
+                    ],
+                    'param' => 'some',
+                ],
+                <<<YAML
+map: {key: "value", a: "b"} # comment
+param: "some"
+YAML
+            ],
             'mixed mapping with compact inline notation on one line' => [
                 [
                     'map' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59378 
| License       | MIT

Recent commit broke parsing yam like:
```yaml
calls:
  # This is a temporary measure. JSON:API should not need to be aware of the Content Moderation module.
  - [setLatestRevisionCheck, ['@?access_check.latest_revision']] # This is only injected when the service is available.
```

This MR adds a test and fixes this.