### PR TITLE
[FrameworkBundle] fix compat with AsCommand attributes from symfony/console < 7.3

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -610,11 +610,11 @@ class FrameworkExtension extends Extension
             ->addTag('assets.package');
         $container->registerForAutoconfiguration(AssetCompilerInterface::class)
             ->addTag('asset_mapper.compiler');
-        $container->registerAttributeForAutoconfiguration(AsCommand::class, static function (ChildDefinition $definition, AsCommand $attribute, \ReflectionClass $reflector): void {
+        $container->registerAttributeForAutoconfiguration(AsCommand::class, static function (ChildDefinition $definition, AsCommand $attribute): void {
             $definition->addTag('console.command', [
                 'command' => $attribute->name,
                 'description' => $attribute->description,
-                'help' => $attribute->help,
+                'help' => $attribute->help ?? null,
             ]);
         });
         $container->registerForAutoconfiguration(Command::class)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

FrameworkBundle 7.3 can be used with older releases of the Console component which do not provide help information through the `AsCommand` attribute.