### PR TITLE
[DoctrineBridge] Add support for doctrine/persistence 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "ext-xml": "*",
         "friendsofphp/proxy-manager-lts": "^1.0.2",
         "doctrine/event-manager": "^1.2|^2",
-        "doctrine/persistence": "^2.5|^3.1",
+        "doctrine/persistence": "^2.5|^3.1|^4",
         "twig/twig": "^2.13|^3.0.4",
         "psr/cache": "^2.0|^3.0",
         "psr/clock": "^1.0",

--- a/src/Symfony/Bridge/Doctrine/Tests/ArgumentResolver/EntityValueResolverTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ArgumentResolver/EntityValueResolverTest.php
@@ -415,9 +415,13 @@ class EntityValueResolverTest extends TestCase
             ->method('getManagerForClass')
             ->willReturn($manager);
 
-        $registry->expects($this->any())
-            ->method('getManager')
-            ->willReturn($manager);
+        if (null === $manager) {
+            $registry->method('getManager')
+                ->willThrowException(new \InvalidArgumentException());
+        } else {
+            $registry->method('getManager')->willReturn($manager);
+        }
+
 
         return $registry;
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
@@ -76,10 +76,16 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
     protected function createRegistryMock($em = null)
     {
         $registry = $this->createMock(ManagerRegistry::class);
-        $registry->expects($this->any())
-                 ->method('getManager')
-                 ->with($this->equalTo(self::EM_NAME))
-                 ->willReturn($em);
+
+        if (null === $em) {
+            $registry->method('getManager')
+                ->with($this->equalTo(self::EM_NAME))
+                ->willThrowException(new \InvalidArgumentException());
+        } else {
+            $registry->method('getManager')
+                ->with($this->equalTo(self::EM_NAME))
+                ->willReturn($em);
+        }
 
         return $registry;
     }

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -69,10 +69,10 @@ class UniqueEntityValidator extends ConstraintValidator
         }
 
         if ($constraint->em) {
-            $em = $this->registry->getManager($constraint->em);
-
-            if (!$em) {
-                throw new ConstraintDefinitionException(sprintf('Object manager "%s" does not exist.', $constraint->em));
+            try {
+                $em = $this->registry->getManager($constraint->em);
+            } catch (\InvalidArgumentException $e) {
+                throw new ConstraintDefinitionException(sprintf('Object manager "%s" does not exist.', $constraint->em), 0, $e);
             }
         } else {
             $em = $this->registry->getManagerForClass($entity::class);

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "doctrine/event-manager": "^1.2|^2",
-        "doctrine/persistence": "^2.5|^3.1",
+        "doctrine/persistence": "^2.5|^3.1|^4",
         "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/polyfill-ctype": "~1.8",
         "symfony/polyfill-mbstring": "~1.0",


### PR DESCRIPTION
[v4](https://github.com/doctrine/persistence/blob/4.0.x/UPGRADE.md#upgrade-to-40) provides a guarantee that `ManagerRegistry::getManager()` returns an entity manager (as opposed to null).

| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | n/a
| License       | MIT
