### PR TITLE
[PropertyInfo] Fix support for inline `@var` docblocks on promoted properties

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -46,6 +46,11 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
     private array $docBlocks = [];
 
     /**
+     * @var array<string, array{DocBlock, string}|false>
+     */
+    private array $promotedPropertyDocBlocks = [];
+
+    /**
      * @var Context[]
      */
     private array $contexts = [];
@@ -80,32 +85,26 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
 
     public function getShortDescription(string $class, string $property, array $context = []): ?string
     {
+        $docBlockData = $this->getPromotedPropertyDocBlockData($class, $property);
+        if ($docBlockData && $shortDescription = $this->getShortDescriptionFromDocBlock($docBlockData[0])) {
+            return $shortDescription;
+        }
+
         [$docBlock] = $this->findDocBlock($class, $property);
         if (!$docBlock) {
             return null;
         }
 
-        $shortDescription = $docBlock->getSummary();
-
-        if ($shortDescription) {
-            return $shortDescription;
-        }
-
-        foreach ($docBlock->getTagsByName('var') as $var) {
-            if ($var && !$var instanceof InvalidTag) {
-                $varDescription = $var->getDescription()->render();
-
-                if ($varDescription) {
-                    return $varDescription;
-                }
-            }
-        }
-
-        return null;
+        return $this->getShortDescriptionFromDocBlock($docBlock);
     }
 
     public function getLongDescription(string $class, string $property, array $context = []): ?string
     {
+        $docBlockData = $this->getPromotedPropertyDocBlockData($class, $property);
+        if ($docBlockData && '' !== $contents = $docBlockData[0]->getDescription()->render()) {
+            return $contents;
+        }
+
         [$docBlock] = $this->findDocBlock($class, $property);
         if (!$docBlock) {
             return null;
@@ -207,61 +206,18 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
 
     public function getType(string $class, string $property, array $context = []): ?Type
     {
-        /** @var DocBlock $docBlock */
+        if ([$propertyDocBlock, $propertyDeclaringClass] = $this->getPromotedPropertyDocBlockData($class, $property)) {
+            if ($type = $this->getTypeFromDocBlock($propertyDocBlock, self::PROPERTY, $class, $propertyDeclaringClass, null)) {
+                return $type;
+            }
+        }
+
         [$docBlock, $source, $prefix, $declaringClass] = $this->findDocBlock($class, $property);
         if (!$docBlock) {
             return null;
         }
 
-        $tag = match ($source) {
-            self::PROPERTY => 'var',
-            self::ACCESSOR => 'return',
-            self::MUTATOR => 'param',
-        };
-
-        $types = [];
-        $typeContext = $this->typeContextFactory->createFromClassName($class, $declaringClass ?? $class);
-
-        /** @var DocBlock\Tags\Var_|DocBlock\Tags\Return_|DocBlock\Tags\Param $tag */
-        foreach ($docBlock->getTagsByName($tag) as $tag) {
-            if ($tag instanceof InvalidTag || !$tagType = $tag->getType()) {
-                continue;
-            }
-
-            $type = $this->phpDocTypeHelper->getType($tagType);
-
-            if (!$type instanceof ObjectType) {
-                $types[] = $type;
-
-                continue;
-            }
-
-            $normalizedClassName = match ($type->getClassName()) {
-                'self' => $typeContext->getDeclaringClass(),
-                'static' => $typeContext->getCalledClass(),
-                default => $type->getClassName(),
-            };
-
-            if ('parent' === $normalizedClassName) {
-                try {
-                    $normalizedClassName = $typeContext->getParentClass();
-                } catch (LogicException) {
-                    // if there is no parent for the current class, we keep the "parent" raw string
-                }
-            }
-
-            $types[] = $type->isNullable() ? Type::nullable(Type::object($normalizedClassName)) : Type::object($normalizedClassName);
-        }
-
-        if (null === $type = $types[0] ?? null) {
-            return null;
-        }
-
-        if (!\in_array($prefix, $this->arrayMutatorPrefixes, true)) {
-            return $type;
-        }
-
-        return Type::list($type);
+        return $this->getTypeFromDocBlock($docBlock, $source, $class, $declaringClass, $prefix);
     }
 
     public function getTypeFromConstructor(string $class, string $property): ?Type
@@ -285,9 +241,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
 
     public function getDocBlock(string $class, string $property): ?DocBlock
     {
-        $output = $this->findDocBlock($class, $property);
-
-        return $output[0];
+        return $this->findDocBlock($class, $property)[0];
     }
 
     private function getDocBlockFromConstructor(string $class, string $property): ?DocBlock
@@ -297,8 +251,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
         } catch (\ReflectionException) {
             return null;
         }
-        $reflectionConstructor = $reflectionClass->getConstructor();
-        if (!$reflectionConstructor) {
+        if (!$reflectionConstructor = $reflectionClass->getConstructor()) {
             return null;
         }
 
@@ -338,25 +291,14 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
 
         $ucFirstProperty = ucfirst($property);
 
-        switch (true) {
-            case $reflectionProperty?->isPromoted() && $docBlock = $this->getDocBlockFromConstructor($reflectionProperty->class, $property):
-                $data = [$docBlock, self::MUTATOR, null, $reflectionProperty->class];
-                break;
-
-            case [$docBlock, $declaringClass] = $this->getDocBlockFromProperty($class, $property):
-                $data = [$docBlock, self::PROPERTY, null, $declaringClass];
-                break;
-
-            case [$docBlock, , $declaringClass] = $this->getDocBlockFromMethod($class, $ucFirstProperty, self::ACCESSOR):
-                $data = [$docBlock, self::ACCESSOR, null, $declaringClass];
-                break;
-
-            case [$docBlock, $prefix, $declaringClass] = $this->getDocBlockFromMethod($class, $ucFirstProperty, self::MUTATOR):
-                $data = [$docBlock, self::MUTATOR, $prefix, $declaringClass];
-                break;
-
-            default:
-                $data = [null, null, null, null];
+        if ($reflectionProperty?->isPromoted() && $docBlock = $this->getDocBlockFromConstructor($reflectionProperty->class, $property)) {
+            $data = [$docBlock, self::MUTATOR, null, $reflectionProperty->class];
+        } elseif ([$docBlock, $declaringClass] = $this->getDocBlockFromProperty($class, $property)) {
+            $data = [$docBlock, self::PROPERTY, null, $declaringClass];
+        } else {
+            $data = $this->getDocBlockFromMethod($class, $ucFirstProperty, self::ACCESSOR)
+                ?? $this->getDocBlockFromMethod($class, $ucFirstProperty, self::MUTATOR)
+                ?? [null, null, null, null];
         }
 
         return $this->docBlocks[$propertyHash] = $data;
@@ -390,12 +332,12 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
             $declaringClass = $reflector->isTrait() ? $originalClass : $reflector->getName();
 
             return [$this->docBlockFactory->create($reflectionProperty, $context), $declaringClass];
-        } catch (\InvalidArgumentException|\RuntimeException $e) {
-            if ($e instanceof \RuntimeException) {
-                // Workaround for phpdocumentor/reflection-docblock < 6 not supporting ?Type<...> syntax
-                if (($rawDoc = $reflectionProperty->getDocComment()) && $docBlock = $this->getNullableGenericDocBlock($rawDoc, $context)) {
-                    return [$docBlock, $declaringClass ?? ($reflector->isTrait() ? $originalClass : $reflector->getName())];
-                }
+        } catch (\InvalidArgumentException) {
+            return null;
+        } catch (\RuntimeException) {
+            // Workaround for phpdocumentor/reflection-docblock < 6 not supporting ?Type<...> syntax
+            if (($rawDoc = $reflectionProperty->getDocComment()) && $docBlock = $this->getNullableGenericDocBlock($rawDoc, $context)) {
+                return [$docBlock, $declaringClass ?? ($reflector->isTrait() ? $originalClass : $reflector->getName())];
             }
 
             return null;
@@ -403,7 +345,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
     }
 
     /**
-     * @return array{DocBlock, string, string}|null
+     * @return array{DocBlock, int, ?string, string}|null
      */
     private function getDocBlockFromMethod(string $class, string $ucFirstProperty, int $type, ?string $originalClass = null): ?array
     {
@@ -449,17 +391,18 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
         }
 
         $context = $this->createFromReflector($reflector);
+        $prefix = self::ACCESSOR === $type ? null : $prefix;
 
         try {
             $declaringClass = $reflector->isTrait() ? $originalClass : $reflector->getName();
 
-            return [$this->docBlockFactory->create($method, $context), $prefix, $declaringClass];
-        } catch (\InvalidArgumentException|\RuntimeException $e) {
-            if ($e instanceof \RuntimeException) {
-                // Workaround for phpdocumentor/reflection-docblock < 6 not supporting ?Type<...> syntax
-                if (($rawDoc = $method->getDocComment()) && $docBlock = $this->getNullableGenericDocBlock($rawDoc, $context)) {
-                    return [$docBlock, $prefix, $declaringClass ?? ($reflector->isTrait() ? $originalClass : $reflector->getName())];
-                }
+            return [$this->docBlockFactory->create($method, $context), $type, $prefix, $declaringClass];
+        } catch (\InvalidArgumentException) {
+            return null;
+        } catch (\RuntimeException) {
+            // Workaround for phpdocumentor/reflection-docblock < 6 not supporting ?Type<...> syntax
+            if (($rawDoc = $method->getDocComment()) && $docBlock = $this->getNullableGenericDocBlock($rawDoc, $context)) {
+                return [$docBlock, $type, $prefix, $declaringClass ?? ($reflector->isTrait() ? $originalClass : $reflector->getName())];
             }
 
             return null;
@@ -469,8 +412,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
     private function getNullableGenericDocBlock(string $rawDoc, Context $context): ?DocBlock
     {
         // Converts "?Type<...>" to "Type<...>|null"
-        $processedDoc = preg_replace('/@(var|param|return)\s+\?(\S+)/', '@$1 $2|null', $rawDoc);
-        if ($processedDoc === $rawDoc) {
+        if ($rawDoc === $processedDoc = preg_replace('/@(var|param|return)\s+\?(\S+)/', '@$1 $2|null', $rawDoc)) {
             return null;
         }
 
@@ -488,12 +430,112 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
     {
         $cacheKey = $reflector->getNamespaceName().':'.$reflector->getFileName();
 
-        if (isset($this->contexts[$cacheKey])) {
-            return $this->contexts[$cacheKey];
+        return $this->contexts[$cacheKey] ??= $this->contextFactory->createFromReflector($reflector);
+    }
+
+    /**
+     * @return array{DocBlock, string}|null
+     */
+    private function getPromotedPropertyDocBlockData(string $class, string $property): ?array
+    {
+        $propertyHash = $class.'::'.$property;
+
+        if (isset($this->promotedPropertyDocBlocks[$propertyHash])) {
+            return false === $this->promotedPropertyDocBlocks[$propertyHash] ? null : $this->promotedPropertyDocBlocks[$propertyHash];
         }
 
-        $this->contexts[$cacheKey] = $this->contextFactory->createFromReflector($reflector);
+        try {
+            $reflectionProperty = new \ReflectionProperty($class, $property);
+        } catch (\ReflectionException) {
+            $this->promotedPropertyDocBlocks[$propertyHash] = false;
 
-        return $this->contexts[$cacheKey];
+            return null;
+        }
+
+        if (!$reflectionProperty->isPromoted() || !$data = $this->getDocBlockFromProperty($class, $property)) {
+            $this->promotedPropertyDocBlocks[$propertyHash] = false;
+
+            return null;
+        }
+
+        return $this->promotedPropertyDocBlocks[$propertyHash] = $data;
+    }
+
+    private function getTypeFromDocBlock(DocBlock $docBlock, int $source, string $class, ?string $declaringClass, ?string $prefix): ?Type
+    {
+        $tag = match ($source) {
+            self::PROPERTY => 'var',
+            self::ACCESSOR => 'return',
+            self::MUTATOR => 'param',
+        };
+
+        $types = [];
+        $typeContext = $this->typeContextFactory->createFromClassName($class, $declaringClass ?? $class);
+
+        /** @var DocBlock\Tags\Var_|DocBlock\Tags\Return_|DocBlock\Tags\Param $tag */
+        foreach ($docBlock->getTagsByName($tag) as $tag) {
+            if ($tag instanceof InvalidTag || !$tagType = $tag->getType()) {
+                continue;
+            }
+
+            $type = $this->phpDocTypeHelper->getType($tagType);
+
+            if (!$type instanceof ObjectType) {
+                $types[] = $type;
+
+                continue;
+            }
+
+            $normalizedClassName = match ($type->getClassName()) {
+                'self' => $typeContext->getDeclaringClass(),
+                'static' => $typeContext->getCalledClass(),
+                default => $type->getClassName(),
+            };
+
+            if ('parent' === $normalizedClassName) {
+                try {
+                    $normalizedClassName = $typeContext->getParentClass();
+                } catch (LogicException) {
+                    // if there is no parent for the current class, we keep the "parent" raw string
+                }
+            }
+
+            $types[] = $type->isNullable() ? Type::nullable(Type::object($normalizedClassName)) : Type::object($normalizedClassName);
+        }
+
+        if (!$type = $types[0] ?? null) {
+            return null;
+        }
+
+        if (self::MUTATOR !== $source || !\in_array($prefix, $this->arrayMutatorPrefixes, true)) {
+            return $type;
+        }
+
+        return Type::list($type);
+    }
+
+    private function getShortDescriptionFromDocBlock(DocBlock $docBlock): ?string
+    {
+        if ($shortDescription = $docBlock->getSummary()) {
+            return $shortDescription;
+        }
+
+        foreach ($docBlock->getTagsByName('var') as $var) {
+            if ($var && !$var instanceof InvalidTag && $varDescription = $var->getDescription()->render()) {
+                return $varDescription;
+            }
+        }
+
+        foreach ($docBlock->getTagsByName('param') as $param) {
+            if (!$param instanceof DocBlock\Tags\Param) {
+                continue;
+            }
+
+            if ($paramDescription = $param->getDescription()?->render()) {
+                return $paramDescription;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
@@ -258,19 +258,17 @@ final class PhpStanExtractor implements PropertyDescriptionExtractorInterface, P
     public function getShortDescription(string $class, string $property, array $context = []): ?string
     {
         /** @var PhpDocNode|null $docNode */
-        [$docNode] = $this->getDocBlockFromProperty($class, $property);
-        if (null === $docNode) {
+        [$docNode, $constructorDocNode] = $this->getDocBlockFromProperty($class, $property);
+        if (null === $docNode && null === $constructorDocNode) {
             return null;
         }
 
-        if ($shortDescription = $this->getDescriptionsFromDocNode($docNode)[0]) {
+        if ($docNode && $shortDescription = $this->getShortDescriptionFromDocNode($docNode, $property)) {
             return $shortDescription;
         }
 
-        foreach ($docNode->getVarTagValues() as $var) {
-            if ($var->description) {
-                return $var->description;
-            }
+        if ($constructorDocNode) {
+            return $this->getShortDescriptionFromDocNode($constructorDocNode, $property);
         }
 
         return null;
@@ -279,12 +277,16 @@ final class PhpStanExtractor implements PropertyDescriptionExtractorInterface, P
     public function getLongDescription(string $class, string $property, array $context = []): ?string
     {
         /** @var PhpDocNode|null $docNode */
-        [$docNode] = $this->getDocBlockFromProperty($class, $property);
-        if (null === $docNode) {
+        [$docNode, $constructorDocNode] = $this->getDocBlockFromProperty($class, $property);
+        if (null === $docNode && null === $constructorDocNode) {
             return null;
         }
 
-        return $this->getDescriptionsFromDocNode($docNode)[1];
+        if ($docNode && $longDescription = $this->getDescriptionsFromDocNode($docNode)[1]) {
+            return $longDescription;
+        }
+
+        return $constructorDocNode ? $this->getDescriptionsFromDocNode($constructorDocNode)[1] : null;
     }
 
     /**
@@ -373,6 +375,41 @@ final class PhpStanExtractor implements PropertyDescriptionExtractorInterface, P
             $shortDescription ?: null,
             $longDescription ?: null,
         ];
+    }
+
+    private function getShortDescriptionFromDocNode(PhpDocNode $docNode, string $property): ?string
+    {
+        if ($shortDescription = $this->getDescriptionsFromDocNode($docNode)[0]) {
+            return $shortDescription;
+        }
+
+        foreach ($docNode->getVarTagValues() as $var) {
+            if (!$var->description) {
+                continue;
+            }
+
+            if (null !== $var->variableName && '' !== $var->variableName && '$'.$property !== $var->variableName) {
+                continue;
+            }
+
+            return $var->description;
+        }
+
+        foreach ($docNode->getTagsByName('@param') as $tagNode) {
+            if (!$tagNode instanceof PhpDocTagNode || !$tagNode->value instanceof ParamTagValueNode) {
+                continue;
+            }
+
+            if ('$'.$property !== $tagNode->value->parameterName) {
+                continue;
+            }
+
+            if ($tagNode->value->description) {
+                return $tagNode->value->description;
+            }
+        }
+
+        return null;
     }
 
     private function getDocBlockFromConstructor(string &$class, string $property): ?ParamTagValueNode

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
@@ -37,6 +37,7 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor\ParentUsingTraitWith
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor\ParentWithPromotedPropertyDocBlock;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor\ParentWithPromotedSelfDocBlock;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor\ParentWithSelfDocBlock;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor\PromotedPropertiesWithDocBlock;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\IFace;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\InvalidDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\ParentDummy;
@@ -1156,6 +1157,23 @@ class PhpDocExtractorTest extends TestCase
         yield 'nested trait property' => [ClassUsingNestedTrait::class, 'innerSelfProp', ClassUsingNestedTrait::class];
         yield 'promoted property' => [ParentWithPromotedSelfDocBlock::class, 'promotedSelfProp', ParentWithPromotedSelfDocBlock::class];
         yield 'promoted property from child' => [ChildOfParentWithPromotedSelfDocBlock::class, 'promotedSelfProp', ParentWithPromotedSelfDocBlock::class];
+    }
+
+    #[DataProvider('providePromotedPropertyDocBlockTestCases')]
+    public function testPromotedPropertyDocBlock(string $class, string $property, ?string $shortDescription, ?string $longDescription, ?Type $type)
+    {
+        $this->assertSame($shortDescription, $this->extractor->getShortDescription($class, $property));
+        $this->assertSame($longDescription, $this->extractor->getLongDescription($class, $property));
+        $this->assertEquals($type, $this->extractor->getType($class, $property));
+    }
+
+    public static function providePromotedPropertyDocBlockTestCases(): iterable
+    {
+        yield 'description from constructor @param' => [PromotedPropertiesWithDocBlock::class, 'foo', 'Just a foo property', null, Type::string()];
+        yield 'promoted property with no docblock' => [PromotedPropertiesWithDocBlock::class, 'bar', null, null, null];
+        yield 'description and type from inline @var' => [PromotedPropertiesWithDocBlock::class, 'baz', 'A baz property', null, Type::string()];
+        yield 'inline @var wins over constructor @param' => [PromotedPropertiesWithDocBlock::class, 'qux', 'An overridden qux property', null, Type::int()];
+        yield 'long description from inline docblock' => [PromotedPropertiesWithDocBlock::class, 'corge', 'A corge property.', 'A detailed explanation of corge.', null];
     }
 }
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
@@ -33,6 +33,7 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyWithTemplateAndParent;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor\DummyInDifferentNs;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor\DummyWithStaticGetterInDifferentNs;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor\DummyWithTemplateAndParentInDifferentNs;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor\PromotedPropertiesWithDocBlock;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\IFace;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\IntRangeDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\InvalidDummy;
@@ -1155,6 +1156,23 @@ class PhpStanExtractorTest extends TestCase
         $this->assertNull($this->extractor->getTypes(VoidNeverReturnTypeDummy::class, 'voidProperty'));
         $this->assertNull($this->extractor->getTypes(VoidNeverReturnTypeDummy::class, 'neverProperty'));
         $this->assertEquals([new LegacyType(LegacyType::BUILTIN_TYPE_STRING)], $this->extractor->getTypes(VoidNeverReturnTypeDummy::class, 'normalProperty'));
+    }
+
+    #[DataProvider('providePromotedPropertyDocBlockTestCases')]
+    public function testPromotedPropertyDocBlock(string $class, string $property, ?string $shortDescription, ?string $longDescription, ?Type $type)
+    {
+        $this->assertSame($shortDescription, $this->extractor->getShortDescription($class, $property));
+        $this->assertSame($longDescription, $this->extractor->getLongDescription($class, $property));
+        $this->assertEquals($type, $this->extractor->getType($class, $property));
+    }
+
+    public static function providePromotedPropertyDocBlockTestCases(): iterable
+    {
+        yield 'description from constructor @param' => [PromotedPropertiesWithDocBlock::class, 'foo', 'Just a foo property', null, Type::string()];
+        yield 'promoted property with no docblock' => [PromotedPropertiesWithDocBlock::class, 'bar', null, null, null];
+        yield 'description and type from inline @var' => [PromotedPropertiesWithDocBlock::class, 'baz', 'A baz property', null, Type::string()];
+        yield 'inline @var wins over constructor @param' => [PromotedPropertiesWithDocBlock::class, 'qux', 'An overridden qux property', null, Type::int()];
+        yield 'long description from inline docblock' => [PromotedPropertiesWithDocBlock::class, 'corge', 'A corge property.', 'A detailed explanation of corge.', null];
     }
 }
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Extractor/PromotedPropertiesWithDocBlock.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Extractor/PromotedPropertiesWithDocBlock.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor;
+
+class PromotedPropertiesWithDocBlock
+{
+    /**
+     * @param string $foo Just a foo property
+     * @param string $qux A qux property
+     */
+    public function __construct(
+        public string $foo,
+        public int $bar,
+        /** @var string $baz A baz property */
+        public string $baz,
+        /** @var int $qux An overridden qux property */
+        public string $qux = '',
+        /**
+         * A corge property.
+         *
+         * A detailed explanation of corge.
+         */
+        public string $corge = '',
+    ) {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`PhpDocExtractor` already supports reading `@param` tags from the constructor docblock for promoted properties. However, inline `@var` docblocks placed directly on promoted parameters were ignored when the constructor also had an `@param` docblock:

```php
class User
{
    /**
     * @param string $name The user's name
     */
    public function __construct(
        public string $name,
        /** @var string The user's email address */
        public string $email,
        /**
         * The user's role.
         *
         * Detailed explanation of roles.
         */
        public string $role = 'user',
    ) {}
}
```

**Before:** descriptions and types from inline docblocks (`$email`, `$role`) were not extracted. The constructor docblock took full precedence and since it had no `@param` for those properties, nothing was returned.

**After:** inline docblocks on promoted properties are now used as a source for short descriptions, long descriptions, and types. The inline `@var` always takes priority over the constructor `@param` as the more specific annotation, with the constructor docblock used as fallback.
