### PR TITLE
[Routing] Fix configuring a single route's hosts

### DIFF
--- a/src/Symfony/Component/Routing/Loader/Configurator/RouteConfigurator.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/RouteConfigurator.php
@@ -42,7 +42,14 @@ class RouteConfigurator
      */
     final public function host(string|array $host): static
     {
+        $previousRoutes = clone $this->route;
         $this->addHost($this->route, $host);
+        foreach ($previousRoutes as $name => $route) {
+            if (!$this->route->get($name)) {
+                $this->collection->remove($name);
+            }
+        }
+        $this->collection->addCollection($this->route);
 
         return $this;
     }

--- a/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
@@ -135,7 +135,7 @@ class XmlFileLoader extends FileLoader
             throw new \InvalidArgumentException(sprintf('The <route> element in file "%s" must not have both a "path" attribute and <path> child nodes.', $path));
         }
 
-        $routes = $this->createLocalizedRoute($collection, $id, $paths ?: $node->getAttribute('path'));
+        $routes = $this->createLocalizedRoute(new RouteCollection(), $id, $paths ?: $node->getAttribute('path'));
         $routes->addDefaults($defaults);
         $routes->addRequirements($requirements);
         $routes->addOptions($options);
@@ -146,6 +146,8 @@ class XmlFileLoader extends FileLoader
         if (null !== $hosts) {
             $this->addHost($routes, $hosts);
         }
+
+        $collection->addCollection($routes);
     }
 
     /**

--- a/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
@@ -157,7 +157,7 @@ class YamlFileLoader extends FileLoader
             $defaults['_stateless'] = $config['stateless'];
         }
 
-        $routes = $this->createLocalizedRoute($collection, $name, $config['path']);
+        $routes = $this->createLocalizedRoute(new RouteCollection(), $name, $config['path']);
         $routes->addDefaults($defaults);
         $routes->addRequirements($requirements);
         $routes->addOptions($options);
@@ -168,6 +168,8 @@ class YamlFileLoader extends FileLoader
         if (isset($config['host'])) {
             $this->addHost($routes, $config['host']);
         }
+
+        $collection->addCollection($routes);
     }
 
     /**

--- a/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/route-with-hosts-expected-collection.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/route-with-hosts-expected-collection.php
@@ -1,0 +1,23 @@
+<?php
+
+use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+return function (string $format) {
+    $expectedRoutes = new RouteCollection();
+    $expectedRoutes->add('static.en', $route = new Route('/example'));
+    $route->setHost('www.example.com');
+    $route->setRequirement('_locale', 'en');
+    $route->setDefault('_locale', 'en');
+    $route->setDefault('_canonical_route', 'static');
+    $expectedRoutes->add('static.nl', $route = new Route('/example'));
+    $route->setHost('www.example.nl');
+    $route->setRequirement('_locale', 'nl');
+    $route->setDefault('_locale', 'nl');
+    $route->setDefault('_canonical_route', 'static');
+
+    $expectedRoutes->addResource(new FileResource(__DIR__."/route-with-hosts.$format"));
+
+    return $expectedRoutes;
+};

--- a/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/route-with-hosts.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/route-with-hosts.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\Routing\Loader\Configurator;
+
+return function (RoutingConfigurator $routes) {
+    $routes->add('static', '/example')->host([
+        'nl' => 'www.example.nl',
+        'en' => 'www.example.com',
+    ]);
+};

--- a/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/route-with-hosts.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/route-with-hosts.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<routes xmlns="http://symfony.com/schema/routing"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing
+        https://symfony.com/schema/routing/routing-1.0.xsd">
+    <route id="static" path="/example">
+        <host locale="nl">www.example.nl</host>
+        <host locale="en">www.example.com</host>
+    </route>
+</routes>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/route-with-hosts.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/route-with-hosts.yml
@@ -1,0 +1,6 @@
+---
+static:
+    path: /example
+    host:
+        nl: www.example.nl
+        en: www.example.com

--- a/src/Symfony/Component/Routing/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/PhpFileLoaderTest.php
@@ -317,6 +317,16 @@ class PhpFileLoaderTest extends TestCase
         $this->assertEquals($expectedRoutes('php'), $routes);
     }
 
+    public function testAddingRouteWithHosts()
+    {
+        $loader = new PhpFileLoader(new FileLocator([__DIR__.'/../Fixtures/locale_and_host']));
+        $routes = $loader->load('route-with-hosts.php');
+
+        $expectedRoutes = require __DIR__.'/../Fixtures/locale_and_host/route-with-hosts-expected-collection.php';
+
+        $this->assertEquals($expectedRoutes('php'), $routes);
+    }
+
     public function testImportingAliases()
     {
         $loader = new PhpFileLoader(new FileLocator([__DIR__.'/../Fixtures/alias']));

--- a/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
@@ -577,6 +577,16 @@ class XmlFileLoaderTest extends TestCase
         $this->assertEquals($expectedRoutes('xml'), $routes);
     }
 
+    public function testAddingRouteWithHosts()
+    {
+        $loader = new XmlFileLoader(new FileLocator([__DIR__.'/../Fixtures/locale_and_host']));
+        $routes = $loader->load('route-with-hosts.xml');
+
+        $expectedRoutes = require __DIR__.'/../Fixtures/locale_and_host/route-with-hosts-expected-collection.php';
+
+        $this->assertEquals($expectedRoutes('xml'), $routes);
+    }
+
     public function testWhenEnv()
     {
         $loader = new XmlFileLoader(new FileLocator([__DIR__.'/../Fixtures']), 'some-env');

--- a/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
@@ -443,6 +443,16 @@ class YamlFileLoaderTest extends TestCase
         $this->assertEquals($expectedRoutes('yml'), $routes);
     }
 
+    public function testAddingRouteWithHosts()
+    {
+        $loader = new YamlFileLoader(new FileLocator([__DIR__.'/../Fixtures/locale_and_host']));
+        $routes = $loader->load('route-with-hosts.yml');
+
+        $expectedRoutes = require __DIR__.'/../Fixtures/locale_and_host/route-with-hosts-expected-collection.php';
+
+        $this->assertEquals($expectedRoutes('yml'), $routes);
+    }
+
     public function testWhenEnv()
     {
         $loader = new YamlFileLoader(new FileLocator([__DIR__.'/../Fixtures']), 'some-env');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58086 
| License       | MIT

All loaders were affected by this issue: when you configure a route it is immediately added to the main collection **and** in the one returned by the `LocalizedRouteTrait`. Problem is: only the latter is updated when configuring hosts, which means they will be ignored.

This PR merges these two collections, with a twist: after its hosts are configured, a route may have to be removed from the main collection  (like `static` becoming `static.nl` and `static.en` in the tests).