### PR TITLE
[Notifier] [Bluesky] Allow to attach website preview card

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Bluesky/BlueskyOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Bluesky/BlueskyOptions.php
@@ -43,4 +43,16 @@ final class BlueskyOptions implements MessageOptionsInterface
 
         return $this;
     }
+
+    public function attachCard(string $uri, File $thumb, string $title = '', string $description = ''): static
+    {
+        $this->options['external'] = [
+            'uri' => $uri,
+            'thumb' => $thumb,
+            'title' => $title,
+            'description' => $description,
+        ];
+
+        return $this;
+    }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Bluesky/BlueskyTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Bluesky/BlueskyTransport.php
@@ -91,6 +91,26 @@ final class BlueskyTransport extends AbstractTransport
             unset($options['attach']);
         }
 
+        if (isset($options['external'])) {
+            $uploadedMedia = $this->uploadMedia([
+                [
+                    'file' => $options['external']['thumb'],
+                    'description' => $options['external']['description'],
+                ],
+            ]);
+
+            $options['record']['embed'] = [
+                '$type' => 'app.bsky.embed.external',
+                'external' => [
+                    'uri' => $options['external']['uri'],
+                    'title' => $options['external']['title'],
+                    'description' => $options['external']['description'],
+                    'thumb' => $uploadedMedia[array_key_first($uploadedMedia)]['image'],
+                ],
+            ];
+            unset($options['external']);
+        }
+
         $response = $this->client->request('POST', \sprintf('https://%s/xrpc/com.atproto.repo.createRecord', $this->getEndpoint()), [
             'auth_bearer' => $this->authSession['accessJwt'] ?? null,
             'json' => $options,

--- a/src/Symfony/Component/Notifier/Bridge/Bluesky/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Bluesky/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.3
+---
+
+ * Add option to attach a website preview card
+
 7.2
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Bluesky/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Bluesky/README.md
@@ -10,6 +10,30 @@ DSN example
 BLUESKY_DSN=bluesky://nyholm.bsky.social:p4ssw0rd@bsky.social
 ```
 
+Adding Options to a Message
+---------------------------
+
+Use a `BlueskyOptions` object to add options to the message:
+
+```php
+use Symfony\Component\Notifier\Bridge\Bluesky\BlueskyOptions;
+use Symfony\Component\Notifier\Message\ChatMessage;
+
+$message = new ChatMessage('My message');
+
+// Add website preview card to the message
+$options = (new BlueskyOptions())
+    ->attachCard('https://example.com', new File('image.jpg'))
+    // You can also add media to the message
+    //->attachMedia(new File($command->fileName), 'description')
+    ;
+
+// Add the custom options to the Bluesky message and send the message
+$message->options($options);
+
+$chatter->send($message);
+```
+
 Resources
 ---------
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3 <!-- see below -->
| Bug fix?      | no
| New feature?  | yes<!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

This addition will allow us to add a preview card to a link: 
![image](https://github.com/user-attachments/assets/c2d5a19c-95e1-4160-8677-8e5cb15af904)

