### PR TITLE
[Translations] Make sure PL translations validators.pl.xlf follow the same style

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.pl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.pl.xlf
@@ -440,35 +440,35 @@
             </trans-unit>
             <trans-unit id="113">
                 <source>This URL is missing a top-level domain.</source>
-                <target>Podany URL nie zawiera domeny najwyższego poziomu.</target>
+                <target>Ten URL nie zawiera domeny najwyższego poziomu.</target>
             </trans-unit>
             <trans-unit id="114">
                 <source>This value is too short. It should contain at least one word.|This value is too short. It should contain at least {{ min }} words.</source>
-                <target>Podana wartość jest zbyt krótka. Powinna zawierać co najmniej jedno słowo.|Podana wartość jest zbyt krótka. Powinna zawierać co najmniej {{ min }} słów.</target>
+                <target>Ta wartość jest zbyt krótka. Powinna zawierać co najmniej jedno słowo.|Ta wartość jest zbyt krótka. Powinna zawierać co najmniej {{ min }} słów.</target>
             </trans-unit>
             <trans-unit id="115">
                 <source>This value is too long. It should contain one word.|This value is too long. It should contain {{ max }} words or less.</source>
-                <target>Podana wartość jest zbyt długa. Powinna zawierać jedno słowo.|Podana wartość jest zbyt długa. Powinna zawierać {{ max }} słów lub mniej.</target>
+                <target>Ta wartość jest zbyt długa. Powinna zawierać jedno słowo.|Ta wartość jest zbyt długa. Powinna zawierać {{ max }} słów lub mniej.</target>
             </trans-unit>
             <trans-unit id="116">
                 <source>This value does not represent a valid week in the ISO 8601 format.</source>
-                <target>Podana wartość nie jest poprawnym oznaczeniem tygodnia w formacie ISO 8601.</target>
+                <target>Ta wartość nie jest poprawnym oznaczeniem tygodnia w formacie ISO 8601.</target>
             </trans-unit>
             <trans-unit id="117">
                 <source>This value is not a valid week.</source>
-                <target>Podana wartość nie jest poprawnym oznaczeniem tygodnia.</target>
+                <target>Ta wartość nie jest poprawnym oznaczeniem tygodnia.</target>
             </trans-unit>
             <trans-unit id="118">
                 <source>This value should not be before week "{{ min }}".</source>
-                <target>Podana wartość nie powinna być przed tygodniem "{{ min }}".</target>
+                <target>Ta wartość nie powinna być przed tygodniem "{{ min }}".</target>
             </trans-unit>
             <trans-unit id="119">
                 <source>This value should not be after week "{{ max }}".</source>
-                <target>Podana wartość nie powinna być po tygodniu "{{ max }}".</target>
+                <target>Ta wartość nie powinna być po tygodniu "{{ max }}".</target>
             </trans-unit>
             <trans-unit id="120">
                 <source>This value is not a valid slug.</source>
-                <target state="needs-review-translation">Ta wartość nie jest prawidłowym slugiem.</target>
+                <target>Ta wartość nie jest prawidłowym slugiem.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      |no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix https://github.com/symfony/symfony/issues/59423 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

Symfony-59423: [Translations] Make sure PL translations validators.pl.xlf follow the same style - use consistently 'Ta wartość' instead of 'Podana wartość' in several places. The translation for 'This value is not a valid slug' has been validated. It looks fine. The word 'slug' is obviously not common in Polish, but it looks correct in the given context. SEO specialists and web developers are aware of that and what does it mean.
