### PR TITLE
[Mailer] Add attachments support for Sweego Mailer Bridge

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Sweego/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.3
+---
+
+ * Add support for attachments
+
 7.2
 ---
 

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/README.md
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/README.md
@@ -24,6 +24,30 @@ MAILER_DSN=sweego+api://API_KEY@default
 where:
  - `API_KEY` is your Sweego API Key
 
+Features
+--------
+
+### Attachments
+
+The bridge supports both regular attachments and inline attachments (for embedding images in HTML emails):
+
+```php
+use Symfony\Component\Mime\Email;
+
+$email = new Email();
+$email
+    ->to('to@example.com')
+    ->from('from@example.com')
+    ->subject('Email with attachments')
+    ->text('Here is the text version')
+    ->html('<p>Here is the HTML content</p>')
+    // Regular attachment
+    ->attach('Hello world!', 'test.txt', 'text/plain')
+    // Inline attachment (embedded image)
+    ->embed(fopen('image.jpg', 'r'), 'image.jpg', 'image/jpeg')
+;
+```
+
 Webhook
 -------
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes<!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

Sweego has added support for attachments on their API. This PR include it in the Bridge.
I tested it in a real application with .txt, .pdf and .png files. Mails are delivered with attachments. 

As no other Bridge has tests for attachments AFAIK, I didn't write them. It could be part of a dedicated PR.