### PR TITLE
[HttpClient] Fix activity tracking leading to negative timeout errors

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/AmpResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/AmpResponse.php
@@ -179,19 +179,17 @@ final class AmpResponse implements ResponseInterface, StreamableInterface
     /**
      * @param AmpClientState $multi
      */
-    private static function perform(ClientState $multi, ?array &$responses = null): void
+    private static function perform(ClientState $multi, ?array $responses = null): void
     {
-        if ($responses) {
-            foreach ($responses as $response) {
-                try {
-                    if ($response->info['start_time']) {
-                        $response->info['total_time'] = microtime(true) - $response->info['start_time'];
-                        ($response->onProgress)();
-                    }
-                } catch (\Throwable $e) {
-                    $multi->handlesActivity[$response->id][] = null;
-                    $multi->handlesActivity[$response->id][] = $e;
+        foreach ($responses ?? [] as $response) {
+            try {
+                if ($response->info['start_time']) {
+                    $response->info['total_time'] = microtime(true) - $response->info['start_time'];
+                    ($response->onProgress)();
                 }
+            } catch (\Throwable $e) {
+                $multi->handlesActivity[$response->id][] = null;
+                $multi->handlesActivity[$response->id][] = $e;
             }
         }
     }

--- a/src/Symfony/Component/HttpClient/Response/CurlResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/CurlResponse.php
@@ -265,11 +265,11 @@ final class CurlResponse implements ResponseInterface, StreamableInterface
     /**
      * @param CurlClientState $multi
      */
-    private static function perform(ClientState $multi, ?array &$responses = null): void
+    private static function perform(ClientState $multi, ?array $responses = null): void
     {
         if ($multi->performing) {
             if ($responses) {
-                $response = current($responses);
+                $response = $responses[array_key_first($responses)];
                 $multi->handlesActivity[(int) $response->handle][] = null;
                 $multi->handlesActivity[(int) $response->handle][] = new TransportException(sprintf('Userland callback cannot use the client nor the response while processing "%s".', curl_getinfo($response->handle, \CURLINFO_EFFECTIVE_URL)));
             }

--- a/src/Symfony/Component/HttpClient/Response/MockResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/MockResponse.php
@@ -167,7 +167,7 @@ class MockResponse implements ResponseInterface, StreamableInterface
         $runningResponses[0][1][$response->id] = $response;
     }
 
-    protected static function perform(ClientState $multi, array &$responses): void
+    protected static function perform(ClientState $multi, array $responses): void
     {
         foreach ($responses as $response) {
             $id = $response->id;

--- a/src/Symfony/Component/HttpClient/Response/NativeResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/NativeResponse.php
@@ -228,7 +228,7 @@ final class NativeResponse implements ResponseInterface, StreamableInterface
     /**
      * @param NativeClientState $multi
      */
-    private static function perform(ClientState $multi, ?array &$responses = null): void
+    private static function perform(ClientState $multi, ?array $responses = null): void
     {
         foreach ($multi->openHandles as $i => [$pauseExpiry, $h, $buffer, $onProgress]) {
             if ($pauseExpiry) {

--- a/src/Symfony/Component/HttpClient/Response/TransportResponseTrait.php
+++ b/src/Symfony/Component/HttpClient/Response/TransportResponseTrait.php
@@ -92,7 +92,7 @@ trait TransportResponseTrait
     /**
      * Performs all pending non-blocking operations.
      */
-    abstract protected static function perform(ClientState $multi, array &$responses): void;
+    abstract protected static function perform(ClientState $multi, array $responses): void;
 
     /**
      * Waits for network activity.
@@ -150,10 +150,15 @@ trait TransportResponseTrait
         $lastActivity = hrtime(true) / 1E9;
         $elapsedTimeout = 0;
 
-        if ($fromLastTimeout = 0.0 === $timeout && '-0' === (string) $timeout) {
-            $timeout = null;
-        } elseif ($fromLastTimeout = 0 > $timeout) {
-            $timeout = -$timeout;
+        if ((0.0 === $timeout && '-0' === (string) $timeout) || 0 > $timeout) {
+            $timeout = $timeout ? -$timeout : null;
+
+            /** @var ClientState $multi */
+            foreach ($runningResponses as [$multi]) {
+                if (null !== $multi->lastTimeout) {
+                    $elapsedTimeout = max($elapsedTimeout, $lastActivity - $multi->lastTimeout);
+                }
+            }
         }
 
         while (true) {
@@ -162,8 +167,7 @@ trait TransportResponseTrait
             $timeoutMin = $timeout ?? \INF;
 
             /** @var ClientState $multi */
-            foreach ($runningResponses as $i => [$multi]) {
-                $responses = &$runningResponses[$i][1];
+            foreach ($runningResponses as $i => [$multi, &$responses]) {
                 self::perform($multi, $responses);
 
                 foreach ($responses as $j => $response) {
@@ -171,26 +175,25 @@ trait TransportResponseTrait
                     $timeoutMin = min($timeoutMin, $response->timeout, 1);
                     $chunk = false;
 
-                    if ($fromLastTimeout && null !== $multi->lastTimeout) {
-                        $elapsedTimeout = hrtime(true) / 1E9 - $multi->lastTimeout;
-                    }
-
                     if (isset($multi->handlesActivity[$j])) {
                         $multi->lastTimeout = null;
+                        $elapsedTimeout = 0;
                     } elseif (!isset($multi->openHandles[$j])) {
+                        $hasActivity = true;
                         unset($responses[$j]);
                         continue;
                     } elseif ($elapsedTimeout >= $timeoutMax) {
                         $multi->handlesActivity[$j] = [new ErrorChunk($response->offset, sprintf('Idle timeout reached for "%s".', $response->getInfo('url')))];
                         $multi->lastTimeout ??= $lastActivity;
+                        $elapsedTimeout = $timeoutMax;
                     } else {
                         continue;
                     }
 
-                    while ($multi->handlesActivity[$j] ?? false) {
-                        $hasActivity = true;
-                        $elapsedTimeout = 0;
+                    $lastActivity = null;
+                    $hasActivity = true;
 
+                    while ($multi->handlesActivity[$j] ?? false) {
                         if (\is_string($chunk = array_shift($multi->handlesActivity[$j]))) {
                             if (null !== $response->inflate && false === $chunk = @inflate_add($response->inflate, $chunk)) {
                                 $multi->handlesActivity[$j] = [null, new TransportException(sprintf('Error while processing content unencoding for "%s".', $response->getInfo('url')))];
@@ -227,7 +230,6 @@ trait TransportResponseTrait
                             }
                         } elseif ($chunk instanceof ErrorChunk) {
                             unset($responses[$j]);
-                            $elapsedTimeout = $timeoutMax;
                         } elseif ($chunk instanceof FirstChunk) {
                             if ($response->logger) {
                                 $info = $response->getInfo();
@@ -274,10 +276,12 @@ trait TransportResponseTrait
                     if ($chunk instanceof ErrorChunk && !$chunk->didThrow()) {
                         // Ensure transport exceptions are always thrown
                         $chunk->getContent();
+                        throw new \LogicException('A transport exception should have been thrown.');
                     }
                 }
 
                 if (!$responses) {
+                    $hasActivity = true;
                     unset($runningResponses[$i]);
                 }
 
@@ -291,7 +295,7 @@ trait TransportResponseTrait
             }
 
             if ($hasActivity) {
-                $lastActivity = hrtime(true) / 1E9;
+                $lastActivity ??= hrtime(true) / 1E9;
                 continue;
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59041
| License       | MIT

The error case leading to the linked issue is very hard to spot. I won't be able to provide a reproducer nor am I 100% sure that this will fix it. This patch comes solely from logical reasoning so I might have missed something, but hopefully this closes any possibility of passing a negative timeout to `self::select()`.

The fix should be provided by the changed lines about `$hasActivity` and `$lastActivity`.
The rest is cleaning / hardening found meanwhile.