### PR TITLE
[AssetMapper] Remove `async` from the polyfill loading script

### DIFF
--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapRenderer.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapRenderer.php
@@ -125,11 +125,10 @@ class ImportMapRenderer
             }
 
             $output .= <<<HTML
-                <script async$scriptAttributes>
+                <script$scriptAttributes>
                 if (!HTMLScriptElement.supports || !HTMLScriptElement.supports('importmap')) (function () {
                     const script = document.createElement('script');
                     script.src = '{$this->escapeAttributeValue($polyfillPath, \ENT_NOQUOTES)}';
-                    script.setAttribute('async', 'async');
                     {$this->createAttributesString($polyfillAttributes, "script.setAttribute('%s', '%s');", "\n    ", \ENT_NOQUOTES)}
                     document.head.appendChild(script);
                 })();

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapRendererTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapRendererTest.php
@@ -132,10 +132,9 @@ class ImportMapRendererTest extends TestCase
         ]);
         $html = $renderer->render([]);
         $this->assertStringContainsString('<script type="importmap" something data-turbo-track="reload">', $html);
-        $this->assertStringContainsString('<script async something data-turbo-track="reload">', $html);
+        $this->assertStringContainsString('<script something data-turbo-track="reload">', $html);
         $this->assertStringContainsString(<<<EOTXT
             script.src = 'https://polyfillUrl.example';
-            script.setAttribute('async', 'async');
             script.setAttribute('something', 'something');
             script.setAttribute('data-turbo-track', 'reload');
         EOTXT, $html);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59547
| License       | MIT

From https://javascript.info/script-async-defer:

> the `async` attribute is ignored if the `<script>` tag has no `src`.

and

> Dynamic scripts behave as “async” by default.