### PR TITLE
[Serializer] Add `NumberNormalizer`

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -32,6 +32,8 @@
                 <referencedClass name="UnitEnum"/>
                 <!-- These classes have been added in PHP 8.2 -->
                 <referencedClass name="Random\*"/>
+                <!-- These classes have been added in PHP 8.4 -->
+                <referencedClass name="BcMath\Number"/>
             </errorLevel>
         </UndefinedClass>
         <UndefinedDocblockClass>

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -170,6 +170,7 @@ use Symfony\Component\Serializer\Mapping\Loader\YamlFileLoader;
 use Symfony\Component\Serializer\NameConverter\SnakeCaseToCamelCaseNameConverter;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NumberNormalizer;
 use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Stopwatch\Stopwatch;
 use Symfony\Component\String\LazyString;
@@ -1931,6 +1932,11 @@ class FrameworkExtension extends Extension
 
         if (!class_exists(Headers::class)) {
             $container->removeDefinition('serializer.normalizer.mime_message');
+        }
+
+        // BC layer Serializer < 7.3
+        if (!class_exists(NumberNormalizer::class)) {
+            $container->removeDefinition('serializer.normalizer.number');
         }
 
         // BC layer Serializer < 7.2

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.php
@@ -44,6 +44,7 @@ use Symfony\Component\Serializer\Normalizer\FormErrorNormalizer;
 use Symfony\Component\Serializer\Normalizer\JsonSerializableNormalizer;
 use Symfony\Component\Serializer\Normalizer\MimeMessageNormalizer;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NumberNormalizer;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\ProblemNormalizer;
 use Symfony\Component\Serializer\Normalizer\PropertyNormalizer;
@@ -220,6 +221,9 @@ return static function (ContainerConfigurator $container) {
             ])
 
         ->set('serializer.normalizer.backed_enum', BackedEnumNormalizer::class)
+            ->tag('serializer.normalizer', ['built_in' => true, 'priority' => -915])
+
+        ->set('serializer.normalizer.number', NumberNormalizer::class)
             ->tag('serializer.normalizer', ['built_in' => true, 'priority' => -915])
     ;
 };

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Deprecate the `CompiledClassMetadataFactory` and `CompiledClassMetadataCacheWarmer` classes
  * Register `NormalizerInterface` and `DenormalizerInterface` aliases for named serializers
+ * Add `NumberNormalizer` to normalize `BcMath\Number` and `GMP` as `string`
 
 7.2
 ---

