### PR TITLE
[Console] Add markdown format to Table

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Deprecate not declaring the parameter type in callable commands defined through `setCode` method
  * Add support for help definition via `AsCommand` attribute
  * Deprecate methods `Command::getDefaultName()` and `Command::getDefaultDescription()` in favor of the `#[AsCommand]` attribute
+ * Add support for Markdown format in `Table`
 
 7.2
 ---

--- a/src/Symfony/Component/Console/Helper/Table.php
+++ b/src/Symfony/Component/Console/Helper/Table.php
@@ -417,7 +417,7 @@ class Table
                     continue;
                 }
 
-                if ($isHeader && !$isHeaderSeparatorRendered) {
+                if ($isHeader && !$isHeaderSeparatorRendered && $this->style->displayOutsideBorder()) {
                     $this->renderRowSeparator(
                         self::SEPARATOR_TOP,
                         $hasTitle ? $this->headerTitle : null,
@@ -449,7 +449,10 @@ class Table
                 }
             }
         }
-        $this->renderRowSeparator(self::SEPARATOR_BOTTOM, $this->footerTitle, $this->style->getFooterTitleFormat());
+
+        if ($this->getStyle()->displayOutsideBorder()) {
+            $this->renderRowSeparator(self::SEPARATOR_BOTTOM, $this->footerTitle, $this->style->getFooterTitleFormat());
+        }
 
         $this->cleanup();
         $this->rendered = true;
@@ -868,6 +871,12 @@ class Table
      */
     private static function initStyles(): array
     {
+        $markdown = new TableStyle();
+        $markdown
+            ->setDefaultCrossingChar('|')
+            ->setDisplayOutsideBorder(false)
+        ;
+
         $borderless = new TableStyle();
         $borderless
             ->setHorizontalBorderChars('=')
@@ -905,6 +914,7 @@ class Table
 
         return [
             'default' => new TableStyle(),
+            'markdown' => $markdown,
             'borderless' => $borderless,
             'compact' => $compact,
             'symfony-style-guide' => $styleGuide,

--- a/src/Symfony/Component/Console/Helper/TableStyle.php
+++ b/src/Symfony/Component/Console/Helper/TableStyle.php
@@ -46,6 +46,7 @@ class TableStyle
     private string $cellRowFormat = '%s';
     private string $cellRowContentFormat = ' %s ';
     private string $borderFormat = '%s';
+    private bool $displayOutsideBorder = true;
     private int $padType = \STR_PAD_RIGHT;
 
     /**
@@ -358,5 +359,17 @@ class TableStyle
         $this->footerTitleFormat = $format;
 
         return $this;
+    }
+
+    public function setDisplayOutsideBorder($displayOutSideBorder): static
+    {
+        $this->displayOutsideBorder = $displayOutSideBorder;
+
+        return $this;
+    }
+
+    public function displayOutsideBorder(): bool
+    {
+        return $this->displayOutsideBorder;
     }
 }

--- a/src/Symfony/Component/Console/Tests/Helper/TableTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableTest.php
@@ -117,6 +117,20 @@ TABLE,
             [
                 ['ISBN', 'Title', 'Author'],
                 $books,
+                'markdown',
+                <<<'TABLE'
+| ISBN          | Title                    | Author           |
+|---------------|--------------------------|------------------|
+| 99921-58-10-7 | Divine Comedy            | Dante Alighieri  |
+| 9971-5-0210-0 | A Tale of Two Cities     | Charles Dickens  |
+| 960-425-059-0 | The Lord of the Rings    | J. R. R. Tolkien |
+| 80-902734-1-6 | And Then There Were None | Agatha Christie  |
+
+TABLE,
+            ],
+            [
+                ['ISBN', 'Title', 'Author'],
+                $books,
                 'compact',
                 implode("\n", [
                     'ISBN          Title                    Author           ',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #17466 
| License       | MIT

Aim: allow rendering markdown tables. Those don't have a Outside border frame line like --------, so we allow to remove them and define the format "markdown".

Our motivation is to pipe symfony console output in CI to GitHub/gitlab merge requests and format them properly.