### PR TITLE
[OptionsResolver] Deprecate defining nested options via `setDefault()` use `setOptions()` instead

### DIFF
--- a/UPGRADE-7.3.md
+++ b/UPGRADE-7.3.md
@@ -94,6 +94,25 @@ FrameworkBundle
  * Deprecate the `--show-arguments` option of the `container:debug` command, as arguments are now always shown
  * Deprecate the `framework.validation.cache` config option
 
+OptionsResolver
+---------------
+
+* Deprecate defining nested options via `setDefault()`, use `setOptions()` instead
+
+  *Before*
+  ```php
+  $resolver->setDefault('option', function (OptionsResolver $resolver) {
+      // ...
+  });
+  ```
+
+  *After*
+  ```php
+  $resolver->setOptions('option', function (OptionsResolver $resolver) {
+      // ...
+  });
+  ```
+
 SecurityBundle
 --------------
 

--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
@@ -170,7 +170,7 @@ class Connection extends AbstractConnection
         $resolver->setAllowedTypes('debug', 'bool');
         $resolver->setDefault('referrals', false);
         $resolver->setAllowedTypes('referrals', 'bool');
-        $resolver->setDefault('options', function (OptionsResolver $options, Options $parent) {
+        $resolver->setOptions('options', function (OptionsResolver $options, Options $parent) {
             $options->setDefined(array_map('strtolower', array_keys((new \ReflectionClass(ConnectionOptions::class))->getConstants())));
 
             if (true === $parent['debug']) {

--- a/src/Symfony/Component/Ldap/composer.json
+++ b/src/Symfony/Component/Ldap/composer.json
@@ -18,14 +18,13 @@
     "require": {
         "php": ">=8.2",
         "ext-ldap": "*",
-        "symfony/options-resolver": "^6.4|^7.0"
+        "symfony/options-resolver": "^7.3"
     },
     "require-dev": {
         "symfony/security-core": "^6.4|^7.0",
         "symfony/security-http": "^6.4|^7.0"
     },
     "conflict": {
-        "symfony/options-resolver": "<6.4",
         "symfony/security-core": "<6.4"
     },
     "autoload": {

--- a/src/Symfony/Component/OptionsResolver/CHANGELOG.md
+++ b/src/Symfony/Component/OptionsResolver/CHANGELOG.md
@@ -5,6 +5,8 @@ CHANGELOG
 ---
 
  * Support union type in `OptionResolver::setAllowedTypes()` method
+ * Add `OptionsResolver::setOptions()` and `OptionConfigurator::options()` methods
+ * Deprecate defining nested options via `setDefault()`, use `setOptions()` instead
 
 6.4
 ---

--- a/src/Symfony/Component/OptionsResolver/Debug/OptionsResolverIntrospector.php
+++ b/src/Symfony/Component/OptionsResolver/Debug/OptionsResolverIntrospector.php
@@ -101,4 +101,14 @@ class OptionsResolverIntrospector
     {
         return ($this->get)('deprecated', $option, \sprintf('No deprecation was set for the "%s" option.', $option));
     }
+
+    /**
+     * @return \Closure[]
+     *
+     * @throws NoConfigurationException when no nested option is configured
+     */
+    public function getNestedOptions(string $option): array
+    {
+        return ($this->get)('nested', $option, \sprintf('No nested option was set for the "%s" option.', $option));
+    }
 }

--- a/src/Symfony/Component/OptionsResolver/OptionConfigurator.php
+++ b/src/Symfony/Component/OptionsResolver/OptionConfigurator.php
@@ -143,4 +143,18 @@ final class OptionConfigurator
 
         return $this;
     }
+
+    /**
+     * Defines nested options.
+     *
+     * @param \Closure(OptionsResolver $resolver, Options $parent): void $nested
+     *
+     * @return $this
+     */
+    public function options(\Closure $nested): static
+    {
+        $this->resolver->setOptions($this->name, $nested);
+
+        return $this;
+    }
 }

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -65,6 +65,13 @@ class OptionsResolver implements Options
     private array $nested = [];
 
     /**
+     * BC layer. Remove in Symfony 8.0.
+     *
+     * @var array<string, true>
+     */
+    private array $deprecatedNestedOptions = [];
+
+    /**
      * The names of required options.
      */
     private array $required = [];
@@ -178,20 +185,6 @@ class OptionsResolver implements Options
      * is spread across different locations of your code, such as base and
      * sub-classes.
      *
-     * If you want to define nested options, you can pass a closure with the
-     * following signature:
-     *
-     *     $options->setDefault('database', function (OptionsResolver $resolver) {
-     *         $resolver->setDefined(['dbname', 'host', 'port', 'user', 'pass']);
-     *     }
-     *
-     * To get access to the parent options, add a second argument to the closure's
-     * signature:
-     *
-     *     function (OptionsResolver $resolver, Options $parent) {
-     *         // 'default' === $parent['connection']
-     *     }
-     *
      * @return $this
      *
      * @throws AccessException If called from a lazy option or normalizer
@@ -226,13 +219,22 @@ class OptionsResolver implements Options
                 $this->lazy[$option][] = $value;
                 $this->defined[$option] = true;
 
-                // Make sure the option is processed and is not nested anymore
-                unset($this->resolved[$option], $this->nested[$option]);
+                // Make sure the option is processed
+                unset($this->resolved[$option]);
+
+                // BC layer. Remove in Symfony 8.0.
+                if (isset($this->deprecatedNestedOptions[$option])) {
+                    unset($this->nested[$option]);
+                }
 
                 return $this;
             }
 
+            // Remove in Symfony 8.0.
             if (isset($params[0]) && ($type = $params[0]->getType()) instanceof \ReflectionNamedType && self::class === $type->getName() && (!isset($params[1]) || (($type = $params[1]->getType()) instanceof \ReflectionNamedType && Options::class === $type->getName()))) {
+                trigger_deprecation('symfony/options-resolver', '7.3', 'Defining nested options via "%s()" is deprecated and will be removed in Symfony 8.0, use "setOptions()" method instead.', __METHOD__);
+                $this->deprecatedNestedOptions[$option] = true;
+
                 // Store closure for later evaluation
                 $this->nested[$option][] = $value;
                 $this->defaults[$option] = [];
@@ -245,8 +247,13 @@ class OptionsResolver implements Options
             }
         }
 
-        // This option is not lazy nor nested anymore
-        unset($this->lazy[$option], $this->nested[$option]);
+        // This option is not lazy anymore
+        unset($this->lazy[$option]);
+
+        // BC layer. Remove in Symfony 8.0.
+        if (isset($this->deprecatedNestedOptions[$option])) {
+            unset($this->nested[$option]);
+        }
 
         // Yet undefined options can be marked as resolved, because we only need
         // to resolve options with lazy closures, normalizers or validation
@@ -401,6 +408,30 @@ class OptionsResolver implements Options
     public function getDefinedOptions(): array
     {
         return array_keys($this->defined);
+    }
+
+    /**
+     * Defines nested options.
+     *
+     * @param \Closure(self $resolver, Options $parent): void $nested
+     *
+     * @return $this
+     */
+    public function setOptions(string $option, \Closure $nested): static
+    {
+        if ($this->locked) {
+            throw new AccessException('Nested options cannot be defined from a lazy option or normalizer.');
+        }
+
+        // Store closure for later evaluation
+        $this->nested[$option][] = $nested;
+        $this->defaults[$option] = [];
+        $this->defined[$option] = true;
+
+        // Make sure the option is processed
+        unset($this->resolved[$option]);
+
+        return $this;
     }
 
     public function isNested(string $option): bool
@@ -947,6 +978,23 @@ class OptionsResolver implements Options
 
         $value = $this->defaults[$option];
 
+        // Resolve the option if the default value is lazily evaluated
+        if (isset($this->lazy[$option])) {
+            // If the closure is already being called, we have a cyclic dependency
+            if (isset($this->calling[$option])) {
+                throw new OptionDefinitionException(\sprintf('The options "%s" have a cyclic dependency.', $this->formatOptions(array_keys($this->calling))));
+            }
+
+            $this->calling[$option] = true;
+            try {
+                foreach ($this->lazy[$option] as $closure) {
+                    $value = $closure($this, $value);
+                }
+            } finally {
+                unset($this->calling[$option]);
+            }
+        }
+
         // Resolve the option if it is a nested definition
         if (isset($this->nested[$option])) {
             // If the closure is already being called, we have a cyclic dependency
@@ -958,7 +1006,6 @@ class OptionsResolver implements Options
                 throw new InvalidOptionsException(\sprintf('The nested option "%s" with value %s is expected to be of type array, but is of type "%s".', $this->formatOptions([$option]), $this->formatValue($value), get_debug_type($value)));
             }
 
-            // The following section must be protected from cyclic calls.
             $this->calling[$option] = true;
             try {
                 $resolver = new self();
@@ -987,29 +1034,6 @@ class OptionsResolver implements Options
                 $resolver->prototypeIndex = null;
                 unset($this->calling[$option]);
             }
-        }
-
-        // Resolve the option if the default value is lazily evaluated
-        if (isset($this->lazy[$option])) {
-            // If the closure is already being called, we have a cyclic
-            // dependency
-            if (isset($this->calling[$option])) {
-                throw new OptionDefinitionException(\sprintf('The options "%s" have a cyclic dependency.', $this->formatOptions(array_keys($this->calling))));
-            }
-
-            // The following section must be protected from cyclic
-            // calls. Set $calling for the current $option to detect a cyclic
-            // dependency
-            // BEGIN
-            $this->calling[$option] = true;
-            try {
-                foreach ($this->lazy[$option] as $closure) {
-                    $value = $closure($this, $value);
-                }
-            } finally {
-                unset($this->calling[$option]);
-            }
-            // END
         }
 
         // Validate the type of the resolved option

--- a/src/Symfony/Component/OptionsResolver/Tests/Debug/OptionsResolverIntrospectorTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/Debug/OptionsResolverIntrospectorTest.php
@@ -263,4 +263,13 @@ class OptionsResolverIntrospectorTest extends TestCase
         $debug = new OptionsResolverIntrospector($resolver);
         $debug->getDeprecation('foo');
     }
