### PR TITLE
[Security] Continuation : Add messages on votes

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/SecurityExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/SecurityExtension.php
@@ -45,6 +45,9 @@ final class SecurityExtension extends AbstractExtension
         }
 
         try {
+            /**
+             * @var bool
+             */
             return $this->securityChecker->isGranted($role, $object);
         } catch (AuthenticationCredentialsNotFoundException) {
             return false;

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -35,6 +35,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecision;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -203,6 +204,22 @@ abstract class AbstractController implements ServiceSubscriberInterface
     }
 
     /**
+     * Checks if the attribute is granted against the current authentication token and optionally supplied subject.
+     *
+     * @throws \LogicException
+     */
+    protected function getAccessDecision(mixed $attribute, mixed $subject = null): AccessDecision
+    {
+        if (!$this->container->has('security.authorization_checker')) {
+            throw new \LogicException('The SecurityBundle is not registered in your application. Try running "composer require symfony/security-bundle".');
+        }
+
+        $decision = $this->container->get('security.authorization_checker')->isGranted($attribute, $subject, AccessDecision::RETURN_AS_OBJECT);
+
+        return $decision instanceof AccessDecision ? $decision : new AccessDecision($decision);
+    }
+
+    /**
      * Throws an exception unless the attribute is granted against the current authentication token and optionally
      * supplied subject.
      *
@@ -210,10 +227,13 @@ abstract class AbstractController implements ServiceSubscriberInterface
      */
     protected function denyAccessUnlessGranted(mixed $attribute, mixed $subject = null, string $message = 'Access Denied.'): void
     {
-        if (!$this->isGranted($attribute, $subject)) {
+        $decision = $this->getAccessDecision($attribute, $subject);
+
+        if ($decision->isDenied()) {
             $exception = $this->createAccessDeniedException($message);
             $exception->setAttributes([$attribute]);
             $exception->setSubject($subject);
+            $exception->setAccessDecision($decision);
 
             throw $exception;
         }

--- a/src/Symfony/Bundle/SecurityBundle/EventListener/VoteListener.php
+++ b/src/Symfony/Bundle/SecurityBundle/EventListener/VoteListener.php
@@ -31,7 +31,7 @@ class VoteListener implements EventSubscriberInterface
 
     public function onVoterVote(VoteEvent $event): void
     {
-        $this->traceableAccessDecisionManager->addVoterVote($event->getVoter(), $event->getAttributes(), $event->getVote());
+        $this->traceableAccessDecisionManager->addVoterVote($event->getVoter(), $event->getAttributes(), $event->getVote(true));
     }
 
     public static function getSubscribedEvents(): array

--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -518,7 +518,8 @@
                             <col style="width: 30px">
                             <col style="width: 120px">
                             <col style="width: 25%">
-                            <col style="width: 60%">
+                            <col style="width: 40%">
+                            <col style="width: 20%">
 
                             <thead>
                                 <tr>
@@ -526,6 +527,7 @@
                                     <th>Result</th>
                                     <th>Attributes</th>
                                     <th>Object</th>
+                                    <th>Message</th>
                                 </tr>
                             </thead>
 
@@ -534,7 +536,7 @@
                                     <tr class="voter_result">
                                         <td class="font-normal text-small text-muted nowrap">{{ loop.index }}</td>
                                         <td class="font-normal">
-                                            {{ decision.result
+                                            {{ decision.result.access
                                                 ? '<span class="label status-success same-width">GRANTED</span>'
                                                 : '<span class="label status-error same-width">DENIED</span>'
                                             }}
@@ -554,6 +556,7 @@
                                             {% endif %}
                                         </td>
                                         <td>{{ profiler_dump(decision.seek('object')) }}</td>
+                                        <td>{{ decision.result.message }}</td>
                                     </tr>
                                     <tr class="voter_details">
                                         <td></td>
@@ -570,14 +573,17 @@
                                                             <td class="font-normal text-small">attribute {{ voter_detail['attributes'][0] }}</td>
                                                             {% endif %}
                                                             <td class="font-normal text-small">
-                                                                {% if voter_detail['vote'] == constant('Symfony\\Component\\Security\\Core\\Authorization\\Voter\\VoterInterface::ACCESS_GRANTED') %}
+                                                                {% if voter_detail['vote'].access == constant('Symfony\\Component\\Security\\Core\\Authorization\\Voter\\VoterInterface::ACCESS_GRANTED') %}
                                                                     ACCESS GRANTED
-                                                                {% elseif voter_detail['vote'] == constant('Symfony\\Component\\Security\\Core\\Authorization\\Voter\\VoterInterface::ACCESS_ABSTAIN') %}
+                                                                {% elseif voter_detail['vote'].access == constant('Symfony\\Component\\Security\\Core\\Authorization\\Voter\\VoterInterface::ACCESS_ABSTAIN') %}
                                                                     ACCESS ABSTAIN
-                                                                {% elseif voter_detail['vote'] == constant('Symfony\\Component\\Security\\Core\\Authorization\\Voter\\VoterInterface::ACCESS_DENIED') %}
+                                                                {% elseif voter_detail['vote'].access == constant('Symfony\\Component\\Security\\Core\\Authorization\\Voter\\VoterInterface::ACCESS_DENIED') %}
                                                                     ACCESS DENIED
                                                                 {% else %}
-                                                                    unknown ({{ voter_detail['vote'] }})
+                                                                    unknown ({{ voter_detail['vote'].access }})
+                                                                {% endif %}
+                                                                {% if voter_detail['vote'].messages is not empty %}
+                                                                : {{ voter_detail['vote'].messages | join(', ')  }}
                                                                 {% endif %}
                                                             </td>
                                                         </tr>

--- a/src/Symfony/Bundle/SecurityBundle/Security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security.php
@@ -58,10 +58,10 @@ class Security implements AuthorizationCheckerInterface, UserAuthorizationChecke
     /**
      * Checks if the attributes are granted against the current authentication token and optionally supplied subject.
      */
-    public function isGranted(mixed $attributes, mixed $subject = null): bool
+    public function isGranted(mixed $attributes, mixed $subject = null, $asObject = false): bool
     {
         return $this->container->get('security.authorization_checker')
-            ->isGranted($attributes, $subject);
+            ->isGranted($attributes, $subject, $asObject);
     }
 
     public function getToken(): ?TokenInterface

--- a/src/Symfony/Bundle/SecurityBundle/Tests/EventListener/VoteListenerTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/EventListener/VoteListenerTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\SecurityBundle\Tests\EventListener;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\SecurityBundle\EventListener\VoteListener;
 use Symfony\Component\Security\Core\Authorization\TraceableAccessDecisionManager;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use Symfony\Component\Security\Core\Event\VoteEvent;
 
@@ -36,5 +37,24 @@ class VoteListenerTest extends TestCase
 
         $sut = new VoteListener($traceableAccessDecisionManager);
         $sut->onVoterVote(new VoteEvent($voter, 'mysubject', ['myattr1', 'myattr2'], VoterInterface::ACCESS_GRANTED));
+    }
+
+    public function testOnVoterVoteWithObject()
+    {
+        $voter = $this->createMock(VoterInterface::class);
+
+        $traceableAccessDecisionManager = $this
+            ->getMockBuilder(TraceableAccessDecisionManager::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['addVoterVote'])
+            ->getMock();
+
+        $traceableAccessDecisionManager
+            ->expects($this->once())
+            ->method('addVoterVote')
+            ->with($voter, ['myattr1', 'myattr2'], new Vote(VoterInterface::ACCESS_GRANTED));
+
+        $sut = new VoteListener($traceableAccessDecisionManager);
+        $sut->onVoterVote(new VoteEvent($voter, 'mysubject', ['myattr1', 'myattr2'], new Vote(VoterInterface::ACCESS_GRANTED)));
     }
 }

--- a/src/Symfony/Component/Security/Core/Authorization/AccessDecision.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AccessDecision.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Authorization;
+
+use Symfony\Component\Security\Core\Authorization\Voter\VoteInterface;
+
+/**
+ * An AccessDecision is returned by an AccessDecisionManager and contains the access verdict and all the related votes.
+ *
+ * @author Dany Maillard <danymaillard93b@gmail.com>
+ * @author Roman JOLY <eltharin18@outlook.fr>
+ */
+final class AccessDecision
+{
+    public const RETURN_AS_OBJECT = true;
+
+    /**
+     * @param VoteInterface[]|int[] $votes
+     */
+    public function __construct(
+        private readonly bool $access,
+        private readonly array $votes = [],
+        private readonly string $message = '',
+    ) {
+    }
+
+    public function getAccess(): bool
+    {
+        return $this->access;
+    }
+
+    public function isGranted(): bool
+    {
+        return true === $this->access;
+    }
+
+    public function isDenied(): bool
+    {
+        return false === $this->access;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    /**
+     * @return VoteInterface[]|int[]
+     */
+    public function getVotes(): array
+    {
+        return $this->votes;
+    }
+}

--- a/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManagerInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManagerInterface.php
@@ -26,5 +26,5 @@ interface AccessDecisionManagerInterface
      * @param array $attributes An array of attributes associated with the method being invoked
      * @param mixed $object     The object to secure
      */
-    public function decide(TokenInterface $token, array $attributes, mixed $object = null): bool;
+    public function decide(TokenInterface $token, array $attributes, mixed $object = null): AccessDecision|bool;
 }

--- a/src/Symfony/Component/Security/Core/Authorization/AuthorizationChecker.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AuthorizationChecker.php
@@ -30,7 +30,7 @@ class AuthorizationChecker implements AuthorizationCheckerInterface
     ) {
     }
 
-    final public function isGranted(mixed $attribute, mixed $subject = null): bool
+    final public function isGranted(mixed $attribute, mixed $subject = null, bool $asObject = false): AccessDecision|bool
     {
         $token = $this->tokenStorage->getToken();
 
@@ -38,6 +38,8 @@ class AuthorizationChecker implements AuthorizationCheckerInterface
             $token = new NullToken();
         }
 
-        return $this->accessDecisionManager->decide($token, [$attribute], $subject);
+        $decision = $this->accessDecisionManager->decide($token, [$attribute], $subject, false, $asObject);
+
+        return (!$asObject || $decision instanceof AccessDecision) ? $decision : new AccessDecision($decision);
     }
 }

