### PR TITLE
[Form] Allow filtering locales in LanguageType

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.3
+---
+
+* Add the `filter_locales` option to `LanguageType`
+
 7.2
 ---
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/LanguageType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/LanguageType.php
@@ -30,11 +30,13 @@ class LanguageType extends AbstractType
                 if (!class_exists(Intl::class)) {
                     throw new LogicException(\sprintf('The "symfony/intl" component is required to use "%s". Try running "composer require symfony/intl".', static::class));
                 }
+                $filterLocales = $options['filter_locales'];
+                $needsFiltering = \count($filterLocales) > 0;
                 $choiceTranslationLocale = $options['choice_translation_locale'];
                 $useAlpha3Codes = $options['alpha3'];
                 $choiceSelfTranslation = $options['choice_self_translation'];
 
-                return ChoiceList::loader($this, new IntlCallbackChoiceLoader(static function () use ($choiceTranslationLocale, $useAlpha3Codes, $choiceSelfTranslation) {
+                return ChoiceList::loader($this, new IntlCallbackChoiceLoader(static function () use ($choiceTranslationLocale, $useAlpha3Codes, $choiceSelfTranslation, $filterLocales, $needsFiltering) {
                     if (true === $choiceSelfTranslation) {
                         foreach (Languages::getLanguageCodes() as $alpha2Code) {
                             try {
@@ -48,9 +50,14 @@ class LanguageType extends AbstractType
                         $languagesList = $useAlpha3Codes ? Languages::getAlpha3Names($choiceTranslationLocale) : Languages::getNames($choiceTranslationLocale);
                     }
 
+                    if ($needsFiltering) {
+                        $languagesList = array_filter($languagesList, static fn ($languageKey) => in_array($languageKey, $filterLocales, true), ARRAY_FILTER_USE_KEY);
+                    }
+
                     return array_flip($languagesList);
                 }), [$choiceTranslationLocale, $useAlpha3Codes, $choiceSelfTranslation]);
             },
+            'filter_locales' => [],
             'choice_translation_domain' => false,
             'choice_translation_locale' => null,
             'alpha3' => false,
@@ -58,6 +65,7 @@ class LanguageType extends AbstractType
             'invalid_message' => 'Please select a valid language.',
         ]);
 
+        $resolver->setAllowedTypes('filter_locales', ['array']);
         $resolver->setAllowedTypes('choice_self_translation', ['bool']);
         $resolver->setAllowedTypes('choice_translation_locale', ['null', 'string']);
         $resolver->setAllowedTypes('alpha3', 'bool');

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
@@ -54,6 +54,41 @@ class LanguageTypeTest extends BaseTypeTestCase
         $this->assertContainsEquals(new ChoiceView('my', 'my', 'бірманська'), $choices);
     }
 
+    /**
+     * @requires extension intl
+     */
+    public function testFilterLocalesOption()
+    {
+        $choices = $this->factory
+            ->create(static::TESTED_TYPE, null, [
+                'filter_locales' => ['fr', 'en'],
+            ])
+            ->createView()->vars['choices'];
+
+        // Don't check objects for identity
+        $this->assertContainsEquals(new ChoiceView('en', 'en', 'English'), $choices);
+        $this->assertContainsEquals(new ChoiceView('fr', 'fr', 'French'), $choices);
+        $this->assertCount(2, $choices);
+    }
+
+    /**
+     * @requires extension intl
+     */
+    public function testFilterLocalesOptionWithAlpha3()
+    {
+        $choices = $this->factory
+            ->create(static::TESTED_TYPE, null, [
+                'filter_locales' => ['fra', 'eng'],
+                'alpha3' => true,
+            ])
+            ->createView()->vars['choices'];
+
+        // Don't check objects for identity
+        $this->assertContainsEquals(new ChoiceView('eng', 'eng', 'English'), $choices);
+        $this->assertContainsEquals(new ChoiceView('fra', 'fra', 'French'), $choices);
+        $this->assertCount(2, $choices);
+    }
+
     public function testAlpha3Option()
     {
         $choices = $this->factory


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

The goal here is to get all the benefits of the locales translation, while restricting the `LanguageType`'s languages to a smaller list. This is important in applications that are not entirely translated, or when users can define their own preferred locale, it being restricted to application-wise locales.

The current "workaround" is to specify locales _and their translations_ manually, either by adding them to translation files, or by using the Intl component to translate it.

This new option simplifies it all, like this:

```php
// Your form
->add('locale', LanguageType::class, [
    'filter_locales' => ['fr', 'en', 'es'],
])
```
