### PR TITLE
[DependencyInjection] Fix cloned lazy services not sharing their dependencies when dumped with PhpDumper

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
@@ -224,6 +224,8 @@ class InlineServiceDefinitionsPass extends AbstractRecursivePass
             return false;
         }
 
-        return $this->container->getDefinition($srcId)->isShared();
+        $srcDefinition = $this->container->getDefinition($srcId);
+
+        return $srcDefinition->isShared() && !$srcDefinition->isLazy();
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -2185,6 +2185,12 @@ EOF;
             if ($edge->isLazy() || !$value instanceof Definition || !$value->isShared()) {
                 return false;
             }
+
+            // When the source node is a proxy or ghost, it will construct its references only when the node itself is initialized.
+            // Since the node can be cloned before being fully initialized, we do not know how often its references are used.
+            if ($this->getProxyDumper()->isProxyCandidate($value)) {
+                return false;
+            }
             $ids[$edge->getSourceNode()->getId()] = true;
         }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -55,6 +55,8 @@ use Symfony\Component\DependencyInjection\Tests\Compiler\SingleMethodInterface;
 use Symfony\Component\DependencyInjection\Tests\Compiler\Wither;
 use Symfony\Component\DependencyInjection\Tests\Compiler\WitherAnnotation;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\CustomDefinition;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\DependencyContainer;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\DependencyContainerInterface;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooClassWithEnumAttribute;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooUnitEnum;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooWithAbstractArgument;
@@ -1675,6 +1677,59 @@ PHP
 
         $wither = $container->get('wither');
         $this->assertInstanceOf(Foo::class, $wither->foo);
