### PR TITLE
[AccessControl] Add Access Control component with strategies and voters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,7 @@
         "symfony/polyfill-uuid": "^1.15"
     },
     "replace": {
+        "symfony/access-control": "self.version",
         "symfony/asset": "self.version",
         "symfony/asset-mapper": "self.version",
         "symfony/browser-kit": "self.version",

--- a/src/Symfony/Component/AccessControl/.gitattributes
+++ b/src/Symfony/Component/AccessControl/.gitattributes
@@ -1,0 +1,3 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/AccessControl/.gitignore
+++ b/src/Symfony/Component/AccessControl/.gitignore
@@ -1,0 +1,4 @@
+vendor/
+composer.lock
+phpunit.xml
+Tests/Fixtures/var/

--- a/src/Symfony/Component/AccessControl/AccessControlManager.php
+++ b/src/Symfony/Component/AccessControl/AccessControlManager.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Symfony\Component\AccessControl;
+
+use Symfony\Component\AccessControl\Event\AccessDecisionEvent;
+use Symfony\Component\AccessControl\Event\VoteEvent;
+use Symfony\Component\AccessControl\Exception\InvalidStrategyException;
+use Symfony\Component\AccessControl\Strategy\AffirmativeStrategy;
+use Symfony\Component\AccessControl\Strategy\StrategyInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @experimental
+ */
+final class AccessControlManager implements AccessControlManagerInterface
+{
+    private readonly string $defaultStrategy;
+
+    /**
+     * @var array<string, StrategyInterface>
+     */
+    private readonly array $strategies;
+
+    /**
+     * @var array<string, array<array-key, bool>>
+     */
+    private array $votersCacheAttributes = [];
+    /**
+     * @var array<string, array<array-key, bool>>
+     */
+    private mixed $votersCacheSubject = [];
+
+    /**
+     * @param iterable<StrategyInterface> $strategies
+     * @param iterable<VoterInterface> $voters
+     */
+    public function __construct(
+        iterable $strategies,
+        private readonly iterable $voters,
+        ?string $defaultStrategy = null,
+        private readonly ?EventDispatcherInterface $dispatcher = null
+    ) {
+        $namedStrategies = [];
+        foreach ($strategies as $strategy) {
+            $namedStrategies[$strategy->getName()] = $strategy;
+        }
+        if (\count($namedStrategies) === 0) {
+            $namedStrategies['affirmative'] = new AffirmativeStrategy();
+            $defaultStrategy = 'affirmative';
+        }
+        if ($defaultStrategy === null) {
+            $defaultStrategy = array_key_first($namedStrategies);
+            assert($defaultStrategy !== null, 'The default strategy cannot be null.');
+        }
+        $this->defaultStrategy = $defaultStrategy;
+        $this->strategies = $namedStrategies;
+    }
+
+    public function decide(AccessRequest $accessRequest, ?string $strategy = null): AccessDecision
+    {
+        $strategy = $strategy ?? $this->defaultStrategy;
+        if (!isset($this->strategies[$strategy])) {
+            throw new InvalidStrategyException(sprintf('Strategy "%s" is not registered. Valid strategies are: %s', $strategy, implode(', ', array_keys($this->strategies))));
+        }
+        $votes = [];
+        foreach ($this->getVoters($accessRequest) as $voter) {
+            $vote = $voter->vote($accessRequest);
+            $votes[] = $vote;
+            $this->dispatcher?->dispatch(new VoteEvent($voter, $accessRequest, $vote));
+        }
+
+        $accessDecision = $this->strategies[$strategy]->evaluate($accessRequest, $votes);
+        if ($accessDecision->decision !== DecisionVote::ACCESS_ABSTAIN) {
+            $this->dispatcher?->dispatch(new AccessDecisionEvent($accessRequest, $accessDecision));
+            return $accessDecision;
+        }
+
+        $accessDecision = AccessDecision::deny($accessRequest, $votes, $accessDecision->reason);
+        if ($accessRequest->allowIfAllAbstainOrTie) {
+            $accessDecision = AccessDecision::grant($accessRequest, $votes, $accessDecision->reason);
+        }
+
+        $this->dispatcher?->dispatch(new AccessDecisionEvent($accessRequest, $accessDecision));
+
+        return $accessDecision;
+    }
+
+    /**
+     * @return iterable<VoterInterface>
+     */
+    private function getVoters(AccessRequest $accessRequest): iterable
+    {
+        $keyAttribute = \is_object($accessRequest->attribute) ? $accessRequest->attribute::class : get_debug_type($accessRequest->attribute);
+        $keySubject = \is_object($accessRequest->subject) ? $accessRequest->subject::class : get_debug_type($accessRequest->subject);
+        foreach ($this->voters as $key => $voter) {
+            if (!isset($this->votersCacheAttributes[$keyAttribute][$key])) {
+                $this->votersCacheAttributes[$keyAttribute][$key] = $voter->supportsAttribute($accessRequest->attribute);
+            }
+            if (!$this->votersCacheAttributes[$keyAttribute][$key]) {
+                continue;
+            }
+
+            if (!isset($this->votersCacheSubject[$keySubject][$key])) {
+                $this->votersCacheSubject[$keySubject][$key] = $voter->supportsSubject($accessRequest->subject);
+            }
+            if (!$this->votersCacheSubject[$keySubject][$key]) {
+                continue;
+            }
+            yield $voter;
+        }
+    }
+}

--- a/src/Symfony/Component/AccessControl/AccessControlManagerInterface.php
+++ b/src/Symfony/Component/AccessControl/AccessControlManagerInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\AccessControl;
+
+/**
+ * @experimental
+ */
+interface AccessControlManagerInterface
+{
+    public function decide(AccessRequest $accessRequest, ?string $strategy = null): AccessDecision;
+}

--- a/src/Symfony/Component/AccessControl/AccessDecision.php
+++ b/src/Symfony/Component/AccessControl/AccessDecision.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Symfony\Component\AccessControl;
+
+/**
+ * @experimental
+ */
+readonly class AccessDecision
+{
+    /**
+     * @param iterable<VoterOutcome> $votes
+     */
+    public function __construct(
+        public AccessRequest $accessRequest,
+        public DecisionVote  $decision,
+        public iterable      $votes,
+        public ?string       $reason = null,
+    ) {
+    }
+
+    /**
+     * @param iterable<VoterOutcome> $votes
+     */
+    public static function grant(AccessRequest $accessRequest, iterable $votes, ?string $reason = null): self
+    {
+        return new self($accessRequest, DecisionVote::ACCESS_GRANTED, $votes, $reason);
+    }
+
+    /**
+     * @param iterable<VoterOutcome> $votes
+     */
+    public static function deny(AccessRequest $accessRequest, iterable $votes, ?string $reason = null): self
+    {
+        return new self($accessRequest, DecisionVote::ACCESS_DENIED, $votes, $reason);
+    }
+
+    public static function abstain(AccessRequest $accessRequest, iterable $votes, ?string $reason = null): self
+    {
+        return new self($accessRequest, DecisionVote::ACCESS_ABSTAIN, $votes, $reason);
+    }
+}

--- a/src/Symfony/Component/AccessControl/AccessRequest.php
+++ b/src/Symfony/Component/AccessControl/AccessRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Symfony\Component\AccessControl;
+
+use Symfony\Component\ExpressionLanguage\Expression;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * @experimental
+ */
+readonly class AccessRequest
+{
+    public function __construct(
+        public null|TokenInterface $requester,
+        public mixed $attribute,
+        public mixed  $subject = null,
+        public MetadataBag $metadata = new MetadataBag(),
+        public bool $allowIfAllAbstainOrTie = false,
+    ) {
+    }
+}

--- a/src/Symfony/Component/AccessControl/Attribute/AccessPolicy.php
+++ b/src/Symfony/Component/AccessControl/Attribute/AccessPolicy.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AccessControl\Attribute;
+
+/**
+ * @experimental
+ */
+#[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_FUNCTION)]
+readonly class AccessPolicy
+{
+    /**
+     * @param array<array-key, mixed> $metadata
+     */
+    public function __construct(
+        public mixed $attribute,
+        public mixed $subject = null,
+        public ?string $strategy = null,
+        public array $metadata = [],
+        public bool $allowIfAllAbstain = false,
+        public string $message = 'Access Denied.',
+        public ?int $statusCode = null,
+        public ?int $exceptionCode = null,
+    ) {
+    }
+}

--- a/src/Symfony/Component/AccessControl/Attribute/All.php
+++ b/src/Symfony/Component/AccessControl/Attribute/All.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AccessControl\Attribute;
+
+/**
+ * @experimental
+ */
+#[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_FUNCTION)]
+final readonly class All
+{
+    /**
+     * @param list<AccessPolicy> $accessPolicies
+     */
+    public function __construct(
+        public array $accessPolicies,
+        public string $message = 'Access Denied.',
+        public ?int $statusCode = null,
+        public ?int $exceptionCode = null,
+    ) {
+    }
+}

--- a/src/Symfony/Component/AccessControl/Attribute/AtLeastOneOf.php
+++ b/src/Symfony/Component/AccessControl/Attribute/AtLeastOneOf.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AccessControl\Attribute;
+
+/**
+ * @experimental
+ */
+#[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_FUNCTION)]
+final readonly class AtLeastOneOf
+{
+    /**
+     * @param list<AccessPolicy> $accessPolicies
+     */
+    public function __construct(
+        public array $accessPolicies,
+    ) {
+    }
+}

--- a/src/Symfony/Component/AccessControl/CHANGELOG.md
+++ b/src/Symfony/Component/AccessControl/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+7.3
+---
+
+ * Add the component as experimental

--- a/src/Symfony/Component/AccessControl/DecisionVote.php
+++ b/src/Symfony/Component/AccessControl/DecisionVote.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\AccessControl;
+
+/**
+ * @experimental
+ */
+enum DecisionVote: string
+{
+    case ACCESS_GRANTED = 'ACCESS_GRANTED';
+    case ACCESS_DENIED= 'ACCESS_DENIED';
+    case ACCESS_ABSTAIN= 'ACCESS_ABSTAIN';
+}

--- a/src/Symfony/Component/AccessControl/Event/AccessDecisionEvent.php
+++ b/src/Symfony/Component/AccessControl/Event/AccessDecisionEvent.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Symfony\Component\AccessControl\Event;
+
+use Symfony\Component\AccessControl\AccessRequest;
+use Symfony\Component\AccessControl\AccessDecision;
+use Symfony\Component\AccessControl\VoterOutcome;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * @experimental
+ */
+final class AccessDecisionEvent extends Event
+{
+    public function __construct(
+        public readonly AccessRequest  $accessRequest,
+        public readonly AccessDecision $accessDecision
+    ) {
+    }
+}

--- a/src/Symfony/Component/AccessControl/Event/VoteEvent.php
+++ b/src/Symfony/Component/AccessControl/Event/VoteEvent.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Symfony\Component\AccessControl\Event;
+
+use Symfony\Component\AccessControl\AccessRequest;
+use Symfony\Component\AccessControl\VoterInterface;
+use Symfony\Component\AccessControl\VoterOutcome;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * @experimental
+ */
+final class VoteEvent extends Event
+{
+    public function __construct(
+        public readonly VoterInterface $voter,
+        public readonly AccessRequest  $accessRequest,
+        public readonly VoterOutcome   $voterOutcome
+    ) {
+    }
+}

--- a/src/Symfony/Component/AccessControl/Exception/InvalidStrategyException.php
+++ b/src/Symfony/Component/AccessControl/Exception/InvalidStrategyException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\AccessControl\Exception;
+
+/**
+ * @experimental
+ */
+final class InvalidStrategyException extends \RuntimeException
+{
+
+}

--- a/src/Symfony/Component/AccessControl/ExpressionLanguage.php
+++ b/src/Symfony/Component/AccessControl/ExpressionLanguage.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AccessControl;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage as BaseExpressionLanguage;
+
+if (!class_exists(BaseExpressionLanguage::class)) {
+    throw new \LogicException(\sprintf('The "%s" class requires the "ExpressionLanguage" component. Try running "composer require symfony/expression-language".', ExpressionLanguage::class));
+}
+
+// Help opcache.preload discover always-needed symbols
+class_exists(ExpressionLanguageProvider::class);
+
+
+/**
+ * @experimental
+ */
+class ExpressionLanguage extends BaseExpressionLanguage
+{
+    public function __construct(?CacheItemPoolInterface $cache = null, array $providers = [])
+    {
+        // prepend the default provider to let users override it easily
+        array_unshift($providers, new ExpressionLanguageProvider());
+
+        parent::__construct($cache, $providers);
+    }
+}

--- a/src/Symfony/Component/AccessControl/ExpressionLanguageProvider.php
+++ b/src/Symfony/Component/AccessControl/ExpressionLanguageProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AccessControl;
+
+use Symfony\Component\ExpressionLanguage\ExpressionFunction;
+use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
+
+
+/**
+ * @experimental
+ */
+class ExpressionLanguageProvider implements ExpressionFunctionProviderInterface
+{
+    public function getFunctions(): array
+    {
+        return [
+            new ExpressionFunction('is_authenticated', static fn () => '$token && $trust_resolver->isAuthenticated($token)', static fn (array $variables) => $variables['token'] && $variables['trust_resolver']->isAuthenticated($variables['token'])),
+            new ExpressionFunction('is_fully_authenticated', static fn () => '$token && $trust_resolver->isFullFledged($token)', static fn (array $variables) => $variables['token'] && $variables['trust_resolver']->isFullFledged($variables['token'])),
+            new ExpressionFunction('is_remember_me', static fn () => '$token && $trust_resolver->isRememberMe($token)', static fn (array $variables) => $variables['token'] && $variables['trust_resolver']->isRememberMe($variables['token'])),
+        ];
+    }
+}

--- a/src/Symfony/Component/AccessControl/LICENSE
+++ b/src/Symfony/Component/AccessControl/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2023-present Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/AccessControl/Listener/AccessPolicyListener.php
+++ b/src/Symfony/Component/AccessControl/Listener/AccessPolicyListener.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Symfony\Component\AccessControl\Listener;
+
+use Symfony\Component\AccessControl\AccessRequest;
+use Symfony\Component\AccessControl\AccessControlManager;
+use Symfony\Component\AccessControl\Attribute\AccessPolicy;
+use Symfony\Component\AccessControl\DecisionVote;
+use Symfony\Component\AccessControl\MetadataBag;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+/**
+ * @experimental
+ */
+final readonly class AccessPolicyListener implements EventSubscriberInterface
+{
+    public function __construct(
+        private TokenStorageInterface $tokenStorage,
+        private AccessControlManager $accessControlManager,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::CONTROLLER_ARGUMENTS => ['onKernelControllerArguments', 20],
+            ConsoleEvents::COMMAND => ['onConsoleCommand', 20],
+        ];
+    }
+
+    public function onConsoleCommand(ConsoleCommandEvent $event): void
+    {
+        $command = $event->getCommand();
+        if ($command === null) {
+            return;
+        }
+        $reflectionClass = new \ReflectionClass($command);
+        $attributes = $reflectionClass->getAttributes(AccessPolicy::class);
+
+        foreach ($attributes as $attribute) {
+            $this->processAttribute(
+                $attribute->newInstance(),
+                [
+                    'input' => $event->getInput(),
+                    'output' => $event->getOutput()
+                ]
+            );
+        }
+    }
+
+    public function onKernelControllerArguments(ControllerArgumentsEvent $event): void
+    {
+        /** @var AccessPolicy[] $attributes */
+        if (!\is_array($attributes = $event->getAttributes()[AccessPolicy::class] ?? null)) {
+            return;
+        }
+
+        foreach ($attributes as $attribute) {
+            $this->processAttribute(
+                $attribute,
+                [
+                    'request' => $event->getRequest(),
+                    'args' => $event->getArguments(),
+                ]
+            );
+        }
+    }
+
+    private function processAttribute(AccessPolicy $attribute, array $metadata): void
+    {
+        $accessRequest = new AccessRequest(
+            $this->tokenStorage->getToken(),
+            $attribute->attribute,
+            $attribute->subject,
+            new MetadataBag([
+                ...$attribute->metadata,
+                ...$metadata,
+            ]),
+            $attribute->allowIfAllAbstain
+        );
+        $accessDecision = $this->accessControlManager->decide($accessRequest, $attribute->strategy);
+
+        if ($accessDecision->decision !== DecisionVote::ACCESS_GRANTED) {
+            if ($statusCode = $attribute->statusCode) {
+                throw new HttpException($statusCode, $attribute->message, code: $attribute->exceptionCode ?? 0);
+            }
+
+            throw new AccessDeniedException(
+                $attribute->message,
+                null,
+                $attribute->exceptionCode ?? 403
+            );
+        }
+    }
+}

