### PR TITLE
[FrameworkBundle][HttpFoundation] Reset Request's formats using the service resetter

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -284,7 +284,9 @@ EOF
             return $matchingServices[0];
         }
 
-        return $io->choice('Select one of the following services to display its information', $matchingServices);
+        natsort($matchingServices);
+
+        return $io->choice('Select one of the following services to display its information', array_values($matchingServices));
     }
 
     private function findProperTagName(InputInterface $input, SymfonyStyle $io, ContainerBuilder $container, string $tagName): string
@@ -302,7 +304,9 @@ EOF
             return $matchingTags[0];
         }
 
-        return $io->choice('Select one of the following tags to display its information', $matchingTags);
+        natsort($matchingTags);
+
+        return $io->choice('Select one of the following tags to display its information', array_values($matchingTags));
     }
 
     private function findServiceIdsContaining(ContainerBuilder $container, string $name, bool $showHidden): array

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
@@ -100,6 +100,7 @@ return static function (ContainerConfigurator $container) {
         ->alias(HttpKernelInterface::class, 'http_kernel')
 
         ->set('request_stack', RequestStack::class)
+            ->tag('kernel.reset', ['method' => 'resetRequestFormats', 'on_invalid' => 'ignore'])
             ->public()
         ->alias(RequestStack::class, 'request_stack')
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
@@ -140,13 +140,13 @@ class ContainerDebugCommandTest extends AbstractWebTestCase
         $tester->run(['command' => 'debug:container', '--tag' => 'kernel.'], ['decorated' => false]);
 
         $this->assertStringContainsString('Select one of the following tags to display its information', $tester->getDisplay());
-        $this->assertStringContainsString('[0] kernel.event_subscriber', $tester->getDisplay());
-        $this->assertStringContainsString('[1] kernel.locale_aware', $tester->getDisplay());
-        $this->assertStringContainsString('[2] kernel.cache_warmer', $tester->getDisplay());
+        $this->assertStringContainsString('[0] kernel.cache_clearer', $tester->getDisplay());
+        $this->assertStringContainsString('[1] kernel.cache_warmer', $tester->getDisplay());
+        $this->assertStringContainsString('[2] kernel.event_subscriber', $tester->getDisplay());
         $this->assertStringContainsString('[3] kernel.fragment_renderer', $tester->getDisplay());
-        $this->assertStringContainsString('[4] kernel.reset', $tester->getDisplay());
-        $this->assertStringContainsString('[5] kernel.cache_clearer', $tester->getDisplay());
-        $this->assertStringContainsString('Symfony Container Services Tagged with "kernel.event_subscriber" Tag', $tester->getDisplay());
+        $this->assertStringContainsString('[4] kernel.locale_aware', $tester->getDisplay());
+        $this->assertStringContainsString('[5] kernel.reset', $tester->getDisplay());
+        $this->assertStringContainsString('Symfony Container Services Tagged with "kernel.cache_clearer" Tag', $tester->getDisplay());
     }
 
     public function testDescribeEnvVars()

--- a/src/Symfony/Component/HttpFoundation/RequestStack.php
+++ b/src/Symfony/Component/HttpFoundation/RequestStack.php
@@ -106,4 +106,11 @@ class RequestStack
 
         throw new SessionNotFoundException();
     }
+
+    public function resetRequestFormats(): void
+    {
+        static $resetRequestFormats;
+        $resetRequestFormats ??= \Closure::bind(static fn () => self::$formats = null, null, Request::class);
+        $resetRequestFormats();
+    }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestStackTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestStackTest.php
@@ -67,4 +67,18 @@ class RequestStackTest extends TestCase
         $requestStack->push($secondSubRequest);
         $this->assertSame($firstSubRequest, $requestStack->getParentRequest());
     }
+
+    public function testResetRequestFormats()
+    {
+        $requestStack = new RequestStack();
+
+        $request = Request::create('/foo');
+        $request->setFormat('foo', ['application/foo']);
+
+        $this->assertSame(['application/foo'], $request->getMimeTypes('foo'));
+
+        $requestStack->resetRequestFormats();
+
+        $this->assertSame([], $request->getMimeTypes('foo'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | https://github.com/symfony/symfony/issues/59036
| License       | MIT
