### PR TITLE
[PhpUnitBridge] Enable configuring mock namespaces with attributes

### DIFF
--- a/.github/workflows/phpunit-bridge.yml
+++ b/.github/workflows/phpunit-bridge.yml
@@ -35,4 +35,4 @@ jobs:
           php-version: "7.2"
 
       - name: Lint
-        run: find ./src/Symfony/Bridge/PhpUnit -name '*.php' | grep -v -e /Tests/ -e ForV7 -e ForV8 -e ForV9 -e ConstraintLogicTrait | parallel -j 4 php -l {}
+        run: find ./src/Symfony/Bridge/PhpUnit -name '*.php' | grep -v -e /Tests/ -e /Attribute/ -e /Extension/ -e /Metadata/ -e ForV7 -e ForV8 -e ForV9 -e ConstraintLogicTrait | parallel -j 4 php -l {}

--- a/src/Symfony/Bridge/PhpUnit/Attribute/DnsSensitive.php
+++ b/src/Symfony/Bridge/PhpUnit/Attribute/DnsSensitive.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+final class DnsSensitive
+{
+    public function __construct(
+        public readonly ?string $class = null,
+    ) {
+    }
+}

--- a/src/Symfony/Bridge/PhpUnit/Attribute/TimeSensitive.php
+++ b/src/Symfony/Bridge/PhpUnit/Attribute/TimeSensitive.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+final class TimeSensitive
+{
+    public function __construct(
+        public readonly ?string $class = null,
+    ) {
+    }
+}

--- a/src/Symfony/Bridge/PhpUnit/CHANGELOG.md
+++ b/src/Symfony/Bridge/PhpUnit/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.3
+---
+
+ * Enable configuring clock and DNS mock namespaces with attributes
+
 7.2
 ---
 

--- a/src/Symfony/Bridge/PhpUnit/Extension/DisableClockMockSubscriber.php
+++ b/src/Symfony/Bridge/PhpUnit/Extension/DisableClockMockSubscriber.php
@@ -15,13 +15,20 @@ use PHPUnit\Event\Code\TestMethod;
 use PHPUnit\Event\Test\Finished;
 use PHPUnit\Event\Test\FinishedSubscriber;
 use PHPUnit\Metadata\Group;
+use Symfony\Bridge\PhpUnit\Attribute\TimeSensitive;
 use Symfony\Bridge\PhpUnit\ClockMock;
+use Symfony\Bridge\PhpUnit\Metadata\AttributeReader;
 
 /**
  * @internal
  */
 class DisableClockMockSubscriber implements FinishedSubscriber
 {
+    public function __construct(
+        private AttributeReader $reader,
+    ) {
+    }
+
     public function notify(Finished $event): void
     {
         $test = $event->test();
@@ -33,7 +40,12 @@ class DisableClockMockSubscriber implements FinishedSubscriber
         foreach ($test->metadata() as $metadata) {
             if ($metadata instanceof Group && 'time-sensitive' === $metadata->groupName()) {
                 ClockMock::withClockMock(false);
+                break;
             }
+        }
+
+        if ($this->reader->forClassAndMethod($test->className(), $test->methodName(), TimeSensitive::class)) {
+            ClockMock::withClockMock(false);
         }
     }
 }

--- a/src/Symfony/Bridge/PhpUnit/Extension/RegisterDnsMockSubscriber.php
+++ b/src/Symfony/Bridge/PhpUnit/Extension/RegisterDnsMockSubscriber.php
@@ -15,13 +15,20 @@ use PHPUnit\Event\Code\TestMethod;
 use PHPUnit\Event\TestSuite\Loaded;
 use PHPUnit\Event\TestSuite\LoadedSubscriber;
 use PHPUnit\Metadata\Group;
+use Symfony\Bridge\PhpUnit\Attribute\DnsSensitive;
 use Symfony\Bridge\PhpUnit\DnsMock;
