### PR TITLE
[JsonEncoder] Add missing changelog entries

### DIFF
--- a/src/Symfony/Component/JsonEncoder/CHANGELOG.md
+++ b/src/Symfony/Component/JsonEncoder/CHANGELOG.md
@@ -6,4 +6,5 @@ CHANGELOG
 
  * Introduce the component as experimental
  * Add native PHP lazy ghost support
+ * Remove `JsonEncoder::$forceEncodeChunks`, `JsonDecoder::$forceEncodeChunks`, and `EncoderDecoderCacheWarmer::$forceEncodeChunks`
  * Allow to select the warmup of object and list in `JsonEncodable` and `json_encoder.encodable`


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Even if the component is experimental and not released, the `CHANGELOG` entries must be kept up to date.
This PR adds the missing ones. 