--- a/src/Symfony/Component/AccessControl/Listener/AllListener.php
+++ b/src/Symfony/Component/AccessControl/Listener/AllListener.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Symfony\Component\AccessControl\Listener;
+
+use Symfony\Component\AccessControl\AccessRequest;
+use Symfony\Component\AccessControl\AccessControlManager;
+use Symfony\Component\AccessControl\Attribute\All;
+use Symfony\Component\AccessControl\DecisionVote;
+use Symfony\Component\AccessControl\MetadataBag;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+/**
+ * @experimental
+ */
+final readonly class AllListener implements EventSubscriberInterface
+{
+    public function __construct(
+        private TokenStorageInterface $tokenStorage,
+        private AccessControlManager $accessControlManager,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::CONTROLLER_ARGUMENTS => ['onKernelControllerArguments', 20],
+            ConsoleEvents::COMMAND => ['onConsoleCommand', 20],
+        ];
+    }
+
+    public function onConsoleCommand(ConsoleCommandEvent $event): void
+    {
+        $command = $event->getCommand();
+        if ($command === null) {
+            return;
+        }
+        $reflectionClass = new \ReflectionClass($command);
+        $attributes = $reflectionClass->getAttributes(All::class);
+
+        foreach ($attributes as $attribute) {
+            $this->processAttribute(
+                $attribute->newInstance(),
+                [
+                    'input' => $event->getInput(),
+                    'output' => $event->getOutput()
+                ]
+            );
+        }
+    }
+
+    public function onKernelControllerArguments(ControllerArgumentsEvent $event): void
+    {
+        /** @var All[] $attributes */
+        if (!\is_array($attributes = $event->getAttributes()[All::class] ?? null)) {
+            return;
+        }
+
+        foreach ($attributes as $attribute) {
+            $this->processAttribute(
+                $attribute,
+                [
+                    'request' => $event->getRequest(),
+                    'args' => $event->getArguments(),
+                ]
+            );
+        }
+    }
+
+    private function processAttribute(All $attribute, array $metadata): void
+    {
+        foreach ($attribute->accessPolicies as $accessPolicy) {
+            $accessRequest = new AccessRequest(
+                $this->tokenStorage->getToken(),
+                $accessPolicy->attribute,
+                $accessPolicy->subject,
+                new MetadataBag([
+                    ...$accessPolicy->metadata,
+                    ...$metadata,
+                ]),
+                $accessPolicy->allowIfAllAbstain
+            );
+            $accessDecision = $this->accessControlManager->decide($accessRequest, $accessPolicy->strategy);
+
+            if ($accessDecision->decision !== DecisionVote::ACCESS_GRANTED) {
+                if ($statusCode = $attribute->statusCode) {
+                    throw new HttpException($statusCode, $attribute->message, code: $attribute->exceptionCode ?? 0);
+                }
+
+                throw new AccessDeniedException(
+                    $attribute->message,
+                    null,
+                    $attribute->exceptionCode ?? 403
+                );
+            }
+        }
+    }
+}

