### PR TITLE
[Lock] introduce delete with confirmation method

### DIFF
--- a/src/Symfony/Component/Lock/CHANGELOG.md
+++ b/src/Symfony/Component/Lock/CHANGELOG.md
@@ -1,5 +1,9 @@
 CHANGELOG
 =========
+7.3
+---
+
+* introduce deleteWithConfirmation method to  `PersistingStoreInterface` used to obtain a return value when deleting a resource to validate its deletion
 
 7.2
 ---

--- a/src/Symfony/Component/Lock/CHANGELOG.md
+++ b/src/Symfony/Component/Lock/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 ---
 
 * introduce deleteWithConfirmation method to  `PersistingStoreInterface` used to obtain a return value when deleting a resource to validate its deletion
+* introduce validateOnDelete parameter to `LockFactory` to decide if deleteWithConfirmation will be used in `PersistingStoreInterface`.
 
 7.2
 ---

--- a/src/Symfony/Component/Lock/Lock.php
+++ b/src/Symfony/Component/Lock/Lock.php
@@ -215,7 +215,7 @@ final class Lock implements SharedLockInterface, LoggerAwareInterface
     {
         try {
             try {
-                $this->store->delete($this->key);
+                $deleted = $this->store->deleteWithConfirmation($this->key);
                 $this->dirty = false;
             } catch (LockReleasingException $e) {
                 throw $e;
@@ -223,7 +223,7 @@ final class Lock implements SharedLockInterface, LoggerAwareInterface
                 throw new LockReleasingException(\sprintf('Failed to release the "%s" lock.', $this->key), 0, $e);
             }
 
-            if ($this->store->exists($this->key)) {
+            if (!$deleted && $this->store->exists($this->key)) {
                 throw new LockReleasingException(\sprintf('Failed to release the "%s" lock, the resource is still locked.', $this->key));
             }
 

--- a/src/Symfony/Component/Lock/Lock.php
+++ b/src/Symfony/Component/Lock/Lock.php
@@ -39,6 +39,7 @@ final class Lock implements SharedLockInterface, LoggerAwareInterface
         private PersistingStoreInterface $store,
         private ?float $ttl = null,
         private bool $autoRelease = true,
+        private bool $validateOnDelete = false,
     ) {
     }
 
@@ -215,7 +216,11 @@ final class Lock implements SharedLockInterface, LoggerAwareInterface
     {
         try {
             try {
-                $deleted = $this->store->deleteWithConfirmation($this->key);
+                if($this->validateOnDelete) {
+                    $deleted = $this->store->deleteWithConfirmation($this->key);
+                }else{
+                    $this->store->delete($this->key);
+                }
                 $this->dirty = false;
             } catch (LockReleasingException $e) {
                 throw $e;
@@ -223,7 +228,7 @@ final class Lock implements SharedLockInterface, LoggerAwareInterface
                 throw new LockReleasingException(\sprintf('Failed to release the "%s" lock.', $this->key), 0, $e);
             }
 
-            if (!$deleted && $this->store->exists($this->key)) {
+            if (($this->validateOnDelete && !$deleted && $this->store->exists($this->key)) || (!$this->validateOnDelete && $this->store->exists($this->key))) {
                 throw new LockReleasingException(\sprintf('Failed to release the "%s" lock, the resource is still locked.', $this->key));
             }
 

--- a/src/Symfony/Component/Lock/Lock.php
+++ b/src/Symfony/Component/Lock/Lock.php
@@ -216,9 +216,9 @@ final class Lock implements SharedLockInterface, LoggerAwareInterface
     {
         try {
             try {
-                if($this->validateOnDelete) {
+                if ($this->validateOnDelete) {
                     $deleted = $this->store->deleteWithConfirmation($this->key);
-                }else{
+                } else {
                     $this->store->delete($this->key);
                 }
                 $this->dirty = false;

--- a/src/Symfony/Component/Lock/LockFactory.php
+++ b/src/Symfony/Component/Lock/LockFactory.php
@@ -32,10 +32,10 @@ class LockFactory implements LoggerAwareInterface
     /**
      * Creates a lock for the given resource.
      *
-     * @param string     $resource    The resource to lock
-     * @param float|null $ttl         Maximum expected lock duration in seconds
-     * @param bool       $autoRelease Whether to automatically release the lock or not when the lock instance is destroyed
-     * @param bool $validateOnDelete  Decides if the return value of delete will be checked upon deleting the lock
+     * @param string     $resource         The resource to lock
+     * @param float|null $ttl              Maximum expected lock duration in seconds
+     * @param bool       $autoRelease      Whether to automatically release the lock or not when the lock instance is destroyed
+     * @param bool       $validateOnDelete Decides if the return value of delete will be checked upon deleting the lock
      */
     public function createLock(string $resource, ?float $ttl = 300.0, bool $autoRelease = true, bool $validateOnDelete = false): SharedLockInterface
     {
@@ -45,10 +45,10 @@ class LockFactory implements LoggerAwareInterface
     /**
      * Creates a lock from the given key.
      *
-     * @param Key        $key         The key containing the lock's state
-     * @param float|null $ttl         Maximum expected lock duration in seconds
-     * @param bool       $autoRelease Whether to automatically release the lock or not when the lock instance is destroyed
-     * @param bool $validateOnDelete Decides if the return value of delete will be checked upon deleting the lock
+     * @param Key        $key              The key containing the lock's state
+     * @param float|null $ttl              Maximum expected lock duration in seconds
+     * @param bool       $autoRelease      Whether to automatically release the lock or not when the lock instance is destroyed
+     * @param bool       $validateOnDelete Decides if the return value of delete will be checked upon deleting the lock
      */
     public function createLockFromKey(Key $key, ?float $ttl = 300.0, bool $autoRelease = true, bool $validateOnDelete = false): SharedLockInterface
     {

--- a/src/Symfony/Component/Lock/LockFactory.php
+++ b/src/Symfony/Component/Lock/LockFactory.php
@@ -35,10 +35,11 @@ class LockFactory implements LoggerAwareInterface
      * @param string     $resource    The resource to lock
      * @param float|null $ttl         Maximum expected lock duration in seconds
      * @param bool       $autoRelease Whether to automatically release the lock or not when the lock instance is destroyed
+     * @param bool $validateOnDelete  Decides if the return value of delete will be checked upon deleting the lock
      */
-    public function createLock(string $resource, ?float $ttl = 300.0, bool $autoRelease = true): SharedLockInterface
+    public function createLock(string $resource, ?float $ttl = 300.0, bool $autoRelease = true, bool $validateOnDelete = false): SharedLockInterface
     {
-        return $this->createLockFromKey(new Key($resource), $ttl, $autoRelease);
+        return $this->createLockFromKey(new Key($resource), $ttl, $autoRelease, $validateOnDelete);
     }
 
     /**
@@ -47,10 +48,11 @@ class LockFactory implements LoggerAwareInterface
      * @param Key        $key         The key containing the lock's state
      * @param float|null $ttl         Maximum expected lock duration in seconds
      * @param bool       $autoRelease Whether to automatically release the lock or not when the lock instance is destroyed
+     * @param bool $validateOnDelete Decides if the return value of delete will be checked upon deleting the lock
      */
-    public function createLockFromKey(Key $key, ?float $ttl = 300.0, bool $autoRelease = true): SharedLockInterface
+    public function createLockFromKey(Key $key, ?float $ttl = 300.0, bool $autoRelease = true, bool $validateOnDelete = false): SharedLockInterface
     {
-        $lock = new Lock($key, $this->store, $ttl, $autoRelease);
+        $lock = new Lock($key, $this->store, $ttl, $autoRelease, $validateOnDelete);
         if ($this->logger) {
             $lock->setLogger($this->logger);
         }

--- a/src/Symfony/Component/Lock/PersistingStoreInterface.php
+++ b/src/Symfony/Component/Lock/PersistingStoreInterface.php
@@ -52,10 +52,9 @@ interface PersistingStoreInterface
     /**
      * Removes a resource from the storage.
      *
-     * @throws LockReleasingException
-     *
      * @return bool $deleted indicates if the resource was deleted
+     *
+     * @throws LockReleasingException
      */
     public function deleteWithConfirmation(Key $key): bool;
 }
-

--- a/src/Symfony/Component/Lock/PersistingStoreInterface.php
+++ b/src/Symfony/Component/Lock/PersistingStoreInterface.php
@@ -48,4 +48,14 @@ interface PersistingStoreInterface
      * @throws LockConflictedException
      */
     public function putOffExpiration(Key $key, float $ttl): void;
+
+    /**
+     * Removes a resource from the storage.
+     *
+     * @throws LockReleasingException
+     *
+     * @return bool $deleted indicates if the resource was deleted
+     */
+    public function deleteWithConfirmation(Key $key): bool;
 }
+

--- a/src/Symfony/Component/Lock/Store/CombinedStore.php
+++ b/src/Symfony/Component/Lock/Store/CombinedStore.php
@@ -198,4 +198,18 @@ class CombinedStore implements SharedLockStoreInterface, LoggerAwareInterface
 
         return false;
     }
+
+    public function deleteWithConfirmation(Key $key): bool
+    {
+        foreach ($this->stores as $store) {
+            try {
+                $store->delete($key);
+            } catch (\Exception $e) {
+                $this->logger?->notice('One store failed to delete the "{resource}" lock.', ['resource' => $key, 'store' => $store, 'exception' => $e]);
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/src/Symfony/Component/Lock/Store/CombinedStore.php
+++ b/src/Symfony/Component/Lock/Store/CombinedStore.php
@@ -206,6 +206,7 @@ class CombinedStore implements SharedLockStoreInterface, LoggerAwareInterface
                 $store->delete($key);
             } catch (\Exception $e) {
                 $this->logger?->notice('One store failed to delete the "{resource}" lock.', ['resource' => $key, 'store' => $store, 'exception' => $e]);
+
                 return false;
             }
         }

--- a/src/Symfony/Component/Lock/Store/DoctrineDbalPostgreSqlStore.php
+++ b/src/Symfony/Component/Lock/Store/DoctrineDbalPostgreSqlStore.php
@@ -282,4 +282,26 @@ class DoctrineDbalPostgreSqlStore implements BlockingSharedLockStoreInterface, B
 
         return self::$storeRegistry[$namespace] ??= new InMemoryStore();
     }
+
+    public function deleteWithConfirmation(Key $key): bool
+    {
+        // Prevent deleting locks own by an other key in the same connection
+        if (!$this->exists($key)) {
+            return false;
+        }
+
+        $this->unlock($key);
+
+        // Prevent deleting Readlocks own by current key AND an other key in the same connection
+        $store = $this->getInternalStore();
+        try {
+            // If lock acquired = there is no other ReadLock
+            $store->save($key);
+            $this->unlockShared($key);
+        } catch (LockConflictedException) {
+            // an other key exists in this ReadLock
+        }
+
+        return $store->deleteWithConfirmation($key);
+    }
 }

--- a/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php
+++ b/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php
@@ -258,4 +258,12 @@ class DoctrineDbalStore implements PersistingStoreInterface
             default => false,
         };
     }
+
+    public function deleteWithConfirmation(Key $key): bool
+    {
+       return $this->conn->delete($this->table, [
+            $this->idCol => $this->getHashedKey($key),
+            $this->tokenCol => $this->getUniqueToken($key),
+        ]);
+    }
 }

--- a/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php
+++ b/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php
@@ -261,7 +261,7 @@ class DoctrineDbalStore implements PersistingStoreInterface
 
     public function deleteWithConfirmation(Key $key): bool
     {
-       return $this->conn->delete($this->table, [
+        return $this->conn->delete($this->table, [
             $this->idCol => $this->getHashedKey($key),
             $this->tokenCol => $this->getUniqueToken($key),
         ]);

--- a/src/Symfony/Component/Lock/Store/FlockStore.php
+++ b/src/Symfony/Component/Lock/Store/FlockStore.php
@@ -144,4 +144,21 @@ class FlockStore implements BlockingStoreInterface, SharedLockStoreInterface
     {
         return $key->hasState(__CLASS__);
     }
+
+    public function deleteWithConfirmation(Key $key): bool
+    {
+        // The lock is maybe not acquired.
+        if (!$key->hasState(__CLASS__)) {
+            return false;
+        }
+
+        $handle = $key->getState(__CLASS__)[1];
+
+        flock($handle, \LOCK_UN | \LOCK_NB);
+        fclose($handle);
+
+        $key->removeState(__CLASS__);
+
+        return true;
+    }
 }

--- a/src/Symfony/Component/Lock/Store/InMemoryStore.php
+++ b/src/Symfony/Component/Lock/Store/InMemoryStore.php
@@ -114,7 +114,8 @@ class InMemoryStore implements SharedLockStoreInterface
 
     public function deleteWithConfirmation(Key $key): bool
     {
-       $this->delete($key);
-       return true;
+        $this->delete($key);
+
+        return true;
     }
 }

--- a/src/Symfony/Component/Lock/Store/InMemoryStore.php
+++ b/src/Symfony/Component/Lock/Store/InMemoryStore.php
@@ -111,4 +111,10 @@ class InMemoryStore implements SharedLockStoreInterface
 
         return $key->getState(__CLASS__);
     }
+
+    public function deleteWithConfirmation(Key $key): bool
+    {
+       $this->delete($key);
+       return true;
+    }
 }

--- a/src/Symfony/Component/Lock/Store/MemcachedStore.php
+++ b/src/Symfony/Component/Lock/Store/MemcachedStore.php
@@ -149,4 +149,25 @@ class MemcachedStore implements PersistingStoreInterface
 
         return [$value, $cas];
     }
+
+    public function deleteWithConfirmation(Key $key): bool
+    {
+        $token = $this->getUniqueToken($key);
+
+        [$value, $cas] = $this->getValueAndCas($key);
+
+        if ($value !== $token) {
+            // we are not the owner of the lock. Nothing to do.
+            return true;
+        }
+
+        // To avoid concurrency in deletion, the trick is to extends the TTL then deleting the key
+        if (!$this->memcached->cas($cas, (string) $key, $token, 2)) {
+            // Someone steal our lock. It does not belongs to us anymore. Nothing to do.
+            return true;
+        }
+
+        // Now, we are the owner of the lock for 2 more seconds, we can delete it.
+        return $this->memcached->delete((string) $key);
+    }
 }

--- a/src/Symfony/Component/Lock/Store/MemcachedStore.php
+++ b/src/Symfony/Component/Lock/Store/MemcachedStore.php
@@ -64,7 +64,7 @@ class MemcachedStore implements PersistingStoreInterface
     public function putOffExpiration(Key $key, float $ttl): void
     {
         if ($ttl < 1) {
-            throw new InvalidTtlException(\sprintf('"%s()" expects a TTL greater or equals to 1 second. Got %s.', __METHOD__, $ttl));
+            throw new InvalidTtlException(\sprintf('"%s()" expects a TTL greater or equals to 1 second. Got "%s".', __METHOD__, $ttl));
         }
 
         // Interface defines a float value but Store required an integer.

--- a/src/Symfony/Component/Lock/Store/MongoDbStore.php
+++ b/src/Symfony/Component/Lock/Store/MongoDbStore.php
@@ -372,4 +372,18 @@ class MongoDbStore implements PersistingStoreInterface
 
         return $key->getState(__CLASS__);
     }
+
+    public function deleteWithConfirmation(Key $key): bool
+    {
+        $write = new BulkWrite();
+        $write->delete(
+            [
+                '_id' => (string) $key,
+                'token' => $this->getUniqueToken($key),
+            ],
+            ['limit' => 1]
+        );
+
+        return $this->getManager()->executeBulkWrite($this->namespace, $write)->getMatchedCount() != null;
+    }
 }

--- a/src/Symfony/Component/Lock/Store/MongoDbStore.php
+++ b/src/Symfony/Component/Lock/Store/MongoDbStore.php
@@ -384,6 +384,6 @@ class MongoDbStore implements PersistingStoreInterface
             ['limit' => 1]
         );
 
