### PR TITLE
[Console] Fix invokable command profiler representation

### DIFF
--- a/src/Symfony/Component/Console/DataCollector/CommandDataCollector.php
+++ b/src/Symfony/Component/Console/DataCollector/CommandDataCollector.php
@@ -37,7 +37,7 @@ final class CommandDataCollector extends DataCollector
         $application = $command->getApplication();
 
         $this->data = [
-            'command' => $this->cloneVar($command->command),
+            'command' => $command->invokableCommandInfo ?? $this->cloneVar($command->command),
             'exit_code' => $command->exitCode,
             'interrupted_by_signal' => $command->interruptedBySignal,
             'duration' => $command->duration,
@@ -95,6 +95,10 @@ final class CommandDataCollector extends DataCollector
      */
     public function getCommand(): array
     {
+        if (\is_array($this->data['command'])) {
+            return $this->data['command'];
+        }
+
         $class = $this->data['command']->getType();
         $r = new \ReflectionMethod($class, 'execute');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The generic command was displayed instead of the actual invokable command.
(there's no test case at all on this part and I just don't feel brave enough writing one for this little detail sorry :)

Before
<img width="822" alt="Screenshot 2025-01-12 at 16 49 19" src="https://github.com/user-attachments/assets/0b07b975-7fc7-4b85-bc4b-ce6e067dd88e" />

After
<img width="744" alt="Screenshot 2025-01-12 at 16 39 26" src="https://github.com/user-attachments/assets/f2a42ebb-fda5-480c-9606-aa21f7781781" />


