### PR TITLE
[DomCrawler] Don't return file infos for empty file fields

### DIFF
--- a/src/Symfony/Component/DomCrawler/Form.php
+++ b/src/Symfony/Component/DomCrawler/Form.php
@@ -104,9 +104,16 @@ class Form extends Link implements \ArrayAccess
                 continue;
             }
 
-            if ($field instanceof Field\FileFormField) {
-                $files[$name] = $field->getValue();
+            if (!$field instanceof Field\FileFormField) {
+                continue;
             }
+
+            $value = $field->getValue();
+            if (empty($value['tmp_name'])) {
+                continue;
+            }
+
+            $files[$name] = $value;
         }
 
         return $files;

--- a/src/Symfony/Component/DomCrawler/Tests/Fixtures/upload.txt
+++ b/src/Symfony/Component/DomCrawler/Tests/Fixtures/upload.txt
@@ -1,0 +1,1 @@
+some content

--- a/src/Symfony/Component/DomCrawler/Tests/FormTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/FormTest.php
@@ -475,19 +475,19 @@ class FormTest extends TestCase
         $this->assertEquals([], $form->getFiles(), '->getFiles() does not return empty fields');
 
         $form = $this->createForm('<form method="post"><input type="file" name="foo[bar]" /><input type="text" name="bar" value="bar" /><input type="submit" /></form>');
-        $form->get('foo[bar]')->setValue(__DIR__ . '/Fixtures/upload.txt');
+        $form->get('foo[bar]')->setValue(__DIR__.'/Fixtures/upload.txt');
         $this->assertEquals(['foo[bar]'], array_keys($form->getFiles()), '->getFiles() only returns file fields for POST');
 
         $form = $this->createForm('<form method="post"><input type="file" name="foo[bar]" /><input type="text" name="bar" value="bar" /><input type="submit" /></form>', 'put');
-        $form->get('foo[bar]')->setValue(__DIR__ . '/Fixtures/upload.txt');
+        $form->get('foo[bar]')->setValue(__DIR__.'/Fixtures/upload.txt');
         $this->assertEquals(['foo[bar]'], array_keys($form->getFiles()), '->getFiles() only returns file fields for PUT');
 
         $form = $this->createForm('<form method="post"><input type="file" name="foo[bar]" /><input type="text" name="bar" value="bar" /><input type="submit" /></form>', 'delete');
-        $form->get('foo[bar]')->setValue(__DIR__ . '/Fixtures/upload.txt');
+        $form->get('foo[bar]')->setValue(__DIR__.'/Fixtures/upload.txt');
         $this->assertEquals(['foo[bar]'], array_keys($form->getFiles()), '->getFiles() only returns file fields for DELETE');
 
         $form = $this->createForm('<form method="post"><input type="file" name="foo[bar]" /><input type="text" name="bar" value="bar" /><input type="submit" /></form>', 'patch');
-        $form->get('foo[bar]')->setValue(__DIR__ . '/Fixtures/upload.txt');
+        $form->get('foo[bar]')->setValue(__DIR__.'/Fixtures/upload.txt');
         $this->assertEquals(['foo[bar]'], array_keys($form->getFiles()), '->getFiles() only returns file fields for PATCH');
 
         $form = $this->createForm('<form method="post"><input type="file" name="foo[bar]" disabled="disabled" /><input type="submit" /></form>');

--- a/src/Symfony/Component/DomCrawler/Tests/FormTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/FormTest.php
@@ -472,16 +472,23 @@ class FormTest extends TestCase
         $this->assertEquals([], $form->getFiles(), '->getFiles() returns an empty array if method is get');
 
         $form = $this->createForm('<form method="post"><input type="file" name="foo[bar]" /><input type="text" name="bar" value="bar" /><input type="submit" /></form>');
-        $this->assertEquals(['foo[bar]' => ['name' => '', 'type' => '', 'tmp_name' => '', 'error' => 4, 'size' => 0]], $form->getFiles(), '->getFiles() only returns file fields for POST');
+        $this->assertEquals([], $form->getFiles(), '->getFiles() does not return empty fields');
+
+        $form = $this->createForm('<form method="post"><input type="file" name="foo[bar]" /><input type="text" name="bar" value="bar" /><input type="submit" /></form>');
+        $form->get('foo[bar]')->setValue(__DIR__ . '/Fixtures/upload.txt');
+        $this->assertEquals(['foo[bar]'], array_keys($form->getFiles()), '->getFiles() only returns file fields for POST');
 
         $form = $this->createForm('<form method="post"><input type="file" name="foo[bar]" /><input type="text" name="bar" value="bar" /><input type="submit" /></form>', 'put');
-        $this->assertEquals(['foo[bar]' => ['name' => '', 'type' => '', 'tmp_name' => '', 'error' => 4, 'size' => 0]], $form->getFiles(), '->getFiles() only returns file fields for PUT');
+        $form->get('foo[bar]')->setValue(__DIR__ . '/Fixtures/upload.txt');
+        $this->assertEquals(['foo[bar]'], array_keys($form->getFiles()), '->getFiles() only returns file fields for PUT');
 
         $form = $this->createForm('<form method="post"><input type="file" name="foo[bar]" /><input type="text" name="bar" value="bar" /><input type="submit" /></form>', 'delete');
-        $this->assertEquals(['foo[bar]' => ['name' => '', 'type' => '', 'tmp_name' => '', 'error' => 4, 'size' => 0]], $form->getFiles(), '->getFiles() only returns file fields for DELETE');
+        $form->get('foo[bar]')->setValue(__DIR__ . '/Fixtures/upload.txt');
+        $this->assertEquals(['foo[bar]'], array_keys($form->getFiles()), '->getFiles() only returns file fields for DELETE');
 
         $form = $this->createForm('<form method="post"><input type="file" name="foo[bar]" /><input type="text" name="bar" value="bar" /><input type="submit" /></form>', 'patch');
-        $this->assertEquals(['foo[bar]' => ['name' => '', 'type' => '', 'tmp_name' => '', 'error' => 4, 'size' => 0]], $form->getFiles(), '->getFiles() only returns file fields for PATCH');
+        $form->get('foo[bar]')->setValue(__DIR__ . '/Fixtures/upload.txt');
+        $this->assertEquals(['foo[bar]'], array_keys($form->getFiles()), '->getFiles() only returns file fields for PATCH');
 
         $form = $this->createForm('<form method="post"><input type="file" name="foo[bar]" disabled="disabled" /><input type="submit" /></form>');
         $this->assertEquals([], $form->getFiles(), '->getFiles() does not include disabled file fields');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #49014
| License       | MIT

Fixes #49014 but not in a meaningful way IMO. But I don't know where else to remove empty files. Could be in `Request` (browser-kit), or even later in `MultipartPart` (mime). I don't understand why dom-crawler works this way, so I don't know how to fix it correctly.

**To do:** fix tests..?