--- a/src/Symfony/Component/Security/Core/Authorization/AuthorizationCheckerInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AuthorizationCheckerInterface.php
@@ -23,5 +23,5 @@ interface AuthorizationCheckerInterface
      *
      * @param mixed $attribute A single attribute to vote on (can be of any type, string and instance of Expression are supported by the core)
      */
-    public function isGranted(mixed $attribute, mixed $subject = null): bool;
+    public function isGranted(mixed $attribute, mixed $subject = null/* , bool $asObject = false */): AccessDecision|bool;
 }

--- a/src/Symfony/Component/Security/Core/Authorization/Strategy/AccessDecisionStrategyInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Strategy/AccessDecisionStrategyInterface.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\Security\Core\Authorization\Strategy;
 
+use Symfony\Component\Security\Core\Authorization\AccessDecision;
+use Symfony\Component\Security\Core\Authorization\Voter\VoteInterface;
+
 /**
  * A strategy for turning a stream of votes into a final decision.
  *
@@ -19,7 +22,7 @@ namespace Symfony\Component\Security\Core\Authorization\Strategy;
 interface AccessDecisionStrategyInterface
 {
     /**
-     * @param \Traversable<int> $results
+     * @param \Traversable<int|VoteInterface> $results
      */
-    public function decide(\Traversable $results): bool;
+    public function decide(\Traversable $results): AccessDecision|bool;
 }

