### PR TITLE
[VarDumper] Fix blank strings display

### DIFF
--- a/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
@@ -663,7 +663,7 @@ pre.sf-dump:after {
    height: 0;
    clear: both;
 }
-pre.sf-dump span {
+pre.sf-dump .sf-dump-ellipsization {
     display: inline-flex;
 }
 pre.sf-dump a {
@@ -681,16 +681,12 @@ pre.sf-dump img {
     background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAAAAAA6mKC9AAAAHUlEQVQY02O8zAABilCaiQEN0EeA8QuUcX9g3QEAAjcC5piyhyEAAAAASUVORK5CYII=) #D3D3D3;
 }
 pre.sf-dump .sf-dump-ellipsis {
-    display: inline-block;
-    overflow: visible;
     text-overflow: ellipsis;
-    max-width: 5em;
     white-space: nowrap;
     overflow: hidden;
-    vertical-align: top;
 }
-pre.sf-dump .sf-dump-ellipsis+.sf-dump-ellipsis {
-    max-width: none;
+pre.sf-dump .sf-dump-ellipsis-tail {
+    flex-shrink: 0;
 }
 pre.sf-dump code {
     display:inline;
@@ -863,66 +859,75 @@ EOHTML
             return sprintf('<a class=sf-dump-ref href=#%s-ref%s title="%d occurrences">%s</a>', $this->dumpId, $r, 1 + $attr['count'], $v);
         }
 
+        $dumpClasses = ['sf-dump-'.$style];
+        $dumpTitle = '';
+
         if ('const' === $style && isset($attr['value'])) {
-            $style .= sprintf(' title="%s"', esc(\is_scalar($attr['value']) ? $attr['value'] : json_encode($attr['value'])));
+            $dumpTitle = esc(\is_scalar($attr['value']) ? $attr['value'] : json_encode($attr['value']));
         } elseif ('public' === $style) {
-            $style .= sprintf(' title="%s"', empty($attr['dynamic']) ? 'Public property' : 'Runtime added dynamic property');
+            $dumpTitle = empty($attr['dynamic']) ? 'Public property' : 'Runtime added dynamic property';
         } elseif ('str' === $style && 1 < $attr['length']) {
-            $style .= sprintf(' title="%d%s characters"', $attr['length'], $attr['binary'] ? ' binary or non-UTF-8' : '');
+            $dumpTitle = sprintf('%d%s characters', $attr['length'], $attr['binary'] ? ' binary or non-UTF-8' : '');
         } elseif ('note' === $style && 0 < ($attr['depth'] ?? 0) && false !== $c = strrpos($value, '\\')) {
-            $style .= ' title=""';
             $attr += [
                 'ellipsis' => \strlen($value) - $c,
                 'ellipsis-type' => 'note',
                 'ellipsis-tail' => 1,
             ];
         } elseif ('protected' === $style) {
-            $style .= ' title="Protected property"';
+            $dumpTitle = 'Protected property';
         } elseif ('meta' === $style && isset($attr['title'])) {
-            $style .= sprintf(' title="%s"', esc($this->utf8Encode($attr['title'])));
+            $dumpTitle = esc($this->utf8Encode($attr['title']));
         } elseif ('private' === $style) {
-            $style .= sprintf(' title="Private property defined in class:&#10;`%s`"', esc($this->utf8Encode($attr['class'])));
+            $dumpTitle = sprintf('Private property defined in class:&#10;`%s`"', esc($this->utf8Encode($attr['class'])));
         }
 
         if (isset($attr['ellipsis'])) {
-            $class = 'sf-dump-ellipsis';
+            $dumpClasses[] = 'sf-dump-ellipsization';
+            $ellipsisClass = 'sf-dump-ellipsis';
             if (isset($attr['ellipsis-type'])) {
-                $class = sprintf('"%s sf-dump-ellipsis-%s"', $class, $attr['ellipsis-type']);
+                $ellipsisClass .= ' sf-dump-ellipsis-'.$attr['ellipsis-type'];
             }
             $label = esc(substr($value, -$attr['ellipsis']));
-            $style = str_replace(' title="', " title=\"$v\n", $style);
-            $v = sprintf('<span class=%s>%s</span>', $class, substr($v, 0, -\strlen($label)));
+            $dumpTitle = $v."\n".$dumpTitle;
+            $v = sprintf('<span class="%s">%s</span>', $ellipsisClass, substr($v, 0, -\strlen($label)));
 
             if (!empty($attr['ellipsis-tail'])) {
                 $tail = \strlen(esc(substr($value, -$attr['ellipsis'], $attr['ellipsis-tail'])));
-                $v .= sprintf('<span class=%s>%s</span>%s', $class, substr($label, 0, $tail), substr($label, $tail));
+                $v .= sprintf('<span class="%s">%s</span><span class="sf-dump-ellipsis-tail">%s</span>', $ellipsisClass, substr($label, 0, $tail), substr($label, $tail));
             } else {
-                $v .= $label;
+                $v .= sprintf('<span class="sf-dump-ellipsis-tail">%s</span>', $label);
             }
         }
 
         $map = static::$controlCharsMap;
-        $v = "<span class=sf-dump-{$style}>".preg_replace_callback(static::$controlCharsRx, function ($c) use ($map) {
-            $s = $b = '<span class="sf-dump-default';
-            $c = $c[$i = 0];
-            if ($ns = "\r" === $c[$i] || "\n" === $c[$i]) {
-                $s .= ' sf-dump-ns';
-            }
-            $s .= '">';
-            do {
-                if (("\r" === $c[$i] || "\n" === $c[$i]) !== $ns) {
-                    $s .= '</span>'.$b;
-                    if ($ns = !$ns) {
-                        $s .= ' sf-dump-ns';
-                    }
-                    $s .= '">';
+        $v = sprintf(
+            '<span class=%s%s%1$s%s>%s</span>',
+            1 === count($dumpClasses) ? '' : '"',
+            implode(' ', $dumpClasses),
+            $dumpTitle ? ' title="'.$dumpTitle.'"' : '',
+            preg_replace_callback(static::$controlCharsRx, function ($c) use ($map) {
+                $s = $b = '<span class="sf-dump-default';
+                $c = $c[$i = 0];
+                if ($ns = "\r" === $c[$i] || "\n" === $c[$i]) {
+                    $s .= ' sf-dump-ns';
                 }
+                $s .= '">';
+                do {
+                    if (("\r" === $c[$i] || "\n" === $c[$i]) !== $ns) {
+                        $s .= '</span>'.$b;
+                        if ($ns = !$ns) {
+                            $s .= ' sf-dump-ns';
+                        }
+                        $s .= '">';
+                    }
 
-                $s .= $map[$c[$i]] ?? sprintf('\x%02X', \ord($c[$i]));
-            } while (isset($c[++$i]));
+                    $s .= $map[$c[$i]] ?? sprintf('\x%02X', \ord($c[$i]));
+                } while (isset($c[++$i]));
 
-            return $s.'</span>';
-        }, $v).'</span>';
+                return $s.'</span>';
+            }, $v)
+        );
 
         if (!($attr['binary'] ?? false)) {
             $v = preg_replace_callback(static::$unicodeCharsRx, function ($c) {

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ExceptionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ExceptionCasterTest.php
@@ -259,12 +259,12 @@ EODUMP;
 <foo></foo><bar><span class=sf-dump-note>Exception</span> {<samp data-depth=1 class=sf-dump-expanded>
   #<span class=sf-dump-protected title="Protected property">message</span>: "<span class=sf-dump-str>1</span>"
   #<span class=sf-dump-protected title="Protected property">code</span>: <span class=sf-dump-num>0</span>
-  #<span class=sf-dump-protected title="Protected property">file</span>: "<span class=sf-dump-str title="%sExceptionCasterTest.php
-%d characters"><span class="sf-dump-ellipsis sf-dump-ellipsis-path">%s%eVarDumper</span><span class="sf-dump-ellipsis sf-dump-ellipsis-path">%e</span>Tests%eCaster%eExceptionCasterTest.php</span>"
+  #<span class=sf-dump-protected title="Protected property">file</span>: "<span class="sf-dump-str sf-dump-ellipsization" title="%sExceptionCasterTest.php
+%d characters"><span class="sf-dump-ellipsis sf-dump-ellipsis-path">%s%eVarDumper</span><span class="sf-dump-ellipsis sf-dump-ellipsis-path">%e</span><span class="sf-dump-ellipsis-tail">Tests%eCaster%eExceptionCasterTest.php</span></span>"
   #<span class=sf-dump-protected title="Protected property">line</span>: <span class=sf-dump-num>%d</span>
   <span class=sf-dump-meta>trace</span>: {<samp data-depth=2 class=sf-dump-compact>
-    <span class=sf-dump-meta title="%sExceptionCasterTest.php
-Stack level %d."><span class="sf-dump-ellipsis sf-dump-ellipsis-path">%s%eVarDumper</span><span class="sf-dump-ellipsis sf-dump-ellipsis-path">%e</span>Tests%eCaster%eExceptionCasterTest.php</span>:<span class=sf-dump-num>%d</span>
+    <span class="sf-dump-meta sf-dump-ellipsization" title="%sExceptionCasterTest.php
+Stack level %d."><span class="sf-dump-ellipsis sf-dump-ellipsis-path">%s%eVarDumper</span><span class="sf-dump-ellipsis sf-dump-ellipsis-path">%e</span><span class="sf-dump-ellipsis-tail">Tests%eCaster%eExceptionCasterTest.php</span></span>:<span class=sf-dump-num>%d</span>
      &#8230;%d
   </samp>}
 </samp>}

--- a/src/Symfony/Component/VarDumper/Tests/Caster/StubCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/StubCasterTest.php
@@ -175,8 +175,8 @@ EODUMP;
 
         $expectedDump = <<<'EODUMP'
 <foo></foo><bar><span class=sf-dump-note>array:1</span> [<samp data-depth=1 class=sf-dump-expanded>
-  <span class=sf-dump-index>0</span> => "<span class=sf-dump-str title="Symfony\Component\VarDumper\Tests\Caster\NotExisting
-52 characters"><span class="sf-dump-ellipsis sf-dump-ellipsis-class">Symfony\Component\VarDumper\Tests\Caster</span><span class="sf-dump-ellipsis sf-dump-ellipsis-class">\</span>NotExisting</span>"
+  <span class=sf-dump-index>0</span> => "<span class="sf-dump-str sf-dump-ellipsization" title="Symfony\Component\VarDumper\Tests\Caster\NotExisting
+52 characters"><span class="sf-dump-ellipsis sf-dump-ellipsis-class">Symfony\Component\VarDumper\Tests\Caster</span><span class="sf-dump-ellipsis sf-dump-ellipsis-class">\</span><span class="sf-dump-ellipsis-tail">NotExisting</span></span>"
 </samp>]
 </bar>
 EODUMP;

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/HtmlDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/HtmlDumperTest.php
@@ -79,18 +79,18 @@ class HtmlDumperTest extends TestCase
     <span class=sf-dump-meta>seekable</span>: <span class=sf-dump-const>true</span>
 %A  <span class=sf-dump-meta>options</span>: []
   </samp>}
-  "<span class=sf-dump-key>obj</span>" => <span class=sf-dump-note title="Symfony\Component\VarDumper\Tests\Fixture\DumbFoo
-"><span class="sf-dump-ellipsis sf-dump-ellipsis-note">Symfony\Component\VarDumper\Tests\Fixture</span><span class="sf-dump-ellipsis sf-dump-ellipsis-note">\</span>DumbFoo</span> {<a class=sf-dump-ref href=#{$dumpId}-ref2%d title="2 occurrences">#%d</a><samp data-depth=2 id={$dumpId}-ref2%d class=sf-dump-compact>
+  "<span class=sf-dump-key>obj</span>" => <span class="sf-dump-note sf-dump-ellipsization" title="Symfony\Component\VarDumper\Tests\Fixture\DumbFoo
+"><span class="sf-dump-ellipsis sf-dump-ellipsis-note">Symfony\Component\VarDumper\Tests\Fixture</span><span class="sf-dump-ellipsis sf-dump-ellipsis-note">\</span><span class="sf-dump-ellipsis-tail">DumbFoo</span></span> {<a class=sf-dump-ref href=#{$dumpId}-ref2%d title="2 occurrences">#%d</a><samp data-depth=2 id={$dumpId}-ref2%d class=sf-dump-compact>
     +<span class=sf-dump-public title="Public property">foo</span>: "<span class=sf-dump-str title="3 characters">foo</span>"
     +"<span class=sf-dump-public title="Runtime added dynamic property">bar</span>": "<span class=sf-dump-str title="3 characters">bar</span>"
   </samp>}
   "<span class=sf-dump-key>closure</span>" => <span class=sf-dump-note>Closure(\$a, ?PDO &amp;\$b = null)</span> {<a class=sf-dump-ref>#%d</a><samp data-depth=2 class=sf-dump-compact>
-    <span class=sf-dump-meta>class</span>: "<span class=sf-dump-str title="Symfony\Component\VarDumper\Tests\Dumper\HtmlDumperTest
-55 characters"><span class="sf-dump-ellipsis sf-dump-ellipsis-class">Symfony\Component\VarDumper\Tests\Dumper</span><span class="sf-dump-ellipsis sf-dump-ellipsis-class">\</span>HtmlDumperTest</span>"
-    <span class=sf-dump-meta>this</span>: <span class=sf-dump-note title="Symfony\Component\VarDumper\Tests\Dumper\HtmlDumperTest
-"><span class="sf-dump-ellipsis sf-dump-ellipsis-note">Symfony\Component\VarDumper\Tests\Dumper</span><span class="sf-dump-ellipsis sf-dump-ellipsis-note">\</span>HtmlDumperTest</span> {<a class=sf-dump-ref>#%d</a> &%s;}
-    <span class=sf-dump-meta>file</span>: "<span class=sf-dump-str title="{$var['file']}
-%d characters"><span class="sf-dump-ellipsis sf-dump-ellipsis-path">%s%eVarDumper</span><span class="sf-dump-ellipsis sf-dump-ellipsis-path">%e</span>Tests%eFixtures%edumb-var.php</span>"
+    <span class=sf-dump-meta>class</span>: "<span class="sf-dump-str sf-dump-ellipsization" title="Symfony\Component\VarDumper\Tests\Dumper\HtmlDumperTest
+55 characters"><span class="sf-dump-ellipsis sf-dump-ellipsis-class">Symfony\Component\VarDumper\Tests\Dumper</span><span class="sf-dump-ellipsis sf-dump-ellipsis-class">\</span><span class="sf-dump-ellipsis-tail">HtmlDumperTest</span></span>"
+    <span class=sf-dump-meta>this</span>: <span class="sf-dump-note sf-dump-ellipsization" title="Symfony\Component\VarDumper\Tests\Dumper\HtmlDumperTest
+"><span class="sf-dump-ellipsis sf-dump-ellipsis-note">Symfony\Component\VarDumper\Tests\Dumper</span><span class="sf-dump-ellipsis sf-dump-ellipsis-note">\</span><span class="sf-dump-ellipsis-tail">HtmlDumperTest</span></span> {<a class=sf-dump-ref>#%d</a> &%s;}
+    <span class=sf-dump-meta>file</span>: "<span class="sf-dump-str sf-dump-ellipsization" title="{$var['file']}
+%d characters"><span class="sf-dump-ellipsis sf-dump-ellipsis-path">%s%eVarDumper</span><span class="sf-dump-ellipsis sf-dump-ellipsis-path">%e</span><span class="sf-dump-ellipsis-tail">Tests%eFixtures%edumb-var.php</span></span>"
     <span class=sf-dump-meta>line</span>: "<span class=sf-dump-str title="%d characters">{$var['line']} to {$var['line']}</span>"
   </samp>}
   "<span class=sf-dump-key>line</span>" => <span class=sf-dump-num>{$var['line']}</span>
@@ -101,8 +101,8 @@ class HtmlDumperTest extends TestCase
     <span class=sf-dump-index>0</span> => <a class=sf-dump-ref href=#{$dumpId}-ref04 title="2 occurrences">&amp;4</a> <span class=sf-dump-note>array:1</span> [<a class=sf-dump-ref href=#{$dumpId}-ref04 title="2 occurrences">&amp;4</a>]
   </samp>]
   <span class=sf-dump-key>8</span> => <a class=sf-dump-ref href=#{$dumpId}-ref01 title="2 occurrences">&amp;1</a> <span class=sf-dump-const>null</span>
-  "<span class=sf-dump-key>sobj</span>" => <span class=sf-dump-note title="Symfony\Component\VarDumper\Tests\Fixture\DumbFoo
-"><span class="sf-dump-ellipsis sf-dump-ellipsis-note">Symfony\Component\VarDumper\Tests\Fixture</span><span class="sf-dump-ellipsis sf-dump-ellipsis-note">\</span>DumbFoo</span> {<a class=sf-dump-ref href=#{$dumpId}-ref2%d title="2 occurrences">#%d</a>}
+  "<span class=sf-dump-key>sobj</span>" => <span class="sf-dump-note sf-dump-ellipsization" title="Symfony\Component\VarDumper\Tests\Fixture\DumbFoo
+"><span class="sf-dump-ellipsis sf-dump-ellipsis-note">Symfony\Component\VarDumper\Tests\Fixture</span><span class="sf-dump-ellipsis sf-dump-ellipsis-note">\</span><span class="sf-dump-ellipsis-tail">DumbFoo</span></span> {<a class=sf-dump-ref href=#{$dumpId}-ref2%d title="2 occurrences">#%d</a>}
   "<span class=sf-dump-key>snobj</span>" => <a class=sf-dump-ref href=#{$dumpId}-ref03 title="2 occurrences">&amp;3</a> {<a class=sf-dump-ref href=#{$dumpId}-ref2%d title="3 occurrences">#%d</a>}
   "<span class=sf-dump-key>snobj2</span>" => {<a class=sf-dump-ref href=#{$dumpId}-ref2%d title="3 occurrences">#%d</a>}
   "<span class=sf-dump-key>file</span>" => "<span class=sf-dump-str title="%d characters">{$var['file']}</span>"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #57980
| License       | MIT

Because `sf-dump-ellipsis` `span`s needed a `text-ellipsis`, their overflowing content was cut using `overflow: hidden`. As it required their inner display type to be `block`, this broke the alignment with the ellipsis’ “tail”. This was fixed by #53147 by making every dump’s `span`s `inline-flex`.

This change made `sf-dump-ellipsis`’ `display`, `max-width` and `vertical-align` properties useless so this PR removes them, as well as a duplicated `overflow` one.

Now, `inline-flex` elements’ content becomes flex items, which caused #57980 because 

> if the entire sequence of [a flex item’s] text runs contains only white space […] it is […] not rendered
>
> https://www.w3.org/TR/css-flexbox-1/#flex-items

Instead of making every dump’s `span`s `inline-flex`, this PR targets a new `sf-dump-ellipsization` class added to `sf-dump-ellipsis`’ parents.

It also wraps ellipsis tails with elements bearing the `sf-dump-ellipsis-tail` class so that we can prevent them to shrink:

**Before**:

![](https://github.com/user-attachments/assets/8dfb21ac-ce39-4202-a5aa-af93bac5c7f5)

**After**:

![](https://github.com/user-attachments/assets/15e8b344-5d12-4c89-8b29-3ef0a3928495)