+use Symfony\Bridge\PhpUnit\Metadata\AttributeReader;
 
 /**
  * @internal
  */
 class RegisterDnsMockSubscriber implements LoadedSubscriber
 {
+    public function __construct(
+        private AttributeReader $reader,
+    ) {
+    }
+
     public function notify(Loaded $event): void
     {
         foreach ($event->testSuite()->tests() as $test) {
@@ -33,6 +40,10 @@ class RegisterDnsMockSubscriber implements LoadedSubscriber
                 if ($metadata instanceof Group && 'dns-sensitive' === $metadata->groupName()) {
                     DnsMock::register($test->className());
                 }
+            }
+
+            foreach ($this->reader->forClassAndMethod($test->className(), $test->methodName(), DnsSensitive::class) as $attribute) {
+                DnsMock::register($attribute->class ?? $test->className());
             }
         }
     }

--- a/src/Symfony/Bridge/PhpUnit/Metadata/AttributeReader.php
+++ b/src/Symfony/Bridge/PhpUnit/Metadata/AttributeReader.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Metadata;
+
+/**
+ * @template T of object
+ */
+final class AttributeReader
+{
+    /**
+     * @var array<string, array<class-string<T>, list<T>>>
+     */
+    private array $cache = [];
+
+    /**
+     * @param class-string    $className
+     * @param class-string<T> $name
+     *
+     * @return list<T>
+     */
+    public function forClass(string $className, string $name): array
+    {
+        $attributes = $this->cache[$className] ??= $this->readAttributes(new \ReflectionClass($className));
+
+        return $attributes[$name] ?? [];
+    }
+
+    /**
+     * @param class-string    $className
+     * @param class-string<T> $name
+     *
+     * @return list<T>
+     */
+    public function forMethod(string $className, string $methodName, string $name): array
+    {
+        $attributes = $this->cache[$className.'::'.$methodName] ??= $this->readAttributes(new \ReflectionMethod($className, $methodName));
+
+        return $attributes[$name] ?? [];
+    }
+
+    /**
+     * @param class-string    $className
+     * @param class-string<T> $name
+     *
+     * @return list<T>
+     */
+    public function forClassAndMethod(string $className, string $methodName, string $name): array
+    {
+        return [
+            ...$this->forClass($className, $name),
+            ...$this->forMethod($className, $methodName, $name),
+        ];
+    }
+
+    private function readAttributes(\ReflectionClass|\ReflectionMethod $reflection): array
+    {
+        $attributeInstances = [];
+
+        foreach ($reflection->getAttributes() as $attribute) {
+            if (!str_starts_with($name = $attribute->getName(), 'Symfony\\Bridge\\PhpUnit\\Attribute\\')) {
+                continue;
+            }
+
+            $attributeInstances[$name][] = $attribute->newInstance();
+        }
+
+        return $attributeInstances;
+    }
+}

--- a/src/Symfony/Bridge/PhpUnit/SymfonyExtension.php
+++ b/src/Symfony/Bridge/PhpUnit/SymfonyExtension.php
@@ -20,6 +20,7 @@ use Symfony\Bridge\PhpUnit\Extension\DisableDnsMockSubscriber;
 use Symfony\Bridge\PhpUnit\Extension\EnableClockMockSubscriber;
 use Symfony\Bridge\PhpUnit\Extension\RegisterClockMockSubscriber;
 use Symfony\Bridge\PhpUnit\Extension\RegisterDnsMockSubscriber;
+use Symfony\Bridge\PhpUnit\Metadata\AttributeReader;
 use Symfony\Component\ErrorHandler\DebugClassLoader;
 
 class SymfonyExtension implements Extension
@@ -30,15 +31,17 @@ class SymfonyExtension implements Extension
             DebugClassLoader::enable();
         }
 
+        $reader = new AttributeReader();
+
         if ($parameters->has('clock-mock-namespaces')) {
             foreach (explode(',', $parameters->get('clock-mock-namespaces')) as $namespace) {
                 ClockMock::register($namespace.'\DummyClass');
             }
         }
 
