### PR TITLE
[Serializer] register named normalizer & denormalizer aliases

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Deprecate the `CompiledClassMetadataFactory` and `CompiledClassMetadataCacheWarmer` classes
+ * Register `NormalizerInterface` and `DenormalizerInterface` aliases for named serializers
 
 7.2
 ---

--- a/src/Symfony/Component/Serializer/DependencyInjection/SerializerPass.php
+++ b/src/Symfony/Component/Serializer/DependencyInjection/SerializerPass.php
@@ -19,6 +19,8 @@ use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Serializer\Debug\TraceableEncoder;
 use Symfony\Component\Serializer\Debug\TraceableNormalizer;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**
@@ -152,6 +154,8 @@ class SerializerPass implements CompilerPassInterface
 
             $container->registerChild($serializerId, 'serializer');
             $container->registerAliasForArgument($serializerId, SerializerInterface::class, $serializerName.'.serializer');
+            $container->registerAliasForArgument($serializerId, NormalizerInterface::class, $serializerName.'.normalizer');
+            $container->registerAliasForArgument($serializerId, DenormalizerInterface::class, $serializerName.'.denormalizer');
 
             $this->configureSerializer($container, $serializerId, $normalizers, $encoders, $serializerName);
 

--- a/src/Symfony/Component/Serializer/Tests/DependencyInjection/SerializerPassTest.php
+++ b/src/Symfony/Component/Serializer/Tests/DependencyInjection/SerializerPassTest.php
@@ -19,6 +19,8 @@ use Symfony\Component\Serializer\Debug\TraceableEncoder;
 use Symfony\Component\Serializer\Debug\TraceableNormalizer;
 use Symfony\Component\Serializer\Debug\TraceableSerializer;
 use Symfony\Component\Serializer\DependencyInjection\SerializerPass;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**
@@ -591,6 +593,8 @@ class SerializerPassTest extends TestCase
         $this->assertTrue($container->hasAlias(\sprintf('%s $apiSerializer', SerializerInterface::class)));
         $this->assertTrue($container->hasDefinition('serializer.api2'));
         $this->assertTrue($container->hasAlias(\sprintf('%s $api2Serializer', SerializerInterface::class)));
+        $this->assertTrue($container->hasAlias(\sprintf('%s $api2Normalizer', NormalizerInterface::class)));
+        $this->assertTrue($container->hasAlias(\sprintf('%s $api2Denormalizer', DenormalizerInterface::class)));
     }
 
     public function testNormalizersAndEncodersAreDecoratedAndOrderedWhenCollectingDataForNamedSerializers()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #59638
| License       | MIT

When defining named serializers register named aliases for NormalizerInterface & DenormalizerInterface too 