### PR TITLE
[PropertyInfo] Allow defining accessors and mutators via an attribute

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Attribute/WithAccessors.php
+++ b/src/Symfony/Component/PropertyInfo/Attribute/WithAccessors.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Attribute;
+
+use Symfony\Component\PropertyInfo\Exception\LogicException;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+final class WithAccessors
+{
+    public function __construct(
+        public readonly ?string $getter = null,
+        public readonly ?string $setter = null,
+        public readonly ?string $adder = null,
+        public readonly ?string $remover = null,
+    ) {
+        if (!($this->getter || $this->setter || $this->adder || $this->remover)) {
+            throw new LogicException('At least one of "getter", "setter", "adder", or "remover" must be defined.');
+        }
+        if ($this->adder xor $this->remover) {
+            throw new LogicException('Both "adder" and "remover" must be defined when either is set.');
+        }
+    }
+}

--- a/src/Symfony/Component/PropertyInfo/CHANGELOG.md
+++ b/src/Symfony/Component/PropertyInfo/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Allow defining accessors and mutators via a `#[WithAccessors]` attribute
+
 8.1
 ---
 

--- a/src/Symfony/Component/PropertyInfo/Exception/ExceptionInterface.php
+++ b/src/Symfony/Component/PropertyInfo/Exception/ExceptionInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Exception;
+
+interface ExceptionInterface extends \Throwable
+{
+}

