### PR TITLE
[Serializer] Correct all implementations of the `NormalizerInterface` to have the correct method signature

### DIFF
--- a/src/Symfony/Component/Messenger/Transport/Serialization/Normalizer/FlattenExceptionNormalizer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/Normalizer/FlattenExceptionNormalizer.php
@@ -26,20 +26,20 @@ final class FlattenExceptionNormalizer implements DenormalizerInterface, Normali
 {
     use NormalizerAwareTrait;
 
-    public function normalize(mixed $object, ?string $format = null, array $context = []): array
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array
     {
         return [
-            'message' => $object->getMessage(),
-            'code' => $object->getCode(),
-            'headers' => $object->getHeaders(),
-            'class' => $object->getClass(),
-            'file' => $object->getFile(),
-            'line' => $object->getLine(),
-            'previous' => null === $object->getPrevious() ? null : $this->normalize($object->getPrevious(), $format, $context),
-            'status' => $object->getStatusCode(),
-            'status_text' => $object->getStatusText(),
-            'trace' => $object->getTrace(),
-            'trace_as_string' => $object->getTraceAsString(),
+            'message' => $data->getMessage(),
+            'code' => $data->getCode(),
+            'headers' => $data->getHeaders(),
+            'class' => $data->getClass(),
+            'file' => $data->getFile(),
+            'line' => $data->getLine(),
+            'previous' => null === $data->getPrevious() ? null : $this->normalize($data->getPrevious(), $format, $context),
+            'status' => $data->getStatusCode(),
+            'status_text' => $data->getStatusText(),
+            'trace' => $data->getTrace(),
+            'trace_as_string' => $data->getTraceAsString(),
         ];
     }
 

--- a/src/Symfony/Component/Serializer/Debug/TraceableNormalizer.php
+++ b/src/Symfony/Component/Serializer/Debug/TraceableNormalizer.php
@@ -40,14 +40,14 @@ class TraceableNormalizer implements NormalizerInterface, DenormalizerInterface,
         return $this->normalizer->getSupportedTypes($format);
     }
 
-    public function normalize(mixed $object, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         if (!$this->normalizer instanceof NormalizerInterface) {
             throw new \BadMethodCallException(\sprintf('The "%s()" method cannot be called as nested normalizer doesn\'t implements "%s".', __METHOD__, NormalizerInterface::class));
         }
 
         $startTime = microtime(true);
-        $normalized = $this->normalizer->normalize($object, $format, $context);
+        $normalized = $this->normalizer->normalize($data, $format, $context);
         $time = microtime(true) - $startTime;
 
         if ($traceId = ($context[TraceableSerializer::DEBUG_TRACE_ID] ?? null)) {

--- a/src/Symfony/Component/Serializer/Debug/TraceableSerializer.php
+++ b/src/Symfony/Component/Serializer/Debug/TraceableSerializer.php
@@ -66,17 +66,17 @@ class TraceableSerializer implements SerializerInterface, NormalizerInterface, D
         return $result;
     }
 
-    public function normalize(mixed $object, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $context[self::DEBUG_TRACE_ID] = $traceId = bin2hex(random_bytes(4));
 
         $startTime = microtime(true);
-        $result = $this->serializer->normalize($object, $format, $context);
+        $result = $this->serializer->normalize($data, $format, $context);
         $time = microtime(true) - $startTime;
 
         $caller = $this->getCaller(__FUNCTION__, NormalizerInterface::class);
 
-        $this->dataCollector->collectNormalize($traceId, $object, $format, $context, $time, $caller, $this->serializerName);
+        $this->dataCollector->collectNormalize($traceId, $data, $format, $context, $time, $caller, $this->serializerName);
 
         return $result;
     }

--- a/src/Symfony/Component/Serializer/Normalizer/BackedEnumNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/BackedEnumNormalizer.php
@@ -33,13 +33,13 @@ final class BackedEnumNormalizer implements NormalizerInterface, DenormalizerInt
         ];
     }
 
