### PR TITLE
[Scheduler] make newly added constructor argument optional

### DIFF
--- a/src/Symfony/Component/Scheduler/Event/PostRunEvent.php
+++ b/src/Symfony/Component/Scheduler/Event/PostRunEvent.php
@@ -20,7 +20,7 @@ class PostRunEvent
         private readonly ScheduleProviderInterface $schedule,
         private readonly MessageContext $messageContext,
         private readonly object $message,
-        private readonly mixed $result,
+        private readonly mixed $result = null,
     ) {
     }
 

--- a/src/Symfony/Component/Scheduler/Tests/EventListener/DispatchSchedulerEventListenerTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/EventListener/DispatchSchedulerEventListenerTest.php
@@ -57,8 +57,8 @@ class DispatchSchedulerEventListenerTest extends TestCase
         $listener->onMessageFailed($workerFailedEvent);
 
         $this->assertInstanceOf(PreRunEvent::class, $secondListener->preRunEvent);
-        $this->assertSame('result', $secondListener->postRunEvent->getResult());
         $this->assertInstanceOf(PostRunEvent::class, $secondListener->postRunEvent);
+        $this->assertSame('result', $secondListener->postRunEvent->getResult());
         $this->assertInstanceOf(FailureEvent::class, $secondListener->failureEvent);
         $this->assertEquals(new \Exception('failed'), $secondListener->failureEvent->getError());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

As the PostRunEvent class is already present in Symfony since 6.4 we cannot add new mandatory constructor arguments without breaking backwards compatibility.
