### PR TITLE
[HttpFoundation] [Runtime] Disallow writing to response during termination in debug mode

### DIFF
--- a/src/Symfony/Component/Runtime/Runner/Symfony/HttpKernelRunner.php
+++ b/src/Symfony/Component/Runtime/Runner/Symfony/HttpKernelRunner.php
@@ -26,7 +26,6 @@ class HttpKernelRunner implements RunnerInterface
     public function __construct(
         private readonly HttpKernelInterface $kernel,
         private readonly Request $request,
-        private readonly bool $debug = false,
     ) {
     }
 
@@ -34,19 +33,16 @@ class HttpKernelRunner implements RunnerInterface
     {
         $response = $this->kernel->handle($this->request);
 
+        $response->send();
         if (Kernel::VERSION_ID >= 60400) {
-            $response->send(false);
-
-            if (\function_exists('fastcgi_finish_request') && !$this->debug) {
+            if (\function_exists('fastcgi_finish_request')) {
                 fastcgi_finish_request();
-            } elseif (\function_exists('litespeed_finish_request') && !$this->debug) {
+            } elseif (\function_exists('litespeed_finish_request')) {
                 litespeed_finish_request();
             } else {
                 Response::closeOutputBuffers(0, true);
                 flush();
             }
-        } else {
-            $response->send();
         }
 
         if ($this->kernel instanceof TerminableInterface) {

--- a/src/Symfony/Component/Runtime/SymfonyRuntime.php
+++ b/src/Symfony/Component/Runtime/SymfonyRuntime.php
@@ -131,7 +131,7 @@ class SymfonyRuntime extends GenericRuntime
     public function getRunner(?object $application): RunnerInterface
     {
         if ($application instanceof HttpKernelInterface) {
-            return new HttpKernelRunner($application, Request::createFromGlobals(), $this->options['debug'] ?? false);
+            return new HttpKernelRunner($application, Request::createFromGlobals());
         }
 
         if ($application instanceof Response) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #59447  <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

Flush response buffers before terminating in debug mode. Thus conforming to the definition of the `KernelEvents::Terminate`-event, by only dispatching it after the response has been "sent". 
