### PR TITLE
[Validator] Add support for the `otherwise` option in the `When` constraint

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -56,6 +56,8 @@ CHANGELOG
    ```
  * Add support for ratio checks for SVG files to the `Image` constraint
  * Add the `Slug` constraint
+ * Add support for the `otherwise` option in the `When` constraint
+ * Add support for multiple fields containing nested constraints in `Composite` constraints
 
 7.2
 ---

--- a/src/Symfony/Component/Validator/Constraints/When.php
+++ b/src/Symfony/Component/Validator/Constraints/When.php
@@ -28,6 +28,7 @@ class When extends Composite
     public string|Expression $expression;
     public array|Constraint $constraints = [];
     public array $values = [];
+    public array|Constraint $otherwise = [];
 
     /**
      * @param string|Expression|array<string,mixed> $expression  The condition to evaluate, written with the ExpressionLanguage syntax
@@ -35,9 +36,10 @@ class When extends Composite
      * @param array<string,mixed>|null              $values      The values of the custom variables used in the expression (defaults to [])
      * @param string[]|null                         $groups
      * @param array<string,mixed>|null              $options
+     * @param Constraint[]|Constraint               $otherwise   One or multiple constraints that are applied if the expression returns false
      */
     #[HasNamedArguments]
-    public function __construct(string|Expression|array $expression, array|Constraint|null $constraints = null, ?array $values = null, ?array $groups = null, $payload = null, ?array $options = null)
+    public function __construct(string|Expression|array $expression, array|Constraint|null $constraints = null, ?array $values = null, ?array $groups = null, $payload = null, ?array $options = null, array|Constraint $otherwise = [])
     {
         if (!class_exists(ExpressionLanguage::class)) {
             throw new LogicException(\sprintf('The "symfony/expression-language" component is required to use the "%s" constraint. Try running "composer require symfony/expression-language".', __CLASS__));
@@ -56,10 +58,15 @@ class When extends Composite
 
             $options['expression'] = $expression;
             $options['constraints'] = $constraints;
+            $options['otherwise'] = $otherwise;
         }
 
-        if (isset($options['constraints']) && !\is_array($options['constraints'])) {
+        if (!\is_array($options['constraints'] ?? [])) {
             $options['constraints'] = [$options['constraints']];
+        }
+
+        if (!\is_array($options['otherwise'] ?? [])) {
+            $options['otherwise'] = [$options['otherwise']];
         }
 
         if (null !== $groups) {
@@ -85,8 +92,8 @@ class When extends Composite
         return [self::CLASS_CONSTRAINT, self::PROPERTY_CONSTRAINT];
     }
 
-    protected function getCompositeOption(): string
+    protected function getCompositeOption(): array|string
     {
-        return 'constraints';
+        return ['constraints', 'otherwise'];
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/WhenValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/WhenValidator.php
@@ -35,9 +35,14 @@ final class WhenValidator extends ConstraintValidator
         $variables['this'] = $context->getObject();
         $variables['context'] = $context;
 
-        if ($this->getExpressionLanguage()->evaluate($constraint->expression, $variables)) {
+        $result = $this->getExpressionLanguage()->evaluate($constraint->expression, $variables);
+
+        if ($result) {
             $context->getValidator()->inContext($context)
                 ->validate($value, $constraint->constraints);
+        } elseif ($constraint->otherwise) {
+            $context->getValidator()->inContext($context)
+                ->validate($value, $constraint->otherwise);
         }
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/WhenTestWithAttributes.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/WhenTestWithAttributes.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Tests\Constraints\Fixtures;
 
 use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\When;
@@ -35,6 +36,9 @@ class WhenTestWithAttributes
 
     #[When(expression: 'true', constraints: new NotNull(), groups: ['foo'])]
     private $qux;
+
+    #[When(expression: 'true', constraints: new NotNull(), otherwise: new Length(exactly: 10), groups: ['foo'])]
+    private $quux;
 
     #[When(expression: 'true', constraints: [
         new NotNull(),

--- a/src/Symfony/Component/Validator/Tests/Constraints/WhenTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/WhenTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\When;
@@ -59,6 +60,7 @@ final class WhenTest extends TestCase
                 groups: ['Default', 'WhenTestWithAttributes'],
             ),
         ], $classConstraint->constraints);
+        self::assertEmpty($classConstraint->otherwise);
 
         [$fooConstraint] = $metadata->properties['foo']->getConstraints();
 
@@ -68,6 +70,7 @@ final class WhenTest extends TestCase
             new NotNull(groups: ['Default', 'WhenTestWithAttributes']),
             new NotBlank(groups: ['Default', 'WhenTestWithAttributes']),
         ], $fooConstraint->constraints);
+        self::assertEmpty($fooConstraint->otherwise);
         self::assertSame(['Default', 'WhenTestWithAttributes'], $fooConstraint->groups);
 
         [$barConstraint] = $metadata->properties['bar']->getConstraints();
@@ -78,6 +81,7 @@ final class WhenTest extends TestCase
             new NotNull(groups: ['foo']),
             new NotBlank(groups: ['foo']),
         ], $barConstraint->constraints);
+        self::assertEmpty($barConstraint->otherwise);
         self::assertSame(['foo'], $barConstraint->groups);
 
         [$quxConstraint] = $metadata->properties['qux']->getConstraints();
@@ -85,6 +89,7 @@ final class WhenTest extends TestCase
         self::assertInstanceOf(When::class, $quxConstraint);
         self::assertSame('true', $quxConstraint->expression);
         self::assertEquals([new NotNull(groups: ['foo'])], $quxConstraint->constraints);
+        self::assertEmpty($quxConstraint->otherwise);
         self::assertSame(['foo'], $quxConstraint->groups);
 
         [$bazConstraint] = $metadata->getters['baz']->getConstraints();
@@ -95,6 +100,15 @@ final class WhenTest extends TestCase
             new NotNull(groups: ['Default', 'WhenTestWithAttributes']),
             new NotBlank(groups: ['Default', 'WhenTestWithAttributes']),
         ], $bazConstraint->constraints);
+        self::assertEmpty($bazConstraint->otherwise);
         self::assertSame(['Default', 'WhenTestWithAttributes'], $bazConstraint->groups);
+
+        [$quuxConstraint] = $metadata->properties['quux']->getConstraints();
+
+        self::assertInstanceOf(When::class, $quuxConstraint);
+        self::assertSame('true', $quuxConstraint->expression);
+        self::assertEquals([new NotNull(groups: ['foo'])], $quuxConstraint->constraints);
+        self::assertEquals([new Length(exactly: 10, groups: ['foo'])], $quuxConstraint->otherwise);
+        self::assertSame(['foo'], $quuxConstraint->groups);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/WhenValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/WhenValidatorTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\Blank;
 use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NegativeOrZero;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\NotNull;
@@ -47,6 +48,20 @@ final class WhenValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate('Foo', new When(
             expression: 'true',
             constraints: $constraint,
+        ));
+    }
+
+    public function testOtherwiseIsExecutedWhenFalse()
+    {
+        $constraint = new NotNull();
+        $otherwise = new Length(exactly: 10);
+
+        $this->expectValidateValue(0, 'Foo', [$otherwise]);
+
+        $this->validator->validate('Foo', new When(
+            expression: 'false',
+            constraints: $constraint,
+            otherwise: $otherwise,
         ));
     }
 
@@ -154,6 +169,21 @@ final class WhenValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate('', new When(
             expression: 'false',
             constraints: $constraints,
+        ));
+
+        $this->assertNoViolation();
+    }
+
+    public function testOtherwiseIsExecutedWhenTrue()
+    {
+        $constraints = [new NotNull()];
+
+        $this->expectValidateValue(0, '', $constraints);
+
+        $this->validator->validate('', new When(
+            expression: 'true',
+            constraints: $constraints,
+            otherwise: new Length(exactly: 10),
         ));
 
         $this->assertNoViolation();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #57370
| License       | MIT

This feature allows to give constraints to `When` when the evaluated expression returns false:

```php
use Symfony\Component\Validator\Constraints\IsNull;
use Symfony\Component\Validator\Constraints\Length;
use Symfony\Component\Validator\Constraints\When;

class BlogPost
{
    public ?int $id = null;
    
    #[When(
        expression: 'this.id !== null', 
        constraints: new Length(min: 10),
        otherwise: new IsNull(),
    )]
    public ?string $content = null;
}
```