### PR TITLE
[Security] Support hashing the hashed password using crc32c when putting the user in the session

### DIFF
--- a/src/Symfony/Component/Security/Core/User/PasswordAuthenticatedUserInterface.php
+++ b/src/Symfony/Component/Security/Core/User/PasswordAuthenticatedUserInterface.php
@@ -14,6 +14,26 @@ namespace Symfony\Component\Security\Core\User;
 /**
  * For users that can be authenticated using a password.
  *
+ * The __serialize/__unserialize() magic methods can be implemented on the user
+ * class to prevent hashed passwords from being put in the session storage.
+ * If the password is not stored at all in the session, getPassword() should
+ * return null after unserialization, and then, changing the user's password
+ * won't invalidate its sessions.
+ * In order to invalidate the user sessions while not storing the password hash
+ * in the session, it's also possible to hash the password hash before
+ * serializing it; crc32c is the only algorithm supported.
+ * For example:
+ *
+ *     public function __serialize(): array
+ *     {
+ *         $data = (array) $this;
+ *         $data["\0".self::class."\0password"] = hash('crc32c', $this->password);
+ *
+ *         return $data;
+ *     }
+ *
+ * Implement EquatableInteface if you need another logic.
+ *
  * @author Robin Chalas <robin.chalas@gmail.com>
  * @author Wouter de Jong <wouter@wouterj.nl>
  */
@@ -23,9 +43,6 @@ interface PasswordAuthenticatedUserInterface
      * Returns the hashed password used to authenticate the user.
      *
      * Usually on authentication, a plain-text password will be compared to this value.
-     *
-     * The __serialize/__unserialize() magic methods can be implemented on the user
-     * class to prevent hashed passwords from being put in the session storage.
      */
     public function getPassword(): ?string;
 }

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add encryption support to `OidcTokenHandler` (JWE)
  * Replace `$hideAccountStatusExceptions` argument with `$exposeSecurityErrors` in `AuthenticatorManager` constructor
  * Add argument `$identifierNormalizer` to `UserBadge::__construct()` to allow normalizing the identifier
+ * Support hashing the hashed password using crc32c when putting the user in the session
 
 7.2
 ---

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -292,9 +292,16 @@ class ContextListener extends AbstractListener
         }
 
         if ($originalUser instanceof PasswordAuthenticatedUserInterface || $refreshedUser instanceof PasswordAuthenticatedUserInterface) {
-            if (!$originalUser instanceof PasswordAuthenticatedUserInterface
-                || !$refreshedUser instanceof PasswordAuthenticatedUserInterface
-                || $refreshedUser->getPassword() !== ($originalUser->getPassword() ?? $refreshedUser->getPassword())
+            if (!$originalUser instanceof PasswordAuthenticatedUserInterface || !$refreshedUser instanceof PasswordAuthenticatedUserInterface) {
+                return true;
+            }
+
+            $originalPassword = $originalUser->getPassword();
+            $refreshedPassword = $refreshedUser->getPassword();
+
+            if (null !== $originalPassword
+                && $refreshedPassword !== $originalPassword
+                && (8 !== \strlen($originalPassword) || hash('crc32c', $refreshedPassword ?? $originalPassword) !== $originalPassword)
             ) {
                 return true;
             }
@@ -303,7 +310,7 @@ class ContextListener extends AbstractListener
                 return true;
             }
 
-            if ($originalUser instanceof LegacyPasswordAuthenticatedUserInterface && $refreshedUser instanceof LegacyPasswordAuthenticatedUserInterface && $originalUser->getSalt() !== $refreshedUser->getSalt()) {
+            if ($originalUser instanceof LegacyPasswordAuthenticatedUserInterface && $originalUser->getSalt() !== $refreshedUser->getSalt()) {
                 return true;
             }
         }

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
@@ -377,9 +377,14 @@ class ContextListenerTest extends TestCase
         $this->assertEmpty($dispatcher->getListeners());
     }
 
