### PR TITLE
[DoctrineBridge] Fix type on `IdleConnection\Driver::$connectionExpiries`

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Middleware/IdleConnection/Driver.php
+++ b/src/Symfony/Bridge/Doctrine/Middleware/IdleConnection/Driver.php
@@ -17,6 +17,9 @@ use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
 
 final class Driver extends AbstractDriverMiddleware
 {
+    /**
+     * @param \ArrayObject<string, int> $connectionExpiries
+     */
     public function __construct(
         DriverInterface $driver,
         private \ArrayObject $connectionExpiries,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

We should be more precise about what kind of `ArrayObject` we expect. This fixes a static analysis problem we have on the DoctrineBundle repository.
