### PR TITLE
[Config][FrameworkBundle] Generate JSON schema for config

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -17,6 +17,7 @@ CHANGELOG
  * Add support for union types with `Symfony\Component\EventDispatcher\Attribute\AsEventListener`
  * Add `framework.allowed_http_method_override` option
  * Initialize `router.request_context`'s `_locale` parameter to `%kernel.default_locale%`
+ * Generate JSON schema for YAML configuration of bundles
 
 7.3
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ConfigSchemaCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ConfigSchemaCacheWarmer.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\CacheWarmer;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Config\Definition\ArrayNode;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\JsonSchemaGenerator;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\ConfigurationExtensionInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ContainerBag;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * Generate config json schema.
+ */
+final readonly class ConfigSchemaCacheWarmer implements CacheWarmerInterface
+{
+    public function __construct(
+        private KernelInterface $kernel,
+        private ?LoggerInterface $logger = null,
+    ) {
+    }
+
+    public function warmUp(string $cacheDir, ?string $buildDir = null): array
+    {
+        if (!$buildDir || !$this->kernel->isDebug() || !class_exists(JsonSchemaGenerator::class)) {
+            return [];
+        }
+
+        $generator = new JsonSchemaGenerator(\dirname($this->kernel->getBuildDir()).'/config.schema.json');
+
+        if ($this->kernel instanceof Kernel) {
+            /** @var ContainerBuilder $container */
+            $container = \Closure::bind(function (Kernel $kernel) {
+                $containerBuilder = $kernel->getContainerBuilder();
+                $kernel->prepareContainer($containerBuilder);
+
+                return $containerBuilder;
+            }, null, $this->kernel)($this->kernel);
+
+            $extensions = $container->getExtensions();
+        } else {
+            $extensions = [];
+            foreach ($this->kernel->getBundles() as $bundle) {
+                $extension = $bundle->getContainerExtension();
+                if (null !== $extension) {
+                    $extensions[] = $extension;
+                }
+            }
+        }
+
+        $tree = new ArrayNode($this->kernel->getEnvironment());
+        foreach ($extensions as $extension) {
+            try {
+                $configuration = null;
+                if ($extension instanceof ConfigurationInterface) {
+                    $configuration = $extension;
+                } elseif ($extension instanceof ConfigurationExtensionInterface) {
+                    $container = $this->kernel->getContainer();
+                    $configuration = $extension->getConfiguration([], new ContainerBuilder($container instanceof Container ? new ContainerBag($container) : new ParameterBag()));
+                }
+
+                if (!$extensionConfigNode = $configuration?->getConfigTreeBuilder()->buildTree()) {
+                    continue;
+                }
+
+                $tree->addChild($extensionConfigNode);
+            } catch (\Exception $e) {
+                $this->logger?->warning('Failed to generate JSON schema for extension {extensionClass}: '.$e->getMessage(), ['exception' => $e, 'extensionClass' => $extension::class]);
+            }
+        }
+
+        try {
+            $generator->merge($tree, (object) [
+                'description' => 'Symfony configuration',
+                'properties' => (object) [
+                    'when@'.$tree->getName() => ['$ref' => '#/definitions/'.$tree->getName()],
+                ],
+                'patternProperties' => (object) [
+                    'when@[a-zA-Z0-9]+' => ['$ref' => '#/'],
+                ],
+            ]);
+        } catch (\Exception $e) {
+            $this->logger?->warning('Failed to generate JSON schema for the configuration: '.$e->getMessage(), ['exception' => $e]);
+        }
+
+        // No need to preload anything
+        return [];
+    }
+
+    public function isOptional(): bool
+    {
+        return true;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 use Psr\Clock\ClockInterface as PsrClockInterface;
 use Psr\EventDispatcher\EventDispatcherInterface as PsrEventDispatcherInterface;
 use Symfony\Bundle\FrameworkBundle\CacheWarmer\ConfigBuilderCacheWarmer;
+use Symfony\Bundle\FrameworkBundle\CacheWarmer\ConfigSchemaCacheWarmer;
 use Symfony\Bundle\FrameworkBundle\HttpCache\HttpCache;
 use Symfony\Component\Clock\Clock;
 use Symfony\Component\Clock\ClockInterface;
@@ -235,6 +236,10 @@ return static function (ContainerConfigurator $container) {
                 service('container.getenv'),
             ])
         ->set('config_builder.warmer', ConfigBuilderCacheWarmer::class)
+            ->args([service(KernelInterface::class), service('logger')->nullOnInvalid()])
+            ->tag('kernel.cache_warmer')
+
+        ->set('config_schema.warmer', ConfigSchemaCacheWarmer::class)
             ->args([service(KernelInterface::class), service('logger')->nullOnInvalid()])
             ->tag('kernel.cache_warmer')
 

--- a/src/Symfony/Component/Config/CHANGELOG.md
+++ b/src/Symfony/Component/Config/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
  * Deprecate accessing the internal scope of the loader in PHP config files, use only its public API instead
  * Deprecate setting a default value to a node that is required, and vice versa
  * Deprecate generating fluent methods in config builders
+ * Add `JsonSchemaGenerator` to generate JSON Schema from configuration definitions
 
 7.3
 ---

--- a/src/Symfony/Component/Config/Definition/BaseNode.php
+++ b/src/Symfony/Component/Config/Definition/BaseNode.php
@@ -170,6 +170,14 @@ abstract class BaseNode implements NodeInterface
     }
 
     /**
+     * @internal
+     */
+    public function getEquivalentValues(): array
+    {
+        return $this->equivalentValues;
+    }
+
+    /**
      * Set this node as required.
      */
     public function setRequired(bool $boolean): void