-    public function normalize(mixed $object, ?string $format = null, array $context = []): int|string
+    public function normalize(mixed $data, ?string $format = null, array $context = []): int|string
     {
-        if (!$object instanceof \BackedEnum) {
+        if (!$data instanceof \BackedEnum) {
             throw new InvalidArgumentException('The data must belong to a backed enumeration.');
         }
 
-        return $object->value;
+        return $data->value;
     }
 
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool

--- a/src/Symfony/Component/Serializer/Normalizer/ConstraintViolationListNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ConstraintViolationListNormalizer.php
@@ -43,7 +43,7 @@ final class ConstraintViolationListNormalizer implements NormalizerInterface
         ];
     }
 
-    public function normalize(mixed $object, ?string $format = null, array $context = []): array
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array
     {
         if (\array_key_exists(self::PAYLOAD_FIELDS, $context)) {
             $payloadFieldsToSerialize = $context[self::PAYLOAD_FIELDS];
@@ -59,7 +59,7 @@ final class ConstraintViolationListNormalizer implements NormalizerInterface
 
         $violations = [];
         $messages = [];
-        foreach ($object as $violation) {
+        foreach ($data as $violation) {
             $propertyPath = $this->nameConverter ? $this->nameConverter->normalize($violation->getPropertyPath(), null, $format, $context) : $violation->getPropertyPath();
 
             $violationEntry = [

--- a/src/Symfony/Component/Serializer/Normalizer/CustomNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/CustomNormalizer.php
@@ -30,9 +30,9 @@ final class CustomNormalizer implements NormalizerInterface, DenormalizerInterfa
         ];
     }
 
-    public function normalize(mixed $object, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
-        return $object->normalize($this->serializer, $format, $context);
+        return $data->normalize($this->serializer, $format, $context);
     }
 
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed

--- a/src/Symfony/Component/Serializer/Normalizer/DataUriNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DataUriNormalizer.php
@@ -47,27 +47,27 @@ final class DataUriNormalizer implements NormalizerInterface, DenormalizerInterf
         return self::SUPPORTED_TYPES;
     }
 
-    public function normalize(mixed $object, ?string $format = null, array $context = []): string
+    public function normalize(mixed $data, ?string $format = null, array $context = []): string
     {
-        if (!$object instanceof \SplFileInfo) {
+        if (!$data instanceof \SplFileInfo) {
             throw new InvalidArgumentException('The object must be an instance of "\SplFileInfo".');
         }
 
-        $mimeType = $this->getMimeType($object);
-        $splFileObject = $this->extractSplFileObject($object);
+        $mimeType = $this->getMimeType($data);
+        $splFileObject = $this->extractSplFileObject($data);
 
-        $data = '';
+        $splFileData = '';
 
         $splFileObject->rewind();
         while (!$splFileObject->eof()) {
-            $data .= $splFileObject->fgets();
+            $splFileData .= $splFileObject->fgets();
         }
 
         if ('text' === explode('/', $mimeType, 2)[0]) {
-            return \sprintf('data:%s,%s', $mimeType, rawurlencode($data));
+            return \sprintf('data:%s,%s', $mimeType, rawurlencode($splFileData));
         }
 
-        return \sprintf('data:%s;base64,%s', $mimeType, base64_encode($data));
+        return \sprintf('data:%s;base64,%s', $mimeType, base64_encode($splFileData));
     }
 
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool

--- a/src/Symfony/Component/Serializer/Normalizer/DateIntervalNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateIntervalNormalizer.php
@@ -43,13 +43,13 @@ final class DateIntervalNormalizer implements NormalizerInterface, DenormalizerI
     /**
      * @throws InvalidArgumentException
      */
-    public function normalize(mixed $object, ?string $format = null, array $context = []): string
+    public function normalize(mixed $data, ?string $format = null, array $context = []): string
     {
-        if (!$object instanceof \DateInterval) {
+        if (!$data instanceof \DateInterval) {
             throw new InvalidArgumentException('The object must be an instance of "\DateInterval".');
         }
 
-        return $object->format($context[self::FORMAT_KEY] ?? $this->defaultContext[self::FORMAT_KEY]);
+        return $data->format($context[self::FORMAT_KEY] ?? $this->defaultContext[self::FORMAT_KEY]);
     }
 
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool

--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
@@ -56,9 +56,9 @@ final class DateTimeNormalizer implements NormalizerInterface, DenormalizerInter
     /**
      * @throws InvalidArgumentException
      */
-    public function normalize(mixed $object, ?string $format = null, array $context = []): int|float|string
+    public function normalize(mixed $data, ?string $format = null, array $context = []): int|float|string
     {
-        if (!$object instanceof \DateTimeInterface) {
+        if (!$data instanceof \DateTimeInterface) {
             throw new InvalidArgumentException('The object must implement the "\DateTimeInterface".');
         }
 
@@ -66,14 +66,14 @@ final class DateTimeNormalizer implements NormalizerInterface, DenormalizerInter
         $timezone = $this->getTimezone($context);
 
         if (null !== $timezone) {
-            $object = clone $object;
-            $object = $object->setTimezone($timezone);
+            $data = clone $data;
+            $data = $data->setTimezone($timezone);
         }
 
         return match ($context[self::CAST_KEY] ?? $this->defaultContext[self::CAST_KEY] ?? false) {
-            'int' => (int) $object->format($dateTimeFormat),
-            'float' => (float) $object->format($dateTimeFormat),
-            default => $object->format($dateTimeFormat),
+            'int' => (int) $data->format($dateTimeFormat),
+            'float' => (float) $data->format($dateTimeFormat),
+            default => $data->format($dateTimeFormat),
         };
     }
 

--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeZoneNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeZoneNormalizer.php
@@ -31,13 +31,13 @@ final class DateTimeZoneNormalizer implements NormalizerInterface, DenormalizerI
     /**
      * @throws InvalidArgumentException
      */
-    public function normalize(mixed $object, ?string $format = null, array $context = []): string
+    public function normalize(mixed $data, ?string $format = null, array $context = []): string
     {
-        if (!$object instanceof \DateTimeZone) {
+        if (!$data instanceof \DateTimeZone) {
             throw new InvalidArgumentException('The object must be an instance of "\DateTimeZone".');
         }
 
-        return $object->getName();
+        return $data->getName();
     }
 
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool

--- a/src/Symfony/Component/Serializer/Normalizer/FormErrorNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/FormErrorNormalizer.php
@@ -22,20 +22,20 @@ final class FormErrorNormalizer implements NormalizerInterface
     public const TYPE = 'type';
     public const CODE = 'status_code';
 
-    public function normalize(mixed $object, ?string $format = null, array $context = []): array
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array
     {
-        $data = [
+        $error = [
             'title' => $context[self::TITLE] ?? 'Validation Failed',
             'type' => $context[self::TYPE] ?? 'https://symfony.com/errors/form',
             'code' => $context[self::CODE] ?? null,
-            'errors' => $this->convertFormErrorsToArray($object),
+            'errors' => $this->convertFormErrorsToArray($data),
         ];
 
-        if (0 !== \count($object->all())) {
-            $data['children'] = $this->convertFormChildrenToArray($object);
+        if (0 !== \count($data->all())) {
+            $error['children'] = $this->convertFormChildrenToArray($data);
         }
 
-        return $data;
+        return $error;
     }
 
     public function getSupportedTypes(?string $format): array

--- a/src/Symfony/Component/Serializer/Normalizer/JsonSerializableNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/JsonSerializableNormalizer.php
@@ -21,13 +21,13 @@ use Symfony\Component\Serializer\Exception\LogicException;
  */
 final class JsonSerializableNormalizer extends AbstractNormalizer
 {
-    public function normalize(mixed $object, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
-        if ($this->isCircularReference($object, $context)) {
-            return $this->handleCircularReference($object, $format, $context);
+        if ($this->isCircularReference($data, $context)) {
+            return $this->handleCircularReference($data, $format, $context);
         }
 
-        if (!$object instanceof \JsonSerializable) {
+        if (!$data instanceof \JsonSerializable) {
             throw new InvalidArgumentException(\sprintf('The object must implement "%s".', \JsonSerializable::class));
         }
 
@@ -35,7 +35,7 @@ final class JsonSerializableNormalizer extends AbstractNormalizer
             throw new LogicException('Cannot normalize object because injected serializer is not a normalizer.');
         }
 
-        return $this->serializer->normalize($object->jsonSerialize(), $format, $context);
+        return $this->serializer->normalize($data->jsonSerialize(), $format, $context);
     }
 
     public function getSupportedTypes(?string $format): array

--- a/src/Symfony/Component/Serializer/Normalizer/MimeMessageNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/MimeMessageNormalizer.php
@@ -62,25 +62,25 @@ final class MimeMessageNormalizer implements NormalizerInterface, DenormalizerIn
         $this->normalizer->setSerializer($serializer);
     }
 
-    public function normalize(mixed $object, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
-        if ($object instanceof Headers) {
+        if ($data instanceof Headers) {
             $ret = [];
-            foreach ($this->headersProperty->getValue($object) as $name => $header) {
+            foreach ($this->headersProperty->getValue($data) as $name => $header) {
                 $ret[$name] = $this->serializer->normalize($header, $format, $context);
             }
 
             return $ret;
         }
 
-        $ret = $this->normalizer->normalize($object, $format, $context);
+        $ret = $this->normalizer->normalize($data, $format, $context);
 
-        if ($object instanceof AbstractPart) {
-            $ret['class'] = $object::class;
+        if ($data instanceof AbstractPart) {
+            $ret['class'] = $data::class;
             unset($ret['seekable'], $ret['cid'], $ret['handle']);
         }
 
-        if ($object instanceof RawMessage && \array_key_exists('message', $ret) && null === $ret['message']) {
+        if ($data instanceof RawMessage && \array_key_exists('message', $ret) && null === $ret['message']) {
             unset($ret['message']);
         }
 

--- a/src/Symfony/Component/Serializer/Normalizer/TranslatableNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/TranslatableNormalizer.php
@@ -34,13 +34,13 @@ final class TranslatableNormalizer implements NormalizerInterface
     /**
      * @throws InvalidArgumentException
      */
-    public function normalize(mixed $object, ?string $format = null, array $context = []): string
+    public function normalize(mixed $data, ?string $format = null, array $context = []): string
     {
-        if (!$object instanceof TranslatableInterface) {
-            throw NotNormalizableValueException::createForUnexpectedDataType(\sprintf('The object must implement the "%s".', TranslatableInterface::class), $object, [TranslatableInterface::class]);
+        if (!$data instanceof TranslatableInterface) {
+            throw NotNormalizableValueException::createForUnexpectedDataType(\sprintf('The object must implement the "%s".', TranslatableInterface::class), $data, [TranslatableInterface::class]);
         }
 
-        return $object->trans($this->translator, $context[self::NORMALIZATION_LOCALE_KEY] ?? $this->defaultContext[self::NORMALIZATION_LOCALE_KEY]);
+        return $data->trans($this->translator, $context[self::NORMALIZATION_LOCALE_KEY] ?? $this->defaultContext[self::NORMALIZATION_LOCALE_KEY]);
     }
 
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool

--- a/src/Symfony/Component/Serializer/Normalizer/UidNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/UidNormalizer.php
@@ -48,16 +48,13 @@ final class UidNormalizer implements NormalizerInterface, DenormalizerInterface
         ];
     }
 
-    /**
-     * @param AbstractUid $object
-     */
-    public function normalize(mixed $object, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         return match ($context[self::NORMALIZATION_FORMAT_KEY] ?? $this->defaultContext[self::NORMALIZATION_FORMAT_KEY]) {
-            self::NORMALIZATION_FORMAT_CANONICAL => (string) $object,
-            self::NORMALIZATION_FORMAT_BASE58 => $object->toBase58(),
-            self::NORMALIZATION_FORMAT_BASE32 => $object->toBase32(),
-            self::NORMALIZATION_FORMAT_RFC4122 => $object->toRfc4122(),
+            self::NORMALIZATION_FORMAT_CANONICAL => (string) $data,
+            self::NORMALIZATION_FORMAT_BASE58 => $data->toBase58(),
+            self::NORMALIZATION_FORMAT_BASE32 => $data->toBase32(),
+            self::NORMALIZATION_FORMAT_RFC4122 => $data->toRfc4122(),
             default => throw new LogicException(\sprintf('The "%s" format is not valid.', $context[self::NORMALIZATION_FORMAT_KEY] ?? $this->defaultContext[self::NORMALIZATION_FORMAT_KEY])),
         };
     }

--- a/src/Symfony/Component/Serializer/Tests/Debug/TraceableSerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Debug/TraceableSerializerTest.php
@@ -142,7 +142,7 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
         return 'deserialized';
     }
 
-    public function normalize(mixed $object, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         return 'normalized';
     }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/AbstractNormalizerDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/AbstractNormalizerDummy.php
@@ -30,7 +30,7 @@ class AbstractNormalizerDummy extends AbstractNormalizer
         return parent::getAllowedAttributes($classOrObject, $context, $attributesAsString);
     }
 
-    public function normalize(mixed $object, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/EnvelopeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/EnvelopeNormalizer.php
@@ -20,9 +20,9 @@ class EnvelopeNormalizer implements NormalizerInterface
 {
     private $serializer;
 
-    public function normalize($envelope, ?string $format = null, array $context = []): array
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array
     {
-        $xmlContent = $this->serializer->serialize($envelope->message, 'xml');
+        $xmlContent = $this->serializer->serialize($data->message, 'xml');
 
         $encodedContent = base64_encode($xmlContent);
 

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/EnvelopedMessageNormalizer.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/EnvelopedMessageNormalizer.php
@@ -18,10 +18,10 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  */
 class EnvelopedMessageNormalizer implements NormalizerInterface
 {
-    public function normalize($message, ?string $format = null, array $context = []): array
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array
     {
         return [
-            'text' => $message->text,
+            'text' => $data->text,
         ];
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -85,11 +85,14 @@ class ObjectNormalizerTest extends TestCase
     use TypeEnforcementTestTrait;
 
     private ObjectNormalizer $normalizer;
+    private NormalizerInterface $normalizerInterface;
     private SerializerInterface&NormalizerInterface&MockObject $serializer;
 
     protected function setUp(): void
     {
         $this->createNormalizer();
+
+        $this->normalizerInterface = $this->normalizer;
     }
 
     private function createNormalizer(array $defaultContext = [], ?ClassMetadataFactoryInterface $classMetadataFactory = null): void

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/TestNormalizer.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/TestNormalizer.php
@@ -20,7 +20,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  */
 class TestNormalizer implements NormalizerInterface
 {
-    public function normalize($object, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         return null;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59495
| License       | MIT

This PR corrects the signatures of all normalizers implementing the NormalizerInterface of the Serializer component effectively changing: `function normalize($object, ... )` to `function normalize(mixed $data, ...)` as is in line with the interface.

Whilst Named Arguments is against the BC promise of Symfony, with the current implementation of the normalizers it is impossible to use named arguments with the Strategy Pattern using the Serializer component, with this change it is possible.