### PR TITLE
chore: PHP CS Fixer fixes

### DIFF
--- a/src/Symfony/Component/Runtime/Tests/phpt/kernel.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/kernel.php
@@ -15,8 +15,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 require __DIR__.'/autoload.php';
 
-class TestKernel implements HttpKernelInterface
-{
+return fn (array $context) => new class($context['APP_ENV'], $context['SOME_VAR']) implements HttpKernelInterface {
     private string $env;
     private string $var;
 
@@ -30,6 +29,4 @@ class TestKernel implements HttpKernelInterface
     {
         return new Response('OK Kernel (env='.$this->env.') '.$this->var);
     }
-}
-
-return fn (array $context) => new TestKernel($context['APP_ENV'], $context['SOME_VAR']);
+};


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3 
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix CS <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

PHP CS Fixer constantly complaining about having a class called `TestKernel` as only class in file that is _not_ called that way.
Maybe we can remove the class name in total, especially as it's test resource file, and other files in this folder already using anonymous classes?