### PR TITLE
[AssetMapper] Fix CssCompiler matches url in comments

### DIFF
--- a/src/Symfony/Component/AssetMapper/Tests/Compiler/CssAssetUrlCompilerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Compiler/CssAssetUrlCompilerTest.php
@@ -114,6 +114,36 @@ class CssAssetUrlCompilerTest extends TestCase
             'expectedOutput' => 'body { background: url("https://cdn.io/images/bar.png"); }',
             'expectedDependencies' => [],
         ];
+
+        yield 'ignore_comments' => [
+            'input' => 'body { background: url("images/foo.png"); /* background: url("images/bar.png"); */ }',
+            'expectedOutput' => 'body { background: url("images/foo.123456.png"); /* background: url("images/bar.png"); */ }',
+            'expectedDependencies' => ['images/foo.png'],
+        ];
+
+        yield 'ignore_comment_after_rule' => [
+            'input' => 'body { background: url("images/foo.png"); } /* url("images/need-ignore.png") */',
+            'expectedOutput' => 'body { background: url("images/foo.123456.png"); } /* url("images/need-ignore.png") */',
+            'expectedDependencies' => ['images/foo.png'],
+        ];
+
+        yield 'ignore_comment_within_rule' => [
+            'input' => 'body { background: url("images/foo.png") /* url("images/need-ignore.png") */; }',
+            'expectedOutput' => 'body { background: url("images/foo.123456.png") /* url("images/need-ignore.png") */; }',
+            'expectedDependencies' => ['images/foo.png'],
+        ];
+
+        yield 'ignore_multiline_comment_after_rule' => [
+            'input' => 'body {
+                background: url("images/foo.png"); /*
+                url("images/need-ignore.png") */
+            }',
+            'expectedOutput' => 'body {
+                background: url("images/foo.123456.png"); /*
+                url("images/need-ignore.png") */
+            }',
+            'expectedDependencies' => ['images/foo.png'],
+        ];
     }
 
     public function testCompileFindsRelativeFilesViaSourcePath()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #59512
| License       | MIT

Add a check to avoid matching url in comments