--- a/src/Symfony/Component/Security/Core/Authorization/Strategy/AffirmativeStrategy.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Strategy/AffirmativeStrategy.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Security\Core\Authorization\Strategy;
 
+use Symfony\Component\Security\Core\Authorization\AccessDecision;
+use Symfony\Component\Security\Core\Authorization\Voter\VoteInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
 /**
@@ -29,12 +31,19 @@ final class AffirmativeStrategy implements AccessDecisionStrategyInterface, \Str
     ) {
     }
 
-    public function decide(\Traversable $results): bool
+    public function decide(\Traversable $results, $asObject = false): AccessDecision|bool
     {
         $deny = 0;
+        $allVotes = [];
+
         foreach ($results as $result) {
+            $allVotes[] = $result;
+            if ($result instanceof VoteInterface) {
+                $result = $result->getAccess();
+            }
+
             if (VoterInterface::ACCESS_GRANTED === $result) {
-                return true;
+                return $this->getReturn(true, $asObject, $allVotes);
             }
 
             if (VoterInterface::ACCESS_DENIED === $result) {
@@ -43,14 +52,19 @@ final class AffirmativeStrategy implements AccessDecisionStrategyInterface, \Str
         }
 
         if ($deny > 0) {
-            return false;
+            return $this->getReturn(false, $asObject, $allVotes);
         }
 
-        return $this->allowIfAllAbstainDecisions;
+        return $this->getReturn($this->allowIfAllAbstainDecisions, $asObject, $allVotes);
     }
 
     public function __toString(): string
     {
         return 'affirmative';
+    }
+
+    private function getReturn(bool $result, bool $asObject, array $votes): AccessDecision|bool
+    {
+        return $asObject ? new AccessDecision($result, $votes) : $result;
     }
 }

--- a/src/Symfony/Component/Security/Core/Authorization/Strategy/PriorityStrategy.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Strategy/PriorityStrategy.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Security\Core\Authorization\Strategy;
 
+use Symfony\Component\Security\Core\Authorization\AccessDecision;
+use Symfony\Component\Security\Core\Authorization\Voter\VoteInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
 /**
@@ -30,23 +32,35 @@ final class PriorityStrategy implements AccessDecisionStrategyInterface, \String
     ) {
     }
 
-    public function decide(\Traversable $results): bool
+    public function decide(\Traversable $results, $asObject = false): AccessDecision|bool
     {
+        $allVotes = [];
+
         foreach ($results as $result) {
+            $allVotes[] = $result;
+            if ($result instanceof VoteInterface) {
+                $result = $result->getAccess();
+            }
+
             if (VoterInterface::ACCESS_GRANTED === $result) {
-                return true;
+                return $this->getReturn(true, $asObject, $allVotes);
             }
 
             if (VoterInterface::ACCESS_DENIED === $result) {
-                return false;
+                return $this->getReturn(false, $asObject, $allVotes);
             }
         }
 
-        return $this->allowIfAllAbstainDecisions;
+        return $this->getReturn($this->allowIfAllAbstainDecisions, $asObject, $allVotes);
     }
 
     public function __toString(): string
     {
         return 'priority';
+    }
+
+    private function getReturn(bool $result, bool $asObject, array $votes): AccessDecision|bool
+    {
+        return $asObject ? new AccessDecision($result, $votes) : $result;
     }
 }

--- a/src/Symfony/Component/Security/Core/Authorization/TraceableAccessDecisionManager.php
+++ b/src/Symfony/Component/Security/Core/Authorization/TraceableAccessDecisionManager.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Core\Authorization;
 
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Strategy\AccessDecisionStrategyInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\VoteInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
 /**
@@ -45,7 +46,7 @@ class TraceableAccessDecisionManager implements AccessDecisionManagerInterface
         }
     }
 
-    public function decide(TokenInterface $token, array $attributes, mixed $object = null, bool $allowMultipleAttributes = false): bool
+    public function decide(TokenInterface $token, array $attributes, mixed $object = null, bool $allowMultipleAttributes = false, bool $asObject = false): AccessDecision|bool
     {
         $currentDecisionLog = [
             'attributes' => $attributes,
@@ -55,7 +56,7 @@ class TraceableAccessDecisionManager implements AccessDecisionManagerInterface
 
         $this->currentLog[] = &$currentDecisionLog;
 
-        $result = $this->manager->decide($token, $attributes, $object, $allowMultipleAttributes);
+        $result = $this->manager->decide($token, $attributes, $object, $allowMultipleAttributes, $asObject);
 
         $currentDecisionLog['result'] = $result;
 
@@ -70,7 +71,7 @@ class TraceableAccessDecisionManager implements AccessDecisionManagerInterface
      * @param array $attributes attributes used for the vote
      * @param int   $vote       vote of the voter
      */