+
+    public function testGetClosureNested()
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setOptions('foo', $closure = function (OptionsResolver $resolver) {});
+
+        $debug = new OptionsResolverIntrospector($resolver);
+        $this->assertSame([$closure], $debug->getNestedOptions('foo'));
+    }
 }

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\OptionsResolver\Tests;
 
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\OptionsResolver\Debug\OptionsResolverIntrospector;
 use Symfony\Component\OptionsResolver\Exception\AccessException;
 use Symfony\Component\OptionsResolver\Exception\InvalidArgumentException;
@@ -26,6 +27,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class OptionsResolverTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     private OptionsResolver $resolver;
 
     protected function setUp(): void
@@ -1091,28 +1094,40 @@ class OptionsResolverTest extends TestCase
         $this->resolver->resolve();
     }
 
-    public function testResolveFailsIfInvalidValueFromNestedOption()
+    /**
+     * @group legacy
+     */
+    public function testLegacyResolveFailsIfInvalidValueFromNestedOption()
     {
-        $this->expectException(InvalidOptionsException::class);
-        $this->expectExceptionMessage('The option "foo[bar]" with value "invalid value" is invalid. Accepted values are: "valid value".');
+        $this->expectDeprecation('Since symfony/options-resolver 7.3: Defining nested options via "Symfony\Component\OptionsResolver\OptionsResolver::setDefault()" is deprecated and will be removed in Symfony 8.0, use "setOptions()" method instead.');
+
         $this->resolver->setDefault('foo', function (OptionsResolver $resolver) {
             $resolver
                 ->setDefined('bar')
                 ->setAllowedValues('bar', 'valid value');
         });
 
+        $this->expectException(InvalidOptionsException::class);
+        $this->expectExceptionMessage('The option "foo[bar]" with value "invalid value" is invalid. Accepted values are: "valid value".');
+
         $this->resolver->resolve(['foo' => ['bar' => 'invalid value']]);
     }
 
-    public function testResolveFailsIfInvalidTypeFromNestedOption()
+    /**
+     * @group legacy
+     */
+    public function testLegacyResolveFailsIfInvalidTypeFromNestedOption()
     {
-        $this->expectException(InvalidOptionsException::class);
-        $this->expectExceptionMessage('The option "foo[bar]" with value 1 is expected to be of type "string", but is of type "int".');
+        $this->expectDeprecation('Since symfony/options-resolver 7.3: Defining nested options via "Symfony\Component\OptionsResolver\OptionsResolver::setDefault()" is deprecated and will be removed in Symfony 8.0, use "setOptions()" method instead.');
+
         $this->resolver->setDefault('foo', function (OptionsResolver $resolver) {
             $resolver
                 ->setDefined('bar')
                 ->setAllowedTypes('bar', 'string');
         });
+
+        $this->expectException(InvalidOptionsException::class);
+        $this->expectExceptionMessage('The option "foo[bar]" with value 1 is expected to be of type "string", but is of type "int".');
 
         $this->resolver->resolve(['foo' => ['bar' => 1]]);
     }
@@ -2096,8 +2111,13 @@ class OptionsResolverTest extends TestCase
         ]);
     }
 
