### PR TITLE
[Console] Add broader support for command "help" definition

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -611,7 +611,11 @@ class FrameworkExtension extends Extension
         $container->registerForAutoconfiguration(AssetCompilerInterface::class)
             ->addTag('asset_mapper.compiler');
         $container->registerAttributeForAutoconfiguration(AsCommand::class, static function (ChildDefinition $definition, AsCommand $attribute, \ReflectionClass $reflector): void {
-            $definition->addTag('console.command', ['command' => $attribute->name, 'description' => $attribute->description]);
+            $definition->addTag('console.command', [
+                'command' => $attribute->name,
+                'description' => $attribute->description,
+                'help' => $attribute->help,
+            ]);
         });
         $container->registerForAutoconfiguration(Command::class)
             ->addTag('console.command');

--- a/src/Symfony/Component/Console/Attribute/AsCommand.php
+++ b/src/Symfony/Component/Console/Attribute/AsCommand.php
@@ -22,12 +22,14 @@ class AsCommand
      * @param string|null $description The description of the command, displayed with the help page
      * @param string[]    $aliases     The list of aliases of the command. The command will be executed when using one of them (i.e. "cache:clean")
      * @param bool        $hidden      If true, the command won't be shown when listing all the available commands, but it can still be run as any other command
+     * @param string|null $help        The help content of the command, displayed with the help page
      */
     public function __construct(
         public string $name,
         public ?string $description = null,
         array $aliases = [],
         bool $hidden = false,
+        public ?string $help = null,
     ) {
         if (!$hidden && !$aliases) {
             return;

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add support for invokable commands and add `#[Argument]` and `#[Option]` attributes to define input arguments and options
  * Deprecate not declaring the parameter type in callable commands defined through `setCode` method
+ * Add support for help definition via `AsCommand` attribute
 
 7.2
 ---

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -100,6 +100,10 @@ class Command
             $this->setDescription(static::getDefaultDescription() ?? '');
         }
 
+        if ('' === $this->help && $attributes = (new \ReflectionClass(static::class))->getAttributes(AsCommand::class)) {
+            $this->setHelp($attributes[0]->newInstance()->help ?? '');
+        }
+
         if (\is_callable($this)) {
             $this->code = new InvokableCommand($this, $this(...));
         }

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -434,6 +434,7 @@ class CommandTest extends TestCase
 
         $this->assertSame('foo', $command->getName());
         $this->assertSame('desc', $command->getDescription());
+        $this->assertSame('help', $command->getHelp());
         $this->assertTrue($command->isHidden());
         $this->assertSame(['f'], $command->getAliases());
     }
@@ -473,7 +474,7 @@ function createClosure()
     };
 }
 
-#[AsCommand(name: 'foo', description: 'desc', hidden: true, aliases: ['f'])]
+#[AsCommand(name: 'foo', description: 'desc', hidden: true, aliases: ['f'], help: 'help')]
 class Php8Command extends Command
 {
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow up https://github.com/symfony/symfony/pull/59340

Invokable and regular commands can now define the command `help` content via the `#[AsCommand]` attribute.

This is particularly useful for invokable commands, as it avoids the need to extend the `Command` class.
```php
#[AsCommand(
    name: 'user:create',
    description: 'Create a new user',
    help: <<<TXT
The <info>%command.name%</info> command generates a new user class for security
and updates your security.yaml file for it. It will also generate a user provider
class if your situation needs a custom class.

<info>php %command.full_name% email</info>

If the argument is missing, the command will ask for the class name interactively.
TXT
)]
class CreateUserCommand
{
    public function __invoke(SymfonyStyle $io, #[Argument] string $email): int
    {
        // ...
    }
}
```

Cheers!