-        return $this->getManager()->executeBulkWrite($this->namespace, $write)->getMatchedCount() != null;
+        return null != $this->getManager()->executeBulkWrite($this->namespace, $write)->getMatchedCount();
     }
 }

--- a/src/Symfony/Component/Lock/Store/NullStore.php
+++ b/src/Symfony/Component/Lock/Store/NullStore.php
@@ -43,6 +43,6 @@ class NullStore implements BlockingSharedLockStoreInterface
 
     public function deleteWithConfirmation(Key $key): bool
     {
-       return true;
+        return true;
     }
 }

--- a/src/Symfony/Component/Lock/Store/NullStore.php
+++ b/src/Symfony/Component/Lock/Store/NullStore.php
@@ -40,4 +40,9 @@ class NullStore implements BlockingSharedLockStoreInterface
     public function waitAndSaveRead(Key $key): void
     {
     }
+
+    public function deleteWithConfirmation(Key $key): bool
+    {
+       return true;
+    }
 }

--- a/src/Symfony/Component/Lock/Store/PdoStore.php
+++ b/src/Symfony/Component/Lock/Store/PdoStore.php
@@ -243,4 +243,16 @@ class PdoStore implements PersistingStoreInterface
             default => false,
         };
     }
+
+    public function deleteWithConfirmation(Key $key): bool
+    {
+        $sql = "DELETE FROM $this->table WHERE $this->idCol = :id AND $this->tokenCol = :token";
+        $stmt = $this->getConnection()->prepare($sql);
+
+        $stmt->bindValue(':id', $this->getHashedKey($key));
+        $stmt->bindValue(':token', $this->getUniqueToken($key));
+        $stmt->execute();
+
+        return (bool) $stmt->rowCount();
+    }
 }

