### PR TITLE
[Console] Invokable command deprecations

### DIFF
--- a/UPGRADE-7.3.md
+++ b/UPGRADE-7.3.md
@@ -8,6 +8,28 @@ Read more about this in the [Symfony documentation](https://symfony.com/doc/7.3/
 
 If you're upgrading from a version below 7.1, follow the [7.2 upgrade guide](UPGRADE-7.2.md) first.
 
+Console
+-------
+
+ * Omitting parameter types in callables configured via `Command::setCode` method is deprecated
+
+   *Before*
+   ```php
+   $command->setCode(function ($input, $output) {
+       // ...
+   });
+   ```
+
+   *After*
+   ```php
+   use Symfony\Component\Console\Input\InputInterface;
+   use Symfony\Component\Console\Output\OutputInterface;
+
+   $command->setCode(function (InputInterface $input, OutputInterface $output) {
+       // ...
+   });
+   ```
+
 FrameworkBundle
 ---------------
 

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -4,8 +4,8 @@ CHANGELOG
 7.3
 ---
 
-* Add support for invokable commands
-* Add `#[Argument]` and `#[Option]` attributes to define input arguments and options for invokable commands
+ * Add support for invokable commands and add `#[Argument]` and `#[Option]` attributes to define input arguments and options
+ * Deprecate not declaring the parameter type in callable commands defined through `setCode` method
 
 7.2
 ---

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -328,7 +328,7 @@ class Command
             $code = $code(...);
         }
 
-        $this->code = new InvokableCommand($this, $code);
+        $this->code = new InvokableCommand($this, $code, triggerDeprecations: true);
 
         return $this;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | -
| License       | MIT

I believe we missed the last commit during the squash and merge of https://github.com/symfony/symfony/pull/59340. It has been applied here, along with the UPGRADE entry.