### PR TITLE
Fix DeduplicateMiddleware changelog

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -5,11 +5,11 @@ CHANGELOG
 ---
 
  * Add `SentForRetryStamp` that identifies whether a failed message was sent for retry
+ * Add `Symfony\Component\Messenger\Middleware\DeduplicateMiddleware` and `Symfony\Component\Messenger\Stamp\DeduplicateStamp`
 
 7.2
 ---
 
- * Add `Symfony\Component\Messenger\Middleware\DeduplicateMiddleware` and `Symfony\Component\Messenger\Stamp\DeduplicateStamp`
  * Add `$previous` to the exception output at the `messenger:failed:show` command
  * `WrappedExceptionsInterface` now extends PHP's `Throwable` interface
  * Add `#[AsMessage]` attribute with `$transport` parameter for message routing


### PR DESCRIPTION
Hi @fabpot

I forgot to update the changelog, but https://github.com/symfony/symfony/pull/54141/files was merged on 7.3.