--- a/src/Symfony/Component/Lock/Store/PostgreSqlStore.php
+++ b/src/Symfony/Component/Lock/Store/PostgreSqlStore.php
@@ -287,4 +287,26 @@ class PostgreSqlStore implements BlockingSharedLockStoreInterface, BlockingStore
 
         return self::$storeRegistry[$namespace] ??= new InMemoryStore();
     }
+
+    public function deleteWithConfirmation(Key $key): bool
+    {
+        // Prevent deleting locks own by an other key in the same connection
+        if (!$this->exists($key)) {
+            return true;
+        }
+
+        $this->unlock($key);
+
+        // Prevent deleting Readlocks own by current key AND an other key in the same connection
+        $store = $this->getInternalStore();
+        try {
+            // If lock acquired = there is no other ReadLock
+            $store->save($key);
+            $this->unlockShared($key);
+        } catch (LockConflictedException) {
+            // an other key exists in this ReadLock
+        }
+
+        return $store->deleteWithConfirmation($key);
+    }
 }

--- a/src/Symfony/Component/Lock/Store/RedisStore.php
+++ b/src/Symfony/Component/Lock/Store/RedisStore.php
@@ -347,4 +347,34 @@ class RedisStore implements SharedLockStoreInterface
             now = math.floor(now * 1000)
         ';
     }
