### PR TITLE
[OptionsResolver] Add missing support of union type in changelog

### DIFF
--- a/src/Symfony/Component/OptionsResolver/CHANGELOG.md
+++ b/src/Symfony/Component/OptionsResolver/CHANGELOG.md
@@ -1,10 +1,15 @@
 CHANGELOG
 =========
 
+7.3
+---
+
+ * Support union type in `OptionResolver::setAllowedTypes()` method
+
 6.4
 ---
 
-* Improve message with full path on invalid type in nested option
+ * Improve message with full path on invalid type in nested option
 
 6.3
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

I found changelog is missing while documenting https://github.com/symfony/symfony-docs/issues/20531

Code PR: https://github.com/symfony/symfony/pull/59354