### PR TITLE
[PropertyAccess] Move dependency definitions outside of Extension

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -143,9 +143,7 @@ use Symfony\Component\PropertyInfo\PropertyDescriptionExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyInitializableExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyListExtractorInterface;
-use Symfony\Component\PropertyInfo\PropertyReadInfoExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
-use Symfony\Component\PropertyInfo\PropertyWriteInfoExtractorInterface;
 use Symfony\Component\RateLimiter\LimiterInterface;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\RateLimiter\Storage\CacheStorage;
@@ -1810,8 +1808,6 @@ class FrameworkExtension extends Extension
             ->getDefinition('property_accessor')
             ->replaceArgument(0, $magicMethods)
             ->replaceArgument(1, $throw)
-            ->replaceArgument(3, new Reference(PropertyReadInfoExtractorInterface::class, ContainerInterface::NULL_ON_INVALID_REFERENCE))
-            ->replaceArgument(4, new Reference(PropertyWriteInfoExtractorInterface::class, ContainerInterface::NULL_ON_INVALID_REFERENCE))
         ;
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/property_access.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/property_access.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Symfony\Component\PropertyInfo\PropertyReadInfoExtractorInterface;
+use Symfony\Component\PropertyInfo\PropertyWriteInfoExtractorInterface;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
@@ -21,8 +23,8 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('magic methods allowed, set by the extension'),
                 abstract_arg('throw exceptions, set by the extension'),
                 service('cache.property_access')->ignoreOnInvalid(),
-                abstract_arg('propertyReadInfoExtractor, set by the extension'),
-                abstract_arg('propertyWriteInfoExtractor, set by the extension'),
+                service(PropertyReadInfoExtractorInterface::class)->nullOnInvalid(),
+                service(PropertyWriteInfoExtractorInterface::class)->nullOnInvalid(),
             ])
 
         ->alias(PropertyAccessorInterface::class, 'property_accessor')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

I see no reason why the dependencies should be defined in the extension.