--- a/src/Symfony/Component/Config/Definition/BooleanNode.php
+++ b/src/Symfony/Component/Config/Definition/BooleanNode.php
@@ -29,6 +29,11 @@ class BooleanNode extends ScalarNode
         parent::__construct($name, $parent, $pathSeparator);
     }
 
+    public function isNullable(): bool
+    {
+        return $this->nullable;
+    }
+
     protected function validateType(mixed $value): void
     {
         if (!\is_bool($value)) {

--- a/src/Symfony/Component/Config/Definition/JsonSchemaGenerator.php
+++ b/src/Symfony/Component/Config/Definition/JsonSchemaGenerator.php
@@ -1,0 +1,236 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Definition;
+
+use Symfony\Component\Config\Definition\Builder\ExprBuilder;
+
+/**
+ * @experimental
+ */
+final readonly class JsonSchemaGenerator
+{
+    public function __construct(private string $outputPath)
+    {
+    }
+
+    public function merge(NodeInterface $node, \stdClass $schema = new \stdClass()): void
+    {
+        if (file_exists($this->outputPath)) {
+            $previousSchema = json_decode(file_get_contents($this->outputPath), flags: \JSON_THROW_ON_ERROR);
+            foreach ($previousSchema as $key => $value) {
+                $schema->$key ??= $value;
+            }
+        }
+
+        if (!\in_array($ref = '#/definitions/'.$node->getName(), array_column($schema->anyOf ??= [], '$ref'))) {
+            $schema->anyOf[] = (object) ['$ref' => $ref];
+        }
+
+        $this->build($node, $schema);
+    }
+
+    public function build(NodeInterface $node, \stdClass $schema = new \stdClass()): void
+    {
+        $rootNodeName = $node->getName() ?? 'root';
+
+        $schema->{'$schema'} ??= 'http://json-schema.org/draft-06/schema#';
+        if (!isset($schema->anyOf)) {
+            $schema->{'$ref'} ??= '#/definitions/'.$rootNodeName;
+        }
+        $schema->definitions ??= new \stdClass();
+        $schema->definitions->$rootNodeName = $this->buildSingleNode($node, $schema->definitions, allowParam: false);
+        $schema->definitions->param = (object) [
+            '$comment' => 'Container parameter',
+            'type' => 'string',
+            'pattern' => '^%[^%]+%$',
+        ];
+
+        file_put_contents($this->outputPath, json_encode($schema, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_THROW_ON_ERROR)."\n");
+    }
+
+    private function buildSingleNode(NodeInterface $node, \stdClass $definitions, bool $allowParam = true): \stdClass
+    {
+        $schema = (object) match (\count($types = $this->createSubSchemas($node, $definitions, $allowParam))) {
+            1 => $types[0],
+            default => ['anyOf' => $types],
+        };
+
+        if ($node->hasDefaultValue()) {
+            $schema->default = $node->getDefaultValue();
+        }
+
+        if ($node instanceof BaseNode) {
+            if ($info = $node->getInfo()) {
+                $schema->description = $info;
+            }
+
+            if ($node->isDeprecated()) {
+                $schema->deprecated = true;
+                $schema->deprecationMessage = $node->getDeprecationMessage($node);
+            }
+        }
+
+        if (!isset($schema->{'$ref'})) {
+            $schema = $this->getReference($schema, $definitions);
+        }
+
+        return $schema;
+    }
+
+    private function createSubSchemas(NodeInterface $node, \stdClass $definitions, bool $allowParam = true): array
+    {
+        [$schema, $validateValue, $allowNull] = match (true) {
+            $node instanceof BooleanNode => [(object) ['type' => 'boolean'], is_bool(...), null],
+            $node instanceof IntegerNode => [$this->createNumericSchema($node), is_int(...), null],
+            $node instanceof NumericNode => [$this->createNumericSchema($node), is_float(...), false],
+            $node instanceof StringNode => [(object) ['type' => 'string'], is_string(...), ($node->isRequired() && $node->getAllowEmptyValue()) ?: null],
+            $node instanceof EnumNode => [$schema = $this->createEnumSchema($node), static fn ($v) => \in_array($v, $schema->enum), null],
+            $node instanceof PrototypedArrayNode => [$this->createArraySchema($node, $definitions), static fn () => false, null],
+            $node instanceof ArrayNode => [$this->createObjectSchema($node, $definitions), static fn () => false, null],
+            $node instanceof ScalarNode => [(object) ['type' => ['boolean', 'number', 'string']], is_scalar(...), null],
+            default => [new \stdClass(), static fn () => true, null],
+        };
+
+        $allowNull ??= (!$node->isRequired() && ($node->hasDefaultValue() || ($node instanceof VariableNode && $node->getAllowEmptyValue())))
+            || ($node->hasDefaultValue() && null === $node->getDefaultValue());
+
+        $allowedExtraValues = [];
+        $subSchemas = null;
+        if ($node instanceof BaseNode && $normalizedTypes = $node->getNormalizedTypes()) {
+            $allowedExtraValues = array_column($node->getEquivalentValues(), 0);
+            $allowNull = $allowNull || \in_array(ExprBuilder::TYPE_NULL, $normalizedTypes);
+            if (\in_array(ExprBuilder::TYPE_ANY, $normalizedTypes)) {
+                // This will make IDEs not complain about configurations containing complex beforeNormalization logic
+                $subSchemas[] = new \stdClass();
+            }
+            if (!\in_array('array', (array) ($schema->type ?? [])) && \in_array(ExprBuilder::TYPE_ARRAY, $normalizedTypes, true)) {
+                $subSchemas[] = (object) ['type' => $allowNull ? ['array', 'null'] : 'array'];
+            }
+            if (!\in_array('string', (array) ($schema->type ?? [])) && \in_array(ExprBuilder::TYPE_STRING, $normalizedTypes, true)) {
+                $subSchemas[] = (object) ['type' => $allowNull ? ['string', 'null'] : 'string'];
+            }
+        }
+
+        if ($node->hasDefaultValue() && !\in_array($defaultValue = $node->getDefaultValue(), $allowedExtraValues, true)) {
+            $allowedExtraValues[] = $defaultValue;
+        }
+
+        foreach ($allowedExtraValues as $i => $allowedExtraValue) {
+            if (null !== $allowedExtraValue && !\is_scalar($allowedExtraValue)) {
+                // IDEs don't seem to understand non-scalar values in "enum", so let's create separate sub-schema
+                unset($allowedExtraValues[$i]);
+                if (\is_array($allowedExtraValue) && array_is_list($allowedExtraValue)) {
+                    $subSchemas[] = (object) ['const' => $allowedExtraValue];
+                }
+            }
+        }
+
+        if ($allowedValues = array_values(array_filter($allowedExtraValues, static fn (mixed $value) => !$validateValue($value)))) {
+            if (!isset($schema->enum)) {
+                // Append "boolean" to "type" instead of [true, false] to "enum"
+                if (false !== ($true = array_search(true, $allowedValues, true)) && false !== ($false = array_search(false, $allowedValues, true))) {
+                    unset($allowedValues[$true], $allowedValues[$false]);
+                    $this->addTypeToSchema($schema, 'boolean');
+                }
+
+                // Append "null" to "type" instead of null to "enum"
+                if (false !== ($null = array_search(null, $allowedValues, true))) {
+                    unset($allowedValues[$null]);
+                    $this->addTypeToSchema($schema, 'null');
+                }
+
+                if ($allowedValues) {
+                    $subSchemas[] = (object) ['enum' => array_values($allowedValues)];
+                }
+            } else {
+                $schema->enum = array_values(array_unique(array_merge($schema->enum, $allowedValues)));
+            }
+        }
+
+        if ($schema) {
+            $subSchemas[] = $schema;
+            if ($allowParam && !\in_array('string', (array) ($schema->type ?? null))) {
+                $subSchemas[] = (object) ['$ref' => '#/definitions/param'];
+            }
+        }
+
+        $subSchemas ??= [new \stdClass()];
+
+        return $subSchemas;
+    }
+
+    private function createArraySchema(PrototypedArrayNode $node, \stdClass $definitions): \stdClass
+    {
+        $prototypeSchema = $this->buildSingleNode($node->getPrototype(), $definitions);
+        $prototypeRef = $this->getReference($prototypeSchema, $definitions);
+
+        $schema = (object) [
+            'type' => ['array', 'object'],
+            'items' => $prototypeRef,
+            'additionalProperties' => $prototypeRef,
+        ];
+
+        if ($node->getMinNumberOfElements() > 0) {
+            $schema->minItems = $schema->minProperties = $node->getMinNumberOfElements();
+        }
+
+        return $schema;
+    }
+
+    private function createObjectSchema(ArrayNode $node, \stdClass $definitions): \stdClass
+    {
+        $schema = (object) [
+            'type' => 'object',
+        ];
+
+        foreach ($node->getChildren() as $child) {
+            $schema->properties ??= new \stdClass();
+            $schema->properties->{$child->getName()} = $this->buildSingleNode($child, $definitions);
+        }
+
+        return $schema;
+    }
+
+    private function createEnumSchema(EnumNode $node): \stdClass
+    {
+        return (object) ['enum' => array_map(static fn ($v) => $v instanceof \UnitEnum ? \sprintf('!php/enum %s::%s', $v::class, $v->name) : $v, $node->getValues())];
+    }
+
+    private function createNumericSchema(NumericNode $node): \stdClass
+    {
+        $schema = (object) ['type' => $node instanceof IntegerNode ? 'integer' : 'number'];
+
+        if (null !== ($min = $node->getMin())) {
+            $schema->minimum = $min;
+        }
+
+        if (null !== ($max = $node->getMax())) {
+            $schema->maximum = $max;
+        }
+
+        return $schema;
+    }
+
+    private function addTypeToSchema(\stdClass $schema, string $type): void
+    {
+        $schema->type = (array) ($schema->type ?? []);
+        $schema->type[] = $type;
+    }
+
+    private function getReference(\stdClass $subSchema, \stdClass $definitions): \stdClass
+    {
+        $id = hash('xxh3', json_encode($subSchema));
+        $definitions->$id ??= $subSchema;
+
+        return (object) ['$ref' => '#/definitions/'.$id];
+    }
+}

--- a/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
@@ -46,6 +46,14 @@ class PrototypedArrayNode extends ArrayNode
     }
 
     /**
+     * @internal
+     */
+    public function getMinNumberOfElements(): int
+    {
+        return $this->minNumberOfElements;
+    }
+
+    /**
      * Sets the attribute which value is to be used as key.
      *
      * This is useful when you have an indexed array that should be an

--- a/src/Symfony/Component/Config/Definition/VariableNode.php
+++ b/src/Symfony/Component/Config/Definition/VariableNode.php
@@ -55,6 +55,14 @@ class VariableNode extends BaseNode implements PrototypeNodeInterface
         $this->allowEmptyValue = $boolean;
     }
 
+    /**
+     * @internal
+     */
+    public function getAllowEmptyValue(): bool
+    {
+        return $this->allowEmptyValue;
+    }
+
     public function setName(string $name): void
     {
         $this->name = $name;

--- a/src/Symfony/Component/Config/Tests/Definition/Dumper/YamlReferenceDumperTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Dumper/YamlReferenceDumperTest.php
@@ -24,7 +24,7 @@ class YamlReferenceDumperTest extends TestCase
 
         $dumper = new YamlReferenceDumper();
 
-        $this->assertEquals($this->getConfigurationAsString(), $dumper->dump($configuration));
+        $this->assertEquals($this->getConfigurationAsString(), "# \$schema: ExampleConfiguration.schema.json\n".$dumper->dump($configuration));
     }
 
     public static function provideDumpAtPath(): array
@@ -82,75 +82,6 @@ class YamlReferenceDumperTest extends TestCase
 
     private function getConfigurationAsString(): string
     {
-        return <<<'EOL'
-            acme_root:
-                boolean:              true
-                scalar_empty:         ~
-                scalar_null:          null
-                scalar_true:          true
-                scalar_false:         false
-                scalar_default:       default
-                scalar_array_empty:   []
-                scalar_array_defaults:
-
-                    # Defaults:
-                    - elem1
-                    - elem2
-                scalar_required:      ~ # Required
-                scalar_deprecated:    ~ # Deprecated (Since vendor/package 1.1: The child node "scalar_deprecated" at path "acme_root" is deprecated.)
-                scalar_deprecated_with_message: ~ # Deprecated (Since vendor/package 1.1: Deprecation custom message for "scalar_deprecated_with_message" at "acme_root")
-                node_with_a_looong_name: ~
-                enum_with_default:    this # One of "this"; "that"
-                enum:                 ~ # One of "this"; "that"; Symfony\Component\Config\Tests\Fixtures\TestEnum::Ccc
-                enum_with_class:      ~ # One of foo; bar
-                unit_enum_with_class: ~ # One of Symfony\Component\Config\Tests\Fixtures\TestEnum::Foo; Symfony\Component\Config\Tests\Fixtures\TestEnum::Bar; Symfony\Component\Config\Tests\Fixtures\TestEnum::Ccc
-
-                # some info
-                array:
-                    child1:               ~
-                    child2:               ~
-
-                    # this is a long
-                    # multi-line info text
-                    # which should be indented
-                    child3:               ~ # Example: 'example setting'
-                scalar_prototyped:    []
-                string_list_default_null: ~
-                variable:             ~
-
-                    # Examples:
-                    # - foo
-                    # - bar
-                parameters:
-
-                    # Prototype: Parameter name
-                    name:                 ~
-                connections:
-
-                    # Prototype
-                    -
-                        user:                 ~
-                        pass:                 ~
-                cms_pages:
-
-                    # Prototype
-                    page:
-
-                        # Prototype
-                        locale:
-                            title:                ~ # Required
-                            path:                 ~ # Required
-                pipou:
-
-                    # Prototype
-                    name:                 []
-                array_with_array_example_and_no_default_value: []
-
-                    # Examples:
-                    # - foo
-                    # - bar
-                custom_node:          true
-
-            EOL;
+        return file_get_contents(__DIR__.'/../../Fixtures/Configuration/ExampleConfiguration.yaml');
     }
 }