-        $facade->registerSubscriber(new RegisterClockMockSubscriber());
-        $facade->registerSubscriber(new EnableClockMockSubscriber());
-        $facade->registerSubscriber(new DisableClockMockSubscriber());
+        $facade->registerSubscriber(new RegisterClockMockSubscriber($reader));
+        $facade->registerSubscriber(new EnableClockMockSubscriber($reader));
+        $facade->registerSubscriber(new DisableClockMockSubscriber($reader));
 
         if ($parameters->has('dns-mock-namespaces')) {
             foreach (explode(',', $parameters->get('dns-mock-namespaces')) as $namespace) {
@@ -46,7 +49,7 @@ class SymfonyExtension implements Extension
             }
         }
 
-        $facade->registerSubscriber(new RegisterDnsMockSubscriber());
-        $facade->registerSubscriber(new DisableDnsMockSubscriber());
+        $facade->registerSubscriber(new RegisterDnsMockSubscriber($reader));
+        $facade->registerSubscriber(new DisableDnsMockSubscriber($reader));
     }
 }

--- a/src/Symfony/Bridge/PhpUnit/Tests/Fixtures/symfonyextension/tests/bootstrap.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/Fixtures/symfonyextension/tests/bootstrap.php
@@ -21,11 +21,14 @@ spl_autoload_register(function ($class) {
 });
 
 require __DIR__.'/../../../../SymfonyExtension.php';
+require __DIR__.'/../../../../Attribute/DnsSensitive.php';
+require __DIR__.'/../../../../Attribute/TimeSensitive.php';
 require __DIR__.'/../../../../Extension/DisableClockMockSubscriber.php';
 require __DIR__.'/../../../../Extension/DisableDnsMockSubscriber.php';
 require __DIR__.'/../../../../Extension/EnableClockMockSubscriber.php';
 require __DIR__.'/../../../../Extension/RegisterClockMockSubscriber.php';
 require __DIR__.'/../../../../Extension/RegisterDnsMockSubscriber.php';
