### PR TITLE
[HttpClient] Add accept-encoding gzip to normalized headers

### DIFF
--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -211,6 +211,7 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
 
         if (\extension_loaded('zlib') && !isset($options['normalized_headers']['accept-encoding'])) {
             $options['headers'][] = 'Accept-Encoding: gzip'; // Expose only one encoding, some servers mess up when more are provided
+            $options['normalized_headers']['accept-encoding'] = ['gzip'];
         }
         $body = $options['body'];
 

--- a/src/Symfony/Component/HttpClient/NativeHttpClient.php
+++ b/src/Symfony/Component/HttpClient/NativeHttpClient.php
@@ -105,6 +105,7 @@ final class NativeHttpClient implements HttpClientInterface, LoggerAwareInterfac
         if (\extension_loaded('zlib') && !isset($options['normalized_headers']['accept-encoding'])) {
             // gzip is the most widely available algo, no need to deal with deflate
             $options['headers'][] = 'Accept-Encoding: gzip';
+            $options['normalized_headers']['accept-encoding'] = ['gzip'];
         }
 
         if ($options['peer_fingerprint']) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Issues        | Fix #59551  
| License       | MIT

Add Accept-Encoding `gzip` to `$options['normalized_headers']` for `CurlHttpClient` and `NativeHttpClient`.
