### PR TITLE
[Lock] Make sure RedisStore will also support Valkey

### DIFF
--- a/src/Symfony/Component/Lock/Store/RedisStore.php
+++ b/src/Symfony/Component/Lock/Store/RedisStore.php
@@ -29,7 +29,7 @@ class RedisStore implements SharedLockStoreInterface
 {
     use ExpiringStoreTrait;
 
-    private const NO_SCRIPT_ERROR_MESSAGE = 'NOSCRIPT No matching script. Please use EVAL.';
+    private const NO_SCRIPT_ERROR_MESSAGE_PREFIX = 'NOSCRIPT No matching script.';
 
     private bool $supportTime;
 
@@ -234,7 +234,7 @@ class RedisStore implements SharedLockStoreInterface
             $this->redis->clearLastError();
 
             $result = $this->redis->evalSha($scriptSha, array_merge([$resource], $args), 1);
-            if (self::NO_SCRIPT_ERROR_MESSAGE === $err = $this->redis->getLastError()) {
+            if (null !== ($err = $this->redis->getLastError()) && str_starts_with($err, self::NO_SCRIPT_ERROR_MESSAGE_PREFIX)) {
                 $this->redis->clearLastError();
 
                 if ($this->redis instanceof \RedisCluster) {
@@ -263,7 +263,7 @@ class RedisStore implements SharedLockStoreInterface
             $client = $this->redis->_instance($this->redis->_target($resource));
             $client->clearLastError();
             $result = $client->evalSha($scriptSha, array_merge([$resource], $args), 1);
-            if (self::NO_SCRIPT_ERROR_MESSAGE === $err = $client->getLastError()) {
+            if (null !== ($err = $this->redis->getLastError()) && str_starts_with($err, self::NO_SCRIPT_ERROR_MESSAGE_PREFIX)) {
                 $client->clearLastError();
 
                 $client->script('LOAD', $script);
@@ -285,7 +285,7 @@ class RedisStore implements SharedLockStoreInterface
         \assert($this->redis instanceof \Predis\ClientInterface);
 
         $result = $this->redis->evalSha($scriptSha, 1, $resource, ...$args);
-        if ($result instanceof Error && self::NO_SCRIPT_ERROR_MESSAGE === $result->getMessage()) {
+        if ($result instanceof Error && str_starts_with($result->getMessage(), self::NO_SCRIPT_ERROR_MESSAGE_PREFIX)) {
             $result = $this->redis->script('LOAD', $script);
             if ($result instanceof Error) {
                 throw new LockStorageException($result->getMessage());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59387
| License       | MIT

As the change happened on Valkey (https://github.com/valkey-io/valkey/pull/617/files#diff-1abc5651133d108c0c420d9411925373c711133e7748d9e4f4c97d5fb543fdd9L1819-R1819), ~it's hard to consider this a bug when `RedisStore` was meant only to support Redis ;)~