+
+    public function deleteWithConfirmation(Key $key): bool
+    {
+        $script = '
+            local key = KEYS[1]
+            local uniqueToken = ARGV[1]
+
+            -- asserts the KEY is compatible with current version (old Symfony <5.2 BC)
+            if redis.call("TYPE", key).ok == "string" then
+                return false
+            end
+
+            -- lock not already acquired
+            if not redis.call("ZSCORE", key, uniqueToken) then
+                return false
+            end
+
+            redis.call("ZREM", key, uniqueToken)
+            redis.call("ZREM", key, "__write__")
+
+            local maxExpiration = redis.call("ZREVRANGE", key, 0, 0, "WITHSCORES")[2]
+            if nil ~= maxExpiration then
+                redis.call("PEXPIREAT", key, maxExpiration)
+            end
+
+            return true
+        ';
+
+        return $this->evaluate($script, (string) $key, [$this->getUniqueToken($key)]);
+    }
 }

--- a/src/Symfony/Component/Lock/Store/SemaphoreStore.php
+++ b/src/Symfony/Component/Lock/Store/SemaphoreStore.php
@@ -96,4 +96,19 @@ class SemaphoreStore implements BlockingStoreInterface
     {
         return $key->hasState(__CLASS__);
     }
+
+    public function deleteWithConfirmation(Key $key): bool
+    {
+        // The lock is maybe not acquired.
+        if (!$key->hasState(__CLASS__)) {
+            return false;
+        }
+
+        $resource = $key->getState(__CLASS__);
+
+        sem_remove($resource);
+
+        $key->removeState(__CLASS__);
+        return true;
+    }
 }