-    public function testRemovingPasswordFromSessionDoesntInvalidateTheToken()
+    /**
+     * @testWith [true]
+     *           [false]
+     *           [null]
+     */
+    public function testNullOrHashedPasswordInSessionDoesntInvalidateTheToken(?bool $hashPassword)
     {
-        $user = new CustomUser('user', ['ROLE_USER'], 'pass');
+        $user = new CustomUser('user', ['ROLE_USER'], 'pass', $hashPassword);
 
         $userProvider = $this->createMock(UserProviderInterface::class);
         $userProvider->expects($this->once())

--- a/src/Symfony/Component/Security/Http/Tests/Fixtures/CustomUser.php
+++ b/src/Symfony/Component/Security/Http/Tests/Fixtures/CustomUser.php
@@ -19,7 +19,8 @@ final class CustomUser implements UserInterface, PasswordAuthenticatedUserInterf
     public function __construct(
         private string $username,
         private array $roles,
-        private ?string $password = null,
+        private ?string $password,
+        private ?bool $hashPassword,
     ) {
     }
 
@@ -44,6 +45,15 @@ final class CustomUser implements UserInterface, PasswordAuthenticatedUserInterf
 
     public function __serialize(): array
     {
-        return [\sprintf("\0%s\0username", self::class) => $this->username];
+        $data = (array) $this;
+        $passwordKey = \sprintf("\0%s\0password", self::class);
+
+        if ($this->hashPassword) {
+            $data[$passwordKey] = hash('crc32c', $this->password);
+        } elseif (null !== $this->hashPassword) {
+            unset($data[$passwordKey]);
+        }
+
+        return $data;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR builds on #59539 following the discussion that happened there.

> Instead of putting the hashed password in the DB to invalidate sessions on password changes, we could store a hash of the hashed password, eg a truncated xxh128 would be fine. This can be implemented in userland with the EquatableInterface. Should we consider making this more "core" somehow?
> 
> DB storage and session storage have different security features, so definitely worth it to me yes.
> I had a look at other frameworks, and django, spring, Express.js, RoR, ASP.net all have something for that in the mean of a password_changed timestamp or similar token that triggers the invalidation. Notably neither Laravel nor Symfony have anything out of the box on the topic (Symfony stores the hashed password, Laravel doesn't, which means it doesn't invalidate on password changes either IIUC.)

Here is what I added to PasswordAuthenticatedUserInterface to explain what this PR enables:

> The __serialize/__unserialize() magic methods can be used on the user class to prevent the password hash from being
> stored in the session. If the password is not stored at all in the session, getPassword() should return null after
> unserialization, and then, changing the user's password won't invalidate its sessions.
> In order to invalidate the user sessions while not storing the password hash in the session, it's also possible to
> hash the password hash before serializing it; crc32c is the only algorithm supported. For example:
>  
> ```php
>    public function __serialize(): array
>    {
>        $data = (array) $this;
>        $data["\0".self::class."\0password"] = hash('crc32c', $this->password);
>
>        return $data;
>    }
> ```
> 
> Implement EquatableInteface if you need another logic.
> 

crc32c is selected because its probability to change when the password hash changes is high, so that the invalidation of sessions is effective. But it's also selected because there are many possible valid password hashes that generate the same crc32c. This protects against brute-forcing the password hash: let's say one is able to find a password hash that has the same crc32c as the real password hash: one would still be unable to confirm that this password hash is the correct one. To do so, they would have to brute-force the password hash itself, and this would require brute-forcing bcrypt et al. The cost of doing so on one bcrypted-password is already prohibitive. Doing so with a very high number of possible candidates (as collisions are generated) would be even more prohibitive.

Note that to generate a collision, one just needs to generate a random string that's formatted as a real hash, like this line for a bcrypted-password:
```php
'$2y$12$'.substr(strtr(base64_encode(random_bytes(40)), '+', '.'), 0, 53)
```
(one could likely create a crc32c-aware collision generator for this purpose, but that wouldn't reduce the difficulty of validating the generated hashes).

On the contrary, using a more collision resistant hashing algorithm would make it too easy to validate that a generated hash is the real hash.