### PR TITLE
[OptionResolver] Allow whitespace in types

### DIFF
--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -1141,6 +1141,7 @@ class OptionsResolver implements Options
 
     private function verifyTypes(string $type, mixed $value, ?array &$invalidTypes = null, int $level = 0): bool
     {
+        $type = trim($type);
         $allowedTypes = $this->splitOutsideParenthesis($type);
         if (\count($allowedTypes) > 1) {
             foreach ($allowedTypes as $allowedType) {

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -790,6 +790,18 @@ class OptionsResolverTest extends TestCase
         $this->assertSame(['foo' => '1'], $options);
     }
 
+    public function testResolveTypedWithUnionAndWhitespaces()
+    {
+        $this->resolver->setDefined('foo');
+        $this->resolver->setAllowedTypes('foo', 'string | int');
+
+        $options = $this->resolver->resolve(['foo' => 1]);
+        $this->assertSame(['foo' => 1], $options);
+
+        $options = $this->resolver->resolve(['foo' => '1']);
+        $this->assertSame(['foo' => '1'], $options);
+    }
+
     public function testResolveTypedWithUnionOfClasse()
     {
         $this->resolver->setDefined('foo');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #... 
| License       | MIT

Since we're now supporting union of type, people might prefer to use whitespace when writing union of type like `int | string` rather than `int|string`. This might be interesting for complex type, and since the support is easy I think it's a good improvement.