--- a/src/Symfony/Component/Serializer/Normalizer/NumberNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/NumberNormalizer.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Normalizer;
+
+use BcMath\Number;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
+
+/**
+ * Normalizes {@see Number} and {@see \GMP} to a string.
+ */
+final class NumberNormalizer implements NormalizerInterface, DenormalizerInterface
+{
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            Number::class => true,
+            \GMP::class => true,
+        ];
+    }
+
+    public function normalize(mixed $data, ?string $format = null, array $context = []): string
+    {
+        if (!$data instanceof Number && !$data instanceof \GMP) {
+            throw new InvalidArgumentException(\sprintf('The data must be an instance of "%s" or "%s".', Number::class, \GMP::class));
+        }
+
+        return (string) $data;
+    }
+
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Number || $data instanceof \GMP;
+    }
+
+    /**
+     * @throws NotNormalizableValueException
+     */
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): Number|\GMP
+    {
+        if (!\is_string($data) && !\is_int($data)) {
+            throw $this->createNotNormalizableValueException($type, $data, $context);
+        }
+
+        try {
+            return match ($type) {
+                Number::class => new Number($data),
+                \GMP::class => new \GMP($data),
+                default => throw new InvalidArgumentException(\sprintf('Only "%s" and "%s" types are supported.', Number::class, \GMP::class)),
+            };
+        } catch (\ValueError $e) {
+            throw $this->createNotNormalizableValueException($type, $data, $context, $e);
+        }
+    }
+
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return \in_array($type, [Number::class, \GMP::class], true) && null !== $data;
+    }
+
+    private function createNotNormalizableValueException(string $type, mixed $data, array $context, ?\Throwable $previous = null): NotNormalizableValueException
+    {
+        $message = match ($type) {
+            Number::class => 'The data must be a "string" representing a decimal number, or an "int".',
+            \GMP::class => 'The data must be a "string" representing an integer, or an "int".',
+        };
+
+        return NotNormalizableValueException::createForUnexpectedDataType($message, $data, ['string', 'int'], $context['deserialization_path'] ?? null, true, 0, $previous);
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/NumberNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/NumberNormalizerTest.php
@@ -1,0 +1,150 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Normalizer;
+
+use BcMath\Number;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
+use Symfony\Component\Serializer\Normalizer\NumberNormalizer;
+
+/**
+ * @requires PHP 8.4
+ * @requires extension bcmath
+ * @requires extension gmp
+ */
+class NumberNormalizerTest extends TestCase
+{
+    private NumberNormalizer $normalizer;
+
+    protected function setUp(): void
+    {
+        $this->normalizer = new NumberNormalizer();
+    }
+
+    /**
+     * @dataProvider supportsNormalizationProvider
+     */
+    public function testSupportsNormalization(mixed $data, bool $expected)
+    {
+        $this->assertSame($expected, $this->normalizer->supportsNormalization($data));
+    }
+
+    public static function supportsNormalizationProvider(): iterable
+    {
+        yield 'GMP object' => [new \GMP('0b111'), true];
+        yield 'Number object' => [new Number('1.23'), true];
+        yield 'object with similar properties as Number' => [(object) ['value' => '1.23', 'scale' => 2], false];
+        yield 'stdClass' => [new \stdClass(), false];
+        yield 'string' => ['1.23', false];
+        yield 'float' => [1.23, false];
+        yield 'null' => [null, false];
+    }
+
+    /**
+     * @dataProvider normalizeGoodValueProvider
+     */
+    public function testNormalize(mixed $data, mixed $expected)
+    {
+        $this->assertSame($expected, $this->normalizer->normalize($data));
+    }
+
+    public static function normalizeGoodValueProvider(): iterable
+    {
+        yield 'Number with scale=2' => [new Number('1.23'), '1.23'];
+        yield 'Number with scale=0' => [new Number('1'), '1'];
+        yield 'Number with integer' => [new Number(123), '123'];
+        yield 'GMP hex' => [new \GMP('0x10'), '16'];
+        yield 'GMP base=10' => [new \GMP('10'), '10'];
+    }
+
+    /**
+     * @dataProvider normalizeBadValueProvider
+     */
+    public function testNormalizeBadValueThrows(mixed $data)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The data must be an instance of "BcMath\Number" or "GMP".');
+
+        $this->normalizer->normalize($data);
+    }
+
+    public static function normalizeBadValueProvider(): iterable
+    {
+        yield 'stdClass' => [new \stdClass()];
+        yield 'string' => ['1.23'];
+        yield 'null' => [null];
+    }
+
+    /**
+     * @dataProvider supportsDenormalizationProvider
+     */
+    public function testSupportsDenormalization(mixed $data, string $type, bool $expected)
+    {
+        $this->assertSame($expected, $this->normalizer->supportsDenormalization($data, $type));
+    }
+
+    public static function supportsDenormalizationProvider(): iterable
+    {
+        yield 'null value, Number' => [null, Number::class, false];
+        yield 'null value, GMP' => [null, \GMP::class, false];
+        yield 'null value, unmatching type' => [null, \stdClass::class, false];
+    }
+
+    /**
+     * @dataProvider denormalizeGoodValueProvider
+     */
+    public function testDenormalize(mixed $data, string $type, mixed $expected)
+    {
+        $this->assertEquals($expected, $this->normalizer->denormalize($data, $type));
+    }
+
+    public static function denormalizeGoodValueProvider(): iterable
+    {
+        yield 'Number, string with decimal point' => ['1.23', Number::class, new Number('1.23')];
+        yield 'Number, integer as string' => ['123', Number::class, new Number('123')];
+        yield 'Number, integer' => [123, Number::class, new Number('123')];
+        yield 'GMP, large number' => ['9223372036854775808', \GMP::class, new \GMP('9223372036854775808')];
+        yield 'GMP, integer' => [123, \GMP::class, new \GMP('123')];
+    }
+
+    /**
+     * @dataProvider denormalizeBadValueProvider
+     */
+    public function testDenormalizeBadValueThrows(mixed $data, string $type, string $expectedException, string $expectedExceptionMessage)
+    {
+        $this->expectException($expectedException);
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
+        $this->normalizer->denormalize($data, $type);
+    }
+
+    public static function denormalizeBadValueProvider(): iterable
+    {
+        $stringOrDecimalExpectedMessage = 'The data must be a "string" representing a decimal number, or an "int".';
+        yield 'Number, null' => [null, Number::class, NotNormalizableValueException::class, $stringOrDecimalExpectedMessage];
+        yield 'Number, boolean' => [true, Number::class, NotNormalizableValueException::class, $stringOrDecimalExpectedMessage];
+        yield 'Number, object' => [new \stdClass(), Number::class, NotNormalizableValueException::class, $stringOrDecimalExpectedMessage];
+        yield 'Number, non-numeric string' => ['foobar', Number::class, NotNormalizableValueException::class, $stringOrDecimalExpectedMessage];
+        yield 'Number, float' => [1.23, Number::class, NotNormalizableValueException::class, $stringOrDecimalExpectedMessage];
+
+        $stringOrIntExpectedMessage = 'The data must be a "string" representing an integer, or an "int".';
+        yield 'GMP, null' => [null, \GMP::class, NotNormalizableValueException::class, $stringOrIntExpectedMessage];
+        yield 'GMP, boolean' => [true, \GMP::class, NotNormalizableValueException::class, $stringOrIntExpectedMessage];
+        yield 'GMP, object' => [new \stdClass(), \GMP::class, NotNormalizableValueException::class, $stringOrIntExpectedMessage];
+        yield 'GMP, non-numeric string' => ['foobar', \GMP::class, NotNormalizableValueException::class, $stringOrIntExpectedMessage];
+        yield 'GMP, scale > 0' => ['1.23', \GMP::class, NotNormalizableValueException::class, $stringOrIntExpectedMessage];
+        yield 'GMP, float' => [1.23, \GMP::class, NotNormalizableValueException::class, $stringOrIntExpectedMessage];
+
+        yield 'unsupported type' => ['1.23', \stdClass::class, InvalidArgumentException::class, 'Only "BcMath\Number" and "GMP" types are supported.'];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #59651
| License       | MIT

Normalize `BcMath\Number` to `string`.

A few changes in comparison to the original issue description:

1. `float`s not supported at all. No point using precision math if you start with non-precise value.
2. `Number` is always normalized to a `string`. If we wanted the `int` cast, it should be opt-in with some context key like `cast_zero_scale_to_int` – though I personally don't see a need for it.