--- a/src/Symfony/Component/AccessControl/Listener/AtLeastOneOfListener.php
+++ b/src/Symfony/Component/AccessControl/Listener/AtLeastOneOfListener.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Symfony\Component\AccessControl\Listener;
+
+use Symfony\Component\AccessControl\AccessRequest;
+use Symfony\Component\AccessControl\AccessControlManager;
+use Symfony\Component\AccessControl\Attribute\All;
+use Symfony\Component\AccessControl\DecisionVote;
+use Symfony\Component\AccessControl\MetadataBag;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+/**
+ * @experimental
+ */
+final readonly class AtLeastOneOfListener implements EventSubscriberInterface
+{
+    public function __construct(
+        private TokenStorageInterface $tokenStorage,
+        private AccessControlManager $accessControlManager,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::CONTROLLER_ARGUMENTS => ['onKernelControllerArguments', 20],
+            ConsoleEvents::COMMAND => ['onConsoleCommand', 20],
+        ];
+    }
+
+    public function onConsoleCommand(ConsoleCommandEvent $event): void
+    {
+        $command = $event->getCommand();
+        if ($command === null) {
+            return;
+        }
+        $reflectionClass = new \ReflectionClass($command);
+        $attributes = $reflectionClass->getAttributes(All::class);
+
+        foreach ($attributes as $attribute) {
+            $this->processAttribute(
+                $attribute->newInstance(),
+                [
+                    'input' => $event->getInput(),
+                    'output' => $event->getOutput()
+                ]
+            );
+        }
+    }
+
+    public function onKernelControllerArguments(ControllerArgumentsEvent $event): void
+    {
+        /** @var All[] $attributes */
+        if (!\is_array($attributes = $event->getAttributes()[All::class] ?? null)) {
+            return;
+        }
+
+        foreach ($attributes as $attribute) {
+            $this->processAttribute(
+                $attribute,
+                [
+                    'request' => $event->getRequest(),
+                    'args' => $event->getArguments(),
+                ]
+            );
+        }
+    }
+
+    private function processAttribute(All $attribute, array $metadata): void
+    {
+        foreach ($attribute->accessPolicies as $accessPolicy) {
+            $accessRequest = new AccessRequest(
+                $this->tokenStorage->getToken(),
+                $accessPolicy->attribute,
+                $accessPolicy->subject,
+                new MetadataBag([
+                    ...$accessPolicy->metadata,
+                    ...$metadata,
+                ]),
+                $accessPolicy->allowIfAllAbstain
+            );
+            $accessDecision = $this->accessControlManager->decide($accessRequest, $accessPolicy->strategy);
+
+            if ($accessDecision->decision === DecisionVote::ACCESS_GRANTED) {
+                return;
+            }
+        }
+
+        if ($statusCode = $attribute->statusCode) {
+            throw new HttpException($statusCode, $attribute->message, code: $attribute->exceptionCode ?? 0);
+        }
+
+        throw new AccessDeniedException(
+            $attribute->message,
+            null,
+            $attribute->exceptionCode ?? 403
+        );
+    }
+}