-    public function addVoterVote(VoterInterface $voter, array $attributes, int $vote): void
+    public function addVoterVote(VoterInterface $voter, array $attributes, VoteInterface|int $vote): void
     {
         $currentLogIndex = \count($this->currentLog) - 1;
         $this->currentLog[$currentLogIndex]['voterDetails'][] = [

--- a/src/Symfony/Component/Security/Core/Authorization/UserAuthorizationChecker.php
+++ b/src/Symfony/Component/Security/Core/Authorization/UserAuthorizationChecker.php
@@ -26,6 +26,9 @@ final class UserAuthorizationChecker implements UserAuthorizationCheckerInterfac
 
     public function isGrantedForUser(UserInterface $user, mixed $attribute, mixed $subject = null): bool
     {
+        /**
+         * @var bool
+         */
         return $this->accessDecisionManager->decide(new UserAuthorizationCheckerToken($user), [$attribute], $subject);
     }
 }

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/TraceableVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/TraceableVoter.php
@@ -30,9 +30,9 @@ class TraceableVoter implements CacheableVoterInterface
     ) {
     }
 
-    public function vote(TokenInterface $token, mixed $subject, array $attributes): int
+    public function vote(TokenInterface $token, mixed $subject, array $attributes, bool $asObject = false): VoteInterface|int
     {
-        $result = $this->voter->vote($token, $subject, $attributes);
+        $result = $this->voter->vote($token, $subject, $attributes, $asObject);
 
         $this->eventDispatcher->dispatch(new VoteEvent($this->voter, $subject, $attributes, $result), 'debug.security.authorization.vote');
 

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/Vote.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/Vote.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Authorization\Voter;
+
+/**
+ * A Vote is returned by a Voter and contains the access and some messages.
+ *
+ * @author Roman JOLY <eltharin18@outlook.fr>
+ */
+class Vote implements VoteInterface
+{
+    private const VALID_VOTES = [
+        VoterInterface::ACCESS_GRANTED => true,
+        VoterInterface::ACCESS_DENIED => true,
+        VoterInterface::ACCESS_ABSTAIN => true,
+    ];
+
+    public function __construct(
+        private int $access,
+        private string|array $messages = [],
+    ) {
+        if (!\in_array($access, [VoterInterface::ACCESS_GRANTED, VoterInterface::ACCESS_ABSTAIN, VoterInterface::ACCESS_DENIED], true)) {
+            throw new \LogicException(\sprintf('"$access" must return one of "%s" constants ("ACCESS_GRANTED", "ACCESS_DENIED" or "ACCESS_ABSTAIN"), "%s" returned.', VoterInterface::class, $access));
+        }
+        $this->setMessages($messages);
+    }
+
+    public function getAccess(): int
+    {
+        return $this->access;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getMessages(): array
+    {
+        return $this->messages;
+    }
+
+    /**
+     * @throws \InvalidArgumentException
+     */
+    public function setMessages(string|array $messages): void
+    {
+        $this->messages = (array) $messages;
+        foreach ($this->messages as $message) {
+            if (!\is_string($message)) {
+                throw new \InvalidArgumentException(\sprintf('Message must be string, "%s" given.', get_debug_type($message)));
+            }
+        }
+    }
+}

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/VoteInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/VoteInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Authorization\Voter;
+
+/**
+ * A VoteInterface implemented object can be returned by a Voter instead simple int for add some data, messages or other.
+ *
+ * @author Roman JOLY <eltharin18@outlook.fr>
+ */
+interface VoteInterface
+{
+    public function getAccess(): int;
+
+    /**
+     * @return string[]
+     */
+    public function getMessages(): array;
+}

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/Voter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/Voter.php
@@ -24,7 +24,7 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
  */
 abstract class Voter implements VoterInterface, CacheableVoterInterface
 {
-    public function vote(TokenInterface $token, mixed $subject, array $attributes): int
+    public function vote(TokenInterface $token, mixed $subject, array $attributes): VoteInterface|int
     {
         // abstain vote by default in case none of the attributes are supported
         $vote = self::ACCESS_ABSTAIN;

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/VoterInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/VoterInterface.php
@@ -35,5 +35,5 @@ interface VoterInterface
      *
      * @return self::ACCESS_*
      */
-    public function vote(TokenInterface $token, mixed $subject, array $attributes): int;
+    public function vote(TokenInterface $token, mixed $subject, array $attributes): VoteInterface|int;
 }

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/VoterWithObjects.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/VoterWithObjects.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Authorization\Voter;
+
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+/**
+ * Voter is an abstract default implementation of a voter.
+ *
+ * @author Roman Marintšenko <inoryy@gmail.com>
+ * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ *
+ * @template TAttribute of string
+ * @template TSubject of mixed
+ *
+ * @extends Voter<TAttribute, TSubject>
+ */
+abstract class VoterWithObjects extends Voter
+{
+    public function vote(TokenInterface $token, mixed $subject, array $attributes, bool $asObject = false): VoteInterface|int
+    {
+        $vote = $this->doVote($token, $subject, $attributes);
+
+        return $asObject ? $vote : $vote->getAccess();
+    }
+
+    public function doVote(TokenInterface $token, mixed $subject, array $attributes): VoteInterface
+    {
+        throw new \LogicException(\sprintf('"vote" or "doVote" methods must be implemented in "%s"', static::class));
+    }
+}

--- a/src/Symfony/Component/Security/Core/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Core/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add `UserAuthorizationChecker::isGrantedForUser()` to test user authorization without relying on the session.
    For example, users not currently logged in, or while processing a message from a message queue.
  * Add `OfflineTokenInterface` to mark tokens that do not represent the currently logged-in user
+ * Add the ability for voter to return decision reason by passing a `Vote` object
 
 7.2
 ---

--- a/src/Symfony/Component/Security/Core/Event/VoteEvent.php
+++ b/src/Symfony/Component/Security/Core/Event/VoteEvent.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Security\Core\Event;
 
+use Symfony\Component\Security\Core\Authorization\Voter\VoteInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
@@ -27,7 +28,7 @@ final class VoteEvent extends Event
         private VoterInterface $voter,
         private mixed $subject,
         private array $attributes,
-        private int $vote,
+        private VoteInterface|int $vote,
     ) {
     }
 
@@ -46,8 +47,12 @@ final class VoteEvent extends Event
         return $this->attributes;
     }
 
-    public function getVote(): int
+    public function getVote($asObject = false): VoteInterface|int
     {
+        if ($this->vote instanceof VoteInterface && !$asObject) {
+            return $this->vote->getAccess();
+        }
+
         return $this->vote;
     }
 }

