### PR TITLE
[PropertyInfo] Move aliases under service definition

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/property_info.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/property_info.php
@@ -48,11 +48,11 @@ return static function (ContainerConfigurator $container) {
             ->tag('property_info.access_extractor', ['priority' => -1000])
             ->tag('property_info.initializable_extractor', ['priority' => -1000])
 
+        ->alias(PropertyReadInfoExtractorInterface::class, 'property_info.reflection_extractor')
+        ->alias(PropertyWriteInfoExtractorInterface::class, 'property_info.reflection_extractor')
+
         ->set('property_info.constructor_extractor', ConstructorExtractor::class)
             ->args([[]])
             ->tag('property_info.type_extractor', ['priority' => -999])
-
-        ->alias(PropertyReadInfoExtractorInterface::class, 'property_info.reflection_extractor')
-        ->alias(PropertyWriteInfoExtractorInterface::class, 'property_info.reflection_extractor')
     ;
 };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow-up to #50334, the aliases are normally defined right after the service.