### PR TITLE
[Console] Command simplification and deprecations

### DIFF
--- a/UPGRADE-7.3.md
+++ b/UPGRADE-7.3.md
@@ -30,6 +30,9 @@ Console
    });
    ```
 
+ * Static methods `Command::getDefaultName()` and `Command::getDefaultDescription()` are deprecated.
+   Extract the command name and description through class reflection instead
+
 FrameworkBundle
 ---------------
 

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -7,6 +7,8 @@ CHANGELOG
  * Add support for invokable commands and add `#[Argument]` and `#[Option]` attributes to define input arguments and options
  * Deprecate not declaring the parameter type in callable commands defined through `setCode` method
  * Add support for help definition via `AsCommand` attribute
+ * Delay command initialization and configuration
+ * Deprecate static methods `Command::getDefaultName()` and `Command::getDefaultDescription()`
 
 7.2
 ---

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -53,9 +53,15 @@ class Command
     private array $synopsis = [];
     private array $usages = [];
     private ?HelperSet $helperSet = null;
+    private bool $initialized = false;
 
+    /**
+     * @deprecated since Symfony 7.3
+     */
     public static function getDefaultName(): ?string
     {
+        trigger_deprecation('symfony/console', '7.3', 'The static method "%s()" is deprecated and will be removed in Symfony 8.0, extract the command name from the "%s" attribute instead.', __METHOD__, AsCommand::class);
+
         if ($attribute = (new \ReflectionClass(static::class))->getAttributes(AsCommand::class)) {
             return $attribute[0]->newInstance()->name;
         }
@@ -63,8 +69,13 @@ class Command
         return null;
     }
 
