### PR TITLE
[PhpUnitBridge] Mark `AttributeReader` as internal

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Metadata/AttributeReader.php
+++ b/src/Symfony/Bridge/PhpUnit/Metadata/AttributeReader.php
@@ -12,6 +12,8 @@
 namespace Symfony\Bridge\PhpUnit\Metadata;
 
 /**
+ * @internal
+ *
  * @template T of object
  */
 final class AttributeReader


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow-up to #59384 

Didn't notice this in my original PR, but it'd make sense for the `AttributeReader` class to be marked as internal.
