### PR TITLE
[symfony-mailer-bridges] Add missing `symfony/http-client-contracts` dependency

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/composer.json
@@ -21,7 +21,8 @@
         "symfony/mailer": "^7.2"
     },
     "require-dev": {
-        "symfony/http-client": "^6.4|^7.0"
+        "symfony/http-client": "^6.4|^7.0",
+        "symfony/http-client-contracts": "^3.5.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Mailer\\Bridge\\Amazon\\": "" },

--- a/src/Symfony/Component/Mailer/Bridge/Azure/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": ">=8.2",
-        "symfony/mailer": "^7.2"
+        "symfony/mailer": "^6.4|^7.0",
+        "symfony/http-client-contracts": "^3.5.2"
     },
     "require-dev": {
         "symfony/http-client": "^6.4|^7.0"

--- a/src/Symfony/Component/Mailer/Bridge/Brevo/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": ">=8.1",
-        "symfony/mailer": "^7.2"
+        "symfony/mailer": "^5.4.21|^6.2.7|^7.0",
+        "symfony/http-client-contracts": "^3.5.2"
     },
     "require-dev": {
         "symfony/http-client": "^6.3|^7.0",

--- a/src/Symfony/Component/Mailer/Bridge/Infobip/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Infobip/composer.json
@@ -21,8 +21,9 @@
     ],
     "require": {
         "php": ">=8.2",
-        "symfony/mailer": "^7.2",
-        "symfony/mime": "^6.4|^7.0"
+        "symfony/mailer": "^6.4|^7.0",
+        "symfony/mime": "^6.4|^7.0",
+        "symfony/http-client-contracts": "^3.5.2"
     },
     "require-dev": {
         "symfony/http-client": "^6.4|^7.0"

--- a/src/Symfony/Component/Mailer/Bridge/MailPace/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/MailPace/composer.json
@@ -22,7 +22,8 @@
     "require": {
         "php": ">=8.2",
         "psr/event-dispatcher": "^1",
-        "symfony/mailer": "^7.2"
+        "symfony/mailer": "^6.4|^7.0",
+        "symfony/http-client-contracts": "^3.5.2"
     },
     "require-dev": {
         "symfony/http-client": "^6.4|^7.0"

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/composer.json
@@ -17,14 +17,11 @@
     ],
     "require": {
         "php": ">=8.2",
-        "symfony/mailer": "^7.2"
+        "symfony/mailer": "^6.4|^7.0",
+        "symfony/http-client-contracts": "^3.5.2"
     },
     "require-dev": {
-        "symfony/http-client": "^6.4|^7.0",
-        "symfony/webhook": "^7.2"
-    },
-    "conflict": {
-        "symfony/webhook": "<7.2"
+        "symfony/http-client": "^6.4|^7.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Mailer\\Bridge\\Mailchimp\\": "" },

--- a/src/Symfony/Component/Mailer/Bridge/MailerSend/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/MailerSend/composer.json
@@ -21,7 +21,8 @@
     ],
     "require": {
         "php": ">=8.2",
-        "symfony/mailer": "^7.2"
+        "symfony/mailer": "^6.4|^7.0",
+        "symfony/http-client-contracts": "^3.5.2"
     },
     "require-dev": {
         "symfony/http-client": "^6.4|^7.0",

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": ">=8.2",
-        "symfony/mailer": "^7.2"
+        "symfony/mailer": "^6.4|^7.0",
+        "symfony/http-client-contracts": "^3.5.2"
     },
     "require-dev": {
         "symfony/http-client": "^6.4|^7.0",

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": ">=8.2",
-        "symfony/mailer": "^7.3"
+        "symfony/mailer": "^6.4|^7.0",
+        "symfony/http-client-contracts": "^3.5.2"
     },
     "require-dev": {
         "symfony/http-client": "^6.4|^7.0",

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/composer.json
@@ -18,7 +18,8 @@
     "require": {
         "php": ">=8.2",
         "psr/event-dispatcher": "^1",
-        "symfony/mailer": "^7.2"
+        "symfony/mailer": "^6.4|^7.0",
+        "symfony/http-client-contracts": "^3.5.2"
     },
     "require-dev": {
         "symfony/http-client": "^6.4|^7.0",

--- a/src/Symfony/Component/Mailer/Bridge/Resend/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Resend/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": ">=8.1",
-        "symfony/mailer": "^7.2"
+        "symfony/mailer": "^6.4|^7.0",
+        "symfony/http-client-contracts": "^3.5.2"
     },
     "require-dev": {
         "symfony/http-client": "^6.4|^7.0",

--- a/src/Symfony/Component/Mailer/Bridge/Scaleway/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Scaleway/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": ">=8.1",
-        "symfony/mailer": "^7.2"
+        "symfony/mailer": "^6.4|^7.0",
+        "symfony/http-client-contracts": "^3.5.2"
     },
     "require-dev": {
         "symfony/http-client": "^6.4|^7.0"

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/composer.json
@@ -17,16 +17,16 @@
     ],
     "require": {
         "php": ">=8.2",
-        "symfony/mailer": "^7.2"
+        "symfony/mailer": "^6.4|^7.0",
+        "symfony/http-client-contracts": "^3.5.2"
     },
     "require-dev": {
         "symfony/http-client": "^6.4|^7.0",
-        "symfony/webhook": "^7.2"
+        "symfony/webhook": "^6.4|^7.0"
     },
     "conflict": {
         "symfony/mime": "<6.4",
-        "symfony/http-foundation": "<6.4",
-        "symfony/webhook": "<7.2"
+        "symfony/http-foundation": "<6.4"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Mailer\\Bridge\\Sendgrid\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3  <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        |  <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

# Issue
When using Symfony Mailer components standalone, the code fails due to missing `symfony/http-client-contracts dependency`, which is required by Transport classes.

# Details
The Transport classes in Symfony Mailer packages depend on classes from `symfony/http-client-contracts`
This dependency is not explicitly declared in the package requirements
When using Mailer packages standalone, without full Symfony framework, class not found errors occur

# Solution 
Added `symfony/http-client-contracts` as a required dependency in composer.json