--- a/src/Symfony/Component/Config/Tests/Definition/JsonSchemaGeneratorTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/JsonSchemaGeneratorTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Tests\Definition;
+
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\ArrayNode;
+use Symfony\Component\Config\Definition\JsonSchemaGenerator;
+use Symfony\Component\Config\Tests\Fixtures\Configuration\ExampleConfiguration;
+
+class JsonSchemaGeneratorTest extends TestCase
+{
+    private string $schemaFile;
+
+    public function testExampleConfiguration()
+    {
+        $this->schemaFile = tempnam(sys_get_temp_dir(), 'json-schema-generator');
+        $configuration = new ExampleConfiguration();
+
+        $root = new ArrayNode(null);
+        $root->addChild($configuration->getConfigTreeBuilder()->buildTree());
+
+        $generator = new JsonSchemaGenerator($this->schemaFile);
+        $generator->build($root);
+
+        // Uncomment to update the schema file
+        // file_put_contents(__DIR__.'/../Fixtures/Configuration/ExampleConfiguration.schema.json', file_get_contents($this->schemaFile));
+
+        self::assertJsonFileEqualsJsonFile(__DIR__.'/../Fixtures/Configuration/ExampleConfiguration.schema.json', $this->schemaFile);
+    }
+
+    #[After]
+    public function removeTempFiles()
+    {
+        unlink($this->schemaFile);
+    }
+}

