### PR TITLE
[JsonEncoder] Allow to warm up object and list

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -746,8 +746,11 @@ class FrameworkExtension extends Extension
                 }
             );
         }
-        $container->registerAttributeForAutoconfiguration(JsonEncodable::class, static function (ChildDefinition $definition): void {
-            $definition->addTag('json_encoder.encodable');
+        $container->registerAttributeForAutoconfiguration(JsonEncodable::class, static function (ChildDefinition $definition, JsonEncodable $attribute): void {
+            $definition->addTag('json_encoder.encodable', [
+                'object' => $attribute->asObject,
+                'list' => $attribute->asList,
+            ]);
             $definition->addTag('container.excluded');
         });
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/JsonEncoderTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/JsonEncoderTest.php
@@ -62,6 +62,6 @@ class JsonEncoderTest extends AbstractWebTestCase
         static::getContainer()->get('json_encoder.cache_warmer.encoder_decoder.alias')->warmUp(static::getContainer()->getParameter('kernel.cache_dir'));
 
         $this->assertFileExists($encodersDir);
-        $this->assertCount(1, glob($encodersDir.'/*'));
+        $this->assertCount(2, glob($encodersDir.'/*'));
     }
 }

--- a/src/Symfony/Component/JsonEncoder/Attribute/JsonEncodable.php
+++ b/src/Symfony/Component/JsonEncoder/Attribute/JsonEncodable.php
@@ -19,4 +19,9 @@ namespace Symfony\Component\JsonEncoder\Attribute;
 #[\Attribute(\Attribute::TARGET_CLASS)]
 final class JsonEncodable
 {
+    public function __construct(
+        public bool $asObject = true,
+        public bool $asList = true,
+    ) {
+    }
 }

--- a/src/Symfony/Component/JsonEncoder/CHANGELOG.md
+++ b/src/Symfony/Component/JsonEncoder/CHANGELOG.md
@@ -6,3 +6,4 @@ CHANGELOG
 
  * Introduce the component as experimental
  * Add native PHP lazy ghost support
+ * Allow to select the warmup of object and list in `JsonEncodable` and `json_encoder.encodable`

--- a/src/Symfony/Component/JsonEncoder/Tests/DependencyInjection/EncodablePassTest.php
+++ b/src/Symfony/Component/JsonEncoder/Tests/DependencyInjection/EncodablePassTest.php
@@ -25,8 +25,8 @@ class EncodablePassTest extends TestCase
         $container->register('.json_encoder.cache_warmer.encoder_decoder')->setArguments([null]);
         $container->register('.json_encoder.cache_warmer.lazy_ghost')->setArguments([null]);
 
-        $container->register('encodable')->setClass('Foo')->addTag('json_encoder.encodable');
-        $container->register('abstractEncodable')->setClass('Bar')->addTag('json_encoder.encodable')->setAbstract(true);
+        $container->register('encodable')->setClass('Foo')->addTag('json_encoder.encodable', ['object' => true, 'list' => true]);
+        $container->register('abstractEncodable')->setClass('Bar')->addTag('json_encoder.encodable', ['object' => true, 'list' => true])->setAbstract(true);
         $container->register('notEncodable')->setClass('Baz');
 
         $pass = new EncodablePass();
@@ -35,9 +35,7 @@ class EncodablePassTest extends TestCase
         $encoderDecoderCacheWarmer = $container->getDefinition('.json_encoder.cache_warmer.encoder_decoder');
         $lazyGhostCacheWarmer = $container->getDefinition('.json_encoder.cache_warmer.lazy_ghost');
 
-        $expectedEncodableClassNames = ['Foo'];
-
-        $this->assertSame($expectedEncodableClassNames, $encoderDecoderCacheWarmer->getArgument(0));
-        $this->assertSame($expectedEncodableClassNames, $lazyGhostCacheWarmer->getArgument(0));
+        $this->assertSame(['Foo' => ['object' => true, 'list' => true]], $encoderDecoderCacheWarmer->getArgument(0));
+        $this->assertSame(['Foo'], $lazyGhostCacheWarmer->getArgument(0));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

As discussed with @chalasr, configuration in FrameworkBundle must be avoided as much as possible.
That's why https://github.com/symfony/symfony/pull/59396 might not be the way to go.

Instead, this PR addresses the most common use cases, which are warming up cache files for `GivenClass` and `list<GivenClass>`.

This can be configured by setting the `object` and `list` attributes of `json_encoder.encodable`, or `asObject` and `asList` of the `JsonEncodable` attribute accordingly.