### PR TITLE
[Security] Avoid refreshing user when `TokenInterface::getUser()` returns null

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -191,7 +191,9 @@ class ContextListener extends AbstractListener
      */
     protected function refreshUser(TokenInterface $token): ?TokenInterface
     {
-        $user = $token->getUser();
+        if (null === $user = $token->getUser()) {
+            return null;
+        }
 
         $userNotFoundByProvider = false;
         $userDeauthenticated = false;

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
@@ -36,6 +36,7 @@ use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Http\Firewall\ContextListener;
+use Symfony\Component\Security\Http\Tests\Fixtures\NullUserToken;
 use Symfony\Contracts\Service\ServiceLocatorTrait;
 
 class ContextListenerTest extends TestCase
@@ -56,6 +57,28 @@ class ContextListenerTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('User provider "stdClass" must implement "Symfony\Component\Security\Core\User\UserProviderInterface');
         $this->handleEventWithPreviousSession([new \stdClass()]);
+    }
+
+    public function testTokenReturnsNullUser()
+    {
+        $tokenStorage = new TokenStorage();
+        $tokenStorage->setToken(new NullUserToken());
+
+        $session = new Session(new MockArraySessionStorage());
+        $session->set('_security_context_key', serialize($tokenStorage->getToken()));
+
+        $request = new Request();
+        $request->setSession($session);
+        $request->cookies->set('MOCKSESSID', true);
+
+        $listener = new ContextListener($tokenStorage, [], 'context_key');
+        $listener->authenticate(new RequestEvent(
+            $this->createMock(HttpKernelInterface::class),
+            $request,
+            HttpKernelInterface::MAIN_REQUEST,
+        ));
+
+        $this->expectNotToPerformAssertions();
     }
 
     public function testOnKernelResponseWillAddSession()

--- a/src/Symfony/Component/Security/Http/Tests/Fixtures/NullUserToken.php
+++ b/src/Symfony/Component/Security/Http/Tests/Fixtures/NullUserToken.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\Fixtures;
+
+use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class NullUserToken extends AbstractToken
+{
+    public function getUser(): ?UserInterface
+    {
+        return null;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59559
| License       | MIT

