### PR TITLE
[Notifier] Avoid failing SNS test with local AWS configuration

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/AmazonSns/Tests/AmazonSnsTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/AmazonSns/Tests/AmazonSnsTransportFactoryTest.php
@@ -18,6 +18,12 @@ class AmazonSnsTransportFactoryTest extends TransportFactoryTestCase
 {
     public function createFactory(): AmazonSnsTransportFactory
     {
+        // Tests will fail if a ~/.aws/config file exists with a default.region value,
+        // or if AWS_REGION env variable is set.
+        // Setting a profile & region names will bypass default options retrieved by \AsyncAws\Core::get
+        $_ENV['AWS_PROFILE'] = 'not-existing';
+        $_ENV['AWS_REGION'] = 'us-east-1';
+
         return new AmazonSnsTransportFactory();
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |6.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? |no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | 
| License       | MIT

Currently, because of [AsyncAws way to get config options](https://github.com/async-aws/core/blob/master/src/EnvVar.php), Notifier tests cannot pass if you have any `AWS_***` default variables in your environment, or if you have a  `~/.aws/config` file with the following content:

```
[default]
region=eu-west-1
```

Setting `AWS_PROFILE` env value allows bypassing default values, and overriding `AWS_REGION` value will allow tests without specified regions to pass. 
