### PR TITLE
[HttpClient] Prevent empty request body stream in HttplugClient and Psr18Client

### DIFF
--- a/src/Symfony/Component/HttpClient/HttplugClient.php
+++ b/src/Symfony/Component/HttpClient/HttplugClient.php
@@ -234,13 +234,13 @@ final class HttplugClient implements ClientInterface, HttpAsyncClient, RequestFa
             }
 
             $headers = $request->getHeaders();
-            if (!$request->hasHeader('content-length') && 0 <= $size = $body->getSize() ?? -1) {
+            if (!$request->hasHeader('content-length') && 0 < $size = $body->getSize() ?? -1) {
                 $headers['Content-Length'] = [$size];
             }
 
             $options = [
                 'headers' => $headers,
-                'body' => static fn (int $size) => $body->read($size),
+                'body' => 0 === $size ? '' : static fn (int $size) => $body->read($size),
                 'buffer' => $buffer,
             ];
 

--- a/src/Symfony/Component/HttpClient/Psr18Client.php
+++ b/src/Symfony/Component/HttpClient/Psr18Client.php
@@ -98,13 +98,13 @@ final class Psr18Client implements ClientInterface, RequestFactoryInterface, Str
             }
 
             $headers = $request->getHeaders();
-            if (!$request->hasHeader('content-length') && 0 <= $size = $body->getSize() ?? -1) {
+            if (!$request->hasHeader('content-length') && 0 < $size = $body->getSize() ?? -1) {
                 $headers['Content-Length'] = [$size];
             }
 
             $options = [
                 'headers' => $headers,
-                'body' => static fn (int $size) => $body->read($size),
+                'body' => 0 === $size ? '' : static fn (int $size) => $body->read($size),
             ];
 
             if ('1.0' === $request->getProtocolVersion()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

I've detected that several headers related to the body content are sent to upstream HTTP servers while sending any GET request with an empty body since I updated my app to Symfony 7.2

This PR prevents sending these headers when the body is known to be empty.