### PR TITLE
[Mime] Fix body validity check in `Email` when using `Message::setBody()`

### DIFF
--- a/src/Symfony/Component/Mime/Email.php
+++ b/src/Symfony/Component/Mime/Email.php
@@ -416,7 +416,7 @@ class Email extends Message
 
     private function ensureBodyValid(): void
     {
-        if (null === $this->text && null === $this->html && !$this->attachments) {
+        if (null === $this->text && null === $this->html && !$this->attachments && null === parent::getBody()) {
             throw new LogicException('A message must have a text or an HTML part or attachments.');
         }
     }

--- a/src/Symfony/Component/Mime/Tests/EmailTest.php
+++ b/src/Symfony/Component/Mime/Tests/EmailTest.php
@@ -695,4 +695,60 @@ EOF;
         $this->assertCount(1, $attachments);
         $this->assertStringContainsString('foo_bar_xyz_123', $attachments[0]->getBody());
     }
+
+    public function testInvalidBodyWithEmptyEmail()
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('A message must have a text or an HTML part or attachments.');
+
+        (new Email())->ensureValidity();
+    }
+
+    public function testBodyWithTextIsValid()
+    {
+        $email = new Email();
+        $email->to('test@example.com')
+            ->from('test@example.com')
+            ->text('foo');
+
+        $email->ensureValidity();
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testBodyWithHtmlIsValid()
+    {
+        $email = new Email();
+        $email->to('test@example.com')
+            ->from('test@example.com')
+            ->html('foo');
+
+        $email->ensureValidity();
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testEmptyBodyWithAttachmentsIsValid()
+    {
+        $email = new Email();
+        $email->to('test@example.com')
+            ->from('test@example.com')
+            ->addPart(new DataPart('foo'));
+
+        $email->ensureValidity();
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testSetBodyIsValid()
+    {
+        $email = new Email();
+        $email->to('test@example.com')
+            ->from('test@example.com')
+            ->setBody(new TextPart('foo'));
+
+        $email->ensureValidity();
+
+        $this->expectNotToPerformAssertions();
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59582
| License       | MIT
