### PR TITLE
[TypeInfo] Fix promoted property phpdoc reading

### DIFF
--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithPhpDoc.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithPhpDoc.php
@@ -10,6 +10,14 @@ final class DummyWithPhpDoc
     public mixed $arrayOfDummies = [];
 
     /**
+     * @param bool $promoted
+     */
+    public function __construct(
+        public mixed $promoted,
+    ) {
+    }
+
+    /**
      * @param Dummy $dummy
      *
      * @return Dummy

--- a/src/Symfony/Component/TypeInfo/Tests/TypeResolver/PhpDocAwareReflectionTypeResolverTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeResolver/PhpDocAwareReflectionTypeResolverTest.php
@@ -28,6 +28,7 @@ class PhpDocAwareReflectionTypeResolverTest extends TestCase
         $reflection = new \ReflectionClass(DummyWithPhpDoc::class);
 
         $this->assertEquals(Type::array(Type::object(Dummy::class)), $resolver->resolve($reflection->getProperty('arrayOfDummies')));
+        $this->assertEquals(Type::bool(), $resolver->resolve($reflection->getProperty('promoted')));
         $this->assertEquals(Type::object(Dummy::class), $resolver->resolve($reflection->getMethod('getNextDummy')));
         $this->assertEquals(Type::object(Dummy::class), $resolver->resolve($reflection->getMethod('getNextDummy')->getParameters()[0]));
     }

--- a/src/Symfony/Component/TypeInfo/TypeResolver/PhpDocAwareReflectionTypeResolver.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/PhpDocAwareReflectionTypeResolver.php
@@ -65,7 +65,7 @@ final readonly class PhpDocAwareReflectionTypeResolver implements TypeResolverIn
         }
 
         $docComment = match (true) {
-            $subject instanceof \ReflectionProperty => $subject->getDocComment(),
+            $subject instanceof \ReflectionProperty => $subject->isPromoted() ? $subject->getDeclaringClass()?->getConstructor()?->getDocComment() : $subject->getDocComment(),
             $subject instanceof \ReflectionParameter => $subject->getDeclaringFunction()->getDocComment(),
             $subject instanceof \ReflectionFunctionAbstract => $subject->getDocComment(),
         };
@@ -77,7 +77,7 @@ final readonly class PhpDocAwareReflectionTypeResolver implements TypeResolverIn
         $typeContext ??= $this->typeContextFactory->createFromReflection($subject);
 
         $tagName = match (true) {
-            $subject instanceof \ReflectionProperty => '@var',
+            $subject instanceof \ReflectionProperty => $subject->isPromoted() ? '@param' : '@var',
             $subject instanceof \ReflectionParameter => '@param',
             $subject instanceof \ReflectionFunctionAbstract => '@return',
         };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59650
| License       | MIT

The read of promoted property's PHPDoc was missing in `PhpDocAwareReflectionTypeResolver`.
This PR adds it.