### PR TITLE
[OptionsResolver] Add support for `array<>` syntax to validate keys

### DIFF
--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -1142,7 +1142,7 @@ class OptionsResolver implements Options
     private function verifyTypes(string $type, mixed $value, ?array &$invalidTypes = null, int $level = 0): bool
     {
         $type = trim($type);
-        $allowedTypes = $this->splitOutsideParenthesis($type);
+        $allowedTypes = $this->splitTypes($type);
         if (\count($allowedTypes) > 1) {
             foreach ($allowedTypes as $allowedType) {
                 if ($this->verifyTypes($allowedType, $value)) {
@@ -1162,17 +1162,29 @@ class OptionsResolver implements Options
             return $this->verifyTypes(substr($type, 1, -1), $value, $invalidTypes, $level);
         }
 
-        if (\is_array($value) && str_ends_with($type, '[]')) {
-            $type = substr($type, 0, -2);
-            $valid = true;
-
-            foreach ($value as $val) {
-                if (!$this->verifyTypes($type, $val, $invalidTypes, $level + 1)) {
-                    $valid = false;
-                }
+        if (\is_array($value)) {
+            if (str_starts_with($type, 'array<') && str_ends_with($type, '>')) {
+                $types = $this->splitTypes(substr($type, 6, -1), ',');
+                $allowedValueType = $types[1] ?? $types[0];
+                $allowedKeyType = isset($types[1]) ? $types[0] : null;
+            } elseif (str_ends_with($type, '[]')) {
+                $allowedValueType = substr($type, 0, -2);
             }
 
-            return $valid;
+            if (isset($allowedValueType)) {
+                $valid = true;
+                foreach ($value as $key => $val) {
+                    if (isset($allowedKeyType) && !$this->verifyTypes($allowedKeyType, $key, $invalidTypes, $level + 1)) {
+                        $valid = false;
+                    }
+
+                    if (!$this->verifyTypes($allowedValueType, $val, $invalidTypes, $level + 1)) {
+                        $valid = false;
+                    }
+                }
+
+                return $valid;
+            }
         }
 
         if (('null' === $type && null === $value) || (isset(self::VALIDATION_FUNCTIONS[$type]) ? self::VALIDATION_FUNCTIONS[$type]($value) : $value instanceof $type)) {
@@ -1189,27 +1201,31 @@ class OptionsResolver implements Options
     /**
      * @return list<string>
      */
-    private function splitOutsideParenthesis(string $type): array
+    private function splitTypes(string $type, string $separator = '|'): array
     {
         $parts = [];
         $currentPart = '';
         $parenthesisLevel = 0;
+        $arrayLevel = 0;
 
         $typeLength = \strlen($type);
         for ($i = 0; $i < $typeLength; ++$i) {
             $char = $type[$i];
+            if ($separator === $char && 0 === $parenthesisLevel && 0 === $arrayLevel) {
+                $parts[] = $currentPart;
+                $currentPart = '';
+                continue;
+            }
 
+            $currentPart .= $char;
             if ('(' === $char) {
                 ++$parenthesisLevel;
             } elseif (')' === $char) {
                 --$parenthesisLevel;
-            }
-
-            if ('|' === $char && 0 === $parenthesisLevel) {
-                $parts[] = $currentPart;
-                $currentPart = '';
-            } else {
-                $currentPart .= $char;
+            } elseif ('<' === $char) {
+                ++$arrayLevel;
+            } elseif ('>' === $char) {
+                --$arrayLevel;
             }
         }
 

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -867,6 +867,15 @@ class OptionsResolverTest extends TestCase
         $this->assertSame(['foo' => ['bar', 'baz']], $options);
     }
 
+    public function testResolveTypedArrayWithStringKeys()
+    {
+        $this->resolver->setDefined('foo');
+        $this->resolver->setAllowedTypes('foo', 'array<string, string>');
+        $options = $this->resolver->resolve(['foo' => ['bar' => 'bar', 'baz' => 'baz']]);
+
+        $this->assertSame(['foo' => ['bar' => 'bar', 'baz' => 'baz']], $options);
+    }
+
     public function testResolveTypedArrayWithInvalidKeys()
     {
         $this->resolver->setDefined('foo');

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -2016,7 +2016,7 @@ class OptionsResolverTest extends TestCase
         $this->resolver->setDefined('foo');
         $this->resolver->setAllowedTypes('foo', 'array<array<int>>');
 
-        $this->assertEquals([
+        $this->assertSame([
             'foo' => [
                 [
                     1, 2,

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -828,6 +828,18 @@ class OptionsResolverTest extends TestCase
         $this->assertSame(['foo' => [1, true]], $options);
     }
 
+    public function testResolveTypedWithUnionOfArray2()
+    {
+        $this->resolver->setDefined('foo');
+        $this->resolver->setAllowedTypes('foo', 'array<string|int>|array<bool|int>');
+
+        $options = $this->resolver->resolve(['foo' => [1, '1']]);
+        $this->assertSame(['foo' => [1, '1']], $options);
+
+        $options = $this->resolver->resolve(['foo' => [1, true]]);
+        $this->assertSame(['foo' => [1, true]], $options);
+    }
+
     public function testResolveTypedArray()
     {
         $this->resolver->setDefined('foo');
@@ -837,10 +849,46 @@ class OptionsResolverTest extends TestCase
         $this->assertSame(['foo' => ['bar', 'baz']], $options);
     }
 
+    public function testResolveTypedArray2()
+    {
+        $this->resolver->setDefined('foo');
+        $this->resolver->setAllowedTypes('foo', 'array<string>');
+        $options = $this->resolver->resolve(['foo' => ['bar', 'baz']]);
+
+        $this->assertSame(['foo' => ['bar', 'baz']], $options);
+    }
+
+    public function testResolveTypedArrayWithKeys()
+    {
+        $this->resolver->setDefined('foo');
+        $this->resolver->setAllowedTypes('foo', 'array<int, string>');
+        $options = $this->resolver->resolve(['foo' => ['bar', 'baz']]);
+
+        $this->assertSame(['foo' => ['bar', 'baz']], $options);
+    }
+
+    public function testResolveTypedArrayWithInvalidKeys()
+    {
+        $this->resolver->setDefined('foo');
+        $this->resolver->setAllowedTypes('foo', 'array<string, string>');
+
+        $this->expectException(InvalidOptionsException::class);
+        $this->resolver->resolve(['foo' => ['bar', 'baz']]);
+    }
+
     public function testResolveTypedArrayWithUnion()
     {
         $this->resolver->setDefined('foo');
         $this->resolver->setAllowedTypes('foo', '(string|int)[]');
+        $options = $this->resolver->resolve(['foo' => ['bar', 1]]);
+
+        $this->assertSame(['foo' => ['bar', 1]], $options);
+    }
+
+    public function testResolveTypedArrayWithUnion2()
+    {
+        $this->resolver->setDefined('foo');
+        $this->resolver->setAllowedTypes('foo', 'array<string|int>');
         $options = $this->resolver->resolve(['foo' => ['bar', 1]]);
 
         $this->assertSame(['foo' => ['bar', 1]], $options);
@@ -1963,10 +2011,48 @@ class OptionsResolverTest extends TestCase
         ]));
     }
 
+    public function testNestedArrays2()
+    {
+        $this->resolver->setDefined('foo');
+        $this->resolver->setAllowedTypes('foo', 'array<array<int>>');
+
+        $this->assertEquals([
+            'foo' => [
+                [
+                    1, 2,
+                ],
+            ],
+        ], $this->resolver->resolve([
+            'foo' => [
+                [1, 2],
+            ],
+        ]));
+    }
+
     public function testNestedArraysWithUnions()
     {
         $this->resolver->setDefined('foo');
         $this->resolver->setAllowedTypes('foo', '(int|float|(int|float)[])[]');
+
+        $this->assertEquals([
+            'foo' => [
+                1,
+                2.0,
+                [1, 2.0],
+            ],
+        ], $this->resolver->resolve([
+            'foo' => [
+                1,
+                2.0,
+                [1, 2.0],
+            ],
+        ]));
+    }
+
+    public function testNestedArraysWithUnions2()
+    {
+        $this->resolver->setDefined('foo');
+        $this->resolver->setAllowedTypes('foo', 'array<int|float|array<int|float>>');
 
         $this->assertEquals([
             'foo' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #... 
| License       | MIT

In PHPdoc there is three way to describe an generic array:
- `string[]`
- `array<string>`

The second syntax has the benefit to allows describing the keys (for instance `array<string, string>`) so I'd like to add the support for this syntax in the OptionResolver.

Require https://github.com/symfony/symfony/pull/59441 first.

The next step would be the support for the `array{foo: string, bar?: int}` syntax, but this might be a little bit more complicated and should be done in another PR anyways.