### PR TITLE
[Lock] Fix Predis error handling

### DIFF
--- a/src/Symfony/Component/Lock/Tests/Store/PredisStoreWithExceptionsTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/PredisStoreWithExceptionsTest.php
@@ -12,18 +12,13 @@
 namespace Symfony\Component\Lock\Tests\Store;
 
 /**
- * @author Jérémy Derussé <jeremy@derusse.com>
- *
  * @group integration
  */
-class PredisStoreTest extends AbstractRedisStoreTestCase
+class PredisStoreWithExceptionsTest extends AbstractRedisStoreTestCase
 {
     public static function setUpBeforeClass(): void
     {
-        $redis = new \Predis\Client(
-            array_combine(['host', 'port'], explode(':', getenv('REDIS_HOST')) + [1 => null]),
-            ['exceptions' => false],
-        );
+        $redis = new \Predis\Client(array_combine(['host', 'port'], explode(':', getenv('REDIS_HOST')) + [1 => null]));
         try {
             $redis->connect();
         } catch (\Exception $e) {
@@ -33,10 +28,7 @@ class PredisStoreTest extends AbstractRedisStoreTestCase
 
     protected function getRedisConnection(): \Predis\Client
     {
-        $redis = new \Predis\Client(
-            array_combine(['host', 'port'], explode(':', getenv('REDIS_HOST')) + [1 => null]),
-            ['exceptions' => false],
-        );
+        $redis = new \Predis\Client(array_combine(['host', 'port'], explode(':', getenv('REDIS_HOST')) + [1 => null]));
         $redis->connect();
 
         return $redis;

--- a/src/Symfony/Component/Lock/Tests/Store/PredisStoreWithoutExceptionsTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/PredisStoreWithoutExceptionsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock\Tests\Store;
+
+/**
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ *
+ * @group integration
+ */
+class PredisStoreWithoutExceptionsTest extends AbstractRedisStoreTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        $redis = new \Predis\Client(
+            array_combine(['host', 'port'], explode(':', getenv('REDIS_HOST')) + [1 => null]),
+            ['exceptions' => false],
+        );
+        try {
+            $redis->connect();
+        } catch (\Exception $e) {
+            self::markTestSkipped($e->getMessage());
+        }
+    }
+
+    protected function getRedisConnection(): \Predis\Client
+    {
+        $redis = new \Predis\Client(
+            array_combine(['host', 'port'], explode(':', getenv('REDIS_HOST')) + [1 => null]),
+            ['exceptions' => false],
+        );
+        $redis->connect();
+
+        return $redis;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59686
| License       | MIT

#59348 completely broke the Redis store when used with a service, eg:

```yaml
framework:
  lock:
    resources:
      default: snc_redis.default
```

The assumption that `exceptions` is always `false` is only correct when a DSN is used.