### PR TITLE
[PhpUnitBridge] Add CAA type in DnsMock

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/CHANGELOG.md
+++ b/src/Symfony/Bridge/PhpUnit/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Enable configuring clock and DNS mock namespaces with attributes
+ * Add support for CAA record type in DnsMock for improved DNS mocking capabilities
 
 7.2
 ---

--- a/src/Symfony/Bridge/PhpUnit/DnsMock.php
+++ b/src/Symfony/Bridge/PhpUnit/DnsMock.php
@@ -30,6 +30,7 @@ class DnsMock
         'NAPTR' => \DNS_NAPTR,
         'TXT' => \DNS_TXT,
         'HINFO' => \DNS_HINFO,
+        'CAA' => '\\' !== \DIRECTORY_SEPARATOR ? \DNS_CAA : 0,
     ];
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| License       | MIT

<!--
Added support for CAA record type in DnsMock for improved DNS mocking capabilities
-->