--- a/src/Symfony/Component/PropertyInfo/Exception/LogicException.php
+++ b/src/Symfony/Component/PropertyInfo/Exception/LogicException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Exception;
+
+class LogicException extends \LogicException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/PropertyInfo/Exception/MappingException.php
+++ b/src/Symfony/Component/PropertyInfo/Exception/MappingException.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Exception;
+
+class MappingException extends \RuntimeException implements ExceptionInterface
+{
+    /**
+     * @param list<string> $invalidMethods
+     */
+    public function __construct(
+        string $message,
+        public readonly string $forClass,
+        public readonly array $invalidMethods,
+        ?\Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
+}

--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\PropertyInfo\Extractor;
 
+use Symfony\Component\PropertyInfo\Attribute\WithAccessors;
+use Symfony\Component\PropertyInfo\Exception\MappingException;
 use Symfony\Component\PropertyInfo\PropertyAccessExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyInitializableExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyListExtractorInterface;
@@ -85,6 +87,10 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
     private array $arrayMutatorPrefixesFirst;
     private array $arrayMutatorPrefixesLast;
     private TypeResolverInterface $typeResolver;
+    /** @var array<string, WithAccessors|null> */
+    private array $accessorsAttributes = [];
+    /** @var array<string, array<string, string>> */
+    private array $accessorMethodToPropertyMap = [];
 
     /**
      * @param string[]|null $mutatorPrefixes
@@ -141,7 +147,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
                 continue;
             }
 
-            $propertyName = $this->getPropertyName($reflectionMethod->name, $reflectionProperties);
+            $propertyName = $this->getPropertyName($reflectionClass, $reflectionMethod->name, $reflectionProperties);
             if (!$propertyName || isset($properties[$propertyName])) {
                 continue;
             }
@@ -160,6 +166,10 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
             $refClass = new \ReflectionClass($class);
         } catch (\ReflectionException) {
             return null;
+        }
+
+        if (null !== $accessors = $this->getAccessorsAttribute($refClass, $property)) {
+            return $this->extractTypeFromAccessors($refClass, $class, $property, $accessors);
         }
 
         [$mutatorReflection, $prefix] = $this->getMutatorMethod($refClass, $property);
@@ -287,6 +297,10 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
             return null;
         }
 
+        if (null !== $accessors = $this->getAccessorsAttribute($refClass, $property)) {
+            return null !== $accessors->setter || null !== $accessors->adder;
+        }
+
         // First test with the camelized property name
         [$reflectionMethod] = $this->getMutatorMethod($refClass, $this->camelize($property));
         if (null !== $reflectionMethod) {
@@ -332,6 +346,12 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
             return null;
         }
 
+        if (null !== $methodName = $this->getAccessorsAttribute($reflClass, $property)?->getter) {
+            $method = $reflClass->getMethod($methodName);
+
+            return new PropertyReadInfo(PropertyReadInfo::TYPE_METHOD, $methodName, $this->getReadVisibilityForMethod($method), $method->isStatic(), false);
+        }
+
         $allowGetterSetter = $context['enable_getter_setter_extraction'] ?? false;
         $magicMethods = $context['enable_magic_methods_extraction'] ?? $this->magicMethodsFlags;
         $allowMagicCall = (bool) ($magicMethods & self::ALLOW_MAGIC_CALL);
@@ -375,12 +395,34 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
             return null;
         }
 
+        $allowAdderRemover = $context['enable_adder_remover_extraction'] ?? true;
+
+        $accessorsAttribute = $this->getAccessorsAttribute($reflClass, $property);
+        $adderAccessName = $accessorsAttribute?->adder;
+        $removerAccessName = $accessorsAttribute?->remover;
+
+        if ($allowAdderRemover && null !== $adderAccessName && null !== $removerAccessName) {
+            $adderMethod = $reflClass->getMethod($adderAccessName);
+            $removerMethod = $reflClass->getMethod($removerAccessName);
+
+            $mutator = new PropertyWriteInfo(PropertyWriteInfo::TYPE_ADDER_AND_REMOVER);
+            $mutator->setAdderInfo(new PropertyWriteInfo(PropertyWriteInfo::TYPE_METHOD, $adderAccessName, $this->getWriteVisibilityForMethod($adderMethod), $adderMethod->isStatic()));
+            $mutator->setRemoverInfo(new PropertyWriteInfo(PropertyWriteInfo::TYPE_METHOD, $removerAccessName, $this->getWriteVisibilityForMethod($removerMethod), $removerMethod->isStatic()));
+
+            return $mutator;
+        }
+
+        if (null !== $methodName = $accessorsAttribute?->setter) {
+            $method = $reflClass->getMethod($methodName);
+
+            return new PropertyWriteInfo(PropertyWriteInfo::TYPE_METHOD, $methodName, $this->getWriteVisibilityForMethod($method), $method->isStatic());
+        }
+
         $allowGetterSetter = $context['enable_getter_setter_extraction'] ?? false;
         $magicMethods = $context['enable_magic_methods_extraction'] ?? $this->magicMethodsFlags;
         $allowMagicCall = (bool) ($magicMethods & self::ALLOW_MAGIC_CALL);
         $allowMagicSet = (bool) ($magicMethods & self::ALLOW_MAGIC_SET);
         $allowConstruct = $context['enable_constructor_extraction'] ?? $this->enableConstructorExtraction;
-        $allowAdderRemover = $context['enable_adder_remover_extraction'] ?? true;
 
         $constructor = $reflClass->getConstructor();
         $errors = [];
@@ -396,19 +438,21 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
         $camelized = $this->camelize($property);
         $nonCamelized = ucfirst($property);
 
-        [$adderAccessName, $removerAccessName, $adderAndRemoverErrors] = $this->findAdderAndRemover($reflClass, $camelized);
-        if ($allowAdderRemover && null !== $adderAccessName && null !== $removerAccessName) {
-            $adderMethod = $reflClass->getMethod($adderAccessName);
-            $removerMethod = $reflClass->getMethod($removerAccessName);
+        if (null === $adderAccessName || null === $removerAccessName) {
+            [$adderAccessName, $removerAccessName, $adderAndRemoverErrors] = $this->findAdderAndRemover($reflClass, $camelized);
+            if ($allowAdderRemover && null !== $adderAccessName && null !== $removerAccessName) {
+                $adderMethod = $reflClass->getMethod($adderAccessName);
+                $removerMethod = $reflClass->getMethod($removerAccessName);
 
-            $mutator = new PropertyWriteInfo(PropertyWriteInfo::TYPE_ADDER_AND_REMOVER);
-            $mutator->setAdderInfo(new PropertyWriteInfo(PropertyWriteInfo::TYPE_METHOD, $adderAccessName, $this->getWriteVisibilityForMethod($adderMethod), $adderMethod->isStatic()));
-            $mutator->setRemoverInfo(new PropertyWriteInfo(PropertyWriteInfo::TYPE_METHOD, $removerAccessName, $this->getWriteVisibilityForMethod($removerMethod), $removerMethod->isStatic()));
+                $mutator = new PropertyWriteInfo(PropertyWriteInfo::TYPE_ADDER_AND_REMOVER);
+                $mutator->setAdderInfo(new PropertyWriteInfo(PropertyWriteInfo::TYPE_METHOD, $adderAccessName, $this->getWriteVisibilityForMethod($adderMethod), $adderMethod->isStatic()));
+                $mutator->setRemoverInfo(new PropertyWriteInfo(PropertyWriteInfo::TYPE_METHOD, $removerAccessName, $this->getWriteVisibilityForMethod($removerMethod), $removerMethod->isStatic()));
 
-            return $mutator;
+                return $mutator;
+            }
+
+            $errors[] = $adderAndRemoverErrors;
         }
-
-        $errors[] = $adderAndRemoverErrors;
 
         foreach ($this->mutatorPrefixes as $mutatorPrefix) {
             $methodName = $mutatorPrefix.$camelized;
@@ -648,8 +692,12 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
         return null;
     }
 
-    private function getPropertyName(string $methodName, array $reflectionProperties): ?string
+    private function getPropertyName(\ReflectionClass $refClass, string $methodName, array $reflectionProperties): ?string
     {
+        if (null !== $propertyName = $this->getAccessorMethodFromAttribute($refClass, $reflectionProperties, $methodName)) {
+            return $propertyName;
+        }
+
         $pattern = implode('|', array_merge($this->accessorPrefixes, $this->mutatorPrefixes));
 
         if ('' !== $pattern && preg_match('/^('.$pattern.')(.+)$/i', $methodName, $matches)) {
@@ -851,5 +899,122 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
         }
 
         return PropertyWriteInfo::VISIBILITY_PUBLIC;
+    }
+
+    /**
+     * Resolves the type from the methods named by the attribute.
+     *
+     * A named method is used as is: the prefix gating and the singular/plural guessing that drive
+     * discovery must not second-guess a choice the application made explicit.
+     */
+    private function extractTypeFromAccessors(\ReflectionClass $refClass, string $class, string $property, WithAccessors $accessors): ?Type
+    {
+        if (null !== $accessors->adder) {
+            try {
+                $type = $this->typeResolver->resolve($refClass->getMethod($accessors->adder)->getParameters()[0]);
+
+                if (!$type instanceof CollectionType) {
+                    $type = $this->isNullableProperty($class, $property) ? Type::nullable(Type::list($type)) : Type::list($type);
+                }
+
+                return $type;
+            } catch (UnsupportedException) {
+            }
+        }
+
+        if (null !== $accessors->setter) {
+            try {
+                return $this->typeResolver->resolve($refClass->getMethod($accessors->setter)->getParameters()[0]);
+            } catch (UnsupportedException) {
+            }
+        }
+
+        if (null !== $accessors->getter) {
+            try {
+                return $this->typeResolver->resolve($refClass->getMethod($accessors->getter));
+            } catch (UnsupportedException) {
+            }
+        }
+
+        try {
+            return $this->typeResolver->resolve($refClass->getProperty($property));
+        } catch (\ReflectionException|UnsupportedException) {
+        }
+
+        return null;
+    }
+
+    private function getAccessorsAttribute(\ReflectionClass $refClass, string $property): ?WithAccessors
+    {
+        $propertyHash = $refClass->name.'::'.$property;
+
+        if (\array_key_exists($propertyHash, $this->accessorsAttributes)) {
+            return $this->accessorsAttributes[$propertyHash];
+        }
+
+        if (!$refClass->hasProperty($property)) {
+            if ($parentClass = $refClass->getParentClass()) {
+                return $this->accessorsAttributes[$propertyHash] = $this->getAccessorsAttribute($parentClass, $property);
+            }
+
+            return $this->accessorsAttributes[$propertyHash] = null;
+        }
+
+        $refProperty = $refClass->getProperty($property);
+
+        /** @var \ReflectionAttribute<WithAccessors> $refAttribute */
+        if (null === $refAttribute = $refProperty->getAttributes(WithAccessors::class)[0] ?? null) {
+            return $this->accessorsAttributes[$propertyHash] = null;
+        }
+
+        $accessorsAttribute = $refAttribute->newInstance();
+
+        $invalidAccessors = [];
+        foreach ([$accessorsAttribute->getter, $accessorsAttribute->setter, $accessorsAttribute->adder, $accessorsAttribute->remover] as $accessor) {
+            if (null !== $accessor && !$refClass->hasMethod($accessor)) {
+                $invalidAccessors[] = $accessor;
+            }
+        }
+
+        if ($invalidAccessors) {
+            throw new MappingException(\sprintf('Invalid #[WithAccessors] mapping on property "%s" of class "%s". The following methods are missing: "%s".', $refProperty->name, $refClass->name, implode('", "', $invalidAccessors)), $refClass->name, $invalidAccessors);
+        }
+
+        return $this->accessorsAttributes[$propertyHash] = $accessorsAttribute;
+    }
+
+    /**
+     * @param \ReflectionProperty[] $reflectionProperties
+     */
+    private function getAccessorMethodFromAttribute(\ReflectionClass $refClass, array $reflectionProperties, string $method): ?string
+    {
+        $className = $refClass->name;
+
+        if (!\array_key_exists($className, $this->accessorMethodToPropertyMap)) {
+            $map = [];
+            foreach ($reflectionProperties as $refProperty) {
+                if (null === $accessorsAttribute = $this->getAccessorsAttribute($refClass, $refProperty->name)) {
+                    continue;
+                }
+
+                foreach ([$accessorsAttribute->getter, $accessorsAttribute->setter, $accessorsAttribute->adder, $accessorsAttribute->remover] as $accessor) {
+                    if (null !== $accessor) {
+                        $map[$accessor] = $refProperty->name;
+                    }
+                }
+            }
+
+            $this->accessorMethodToPropertyMap[$className] = $map;
+        }
+
+        if (isset($this->accessorMethodToPropertyMap[$className][$method])) {
+            return $this->accessorMethodToPropertyMap[$className][$method];
+        }
+
+        if ($parentClass = $refClass->getParentClass()) {
+            return $this->getAccessorMethodFromAttribute($parentClass, $parentClass->getProperties(), $method);
+        }
+
+        return null;
     }
 }

