### PR TITLE
[DependencyInjection] Do not preload functions

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -353,7 +353,7 @@ $preloadedFiles
 EOF;
 
                 foreach ($this->preload as $class) {
-                    if (!$class || str_contains($class, '$') || \in_array($class, ['int', 'float', 'string', 'bool', 'resource', 'object', 'array', 'null', 'callable', 'iterable', 'mixed', 'void'], true)) {
+                    if (!$class || str_contains($class, '$') || \in_array($class, ['int', 'float', 'string', 'bool', 'resource', 'object', 'array', 'null', 'callable', 'iterable', 'mixed', 'void', 'never'], true)) {
                         continue;
                     }
                     if (!(class_exists($class, false) || interface_exists($class, false) || trait_exists($class, false)) || (new \ReflectionClass($class))->isUserDefined()) {
@@ -846,8 +846,7 @@ EOF;
         if ($class = $definition->getClass()) {
             $class = $class instanceof Parameter ? '%'.$class.'%' : $this->container->resolveEnvPlaceholders($class);
             $return[] = sprintf(str_starts_with($class, '%') ? '@return object A %1$s instance' : '@return \%s', ltrim($class, '\\'));
-        } elseif ($definition->getFactory()) {
-            $factory = $definition->getFactory();
+        } elseif ($factory = $definition->getFactory()) {
             if (\is_string($factory) && !str_starts_with($factory, '@=')) {
                 $return[] = sprintf('@return object An instance returned by %s()', $factory);
             } elseif (\is_array($factory) && (\is_string($factory[0]) || $factory[0] instanceof Definition || $factory[0] instanceof Reference)) {
@@ -1170,9 +1169,7 @@ EOTXT
             $arguments[] = (\is_string($i) ? $i.': ' : '').$this->dumpValue($value);
         }
 
-        if (null !== $definition->getFactory()) {
-            $callable = $definition->getFactory();
-
+        if ($callable = $definition->getFactory()) {
             if ('current' === $callable && [0] === array_keys($definition->getArguments()) && \is_array($value) && [0] === array_keys($value)) {
                 return $return.$this->dumpValue($value[0]).$tail;
             }
@@ -2293,7 +2290,6 @@ EOF;
     private function getClasses(Definition $definition, string $id): array
     {
         $classes = [];
-        $resolve = $this->container->getParameterBag()->resolveValue(...);
 
         while ($definition instanceof Definition) {
             foreach ($definition->getTag($this->preloadTags[0]) as $tag) {
@@ -2305,24 +2301,24 @@ EOF;
             }
 
             if ($class = $definition->getClass()) {
-                $classes[] = trim($resolve($class), '\\');
+                $classes[] = trim($class, '\\');
             }
             $factory = $definition->getFactory();
 
-            if (!\is_array($factory)) {
-                $factory = [$factory];
+            if (\is_string($factory) && !str_starts_with($factory, '@=') && str_contains($factory, '::')) {
+                $factory = explode('::', $factory);
             }
 
-            if (\is_string($factory[0])) {
-                $factory[0] = $resolve($factory[0]);
+            if (!\is_array($factory)) {
+                $definition = $factory;
+                continue;
+            }
 
-                if (false !== $i = strrpos($factory[0], '::')) {
-                    $factory[0] = substr($factory[0], 0, $i);
-                }
+            $definition = $factory[0] ?? null;
+
+            if (\is_string($definition)) {
                 $classes[] = trim($factory[0], '\\');
             }
-
-            $definition = $factory[0];
         }
 
         return $classes;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT

Ensure `preload.php` does not have functions in preloaded class names:
```
$ grep "current" var/cache/prod/App_KernelProdContainer.preload.php 
$classes[] = 'current';
```

Happens because the DI declares a factory, which uses built-in `\current`: https://github.com/symfony/symfony/blob/v6.4.18/src/Symfony/Bundle/FrameworkBundle/Resources/config/http_client.php#L39
And then the "class" is added by https://github.com/symfony/symfony/blob/v6.4.18/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php#L2317

Similar to the #36866 
