### PR TITLE
[Mailer] [Smtp] Add DSN option to make SocketStream bind to IPv4

### DIFF
--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add DSN param `retry_period` to override default email transport retry period
  * Add `Dsn::getBooleanOption()`
+ * Add DSN param `source_ip` to allow binding to a (specific) IPv4 or IPv6 address.
 
 7.2
 ---

--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportFactoryTest.php
@@ -180,6 +180,20 @@ class EsmtpTransportFactoryTest extends AbstractTransportFactoryTestCase
             Dsn::fromString('smtp://:@example.com:465?auto_tls=false'),
             $transport,
         ];
+
+        $transport = new EsmtpTransport('example.com', 465, true, null, $logger);
+        $transport->getStream()->setSourceIp('0.0.0.0');
+        yield [
+            Dsn::fromString('smtps://:@example.com:465?source_ip=0.0.0.0'),
+            $transport,
+        ];
+
+        $transport = new EsmtpTransport('example.com', 465, true, null, $logger);
+        $transport->getStream()->setSourceIp('[2606:4700:20::681a:5fb]');
+        yield [
+            Dsn::fromString('smtps://:@example.com:465?source_ip=[2606:4700:20::681a:5fb]'),
+            $transport,
+        ];
     }
 
     public static function unsupportedSchemeProvider(): iterable

--- a/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransportFactory.php
@@ -38,6 +38,9 @@ final class EsmtpTransportFactory extends AbstractTransportFactory
 
         /** @var SocketStream $stream */
         $stream = $transport->getStream();
+        if ('' !== $sourceIp = $dsn->getOption('source_ip', '')) {
+            $stream->setSourceIp($sourceIp);
+        }
         $streamOptions = $stream->getStreamOptions();
 
         if ('' !== $dsn->getOption('verify_peer') && !filter_var($dsn->getOption('verify_peer', true), \FILTER_VALIDATE_BOOL)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | see below
| License       | MIT

We are sending emails through a Microsoft connector, which verifies the sending server's IP address and sender email address. We started getting these error messages recently:
```
Symfony\Component\Messenger\Exception\HandlerFailedException(code: 450):
Handling "\Symfony\\Component\\Mailer\\Messenger\\SendEmailMessage" failed:
Expected response code "250" but got code "450", with message
"450 4.7.26 Service does not accept messages sent over IPv6"
```
Apparently, our server started to connect using IPv6 and the connector only accepts IPv4 addresses. With this PR, we can force the SocketStream to connect to the smtp server via IPv4, by supplying an option in the DSN. Example usage: 
```
MAILER_DSN=smtp://<mydomain>.mail.protection.outlook.com:25?force_ipv4=true
```

This is my first PR to Symfony, so I tried doing my best to follow the guide.

From the errors I received, I think with DKIM signing IPv6 should be allowed as well. However, I do not have access the DNS records and needed a quick fix. This PR is based on a patch I did in my own project. Probably I will implement an available Microsoft Graph Transport in the future. But perhaps it's worth to keep this option available as well.
