### PR TITLE
introduce delete with confirmation method

### DIFF
--- a/src/Symfony/Component/Lock/Store/CombinedStore.php
+++ b/src/Symfony/Component/Lock/Store/CombinedStore.php
@@ -198,4 +198,18 @@ class CombinedStore implements SharedLockStoreInterface, LoggerAwareInterface
 
         return false;
     }
+
+    public function deleteWithConfirmation(Key $key): bool
+    {
+        foreach ($this->stores as $store) {
+            try {
+                $store->delete($key);
+            } catch (\Exception $e) {
+                $this->logger?->notice('One store failed to delete the "{resource}" lock.', ['resource' => $key, 'store' => $store, 'exception' => $e]);
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/src/Symfony/Component/Lock/Store/DoctrineDbalPostgreSqlStore.php
+++ b/src/Symfony/Component/Lock/Store/DoctrineDbalPostgreSqlStore.php
@@ -33,6 +33,7 @@ use Symfony\Component\Lock\SharedLockStoreInterface;
 class DoctrineDbalPostgreSqlStore implements BlockingSharedLockStoreInterface, BlockingStoreInterface
 {
     private Connection $conn;
+    private static array $storeRegistry = [];
 
     /**
      * You can either pass an existing database connection a Doctrine DBAL Connection
@@ -277,8 +278,30 @@ class DoctrineDbalPostgreSqlStore implements BlockingSharedLockStoreInterface, B
 
     private function getInternalStore(): SharedLockStoreInterface
     {
-        static $storeRegistry = new \WeakMap();
+        $namespace = spl_object_hash($this->conn);
 
-        return $storeRegistry[$this->conn] ??= new InMemoryStore();
+        return self::$storeRegistry[$namespace] ??= new InMemoryStore();
+    }
+
+    public function deleteWithConfirmation(Key $key): bool
+    {
+        // Prevent deleting locks own by an other key in the same connection
+        if (!$this->exists($key)) {
+            return false;
+        }
+
+        $this->unlock($key);
+
+        // Prevent deleting Readlocks own by current key AND an other key in the same connection
+        $store = $this->getInternalStore();
+        try {
+            // If lock acquired = there is no other ReadLock
+            $store->save($key);
+            $this->unlockShared($key);
+        } catch (LockConflictedException) {
+            // an other key exists in this ReadLock
+        }
+
+        return $store->deleteWithConfirmation($key);
     }
 }

--- a/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php
+++ b/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php
@@ -258,4 +258,12 @@ class DoctrineDbalStore implements PersistingStoreInterface
             default => false,
         };
     }
+
+    public function deleteWithConfirmation(Key $key): bool
+    {
+       return $this->conn->delete($this->table, [
+            $this->idCol => $this->getHashedKey($key),
+            $this->tokenCol => $this->getUniqueToken($key),
+        ]);
+    }
 }

--- a/src/Symfony/Component/Lock/Store/FlockStore.php
+++ b/src/Symfony/Component/Lock/Store/FlockStore.php
@@ -144,4 +144,21 @@ class FlockStore implements BlockingStoreInterface, SharedLockStoreInterface
     {
         return $key->hasState(__CLASS__);
     }
+
+    public function deleteWithConfirmation(Key $key): bool
+    {
+        // The lock is maybe not acquired.
+        if (!$key->hasState(__CLASS__)) {
+            return false;
+        }
+
+        $handle = $key->getState(__CLASS__)[1];
+
+        flock($handle, \LOCK_UN | \LOCK_NB);
+        fclose($handle);
+
+        $key->removeState(__CLASS__);
+
+        return true;
+    }
 }

--- a/src/Symfony/Component/Lock/Store/InMemoryStore.php
+++ b/src/Symfony/Component/Lock/Store/InMemoryStore.php
@@ -111,4 +111,10 @@ class InMemoryStore implements SharedLockStoreInterface
 
         return $key->getState(__CLASS__);
     }
+
+    public function deleteWithConfirmation(Key $key): bool
+    {
+       $this->delete($key);
+       return true;
+    }
 }

--- a/src/Symfony/Component/Lock/Store/MemcachedStore.php
+++ b/src/Symfony/Component/Lock/Store/MemcachedStore.php
@@ -149,4 +149,25 @@ class MemcachedStore implements PersistingStoreInterface
 
         return [$value, $cas];
     }
+
+    public function deleteWithConfirmation(Key $key): bool
+    {
+        $token = $this->getUniqueToken($key);
+
+        [$value, $cas] = $this->getValueAndCas($key);
+
+        if ($value !== $token) {
+            // we are not the owner of the lock. Nothing to do.
+            return true;
+        }
+
+        // To avoid concurrency in deletion, the trick is to extends the TTL then deleting the key
+        if (!$this->memcached->cas($cas, (string) $key, $token, 2)) {
+            // Someone steal our lock. It does not belongs to us anymore. Nothing to do.
+            return true;
+        }
+
+        // Now, we are the owner of the lock for 2 more seconds, we can delete it.
+        return $this->memcached->delete((string) $key);
+    }
 }

--- a/src/Symfony/Component/Lock/Store/MongoDbStore.php
+++ b/src/Symfony/Component/Lock/Store/MongoDbStore.php
@@ -372,4 +372,18 @@ class MongoDbStore implements PersistingStoreInterface
 
         return $key->getState(__CLASS__);
     }
+
+    public function deleteWithConfirmation(Key $key): bool
+    {
+        $write = new BulkWrite();
+        $write->delete(
+            [
+                '_id' => (string) $key,
+                'token' => $this->getUniqueToken($key),
+            ],
+            ['limit' => 1]
+        );
+
+        return $this->getManager()->executeBulkWrite($this->namespace, $write)->getMatchedCount() != null;
+    }
 }

--- a/src/Symfony/Component/Lock/Store/NullStore.php
+++ b/src/Symfony/Component/Lock/Store/NullStore.php
@@ -40,4 +40,9 @@ class NullStore implements BlockingSharedLockStoreInterface
     public function waitAndSaveRead(Key $key): void
     {
     }
+
+    public function deleteWithConfirmation(Key $key): bool
+    {
+       return true;
+    }
 }

--- a/src/Symfony/Component/Lock/Store/PdoStore.php
+++ b/src/Symfony/Component/Lock/Store/PdoStore.php
@@ -243,4 +243,16 @@ class PdoStore implements PersistingStoreInterface
             default => false,
         };
     }
+
+    public function deleteWithConfirmation(Key $key): bool
+    {
+        $sql = "DELETE FROM $this->table WHERE $this->idCol = :id AND $this->tokenCol = :token";
+        $stmt = $this->getConnection()->prepare($sql);
+
+        $stmt->bindValue(':id', $this->getHashedKey($key));
+        $stmt->bindValue(':token', $this->getUniqueToken($key));
+        $stmt->execute();
+
+        return (bool) $stmt->rowCount();
+    }
 }

--- a/src/Symfony/Component/Lock/Store/PostgreSqlStore.php
+++ b/src/Symfony/Component/Lock/Store/PostgreSqlStore.php
@@ -31,6 +31,7 @@ class PostgreSqlStore implements BlockingSharedLockStoreInterface, BlockingStore
     private ?string $username = null;
     private ?string $password = null;
     private array $connectionOptions = [];
+    private static array $storeRegistry = [];
 
     /**
      * You can either pass an existing database connection as PDO instance or
@@ -282,8 +283,30 @@ class PostgreSqlStore implements BlockingSharedLockStoreInterface, BlockingStore
 
     private function getInternalStore(): SharedLockStoreInterface
     {
-        static $storeRegistry = new \WeakMap();
+        $namespace = spl_object_hash($this->getConnection());
 
-        return $storeRegistry[$this->getConnection()] ??= new InMemoryStore();
+        return self::$storeRegistry[$namespace] ??= new InMemoryStore();
+    }
+
+    public function deleteWithConfirmation(Key $key): bool
+    {
+        // Prevent deleting locks own by an other key in the same connection
+        if (!$this->exists($key)) {
+            return true;
+        }
+
+        $this->unlock($key);
+
+        // Prevent deleting Readlocks own by current key AND an other key in the same connection
+        $store = $this->getInternalStore();
+        try {
+            // If lock acquired = there is no other ReadLock
+            $store->save($key);
+            $this->unlockShared($key);
+        } catch (LockConflictedException) {
+            // an other key exists in this ReadLock
+        }
+
+        return $store->deleteWithConfirmation($key);
     }
 }

--- a/src/Symfony/Component/Lock/Store/RedisStore.php
+++ b/src/Symfony/Component/Lock/Store/RedisStore.php
@@ -347,4 +347,34 @@ class RedisStore implements SharedLockStoreInterface
             now = math.floor(now * 1000)
         ';
     }
+
+    public function deleteWithConfirmation(Key $key): bool
+    {
+        $script = '
+            local key = KEYS[1]
+            local uniqueToken = ARGV[1]
+
+            -- asserts the KEY is compatible with current version (old Symfony <5.2 BC)
+            if redis.call("TYPE", key).ok == "string" then
+                return false
+            end
+
+            -- lock not already acquired
+            if not redis.call("ZSCORE", key, uniqueToken) then
+                return false
+            end
+
+            redis.call("ZREM", key, uniqueToken)
+            redis.call("ZREM", key, "__write__")
+
+            local maxExpiration = redis.call("ZREVRANGE", key, 0, 0, "WITHSCORES")[2]
+            if nil ~= maxExpiration then
+                redis.call("PEXPIREAT", key, maxExpiration)
+            end
+
+            return true
+        ';
+
+        return $this->evaluate($script, (string) $key, [$this->getUniqueToken($key)]);
+    }
 }

--- a/src/Symfony/Component/Lock/Store/SemaphoreStore.php
+++ b/src/Symfony/Component/Lock/Store/SemaphoreStore.php
@@ -96,4 +96,19 @@ class SemaphoreStore implements BlockingStoreInterface
     {
         return $key->hasState(__CLASS__);
     }
+
+    public function deleteWithConfirmation(Key $key): bool
+    {
+        // The lock is maybe not acquired.
+        if (!$key->hasState(__CLASS__)) {
+            return false;
+        }
+
+        $resource = $key->getState(__CLASS__);
+
+        sem_remove($resource);
+
+        $key->removeState(__CLASS__);
+        return true;
+    }
 }

--- a/src/Symfony/Component/Lock/Store/ZookeeperStore.php
+++ b/src/Symfony/Component/Lock/Store/ZookeeperStore.php
@@ -152,4 +152,20 @@ class ZookeeperStore implements PersistingStoreInterface
 
         return $key->getState(self::class);
     }
+
+    public function deleteWithConfirmation(Key $key): bool
+    {
+        if (!$this->exists($key)) {
+            return true;
+        }
+        $resource = $this->getKeyResource($key);
+        try {
+            $this->zookeeper->delete($resource);
+            return true;
+        } catch (\ZookeeperException $exception) {
+            // For Zookeeper Ephemeral Nodes, the node will be deleted upon session death. But, if we want to unlock
+            // the lock before proceeding further in the session, the client should be aware of this
+            throw new LockReleasingException($exception);
+        }
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes|
| New feature?  | no 
| Deprecations | no 
| Issues        | Fix #54234 
| License       | MIT

<!--
In a high concurent environment it can happen that locks are not properly released.
Process 1: Deletes the key
Process 2. Acquires the lock
Process 1: has a check (if key exists, throw exception)

```

$lock = $factory->createLock('pdf-creation', ttl: 30);
if (!$lock->acquire()) {
    return;
}

$lock->release(); // <------ This may erroneously result in an exception by design
```


This fix is an idea to try and utilize the return value of the delete method, and not to check the exists if delete returned a success.