--- a/src/Symfony/Component/Lock/Store/SemaphoreStore.php
+++ b/src/Symfony/Component/Lock/Store/SemaphoreStore.php
@@ -109,6 +109,7 @@ class SemaphoreStore implements BlockingStoreInterface
         sem_remove($resource);
 
         $key->removeState(__CLASS__);
+
         return true;
     }
 }

--- a/src/Symfony/Component/Lock/Store/ZookeeperStore.php
+++ b/src/Symfony/Component/Lock/Store/ZookeeperStore.php
@@ -152,4 +152,20 @@ class ZookeeperStore implements PersistingStoreInterface
 
         return $key->getState(self::class);
     }
+
+    public function deleteWithConfirmation(Key $key): bool
+    {
+        if (!$this->exists($key)) {
+            return true;
+        }
+        $resource = $this->getKeyResource($key);
+        try {
+            $this->zookeeper->delete($resource);
+            return true;
+        } catch (\ZookeeperException $exception) {
+            // For Zookeeper Ephemeral Nodes, the node will be deleted upon session death. But, if we want to unlock
+            // the lock before proceeding further in the session, the client should be aware of this
+            throw new LockReleasingException($exception);
+        }
+    }
 }

--- a/src/Symfony/Component/Lock/Store/ZookeeperStore.php
+++ b/src/Symfony/Component/Lock/Store/ZookeeperStore.php
@@ -161,6 +161,7 @@ class ZookeeperStore implements PersistingStoreInterface
         $resource = $this->getKeyResource($key);
         try {
             $this->zookeeper->delete($resource);
+
             return true;
         } catch (\ZookeeperException $exception) {
             // For Zookeeper Ephemeral Nodes, the node will be deleted upon session death. But, if we want to unlock

--- a/src/Symfony/Component/Lock/Tests/LockTest.php
+++ b/src/Symfony/Component/Lock/Tests/LockTest.php
@@ -495,6 +495,12 @@ class LockTest extends TestCase
                 $key->reduceLifetime($ttl);
                 $this->checkNotExpired($key);
             }
+
+            public function deleteWithConfirmation(Key $key): bool
+            {
+               $this->delete($key);
+               return true;
+            }
         };
         $ttl = 1;
         $lock = new Lock($key, $store, $ttl);

--- a/src/Symfony/Component/Lock/Tests/LockTest.php
+++ b/src/Symfony/Component/Lock/Tests/LockTest.php
@@ -498,8 +498,9 @@ class LockTest extends TestCase
 
             public function deleteWithConfirmation(Key $key): bool
             {
-               $this->delete($key);
-               return true;
+                $this->delete($key);
+
+                return true;
             }
         };
         $ttl = 1;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes|
| New feature?  | yes 
| Deprecations | no 
| Issues        | Fix #54234 
| License       | MIT


In a high concurent environment it can happen that locks are not properly released.
Process 1: Deletes the key
Process 2. Acquires the lock
Process 1: has a check (if key exists, throw exception)

```

$lock = $factory->createLock('pdf-creation', ttl: 30);
if (!$lock->acquire()) {
    return;
}

$lock->release(); // <------ This may erroneously result in an exception by design
```


This fix is an idea to try and utilize the return value of the delete method, and not to check the exists if delete returned a success.