### PR TITLE
[Validator] `Image` constraint fix typo in minRatio comment

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Image.php
+++ b/src/Symfony/Component/Validator/Constraints/Image.php
@@ -107,7 +107,7 @@ class Image extends File
      * @param int|null                 $maxHeight                   Maximum image height
      * @param int|null                 $minHeight                   Minimum image weight
      * @param int|float|null           $maxRatio                    Maximum image ratio
-     * @param int|float|null           $minRatio                    Minimum image ration
+     * @param int|float|null           $minRatio                    Minimum image ratio
      * @param int|float|null           $minPixels                   Minimum amount of pixels
      * @param int|float|null           $maxPixels                   Maximum amount of pixels
      * @param bool|null                $allowSquare                 Whether to allow a square image (defaults to true)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

Just fixing a quick typo on the `Image` constraint, in the `$minRatio` comment.
