### PR TITLE
[Serializer] Handle default context in named Serializer

### DIFF
--- a/src/Symfony/Component/Serializer/DependencyInjection/SerializerPass.php
+++ b/src/Symfony/Component/Serializer/DependencyInjection/SerializerPass.php
@@ -151,7 +151,7 @@ class SerializerPass implements CompilerPassInterface
 
             $this->bindDefaultContext($container, array_merge($normalizers, $encoders), $config['default_context']);
 
-            $container->registerChild($serializerId, 'serializer');
+            $container->registerChild($serializerId, 'serializer')->setArgument('$defaultContext', $config['default_context']);
             $container->registerAliasForArgument($serializerId, SerializerInterface::class, $serializerName.'.serializer');
 
             $this->configureSerializer($container, $serializerId, $normalizers, $encoders, $serializerName);

--- a/src/Symfony/Component/Serializer/Tests/DependencyInjection/SerializerPassTest.php
+++ b/src/Symfony/Component/Serializer/Tests/DependencyInjection/SerializerPassTest.php
@@ -556,7 +556,7 @@ class SerializerPassTest extends TestCase
             'api' => ['default_context' => $defaultContext = ['enable_max_depth' => true]],
         ]);
 
-        $container->register('serializer')->setArguments([null, null]);
+        $container->register('serializer')->setArguments([null, null, []]);
         $definition = $container->register('n1')
             ->addTag('serializer.normalizer', ['serializer' => '*'])
             ->addTag('serializer.encoder', ['serializer' => '*'])
@@ -570,6 +570,8 @@ class SerializerPassTest extends TestCase
         $bindings = $container->getDefinition('n1.api')->getBindings();
         $this->assertArrayHasKey('array $defaultContext', $bindings);
         $this->assertEquals($bindings['array $defaultContext'], new BoundArgument($defaultContext, false));
+        $this->assertArrayNotHasKey('$defaultContext', $container->getDefinition('serializer')->getArguments());
+        $this->assertEquals($defaultContext, $container->getDefinition('serializer.api')->getArgument('$defaultContext'));
     }
 
     public function testNamedSerializersAreRegistered()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow up to #58889.

Same should be applied to named serializers.