+    }
+
+    public function testCloningLazyGhostWithDependency()
+    {
+        $container = new ContainerBuilder();
+        $container->register('dependency', \stdClass::class);
+        $container->register(DependencyContainer::class)
+            ->addArgument(new Reference('dependency'))
+            ->setLazy(true)
+            ->setPublic(true);
+
+        $container->compile();
+        $dumper = new PhpDumper($container);
+        $dump = $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Service_CloningLazyGhostWithDependency']);
+        eval('?>'.$dump);
+
+        $container = new \Symfony_DI_PhpDumper_Service_CloningLazyGhostWithDependency();
+
+        $bar = $container->get(DependencyContainer::class);
+        $this->assertInstanceOf(DependencyContainer::class, $bar);
+
+        $first_clone = clone $bar;
+        $second_clone = clone $bar;
+
+        $this->assertSame($first_clone->dependency, $second_clone->dependency);
+    }
+
+    public function testCloningProxyWithDependency()
+    {
+        $container = new ContainerBuilder();
+        $container->register('dependency', \stdClass::class);
+        $container->register(DependencyContainer::class)
+            ->addArgument(new Reference('dependency'))
+            ->setLazy(true)
+            ->addTag('proxy', [
+                'interface' => DependencyContainerInterface::class,
+            ])
+            ->setPublic(true);
+
+        $container->compile();
+        $dumper = new PhpDumper($container);
+        $dump = $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Service_CloningProxyWithDependency']);
+        eval('?>'.$dump);
+
+        $container = new \Symfony_DI_PhpDumper_Service_CloningProxyWithDependency();
+
+        $bar = $container->get(DependencyContainer::class);
+        $this->assertInstanceOf(DependencyContainerInterface::class, $bar);
+
+        $first_clone = clone $bar;
+        $second_clone = clone $bar;
+
+        $this->assertSame($first_clone->getDependency(), $second_clone->getDependency());
     }
 
     public function testCurrentFactoryInlining()

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/DependencyContainer.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/DependencyContainer.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+class DependencyContainer implements DependencyContainerInterface
+{
+    public function __construct(
+        public mixed $dependency,
+    ) {
+    }
+
+    public function getDependency(): mixed
+    {
+        return $this->dependency;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/DependencyContainerInterface.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/DependencyContainerInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+interface DependencyContainerInterface
+{
+    public function getDependency(): mixed;
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/child.expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/child.expected.yml
@@ -11,7 +11,9 @@ services:
             - container.decorator: { id: bar, inner: b }
         file: file.php
         lazy: true
-        arguments: [!service { class: Class1 }]
+        arguments: ['@b']
+    b:
+        class: Class1
     bar:
         alias: foo
         public: true

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/from_callable.expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/from_callable.expected.yml
@@ -8,5 +8,7 @@ services:
         class: stdClass
         public: true
         lazy: true
-        arguments: [[!service { class: stdClass }, do]]
+        arguments: [['@bar', do]]
         factory: [Closure, fromCallable]
+    bar:
+        class: stdClass

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/closure_proxy.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/closure_proxy.php
@@ -55,6 +55,6 @@ class Symfony_DI_PhpDumper_Test_Closure_Proxy extends Container
      */
     protected static function getClosureProxyService($container, $lazyLoad = true)
     {
-        return $container->services['closure_proxy'] = new class(fn () => new \Symfony\Component\DependencyInjection\Tests\Compiler\Foo()) extends \Symfony\Component\DependencyInjection\Argument\LazyClosure implements \Symfony\Component\DependencyInjection\Tests\Compiler\SingleMethodInterface { public function theMethod() { return $this->service->cloneFoo(...\func_get_args()); } };
+        return $container->services['closure_proxy'] = new class(fn () => ($container->privates['foo'] ??= new \Symfony\Component\DependencyInjection\Tests\Compiler\Foo())) extends \Symfony\Component\DependencyInjection\Argument\LazyClosure implements \Symfony\Component\DependencyInjection\Tests\Compiler\SingleMethodInterface { public function theMethod() { return $this->service->cloneFoo(...\func_get_args()); } };
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/lazy_closure.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/lazy_closure.php
@@ -57,7 +57,7 @@ class Symfony_DI_PhpDumper_Test_Lazy_Closure extends Container
      */
     protected static function getClosure1Service($container, $lazyLoad = true)
     {
-        return $container->services['closure1'] = (new class(fn () => new \Symfony\Component\DependencyInjection\Tests\Compiler\Foo()) extends \Symfony\Component\DependencyInjection\Argument\LazyClosure { public function cloneFoo(?\stdClass $bar = null): \Symfony\Component\DependencyInjection\Tests\Compiler\Foo { return $this->service->cloneFoo(...\func_get_args()); } })->cloneFoo(...);
+        return $container->services['closure1'] = (new class(fn () => ($container->privates['foo'] ??= new \Symfony\Component\DependencyInjection\Tests\Compiler\Foo())) extends \Symfony\Component\DependencyInjection\Argument\LazyClosure { public function cloneFoo(?\stdClass $bar = null): \Symfony\Component\DependencyInjection\Tests\Compiler\Foo { return $this->service->cloneFoo(...\func_get_args()); } })->cloneFoo(...);
     }
 
     /**
@@ -67,6 +67,6 @@ class Symfony_DI_PhpDumper_Test_Lazy_Closure extends Container
      */
     protected static function getClosure2Service($container, $lazyLoad = true)
     {
-        return $container->services['closure2'] = (new class(fn () => new \Symfony\Component\DependencyInjection\Tests\Compiler\FooVoid()) extends \Symfony\Component\DependencyInjection\Argument\LazyClosure { public function __invoke(string $name): void { $this->service->__invoke(...\func_get_args()); } })->__invoke(...);
+        return $container->services['closure2'] = (new class(fn () => ($container->privates['foo_void'] ??= new \Symfony\Component\DependencyInjection\Tests\Compiler\FooVoid())) extends \Symfony\Component\DependencyInjection\Argument\LazyClosure { public function __invoke(string $name): void { $this->service->__invoke(...\func_get_args()); } })->__invoke(...);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_private.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_private.php
@@ -373,15 +373,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
      */
     protected static function getManager3Service($container, $lazyLoad = true)
     {
-        $a = ($container->services['listener3'] ?? self::getListener3Service($container));
+        $a = ($container->privates['connection3'] ?? self::getConnection3Service($container));
 
         if (isset($container->services['manager3'])) {
             return $container->services['manager3'];
         }
-        $b = new \stdClass();
-        $b->listener = [$a];
 
-        return $container->services['manager3'] = new \stdClass($b);
+        return $container->services['manager3'] = new \stdClass($a);
     }
 
     /**
@@ -482,6 +480,34 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
     }
 
     /**
+     * Gets the private 'connection3' shared service.
+     *
+     * @return \stdClass
+     */
+    protected static function getConnection3Service($container)
+    {
+        $container->privates['connection3'] = $instance = new \stdClass();
+
+        $instance->listener = [($container->services['listener3'] ?? self::getListener3Service($container))];
+
+        return $instance;
+    }
+
+    /**
+     * Gets the private 'connection4' shared service.
+     *
+     * @return \stdClass
+     */
+    protected static function getConnection4Service($container)
+    {
+        $container->privates['connection4'] = $instance = new \stdClass();
+
+        $instance->listener = [($container->services['listener4'] ?? self::getListener4Service($container))];
+
+        return $instance;
+    }
+
+    /**
      * Gets the private 'doctrine.listener' shared service.
      *
      * @return \stdClass
@@ -572,13 +598,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
      */
     protected static function getManager4Service($container, $lazyLoad = true)
     {
-        $a = new \stdClass();
+        $a = ($container->privates['connection4'] ?? self::getConnection4Service($container));
 
-        $container->privates['manager4'] = $instance = new \stdClass($a);
+        if (isset($container->privates['manager4'])) {
+            return $container->privates['manager4'];
+        }
 
-        $a->listener = [($container->services['listener4'] ?? self::getListener4Service($container))];
-
-        return $instance;
+        return $container->privates['manager4'] = new \stdClass($a);
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_public.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_public.php
@@ -259,7 +259,7 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
     {
         $container->services['dispatcher2'] = $instance = new \stdClass();
 
-        $instance->subscriber2 = new \stdClass(($container->services['manager2'] ?? self::getManager2Service($container)));
+        $instance->subscriber2 = ($container->privates['subscriber2'] ?? self::getSubscriber2Service($container));
 
         return $instance;
     }
@@ -819,5 +819,21 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
         }
 
         return $container->privates['manager4'] = new \stdClass($a);
+    }
+
+    /**
+     * Gets the private 'subscriber2' shared service.
+     *
+     * @return \stdClass
+     */
+    protected static function getSubscriber2Service($container)
+    {
+        $a = ($container->services['manager2'] ?? self::getManager2Service($container));
+
+        if (isset($container->privates['subscriber2'])) {
+            return $container->privates['subscriber2'];
+        }
+
+        return $container->privates['subscriber2'] = new \stdClass($a);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_wither_lazy.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_wither_lazy.php
@@ -61,7 +61,7 @@ class Symfony_DI_PhpDumper_Service_Wither_Lazy extends Container
 
         $instance = new \Symfony\Component\DependencyInjection\Tests\Compiler\Wither();
 
-        $a = new \Symfony\Component\DependencyInjection\Tests\Compiler\Foo();
+        $a = ($container->privates['Symfony\\Component\\DependencyInjection\\Tests\\Compiler\\Foo'] ??= new \Symfony\Component\DependencyInjection\Tests\Compiler\Foo());
 
         $instance = $instance->withFoo1($a);
         $instance = $instance->withFoo2($a);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59706
| License       | MIT

Fixes referenced services not being shared when lazy services are cloned before being initialized. Adds tests for both the ghost and proxy scenario's. 

This makes the inlining behaviour more conservative, which impacts the outputs of some other test cases.

First commit adds a test, second commit has the fix. Third commit also considers the proxy case, which is also affected. I can squash if necessary.

Targeted 6.4, but this also applies to 7.x.