### PR TITLE
[FrameworkBundle] Fix wiring ConsoleProfilerListener

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/profiling.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/profiling.php
@@ -40,13 +40,18 @@ return static function (ContainerConfigurator $container) {
 
         ->set('console_profiler_listener', ConsoleProfilerListener::class)
             ->args([
-                service('profiler'),
+                service('.lazy_profiler'),
                 service('.virtual_request_stack'),
                 service('debug.stopwatch'),
                 param('kernel.runtime_mode.cli'),
                 service('router')->nullOnInvalid(),
             ])
             ->tag('kernel.event_subscriber')
+
+        ->set('.lazy_profiler', Profiler::class)
+            ->factory('current')
+            ->args([[service('profiler')]])
+            ->lazy()
 
         ->set('.virtual_request_stack', VirtualRequestStack::class)
             ->args([service('request_stack')])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

At the moment, when cache:clear is called, the profiler is instantiated, with all its data collectors.
When one of them needs an env var to be constructed, :boom: 

But this should not happen in the first place: command profiling is an opt-in feature. Nothing related should be instantiated unless asked to do so.

The issue happens because service registration doesn't take care of not using the profiler unless really needed.

This fixes it by:
1. not using the profiler to "disable" it
2. injecting a lazy profiler service so that it's instantiated only when actually required