--- a/src/Symfony/Component/AccessControl/MetadataBag.php
+++ b/src/Symfony/Component/AccessControl/MetadataBag.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Symfony\Component\AccessControl;
+
+/**
+ * @experimental
+ */
+final readonly class MetadataBag implements \IteratorAggregate, \Countable
+{
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    public function __construct(
+        private array $parameters = [],
+    ) {
+    }
+
+    /**
+     * Returns the parameter keys.
+     */
+    public function keys(): array
+    {
+        return array_keys($this->parameters);
+    }
+
+    public function get(string $key, mixed $default = null): mixed
+    {
+        return \array_key_exists($key, $this->parameters) ? $this->parameters[$key] : $default;
+    }
+
+    /**
+     * Returns true if the parameter is defined.
+     */
+    public function has(string $key): bool
+    {
+        return \array_key_exists($key, $this->parameters);
+    }
+
+    /**
+     * Returns an iterator for parameters.
+     *
+     * @return \ArrayIterator<string, mixed>
+     */
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->parameters);
+    }
+
+    /**
+     * Returns the number of parameters.
+     */
+    public function count(): int
+    {
+        return \count($this->parameters);
+    }
+}

--- a/src/Symfony/Component/AccessControl/README.md
+++ b/src/Symfony/Component/AccessControl/README.md
@@ -1,0 +1,16 @@
+AssetMapper Component
+=====================
+
+The AssetMapper component allows you to expose directories of assets that are
+then moved to a public directory with digested (i.e. versioned) filenames. It
+also allows you to dump an [importmap](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap)
+to allow writing modern JavaScript without a build system.
+
+Resources
+---------
+
+ * [Documentation](https://symfony.com/doc/current/frontend/asset_mapper.html)
+ * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+ * [Report issues](https://github.com/symfony/symfony/issues) and
+   [send Pull Requests](https://github.com/symfony/symfony/pulls)
+   in the [main Symfony repository](https://github.com/symfony/symfony)

--- a/src/Symfony/Component/AccessControl/Strategy/AffirmativeStrategy.php
+++ b/src/Symfony/Component/AccessControl/Strategy/AffirmativeStrategy.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Symfony\Component\AccessControl\Strategy;
+
+use Symfony\Component\AccessControl\AccessRequest;
+use Symfony\Component\AccessControl\AccessDecision;
+use Symfony\Component\AccessControl\DecisionVote;
+use Symfony\Component\AccessControl\VoterOutcome;
+
+/**
+ * A simple “affirmative” strategy:
+ *  - If at least one voter grants access, the final decision is granted.
+ *  - If all abstain, the final decision depends on the allowIfAllAbstainOrTie property value.
+ *  - Otherwise, (i.e. at least one voter denies access) the final decision is denied.
+ *
+ * @experimental
+ */
+final readonly class AffirmativeStrategy implements StrategyInterface
+{
+    public function getName(): string
+    {
+        return 'affirmative';
+    }
+
+    /**
+     * @param iterable<VoterOutcome> $votes
+     */
+    public function evaluate(AccessRequest $accessRequest, iterable $votes): AccessDecision
+    {
+        $deny = 0;
+
+        foreach ($votes as $vote) {
+            if ($vote->decision === DecisionVote::ACCESS_GRANTED) {
+                return AccessDecision::grant($accessRequest, $votes, $vote->reason);
+            }
+
+            if ($vote->decision === DecisionVote::ACCESS_DENIED) {
+                ++$deny;
+            }
+        }
+
+        if ($deny > 0) {
+            return AccessDecision::deny($accessRequest, $votes, 'At least one voter denied access.');
+        }
+
+        return AccessDecision::abstain($accessRequest, $votes, 'All voters abstained from voting.');
+    }
+}

--- a/src/Symfony/Component/AccessControl/Strategy/ConsensusStrategy.php
+++ b/src/Symfony/Component/AccessControl/Strategy/ConsensusStrategy.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Symfony\Component\AccessControl\Strategy;
+
+use Symfony\Component\AccessControl\AccessRequest;
+use Symfony\Component\AccessControl\AccessDecision;
+use Symfony\Component\AccessControl\DecisionVote;
+use Symfony\Component\AccessControl\VoterOutcome;
+
+/**
+ * A majority of “GRANT” votes leads to granted; more “DENIED” votes leads to deny.
+ * Abstentions are not counted.
+ * If there is a tie, the decision depends on the allowIfAllAbstainOrTie property value.
+ * The vote weight is taken into account.
+ *
+ * @experimental
+ */
+final readonly class ConsensusStrategy implements StrategyInterface
+{
+    public function getName(): string
+    {
+        return 'consensus';
+    }
+
+    /**
+     * @param iterable<VoterOutcome> $votes
+     */
+    public function evaluate(AccessRequest $accessRequest, iterable $votes): AccessDecision
+    {
+        $grantCount = 0;
+        $denyCount  = 0;
+
+        foreach ($votes as $vote) {
+            if ($vote->decision === DecisionVote::ACCESS_GRANTED) {
+                $grantCount += $vote->weight;
+            } elseif ($vote->decision === DecisionVote::ACCESS_DENIED) {
+                $denyCount += $vote->weight;
+            }
+        }
+
+        if ($denyCount > $grantCount) {
+            return AccessDecision::deny($accessRequest, $votes, 'A majority of voters denied access.');
+        }
+
+        if ($grantCount > $denyCount) {
+            return AccessDecision::grant($accessRequest, $votes, 'A majority of voters granted access.');
+        }
+
+        return AccessDecision::abstain($accessRequest, $votes, $grantCount === 0 ? 'All voters abstained from voting.' : 'There is a tie.');
+    }
+}

--- a/src/Symfony/Component/AccessControl/Strategy/StrategyInterface.php
+++ b/src/Symfony/Component/AccessControl/Strategy/StrategyInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Symfony\Component\AccessControl\Strategy;
+
+use Symfony\Component\AccessControl\AccessRequest;
+use Symfony\Component\AccessControl\AccessDecision;
+use Symfony\Component\AccessControl\VoterOutcome;
+
+/**
+ * @experimental
+ */
+interface StrategyInterface
+{
+    public function getName(): string;
+
+    /**
+     * @param iterable<VoterOutcome> $votes
+     */
+    public function evaluate(AccessRequest $accessRequest, iterable $votes): AccessDecision;
+}

--- a/src/Symfony/Component/AccessControl/Strategy/UnanimousStrategy.php
+++ b/src/Symfony/Component/AccessControl/Strategy/UnanimousStrategy.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Symfony\Component\AccessControl\Strategy;
+
+use Symfony\Component\AccessControl\AccessRequest;
+use Symfony\Component\AccessControl\AccessDecision;
+use Symfony\Component\AccessControl\DecisionVote;
+use Symfony\Component\AccessControl\VoterOutcome;
+
+/**
+ * A simple “unanimous” strategy:
+ *  - If at least one voter denies, the final decision is denied.
+ *  - If all abstain, the final decision depends on the allowIfAllAbstainDecisions property value.
+ *  - Otherwise, (i.e. at least one voter grants access) the final decision is granted.
+ *
+ * @experimental
+ */
+final readonly class UnanimousStrategy implements StrategyInterface
+{
+    public function getName(): string
+    {
+        return 'unanimous';
+    }
+
+    /**
+     * @param iterable<VoterOutcome> $votes
+     */
+    public function evaluate(AccessRequest $accessRequest, iterable $votes): AccessDecision
+    {
+        $grant = 0;
+
+        foreach ($votes as $vote) {
+            if ($vote->decision === DecisionVote::ACCESS_DENIED) {
+                return AccessDecision::deny($accessRequest, $votes, $vote->reason);
+            }
+
+            if ($vote->decision === DecisionVote::ACCESS_GRANTED) {
+                ++$grant;
+            }
+        }
+
+        if ($grant > 0) {
+            return AccessDecision::grant($accessRequest, $votes, 'All non-abstaining voters granted access.');
+        }
+
+        return AccessDecision::abstain($accessRequest, $votes, 'All voters abstained from voting.');
+    }
+}

--- a/src/Symfony/Component/AccessControl/Tests/AffirmativeStrategyTest.php
+++ b/src/Symfony/Component/AccessControl/Tests/AffirmativeStrategyTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Symfony\Component\AccessControl\Tests;
+
+use Symfony\Component\AccessControl\AccessRequest;
+use Symfony\Component\AccessControl\DecisionVote;
+use Symfony\Component\ExpressionLanguage\Expression;
+use Symfony\Component\Security\Core\Authentication\Token\NullToken;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+final class AffirmativeStrategyTest extends StrategyTestCase
+{
+    /**
+     * @dataProvider provideScenarios
+     */
+    public function testDecide(AccessRequest $accessRequest, DecisionVote $expectedDecision, ?string $reason): void
+    {
+        // Arrange
+        $accessControlManger = $this->getAccessControlManager();
+
+        // Act
+        $decision = $accessControlManger->decide($accessRequest, 'affirmative');
+
+        // Assert
+        $this->assertEquals($expectedDecision, $decision->decision);
+        $this->assertEquals($reason, $decision->reason);
+    }
+
+    /**
+     * @return iterable{0: string, 1: AccessRequest, 2: DecisionVote, 3: string}
+     */
+    public function provideScenarios(): iterable
+    {
+        yield 'affirmative strategy and deny on abstain' => [
+            new AccessRequest(new NullToken(),'read', 'article'),
+            DecisionVote::ACCESS_DENIED,
+            'All voters abstained from voting.',
+        ];
+
+        yield 'affirmative strategy and grant on abstain' => [
+            new AccessRequest(new NullToken(),'read', 'article', allowIfAllAbstainOrTie: true),
+            DecisionVote::ACCESS_GRANTED,
+            'All voters abstained from voting.',
+        ];
+        yield 'affirmative strategy and deny on unauthenticated user' => [
+            new AccessRequest(new NullToken(),'ROLE_USER'),
+            DecisionVote::ACCESS_DENIED,
+            'At least one voter denied access.',
+        ];
+
+        $userToken = $this->createMock(TokenInterface::class);
+        $userToken->method('getUser')->willReturn(new FakeUser);
+        yield 'affirmative strategy and grant on authenticated user (classic interface)' => [
+            new AccessRequest($userToken,'ROLE_USER'),
+            DecisionVote::ACCESS_GRANTED,
+            'The user has the required role.',
+        ];
+
+        $userToken = $this->createMock(TokenInterface::class);
+        $userToken->method('getUser')->willReturn(new FakeUserWithRole);
+        yield 'affirmative strategy and grant on authenticated user (new interface)' => [
+            new AccessRequest($userToken,'ROLE_USER'),
+            DecisionVote::ACCESS_GRANTED,
+            'The user has the required role.',
+        ];
+
+        $userToken = $this->createMock(TokenInterface::class);
+        $userToken->method('getUser')->willReturn(new FakeUserWithRole(roles: ['ROLE_SUPER_ADMIN']));
+        yield 'affirmative strategy and grant on authenticated user (inherited role)' => [
+            new AccessRequest($userToken,'ROLE_ALLOWED_TO_SWITCH'),
+            DecisionVote::ACCESS_GRANTED,
+            'The user has the required role.',
+        ];
+
+        $userToken = $this->createMock(TokenInterface::class);
+        $userToken->method('getUser')->willReturn(new FakeUserWithRole(roles: ['ROLE_ADMIN']));
+        yield 'affirmative strategy and deny on authenticated user (inherited role)' => [
+            new AccessRequest($userToken,'ROLE_ALLOWED_TO_SWITCH'),
+            DecisionVote::ACCESS_DENIED,
+            'At least one voter denied access.',
+        ];
+
+        $userToken = $this->createMock(TokenInterface::class);
+        $userToken->method('getUser')->willReturn(new FakeUserWithRole(roles: ['ROLE_ADMIN']));
+        $expression = new Expression('"ROLE_ADMIN" in role_names and is_authenticated()');
+        yield 'affirmative strategy and grant on expression' => [
+            new AccessRequest($userToken,$expression),
+            DecisionVote::ACCESS_GRANTED,
+            'Access granted by expression',
+        ];
+
+        $userToken = $this->createMock(TokenInterface::class);
+        $userToken->method('getUser')->willReturn(new FakeUserWithRole(roles: ['ROLE_ADMIN']));
+        $expression = new Expression('"ROLE_SUPER_ADMIN" in role_names and is_fully_authenticated()');
+        yield 'affirmative strategy and denied on expression' => [
+            new AccessRequest($userToken,$expression),
+            DecisionVote::ACCESS_DENIED,
+            'At least one voter denied access.',
+        ];
+    }
+}

--- a/src/Symfony/Component/AccessControl/Tests/ConsensusStrategyTest.php
+++ b/src/Symfony/Component/AccessControl/Tests/ConsensusStrategyTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Symfony\Component\AccessControl\Tests;
+
+use Symfony\Component\AccessControl\AccessRequest;
+use Symfony\Component\AccessControl\DecisionVote;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+final class ConsensusStrategyTest extends StrategyTestCase
+{
+    /**
+     * @dataProvider provideScenarios
+     */
+    public function testDecide(AccessRequest $accessRequest, DecisionVote $expectedDecision, ?string $reason): void
+    {
+        // Arrange
+        $accessControlManger = $this->getAccessControlManager();
+
+        // Act
+        $decision = $accessControlManger->decide($accessRequest, 'consensus');
+
+        // Assert
+        $this->assertEquals($expectedDecision, $decision->decision);
+        $this->assertEquals($reason, $decision->reason);
+    }
+
+    /**
+     * @return iterable{0: string, 1: AccessRequest, 2: DecisionVote, 3: string}
+     */
+    public function provideScenarios(): iterable
+    {
+        $userToken = $this->createMock(TokenInterface::class);
+        $userToken->method('getUser')->willReturn(new FakeUserWithRole(roles: ['ROLE_SUPER_ADMIN']));
+        yield 'consensus strategy and deny on authenticated user' => [
+            new AccessRequest($userToken,'ROLE_ALLOWED_TO_SWITCH'),
+            DecisionVote::ACCESS_DENIED,
+            'There is a tie.',
+        ];
+
+        $userToken = $this->createMock(TokenInterface::class);
+        $userToken->method('getUser')->willReturn(new FakeUserWithRole(roles: ['ROLE_SUPER_ADMIN']));
+        yield 'consensus strategy and grant on authenticated user' => [
+            new AccessRequest($userToken,'ROLE_ALLOWED_TO_SWITCH', allowIfAllAbstainOrTie: true),
+            DecisionVote::ACCESS_GRANTED,
+            'There is a tie.',
+        ];
+    }
+}

--- a/src/Symfony/Component/AccessControl/Tests/EventsTest.php
+++ b/src/Symfony/Component/AccessControl/Tests/EventsTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Symfony\Component\AccessControl\Tests;
+
+use Symfony\Component\AccessControl\AccessRequest;
+use Symfony\Component\AccessControl\Event\AccessDecisionEvent;
+use Symfony\Component\AccessControl\Event\VoteEvent;
+use Symfony\Component\Security\Core\Authentication\Token\NullToken;
+
+final class EventsTest extends StrategyTestCase
+{
+    public function testDecide(): void
+    {
+        // Arrange
+        $accessRequest = new AccessRequest(new NullToken(), 'PUBLIC_ACCESS');
+
+        // Act
+        $this->getAccessControlManager()->decide($accessRequest);
+
+        // Assert
+        $events = $this->getEventDispatcher()->events;
+        $this->assertCount(2, $events);
+        $this->assertInstanceOf(VoteEvent::class, $events[0]);
+        $this->assertInstanceOf(AccessDecisionEvent::class, $events[1]);
+    }
+}

--- a/src/Symfony/Component/AccessControl/Tests/FakeEventDispatcher.php
+++ b/src/Symfony/Component/AccessControl/Tests/FakeEventDispatcher.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Symfony\Component\AccessControl\Tests;
+
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+final class FakeEventDispatcher implements EventDispatcherInterface
+{
+    public array $events = [];
+    public function dispatch(object $event, ?string $eventName = null): object
+    {
+        $this->events[] = $event;
+
+        return $event;
+    }
+}

--- a/src/Symfony/Component/AccessControl/Tests/FakeTokenStorage.php
+++ b/src/Symfony/Component/AccessControl/Tests/FakeTokenStorage.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Symfony\Component\AccessControl\Tests;
+
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+final class FakeTokenStorage implements TokenStorageInterface
+{
+    private ?TokenInterface $token = null;
+
+    public function getToken(): ?TokenInterface
+    {
+        return $this->token;
+    }
+
+    public function setToken(?TokenInterface $token): void
+    {
+        $this->token = $token;
+    }
+}

--- a/src/Symfony/Component/AccessControl/Tests/FakeUser.php
+++ b/src/Symfony/Component/AccessControl/Tests/FakeUser.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Symfony\Component\AccessControl\Tests;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+
+final readonly class FakeUser implements UserInterface
+{
+    public function __construct(
+        private string $username = 'foo',
+        private array $roles = ['ROLE_USER']
+    )
+    {
+    }
+
+    public function eraseCredentials(): void
+    {
+        //Nothing to do here
+    }
+
+    public function getUserIdentifier(): string
+    {
+        return $this->username;
+    }
+
+    public function getRoles(): array
+    {
+        return $this->roles;
+    }
+}

--- a/src/Symfony/Component/AccessControl/Tests/FakeUserWithRole.php
+++ b/src/Symfony/Component/AccessControl/Tests/FakeUserWithRole.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Symfony\Component\AccessControl\Tests;
+
+use Symfony\Component\AccessControl\Voter\RBAC\UserWithRoleInterface;
+
+final readonly class FakeUserWithRole implements UserWithRoleInterface
+{
+    public function __construct(
+        private string $username = 'foo',
+        private array $roles = ['ROLE_USER']
+    )
+    {
+    }
+
+    public function eraseCredentials(): void
+    {
+        //Nothing to do here
+    }
+
+    public function getUserIdentifier(): string
+    {
+        return $this->username;
+    }
+
+    public function getRoles(): array
+    {
+        return $this->roles;
+    }
+}

--- a/src/Symfony/Component/AccessControl/Tests/StrategyTestCase.php
+++ b/src/Symfony/Component/AccessControl/Tests/StrategyTestCase.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Symfony\Component\AccessControl\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\AccessControl\AccessControlManager;
+use Symfony\Component\AccessControl\ExpressionLanguage;
+use Symfony\Component\AccessControl\Strategy\AffirmativeStrategy;
+use Symfony\Component\AccessControl\Strategy\ConsensusStrategy;
+use Symfony\Component\AccessControl\Strategy\UnanimousStrategy;
+use Symfony\Component\AccessControl\Voter\ABAC\AuthenticatedVoter;
+use Symfony\Component\AccessControl\Voter\Expression\ExpressionVoter;
+use Symfony\Component\AccessControl\Voter\RBAC\RoleHierarchyVoter;
+use Symfony\Component\AccessControl\Voter\RBAC\RoleVoter;
+use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolver;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Role\RoleHierarchy;
+use Symfony\Component\Security\Core\Role\RoleHierarchyInterface;
+
+abstract class StrategyTestCase extends TestCase
+{
+    private ?AccessControlManager $accessControlManager = null;
+    private ?FakeEventDispatcher $eventDispatcher = null;
+    private ?TokenStorageInterface $tokenStorage = null;
+
+    protected function getTokenStorage(): TokenStorageInterface
+    {
+        if ($this->tokenStorage === null) {
+            $this->tokenStorage = new FakeTokenStorage();
+        }
+
+        return $this->tokenStorage;
+    }
+
+    protected function getAccessControlManager(): AccessControlManager
+    {
+        if ($this->accessControlManager === null) {
+            $this->accessControlManager = new AccessControlManager(
+                [
+                    new AffirmativeStrategy(),
+                    new ConsensusStrategy(),
+                    new UnanimousStrategy(),
+                ],
+                [
+                    new ExpressionVoter(
+                        new ExpressionLanguage(),
+                        new AuthenticationTrustResolver(),
+                        $this->getRoleHierarchy(),
+                    ),
+                    new RoleVoter(),
+                    new RoleHierarchyVoter($this->getRoleHierarchy()),
+                    new AuthenticatedVoter(
+                        new AuthenticationTrustResolver(),
+                        $this->getTokenStorage()
+                    ),
+                ],
+                dispatcher: $this->getEventDispatcher(),
+            );
+        }
+
+        return $this->accessControlManager;
+    }
+
+    protected function getEventDispatcher(): FakeEventDispatcher
+    {
+        if ($this->eventDispatcher === null) {
+            $this->eventDispatcher = new FakeEventDispatcher();
+        }
+
+        return $this->eventDispatcher;
+    }
+
+    protected function getRoleHierarchy(): RoleHierarchyInterface
+    {
+        return new RoleHierarchy([
+            'ROLE_ADMIN' => ['ROLE_USER'],
+            'ROLE_SUPER_ADMIN' => ['ROLE_ADMIN', 'ROLE_ALLOWED_TO_SWITCH'],
+        ]);
+    }
+}

--- a/src/Symfony/Component/AccessControl/Tests/UnanimousStrategyTest.php
+++ b/src/Symfony/Component/AccessControl/Tests/UnanimousStrategyTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Symfony\Component\AccessControl\Tests;
+
+use Symfony\Component\AccessControl\AccessRequest;
+use Symfony\Component\AccessControl\DecisionVote;
+use Symfony\Component\Security\Core\Authentication\Token\NullToken;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+final class UnanimousStrategyTest extends StrategyTestCase
+{
+    /**
+     * @dataProvider provideScenarios
+     */
+    public function testDecide(AccessRequest $accessRequest, DecisionVote $expectedDecision, ?string $reason): void
+    {
+        // Arrange
+        $accessControlManger = $this->getAccessControlManager();
+
+        // Act
+        $decision = $accessControlManger->decide($accessRequest, 'unanimous');
+
+        // Assert
+        $this->assertEquals($expectedDecision, $decision->decision);
+        $this->assertEquals($reason, $decision->reason);
+    }
+
+    /**
+     * @return iterable{0: string, 1: AccessRequest, 2: DecisionVote, 3: string}
+     */
+    public function provideScenarios(): iterable
+    {
+        // In this scenario, both RoleVoter and RoleHierarchyVoter will vote. The former will deny access.
+        $userToken = $this->createMock(TokenInterface::class);
+        $userToken->method('getUser')->willReturn(new FakeUserWithRole(roles: ['ROLE_SUPER_ADMIN']));
+        yield 'unanimous strategy and deny on authenticated user' => [
+            new AccessRequest($userToken,'ROLE_ALLOWED_TO_SWITCH'),
+            DecisionVote::ACCESS_DENIED,
+            'The user does not have the required role.',
+        ];
+
+        $userToken = $this->createMock(TokenInterface::class);
+        $userToken->method('getUser')->willReturn(new FakeUserWithRole(roles: ['ROLE_ADMIN']));
+        yield 'unanimous strategy and grant on authenticated user' => [
+            new AccessRequest($userToken,'ROLE_ADMIN'),
+            DecisionVote::ACCESS_GRANTED,
+            'All non-abstaining voters granted access.',
+        ];
+    }
+}

--- a/src/Symfony/Component/AccessControl/Voter/ABAC/AuthenticatedVoter.php
+++ b/src/Symfony/Component/AccessControl/Voter/ABAC/AuthenticatedVoter.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Symfony\Component\AccessControl\Voter\ABAC;
+
+use Symfony\Component\AccessControl\AccessRequest;
+use Symfony\Component\AccessControl\VoterInterface;
+use Symfony\Component\AccessControl\VoterOutcome;
+use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface;
+use Symfony\Component\Security\Core\Authentication\Token\OfflineTokenInterface;
+use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\InvalidArgumentException;
+
+/**
+ * @experimental
+ */
+final readonly class AuthenticatedVoter implements VoterInterface
+{
+    public function __construct(
+        private AuthenticationTrustResolverInterface $authenticationTrustResolver,
+    ){}
+
+    public function vote(AccessRequest $accessRequest): VoterOutcome
+    {
+        $attribute = AuthenticationState::fromValue($accessRequest->attribute);
+        if (!$accessRequest->requester instanceof TokenInterface) {
+            return VoterOutcome::deny('The token is not an instance of TokenInterface.');
+        }
+
+        if ($attribute === null) {
+            return VoterOutcome::abstain('The attribute is not an authentication state.');
+        }
+        if ($attribute === AuthenticationState::PUBLIC_ACCESS) {
+            return VoterOutcome::grant('Access granted to public access');
+        }
+
+        if ($accessRequest->requester instanceof OfflineTokenInterface) {
+            throw new InvalidArgumentException('Cannot decide on authentication attributes when an offline token is used.');
+        }
+
+        if (AuthenticationState::IS_AUTHENTICATED_FULLY === $attribute
+            && $this->authenticationTrustResolver->isFullFledged($accessRequest->requester)) {
+            return VoterOutcome::grant('Access granted by fully authenticated user.');
+        }
+
+        if (AuthenticationState::IS_AUTHENTICATED_REMEMBERED === $attribute
+            && ($this->authenticationTrustResolver->isRememberMe($accessRequest->requester)
+                || $this->authenticationTrustResolver->isFullFledged($accessRequest->requester))) {
+            return VoterOutcome::grant('Access granted by remembered user.');
+        }
+
+        if (AuthenticationState::IS_AUTHENTICATED === $attribute && $this->authenticationTrustResolver->isAuthenticated($accessRequest->requester)) {
+            return VoterOutcome::grant('Access granted by authenticated user.');
+        }
+
+        if (AuthenticationState::IS_REMEMBERED === $attribute && $this->authenticationTrustResolver->isRememberMe($accessRequest->requester)) {
+            return VoterOutcome::grant('Access granted by remembered user.');
+        }
+
+        if (AuthenticationState::IS_IMPERSONATOR === $attribute && $accessRequest->requester instanceof SwitchUserToken) {
+            return VoterOutcome::grant('Access granted by impersonator.');
+        }
+
+        return VoterOutcome::deny('The user does not have the required authentication state.');
+    }
+
+    public function supportsAttribute(mixed $attribute): bool
+    {
+        return \is_string($attribute) && \in_array($attribute, AuthenticationState::caseNames(), true);
+    }
+
+    public function supportsSubject(mixed $subject): bool
+    {
+        return true;
+    }
+}
+

--- a/src/Symfony/Component/AccessControl/Voter/ABAC/AuthenticationState.php
+++ b/src/Symfony/Component/AccessControl/Voter/ABAC/AuthenticationState.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Symfony\Component\AccessControl\Voter\ABAC;
+
+/**
+ * @experimental
+ */
+enum AuthenticationState: string
+{
+    case IS_AUTHENTICATED_FULLY = 'IS_AUTHENTICATED_FULLY';
+    case IS_AUTHENTICATED_REMEMBERED = 'IS_AUTHENTICATED_REMEMBERED';
+    case IS_AUTHENTICATED = 'IS_AUTHENTICATED';
+    case IS_IMPERSONATOR = 'IS_IMPERSONATOR';
+    case IS_REMEMBERED = 'IS_REMEMBERED';
+    case PUBLIC_ACCESS = 'PUBLIC_ACCESS';
+
+    /**
+     * @return list<string>
+     */
+    public static function caseNames(): array
+    {
+        return array_map(static fn (AuthenticationState $state):string => $state->value, self::cases());
+    }
+
+    public static function fromValue(string $state): ?AuthenticationState
+    {
+        return match ($state) {
+            'IS_AUTHENTICATED_FULLY' => self::IS_AUTHENTICATED_FULLY,
+            'IS_AUTHENTICATED_REMEMBERED' => self::IS_AUTHENTICATED_REMEMBERED,
+            'IS_AUTHENTICATED' => self::IS_AUTHENTICATED,
+            'IS_IMPERSONATOR' => self::IS_IMPERSONATOR,
+            'IS_REMEMBERED' => self::IS_REMEMBERED,
+            'PUBLIC_ACCESS' => self::PUBLIC_ACCESS,
+            default => null,
+        };
+    }
+}
+

--- a/src/Symfony/Component/AccessControl/Voter/Expression/ExpressionVoter.php
+++ b/src/Symfony/Component/AccessControl/Voter/Expression/ExpressionVoter.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AccessControl\Voter\Expression;
+
+use Symfony\Component\AccessControl\AccessRequest;
+use Symfony\Component\AccessControl\Voter\RBAC\UserWithRoleInterface;
+use Symfony\Component\AccessControl\VoterInterface;
+use Symfony\Component\AccessControl\VoterOutcome;
+use Symfony\Component\ExpressionLanguage\Expression;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Role\RoleHierarchyInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * @experimental
+ */
+final readonly class ExpressionVoter implements VoterInterface
+{
+    public function __construct(
+        private ExpressionLanguage $expressionLanguage,
+        private AuthenticationTrustResolverInterface $trustResolver,
+        private ?RoleHierarchyInterface $roleHierarchy = null,
+    ) {
+    }
+
+    public function supportsAttribute(mixed $attribute): bool
+    {
+        return $attribute instanceof Expression;
+    }
+
+    public function supportsSubject(mixed $subject): bool
+    {
+        return true;
+    }
+
+    public function vote(AccessRequest $accessRequest): VoterOutcome
+    {
+        $variables = $this->getVariables($accessRequest);
+        if ($this->expressionLanguage->evaluate($accessRequest->attribute, $variables)) {
+            return VoterOutcome::grant('Access granted by expression');
+        }
+
+        return VoterOutcome::deny('Access denied by expression');
+    }
+
+    /**
+     * @return array{token: TokenInterface, user: UserInterface|null, object: mixed, subject: mixed, roles: array<int, string>, role_names: array<int, string>, trust_resolver: AuthenticationTrustResolverInterface, auth_checker: AuthorizationCheckerInterface, request: Request|null}
+     */
+    private function getVariables(AccessRequest $accessRequest): array
+    {
+        $user = $accessRequest->requester?->getUser();
+        $roleNames = [];
+        if ($user !== null && ($user instanceof UserWithRoleInterface || method_exists($user, 'getRoles'))) {
+            $roleNames = $user->getRoles();
+        }
+
+        if ($this->roleHierarchy !== null) {
+            $roleNames = $this->roleHierarchy->getReachableRoleNames($roleNames);
+        }
+
+        $variables = [
+            'token' => $accessRequest->requester,
+            'user' => $user,
+            'object' => $accessRequest->subject,
+            'subject' => $accessRequest->subject,
+            'role_names' => $roleNames,
+            'trust_resolver' => $this->trustResolver,
+            'metadata' => $accessRequest->metadata,
+        ];
+
+        if ($accessRequest->subject instanceof Request) {
+            $variables['request'] = $accessRequest->subject;
+        }
+
+        return $variables;
+    }
+}

--- a/src/Symfony/Component/AccessControl/Voter/RBAC/RoleHierarchyVoter.php
+++ b/src/Symfony/Component/AccessControl/Voter/RBAC/RoleHierarchyVoter.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AccessControl\Voter\RBAC;
+
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Role\RoleHierarchyInterface;
+
+/**
+ * @experimental
+ */
+readonly class RoleHierarchyVoter extends RoleVoter
+{
+    public function __construct(
+        private RoleHierarchyInterface $roleHierarchy,
+        string $prefix = 'ROLE_',
+    ){
+        parent::__construct($prefix);
+    }
+
+    protected function extractRoles(?TokenInterface $requester): array
+    {
+        $roles = parent::extractRoles($requester);
+
+        return $this->roleHierarchy->getReachableRoleNames($roles);
+    }
+}

--- a/src/Symfony/Component/AccessControl/Voter/RBAC/RoleVoter.php
+++ b/src/Symfony/Component/AccessControl/Voter/RBAC/RoleVoter.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AccessControl\Voter\RBAC;
+
+use Symfony\Component\AccessControl\AccessRequest;
+use Symfony\Component\AccessControl\VoterInterface;
+use Symfony\Component\AccessControl\VoterOutcome;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * @experimental
+ */
+readonly class RoleVoter implements VoterInterface
+{
+    public function __construct(
+        private string $prefix = 'ROLE_',
+    ){}
+
+    public function vote(AccessRequest $accessRequest): VoterOutcome
+    {
+        $roles = $this->extractRoles($accessRequest->requester);
+
+        if (!\is_string($accessRequest->attribute) || !str_starts_with($accessRequest->attribute, $this->prefix)) {
+            return VoterOutcome::abstain('The attribute is not a role.');
+        }
+
+        if (\in_array($accessRequest->attribute, $roles, true)) {
+            return VoterOutcome::grant('The user has the required role.');
+        }
+
+        return VoterOutcome::deny('The user does not have the required role.');
+    }
+
+    public function supportsAttribute(mixed $attribute): bool
+    {
+        return \is_string($attribute) && str_starts_with($attribute, $this->prefix);
+    }
+
+    public function supportsSubject(mixed $subject): bool
+    {
+        return true;
+    }
+
+    protected function extractRoles(?TokenInterface $requester): array
+    {
+        $user = $requester?->getUser();
+        if (!$user instanceof UserInterface && !$user instanceof UserWithRoleInterface) {
+            return [];
+        }
+
+        if ($user instanceof UserWithRoleInterface || method_exists($user, 'getRoles')) {
+            return $user->getRoles();
+        }
+
+        return [];
+    }
+}

--- a/src/Symfony/Component/AccessControl/Voter/RBAC/UserWithRoleInterface.php
+++ b/src/Symfony/Component/AccessControl/Voter/RBAC/UserWithRoleInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AccessControl\Voter\RBAC;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * @experimental
+ */
+interface UserWithRoleInterface extends UserInterface
+{
+    /**
+     * Returns the roles granted to the user.
+     *
+     * @return string[]
+     */
+    public function getRoles(): array;
+}

--- a/src/Symfony/Component/AccessControl/VoterInterface.php
+++ b/src/Symfony/Component/AccessControl/VoterInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AccessControl;
+
+/**
+ * @experimental
+ */
+interface VoterInterface
+{
+    public function vote(AccessRequest $accessRequest): VoterOutcome;
+
+    public function supportsAttribute(mixed $attribute): bool;
+
+    public function supportsSubject(mixed $subject): bool;
+}

--- a/src/Symfony/Component/AccessControl/VoterOutcome.php
+++ b/src/Symfony/Component/AccessControl/VoterOutcome.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Symfony\Component\AccessControl;
+
+/**
+ * @experimental
+ */
+final readonly class VoterOutcome
+{
+    public function __construct(
+        public DecisionVote $decision,
+        public ?string $reason = null,
+        public int|float $weight = 1,
+    ) {
+    }
+
+    public static function grant(?string $reason = null, int|float $weight = 1): self
+    {
+        return new self(DecisionVote::ACCESS_GRANTED, $reason, $weight);
+    }
+
+    public static function deny(?string $reason = null, int|float $weight = 1): self
+    {
+        return new self(DecisionVote::ACCESS_DENIED, $reason, $weight);
+    }
+
+    public static function abstain(?string $reason = null, int|float $weight = 1): self
+    {
+        return new self(DecisionVote::ACCESS_ABSTAIN, $reason, $weight);
+    }
+}

--- a/src/Symfony/Component/AccessControl/composer.json
+++ b/src/Symfony/Component/AccessControl/composer.json
@@ -1,0 +1,31 @@
+{
+    "name": "symfony/access-control",
+    "type": "library",
+    "description": "Symfony Access Control Component",
+    "keywords": [],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Fabien Potencier",
+            "email": "fabien@symfony.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=8.2",
+        "composer/semver": "^3.0"
+    },
+    "require-dev": {
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Component\\AccessControl\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev"
+}

--- a/src/Symfony/Component/AccessControl/phpunit.xml.dist
+++ b/src/Symfony/Component/AccessControl/phpunit.xml.dist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/9.3/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony Access Control Component Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage>
+        <include>
+            <directory>./</directory>
+        </include>
+        <exclude>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </coverage>
+</phpunit>


### PR DESCRIPTION
Introduce the new Access Control component in Symfony, providing core access decision-making and voting mechanisms. This includes support for affirmative, unanimous, and consensus strategies, along with role-based and expression-based voters. Tests and examples included to validate behavior.

| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #59300
| License       | MIT

Hi,

As I mentioned in the issue I submitted, I’m proposing a new component. Currently, it doesn’t do anything beyond what the existing access control feature in the security component already offers. It’s still in an early stage of exploration and development, so please don’t expect a fully functional component at this point.

The main goal is to remove the `getRoles()` method from the user interface and decouple from the authentication features. As noted in the original issue, this could potentially be accomplished within the existing security component. However, if we continue with this proposal, our biggest challenge will be handling multiple classes with incompatible interfaces within the same namespace. Creating a separate component will simplify development (I guess the console/terminal components face a similar challenge).

The design I’m proposing is not particularly groundbreaking.
There is a single `AccessControlManagerInterface` with one method:

```php
public function decide(AccessRequest $accessRequest, ?string $strategy = null): AccessDecision;
```

`AccessRequest` contains:
* The `requester` i.e. the user who is requesting an authorization. A TokenInterface is expected. This can be the current logged in user, a user for another user, a console command or anything relevant as per your application needs,
* The attribute (`mixed` type) for which you want to gather votes,
* The subject (also `mixed` type),
* The metadata associated to the request and used by the voters (the Http Request, the Console Command...).

The decision is determined by the specified strategy depending on the voter outcomes.
RBAC or Expression voters and `affirmative`, `consensus`, or `unanimous` strategies in this initial commit. The returned `AccessDecision` object contains
* the access request,
* the final decision,
* the vote outcomes (you can keep track on the voter results,
* and an optional reason (as a `string`).

Also, for this first commit, I created three attributes:

1. `AccessPolicy` – similar to `isGranted`:

```php
AccessPolicy('ROLE_ADMIN');
AccessPolicy('read', $post);
```

The difference is that you can override the default strategy or allow access if all voters abstain:

```php
AccessPolicy('read', $post, strategy: 'unanimous');
AccessPolicy('read', $post, allowIfAllAbstain: true);
```

2. `All` and `AtLeastOneOf`

These attributes enable fine-grained decisions on multiple AccessPolicy attributes, intended for more complex scenarios:

```php
#[All([
    new AccessPolicy('read', $post),
    new AccessPolicy('not-before', '2026-01-01'),
    new AccessPolicy('internal-ip-address'),
])]
```

I’m looking forward to your feedback and suggestions!