### PR TITLE
[Mime] use isRendered method to ensure we can avoid rendering an emai…

### DIFF
--- a/src/Symfony/Bridge/Twig/Mime/BodyRenderer.php
+++ b/src/Symfony/Bridge/Twig/Mime/BodyRenderer.php
@@ -42,7 +42,7 @@ final class BodyRenderer implements BodyRendererInterface
             return;
         }
 
-        if (null === $message->getTextTemplate() && null === $message->getHtmlTemplate()) {
+        if ($message->isRendered()) {
             // email has already been rendered
             return;
         }


### PR DESCRIPTION
…l twice

| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | 
| License       | MIT

Following up my comment on https://github.com/symfony/symfony/pull/47075/files.

I would recommend using the method TemplatedEmail::isRendered() the same way it is used in [AbstractTransport.php](https://github.com/symfony/symfony/blob/7.3/src/Symfony/Component/Mailer/Transport/AbstractTransport.php#L83).

Keeping like this prevents subclass of TemplatedEmail with computed html template to not be rendered twice, such as [NotificationEmail](https://github.com/symfony/symfony/blob/7.3/src/Symfony/Bridge/Twig/Mime/NotificationEmail.php#L202).

This change will allow developers to create a subclass of template emails and render them before sending them async, without rendering them twice.