### PR TITLE
[HtmlSanitizer] Fix access to undefined keys in UrlSanitizer

### DIFF
--- a/src/Symfony/Component/HtmlSanitizer/Tests/TextSanitizer/UrlSanitizerTest.php
+++ b/src/Symfony/Component/HtmlSanitizer/Tests/TextSanitizer/UrlSanitizerTest.php
@@ -274,6 +274,15 @@ class UrlSanitizerTest extends TestCase
             'expected' => null,
         ];
 
+        yield [
+            'input' => 'https://trusted.com/link.php',
+            'allowedSchemes' => ['http', 'https'],
+            'allowedHosts' => ['subdomain.trusted.com', 'trusted.com'],
+            'forceHttps' => false,
+            'allowRelative' => false,
+            'expected' => 'https://trusted.com/link.php',
+        ];
+
         // Allow relative
         yield [
             'input' => '/link.php',

--- a/src/Symfony/Component/HtmlSanitizer/TextSanitizer/UrlSanitizer.php
+++ b/src/Symfony/Component/HtmlSanitizer/TextSanitizer/UrlSanitizer.php
@@ -132,7 +132,7 @@ final class UrlSanitizer
     {
         // Check each chunk of the domain is valid
         foreach ($trustedParts as $key => $trustedPart) {
-            if ($uriParts[$key] !== $trustedPart) {
+            if (!array_key_exists($key, $uriParts) || $uriParts[$key] !== $trustedPart) {
                 return false;
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Issues        | Fix #59524 
| License       | MIT

This PR fixes the bug highlighted in #59524 and adds the unit test used to prove the error.
