### PR TITLE
[HttpClient] `curl_multi_select()` timeout must be positive

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/CurlResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/CurlResponse.php
@@ -354,7 +354,7 @@ final class CurlResponse implements ResponseInterface, StreamableInterface
             }
         }
 
-        if (0 !== $selected = curl_multi_select($multi->handle, $timeout < 0 ? $timeout : 1.1)) {
+        if (0 !== $selected = curl_multi_select($multi->handle, 0 < $timeout ? $timeout : 1.0)) {
             return $selected;
         }
 

--- a/src/Symfony/Component/HttpClient/Response/CurlResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/CurlResponse.php
@@ -354,7 +354,7 @@ final class CurlResponse implements ResponseInterface, StreamableInterface
             }
         }
 
-        if (0 !== $selected = curl_multi_select($multi->handle, $timeout)) {
+        if (0 !== $selected = curl_multi_select($multi->handle, $timeout < 0 ? $timeout : 1.1)) {
             return $selected;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Issues        | Fix #59041
| License       | MIT

Ensure that the timeout can never be negative
Blind proposed based on  #59041