--- a/src/Symfony/Component/Security/Core/Exception/AccessDeniedException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AccessDeniedException.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Core\Exception;
 
 use Symfony\Component\HttpKernel\Attribute\WithHttpStatus;
+use Symfony\Component\Security\Core\Authorization\AccessDecision;
 
 /**
  * AccessDeniedException is thrown when the account has not the required role.
@@ -23,6 +24,7 @@ class AccessDeniedException extends RuntimeException
 {
     private array $attributes = [];
     private mixed $subject = null;
+    private ?AccessDecision $accessDecision = null;
 
     public function __construct(string $message = 'Access Denied.', ?\Throwable $previous = null, int $code = 403)
     {
@@ -47,5 +49,18 @@ class AccessDeniedException extends RuntimeException
     public function setSubject(mixed $subject): void
     {
         $this->subject = $subject;
+    }
+
+    /**
+     * Sets an access decision and appends the denied reasons to the exception message.
+     */
+    public function setAccessDecision(AccessDecision $accessDecision): void
+    {
+        $this->accessDecision = $accessDecision;
+    }
+
+    public function getAccessDecision(): ?AccessDecision
+    {
+        return $this->accessDecision;
     }
 }

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Strategy/AffirmativeStrategyTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Strategy/AffirmativeStrategyTest.php
@@ -25,6 +25,27 @@ class AffirmativeStrategyTest extends AccessDecisionStrategyTestCase
         yield [$strategy, self::getVoters(0, 1, 0), false];
         yield [$strategy, self::getVoters(0, 0, 1), false];
 
