### PR TITLE
[Mailer] [Smtp] Add DSN param to enforce TLS/STARTTLS

### DIFF
--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add DSN param `retry_period` to override default email transport retry period
  * Add `Dsn::getBooleanOption()`
  * Add DSN param `source_ip` to allow binding to a (specific) IPv4 or IPv6 address.
+ * Add DSN param `require_tls` to enforce use of TLS/STARTTLS
  * Add `DkimSignedMessageListener`, `SmimeEncryptedMessageListener`, and `SmimeSignedMessageListener`
 
 7.2

--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportFactoryTest.php
@@ -194,6 +194,18 @@ class EsmtpTransportFactoryTest extends AbstractTransportFactoryTestCase
             Dsn::fromString('smtps://:@example.com:465?source_ip=[2606:4700:20::681a:5fb]'),
             $transport,
         ];
+
+        $transport = new EsmtpTransport('example.com', 465, true, null, $logger);
+        $transport->setRequireTls(true);
+
+        yield [
+            new Dsn('smtps', 'example.com', '', '', 465, ['require_tls' => true]),
+            $transport,
+        ];
+        yield [
+            Dsn::fromString('smtps://:@example.com?require_tls=true'),
+            $transport,
+        ];
     }
 
     public static function unsupportedSchemeProvider(): iterable

--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportTest.php
@@ -297,6 +297,23 @@ class EsmtpTransportTest extends TestCase
             $stream->getCommands()
         );
     }
+
+    public function testRequireTls()
+    {
+        $stream = new DummyStream();
+        $transport = new EsmtpTransport(stream: $stream);
+        $transport->setRequireTls(true);
+
+        $message = new Email();
+        $message->from('sender@example.org');
+        $message->addTo('recipient@example.org');
+        $message->text('.');
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('TLS required but neither TLS or STARTTLS are in use.');
+
+        $transport->send($message);
+    }
 }
 
 class CustomEsmtpTransport extends EsmtpTransport

--- a/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransportFactory.php
@@ -35,6 +35,7 @@ final class EsmtpTransportFactory extends AbstractTransportFactory
 
         $transport = new EsmtpTransport($host, $port, $tls, $this->dispatcher, $this->logger);
         $transport->setAutoTls($autoTls);
+        $transport->setRequireTls($dsn->getBooleanOption('require_tls'));
 
         /** @var SocketStream $stream */
         $stream = $transport->getStream();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #48297
| License       | MIT


Adds 'require_tls' param which can be set to true to enforce the use of TLS/STARTTLS within the ESMTP transport.
This was discussed in #48297.
These changes are based upon patches [I've been maintaining](https://github.com/ssddanbrown/symfony-mailer/commit/e9de8dccd76a63fc23475016e6574da6f5f12a2d) for my own projects.

This is my first PR to Symfony, I've tried to follow the guide as best as possible, and I was also using #53621 as a general guide. There are some other ways I could have gone about things, but I've tried to avoid touching as much existing Symfony code as possible. 

In #48297, nicolas-grekas mentioned unifying such an option with `auto_tls` under a `tls` option, but I think these are distinct options which may not be as clear combined (in addition to any expectations of such an option disabling/enabling TLS in general).