-    public function testIsNestedOption()
+    /**
+     * @group legacy
+     */
+    public function testLegacyIsNestedOption()
     {
+        $this->expectDeprecation('Since symfony/options-resolver 7.3: Defining nested options via "Symfony\Component\OptionsResolver\OptionsResolver::setDefault()" is deprecated and will be removed in Symfony 8.0, use "setOptions()" method instead.');
+
         $this->resolver->setDefaults([
             'database' => function (OptionsResolver $resolver) {
                 $resolver->setDefined(['host', 'port']);
@@ -2106,40 +2126,57 @@ class OptionsResolverTest extends TestCase
         $this->assertTrue($this->resolver->isNested('database'));
     }
 
-    public function testFailsIfUndefinedNestedOption()
+    /**
+     * @group legacy
+     */
+    public function testLegacyFailsIfUndefinedNestedOption()
     {
-        $this->expectException(UndefinedOptionsException::class);
-        $this->expectExceptionMessage('The option "database[foo]" does not exist. Defined options are: "host", "port".');
+        $this->expectDeprecation('Since symfony/options-resolver 7.3: Defining nested options via "Symfony\Component\OptionsResolver\OptionsResolver::setDefault()" is deprecated and will be removed in Symfony 8.0, use "setOptions()" method instead.');
+
         $this->resolver->setDefaults([
             'name' => 'default',
             'database' => function (OptionsResolver $resolver) {
                 $resolver->setDefined(['host', 'port']);
             },
         ]);
+
+        $this->expectException(UndefinedOptionsException::class);
+        $this->expectExceptionMessage('The option "database[foo]" does not exist. Defined options are: "host", "port".');
+
         $this->resolver->resolve([
             'database' => ['foo' => 'bar'],
         ]);
     }
 
-    public function testFailsIfMissingRequiredNestedOption()
+    /**
+     * @group legacy
+     */
+    public function testLegacyFailsIfMissingRequiredNestedOption()
     {
-        $this->expectException(MissingOptionsException::class);
-        $this->expectExceptionMessage('The required option "database[host]" is missing.');
+        $this->expectDeprecation('Since symfony/options-resolver 7.3: Defining nested options via "Symfony\Component\OptionsResolver\OptionsResolver::setDefault()" is deprecated and will be removed in Symfony 8.0, use "setOptions()" method instead.');
+
         $this->resolver->setDefaults([
             'name' => 'default',
             'database' => function (OptionsResolver $resolver) {
                 $resolver->setRequired('host');
             },
         ]);
+
+        $this->expectException(MissingOptionsException::class);
+        $this->expectExceptionMessage('The required option "database[host]" is missing.');
+
         $this->resolver->resolve([
             'database' => [],
         ]);
     }
 
-    public function testFailsIfInvalidTypeNestedOption()
+    /**
+     * @group legacy
+     */
+    public function testLegacyFailsIfInvalidTypeNestedOption()
     {
-        $this->expectException(InvalidOptionsException::class);
-        $this->expectExceptionMessage('The option "database[logging]" with value null is expected to be of type "bool", but is of type "null".');
+        $this->expectDeprecation('Since symfony/options-resolver 7.3: Defining nested options via "Symfony\Component\OptionsResolver\OptionsResolver::setDefault()" is deprecated and will be removed in Symfony 8.0, use "setOptions()" method instead.');
+
         $this->resolver->setDefaults([
             'name' => 'default',
             'database' => function (OptionsResolver $resolver) {
@@ -2148,28 +2185,44 @@ class OptionsResolverTest extends TestCase
                     ->setAllowedTypes('logging', 'bool');
             },
         ]);
+
+        $this->expectException(InvalidOptionsException::class);
+        $this->expectExceptionMessage('The option "database[logging]" with value null is expected to be of type "bool", but is of type "null".');
+
         $this->resolver->resolve([
             'database' => ['logging' => null],
         ]);
     }
 
-    public function testFailsIfNotArrayIsGivenForNestedOptions()
+    /**
+     * @group legacy
+     */
+    public function testLegacyFailsIfNotArrayIsGivenForNestedOptions()
     {
-        $this->expectException(InvalidOptionsException::class);
-        $this->expectExceptionMessage('The nested option "database" with value null is expected to be of type array, but is of type "null".');
+        $this->expectDeprecation('Since symfony/options-resolver 7.3: Defining nested options via "Symfony\Component\OptionsResolver\OptionsResolver::setDefault()" is deprecated and will be removed in Symfony 8.0, use "setOptions()" method instead.');
+
         $this->resolver->setDefaults([
             'name' => 'default',
             'database' => function (OptionsResolver $resolver) {
                 $resolver->setDefined('host');
             },
         ]);
+
+        $this->expectException(InvalidOptionsException::class);
+        $this->expectExceptionMessage('The nested option "database" with value null is expected to be of type array, but is of type "null".');
+
         $this->resolver->resolve([
             'database' => null,
         ]);
     }
 
-    public function testResolveNestedOptionsWithoutDefault()
+    /**
+     * @group legacy
+     */
+    public function testLegacyResolveNestedOptionsWithoutDefault()
     {
+        $this->expectDeprecation('Since symfony/options-resolver 7.3: Defining nested options via "Symfony\Component\OptionsResolver\OptionsResolver::setDefault()" is deprecated and will be removed in Symfony 8.0, use "setOptions()" method instead.');
+
         $this->resolver->setDefaults([
             'name' => 'default',
             'database' => function (OptionsResolver $resolver) {
@@ -2184,8 +2237,13 @@ class OptionsResolverTest extends TestCase
         $this->assertSame($expectedOptions, $actualOptions);
     }
 
-    public function testResolveNestedOptionsWithDefault()
+    /**
+     * @group legacy
+     */
+    public function testLegacyResolveNestedOptionsWithDefault()
     {
+        $this->expectDeprecation('Since symfony/options-resolver 7.3: Defining nested options via "Symfony\Component\OptionsResolver\OptionsResolver::setDefault()" is deprecated and will be removed in Symfony 8.0, use "setOptions()" method instead.');
+
         $this->resolver->setDefaults([
             'name' => 'default',
             'database' => function (OptionsResolver $resolver) {
@@ -2206,8 +2264,13 @@ class OptionsResolverTest extends TestCase
         $this->assertSame($expectedOptions, $actualOptions);
     }
 
-    public function testResolveMultipleNestedOptions()
+    /**
+     * @group legacy
+     */
+    public function testLegacyResolveMultipleNestedOptions()
     {
+        $this->expectDeprecation('Since symfony/options-resolver 7.3: Defining nested options via "Symfony\Component\OptionsResolver\OptionsResolver::setDefault()" is deprecated and will be removed in Symfony 8.0, use "setOptions()" method instead.');
+
         $this->resolver->setDefaults([
             'name' => 'default',
             'database' => function (OptionsResolver $resolver) {
@@ -2245,8 +2308,13 @@ class OptionsResolverTest extends TestCase
         $this->assertSame($expectedOptions, $actualOptions);
     }
 
-    public function testResolveLazyOptionUsingNestedOption()
+    /**
+     * @group legacy
+     */
+    public function testLegacyResolveLazyOptionUsingNestedOption()
     {
+        $this->expectDeprecation('Since symfony/options-resolver 7.3: Defining nested options via "Symfony\Component\OptionsResolver\OptionsResolver::setDefault()" is deprecated and will be removed in Symfony 8.0, use "setOptions()" method instead.');
+
         $this->resolver->setDefaults([
             'version' => fn (Options $options) => $options['database']['server_version'],
             'database' => function (OptionsResolver $resolver) {
@@ -2261,8 +2329,13 @@ class OptionsResolverTest extends TestCase
         $this->assertSame($expectedOptions, $actualOptions);
     }
 
-    public function testNormalizeNestedOptionValue()
+    /**
+     * @group legacy
+     */
+    public function testLegacyNormalizeNestedOptionValue()
     {
+        $this->expectDeprecation('Since symfony/options-resolver 7.3: Defining nested options via "Symfony\Component\OptionsResolver\OptionsResolver::setDefault()" is deprecated and will be removed in Symfony 8.0, use "setOptions()" method instead.');
+
         $this->resolver
             ->setDefaults([
                 'database' => function (OptionsResolver $resolver) {
@@ -2287,8 +2360,13 @@ class OptionsResolverTest extends TestCase
         $this->assertSame($expectedOptions, $actualOptions);
     }
 
+    /**
+     * @group legacy
+     */
     public function testOverwrittenNestedOptionNotEvaluatedIfLazyDefault()
     {
+        $this->expectDeprecation('Since symfony/options-resolver 7.3: Defining nested options via "Symfony\Component\OptionsResolver\OptionsResolver::setDefault()" is deprecated and will be removed in Symfony 8.0, use "setOptions()" method instead.');
+
         // defined by superclass
         $this->resolver->setDefault('foo', function (OptionsResolver $resolver) {
             Assert::fail('Should not be called');
@@ -2298,8 +2376,13 @@ class OptionsResolverTest extends TestCase
         $this->assertSame(['foo' => 'lazy'], $this->resolver->resolve());
     }
 
+    /**
+     * @group legacy
+     */
     public function testOverwrittenNestedOptionNotEvaluatedIfScalarDefault()
     {
+        $this->expectDeprecation('Since symfony/options-resolver 7.3: Defining nested options via "Symfony\Component\OptionsResolver\OptionsResolver::setDefault()" is deprecated and will be removed in Symfony 8.0, use "setOptions()" method instead.');
+
         // defined by superclass
         $this->resolver->setDefault('foo', function (OptionsResolver $resolver) {
             Assert::fail('Should not be called');
@@ -2309,8 +2392,13 @@ class OptionsResolverTest extends TestCase
         $this->assertSame(['foo' => 'bar'], $this->resolver->resolve());
     }
 
+    /**
+     * @group legacy
+     */
     public function testOverwrittenLazyOptionNotEvaluatedIfNestedOption()
     {
+        $this->expectDeprecation('Since symfony/options-resolver 7.3: Defining nested options via "Symfony\Component\OptionsResolver\OptionsResolver::setDefault()" is deprecated and will be removed in Symfony 8.0, use "setOptions()" method instead.');
+
         // defined by superclass
         $this->resolver->setDefault('foo', function (Options $options) {
             Assert::fail('Should not be called');
@@ -2322,8 +2410,13 @@ class OptionsResolverTest extends TestCase
         $this->assertSame(['foo' => ['bar' => 'baz']], $this->resolver->resolve());
     }
 
-    public function testResolveAllNestedOptionDefinitions()
+    /**
+     * @group legacy
+     */
+    public function testLegacyResolveAllNestedOptionDefinitions()
     {
+        $this->expectDeprecation('Since symfony/options-resolver 7.3: Defining nested options via "Symfony\Component\OptionsResolver\OptionsResolver::setDefault()" is deprecated and will be removed in Symfony 8.0, use "setOptions()" method instead.');
+
         // defined by superclass
         $this->resolver->setDefault('foo', function (OptionsResolver $resolver) {
             $resolver->setRequired('bar');
@@ -2339,8 +2432,13 @@ class OptionsResolverTest extends TestCase
         $this->assertSame(['foo' => ['ping' => 'pong', 'bar' => 'baz']], $this->resolver->resolve());
     }
 
-    public function testNormalizeNestedValue()
+    /**
+     * @group legacy
+     */
+    public function testLegacyNormalizeNestedValue()
     {
+        $this->expectDeprecation('Since symfony/options-resolver 7.3: Defining nested options via "Symfony\Component\OptionsResolver\OptionsResolver::setDefault()" is deprecated and will be removed in Symfony 8.0, use "setOptions()" method instead.');
+
         // defined by superclass
         $this->resolver->setDefault('foo', function (OptionsResolver $resolver) {
             $resolver->setDefault('bar', null);
@@ -2354,30 +2452,48 @@ class OptionsResolverTest extends TestCase
         $this->assertSame(['foo' => ['bar' => 'baz']], $this->resolver->resolve());
     }
 
-    public function testFailsIfCyclicDependencyBetweenSameNestedOption()
+    /**
+     * @group legacy
+     */
+    public function testLegacyFailsIfCyclicDependencyBetweenSameNestedOption()
     {
-        $this->expectException(OptionDefinitionException::class);
+        $this->expectDeprecation('Since symfony/options-resolver 7.3: Defining nested options via "Symfony\Component\OptionsResolver\OptionsResolver::setDefault()" is deprecated and will be removed in Symfony 8.0, use "setOptions()" method instead.');
+
         $this->resolver->setDefault('database', function (OptionsResolver $resolver, Options $parent) {
             $resolver->setDefault('replicas', $parent['database']);
         });
+
+        $this->expectException(OptionDefinitionException::class);
+
         $this->resolver->resolve();
     }
 
-    public function testFailsIfCyclicDependencyBetweenNestedOptionAndParentLazyOption()
+    /**
+     * @group legacy
+     */
+    public function testLegacyFailsIfCyclicDependencyBetweenNestedOptionAndParentLazyOption()
     {
-        $this->expectException(OptionDefinitionException::class);
+        $this->expectDeprecation('Since symfony/options-resolver 7.3: Defining nested options via "Symfony\Component\OptionsResolver\OptionsResolver::setDefault()" is deprecated and will be removed in Symfony 8.0, use "setOptions()" method instead.');
+
         $this->resolver->setDefaults([
             'version' => fn (Options $options) => $options['database']['server_version'],
             'database' => function (OptionsResolver $resolver, Options $parent) {
                 $resolver->setDefault('server_version', $parent['version']);
             },
         ]);
+
+        $this->expectException(OptionDefinitionException::class);
+
         $this->resolver->resolve();
     }
 
-    public function testFailsIfCyclicDependencyBetweenNormalizerAndNestedOption()
+    /**
+     * @group legacy
+     */
+    public function testLegacyFailsIfCyclicDependencyBetweenNormalizerAndNestedOption()
     {
-        $this->expectException(OptionDefinitionException::class);
+        $this->expectDeprecation('Since symfony/options-resolver 7.3: Defining nested options via "Symfony\Component\OptionsResolver\OptionsResolver::setDefault()" is deprecated and will be removed in Symfony 8.0, use "setOptions()" method instead.');
+
         $this->resolver
             ->setDefault('name', 'default')
             ->setDefault('database', function (OptionsResolver $resolver, Options $parent) {
@@ -2386,23 +2502,38 @@ class OptionsResolverTest extends TestCase
             ->setNormalizer('name', function (Options $options, $value) {
                 $options['database'];
             });
+
+        $this->expectException(OptionDefinitionException::class);
+
         $this->resolver->resolve();
     }
 
-    public function testFailsIfCyclicDependencyBetweenNestedOptions()
+    /**
+     * @group legacy
+     */
+    public function testLegacyFailsIfCyclicDependencyBetweenNestedOptions()
     {
-        $this->expectException(OptionDefinitionException::class);
+        $this->expectDeprecation('Since symfony/options-resolver 7.3: Defining nested options via "Symfony\Component\OptionsResolver\OptionsResolver::setDefault()" is deprecated and will be removed in Symfony 8.0, use "setOptions()" method instead.');
+
         $this->resolver->setDefault('database', function (OptionsResolver $resolver, Options $parent) {
             $resolver->setDefault('host', $parent['replica']['host']);
         });
         $this->resolver->setDefault('replica', function (OptionsResolver $resolver, Options $parent) {
             $resolver->setDefault('host', $parent['database']['host']);
         });
+
+        $this->expectException(OptionDefinitionException::class);
+
         $this->resolver->resolve();
     }
 
-    public function testGetAccessToParentOptionFromNestedOption()
+    /**
+     * @group legacy
+     */
+    public function testLegacyGetAccessToParentOptionFromNestedOption()
     {
+        $this->expectDeprecation('Since symfony/options-resolver 7.3: Defining nested options via "Symfony\Component\OptionsResolver\OptionsResolver::setDefault()" is deprecated and will be removed in Symfony 8.0, use "setOptions()" method instead.');
+
         $this->resolver->setDefaults([
             'version' => 3.15,
             'database' => function (OptionsResolver $resolver, Options $parent) {
@@ -2430,8 +2561,13 @@ class OptionsResolverTest extends TestCase
         $this->assertSame(['foo' => $closure], $this->resolver->resolve());
     }
 
-    public function testResolveLazyOptionWithTransitiveDefaultDependency()
+    /**
+     * @group legacy
+     */
+    public function testLegacyResolveLazyOptionWithTransitiveDefaultDependency()
     {
+        $this->expectDeprecation('Since symfony/options-resolver 7.3: Defining nested options via "Symfony\Component\OptionsResolver\OptionsResolver::setDefault()" is deprecated and will be removed in Symfony 8.0, use "setOptions()" method instead.');
+
         $this->resolver->setDefaults([
             'ip' => null,
             'database' => function (OptionsResolver $resolver, Options $parent) {
@@ -2454,8 +2590,13 @@ class OptionsResolverTest extends TestCase
         $this->assertSame($expectedOptions, $actualOptions);
     }
 
-    public function testAccessToParentOptionFromNestedNormalizerAndLazyOption()
+    /**
+     * @group legacy
+     */
+    public function testLegacyAccessToParentOptionFromNestedNormalizerAndLazyOption()
     {
+        $this->expectDeprecation('Since symfony/options-resolver 7.3: Defining nested options via "Symfony\Component\OptionsResolver\OptionsResolver::setDefault()" is deprecated and will be removed in Symfony 8.0, use "setOptions()" method instead.');
+
         $this->resolver->setDefaults([
             'debug' => true,
             'database' => function (OptionsResolver $resolver, Options $parent) {
@@ -2495,6 +2636,11 @@ class OptionsResolverTest extends TestCase
             ->normalize(static fn (Options $options, $value) => $value)
             ->info('info message')
         ;
+        $this->resolver->define('table')
+            ->options(function (OptionsResolver $resolver) {
+                $resolver->setDefault('ping', 'pong');
+            })
+        ;
         $introspector = new OptionsResolverIntrospector($this->resolver);
 
         $this->assertTrue(true, $this->resolver->isDefined('foo'));
@@ -2505,6 +2651,7 @@ class OptionsResolverTest extends TestCase
         $this->assertSame(['bar', 'zab'], $introspector->getAllowedValues('foo'));
         $this->assertCount(1, $introspector->getNormalizers('foo'));
         $this->assertSame('info message', $this->resolver->getInfo('foo'));
+        $this->assertTrue($this->resolver->isNested('table'));
     }
 
     public function testGetInfo()
@@ -2527,6 +2674,18 @@ class OptionsResolverTest extends TestCase
         });
 
         $this->resolver->resolve(['foo' => 'bar']);
+    }
+
+    public function testSetNestedOnNormalization()
+    {
+        $this->expectException(AccessException::class);
+        $this->expectExceptionMessage('Nested options cannot be defined from a lazy option or normalizer.');
+
+        $this->resolver->setDefault('foo', function (Options $options) {
+            $options->setOptions('foo', function () {});
+        });
+
+        $this->resolver->resolve();
     }
 
     public function testSetInfoOnUndefinedOption()
@@ -2562,36 +2721,42 @@ class OptionsResolverTest extends TestCase
         $this->resolver->resolve(['expires' => new \DateTimeImmutable('-1 hour')]);
     }
 
-    public function testInvalidValueForPrototypeDefinition()
+    /**
+     * @group legacy
+     */
+    public function testLegacyInvalidValueForPrototypeDefinition()
     {
-        $this->expectException(InvalidOptionsException::class);
-        $this->expectExceptionMessage('The value of the option "connections" is expected to be of type array of array, but is of type array of "string".');
+        $this->expectDeprecation('Since symfony/options-resolver 7.3: Defining nested options via "Symfony\Component\OptionsResolver\OptionsResolver::setDefault()" is deprecated and will be removed in Symfony 8.0, use "setOptions()" method instead.');
 
         $this->resolver
             ->setDefault('connections', static function (OptionsResolver $resolver) {
                 $resolver
                     ->setPrototype(true)
-                    ->setDefined(['table', 'user', 'password'])
-                ;
-            })
-        ;
+                    ->setDefined(['table', 'user', 'password']);
+            });
+
+        $this->expectException(InvalidOptionsException::class);
+        $this->expectExceptionMessage('The value of the option "connections" is expected to be of type array of array, but is of type array of "string".');
 
         $this->resolver->resolve(['connections' => ['foo']]);
     }
 
-    public function testMissingOptionForPrototypeDefinition()
+    /**
+     * @group legacy
+     */
+    public function testLegacyMissingOptionForPrototypeDefinition()
     {
-        $this->expectException(MissingOptionsException::class);
-        $this->expectExceptionMessage('The required option "connections[1][table]" is missing.');
+        $this->expectDeprecation('Since symfony/options-resolver 7.3: Defining nested options via "Symfony\Component\OptionsResolver\OptionsResolver::setDefault()" is deprecated and will be removed in Symfony 8.0, use "setOptions()" method instead.');
 
         $this->resolver
             ->setDefault('connections', static function (OptionsResolver $resolver) {
                 $resolver
                     ->setPrototype(true)
-                    ->setRequired('table')
-                ;
-            })
-        ;
+                    ->setRequired('table');
+            });
+
+        $this->expectException(MissingOptionsException::class);
+        $this->expectExceptionMessage('The required option "connections[1][table]" is missing.');
 
         $this->resolver->resolve(['connections' => [
             ['table' => 'default'],
@@ -2607,8 +2772,13 @@ class OptionsResolverTest extends TestCase
         $this->resolver->setPrototype(true);
     }
 
-    public function testPrototypeDefinition()
+    /**
+     * @group legacy
+     */
+    public function testLegacyPrototypeDefinition()
     {
+        $this->expectDeprecation('Since symfony/options-resolver 7.3: Defining nested options via "Symfony\Component\OptionsResolver\OptionsResolver::setDefault()" is deprecated and will be removed in Symfony 8.0, use "setOptions()" method instead.');
+
         $this->resolver
             ->setDefault('connections', static function (OptionsResolver $resolver) {
                 $resolver
@@ -2644,6 +2814,512 @@ class OptionsResolverTest extends TestCase
                     'table' => 'symfony',
                 ],
             ],
+        ];
+
+        $this->assertSame($expectedOptions, $actualOptions);
+    }
+
+    public function testPrototypeDefinition()
+    {
+        $this->resolver
+            ->setOptions('connections', static function (OptionsResolver $resolver) {
+                $resolver
+                    ->setPrototype(true)
+                    ->setRequired('table')
+                    ->setDefaults(['user' => 'root', 'password' => null]);
+            });
+
+        $actualOptions = $this->resolver->resolve([
+            'connections' => [
+                'default' => [
+                    'table' => 'default',
+                ],
+                'custom' => [
+                    'user' => 'foo',
+                    'password' => 'pa$$',
+                    'table' => 'symfony',
+                ],
+            ],
+        ]);
+        $expectedOptions = [
+            'connections' => [
+                'default' => [
+                    'user' => 'root',
+                    'password' => null,
+                    'table' => 'default',
+                ],
+                'custom' => [
+                    'user' => 'foo',
+                    'password' => 'pa$$',
+                    'table' => 'symfony',
+                ],
+            ],
+        ];
+
+        $this->assertSame($expectedOptions, $actualOptions);
+    }
+
+    public function testInvalidValueForPrototypeDefinition()
+    {
+        $this->resolver
+            ->setOptions('connections', static function (OptionsResolver $resolver) {
+                $resolver
+                    ->setPrototype(true)
+                    ->setDefined(['table', 'user', 'password']);
+            });
+
+        $this->expectException(InvalidOptionsException::class);
+        $this->expectExceptionMessage('The value of the option "connections" is expected to be of type array of array, but is of type array of "string".');
+
+        $this->resolver->resolve(['connections' => ['foo']]);
+    }
+
+    public function testMissingOptionForPrototypeDefinition()
+    {
+        $this->resolver
+            ->setOptions('connections', static function (OptionsResolver $resolver) {
+                $resolver
+                    ->setPrototype(true)
+                    ->setRequired('table');
+            });
+
+        $this->expectException(MissingOptionsException::class);
+        $this->expectExceptionMessage('The required option "connections[1][table]" is missing.');
+
+        $this->resolver->resolve(['connections' => [
+            ['table' => 'default'],
+            [], // <- missing required option "table"
+        ]]);
+    }
+
+    public function testResolveFailsIfInvalidValueFromNestedOption()
+    {
+        $this->resolver->setOptions('foo', function (OptionsResolver $resolver) {
+            $resolver
+                ->setDefined('bar')
+                ->setAllowedValues('bar', 'valid value');
+        });
+
+        $this->expectException(InvalidOptionsException::class);
+        $this->expectExceptionMessage('The option "foo[bar]" with value "invalid value" is invalid. Accepted values are: "valid value".');
+
+        $this->resolver->resolve(['foo' => ['bar' => 'invalid value']]);
+    }
+
+    public function testResolveFailsIfInvalidTypeFromNestedOption()
+    {
+        $this->resolver->setOptions('foo', function (OptionsResolver $resolver) {
+            $resolver
+                ->setDefined('bar')
+                ->setAllowedTypes('bar', 'string');
+        });
+
+        $this->expectException(InvalidOptionsException::class);
+        $this->expectExceptionMessage('The option "foo[bar]" with value 1 is expected to be of type "string", but is of type "int".');
+
+        $this->resolver->resolve(['foo' => ['bar' => 1]]);
+    }
+
+    public function testIsNestedOption()
+    {
+        $this->resolver->setOptions('database', function (OptionsResolver $resolver) {
+            $resolver->setDefined(['host', 'port']);
+        });
+
+        $this->assertTrue($this->resolver->isNested('database'));
+    }
+
+    public function testFailsIfUndefinedNestedOption()
+    {
+        $this->resolver
+            ->setDefault('name', 'default')
+            ->setOptions('database', function (OptionsResolver $resolver) {
+                $resolver->setDefined(['host', 'port']);
+            });
+
+        $this->expectException(UndefinedOptionsException::class);
+        $this->expectExceptionMessage('The option "database[foo]" does not exist. Defined options are: "host", "port".');
+
+        $this->resolver->resolve([
+            'database' => ['foo' => 'bar'],
+        ]);
+    }
+
+    public function testFailsIfMissingRequiredNestedOption()
+    {
+        $this->resolver
+            ->setDefault('name', 'default')
+            ->setOptions('database', function (OptionsResolver $resolver) {
+                $resolver->setRequired('host');
+            });
+
+        $this->expectException(MissingOptionsException::class);
+        $this->expectExceptionMessage('The required option "database[host]" is missing.');
+
+        $this->resolver->resolve([
+            'database' => [],
+        ]);
+    }
+
+    public function testFailsIfInvalidTypeNestedOption()
+    {
+        $this->resolver
+            ->setDefault('name', 'default')
+            ->setOptions('database', function (OptionsResolver $resolver) {
+                $resolver
+                    ->setDefined('logging')
+                    ->setAllowedTypes('logging', 'bool');
+            });
+
+        $this->expectException(InvalidOptionsException::class);
+        $this->expectExceptionMessage('The option "database[logging]" with value null is expected to be of type "bool", but is of type "null".');
+
+        $this->resolver->resolve([
+            'database' => ['logging' => null],
+        ]);
+    }
+
+    public function testFailsIfNotArrayIsGivenForNestedOptions()
+    {
+        $this->resolver
+            ->setDefault('name', 'default')
+            ->setOptions('database', function (OptionsResolver $resolver) {
+                $resolver->setDefined('host');
+            });
+
+        $this->expectException(InvalidOptionsException::class);
+        $this->expectExceptionMessage('The nested option "database" with value null is expected to be of type array, but is of type "null".');
+
+        $this->resolver->resolve([
+            'database' => null,
+        ]);
+    }
+
+    public function testResolveNestedOptionsWithoutDefault()
+    {
+        $this->resolver
+            ->setDefault('name', 'default')
+            ->setOptions('database', function (OptionsResolver $resolver) {
+                $resolver->setDefined(['host', 'port']);
+            });
+
+        $actualOptions = $this->resolver->resolve();
+        $expectedOptions = [
+            'name' => 'default',
+            'database' => [],
+        ];
+
+        $this->assertSame($expectedOptions, $actualOptions);
+    }
+
+    public function testResolveNestedOptionsWithDefault()
+    {
+        $this->resolver
+            ->setDefault('name', 'default')
+            ->setOptions('database', function (OptionsResolver $resolver) {
+                $resolver->setDefaults([
+                    'host' => 'localhost',
+                    'port' => 3306,
+                ]);
+            });
+
+        $actualOptions = $this->resolver->resolve();
+        $expectedOptions = [
+            'name' => 'default',
+            'database' => [
+                'host' => 'localhost',
+                'port' => 3306,
+            ],
+        ];
+
+        $this->assertSame($expectedOptions, $actualOptions);
+    }
+
+    public function testResolveMultipleNestedOptions()
+    {
+        $this->resolver
+            ->setDefaults(['name' => 'default'])
+            ->setOptions('database', function (OptionsResolver $resolver) {
+                $resolver
+                    ->setRequired(['dbname', 'host'])
+                    ->setDefaults(['port' => 3306])
+                    ->setOptions('replicas', function (OptionsResolver $resolver) {
+                        $resolver->setDefaults([
+                            'host' => 'replica1',
+                            'port' => 3306,
+                        ]);
+                    });
+            });
+
+        $actualOptions = $this->resolver->resolve([
+            'name' => 'custom',
+            'database' => [
+                'dbname' => 'test',
+                'host' => 'localhost',
+                'port' => null,
+                'replicas' => ['host' => 'replica2'],
+            ],
+        ]);
+        $expectedOptions = [
+            'name' => 'custom',
+            'database' => [
+                'port' => null,
+                'replicas' => ['port' => 3306, 'host' => 'replica2'],
+                'dbname' => 'test',
+                'host' => 'localhost',
+            ],
+        ];
+        $this->assertSame($expectedOptions, $actualOptions);
+    }
+
+    public function testResolveLazyOptionUsingNestedOption()
+    {
+        $this->resolver
+            ->setDefault('version', function (Options $options) {
+                return $options['database']['server_version'];
+            })
+            ->setOptions('database', function (OptionsResolver $resolver) {
+                $resolver->setDefault('server_version', '3.15');
+            });
+
+        $actualOptions = $this->resolver->resolve();
+        $expectedOptions = [
+            'database' => ['server_version' => '3.15'],
+            'version' => '3.15',
+        ];
+
+        $this->assertSame($expectedOptions, $actualOptions);
+    }
+
+    public function testNormalizeNestedOptionValue()
+    {
+        $this->resolver
+            ->setOptions('database', function (OptionsResolver $resolver) {
+                $resolver->setDefaults([
+                    'port' => 3306,
+                    'host' => 'localhost',
+                    'dbname' => 'demo',
+                ]);
+            })
+            ->setNormalizer('database', function (Options $options, $value) {
+                ksort($value);
+
+                return $value;
+            });
+
+        $actualOptions = $this->resolver->resolve([
+            'database' => ['dbname' => 'test'],
+        ]);
+        $expectedOptions = [
+            'database' => ['dbname' => 'test', 'host' => 'localhost', 'port' => 3306],
+        ];
+
+        $this->assertSame($expectedOptions, $actualOptions);
+    }
+
+    public function testNestedOptionEvaluatedWithLazyDefault()
+    {
+        // defined by superclass
+        $this->resolver->setOptions('foo', function (OptionsResolver $resolver) {
+            $resolver->define('bar')->allowedTypes('string');
+        });
+        // defined by subclass
+        $this->resolver->setDefault('foo', fn (Options $options) => ['bar' => 'lazy']);
+
+        $this->assertSame(['foo' => ['bar' => 'lazy']], $this->resolver->resolve());
+    }
+
+    public function testNestedOptionWithDefault()
+    {
+        // defined by superclass
+        $this->resolver->setOptions('foo', function (OptionsResolver $resolver) {
+            $resolver->define('bar')->allowedTypes('string');
+        });
+        // defined by subclass
+        $this->resolver->setDefault('foo', ['bar' => 'default']);
+
+        $this->assertSame(['foo' => ['bar' => 'default']], $this->resolver->resolve());
+    }
+
+    public function testResolveAllNestedOptionDefinitions()
+    {
+        // defined by superclass
+        $this->resolver->setOptions('foo', function (OptionsResolver $resolver) {
+            $resolver->setRequired('bar');
+        });
+        // defined by subclass
+        $this->resolver->setOptions('foo', function (OptionsResolver $resolver) {
+            $resolver->setDefault('bar', 'baz');
+        });
+        // defined by subclass
+        $this->resolver->setOptions('foo', function (OptionsResolver $resolver) {
+            $resolver->setDefault('ping', 'pong');
+        });
+        $this->assertSame(['foo' => ['ping' => 'pong', 'bar' => 'baz']], $this->resolver->resolve());
+    }
+
+    public function testSetNestedOptionWithInvalidDefault()
+    {
+        // defined by superclass
+        $this->resolver->setOptions('foo', function (OptionsResolver $resolver) {
+            $resolver->define('bar')->allowedTypes('int');
+        });
+        // defined by subclass
+        $this->resolver->setDefault('foo', ['bar' => 'invalid']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The option "foo[bar]" with value "invalid" is expected to be of type "int", but is of type "string".');
+
+        $this->resolver->resolve();
+    }
+
+    public function testSetNestedOptionWithInvalidLazyDefault()
+    {
+        // defined by superclass
+        $this->resolver->setOptions('foo', function (OptionsResolver $resolver) {
+            $resolver->define('bar')->allowedTypes('int');
+        });
+        // defined by subclass
+        $this->resolver->setDefault('foo', function (Options $options) {
+            return ['bar' => 'invalid'];
+        });
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The option "foo[bar]" with value "invalid" is expected to be of type "int", but is of type "string".');
+
+        $this->resolver->resolve();
+    }
+
+    public function testNormalizeNestedValue()
+    {
+        // defined by superclass
+        $this->resolver->setOptions('foo', function (OptionsResolver $resolver) {
+            $resolver->setDefault('bar', null);
+        });
+        // defined by subclass
+        $this->resolver->setNormalizer('foo', function (Options $options, $resolvedValue) {
+            $resolvedValue['bar'] ??= 'baz';
+
+            return $resolvedValue;
+        });
+
+        $this->assertSame(['foo' => ['bar' => 'baz']], $this->resolver->resolve());
+    }
+
+    public function testFailsIfCyclicDependencyBetweenSameNestedOption()
+    {
+        $this->resolver->setOptions('database', function (OptionsResolver $resolver, Options $parent) {
+            $resolver->setDefault('replicas', $parent['database']);
+        });
+
+        $this->expectException(OptionDefinitionException::class);
+
+        $this->resolver->resolve();
+    }
+
+    public function testFailsIfCyclicDependencyBetweenNestedOptionAndParentLazyOption()
+    {
+        $this->resolver
+            ->setDefault('version', function (Options $options) {
+                return $options['database']['server_version'];
+            })
+            ->setOptions('database', function (OptionsResolver $resolver, Options $parent) {
+                $resolver->setDefault('server_version', $parent['version']);
+            });
+
+        $this->expectException(OptionDefinitionException::class);
+
+        $this->resolver->resolve();
+    }
+
+    public function testFailsIfCyclicDependencyBetweenNormalizerAndNestedOption()
+    {
+        $this->resolver
+            ->setDefault('name', 'default')
+            ->setOptions('database', function (OptionsResolver $resolver, Options $parent) {
+                $resolver->setDefault('host', $parent['name']);
+            })
+            ->setNormalizer('name', function (Options $options, $value) {
+                $options['database'];
+            });
+
+        $this->expectException(OptionDefinitionException::class);
+
+        $this->resolver->resolve();
+    }
+
+    public function testFailsIfCyclicDependencyBetweenNestedOptions()
+    {
+        $this->resolver->setOptions('database', function (OptionsResolver $resolver, Options $parent) {
+            $resolver->setDefault('host', $parent['replica']['host']);
+        });
+        $this->resolver->setOptions('replica', function (OptionsResolver $resolver, Options $parent) {
+            $resolver->setDefault('host', $parent['database']['host']);
+        });
+
+        $this->expectException(OptionDefinitionException::class);
+
+        $this->resolver->resolve();
+    }
+
+    public function testGetAccessToParentOptionFromNestedOption()
+    {
+        $this->resolver
+            ->setDefault('version', 3.15)
+            ->setOptions('database', function (OptionsResolver $resolver, Options $parent) {
+                $resolver->setDefault('server_version', $parent['version']);
+            });
+
+        $this->assertSame(['version' => 3.15, 'database' => ['server_version' => 3.15]], $this->resolver->resolve());
+    }
+
+    public function testResolveLazyOptionWithTransitiveDefaultDependency()
+    {
+        $this->resolver
+            ->setDefaults([
+                'ip' => null,
+                'secondary_replica' => function (Options $options) {
+                    return $options['database']['primary_replica']['host'];
+                },
+            ])
+            ->setOptions('database', function (OptionsResolver $resolver, Options $parent) {
+                $resolver
+                    ->setDefault('host', $parent['ip'])
+                    ->setOptions('primary_replica', function (OptionsResolver $resolver, Options $parent) {
+                        $resolver->setDefault('host', $parent['host']);
+                    });
+            });
+
+        $actualOptions = $this->resolver->resolve(['ip' => '127.0.0.1']);
+        $expectedOptions = [
+            'ip' => '127.0.0.1',
+            'database' => [
+                'host' => '127.0.0.1',
+                'primary_replica' => ['host' => '127.0.0.1'],
+            ],
+            'secondary_replica' => '127.0.0.1',
+        ];
+        $this->assertSame($expectedOptions, $actualOptions);
+    }
+
+    public function testAccessToParentOptionFromNestedNormalizerAndLazyOption()
+    {
+        $this->resolver
+            ->setDefault('debug', true)
+            ->setOptions('database', function (OptionsResolver $resolver, Options $parent) {
+                $resolver
+                    ->setDefined('logging')
+                    ->setDefault('profiling', fn (Options $options) => $parent['debug'])
+                    ->setNormalizer('logging', fn (Options $options, $value) => false === $parent['debug'] ? true : $value);
+            });
+
+        $actualOptions = $this->resolver->resolve([
+            'debug' => false,
+            'database' => ['logging' => false],
+        ]);
+        $expectedOptions = [
+            'debug' => false,
+            'database' => ['profiling' => false, 'logging' => true],
         ];
 
         $this->assertSame($expectedOptions, $actualOptions);

--- a/src/Symfony/Component/RateLimiter/RateLimiterFactory.php
+++ b/src/Symfony/Component/RateLimiter/RateLimiterFactory.php
@@ -82,7 +82,7 @@ final class RateLimiterFactory implements RateLimiterFactoryInterface
             ->define('limit')->allowedTypes('int')
             ->define('interval')->allowedTypes('string')->normalize($intervalNormalizer)
             ->define('rate')
-                ->default(function (OptionsResolver $rate) use ($intervalNormalizer) {
+                ->options(function (OptionsResolver $rate) use ($intervalNormalizer) {
                     $rate
                         ->define('amount')->allowedTypes('int')->default(1)
                         ->define('interval')->allowedTypes('string')->normalize($intervalNormalizer)

--- a/src/Symfony/Component/RateLimiter/composer.json
+++ b/src/Symfony/Component/RateLimiter/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=8.2",
-        "symfony/options-resolver": "^6.4|^7.0"
+        "symfony/options-resolver": "^7.3"
     },
     "require-dev": {
         "psr/cache": "^1.0|^2.0|^3.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | -
| License       | MIT

this removes unnecessary limitations that I hadn't considered when introducing nested options feature in https://github.com/symfony/symfony/pull/27291.

#### 1. Allow defining default values for nested options

Imagine you want to define the following nested option in a generic form type:

```php
class GenericType extends AbstractType
{
    public function configureOptions(OptionsResolver $resolver): void
    {
        $resolver->setDefault('foo', function (OptionsResolver $foo) {
            $foo->define('bar')->allowedTypes('int');
        });
    }
}
```

then, I'd like to define a concrete type with a default value for it.

```php
class ConcreteType extends AbstractType
{
    public function configureOptions(OptionsResolver $resolver): void
    {
        $resolver->setDefault('foo', ['bar' => 23]);
    }

    public function getParent(): string
    {
        return GenericType::class;
    }
}
```

this might seem unexpected, but the fact is that the nested definition for `foo` option in `ConcreteType` is gone. As a result, when resolved, the `foo` option will have a default value (`['bar' => 23]`) but without any constraints, allowing end users any value/type to be passed through this option for `ConcreteType` instances

For example, passing `['foo' => false]` as options for `ConcreteType` would be allowed, instead of requiring an array where `bar` expects an integer value.

#### 2. Allow defining lazy default for nested options

the same problem would occur with a lazy default for a nested definition:

```php
class ConcreteType extends AbstractType
{
    public function configureOptions(OptionsResolver $resolver): void
    {
        $resolver->setRequired(['baz'])
        $resolver->setDefault('foo', function (Options $options) {
            return ['bar' => $options['baz']];
        });
    }

    public function getParent(): string
    {
        return GenericType::class;
    }
}
```

the issue here is the same as in the previous example, meaning this new default essentially overrides/removes the original nested definition

---

the two features mentioned earlier are now supported by introducing a new method `setOptions()`, which separates the nested definition from its default value (whether direct or lazy). Additionally this PR deprecates the practice of defining nested options using `setDefault()` method

this also enables the ability to set default values for prototyped options, which wasn't possible before. For example:
```php
class NavigatorType extends AbstractType
{
    public function configureOptions(OptionsResolver $resolver): void
    {
        $resolver->define('buttons')
            ->options(function (OptionsResolver $buttons) {
                $buttons->setPrototype(true);
                $buttons->define('name')->required()->allowedTypes('string');
                $buttons->define('type')->default(SubmitType::class)->allowedTypes('string');
                $buttons->define('options')->default([])->allowedTypes('array'); 
            })
            ->default([
                'back' => ['name' => 'back', 'options' => ['validate' => false, 'validation_groups' => false]],
                'next' => ['name' => 'next'],
                'submit' => ['name' => 'submit'],
            ]);
    }
}
```

cheers!