+        yield [$strategy, [
+            self::getVoterWithVoteObject(0),
+            self::getVoter(-1),
+            self::getVoter(0),
+            self::getVoterWithVoteObject(1),
+        ], true];
+
+        yield [$strategy, [
+            self::getVoterWithVoteObject(0),
+            self::getVoter(-1),
+            self::getVoter(0),
+            self::getVoterWithVoteObject(0),
+        ], false];
+
+        yield [$strategy, [
+            self::getVoterWithVoteObject(0),
+            self::getVoter(1),
+            self::getVoter(0),
+            self::getVoterWithVoteObject(-1),
+        ], true];
+
         $strategy = new AffirmativeStrategy(true);
 
         yield [$strategy, self::getVoters(0, 0, 1), true];

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Strategy/ConsensusStrategyTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Strategy/ConsensusStrategyTest.php
@@ -36,5 +36,26 @@ class ConsensusStrategyTest extends AccessDecisionStrategyTestCase
 
         yield [$strategy, self::getVoters(2, 2, 0), false];
         yield [$strategy, self::getVoters(2, 2, 1), false];
+
+        yield [$strategy, [
+            self::getVoterWithVoteObject(1),
+            self::getVoter(-1),
+            self::getVoter(0),
+            self::getVoterWithVoteObject(1),
+        ], true];
+
+        yield [$strategy, [
+            self::getVoterWithVoteObject(1),
+            self::getVoter(-1),
+            self::getVoter(-1),
+            self::getVoterWithVoteObject(1),
+        ], false];
+
+        yield [$strategy, [
+            self::getVoterWithVoteObject(1),
+            self::getVoter(-1),
+            self::getVoter(-1),
+            self::getVoterWithVoteObject(0),
+        ], false];
     }
 }

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Strategy/PriorityStrategyTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Strategy/PriorityStrategyTest.php
@@ -35,6 +35,27 @@ class PriorityStrategyTest extends AccessDecisionStrategyTestCase
             self::getVoter(VoterInterface::ACCESS_GRANTED),
         ], false];
 
