### PR TITLE
[Serializer] Named serializer should get correct normalizer instance

### DIFF
--- a/src/Symfony/Component/Serializer/DependencyInjection/SerializerPass.php
+++ b/src/Symfony/Component/Serializer/DependencyInjection/SerializerPass.php
@@ -185,24 +185,17 @@ class SerializerPass implements CompilerPassInterface
 
             $definition = $container->registerChild($childId, (string) $id);
 
-            if (null !== $nameConverterIndex = $this->findNameConverterIndex($container, (string) $id)) {
-                $definition->replaceArgument($nameConverterIndex, new Reference($config['name_converter']));
+            foreach ($container->getDefinition($id)->getArguments() as $index => $argument) {
+                if ($argument instanceof Reference && self::NAME_CONVERTER_METADATA_AWARE_ID === (string) $argument) {
+                    $definition->replaceArgument($index, new Reference($config['name_converter']));
+                } elseif ($argument instanceof Reference && str_starts_with((string) $argument, 'serializer.normalizer.')) {
+                    $definition->replaceArgument($index, new Reference((string) $argument.'.'.$serializerName));
+                }
             }
 
             $id = new Reference($childId);
         }
 
         return $services;
-    }
-
-    private function findNameConverterIndex(ContainerBuilder $container, string $id): int|string|null
-    {
-        foreach ($container->getDefinition($id)->getArguments() as $index => $argument) {
-            if ($argument instanceof Reference && self::NAME_CONVERTER_METADATA_AWARE_ID === (string) $argument) {
-                return $index;
-            }
-        }
-
-        return null;
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/DependencyInjection/SerializerPassTest.php
+++ b/src/Symfony/Component/Serializer/Tests/DependencyInjection/SerializerPassTest.php
@@ -637,4 +637,34 @@ class SerializerPassTest extends TestCase
         $this->assertEquals(new Reference('serializer.data_collector'), $traceableEncoderDefinition->getArgument(1));
         $this->assertSame('api', $traceableEncoderDefinition->getArgument(2));
     }
+
+    public function testPropertyNormalizerIsCorrectInstanceWhenUsingNamedSerializer()
+    {
+        $container = new ContainerBuilder();
+
+        $container->setParameter('kernel.debug', false);
+        $container->setParameter('.serializer.named_serializers', [
+            'api' => [],
+        ]);
+
+        $container->register('serializer')->setArguments([null, null]);
+        $container->register('n0')
+            ->setArguments([
+                new Reference('serializer.normalizer.property'),
+            ])
+            ->addTag('serializer.normalizer', ['serializer' => 'default']);
+        $container->register('n1')
+            ->setArguments([
+                new Reference('serializer.normalizer.property'),
+            ])
+            ->addTag('serializer.normalizer', ['serializer' => 'api']);
+
+        $container->register('e1')->addTag('serializer.encoder', ['serializer' => ['*']]);
+
+        $serializerPass = new SerializerPass();
+        $serializerPass->process($container);
+
+        $this->assertEquals(new Reference('serializer.normalizer.property'), $container->getDefinition('n0')->getArgument(0));
+        $this->assertEquals(new Reference('serializer.normalizer.property.api'), $container->getDefinition('n1.api')->getArgument(0));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Named serializers were introduced in https://github.com/symfony/symfony/pull/56823 and they work great.

We noticed a small bug when using custom name convertors.

The MimeMessageNormalizer holds a reference to `serializer.normalizer.property`.
But when using named serializers, it should use the specific child normalizer instead.

With this change, we fix this problem for any service that starts with `serializer.normalizer.`.

/cc @HypeMC