### PR TITLE
[FrameworkBundle] Fix patching refs to the tmp warmup dir in files generated by optional cache warmers

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -146,6 +146,16 @@ EOF
                     }
                     $this->warmupOptionals($useBuildDir ? $realCacheDir : $warmupDir, $warmupDir, $io);
                 }
+
+                // fix references to cached files with the real cache directory name
+                $search = [$warmupDir, str_replace('/', '\\/', $warmupDir), str_replace('\\', '\\\\', $warmupDir)];
+                $replace = str_replace('\\', '/', $realBuildDir);
+                foreach (Finder::create()->files()->in($warmupDir) as $file) {
+                    $content = str_replace($search, $replace, file_get_contents($file), $count);
+                    if ($count) {
+                        file_put_contents($file, $content);
+                    }
+                }
             }
 
             if (!$fs->exists($warmupDir.'/'.$containerDir)) {
@@ -227,16 +237,6 @@ EOF
             throw new \LogicException('Calling "cache:clear" with a kernel that does not implement "Symfony\Component\HttpKernel\RebootableInterface" is not supported.');
         }
         $kernel->reboot($warmupDir);
-
-        // fix references to cached files with the real cache directory name
-        $search = [$warmupDir, str_replace('\\', '\\\\', $warmupDir)];
-        $replace = str_replace('\\', '/', $realBuildDir);
-        foreach (Finder::create()->files()->in($warmupDir) as $file) {
-            $content = str_replace($search, $replace, file_get_contents($file), $count);
-            if ($count) {
-                file_put_contents($file, $content);
-            }
-        }
     }
 
     private function warmupOptionals(string $cacheDir, string $warmupDir, SymfonyStyle $io): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

E.g. in dev mode, the RouterCacheWarmer is immediately invalidated at the moment because we track a temporary file in `var/cache/de_`.