+        yield [$strategy, [
+            self::getVoterWithVoteObject(1),
+            self::getVoter(-1),
+            self::getVoter(0),
+            self::getVoterWithVoteObject(1),
+        ], true];
+
+        yield [$strategy, [
+            self::getVoterWithVoteObject(0),
+            self::getVoter(-1),
+            self::getVoter(0),
+            self::getVoterWithVoteObject(1),
+        ], false];
+
+        yield [$strategy, [
+            self::getVoterWithVoteObject(-1),
+            self::getVoter(1),
+            self::getVoter(0),
+            self::getVoterWithVoteObject(1),
+        ], false];
+
         yield [$strategy, self::getVoters(0, 0, 2), false];
 
         $strategy = new PriorityStrategy(true);

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Strategy/UnanimousStrategyTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Strategy/UnanimousStrategyTest.php
@@ -29,5 +29,26 @@ class UnanimousStrategyTest extends AccessDecisionStrategyTestCase
         $strategy = new UnanimousStrategy(true);
 
         yield [$strategy, self::getVoters(0, 0, 2), true];
+
+        yield [$strategy, [
+            self::getVoterWithVoteObject(1),
+            self::getVoter(-1),
+            self::getVoter(0),
+            self::getVoterWithVoteObject(1),
+        ], false];
+
+        yield [$strategy, [
+            self::getVoterWithVoteObject(-1),
+            self::getVoter(1),
+            self::getVoter(0),
+            self::getVoterWithVoteObject(1),
+        ], false];
+
+        yield [$strategy, [
+            self::getVoterWithVoteObject(0),
+            self::getVoter(0),
+            self::getVoter(0),
+            self::getVoterWithVoteObject(1),
+        ], true];
     }
 }

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/TraceableAccessDecisionManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/TraceableAccessDecisionManagerTest.php
@@ -16,8 +16,10 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManager;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 use Symfony\Component\Security\Core\Authorization\TraceableAccessDecisionManager;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use Symfony\Component\Security\Core\Tests\Fixtures\DummyVoter;
+use Symfony\Component\Security\Core\Tests\Fixtures\DummyVoterWithObject;
 
 class TraceableAccessDecisionManagerTest extends TestCase
 {
@@ -54,6 +56,7 @@ class TraceableAccessDecisionManagerTest extends TestCase
     {
         $voter1 = new DummyVoter();
         $voter2 = new DummyVoter();
+        $voter3 = new DummyVoterWithObject();
 
         yield [
             [[
@@ -168,6 +171,27 @@ class TraceableAccessDecisionManagerTest extends TestCase
                 [$voter2, VoterInterface::ACCESS_DENIED],
             ],
             false,
+        ];
+
+        yield [
+            [[
+                 'attributes' => ['ATTRIBUTE_1'],
+                 'object' => null,
+                 'result' => true,
+                 'voterDetails' => [
+                     ['voter' => $voter1, 'attributes' => ['ATTRIBUTE_1'], 'vote' => VoterInterface::ACCESS_GRANTED],
+                     ['voter' => $voter2, 'attributes' => ['ATTRIBUTE_1'], 'vote' => VoterInterface::ACCESS_GRANTED],
+                     ['voter' => $voter3, 'attributes' => ['ATTRIBUTE_1'], 'vote' => new Vote(VoterInterface::ACCESS_GRANTED)],
+                 ],
+             ]],
+            ['ATTRIBUTE_1'],
+            null,
+            [
+                [$voter1, VoterInterface::ACCESS_GRANTED],
+                [$voter2, VoterInterface::ACCESS_GRANTED],
+                [$voter3, new Vote(VoterInterface::ACCESS_GRANTED)],
+            ],
+            true,
         ];
     }
 

--- a/src/Symfony/Component/Security/Core/Tests/Fixtures/DummyVoterWithObject.php
+++ b/src/Symfony/Component/Security/Core/Tests/Fixtures/DummyVoterWithObject.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Tests\Fixtures;
+
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\VoteInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+final class DummyVoterWithObject implements VoterInterface
+{
+    public function vote(TokenInterface $token, $subject, array $attributes, $asObject = true): VoteInterface|int
+    {
+    }
+}

--- a/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\Security\Core\Authentication\Token\NullToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecision;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
@@ -73,16 +74,23 @@ class AccessListener extends AbstractListener
 
         $token = $this->tokenStorage->getToken() ?? new NullToken();
 
-        if (!$this->accessDecisionManager->decide($token, $attributes, $request, true)) {
-            throw $this->createAccessDeniedException($request, $attributes);
+        $decision = $this->accessDecisionManager->decide($token, $attributes, $request, true, AccessDecision::RETURN_AS_OBJECT);
+
+        if(! $decision instanceof AccessDecision) {
+            $decision = new AccessDecision($decision);
+        }
+        
+        if ($decision->isDenied()) {
+            throw $this->createAccessDeniedException($request, $attributes, $decision);
         }
     }
 
-    private function createAccessDeniedException(Request $request, array $attributes): AccessDeniedException
+    private function createAccessDeniedException(Request $request, array $attributes, AccessDecision $accessDecision): AccessDeniedException
     {
         $exception = new AccessDeniedException();
         $exception->setAttributes($attributes);
         $exception->setSubject($request);
+        $exception->setAccessDecision($accessDecision);
 
         return $exception;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Issues        | Fix https://github.com/symfony/symfony/issues/27995, https://github.com/symfony/symfony/issues/26343, https://github.com/symfony/symfony/pull/35592, https://github.com/symfony/symfony/pull/43147
| License       | MIT


This PR continue the work started by @maidmaid and @noniagriconomie in https://github.com/symfony/symfony/pull/35592, continued by @yellow1912 in https://github.com/symfony/symfony/pull/43147 continued by @alamirault in https://github.com/symfony/symfony/pull/46493.

I rebase on 7.2 and remove deprecation as suggested by nicolas-grekas for not causing backward compatiblity breaks.

It allow to have informations about AccessDecisionManager and Voters (And understand why we have an AccessDeniedException with clear infos).
![170878112-f93f8d90-97b7-42f8-8494-603d6b2019e2](https://github.com/user-attachments/assets/6ea5ea3b-2a9b-4059-bb74-b7ce9fe2cf13)


After https://github.com/symfony/symfony/pull/58107, I take the work from the beginning so I open a new PR.