### PR TITLE
[HttpClient] Fix processing a NativeResponse after its client has been reset

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/NativeResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/NativeResponse.php
@@ -79,7 +79,7 @@ final class NativeResponse implements ResponseInterface, StreamableInterface
         };
 
         $this->canary = new Canary(static function () use ($multi, $id) {
-            if (null !== ($host = $multi->openHandles[$id][6] ?? null) && 0 >= --$multi->hosts[$host]) {
+            if (null !== ($host = $multi->openHandles[$id][6] ?? null) && isset($multi->hosts[$host]) && 0 >= --$multi->hosts[$host]) {
                 unset($multi->hosts[$host]);
             }
             unset($multi->openHandles[$id], $multi->handlesActivity[$id]);
@@ -123,7 +123,7 @@ final class NativeResponse implements ResponseInterface, StreamableInterface
                 throw new TransportException($msg);
             }
 
-            $this->logger?->info(sprintf('%s for "%s".', $msg, $url ?? $this->url));
+            $this->logger?->info(\sprintf('%s for "%s".', $msg, $url ?? $this->url));
         });
 
         try {
@@ -142,7 +142,7 @@ final class NativeResponse implements ResponseInterface, StreamableInterface
                     $this->info['request_header'] = $this->info['url']['path'].$this->info['url']['query'];
                 }
 
-                $this->info['request_header'] = sprintf("> %s %s HTTP/%s \r\n", $context['http']['method'], $this->info['request_header'], $context['http']['protocol_version']);
+                $this->info['request_header'] = \sprintf("> %s %s HTTP/%s \r\n", $context['http']['method'], $this->info['request_header'], $context['http']['protocol_version']);
                 $this->info['request_header'] .= implode("\r\n", $context['http']['header'])."\r\n\r\n";
 
                 if (\array_key_exists('peer_name', $context['ssl']) && null === $context['ssl']['peer_name']) {
@@ -159,7 +159,7 @@ final class NativeResponse implements ResponseInterface, StreamableInterface
                     break;
                 }
 
-                $this->logger?->info(sprintf('Redirecting: "%s %s"', $this->info['http_code'], $url ?? $this->url));
+                $this->logger?->info(\sprintf('Redirecting: "%s %s"', $this->info['http_code'], $url ?? $this->url));
             }
         } catch (\Throwable $e) {
             $this->close();
@@ -294,7 +294,7 @@ final class NativeResponse implements ResponseInterface, StreamableInterface
 
                 if (null === $e) {
                     if (0 < $remaining) {
-                        $e = new TransportException(sprintf('Transfer closed with %s bytes remaining to read.', $remaining));
+                        $e = new TransportException(\sprintf('Transfer closed with %s bytes remaining to read.', $remaining));
                     } elseif (-1 === $remaining && fwrite($buffer, '-') && '' !== stream_get_contents($buffer, -1, 0)) {
                         $e = new TransportException('Transfer closed with outstanding data remaining from chunked response.');
                     }
@@ -302,7 +302,7 @@ final class NativeResponse implements ResponseInterface, StreamableInterface
 
                 $multi->handlesActivity[$i][] = null;
                 $multi->handlesActivity[$i][] = $e;
-                if (null !== ($host = $multi->openHandles[$i][6] ?? null) && 0 >= --$multi->hosts[$host]) {
+                if (null !== ($host = $multi->openHandles[$i][6] ?? null) && isset($multi->hosts[$host]) && 0 >= --$multi->hosts[$host]) {
                     unset($multi->hosts[$host]);
                 }
                 unset($multi->openHandles[$i]);

--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
@@ -695,4 +695,17 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
         $this->assertSame('GET', $body['REQUEST_METHOD']);
         $this->assertSame('/', $body['REQUEST_URI']);
     }
+
+    public function testResponseCanBeProcessedAfterClientReset()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+        $response = $client->request('GET', 'http://127.0.0.1:8057/timeout-body');
+        $stream = $client->stream($response);
+
+        $response->getStatusCode();
+        $client->reset();
+        $stream->current();
+
+        $this->addToAssertionCount(1);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

An exception is thrown in dev when a response is processed before streaming it. 

It is due to the HttpClientDataCollector [which resets the client](https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php#L41) between the first access to the response and the next ones. This operation resets the `NativeClientState` and its `hosts` property which is used in the `NativeReponse` when the stream is cancelled or completed.

Reproducer
```php
/** @var NativeHttpClient $appClient **/
$response = $appClient->request('GET', 'https://google.com');

return new StreamedResponse(
    function () use ($appClient, $response): void {
        foreach ($appClient->stream($response) as $chunk) {
            echo $chunk->getContent(); // it fails because this code is executed AFTER collecting data and so, the client reset
            flush();
        }
    },
    $response->getStatusCode(), // the status code is retrieved BEFORE the reset done by the HttpClientDataCollector
);
```
