### PR TITLE
Remove comment about AppVeyor in `phpunit`

### DIFF
--- a/phpunit
+++ b/phpunit
@@ -1,10 +1,6 @@
 #!/usr/bin/env php
 <?php
 
-// Cache-Id: 2021-05-27 20:30 UTC
-// For caching to work properly on appveyor, this file
-// must be exactly the same in all maintained branches
-
 if (!file_exists(__DIR__.'/vendor/symfony/phpunit-bridge/bin/simple-phpunit')) {
     echo "Unable to find the `simple-phpunit` script in `vendor/symfony/phpunit-bridge/bin/`.\nPlease run `composer update` before running this command.\n";
     exit(1);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow-up for #59394. Removes a now-necessary comment. It is the last occurrence of AppVeyor in the codebase.