--- a/src/Symfony/Component/Config/Tests/Fixtures/Configuration/ExampleConfiguration.schema.json
+++ b/src/Symfony/Component/Config/Tests/Fixtures/Configuration/ExampleConfiguration.schema.json
@@ -1,0 +1,604 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$ref": "#/definitions/",
+    "definitions": {
+        "7e9272c1a47137c4": {
+            "anyOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/param"
+                }
+            ],
+            "default": true
+        },
+        "10b40a06ad0d1ec2": {
+            "type": [
+                "boolean",
+                "number",
+                "string"
+            ]
+        },
+        "ac3318c4415dfb1e": {
+            "type": [
+                "boolean",
+                "number",
+                "string",
+                "null"
+            ],
+            "default": null
+        },
+        "cdeee702d36f9e3c": {
+            "type": [
+                "boolean",
+                "number",
+                "string"
+            ],
+            "default": true
+        },
+        "12fbc9023cab7dd5": {
+            "type": [
+                "boolean",
+                "number",
+                "string"
+            ],
+            "default": false
+        },
+        "2a4e9ebdea3312c9": {
+            "type": [
+                "boolean",
+                "number",
+                "string"
+            ],
+            "default": "default"
+        },
+        "f62d46268f02deb9": {
+            "anyOf": [
+                {
+                    "const": []
+                },
+                {
+                    "type": [
+                        "boolean",
+                        "number",
+                        "string"
+                    ]
+                }
+            ],
+            "default": []
+        },
+        "7cbe815900004450": {
+            "anyOf": [
+                {
+                    "const": [
+                        "elem1",
+                        "elem2"
+                    ]
+                },
+                {
+                    "type": [
+                        "boolean",
+                        "number",
+                        "string"
+                    ]
+                }
+            ],
+            "default": [
+                "elem1",
+                "elem2"
+            ]
+        },
+        "3e43ead3d5f69efe": {
+            "type": [
+                "boolean",
+                "number",
+                "string"
+            ],
+            "deprecated": true,
+            "deprecationMessage": "Since vendor/package 1.1: The child node \"scalar_deprecated\" at path \"acme_root.scalar_deprecated\" is deprecated."
+        },
+        "186834a53bfd6ad3": {
+            "type": [
+                "boolean",
+                "number",
+                "string"
+            ],
+            "deprecated": true,
+            "deprecationMessage": "Since vendor/package 1.1: Deprecation custom message for \"scalar_deprecated_with_message\" at \"acme_root.scalar_deprecated_with_message\""
+        },
+        "d5d8f6dd360b816e": {
+            "anyOf": [
+                {
+                    "enum": [
+                        "this",
+                        "that"
+                    ]
+                },
+                {
+                    "$ref": "#/definitions/param"
+                }
+            ],
+            "default": "this"
+        },
+        "134ebd09c31f5a84": {
+            "anyOf": [
+                {
+                    "enum": [
+                        "this",
+                        "that",
+                        "!php/enum Symfony\\Component\\Config\\Tests\\Fixtures\\TestEnum::Ccc"
+                    ]
+                },
+                {
+                    "$ref": "#/definitions/param"
+                }
+            ]
+        },
+        "1454b7339d0adf11": {
+            "anyOf": [
+                {
+                    "enum": [
+                        "!php/enum Symfony\\Component\\Config\\Tests\\Fixtures\\StringBackedTestEnum::Foo",
+                        "!php/enum Symfony\\Component\\Config\\Tests\\Fixtures\\StringBackedTestEnum::Bar"
+                    ]
+                },
+                {
+                    "$ref": "#/definitions/param"
+                }
+            ]
+        },
+        "59c3318633430a9e": {
+            "anyOf": [
+                {
+                    "enum": [
+                        "!php/enum Symfony\\Component\\Config\\Tests\\Fixtures\\TestEnum::Foo",
+                        "!php/enum Symfony\\Component\\Config\\Tests\\Fixtures\\TestEnum::Bar",
+                        "!php/enum Symfony\\Component\\Config\\Tests\\Fixtures\\TestEnum::Ccc"
+                    ]
+                },
+                {
+                    "$ref": "#/definitions/param"
+                }
+            ]
+        },
+        "d1ca11b513832c81": {
+            "type": [
+                "boolean",
+                "number",
+                "string"
+            ],
+            "description": "this is a long\nmulti-line info text\nwhich should be indented"
+        },
+        "8f5cbc4716c25a8a": {
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "child1": {
+                            "$ref": "#/definitions/10b40a06ad0d1ec2"
+                        },
+                        "child2": {
+                            "$ref": "#/definitions/10b40a06ad0d1ec2"
+                        },
+                        "child3": {
+                            "$ref": "#/definitions/d1ca11b513832c81"
+                        }
+                    }
+                },
+                {
+                    "$ref": "#/definitions/param"
+                }
+            ],
+            "description": "some info"
+        },
+        "98f6c37b28a94f0b": {
+            "$ref": "#/definitions/10b40a06ad0d1ec2"
+        },
+        "06e7e49a279c4e95": {
+            "anyOf": [
+                {
+                    "const": []
+                },
+                {
+                    "type": [
+                        "array",
+                        "object"
+                    ],
+                    "items": {
+                        "$ref": "#/definitions/98f6c37b28a94f0b"
+                    },
+                    "additionalProperties": {
+                        "$ref": "#/definitions/98f6c37b28a94f0b"
+                    }
+                },
+                {
+                    "$ref": "#/definitions/param"
+                }
+            ],
+            "default": []
+        },
+        "04e12a2ab958e1d2": {
+            "type": "string"
+        },
+        "7e28bcfce621d5a6": {
+            "$ref": "#/definitions/04e12a2ab958e1d2"
+        },
+        "c22a41f53ff4799f": {
+            "anyOf": [
+                {
+                    "type": [
+                        "array",
+                        "object",
+                        "null"
+                    ],
+                    "items": {
+                        "$ref": "#/definitions/7e28bcfce621d5a6"
+                    },
+                    "additionalProperties": {
+                        "$ref": "#/definitions/7e28bcfce621d5a6"
+                    }
+                },
+                {
+                    "$ref": "#/definitions/param"
+                }
+            ],
+            "default": null
+        },
+        "15aa10f64e9783ee": {
+            "anyOf": [
+                {},
+                {
+                    "$ref": "#/definitions/param"
+                }
+            ]
+        },
+        "ebe6fbbc9144c534": {
+            "type": [
+                "boolean",
+                "number",
+                "string"
+            ],
+            "description": "Parameter name"
+        },
+        "ceafdf76f079dcad": {
+            "$ref": "#/definitions/ebe6fbbc9144c534"
+        },
+        "aed611cfe0427f98": {
+            "anyOf": [
+                {
+                    "const": []
+                },
+                {
+                    "type": [
+                        "array",
+                        "object"
+                    ],
+                    "items": {
+                        "$ref": "#/definitions/ceafdf76f079dcad"
+                    },
+                    "additionalProperties": {
+                        "$ref": "#/definitions/ceafdf76f079dcad"
+                    }
+                },
+                {
+                    "$ref": "#/definitions/param"
+                }
+            ],
+            "default": []
+        },
+        "90e3d83fd5168a0c": {
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "user": {
+                            "$ref": "#/definitions/10b40a06ad0d1ec2"
+                        },
+                        "pass": {
+                            "$ref": "#/definitions/10b40a06ad0d1ec2"
+                        }
+                    }
+                },
+                {
+                    "$ref": "#/definitions/param"
+                }
+            ]
+        },
+        "7fc27558c4207e63": {
+            "$ref": "#/definitions/90e3d83fd5168a0c"
+        },
+        "e240c194c1f625a3": {
+            "anyOf": [
+                {
+                    "const": []
+                },
+                {
+                    "type": [
+                        "array",
+                        "object"
+                    ],
+                    "items": {
+                        "$ref": "#/definitions/7fc27558c4207e63"
+                    },
+                    "additionalProperties": {
+                        "$ref": "#/definitions/7fc27558c4207e63"
+                    }
+                },
+                {
+                    "$ref": "#/definitions/param"
+                }
+            ],
+            "default": []
+        },
+        "80710161d0b1ffe2": {
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "title": {
+                            "$ref": "#/definitions/10b40a06ad0d1ec2"
+                        },
+                        "path": {
+                            "$ref": "#/definitions/10b40a06ad0d1ec2"
+                        }
+                    }
+                },
+                {
+                    "$ref": "#/definitions/param"
+                }
+            ]
+        },
+        "1fe19a5fe501bd3c": {
+            "$ref": "#/definitions/80710161d0b1ffe2"
+        },
+        "201416b4f65e3e65": {
+            "anyOf": [
+                {
+                    "const": []
+                },
+                {
+                    "type": [
+                        "array",
+                        "object"
+                    ],
+                    "items": {
+                        "$ref": "#/definitions/1fe19a5fe501bd3c"
+                    },
+                    "additionalProperties": {
+                        "$ref": "#/definitions/1fe19a5fe501bd3c"
+                    }
+                },
+                {
+                    "$ref": "#/definitions/param"
+                }
+            ],
+            "default": []
+        },
+        "bab751c93618d777": {
+            "$ref": "#/definitions/201416b4f65e3e65"
+        },
+        "df037e0f40a5be1e": {
+            "anyOf": [
+                {
+                    "const": []
+                },
+                {
+                    "type": [
+                        "array",
+                        "object"
+                    ],
+                    "items": {
+                        "$ref": "#/definitions/bab751c93618d777"
+                    },
+                    "additionalProperties": {
+                        "$ref": "#/definitions/bab751c93618d777"
+                    }
+                },
+                {
+                    "$ref": "#/definitions/param"
+                }
+            ],
+            "default": []
+        },
+        "ebd0a644d2f3e997": {
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "didou": {
+                            "$ref": "#/definitions/10b40a06ad0d1ec2"
+                        }
+                    }
+                },
+                {
+                    "$ref": "#/definitions/param"
+                }
+            ]
+        },
+        "99d36cdc6404a29a": {
+            "$ref": "#/definitions/ebd0a644d2f3e997"
+        },
+        "9054d5546beaa213": {
+            "anyOf": [
+                {
+                    "const": []
+                },
+                {
+                    "type": [
+                        "array",
+                        "object"
+                    ],
+                    "items": {
+                        "$ref": "#/definitions/99d36cdc6404a29a"
+                    },
+                    "additionalProperties": {
+                        "$ref": "#/definitions/99d36cdc6404a29a"
+                    }
+                },
+                {
+                    "$ref": "#/definitions/param"
+                }
+            ],
+            "default": []
+        },
+        "860a0e18744eedfd": {
+            "$ref": "#/definitions/9054d5546beaa213"
+        },
+        "74df63e8948e01fe": {
+            "anyOf": [
+                {
+                    "const": []
+                },
+                {
+                    "type": [
+                        "array",
+                        "object"
+                    ],
+                    "items": {
+                        "$ref": "#/definitions/860a0e18744eedfd"
+                    },
+                    "additionalProperties": {
+                        "$ref": "#/definitions/860a0e18744eedfd"
+                    }
+                },
+                {
+                    "$ref": "#/definitions/param"
+                }
+            ],
+            "default": []
+        },
+        "f6f6b8a89b9de154": {
+            "anyOf": [
+                {
+                    "type": "object"
+                },
+                {
+                    "$ref": "#/definitions/param"
+                }
+            ]
+        },
+        "8596700018243360": {
+            "anyOf": [
+                {},
+                {
+                    "$ref": "#/definitions/param"
+                }
+            ],
+            "default": true
+        },
+        "91b6599a07770898": {
+            "anyOf": [
+                {
+                    "type": "array"
+                },
+                {
+                    "type": [
+                        "object",
+                        "boolean",
+                        "null"
+                    ],
+                    "properties": {
+                        "boolean": {
+                            "$ref": "#/definitions/7e9272c1a47137c4"
+                        },
+                        "scalar_empty": {
+                            "$ref": "#/definitions/10b40a06ad0d1ec2"
+                        },
+                        "scalar_null": {
+                            "$ref": "#/definitions/ac3318c4415dfb1e"
+                        },
+                        "scalar_true": {
+                            "$ref": "#/definitions/cdeee702d36f9e3c"
+                        },
+                        "scalar_false": {
+                            "$ref": "#/definitions/12fbc9023cab7dd5"
+                        },
+                        "scalar_default": {
+                            "$ref": "#/definitions/2a4e9ebdea3312c9"
+                        },
+                        "scalar_array_empty": {
+                            "$ref": "#/definitions/f62d46268f02deb9"
+                        },
+                        "scalar_array_defaults": {
+                            "$ref": "#/definitions/7cbe815900004450"
+                        },
+                        "scalar_required": {
+                            "$ref": "#/definitions/10b40a06ad0d1ec2"
+                        },
+                        "scalar_deprecated": {
+                            "$ref": "#/definitions/3e43ead3d5f69efe"
+                        },
+                        "scalar_deprecated_with_message": {
+                            "$ref": "#/definitions/186834a53bfd6ad3"
+                        },
+                        "node_with_a_looong_name": {
+                            "$ref": "#/definitions/10b40a06ad0d1ec2"
+                        },
+                        "enum_with_default": {
+                            "$ref": "#/definitions/d5d8f6dd360b816e"
+                        },
+                        "enum": {
+                            "$ref": "#/definitions/134ebd09c31f5a84"
+                        },
+                        "enum_with_class": {
+                            "$ref": "#/definitions/1454b7339d0adf11"
+                        },
+                        "unit_enum_with_class": {
+                            "$ref": "#/definitions/59c3318633430a9e"
+                        },
+                        "array": {
+                            "$ref": "#/definitions/8f5cbc4716c25a8a"
+                        },
+                        "scalar_prototyped": {
+                            "$ref": "#/definitions/06e7e49a279c4e95"
+                        },
+                        "string_list_default_null": {
+                            "$ref": "#/definitions/c22a41f53ff4799f"
+                        },
+                        "variable": {
+                            "$ref": "#/definitions/15aa10f64e9783ee"
+                        },
+                        "parameters": {
+                            "$ref": "#/definitions/aed611cfe0427f98"
+                        },
+                        "connections": {
+                            "$ref": "#/definitions/e240c194c1f625a3"
+                        },
+                        "cms_pages": {
+                            "$ref": "#/definitions/df037e0f40a5be1e"
+                        },
+                        "pipou": {
+                            "$ref": "#/definitions/74df63e8948e01fe"
+                        },
+                        "array_with_array_example_and_no_default_value": {
+                            "$ref": "#/definitions/f6f6b8a89b9de154"
+                        },
+                        "custom_node": {
+                            "$ref": "#/definitions/8596700018243360"
+                        }
+                    }
+                },
+                {
+                    "$ref": "#/definitions/param"
+                }
+            ]
+        },
+        "38064c3c5331b296": {
+            "type": "object",
+            "properties": {
+                "acme_root": {
+                    "$ref": "#/definitions/91b6599a07770898"
+                }
+            }
+        },
+        "": {
+            "$ref": "#/definitions/38064c3c5331b296"
+        },
+        "param": {
+            "$comment": "Container parameter",
+            "type": "string",
+            "pattern": "^%[^%]+%$"
+        }
+    }
+}

