### PR TITLE
[Validator] Add `Base64Encoded` constraint

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Base64Encoded.php
+++ b/src/Symfony/Component/Validator/Constraints/Base64Encoded.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Ensures that the value is a valid Base64-encoded.
+ * 
+ * @author Refat Alsakka <refatalsakka@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+class Base64Encoded extends Constraint
+{
+    public string $message = 'The string "{{ value }}" is not a valid Base64-encoded value.';
+}

--- a/src/Symfony/Component/Validator/Constraints/Base64Encoded.php
+++ b/src/Symfony/Component/Validator/Constraints/Base64Encoded.php
@@ -15,7 +15,7 @@ use Symfony\Component\Validator\Constraint;
 
 /**
  * Ensures that the value is a valid Base64-encoded.
- * 
+ *
  * @author Refat Alsakka <refatalsakka@gmail.com>
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]

--- a/src/Symfony/Component/Validator/Constraints/Base64EncodedValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/Base64EncodedValidator.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+/**
+ * @author Refat Alsakka <refatalsakka@gmail.com>
+ */
+class Base64EncodedValidator extends ConstraintValidator
+{
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$constraint instanceof Base64Encoded) {
+            throw new UnexpectedTypeException($constraint, Base64Encoded::class);
+        }
+
+        if (!$this->isValidBase64($value)) {
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $value)
+                ->addViolation();
+        }
+    }
+
+    private function isValidBase64(string $value): bool
+    {
+        return base64_encode(base64_decode($value, true)) == $value;
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/Base64EncodedValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/Base64EncodedValidator.php
@@ -20,7 +20,7 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  */
 class Base64EncodedValidator extends ConstraintValidator
 {
-    public function validate($value, Constraint $constraint)
+    public function validate(mixed $value, Constraint $constraint): void
     {
         if (!$constraint instanceof Base64Encoded) {
             throw new UnexpectedTypeException($constraint, Base64Encoded::class);

--- a/src/Symfony/Component/Validator/Tests/Constraints/Base64EncodedValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/Base64EncodedValidatorTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\Base64Encoded;
+use Symfony\Component\Validator\Constraints\Base64EncodedValidator;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+/**
+ * @author Refat Alsakka <refatalsakka@gmail.com>
+ */
+class Base64EncodedValidatorTest extends ConstraintValidatorTestCase
+{
+    protected function createValidator(): Base64EncodedValidator
+    {
+        return new Base64EncodedValidator();
+    }
+
+    public function testValidBase64()
+    {
+        $this->validator->validate('U3ltZm9ueQ==', new Base64Encoded());
+        $this->assertNoViolation();
+    }
+
+    public function testInvalidBase64()
+    {
+        $this->validator->validate('invalid@base64', new Base64Encoded());
+
+        $this->buildViolation('The value "{{ value }}" is not a valid Base64-encoded string.')
+            ->setParameter('{{ value }}', 'invalid@base64')
+            ->assertRaised();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | N/A
| License       | MIT

### Description

This PR introduces a new `Base64Encoded` constraint to the Symfony Validator component.

#### Features:
- Ensures that a given string is correctly Base64-encoded.
- Supports optional `data:` URI prefixes.
- Includes unit tests for validation.

### **Update features description**
- ~~Supports optional `data:` URI prefixes.~~