### PR TITLE
[EventDispatcher] add skip propagation capability

### DIFF
--- a/src/Symfony/Component/EventDispatcher/CHANGELOG.md
+++ b/src/Symfony/Component/EventDispatcher/CHANGELOG.md
@@ -1,10 +1,15 @@
 CHANGELOG
 =========
 
+7.3
+---
+
+* Add `skipPropagationUntil` method to omit listeners but keeping some importants.
+
 6.0
 ---
 
- * Remove `LegacyEventDispatcherProxy`
+* Remove `LegacyEventDispatcherProxy`
 
 5.4
 ---

--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
@@ -291,6 +291,10 @@ class TraceableEventDispatcher implements EventDispatcherInterface, ResetInterfa
 
                 $skipped = true;
             }
+
+            if (null !== $listener->skippedPropagationUntil()) {
+                $this->logger?->debug('Listener "{listener}" skipped propagation of the event "{event}" until priority '.$listener->skippedPropagationUntil().'.', $context);
+            }
         }
     }
 

--- a/src/Symfony/Component/EventDispatcher/Debug/WrappedListener.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/WrappedListener.php
@@ -15,6 +15,7 @@ use Psr\EventDispatcher\StoppableEventInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
 use Symfony\Component\VarDumper\Caster\ClassStub;
+use Symfony\Contracts\EventDispatcher\SkippableEventInterface;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -30,6 +31,7 @@ final class WrappedListener
     private string $callableRef;
     private ClassStub|string $stub;
     private static bool $hasClassStub;
+    private ?int $skippedPropagationUntil = null;
 
     public function __construct(
         callable|array $listener,
@@ -85,6 +87,11 @@ final class WrappedListener
         return $this->stoppedPropagation;
     }
 
+    public function skippedPropagationUntil(): ?int
+    {
+        return $this->skippedPropagationUntil;
+    }
+
     public function getPretty(): string
     {
         return $this->pretty;
@@ -121,6 +128,10 @@ final class WrappedListener
 
         if ($event instanceof StoppableEventInterface && $event->isPropagationStopped()) {
             $this->stoppedPropagation = true;
+        }
+
+        if ($event instanceof SkippableEventInterface && $event->isPropagationSkipped()) {
+            $this->skippedPropagationUntil = $event->getPropagationSkipUntilPriority();
         }
     }
 

--- a/src/Symfony/Contracts/EventDispatcher/Event.php
+++ b/src/Symfony/Contracts/EventDispatcher/Event.php
@@ -27,10 +27,12 @@ use Psr\EventDispatcher\StoppableEventInterface;
  * @author Roman Borschel <roman@code-factory.org>
  * @author Bernhard Schussek <bschussek@gmail.com>
  * @author Nicolas Grekas <p@tchwork.com>
+ * @author Roman JOLY <roman.joly@outlook.fr>
  */
-class Event implements StoppableEventInterface
+class Event implements StoppableEventInterface, SkippableEventInterface
 {
     private bool $propagationStopped = false;
+    private ?int $propagationSkippeduntil = null;
 
     public function isPropagationStopped(): bool
     {
@@ -47,5 +49,25 @@ class Event implements StoppableEventInterface
     public function stopPropagation(): void
     {
         $this->propagationStopped = true;
+    }
+
+    public function isPropagationSkipped(): bool
+    {
+        return null !== $this->propagationSkippeduntil;
+    }
+
+    public function getPropagationSkipUntilPriority(): ?int
+    {
+        return $this->propagationSkippeduntil;
+    }
+
+    /**
+     * Skip the propagation of the event to further event listeners until a point.
+     *
+     * The end Point can be a int for specify the next priority whitch will be executed.
+     */
+    public function skipPropagationUntil(?int $restartPoint): void
+    {
+        $this->propagationSkippeduntil = $restartPoint;
     }
 }

--- a/src/Symfony/Contracts/EventDispatcher/SkippableEventInterface.php
+++ b/src/Symfony/Contracts/EventDispatcher/SkippableEventInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Contracts\EventDispatcher;
+
+/**
+ * An Event can skip processing listeners until a specific priority.
+ *
+ * @author Roman JOLY <roman.joly@outlook.fr>
+ */
+interface SkippableEventInterface
+{
+    public function isPropagationSkipped(): bool;
+
+    public function getPropagationSkipUntilPriority(): ?int;
+
+    /**
+     * Skip the propagation of the event to further event listeners until a point.
+     *
+     * The end Point can be a int for specify the next priority whitch will be executed.
+     */
+    public function skipPropagationUntil(?int $restartPoint): void;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

Add capability in Event / Listeners to skip propagation instead of stopping all.
It can permit to omit certains listeners, keeping the essentials (with low priority)
