### PR TITLE
[Notifier] Add SentMessage additional info

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/AllMySms/AllMySmsTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/AllMySms/AllMySmsTransport.php
@@ -48,6 +48,9 @@ final class AllMySmsTransport extends AbstractTransport
         return $message instanceof SmsMessage && (null === $message->getOptions() || $message->getOptions() instanceof AllMySmsOptions);
     }
 
+    /**
+     * @See https://doc.allmysms.com/api/en/#api-SMS-sendsimple
+     */
     protected function doSend(MessageInterface $message): SentMessage
     {
         if (!$message instanceof SmsMessage) {
@@ -83,7 +86,13 @@ final class AllMySmsTransport extends AbstractTransport
             throw new TransportException(\sprintf('Unable to send the SMS: "%s" (%s).', $success['description'], $success['code']), $response);
         }
 
-        $sentMessage = new SentMessage($message, (string) $this);
+        $additionalInfo = [
+            'nbSms' => $success['nbSms'] ?? null,
+            'balance' => $success['balance'] ?? null,
+            'cost' => $success['cost'] ?? null,
+        ];
+
+        $sentMessage = new SentMessage($message, (string) $this, $additionalInfo);
         $sentMessage->setMessageId($success['smsId']);
 
         return $sentMessage;

--- a/src/Symfony/Component/Notifier/Bridge/AllMySms/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/AllMySms/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.3
+---
+
+ * Add `nbSms`, `balance`, and `cost` info into returned `SentMessage`
+
 6.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/AllMySms/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/AllMySms/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.2",
         "symfony/http-client": "^6.4|^7.0",
-        "symfony/notifier": "^7.2"
+        "symfony/notifier": "^7.3"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\AllMySms\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.3
+---
+
+ * Add `totalCreditsRemoved` info into returned `SentMessage`
+
 6.2
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/Tests/OvhCloudTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/Tests/OvhCloudTransportTest.php
@@ -64,10 +64,10 @@ final class OvhCloudTransportTest extends TransportTestCase
         $time = time();
 
         $data = json_encode([
-            'totalCreditsRemoved' => '1',
+            'totalCreditsRemoved' => 1,
             'invalidReceivers' => [],
             'ids' => [
-                '26929925',
+                26929925,
             ],
             'validReceivers' => [
                 '0611223344',
@@ -96,7 +96,7 @@ final class OvhCloudTransportTest extends TransportTestCase
         $smsMessage = new SmsMessage('invalid_receiver', 'lorem ipsum');
 
         $data = json_encode([
-            'totalCreditsRemoved' => '1',
+            'totalCreditsRemoved' => 0,
             'invalidReceivers' => ['invalid_receiver'],
             'ids' => [],
             'validReceivers' => [],
@@ -111,5 +111,30 @@ final class OvhCloudTransportTest extends TransportTestCase
         $this->expectException(TransportException::class);
         $this->expectExceptionMessage('Attempt to send the SMS to invalid receivers: "invalid_receiver"');
         $transport->send($smsMessage);
+    }
+
+    public function testSentMessageInfo()
+    {
+        $smsMessage = new SmsMessage('0611223344', 'lorem ipsum');
+
+        $data = json_encode([
+            'totalCreditsRemoved' => 1,
+            'invalidReceivers' => [],
+            'ids' => [
+                26929925,
+            ],
+            'validReceivers' => [
+                '0611223344',
+            ],
+        ]);
+        $responses = [
+            new MockResponse(time()),
+            new MockResponse($data),
+        ];
+
+        $transport = self::createTransport(new MockHttpClient($responses));
+        $sentMessage = $transport->send($smsMessage);
+
+        $this->assertSame(1, $sentMessage->getInfo('totalCreditsRemoved'));
     }
 }

--- a/src/Symfony/Component/Notifier/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `Dsn::getBooleanOption()`
+ * Add `info` property in `SentMessage`
 
 7.2
 ---

--- a/src/Symfony/Component/Notifier/Message/SentMessage.php
+++ b/src/Symfony/Component/Notifier/Message/SentMessage.php
@@ -18,9 +18,13 @@ class SentMessage
 {
     private ?string $messageId = null;
 
+    /**
+     * @param array $info attaches any Transport-related information to the sent message
+     */
     public function __construct(
         private MessageInterface $original,
         private string $transport,
+        private array $info = [],
     ) {
     }
 
@@ -42,5 +46,19 @@ class SentMessage
     public function getMessageId(): ?string
     {
         return $this->messageId;
+    }
+
+    /**
+     * Returns extra info attached to the message.
+     *
+     * @param string|null $key if null, the whole info array will be returned, else returns the info value or null
+     */
+    public function getInfo(?string $key = null): mixed
+    {
+        if (null !== $key) {
+            return $this->info[$key] ?? null;
+        }
+
+        return $this->info;
     }
 }

--- a/src/Symfony/Component/Notifier/Tests/Message/SentMessageTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Message/SentMessageTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Tests\Message;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Notifier\Message\SentMessage;
+use Symfony\Component\Notifier\Tests\Transport\DummyMessage;
+
+class SentMessageTest extends TestCase
+{
+    public function test()
+    {
+        $originalMessage = new DummyMessage();
+
+        $sentMessage = new SentMessage($originalMessage, 'any', ['foo' => 'bar']);
+        $sentMessage->setMessageId('the_id');
+
+        $this->assertSame($originalMessage, $sentMessage->getOriginalMessage());
+        $this->assertSame('any', $sentMessage->getTransport());
+        $this->assertSame('the_id', $sentMessage->getMessageId());
+        $this->assertSame(['foo' => 'bar'], $sentMessage->getInfo());
+        $this->assertSame('bar', $sentMessage->getInfo('foo'));
+        $this->assertNull($sentMessage->getInfo('not_existing'));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #49793
| License       | MIT

This PR allows adding additional data into [Notifier/Message/SentMessage.php](https://github.com/symfony/symfony/blob/7.3/src/Symfony/Component/Notifier/Message/SentMessage.php), based on (and using) [HttpClient Response's info](https://github.com/symfony/symfony/blob/7.3/src/Symfony/Component/HttpClient/Response/AsyncContext.php#L118-L145). The initial need behind this feature is to be able to access to some data of the Transport's response (e.g.: [`nbSms` and `cost` for allmysms](https://doc.allmysms.com/api/fr/#api-SMS-sendsimple), or [`totalCreditsRemoved` for OVH Cloud](https://eu.api.ovh.com/console/?section=%2Fsms&branch=v1#post-/sms/-serviceName-/jobs)).

Original (closed) PR: https://github.com/symfony/symfony/pull/51746

Some points to discuss:
- It would be a lot easier to inject the eventual `ResponseInterface` object into the constructor as a readonly property, but not all Transports are using HTTP
- [Having a free-form array where each transport can add anything looks like a bad idea](https://github.com/symfony/symfony/pull/51746#issuecomment-1741720193), but [In HttpClient you documented the standard info keys, and decorators can add their own things there](https://github.com/symfony/symfony/pull/51746#issuecomment-2051685563)
