### PR TITLE
[DependencyInjection] Add `Definition::addResourceTag()` and `ContainerBuilder::findTaggedResourceIds()` for auto-discovering value-objects

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -7,6 +7,8 @@ CHANGELOG
  * Make `#[AsTaggedItem]` repeatable
  * Support `@>` as a shorthand for `!service_closure` in yaml files
  * Don't skip classes with private constructor when autodiscovering
+ * Add `Definition::addExcludeTag()` and `ContainerBuilder::findExcludedServiceIds()`
+   for auto-configuration of classes excluded from the service container
 
 7.2
 ---

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1352,6 +1352,38 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     }
 
     /**
+     * Returns service ids for a given tag, asserting they have the "container.excluded" tag.
+     *
+     *  Example:
+     *
+     *      $container->register('foo')->addExcludeTag('my.tag', ['hello' => 'world'])
+     *
+     *      $serviceIds = $container->findExcludedServiceIds('my.tag');
+     *      foreach ($serviceIds as $serviceId => $tags) {
+     *          foreach ($tags as $tag) {
+     *              echo $tag['hello'];
+     *          }
+     *      }
+     *
+     * @return array<string, array> An array of tags with the tagged service as key, holding a list of attribute arrays
+     */
+    public function findExcludedServiceIds(string $tagName): array
+    {
+        $this->usedTags[] = $tagName;
+        $tags = [];
+        foreach ($this->getDefinitions() as $id => $definition) {
+            if ($definition->hasTag($tagName)) {
+                if (!$definition->hasTag('container.excluded')) {
+                    throw new InvalidArgumentException(\sprintf('The service "%s" tagged "%s" is missing the "container.excluded" tag.', $id, $tagName));
+                }
+                $tags[$id] = $definition->getTag($tagName);
+            }
+        }
+
+        return $tags;
+    }
+
+    /**
      * Returns all tags the defined services use.
      *
      * @return string[]

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -456,6 +456,20 @@ class Definition
     }
 
     /**
+     * Adds a tag to the definition and marks it as excluded.
+     *
+     * These definitions should be processed using {@see ContainerBuilder::findExcludedServiceIds()}
+     *
+     * @return $this
+     */
+    public function addExcludeTag(string $name, array $attributes = []): static
+    {
+        return $this->addTag($name, $attributes)
+            ->addTag('container.excluded', ['source' => \sprintf('by tag "%s"', $name)])
+            ->setAbstract(true);
+    }
+
+    /**
      * Whether this definition has a tag with the given name.
      */
     public function hasTag(string $name): bool

--- a/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
@@ -258,6 +258,16 @@ class DefinitionTest extends TestCase
         ], $def->getTags(), '->getTags() returns all tags');
     }
 
+    public function testAddExcludeTag()
+    {
+        $def = new Definition('stdClass');
+        $def->addExcludeTag('foo', ['bar' => true]);
+
+        $this->assertSame([['bar' => true]], $def->getTag('foo'));
+        $this->assertTrue($def->isAbstract());
+        $this->assertSame([['source' => 'by tag "foo"']], $def->getTag('container.excluded'));
+    }
+
     public function testSetArgument()
     {
         $def = new Definition('stdClass');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

We could **not** use the method `findTaggedServiceIds` in https://github.com/symfony/symfony/pull/59401#discussion_r1907681056, same for https://github.com/api-platform/core/pull/6943.

As "using the container loading tools to do resource discovery quite seamlessly" [seems to be a good idea](https://github.com/symfony/symfony/pull/59401#pullrequestreview-2540180421), this changes make it easier.

I'm not closed to alternative ideas if we want to go further with this use-case.

### Usage

Let's create a `AppModel` attribute class and use it on any class of the project.

In the extension class:
```php
$this->registerAttributeForAutoconfiguration(AppModel::class, static function (ChildDefinition $definition) {
    $definition->addExcludedTag('app.model');
});
```

In a compiler pass:
```php
$classes = [];
foreach($containerBuilder->findExcludedServiceIds('app.model') as $id => $tags) {
    $classes[] = $containerBuilder->getDefinition($id)->getClass();
}

$containerBuilder->setParameter('.app.model_classes', $classes);
```

And this parameter can be injected into a service, or directly update a service definition to inject this list of classes. The attribute parameters can be injected into the tag, and retrieved in the compiler pass, for more advanced configuration.