### PR TITLE
Update Sponsor Section for 7.2 with Sulu and Rector

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,25 +17,20 @@ Installation
 Sponsor
 -------
 
-Symfony 7.1 is [backed][27] by
-- [Rector][29]
-- [JoliCode][30]
-- [Les-Tilleuls.coop][31]
+Symfony 7.2 is [backed][27] by
+- [Sulu][29]
+- [Rector][30]
+
+**Sulu** is the CMS for Symfony developers. It provides pre-built content-management
+features while giving developers the freedom to build, deploy, and maintain custom
+solutions using full-stack Symfony. Sulu is ideal for creating complex websites,
+integrating external tools, and building custom-built solutions.
 
 **Rector** helps successful and growing companies to get the most of the code
 they already have. Including upgrading to the latest Symfony LTS. They deliver
 automated refactoring, reduce maintenance costs, speed up feature delivery, and
 transform legacy code into a strategic asset. They can handle the dirty work,
 so you can focus on the features.
-
-**JoliCode** is a team of passionate developers and open-source lovers, with a
-strong expertise in PHP & Symfony technologies. They can help you build your
-projects using state-of-the-art practices.
-
-**Les-Tilleuls.coop** is a team of 70+ Symfony experts who can help you design, develop and
-fix your projects. They provide a wide range of professional services including development,
-consulting, coaching, training and audits. They also are highly skilled in JS, Go and DevOps.
-They are a worker cooperative!
 
 Help Symfony by [sponsoring][28] its development!
 
@@ -101,6 +96,5 @@ and supported by [Symfony contributors][19].
 [26]: https://symfony.com/book
 [27]: https://symfony.com/backers
 [28]: https://symfony.com/sponsor
-[29]: https://getrector.com
-[30]: https://jolicode.com
-[31]: https://les-tilleuls.coop
+[29]: https://sulu.io
+[30]: https://getrector.com


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

Update Sponsor Section for 7.2 with Sulu and Rector.

Looks like still list the 7.1, but it seems also miss the new on 7.3 branch. https://symfony.com/backers

Not sure if there is a automation behind it which not longer works?