### PR TITLE
[Security] Unset token roles when serializing it and user implements EquatableInterface

### DIFF
--- a/src/Symfony/Component/Security/Core/Tests/Exception/CustomUserMessageAuthenticationExceptionTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Exception/CustomUserMessageAuthenticationExceptionTest.php
@@ -53,6 +53,7 @@ class CustomUserMessageAuthenticationExceptionTest extends TestCase
         $exception->setSafeMessage('message', ['token' => $token]);
 
         $processed = unserialize(serialize($exception));
+        $this->assertSame($token->getRoleNames(), $processed->getToken()->getRoleNames());
         $this->assertEquals($token, $processed->getToken());
         $this->assertEquals($token, $processed->getMessageData()['token']);
         $this->assertSame($processed->getToken(), $processed->getMessageData()['token']);
@@ -67,6 +68,7 @@ class CustomUserMessageAuthenticationExceptionTest extends TestCase
         $exception->setToken($token);
 
         $processed = unserialize(serialize($exception));
+        $this->assertSame($token->getRoleNames(), $processed->getToken()->getRoleNames());
         $this->assertEquals($token, $processed->childMember);
         $this->assertEquals($token, $processed->getToken());
         $this->assertSame($processed->getToken(), $processed->childMember);

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -301,11 +301,12 @@ class ContextListener extends AbstractListener
             }
         }
 
-        $userRoles = array_map('strval', $refreshedUser->getRoles());
+        $refreshedRoles = array_map('strval', $refreshedUser->getRoles());
+        $originalRoles = $refreshedToken->getRoleNames(); // This comes from cloning the original token, so it still contains the roles of the original user
 
         if (
-            \count($userRoles) !== \count($refreshedToken->getRoleNames())
-            || \count($userRoles) !== \count(array_intersect($userRoles, $refreshedToken->getRoleNames()))
+            \count($refreshedRoles) !== \count($originalRoles)
+            || \count($refreshedRoles) !== \count(array_intersect($refreshedRoles, $originalRoles))
         ) {
             return true;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When the user object implement EquatableInterface, we never read the roles stored in the token object that wraps the user in the session storage.

This PR ensures we don't store these roles either - they're just wasting space.
