### PR TITLE
[Form][FrameworkBundle] Use auto-configuration to make the default CSRF token id apply only to the app; not to bundles

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -615,7 +615,7 @@ class FrameworkExtension extends Extension
         $container->registerForAutoconfiguration(DataCollectorInterface::class)
             ->addTag('data_collector');
         $container->registerForAutoconfiguration(FormTypeInterface::class)
-            ->addTag('form.type');
+            ->addTag('form.type', ['csrf_token_id' => '%.form.type_extension.csrf.token_id%']);
         $container->registerForAutoconfiguration(FormTypeGuesserInterface::class)
             ->addTag('form.type_guesser');
         $container->registerForAutoconfiguration(FormTypeExtensionInterface::class)
@@ -777,9 +777,7 @@ class FrameworkExtension extends Extension
             $container->setParameter('form.type_extension.csrf.enabled', true);
             $container->setParameter('form.type_extension.csrf.field_name', $config['form']['csrf_protection']['field_name']);
             $container->setParameter('form.type_extension.csrf.field_attr', $config['form']['csrf_protection']['field_attr']);
-
-            $container->getDefinition('form.type_extension.csrf')
-                ->replaceArgument(7, $config['form']['csrf_protection']['token_id']);
+            $container->setParameter('.form.type_extension.csrf.token_id', $config['form']['csrf_protection']['token_id']);
         } else {
             $container->setParameter('form.type_extension.csrf.enabled', false);
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form_csrf.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form_csrf.php
@@ -24,7 +24,7 @@ return static function (ContainerConfigurator $container) {
                 param('validator.translation_domain'),
                 service('form.server_params'),
                 param('form.type_extension.csrf.field_attr'),
-                abstract_arg('framework.form.csrf_protection.token_id'),
+                param('.form.type_extension.csrf.token_id'),
             ])
             ->tag('form.type_extension')
     ;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

After https://github.com/EasyCorp/EasyAdminBundle/pull/6724, I realized I made a mistake in #58095:

The `framework.form.csrf_protection.token_id` config option should not configure the default CSRF token id for *all* forms. Instead, we want this option to apply only to forms managed by the app. Bundles shouldn't be affected.

This is what this PR does: it switches from global config to auto-configured form types only (which means app's form types).