--- a/src/Symfony/Component/PropertyInfo/Tests/Attribute/WithAccessorsTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Attribute/WithAccessorsTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Attribute;
+
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyInfo\Attribute\WithAccessors;
+use Symfony\Component\PropertyInfo\Exception\LogicException;
+
+class WithAccessorsTest extends TestCase
+{
+    public function testExceptionIsThrownWhenNoAccessorsAreDefined()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('At least one of "getter", "setter", "adder", or "remover" must be defined.');
+
+        new WithAccessors();
+    }
+
+    #[TestWith(['foo', null])]
+    #[TestWith([null, 'foo'])]
+    public function testExceptionIsThrownWhenOnlyAdderOrRemoverAreDefined(?string $adder, ?string $remover)
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Both "adder" and "remover" must be defined when either is set.');
+
+        new WithAccessors(adder: $adder, remover: $remover);
+    }
+}

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -12,7 +12,9 @@
 namespace Symfony\Component\PropertyInfo\Tests\Extractor;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyInfo\Exception\MappingException;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\PropertyReadInfo;
 use Symfony\Component\PropertyInfo\PropertyWriteInfo;
@@ -41,6 +43,11 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\SnakeCaseDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\UnderscoreDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\VirtualProperties;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\VoidNeverReturnTypeDummy;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\WithAccessors\Bar;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\WithAccessors\DivergingTypes;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\WithAccessors\InvalidMapping;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\WithAccessors\JustAdderAndRemover;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\WithAccessors\JustGetterOrSetter;
 use Symfony\Component\TypeInfo\Type;
 
 /**
@@ -239,6 +246,13 @@ class ReflectionExtractorTest extends TestCase
         $this->assertFalse($this->extractor->isWritable(MultiParameterAdderParentDummy::class, 'link'));
     }
 
+    public function testGetPropertiesWithAttribute()
+    {
+        $extractor = new ReflectionExtractor();
+
+        self::assertSame(['priority', 'tags', 'mailbox', 'active', 'name'], $extractor->getProperties(Bar::class));
+    }
+
     public function testReadonlyPropertiesAreNotWriteable()
     {
         $this->assertFalse($this->extractor->isWritable(Php81Dummy::class, 'foo'));
@@ -308,12 +322,36 @@ class ReflectionExtractorTest extends TestCase
         $this->assertTrue($this->extractor->isReadable(SnakeCaseDummy::class, 'snake_readonly'));
     }
 
+    public function testIsReadableWithAttribute()
+    {
+        $extractor = new ReflectionExtractor();
+
+        self::assertTrue($extractor->isReadable(Bar::class, 'name'));
+        self::assertTrue($extractor->isReadable(Bar::class, 'priority'));
+
+        self::assertTrue($extractor->isReadable(JustGetterOrSetter::class, 'visible'));
+        self::assertFalse($extractor->isReadable(JustGetterOrSetter::class, 'status'));
+        self::assertFalse($extractor->isReadable(JustAdderAndRemover::class, 'items'));
+    }
+
     public function testIsWriteableSnakeCase()
     {
         $this->assertTrue($this->extractor->isWritable(SnakeCaseDummy::class, 'snake_property'));
         $this->assertFalse($this->extractor->isWritable(SnakeCaseDummy::class, 'snake_readonly'));
         // Ensure that it's still possible to write to the property using the (old) snake name
         $this->assertTrue($this->extractor->isWritable(SnakeCaseDummy::class, 'snake_method'));
+    }
+
+    public function testIsWritableWithAttribute()
+    {
+        $extractor = new ReflectionExtractor();
+
+        self::assertTrue($extractor->isWritable(Bar::class, 'name'));
+        self::assertTrue($extractor->isWritable(Bar::class, 'priority'));
+
+        self::assertFalse($extractor->isWritable(JustGetterOrSetter::class, 'visible'));
+        self::assertTrue($extractor->isWritable(JustGetterOrSetter::class, 'status'));
+        self::assertTrue($extractor->isWritable(JustAdderAndRemover::class, 'items'));
     }
 
     public function testSingularize()
@@ -412,6 +450,23 @@ class ReflectionExtractorTest extends TestCase
         ];
     }
 
+    #[TestWith(['name', 'retrieveName'])]
+    #[TestWith(['priority', 'currentPriority'])]
+    #[TestWith(['tags', 'allTags'])]
+    #[TestWith(['mailbox', 'readMailbox'])]
+    #[TestWith(['active', 'isEnabled'])]
+    public function testGetReadAccessorWithAttribute(string $property, string $expectedAccessorName)
+    {
+        $extractor = new ReflectionExtractor();
+        $readAccessor = $extractor->getReadInfo(Bar::class, $property);
+
+        self::assertNotNull($readAccessor);
+        self::assertSame(PropertyReadInfo::TYPE_METHOD, $readAccessor->getType());
+        self::assertSame($expectedAccessorName, $readAccessor->getName());
+        self::assertSame(PropertyReadInfo::VISIBILITY_PUBLIC, $readAccessor->getVisibility());
+        self::assertFalse($readAccessor->isStatic());
+    }
+
     #[DataProvider('writeMutatorProvider')]
     public function testGetWriteMutator($class, $property, $allowConstruct, $found, $type, $name, $addName, $removeName, $visibility, $static)
     {
@@ -465,7 +520,7 @@ class ReflectionExtractorTest extends TestCase
             [Dummy::class, 'foo', false, true, PropertyWriteInfo::TYPE_PROPERTY, 'foo', null, null, PropertyWriteInfo::VISIBILITY_PUBLIC, false],
             [Php71Dummy::class, 'bar', false, true, PropertyWriteInfo::TYPE_METHOD, 'setBar', null, null, PropertyWriteInfo::VISIBILITY_PUBLIC, false],
             [Php71Dummy::class, 'string', false, false, '', '', null, null, PropertyWriteInfo::VISIBILITY_PUBLIC, false],
-            [Php71Dummy::class, 'string', true, true,  PropertyWriteInfo::TYPE_CONSTRUCTOR, 'string', null, null, PropertyWriteInfo::VISIBILITY_PUBLIC, false],
+            [Php71Dummy::class, 'string', true, true, PropertyWriteInfo::TYPE_CONSTRUCTOR, 'string', null, null, PropertyWriteInfo::VISIBILITY_PUBLIC, false],
             [Php71Dummy::class, 'baz', false, true, PropertyWriteInfo::TYPE_ADDER_AND_REMOVER, null, 'addBaz', 'removeBaz', PropertyWriteInfo::VISIBILITY_PUBLIC, false],
             [Php71DummyExtended::class, 'bar', false, true, PropertyWriteInfo::TYPE_METHOD, 'setBar', null, null, PropertyWriteInfo::VISIBILITY_PUBLIC, false],
             [Php71DummyExtended::class, 'string', false, false, -1, '', null, null, PropertyWriteInfo::VISIBILITY_PUBLIC, false],
@@ -473,7 +528,7 @@ class ReflectionExtractorTest extends TestCase
             [Php71DummyExtended::class, 'baz', false, true, PropertyWriteInfo::TYPE_ADDER_AND_REMOVER, null, 'addBaz', 'removeBaz', PropertyWriteInfo::VISIBILITY_PUBLIC, false],
             [Php71DummyExtended2::class, 'bar', false, true, PropertyWriteInfo::TYPE_METHOD, 'setBar', null, null, PropertyWriteInfo::VISIBILITY_PUBLIC, false],
             [Php71DummyExtended2::class, 'string', false, false, '', '', null, null, PropertyWriteInfo::VISIBILITY_PUBLIC, false],
-            [Php71DummyExtended2::class, 'string', true, false,  '', '', null, null, PropertyWriteInfo::VISIBILITY_PUBLIC, false],
+            [Php71DummyExtended2::class, 'string', true, false, '', '', null, null, PropertyWriteInfo::VISIBILITY_PUBLIC, false],
             [Php71DummyExtended2::class, 'baz', false, true, PropertyWriteInfo::TYPE_ADDER_AND_REMOVER, null, 'addBaz', 'removeBaz', PropertyWriteInfo::VISIBILITY_PUBLIC, false],
             [SnakeCaseDummy::class, 'snake_property', false, true, PropertyWriteInfo::TYPE_METHOD, 'setSnakeProperty', null, null, PropertyWriteInfo::VISIBILITY_PUBLIC, false],
             [SnakeCaseDummy::class, 'snake_method', false, true, PropertyWriteInfo::TYPE_METHOD, 'setSnake_method', null, null, PropertyWriteInfo::VISIBILITY_PUBLIC, false],
@@ -490,6 +545,83 @@ class ReflectionExtractorTest extends TestCase
         self::assertNotNull($writeMutator);
         self::assertSame(PropertyWriteInfo::TYPE_NONE, $writeMutator->getType());
         self::assertSame([\sprintf('The property "baz" in class "%s" can be defined with the methods "addBaz()", "removeBaz()" but the new value must be an array or an instance of \Traversable', Php71Dummy::class)], $writeMutator->getErrors());
+    }
+
+    #[TestWith([Bar::class, 'name', PropertyWriteInfo::TYPE_METHOD, 'renameTo', null, null])]
+    #[TestWith([Bar::class, 'priority', PropertyWriteInfo::TYPE_METHOD, 'changePriority', null, null])]
+    #[TestWith([Bar::class, 'tags', PropertyWriteInfo::TYPE_ADDER_AND_REMOVER, 'replaceTags', 'attachTag', 'detachTag'])]
+    #[TestWith([Bar::class, 'mailbox', PropertyWriteInfo::TYPE_ADDER_AND_REMOVER, 'replaceMailbox', 'attachLetter', 'detachLetter'])]
+    #[TestWith([JustGetterOrSetter::class, 'status', PropertyWriteInfo::TYPE_METHOD, 'updateStatus', null, null])]
+    public function testGetWriteMutatorWithAttribute(string $class, string $property, string $type, string $name, ?string $addName, ?string $removeName)
+    {
+        $extractor = new ReflectionExtractor();
+        $writeMutator = $extractor->getWriteInfo($class, $property);
+
+        self::assertNotNull($writeMutator);
+        self::assertSame($type, $writeMutator->getType());
+
+        if (PropertyWriteInfo::TYPE_ADDER_AND_REMOVER === $writeMutator->getType()) {
+            self::assertNotNull($writeMutator->getAdderInfo());
+            self::assertSame($addName, $writeMutator->getAdderInfo()->getName());
+            self::assertNotNull($writeMutator->getRemoverInfo());
+            self::assertSame($removeName, $writeMutator->getRemoverInfo()->getName());
+        } elseif (PropertyWriteInfo::TYPE_METHOD === $writeMutator->getType()) {
+            self::assertSame($name, $writeMutator->getName());
+            self::assertSame(PropertyWriteInfo::VISIBILITY_PUBLIC, $writeMutator->getVisibility());
+            self::assertFalse($writeMutator->isStatic());
+        }
+    }
+
+    public function testDisabledAdderAndRemoverWithAttributeReturnsError()
+    {
+        $extractor = new ReflectionExtractor();
+        $writeMutator = $extractor->getWriteInfo(JustAdderAndRemover::class, 'items', [
+            'enable_adder_remover_extraction' => false,
+        ]);
+
+        self::assertNotNull($writeMutator);
+        self::assertSame(PropertyWriteInfo::TYPE_NONE, $writeMutator->getType());
+        self::assertSame([\sprintf('The property "items" in class "%s" can be defined with the methods "enqueue()", "dequeue()" but the new value must be an array or an instance of \Traversable', JustAdderAndRemover::class)], $writeMutator->getErrors());
+    }
+
+    #[DataProvider('accessorPrefixesProvider')]
+    public function testAttributeAccessorWinsWhateverThePrefixesAre(?array $accessorPrefixes)
+    {
+        $extractor = new ReflectionExtractor(accessorPrefixes: $accessorPrefixes);
+
+        self::assertEquals(Type::bool(), $extractor->getType(DivergingTypes::class, 'enabled'));
+    }
+
+    #[DataProvider('mutatorPrefixesProvider')]
+    public function testAttributeAdderWinsWhateverThePrefixesAre(?array $mutatorPrefixes)
+    {
+        $extractor = new ReflectionExtractor(mutatorPrefixes: $mutatorPrefixes);
+
+        self::assertEquals(Type::list(Type::string()), $extractor->getType(DivergingTypes::class, 'items'));
+    }
+
+    public static function accessorPrefixesProvider(): iterable
+    {
+        yield 'defaults' => [null];
+        yield 'is before get' => [['is', 'get', 'has', 'can']];
+        yield 'no get at all' => [['is']];
+    }
+
+    public static function mutatorPrefixesProvider(): iterable
+    {
+        yield 'defaults' => [null];
+        yield 'set before add' => [['set', 'add', 'remove']];
+        yield 'no add at all' => [['set']];
+    }
+
+    public function testMappingExceptionOnInvalidAccessorMethod()
+    {
+        $extractor = new ReflectionExtractor();
+
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('Invalid #[WithAccessors] mapping on property "prop" of class');
+
+        $extractor->isReadable(InvalidMapping::class, 'prop');
     }
 
     public function testGetWriteInfoReadonlyProperties()
@@ -757,6 +889,26 @@ class ReflectionExtractorTest extends TestCase
         yield ['defaultString', Type::string()];
         yield ['defaultArray', Type::array()];
         yield ['defaultNull', null];
+    }
+
+    #[DataProvider('provideTypesWithAttribute')]
+    public function testExtractTypeWithAttribute(string $class, string $property, Type $type)
+    {
+        $extractor = new ReflectionExtractor();
+
+        self::assertEquals($type, $extractor->getType($class, $property));
+    }
+
+    public static function provideTypesWithAttribute(): iterable
+    {
+        yield [Bar::class, 'name', Type::string()];
+        yield [Bar::class, 'priority', Type::int()];
+        yield [Bar::class, 'tags', Type::list(Type::int())];
+        yield [Bar::class, 'mailbox', Type::list(Type::int())];
+        yield [Bar::class, 'active', Type::bool()];
+        yield [JustGetterOrSetter::class, 'visible', Type::bool()];
+        yield [JustGetterOrSetter::class, 'status', Type::nullable(Type::string())];
+        yield [JustAdderAndRemover::class, 'items', Type::list(Type::int())];
     }
 
     #[DataProvider('constructorTypesProvider')]

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/WithAccessors/Bar.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/WithAccessors/Bar.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures\WithAccessors;
+
+use Symfony\Component\PropertyInfo\Attribute\WithAccessors;
+
+class Bar extends Foo
+{
+    #[WithAccessors(getter: 'currentPriority', setter: 'changePriority')]
+    private int $priority;
+    #[WithAccessors(getter: 'allTags', setter: 'replaceTags', adder: 'attachTag', remover: 'detachTag')]
+    private array $tags;
+    #[WithAccessors(getter: 'readMailbox', setter: 'replaceMailbox', adder: 'attachLetter', remover: 'detachLetter')]
+    private array $mailbox;
+    #[WithAccessors(getter: 'isEnabled')]
+    private int $active;
+
+    public function currentPriority(): int
+    {
+    }
+
+    public function changePriority(int $priority): void
+    {
+    }
+
+    public function allTags(): array
+    {
+    }
+
+    public function replaceTags(array $tags): void
+    {
+    }
+
+    public function attachTag(int $tag): void
+    {
+    }
+
+    public function detachTag(): void
+    {
+    }
+
+    public function readMailbox(): array
+    {
+    }
+
+    public function replaceMailbox(array $mailbox): void
+    {
+    }
+
+    public function attachLetter(int $letter): void
+    {
+    }
+
+    public function detachLetter(): void
+    {
+    }
+
+    public function isEnabled(): bool
+    {
+    }
+}

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/WithAccessors/DivergingTypes.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/WithAccessors/DivergingTypes.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures\WithAccessors;
+
+use Symfony\Component\PropertyInfo\Attribute\WithAccessors;
+
+class DivergingTypes
+{
+    #[WithAccessors(getter: 'isEnabled')]
+    private ?string $enabled = null;
+
+    #[WithAccessors(adder: 'push', remover: 'pop')]
+    private array $items = [];
+
+    public function isEnabled(): bool
+    {
+    }
+
+    public function push(string $item): void
+    {
+    }
+
+    public function pop(string $item): void
+    {
+    }
+}

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/WithAccessors/Foo.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/WithAccessors/Foo.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures\WithAccessors;
+
+use Symfony\Component\PropertyInfo\Attribute\WithAccessors;
+
+class Foo
+{
+    #[WithAccessors(getter: 'retrieveName', setter: 'renameTo')]
+    private string $name;
+
+    public function retrieveName(): string
+    {
+    }
+
+    public function renameTo(string $name): void
+    {
+    }
+}

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/WithAccessors/InvalidMapping.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/WithAccessors/InvalidMapping.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures\WithAccessors;
+
+use Symfony\Component\PropertyInfo\Attribute\WithAccessors;
+
+class InvalidMapping
+{
+    #[WithAccessors(getter: 'nonExistentMethod')]
+    private string $prop;
+}

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/WithAccessors/JustAdderAndRemover.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/WithAccessors/JustAdderAndRemover.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures\WithAccessors;
+
+use Symfony\Component\PropertyInfo\Attribute\WithAccessors;
+
+class JustAdderAndRemover
+{
+    #[WithAccessors(adder: 'enqueue', remover: 'dequeue')]
+    private array $items = [];
+
+    public function enqueue(int $item): void
+    {
+    }
+
+    public function dequeue(int $item): array
+    {
+    }
+}

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/WithAccessors/JustGetterOrSetter.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/WithAccessors/JustGetterOrSetter.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures\WithAccessors;
+
+use Symfony\Component\PropertyInfo\Attribute\WithAccessors;
+
+class JustGetterOrSetter
+{
+    #[WithAccessors(getter: 'checkVisibility')]
+    private int $visible = 1;
+    #[WithAccessors(setter: 'updateStatus')]
+    private int $status;
+
+    public function checkVisibility(): bool
+    {
+    }
+
+    public function updateStatus(?string $status): void
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

A continuation of #38515.

`ReflectionExtractor` finds accessors and mutators by convention: it tries each configured prefix against the property name, and asks the inflector whether that name is singular to decide between a whole-collection setter and an element-wise adder. Code that does not follow the convention is invisible to it, and the only way out today is a custom extractor.

`#[WithAccessors]` lets a property name its methods instead:

```php
class Foo
{
    #[WithAccessors(getter: 'giveProp', setter: 'receiveProp', adder: 'pushProp', remover: 'popProp')]
    private array $prop;

    public function giveProp(): array {}

    public function receiveProp(array $prop): void {}

    public function pushProp(string $prop): void {}

    public function popProp(string $prop): void {}
}
```

All four arguments are optional, and at least one must be given. `adder` and `remover` go together: naming one without the other throws. A setter may sit next to an adder and remover, the same way `setTags()` can coexist with `addTag()`/`removeTag()` under the existing conventions.

Naming a method that does not exist throws a `MappingException` when the metadata is read, rather than falling back to discovery and silently resolving something else.

The attribute is read on the declaring class and inherited, so a private property annotated on a parent applies to its children.

Named methods are used as given. The prefix gating, the `is`/`has`/`can` handling and the singular/plural guessing all belong to discovery and are skipped entirely, so results do not shift with the extractor's configured prefixes. When both a setter and an adder are named, the adder determines the type, which yields the element type rather than the bare collection.

Documentation should cover: the four arguments and that at least one is required, the adder/remover pairing rule, that a setter and an adder can be declared together and what each is used for, the `MappingException` on a missing method, inheritance from a parent's property, and that a named method bypasses the naming conventions.
