### PR TITLE
[JsonEncoder] Add `JsonEncodable` attribute

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
@@ -54,7 +54,6 @@ class UnusedTagsPass implements CompilerPassInterface
         'html_sanitizer',
         'http_client.client',
         'json_encoder.denormalizer',
-        'json_encoder.encodable',
         'json_encoder.normalizer',
         'kernel.cache_clearer',
         'kernel.cache_warmer',

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -100,6 +100,7 @@ use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
 use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\HttpKernel\Log\DebugLoggerConfigurator;
+use Symfony\Component\JsonEncoder\Attribute\JsonEncodable;
 use Symfony\Component\JsonEncoder\Decode\Denormalizer\DenormalizerInterface as JsonEncoderDenormalizerInterface;
 use Symfony\Component\JsonEncoder\DecoderInterface as JsonEncoderDecoderInterface;
 use Symfony\Component\JsonEncoder\Encode\Normalizer\NormalizerInterface as JsonEncoderNormalizerInterface;
@@ -745,6 +746,10 @@ class FrameworkExtension extends Extension
                 }
             );
         }
+        $container->registerAttributeForAutoconfiguration(JsonEncodable::class, static function (ChildDefinition $definition): void {
+            $definition->addTag('json_encoder.encodable');
+            $definition->addTag('container.excluded');
+        });
 
         if (!$container->getParameter('kernel.debug')) {
             // remove tagged iterator argument for resource checkers

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/JsonEncoder/Dto/Dummy.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/JsonEncoder/Dto/Dummy.php
@@ -14,11 +14,13 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\app\JsonEncoder\Dto;
 use Symfony\Bundle\FrameworkBundle\Tests\Functional\app\JsonEncoder\RangeNormalizer;
 use Symfony\Component\JsonEncoder\Attribute\Denormalizer;
 use Symfony\Component\JsonEncoder\Attribute\EncodedName;
+use Symfony\Component\JsonEncoder\Attribute\JsonEncodable;
 use Symfony\Component\JsonEncoder\Attribute\Normalizer;
 
 /**
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  */
+#[JsonEncodable]
 class Dummy
 {
     #[EncodedName('@name')]

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/JsonEncoder/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/JsonEncoder/config.yml
@@ -18,4 +18,9 @@ services:
         alias: json_encoder.decoder
         public: true
 
+    json_encoder.cache_warmer.encoder_decoder.alias:
+        alias: .json_encoder.cache_warmer.encoder_decoder
+        public: true
+
+    Symfony\Bundle\FrameworkBundle\Tests\Functional\app\JsonEncoder\Dto\Dummy: ~
     Symfony\Bundle\FrameworkBundle\Tests\Functional\app\JsonEncoder\RangeNormalizer: ~

--- a/src/Symfony/Component/JsonEncoder/Attribute/JsonEncodable.php
+++ b/src/Symfony/Component/JsonEncoder/Attribute/JsonEncodable.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonEncoder\Attribute;
+
+/**
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ *
+ * @experimental
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class JsonEncodable
+{
+}

--- a/src/Symfony/Component/JsonEncoder/DependencyInjection/EncodablePass.php
+++ b/src/Symfony/Component/JsonEncoder/DependencyInjection/EncodablePass.php
@@ -30,7 +30,11 @@ class EncodablePass implements CompilerPassInterface
         $encodableClassNames = [];
 
         // retrieve concrete services tagged with "json_encoder.encodable" tag
-        foreach ($container->findTaggedServiceIds('json_encoder.encodable') as $id => $tags) {
+        foreach ($container->getDefinitions() as $id => $definition) {
+            if (!$definition->hasTag('json_encoder.encodable')) {
+                continue;
+            }
+
             if (($className = $container->getDefinition($id)->getClass()) && !$container->getDefinition($id)->isAbstract()) {
                 $encodableClassNames[] = $className;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

Add `JsonEncodable` attribute that autoconfigures `json_encoder.encodable` tag.