### PR TITLE
[Security] Don't invalidate the user when the password was not stored in the session

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -191,7 +191,7 @@ class ContextListener extends AbstractListener
      *
      * @throws \RuntimeException
      */
-    protected function refreshUser(TokenInterface $token): ?TokenInterface
+    private function refreshUser(TokenInterface $token): ?TokenInterface
     {
         $user = $token->getUser();
 
@@ -292,7 +292,10 @@ class ContextListener extends AbstractListener
         }
 
         if ($originalUser instanceof PasswordAuthenticatedUserInterface || $refreshedUser instanceof PasswordAuthenticatedUserInterface) {
-            if (!$originalUser instanceof PasswordAuthenticatedUserInterface || !$refreshedUser instanceof PasswordAuthenticatedUserInterface || $originalUser->getPassword() !== $refreshedUser->getPassword()) {
+            if (!$originalUser instanceof PasswordAuthenticatedUserInterface
+                || !$refreshedUser instanceof PasswordAuthenticatedUserInterface
+                || $refreshedUser->getPassword() !== ($originalUser->getPassword() ?? $refreshedUser->getPassword())
+            ) {
                 return true;
             }
 

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/AccessListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/AccessListenerTest.php
@@ -42,11 +42,7 @@ class AccessListenerTest extends TestCase
             ->willReturn([['foo' => 'bar'], null])
         ;
 
-        $token = new class extends AbstractToken {
-            public function getCredentials(): mixed
-            {
-            }
-        };
+        $token = new class extends AbstractToken {};
 
         $tokenStorage = $this->createMock(TokenStorageInterface::class);
         $tokenStorage

--- a/src/Symfony/Component/Security/Http/Tests/Fixtures/CustomUser.php
+++ b/src/Symfony/Component/Security/Http/Tests/Fixtures/CustomUser.php
@@ -9,15 +9,17 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Security\Core\Tests\Authentication\Token\Fixtures;
+namespace Symfony\Component\Security\Http\Tests\Fixtures;
 
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
-final class CustomUser implements UserInterface
+final class CustomUser implements UserInterface, PasswordAuthenticatedUserInterface
 {
     public function __construct(
         private string $username,
         private array $roles,
+        private ?string $password = null,
     ) {
     }
 
@@ -31,7 +33,17 @@ final class CustomUser implements UserInterface
         return $this->roles;
     }
 
+    public function getPassword(): ?string
+    {
+        return $this->password ?? null;
+    }
+
     public function eraseCredentials(): void
     {
+    }
+
+    public function __serialize(): array
+    {
+        return [\sprintf("\0%s\0username", self::class) => $this->username];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Related to #59106: this PR does is considering that if `$originalUser` (the object coming from the session) has a null password, then we don't consider it changed from `$refreshedUser`. Aka we don't log out the user in such case.

The benefit is allowing to not put the hashed password in the session. I think that's desirable.