+require __DIR__.'/../../../../Metadata/AttributeReader.php';
 
 if (file_exists(__DIR__.'/../../../../vendor/autoload.php')) {
     require __DIR__.'/../../../../vendor/autoload.php';

--- a/src/Symfony/Bridge/PhpUnit/Tests/Metadata/AttributeReaderTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/Metadata/AttributeReaderTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Tests\Metadata;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\Attribute\DnsSensitive;
+use Symfony\Bridge\PhpUnit\Attribute\TimeSensitive;
+use Symfony\Bridge\PhpUnit\Metadata\AttributeReader;
+use Symfony\Bridge\PhpUnit\Tests\Metadata\Fixtures\FooBar;
+
+/**
+ * @requires PHP 8.0
+ */
+final class AttributeReaderTest extends TestCase
+{
+    /**
+     * @dataProvider provideReadCases
+     */
+    public function testAttributesAreRead(string $method, string $attributeClass, array $expected)
+    {
+        $reader = new AttributeReader();
+
+        $attributes = $reader->forClassAndMethod(FooBar::class, $method, $attributeClass);
+
+        self::assertContainsOnlyInstancesOf($attributeClass, $attributes);
+        self::assertSame($expected, array_column($attributes, 'class'));
+    }
+
+    public static function provideReadCases(): iterable
+    {
+        yield ['testOne', DnsSensitive::class, [
+            'App\Foo\Bar\A',
+            'App\Foo\Bar\B',
+            'App\Foo\Baz\C',
+        ]];
+        yield ['testTwo', DnsSensitive::class, [
+            'App\Foo\Bar\A',
+            'App\Foo\Bar\B',
+        ]];
+        yield ['testThree', DnsSensitive::class, [
+            'App\Foo\Bar\A',
+            'App\Foo\Bar\B',
+            'App\Foo\Corge\F',
+        ]];
+
+        yield ['testOne', TimeSensitive::class, [
+            'App\Foo\Bar\A',
+        ]];
+        yield ['testTwo', TimeSensitive::class, [
+            'App\Foo\Bar\A',
+            'App\Foo\Qux\D',
+            'App\Foo\Qux\E',
+        ]];
+        yield ['testThree', TimeSensitive::class, [
+            'App\Foo\Bar\A',
+            'App\Foo\Corge\G',
+        ]];
+    }
+
+    public function testAttributesAreCached()
+    {
+        $reader = new AttributeReader();
+        $cacheRef = new \ReflectionProperty(AttributeReader::class, 'cache');
+
+        self::assertEmpty($cacheRef->getValue($reader));
+
+        $reader->forClass(FooBar::class, TimeSensitive::class);
+
+        self::assertCount(1, $cache = $cacheRef->getValue($reader));
+        self::assertArrayHasKey(FooBar::class, $cache);
+        self::assertAttributesCount($cache[FooBar::class], 2, 1);
+
+        $reader->forMethod(FooBar::class, 'testThree', DnsSensitive::class);
+
+        self::assertCount(2, $cache = $cacheRef->getValue($reader));
+        self::assertArrayHasKey($key = FooBar::class.'::testThree', $cache);
+        self::assertAttributesCount($cache[$key], 1, 1);
+    }
+
+    private static function assertAttributesCount(array $attributes, int $expectedDnsCount, int $expectedTimeCount): void
+    {
+        self::assertArrayHasKey(DnsSensitive::class, $attributes);
+        self::assertCount($expectedDnsCount, $attributes[DnsSensitive::class]);
+        self::assertArrayHasKey(TimeSensitive::class, $attributes);
+        self::assertCount($expectedTimeCount, $attributes[TimeSensitive::class]);
+    }
+}

--- a/src/Symfony/Bridge/PhpUnit/Tests/Metadata/Fixtures/FooBar.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/Metadata/Fixtures/FooBar.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Tests\Metadata\Fixtures;
+
+use Symfony\Bridge\PhpUnit\Attribute\DnsSensitive;
+use Symfony\Bridge\PhpUnit\Attribute\TimeSensitive;
+
+#[DnsSensitive('App\Foo\Bar\A')]
+#[DnsSensitive('App\Foo\Bar\B')]
+#[TimeSensitive('App\Foo\Bar\A')]
+final class FooBar
+{
+    #[DnsSensitive('App\Foo\Baz\C')]
+    public function testOne()
+    {
+    }
+
+    #[TimeSensitive('App\Foo\Qux\D')]
+    #[TimeSensitive('App\Foo\Qux\E')]
+    public function testTwo()
+    {
+    }
+
+    #[DnsSensitive('App\Foo\Corge\F')]
+    #[TimeSensitive('App\Foo\Corge\G')]
+    public function testThree()
+    {
+    }
+}

--- a/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php
@@ -14,9 +14,13 @@ namespace Symfony\Bridge\PhpUnit\Tests;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\Attribute\DnsSensitive;
+use Symfony\Bridge\PhpUnit\Attribute\TimeSensitive;
 use Symfony\Bridge\PhpUnit\Tests\Fixtures\symfonyextension\src\ClassExtendingFinalClass;
 use Symfony\Bridge\PhpUnit\Tests\Fixtures\symfonyextension\src\FinalClass;
 
+#[DnsSensitive('App\Foo\A')]
+#[TimeSensitive('App\Foo\A')]
 class SymfonyExtension extends TestCase
 {
     public function testExtensionOfFinalClass()
@@ -28,6 +32,7 @@ class SymfonyExtension extends TestCase
 
     #[DataProvider('mockedNamespaces')]
     #[Group('time-sensitive')]
+    #[TimeSensitive('App\Bar\B')]
     public function testTimeMockIsRegistered(string $namespace)
     {
         $this->assertTrue(\function_exists(\sprintf('%s\time', $namespace)));
@@ -35,6 +40,7 @@ class SymfonyExtension extends TestCase
 
     #[DataProvider('mockedNamespaces')]
     #[Group('time-sensitive')]
+    #[TimeSensitive('App\Bar\B')]
     public function testMicrotimeMockIsRegistered(string $namespace)
     {
         $this->assertTrue(\function_exists(\sprintf('%s\microtime', $namespace)));
@@ -42,6 +48,7 @@ class SymfonyExtension extends TestCase
 
     #[DataProvider('mockedNamespaces')]
     #[Group('time-sensitive')]
+    #[TimeSensitive('App\Bar\B')]
     public function testSleepMockIsRegistered(string $namespace)
     {
         $this->assertTrue(\function_exists(\sprintf('%s\sleep', $namespace)));
@@ -49,6 +56,7 @@ class SymfonyExtension extends TestCase
 
     #[DataProvider('mockedNamespaces')]
     #[Group('time-sensitive')]
+    #[TimeSensitive('App\Bar\B')]
     public function testUsleepMockIsRegistered(string $namespace)
     {
         $this->assertTrue(\function_exists(\sprintf('%s\usleep', $namespace)));
@@ -56,6 +64,7 @@ class SymfonyExtension extends TestCase
 
     #[DataProvider('mockedNamespaces')]
     #[Group('time-sensitive')]
+    #[TimeSensitive('App\Bar\B')]
     public function testDateMockIsRegistered(string $namespace)
     {
         $this->assertTrue(\function_exists(\sprintf('%s\date', $namespace)));
@@ -63,6 +72,7 @@ class SymfonyExtension extends TestCase
 
     #[DataProvider('mockedNamespaces')]
     #[Group('time-sensitive')]
+    #[TimeSensitive('App\Bar\B')]
     public function testGmdateMockIsRegistered(string $namespace)
     {
         $this->assertTrue(\function_exists(\sprintf('%s\gmdate', $namespace)));
@@ -70,6 +80,7 @@ class SymfonyExtension extends TestCase
 
     #[DataProvider('mockedNamespaces')]
     #[Group('time-sensitive')]
+    #[TimeSensitive('App\Bar\B')]
     public function testHrtimeMockIsRegistered(string $namespace)
     {
         $this->assertTrue(\function_exists(\sprintf('%s\hrtime', $namespace)));
@@ -77,6 +88,7 @@ class SymfonyExtension extends TestCase
 
     #[DataProvider('mockedNamespaces')]
     #[Group('dns-sensitive')]
+    #[DnsSensitive('App\Bar\B')]
     public function testCheckdnsrrMockIsRegistered(string $namespace)
     {
         $this->assertTrue(\function_exists(\sprintf('%s\checkdnsrr', $namespace)));
@@ -84,6 +96,7 @@ class SymfonyExtension extends TestCase
 
     #[DataProvider('mockedNamespaces')]
     #[Group('dns-sensitive')]
+    #[DnsSensitive('App\Bar\B')]
     public function testDnsCheckRecordMockIsRegistered(string $namespace)
     {
         $this->assertTrue(\function_exists(\sprintf('%s\dns_check_record', $namespace)));
@@ -91,6 +104,7 @@ class SymfonyExtension extends TestCase
 
     #[DataProvider('mockedNamespaces')]
     #[Group('dns-sensitive')]
+    #[DnsSensitive('App\Bar\B')]
     public function testGetmxrrMockIsRegistered(string $namespace)
     {
         $this->assertTrue(\function_exists(\sprintf('%s\getmxrr', $namespace)));
@@ -98,6 +112,7 @@ class SymfonyExtension extends TestCase
 
     #[DataProvider('mockedNamespaces')]
     #[Group('dns-sensitive')]
+    #[DnsSensitive('App\Bar\B')]
     public function testDnsGetMxMockIsRegistered(string $namespace)
     {
         $this->assertTrue(\function_exists(\sprintf('%s\dns_get_mx', $namespace)));
@@ -105,6 +120,7 @@ class SymfonyExtension extends TestCase
 
     #[DataProvider('mockedNamespaces')]
     #[Group('dns-sensitive')]
+    #[DnsSensitive('App\Bar\B')]
     public function testGethostbyaddrMockIsRegistered(string $namespace)
     {
         $this->assertTrue(\function_exists(\sprintf('%s\gethostbyaddr', $namespace)));
@@ -112,6 +128,7 @@ class SymfonyExtension extends TestCase
 
     #[DataProvider('mockedNamespaces')]
     #[Group('dns-sensitive')]
+    #[DnsSensitive('App\Bar\B')]
     public function testGethostbynameMockIsRegistered(string $namespace)
     {
         $this->assertTrue(\function_exists(\sprintf('%s\gethostbyname', $namespace)));
@@ -119,6 +136,7 @@ class SymfonyExtension extends TestCase
 
     #[DataProvider('mockedNamespaces')]
     #[Group('dns-sensitive')]
+    #[DnsSensitive('App\Bar\B')]
     public function testGethostbynamelMockIsRegistered(string $namespace)
     {
         $this->assertTrue(\function_exists(\sprintf('%s\gethostbynamel', $namespace)));
@@ -126,6 +144,7 @@ class SymfonyExtension extends TestCase
 
     #[DataProvider('mockedNamespaces')]
     #[Group('dns-sensitive')]
+    #[DnsSensitive('App\Bar\B')]
     public function testDnsGetRecordMockIsRegistered(string $namespace)
     {
         $this->assertTrue(\function_exists(\sprintf('%s\dns_get_record', $namespace)));
@@ -136,5 +155,7 @@ class SymfonyExtension extends TestCase
         yield 'test class namespace' => [__NAMESPACE__];
         yield 'namespace derived from test namespace' => ['Symfony\Bridge\PhpUnit'];
         yield 'explicitly configured namespace' => ['App'];
+        yield 'explicitly configured namespace through attribute on class' => ['App\Foo'];
+        yield 'explicitly configured namespace through attribute on method' => ['App\Bar'];
     }
 }

--- a/src/Symfony/Bridge/PhpUnit/Tests/symfonyextension.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/symfonyextension.phpt
@@ -11,9 +11,10 @@ PHPUnit %s
 Runtime:       PHP %s
 Configuration: %s/src/Symfony/Bridge/PhpUnit/Tests/Fixtures/symfonyextension/phpunit-with-extension.xml.dist
 
-D.............................................                    46 / 46 (100%)
+D................................................................ 65 / 76 ( 85%)
+...........                                                       76 / 76 (100%)
 
 Time: %s, Memory: %s
 
 OK, but there were issues!
-Tests: 46, Assertions: 46, Deprecations: 1.
+Tests: 76, Assertions: 76, Deprecations: 1.

--- a/src/Symfony/Bridge/PhpUnit/Tests/symfonyextensionnotregistered.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/symfonyextensionnotregistered.phpt
@@ -11,11 +11,12 @@ PHPUnit %s
 Runtime:       PHP %s
 Configuration: %s/src/Symfony/Bridge/PhpUnit/Tests/Fixtures/symfonyextension/phpunit-without-extension.xml.dist
 
-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF                    46 / 46 (100%)
+FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF 65 / 76 ( 85%)
+FFFFFFFFFFF                                                       76 / 76 (100%)
 
 Time: %s, Memory: %s
 
-There were 46 failures:
+There were 76 failures:
 
 %d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testExtensionOfFinalClass
 Expected deprecation with message "The "Symfony\Bridge\PhpUnit\Tests\Fixtures\symfonyextension\src\FinalClass" class is considered final. It may change without further notice as of its next major version. You should not extend it from "Symfony\Bridge\PhpUnit\Tests\Fixtures\symfonyextension\src\ClassExtendingFinalClass"." was not triggered
@@ -40,6 +41,18 @@ Failed asserting that false is true.
 %s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
 %s/.phpunit/phpunit-%s/phpunit:%d
 
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testTimeMockIsRegistered with data set "explicitly configured namespace through attribute on class" ('App\Foo')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testTimeMockIsRegistered with data set "explicitly configured namespace through attribute on method" ('App\Bar')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
 %d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testMicrotimeMockIsRegistered with data set "test class namespace" ('Symfony\Bridge\PhpUnit\Tests')
 Failed asserting that false is true.
 
@@ -53,6 +66,18 @@ Failed asserting that false is true.
 %s/.phpunit/phpunit-%s/phpunit:%d
 
 %d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testMicrotimeMockIsRegistered with data set "explicitly configured namespace" ('App')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testMicrotimeMockIsRegistered with data set "explicitly configured namespace through attribute on class" ('App\Foo')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testMicrotimeMockIsRegistered with data set "explicitly configured namespace through attribute on method" ('App\Bar')
 Failed asserting that false is true.
 
 %s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
@@ -76,6 +101,18 @@ Failed asserting that false is true.
 %s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
 %s/.phpunit/phpunit-%s/phpunit:%d
 
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testSleepMockIsRegistered with data set "explicitly configured namespace through attribute on class" ('App\Foo')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testSleepMockIsRegistered with data set "explicitly configured namespace through attribute on method" ('App\Bar')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
 %d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testUsleepMockIsRegistered with data set "test class namespace" ('Symfony\Bridge\PhpUnit\Tests')
 Failed asserting that false is true.
 
@@ -89,6 +126,18 @@ Failed asserting that false is true.
 %s/.phpunit/phpunit-%s/phpunit:%d
 
 %d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testUsleepMockIsRegistered with data set "explicitly configured namespace" ('App')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testUsleepMockIsRegistered with data set "explicitly configured namespace through attribute on class" ('App\Foo')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testUsleepMockIsRegistered with data set "explicitly configured namespace through attribute on method" ('App\Bar')
 Failed asserting that false is true.
 
 %s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
@@ -112,6 +161,18 @@ Failed asserting that false is true.
 %s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
 %s/.phpunit/phpunit-%s/phpunit:%d
 
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testDateMockIsRegistered with data set "explicitly configured namespace through attribute on class" ('App\Foo')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testDateMockIsRegistered with data set "explicitly configured namespace through attribute on method" ('App\Bar')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
 %d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testGmdateMockIsRegistered with data set "test class namespace" ('Symfony\Bridge\PhpUnit\Tests')
 Failed asserting that false is true.
 
@@ -125,6 +186,18 @@ Failed asserting that false is true.
 %s/.phpunit/phpunit-%s/phpunit:%d
 
 %d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testGmdateMockIsRegistered with data set "explicitly configured namespace" ('App')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testGmdateMockIsRegistered with data set "explicitly configured namespace through attribute on class" ('App\Foo')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testGmdateMockIsRegistered with data set "explicitly configured namespace through attribute on method" ('App\Bar')
 Failed asserting that false is true.
 
 %s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
@@ -148,6 +221,18 @@ Failed asserting that false is true.
 %s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
 %s/.phpunit/phpunit-%s/phpunit:%d
 
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testHrtimeMockIsRegistered with data set "explicitly configured namespace through attribute on class" ('App\Foo')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testHrtimeMockIsRegistered with data set "explicitly configured namespace through attribute on method" ('App\Bar')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
 %d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testCheckdnsrrMockIsRegistered with data set "test class namespace" ('Symfony\Bridge\PhpUnit\Tests')
 Failed asserting that false is true.
 
@@ -161,6 +246,18 @@ Failed asserting that false is true.
 %s/.phpunit/phpunit-%s/phpunit:%d
 
 %d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testCheckdnsrrMockIsRegistered with data set "explicitly configured namespace" ('App')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testCheckdnsrrMockIsRegistered with data set "explicitly configured namespace through attribute on class" ('App\Foo')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testCheckdnsrrMockIsRegistered with data set "explicitly configured namespace through attribute on method" ('App\Bar')
 Failed asserting that false is true.
 
 %s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
@@ -184,6 +281,18 @@ Failed asserting that false is true.
 %s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
 %s/.phpunit/phpunit-%s/phpunit:%d
 
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testDnsCheckRecordMockIsRegistered with data set "explicitly configured namespace through attribute on class" ('App\Foo')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testDnsCheckRecordMockIsRegistered with data set "explicitly configured namespace through attribute on method" ('App\Bar')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
 %d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testGetmxrrMockIsRegistered with data set "test class namespace" ('Symfony\Bridge\PhpUnit\Tests')
 Failed asserting that false is true.
 
@@ -197,6 +306,18 @@ Failed asserting that false is true.
 %s/.phpunit/phpunit-%s/phpunit:%d
 
 %d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testGetmxrrMockIsRegistered with data set "explicitly configured namespace" ('App')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testGetmxrrMockIsRegistered with data set "explicitly configured namespace through attribute on class" ('App\Foo')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testGetmxrrMockIsRegistered with data set "explicitly configured namespace through attribute on method" ('App\Bar')
 Failed asserting that false is true.
 
 %s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
@@ -220,6 +341,18 @@ Failed asserting that false is true.
 %s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
 %s/.phpunit/phpunit-%s/phpunit:%d
 
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testDnsGetMxMockIsRegistered with data set "explicitly configured namespace through attribute on class" ('App\Foo')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testDnsGetMxMockIsRegistered with data set "explicitly configured namespace through attribute on method" ('App\Bar')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
 %d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testGethostbyaddrMockIsRegistered with data set "test class namespace" ('Symfony\Bridge\PhpUnit\Tests')
 Failed asserting that false is true.
 
@@ -233,6 +366,18 @@ Failed asserting that false is true.
 %s/.phpunit/phpunit-%s/phpunit:%d
 
 %d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testGethostbyaddrMockIsRegistered with data set "explicitly configured namespace" ('App')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testGethostbyaddrMockIsRegistered with data set "explicitly configured namespace through attribute on class" ('App\Foo')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testGethostbyaddrMockIsRegistered with data set "explicitly configured namespace through attribute on method" ('App\Bar')
 Failed asserting that false is true.
 
 %s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
@@ -256,6 +401,18 @@ Failed asserting that false is true.
 %s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
 %s/.phpunit/phpunit-%s/phpunit:%d
 
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testGethostbynameMockIsRegistered with data set "explicitly configured namespace through attribute on class" ('App\Foo')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testGethostbynameMockIsRegistered with data set "explicitly configured namespace through attribute on method" ('App\Bar')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
 %d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testGethostbynamelMockIsRegistered with data set "test class namespace" ('Symfony\Bridge\PhpUnit\Tests')
 Failed asserting that false is true.
 
@@ -269,6 +426,18 @@ Failed asserting that false is true.
 %s/.phpunit/phpunit-%s/phpunit:%d
 
 %d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testGethostbynamelMockIsRegistered with data set "explicitly configured namespace" ('App')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testGethostbynamelMockIsRegistered with data set "explicitly configured namespace through attribute on class" ('App\Foo')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testGethostbynamelMockIsRegistered with data set "explicitly configured namespace through attribute on method" ('App\Bar')
 Failed asserting that false is true.
 
 %s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
@@ -292,5 +461,17 @@ Failed asserting that false is true.
 %s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
 %s/.phpunit/phpunit-%s/phpunit:%d
 
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testDnsGetRecordMockIsRegistered with data set "explicitly configured namespace through attribute on class" ('App\Foo')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
+%d) Symfony\Bridge\PhpUnit\Tests\SymfonyExtension::testDnsGetRecordMockIsRegistered with data set "explicitly configured namespace through attribute on method" ('App\Bar')
+Failed asserting that false is true.
+
+%s/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtension.php:%d
+%s/.phpunit/phpunit-%s/phpunit:%d
+
 FAILURES!
-Tests: 46, Assertions: 46, Failures: 46.
+Tests: 76, Assertions: 76, Failures: 76.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR adds the ability to configure clock and DNS mock namespaces through attributes, removing the need to add them to `phpunit.xml`:

```php
#[DnsSensitive(Foo::class)]
class FooTest extends KernelTestCase
{
    #[TimeSensitive(Bar::class)]
    public function testFoo()
    {
        // ...
    }
}
```