### PR TITLE
[Mailer][Notifier] Fix channel parameter value to fixed value for Mailer and Notifier Sweego Transports

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Transport/SweegoApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Transport/SweegoApiTransportTest.php
@@ -110,6 +110,9 @@ class SweegoApiTransportTest extends TestCase
             $this->assertSame('https://api.sweego.io:8984/send', $url);
             $this->assertStringContainsString('Accept: */*', $options['headers'][2] ?? $options['request_headers'][1]);
 
+            $payload = json_decode($options['body'], true);
+            $this->assertSame('email', $payload['channel']);
+
             return new JsonMockResponse(['transaction_id' => 'foobar'], [
                 'http_code' => 200,
             ]);

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Transport/SweegoApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Transport/SweegoApiTransport.php
@@ -90,6 +90,7 @@ final class SweegoApiTransport extends AbstractApiTransport
             'from' => $this->formatAddress($envelope->getSender()),
             'subject' => $email->getSubject(),
             'campaign-type' => 'transac',
+            'channel' => 'email',
         ];
 
         if ($email->getTextBody()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

Sweego made a change on their API: the `channel` parameter in body is now mandatory with no default value (their documentation does not reflect this yet, but @pydubreucq reach me directly for this change).

As the fix is surgical and does not require backward compatibility layer, I guess we can pass it as bug fix. WDYT @OskarStark?