### PR TITLE
[DomCrawler] Make `ChoiceFormField::isDisabled` return `true` for unchecked disabled checkboxes

### DIFF
--- a/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
@@ -45,6 +45,10 @@ class ChoiceFormField extends FormField
      */
     public function isDisabled(): bool
     {
+        if ('checkbox' === $this->type) {
+            return parent::isDisabled();
+        }
+
         if (parent::isDisabled() && 'select' === $this->type) {
             return true;
         }

--- a/src/Symfony/Component/DomCrawler/Tests/Field/ChoiceFormFieldTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Field/ChoiceFormFieldTest.php
@@ -272,6 +272,17 @@ class ChoiceFormFieldTest extends FormFieldTestCase
         $this->assertEquals('foo', $field->getValue());
     }
 
+    public function testCheckboxIsDisabled()
+    {
+        $node = $this->createNode('input', '', ['type' => 'checkbox', 'name' => 'name', 'disabled' => '']);
+        $field = new ChoiceFormField($node);
+
+        $this->assertTrue($field->isDisabled(), '->isDisabled() returns true when the checkbox is disabled, even if it is not checked');
+
+        $field->tick();
+        $this->assertTrue($field->isDisabled(), '->isDisabled() returns true when the checkbox is disabled, even if it is checked');
+    }
+
     public function testTick()
     {
         $node = $this->createSelectNode(['foo' => false, 'bar' => false]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #8348
| License       | MIT

`ChoiceFormField::isDisabled`’s PHPDoc reads

> Check if the current selected option is disabled.

But a checkbox really embeds two options: either you check it, or not; which means it always has a selected option.
Then, if a checkbox is disabled, these two options are too.
So, `ChoiceFormField::isDisabled` should return `true` for disabled checkboxes, checked or not.

This also matches what you intuitively would expect from this method.