### PR TITLE
[Mailer] Ensure TransportExceptionInterface populates stream debug data

### DIFF
--- a/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
@@ -205,11 +205,11 @@ class SmtpTransport extends AbstractTransport
             $this->ping();
         }
 
-        if (!$this->started) {
-            $this->start();
-        }
-
         try {
+            if (!$this->started) {
+                $this->start();
+            }
+
             $envelope = $message->getEnvelope();
             $this->doMailFromCommand($envelope->getSender()->getEncodedAddress());
             foreach ($envelope->getRecipients() as $recipient) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        |  <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

There is a discrepancy when `TransportExceptionInterface` is thrown. Sometimes `$e->getDebug()` is `''` and other times it contains information. Similarly, `$transport->getStream()->getDebug();` sometimes returns `''` because something else has already beaten you to the call... https://github.com/symfony/symfony/blob/05d5bb3b6a887c55b65d1247472d23e5dcbaa4f3/src/Symfony/Component/Mailer/Transport/Smtp/Stream/AbstractStream.php#L103

This results in you having to do something like the following to get the debug log...
```
} catch (TransportExceptionInterface $e) {
    $log = $e->getDebug() ?: $transport->getStream()->getDebug();
```

This PR ensures that any `TransportExceptionInterface` thrown by `send()` sets the debug information. The notable case where this occurs is in `handleAuth` which is part of `start` (`doHeloCommand`).

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
