### PR TITLE
[Validator] Checked Turkish validators translations and confirmed

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.tr.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.tr.xlf
@@ -192,7 +192,7 @@
             </trans-unit>
             <trans-unit id="51" resname="No temporary folder was configured in php.ini.">
                 <source>No temporary folder was configured in php.ini, or the configured folder does not exist.</source>
-                <target state="needs-review-translation">php.ini'de geçici bir klasör yapılandırılmadı, veya yapılandırılan klasör mevcut değildir.</target>
+                <target>php.ini'de geçici bir klasör yapılandırılmadı veya yapılandırılan klasör mevcut değildir.</target>
             </trans-unit>
             <trans-unit id="52">
                 <source>Cannot write temporary file to disk.</source>
@@ -468,7 +468,7 @@
             </trans-unit>
             <trans-unit id="120">
                 <source>This value is not a valid slug.</source>
-                <target state="needs-review-translation">Bu değer geçerli bir slug değildir.</target>
+                <target>Bu değer geçerli bir “slug” değildir.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59432 
| License       | MIT

Checked the Turkish validators translations.
I removed comma from **trans-unit=51** because in Turkish we **GENERALLY** dont use comma just before conjunctions.
In addition, since the word **_slug_** is not understandable for Turkish speakers and there is no exact translation, I replaced **_slug_** word with the a Turkish word (**_Alan adı_**) which is more understandable.
