### PR TITLE
[Validator] Add support for enum in `Choice` constraint

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -56,6 +56,7 @@ CHANGELOG
    ```
  * Add support for ratio checks for SVG files to the `Image` constraint
  * Add the `Slug` constraint
+ * Add support for enums in `Choice` constraint
 
 7.2
 ---

--- a/src/Symfony/Component/Validator/ConstraintValidator.php
+++ b/src/Symfony/Component/Validator/ConstraintValidator.php
@@ -86,7 +86,7 @@ abstract class ConstraintValidator implements ConstraintValidatorInterface
         }
 
         if ($value instanceof \UnitEnum) {
-            return $value->name;
+            $value = $value instanceof \BackedEnum ? $value->value : $value->name;
         }
 
         if (\is_object($value)) {

--- a/src/Symfony/Component/Validator/Constraints/Cidr.php
+++ b/src/Symfony/Component/Validator/Constraints/Cidr.php
@@ -33,7 +33,7 @@ class Cidr extends Constraint
 
     protected const ERROR_NAMES = [
         self::INVALID_CIDR_ERROR => 'INVALID_CIDR_ERROR',
-        self::OUT_OF_RANGE_ERROR => 'OUT_OF_RANGE_VIOLATION',
+        self::OUT_OF_RANGE_ERROR => 'OUT_OF_RANGE_ERROR',
     ];
 
     private const NET_MAXES = [

--- a/src/Symfony/Component/Validator/Tests/ConstraintValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintValidatorTest.php
@@ -14,7 +14,9 @@ namespace Symfony\Component\Validator\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
-use Symfony\Component\Validator\Tests\Fixtures\TestEnum;
+use Symfony\Component\Validator\Tests\Fixtures\TestEnumBackendInteger;
+use Symfony\Component\Validator\Tests\Fixtures\TestEnumBackendString;
+use Symfony\Component\Validator\Tests\Fixtures\TestEnumUnit;
 
 class ConstraintValidatorTest extends TestCase
 {
@@ -49,7 +51,9 @@ class ConstraintValidatorTest extends TestCase
             [class_exists(\IntlDateFormatter::class) ? static::normalizeIcuSpaces("Feb 2, 1971, 8:00\u{202F}AM") : '1971-02-02 08:00:00', $dateTime, ConstraintValidator::PRETTY_DATE],
             [class_exists(\IntlDateFormatter::class) ? static::normalizeIcuSpaces("Jan 1, 1970, 6:00\u{202F}AM") : '1970-01-01 06:00:00', new \DateTimeImmutable('1970-01-01T06:00:00Z'), ConstraintValidator::PRETTY_DATE],
             [class_exists(\IntlDateFormatter::class) ? static::normalizeIcuSpaces("Jan 1, 1970, 3:00\u{202F}PM") : '1970-01-01 15:00:00', (new \DateTimeImmutable('1970-01-01T23:00:00'))->setTimezone(new \DateTimeZone('America/New_York')), ConstraintValidator::PRETTY_DATE],
-            ['FirstCase', TestEnum::FirstCase],
+            ['"FirstCase"', TestEnumUnit::FirstCase],
+            ['"a"', TestEnumBackendString::FirstCase],
+            ['3', TestEnumBackendInteger::FirstCase],
         ];
 
         date_default_timezone_set($defaultTimezone);

--- a/src/Symfony/Component/Validator/Tests/Constraints/ChoiceTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ChoiceTest.php
@@ -16,9 +16,19 @@ use Symfony\Component\Validator\Constraints\Choice;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintChoiceWithPreset;
+use Symfony\Component\Validator\Tests\Fixtures\TestEnumBackendInteger;
+use Symfony\Component\Validator\Tests\Fixtures\TestEnumBackendString;
+use Symfony\Component\Validator\Tests\Fixtures\TestEnumUnit;
 
 class ChoiceTest extends TestCase
 {
+    public function testNormalizerCanBeSet()
+    {
+        $choice = new Choice(normalizer: 'trim');
+
+        $this->assertEquals(trim(...), $choice->normalizer);
+    }
+
     public function testSetDefaultPropertyChoice()
     {
         $constraint = new ConstraintChoiceWithPreset('A');
@@ -52,6 +62,18 @@ class ChoiceTest extends TestCase
         /** @var Choice $stringIndexedConstraint */
         [$stringIndexedConstraint] = $metadata->properties['stringIndexed']->getConstraints();
         self::assertSame(['one' => 1, 'two' => 2], $stringIndexedConstraint->choices);
+
+        /** @var Choice $enumUnitConstraint */
+        [$enumUnitConstraint] = $metadata->properties['enumUnit']->getConstraints();
+        self::assertSame(TestEnumUnit::class, $enumUnitConstraint->choices);
+
+        /** @var Choice $enumBackendStringConstraint */
+        [$enumBackendStringConstraint] = $metadata->properties['enumBackendString']->getConstraints();
+        self::assertSame(TestEnumBackendString::class, $enumBackendStringConstraint->choices);
+
+        /** @var Choice $enumBackendIntegerConstraint */
+        [$enumBackendIntegerConstraint] = $metadata->properties['enumBackendInteger']->getConstraints();
+        self::assertSame(TestEnumBackendInteger::class, $enumBackendIntegerConstraint->choices);
     }
 }
 
@@ -68,4 +90,13 @@ class ChoiceDummy
 
     #[Choice(choices: ['one' => 1, 'two' => 2])]
     private $stringIndexed;
+
+    #[Choice(choices: TestEnumUnit::class)]
+    private $enumUnit;
+
+    #[Choice(choices: TestEnumBackendString::class)]
+    private $enumBackendString;
+
+    #[Choice(choices: TestEnumBackendInteger::class)]
+    private $enumBackendInteger;
 }

--- a/src/Symfony/Component/Validator/Tests/Fixtures/TestEnumBackendInteger.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/TestEnumBackendInteger.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+/**
+ * @author Ninos Ego <me@ninosego.de>
+ */
+enum TestEnumBackendInteger: int
+{
+    case FirstCase = 3;
+    case SecondCase = 4;
+}

--- a/src/Symfony/Component/Validator/Tests/Fixtures/TestEnumBackendString.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/TestEnumBackendString.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+/**
+ * @author Ninos Ego <me@ninosego.de>
+ */
+enum TestEnumBackendString: string
+{
+    case FirstCase = 'a';
+    case SecondCase = 'b';
+}

--- a/src/Symfony/Component/Validator/Tests/Fixtures/TestEnumUnit.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/TestEnumUnit.php
@@ -11,7 +11,10 @@
 
 namespace Symfony\Component\Validator\Tests\Fixtures;
 
-enum TestEnum
+/**
+ * @author Ninos Ego <me@ninosego.de>
+ */
+enum TestEnumUnit
 {
     case FirstCase;
     case SecondCase;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no + very small
| New feature?  | yes
| Deprecations? | no
| License       | MIT

### Feature
Supporting enum `\class-string` for `choices` attribute in `Choice` constraint.

### Fix
- `ConstraintValidator->formatValue()` returning correct value for enum type
- Typo

### Note
Using `Choice` constraint for attributes already defined as enum does not make sense (`BackedEnumNormalizer` already throws exception -> `The data must belong to a backed enumeration of type App\\CustomEnum`). It's only possible additionally using enum-classes instead of just arrays & callbacks.

### Example
```php
enum EnumTest: string
{
    case FirstCase = 'a';
    case SecondCase = 'b';
}

class SampleEntity {
    // Working
    #[Assert\Choice(choices: EnumTest::class)]
    #[ORM\Column(type: 'string', nullable: true)]
    private ?string $enum = EnumTest::FirstCase->value;

    // Not working
#    #[Assert\Choice(choices: EnumTest::class)]
#    #[ORM\Column(type: 'string', nullable: true, enumType: EnumTest::class)]
#    private ?EnumTest $enum = EnumTest::FirstCase;
}
```