+    /**
+     * @deprecated since Symfony 7.3
+     */
     public static function getDefaultDescription(): ?string
     {
+        trigger_deprecation('symfony/console', '7.3', 'The static method "%s()" is deprecated and will be removed in Symfony 8.0, extract the command description from the "%s" attribute instead.', __METHOD__, AsCommand::class);
+
         if ($attribute = (new \ReflectionClass(static::class))->getAttributes(AsCommand::class)) {
             return $attribute[0]->newInstance()->description;
         }
@@ -79,36 +90,7 @@ class Command
      */
     public function __construct(?string $name = null)
     {
-        $this->definition = new InputDefinition();
-
-        if (null === $name && null !== $name = static::getDefaultName()) {
-            $aliases = explode('|', $name);
-
-            if ('' === $name = array_shift($aliases)) {
-                $this->setHidden(true);
-                $name = array_shift($aliases);
-            }
-
-            $this->setAliases($aliases);
-        }
-
-        if (null !== $name) {
-            $this->setName($name);
-        }
-
-        if ('' === $this->description) {
-            $this->setDescription(static::getDefaultDescription() ?? '');
-        }
-
-        if ('' === $this->help && $attributes = (new \ReflectionClass(static::class))->getAttributes(AsCommand::class)) {
-            $this->setHelp($attributes[0]->newInstance()->help ?? '');
-        }
-
-        if (\is_callable($this)) {
-            $this->code = new InvokableCommand($this, $this(...));
-        }
-
-        $this->configure();
+        $this->init($name);
     }
 
     /**
@@ -333,6 +315,8 @@ class Command
      */
     public function mergeApplicationDefinition(bool $mergeArgs = true): void
     {
+        $this->init();
+
         if (null === $this->application) {
             return;
         }
@@ -356,6 +340,8 @@ class Command
      */
     public function setDefinition(array|InputDefinition $definition): static
     {
+        $this->init();
+
         if ($definition instanceof InputDefinition) {
             $this->definition = $definition;
         } else {
@@ -385,6 +371,8 @@ class Command
      */
     public function getNativeDefinition(): InputDefinition
     {
+        $this->init();
+
         $definition = $this->definition ?? throw new LogicException(\sprintf('Command class "%s" is not correctly initialized. You probably forgot to call the parent constructor.', static::class));
 
         if ($this->code && !$definition->getArguments() && !$definition->getOptions()) {
@@ -407,6 +395,8 @@ class Command
      */
     public function addArgument(string $name, ?int $mode = null, string $description = '', mixed $default = null, array|\Closure $suggestedValues = []): static
     {
+        $this->init();
+
         $this->definition->addArgument(new InputArgument($name, $mode, $description, $default, $suggestedValues));
         $this->fullDefinition?->addArgument(new InputArgument($name, $mode, $description, $default, $suggestedValues));
 
@@ -427,6 +417,8 @@ class Command
      */
     public function addOption(string $name, string|array|null $shortcut = null, ?int $mode = null, string $description = '', mixed $default = null, array|\Closure $suggestedValues = []): static
     {
+        $this->init();
+
         $this->definition->addOption(new InputOption($name, $shortcut, $mode, $description, $default, $suggestedValues));
         $this->fullDefinition?->addOption(new InputOption($name, $shortcut, $mode, $description, $default, $suggestedValues));
 
@@ -474,6 +466,8 @@ class Command
      */
     public function getName(): ?string
     {
+        $this->init();
+
         return $this->name;
     }
 
@@ -494,6 +488,8 @@ class Command
      */
     public function isHidden(): bool
     {
+        $this->init();
+
         return $this->hidden;
     }
 
@@ -514,6 +510,8 @@ class Command
      */
     public function getDescription(): string
     {
+        $this->init();
+
         return $this->description;
     }
 
@@ -534,6 +532,8 @@ class Command
      */
     public function getHelp(): string
     {
+        $this->init();
+
         return $this->help;
     }
 
@@ -586,6 +586,8 @@ class Command
      */
     public function getAliases(): array
     {
+        $this->init();
+
         return $this->aliases;
     }
 
@@ -596,6 +598,8 @@ class Command
      */
     public function getSynopsis(bool $short = false): string
     {
+        $this->init();
+
         $key = $short ? 'short' : 'long';
 
         if (!isset($this->synopsis[$key])) {
@@ -642,6 +646,48 @@ class Command
         }
 
         return $this->helperSet->get($name);
+    }
+
+    private function init(?string $name = null): void
+    {
+        if ($this->initialized) {
+            return;
+        }
+
+        $this->definition = new InputDefinition();
+
+        $attribute = ((new \ReflectionClass(static::class))->getAttributes(AsCommand::class)[0] ?? null)?->newInstance();
+
+        if (null === $name && null !== $name = $attribute?->name) {
+            $aliases = explode('|', $name);
+
+            if ('' === $name = array_shift($aliases)) {
+                $this->setHidden(true);
+                $name = array_shift($aliases);
+            }
+
+            $this->setAliases($aliases);
+        }
+
+        if (null !== $name) {
+            $this->setName($name);
+        }
+
+        if ('' === $this->description && $attribute?->description) {
+            $this->setDescription($attribute->description);
+        }
+
+        if ('' === $this->help && $attribute?->help) {
+            $this->setHelp($attribute->help);
+        }
+
+        if (\is_callable($this)) {
+            $this->code = new InvokableCommand($this, $this(...));
+        }
+
+        $this->initialized = true;
+
+        $this->configure();
     }
 
     /**

--- a/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
+++ b/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Console\DependencyInjection;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Command\LazyCommand;
 use Symfony\Component\Console\CommandLoader\ContainerCommandLoader;
@@ -57,7 +58,10 @@ class AddConsoleCommandPass implements CompilerPassInterface
                 $invokableRef = null;
             }
 
-            $aliases = $tags[0]['command'] ?? str_replace('%', '%%', $class::getDefaultName() ?? '');
+            /** @var AsCommand|null $attribute */
+            $attribute = ($r->getAttributes(AsCommand::class)[0] ?? null)?->newInstance();
+
+            $aliases = str_replace('%', '%%', $tags[0]['command'] ?? $attribute?->name ?? '');
             $aliases = explode('|', $aliases);
             $commandName = array_shift($aliases);
 
@@ -111,10 +115,10 @@ class AddConsoleCommandPass implements CompilerPassInterface
                 $definition->addMethodCall('setHelp', [str_replace('%', '%%', $help)]);
             }
 
-            $description ??= str_replace('%', '%%', $class::getDefaultDescription() ?? '');
+            $description ??= $attribute?->description ?? '';
 
             if ($description) {
-                $definition->addMethodCall('setDescription', [$description]);
+                $definition->addMethodCall('setDescription', [str_replace('%', '%%', $description)]);
 
                 $container->register('.'.$id.'.lazy', LazyCommand::class)
                     ->setArguments([$commandName, $aliases, $description, $isHidden, new ServiceClosureArgument($lazyCommandRefs[$id])]);

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -232,7 +232,7 @@ class ApplicationTest extends TestCase
     public function testAddCommandWithEmptyConstructor()
     {
         $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Command class "Foo5Command" is not correctly initialized. You probably forgot to call the parent constructor.');
+        $this->expectExceptionMessage('The command defined in "Foo5Command" cannot have an empty name.');
 
         (new Application())->add(new \Foo5Command());
     }
@@ -2404,7 +2404,9 @@ class ApplicationTest extends TestCase
         if ($dispatcher) {
             $application->setDispatcher($dispatcher);
         }
-        $application->add(new LazyCommand($command::getDefaultName(), [], '', false, fn () => $command, true));
+        /** @var AsCommand $attribute */
+        $attribute = ((new \ReflectionClass($command))->getAttributes(AsCommand::class)[0] ?? null)?->newInstance();
+        $application->add(new LazyCommand($attribute->name, [], '', false, fn () => $command, true));
 
         return $application;
     }

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -427,9 +427,6 @@ class CommandTest extends TestCase
 
     public function testCommandAttribute()
     {
-        $this->assertSame('|foo|f', Php8Command::getDefaultName());
-        $this->assertSame('desc', Php8Command::getDefaultDescription());
-
         $command = new Php8Command();
 
         $this->assertSame('foo', $command->getName());
@@ -439,26 +436,41 @@ class CommandTest extends TestCase
         $this->assertSame(['f'], $command->getAliases());
     }
 
+    /**
+     * @group legacy
+     */
+    public function testCommandAttributeWithDeprecatedMethods()
+    {
+        $this->assertSame('|foo|f', Php8Command::getDefaultName());
+        $this->assertSame('desc', Php8Command::getDefaultDescription());
+    }
+
     public function testAttributeOverridesProperty()
     {
-        $this->assertSame('my:command', MyAnnotatedCommand::getDefaultName());
-        $this->assertSame('This is a command I wrote all by myself', MyAnnotatedCommand::getDefaultDescription());
-
         $command = new MyAnnotatedCommand();
 
         $this->assertSame('my:command', $command->getName());
         $this->assertSame('This is a command I wrote all by myself', $command->getDescription());
     }
 
+    /**
+     * @group legacy
+     */
+    public function testAttributeOverridesPropertyWithDeprecatedMethods()
+    {
+        $this->assertSame('my:command', MyAnnotatedCommand::getDefaultName());
+        $this->assertSame('This is a command I wrote all by myself', MyAnnotatedCommand::getDefaultDescription());
+    }
+
     public function testDefaultCommand()
     {
         $apl = new Application();
-        $apl->setDefaultCommand(Php8Command::getDefaultName());
+        $apl->setDefaultCommand('foo');
         $property = new \ReflectionProperty($apl, 'defaultCommand');
 
         $this->assertEquals('foo', $property->getValue($apl));
 
-        $apl->setDefaultCommand(Php8Command2::getDefaultName());
+        $apl->setDefaultCommand('foo2');
         $property = new \ReflectionProperty($apl, 'defaultCommand');
 
         $this->assertEquals('foo2', $property->getValue($apl));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | -
| License       | MIT

2 goals in this PR, one feature and one deprecation.

The feature is about delaying the command initialization, making the `parent::__construct()` call unnecessary in regular/new-invokable commands extending from `Command` class.

Example:
```php
#[AsCommand(name: 'foo')]
class FooCommand extends Command
{
    public function __construct(private BarInterface $bar)
    {
        parent::__construct(); // <-- unnecessary and can be removed from now on.
    }
}
```

Additionally, the static methods `Command::getDefaultName()` and `Command::getDefaultDescription()` are deprecated (see discussion https://github.com/symfony/symfony/pull/59473#discussion_r1912932019). These methods are now obsolete because `AsCommand::name` and `AsCommand::description` are configured directly in the service tag. These methods were mainly intended for framework/DI purposes, making it clearer for end users seeking to set the command name.