--- a/src/Symfony/Component/Config/Tests/Fixtures/Configuration/ExampleConfiguration.yaml
+++ b/src/Symfony/Component/Config/Tests/Fixtures/Configuration/ExampleConfiguration.yaml
@@ -1,0 +1,68 @@
+# $schema: ExampleConfiguration.schema.json
+acme_root:
+    boolean:              true
+    scalar_empty:         ~
+    scalar_null:          null
+    scalar_true:          true
+    scalar_false:         false
+    scalar_default:       default
+    scalar_array_empty:   []
+    scalar_array_defaults:
+
+        # Defaults:
+        - elem1
+        - elem2
+    scalar_required:      ~ # Required
+    scalar_deprecated:    ~ # Deprecated (Since vendor/package 1.1: The child node "scalar_deprecated" at path "acme_root" is deprecated.)
+    scalar_deprecated_with_message: ~ # Deprecated (Since vendor/package 1.1: Deprecation custom message for "scalar_deprecated_with_message" at "acme_root")
+    node_with_a_looong_name: ~
+    enum_with_default:    this # One of "this"; "that"
+    enum:                 ~ # One of "this"; "that"; Symfony\Component\Config\Tests\Fixtures\TestEnum::Ccc
+    enum_with_class:      ~ # One of foo; bar
+    unit_enum_with_class: ~ # One of Symfony\Component\Config\Tests\Fixtures\TestEnum::Foo; Symfony\Component\Config\Tests\Fixtures\TestEnum::Bar; Symfony\Component\Config\Tests\Fixtures\TestEnum::Ccc
+
+    # some info
+    array:
+        child1:               ~
+        child2:               ~
+
+        # this is a long
+        # multi-line info text
+        # which should be indented
+        child3:               ~ # Example: 'example setting'
+    scalar_prototyped:    []
+    string_list_default_null: ~
+    variable:             ~
+
+        # Examples:
+        # - foo
+        # - bar
+    parameters:
+
+        # Prototype: Parameter name
+        name:                 ~
+    connections:
+
+        # Prototype
+        -
+            user:                 ~
+            pass:                 ~
+    cms_pages:
+
+        # Prototype
+        page:
+
+            # Prototype
+            locale:
+                title:                ~ # Required
+                path:                 ~ # Required
+    pipou:
+
+        # Prototype
+        name:                 []
+    array_with_array_example_and_no_default_value: []
+
+        # Examples:
+        # - foo
+        # - bar
+    custom_node:          true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #59603
| License       | MIT

Generate JSON schema in `%kernel.build_dir%/config.schema.json` for YAML config when the container is built to improve DX.

### To discuss:

1. ~~Is there any way to deal with PHP enums (`!php/enum` yaml tag)? At the moment they are just ignored/excluded~~ // just allowed a string `!php/enum ...`
1. ~~Should we include `# $schema: path/to/schema.json` in generated yaml files?~~ probably no / up to Flex etc
1. Any edge-cases I missed?
1. ~~Should we rather bump `symfony/config` version constraint in `symfony/framework-bundle` than check for class existence? This is kinda optional stuff so I thought we don't need to enforce it.~~ already bumped in #59649