### PR TITLE
[Cache] Don't clear system caches on `cache:clear`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolsTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolsTest.php
@@ -88,10 +88,6 @@ class CachePoolsTest extends AbstractWebTestCase
         $pool2 = $container->get('cache.pool2');
         $pool2->save($item);
 
-        $container->get('cache_clearer.alias')->clear($container->getParameter('kernel.cache_dir'));
-        $item = $pool1->getItem($key);
-        $this->assertFalse($item->isHit());
-
         $item = $pool2->getItem($key);
         $this->assertTrue($item->isHit());
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
@@ -139,14 +139,18 @@ class ContainerDebugCommandTest extends AbstractWebTestCase
         $tester->setInputs(['0']);
         $tester->run(['command' => 'debug:container', '--tag' => 'kernel.'], ['decorated' => false]);
 
-        $this->assertStringContainsString('Select one of the following tags to display its information', $tester->getDisplay());
-        $this->assertStringContainsString('[0] kernel.cache_clearer', $tester->getDisplay());
-        $this->assertStringContainsString('[1] kernel.cache_warmer', $tester->getDisplay());
-        $this->assertStringContainsString('[2] kernel.event_subscriber', $tester->getDisplay());
-        $this->assertStringContainsString('[3] kernel.fragment_renderer', $tester->getDisplay());
-        $this->assertStringContainsString('[4] kernel.locale_aware', $tester->getDisplay());
-        $this->assertStringContainsString('[5] kernel.reset', $tester->getDisplay());
-        $this->assertStringContainsString('Symfony Container Services Tagged with "kernel.cache_clearer" Tag', $tester->getDisplay());
+        $this->assertStringMatchesFormat(<<<EOTXT
+
+             Select one of the following tags to display its information:
+            %A
+              [%d] kernel.reset
+            %A
+
+            Symfony Container Services Tagged with "kernel.%a" Tag
+            %A
+            EOTXT,
+            $tester->getDisplay()
+        );
     }
 
     public function testDescribeEnvVars()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/CachePools/default.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/CachePools/default.yml
@@ -1,7 +1,2 @@
 imports:
     - { resource: ../config/default.yml }
-
-services:
-    cache_clearer.alias:
-        alias: cache_clearer
-        public: true

--- a/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
+++ b/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
@@ -197,10 +197,6 @@ class CachePoolPass implements CompilerPassInterface
                 $clearer->setArgument(0, $pools);
             }
             $clearer->addTag('cache.pool.clearer');
-
-            if ('cache.system_clearer' === $id) {
-                $clearer->addTag('kernel.cache_clearer');
-            }
         }
 
         $allPoolsKeys = array_keys($allPools);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59445
| License       | MIT

As spotted by @MatTheCat in https://github.com/symfony/symfony/issues/59445#issuecomment-2585367862, non-optional cache warmers currently cannot use any cache pools derived from the `cache.system` one.

The reason is that when running `cache:clear` with no `var/cache` folder, we skip running those cache warmers since they already ran to execute the command, but we still call the cache clearer service, which empties system pools at the moment, annihilating anything non-optional cache warmers put in these pools.

I propose to fix this by just not clearing cache pools derived from the system pool anymore. System pools are meant to we stored in the `kernel.cache_dir` anyway, so they're already cleared when `cache:clear` empties that folder.
