### PR TITLE
[Config] Add missing `json_encode` flags when creating `.meta.json` files

### DIFF
--- a/src/Symfony/Component/Config/ResourceCheckerConfigCache.php
+++ b/src/Symfony/Component/Config/ResourceCheckerConfigCache.php
@@ -128,7 +128,7 @@ class ResourceCheckerConfigCache implements ConfigCacheInterface
             $ser = preg_replace_callback('/;O:(\d+):"/', static fn ($m) => ';O:'.(9 + $m[1]).':"Tracking\\', $ser);
             $ser = preg_replace_callback('/s:(\d+):"\0[^\0]++\0/', static fn ($m) => 's:'.($m[1] - \strlen($m[0]) + 6).':"', $ser);
             $ser = unserialize($ser);
-            $ser = @json_encode($ser) ?: [];
+            $ser = @json_encode($ser, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE) ?: [];
             $ser = str_replace('"__PHP_Incomplete_Class_Name":"Tracking\\\\', '"@type":"', $ser);
             $ser = \sprintf('{"resources":%s}', $ser);
 

--- a/src/Symfony/Component/Config/Tests/ResourceCheckerConfigCacheTest.php
+++ b/src/Symfony/Component/Config/Tests/ResourceCheckerConfigCacheTest.php
@@ -168,6 +168,6 @@ class ResourceCheckerConfigCacheTest extends TestCase
                     'resource' => __FILE__,
                 ],
             ],
-        ]));
+        ], \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

So that cache:clear can find refs to `var/cache/de_` and patch them. (currently it fails as those are encoded as `var\/cache\/de_`.)