### PR TITLE
Update old Appveyor skip conditions

### DIFF
--- a/src/Symfony/Component/VarDumper/Tests/Dumper/ServerDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/ServerDumperTest.php
@@ -39,8 +39,8 @@ class ServerDumperTest extends TestCase
 
     public function testDump()
     {
-        if ('True' === getenv('APPVEYOR')) {
-            $this->markTestSkipped('Skip transient test on AppVeyor');
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('Skip transient test on Windows');
         }
 
         $wrappedDumper = $this->createMock(DataDumperInterface::class);

--- a/src/Symfony/Component/VarDumper/Tests/Server/ConnectionTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Server/ConnectionTest.php
@@ -24,8 +24,8 @@ class ConnectionTest extends TestCase
 
     public function testDump()
     {
-        if ('True' === getenv('APPVEYOR')) {
-            $this->markTestSkipped('Skip transient test on AppVeyor');
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('Skip transient test on Windows');
         }
 
         $cloner = new VarCloner();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Appveyor isn't used anymore in this codebase, still these tests are transient and the condition should be updated.