### PR TITLE
Make data providers static

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Bluesky/Tests/BlueskyTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Bluesky/Tests/BlueskyTransportTest.php
@@ -317,7 +317,7 @@ final class BlueskyTransportTest extends TransportTestCase
         $this->assertSame('103254962155278888', $result->getMessageId());
     }
 
-    public function sendMessageWithEmbedDataProvider(): iterable
+    public static function sendMessageWithEmbedDataProvider(): iterable
     {
         yield 'With media' => [
             'options' => (new BlueskyOptions())->attachMedia(new File(__DIR__.'/fixtures.gif'), 'A fixture'),

--- a/src/Symfony/Component/PropertyInfo/Tests/PropertyInfoCacheExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/PropertyInfoCacheExtractorTest.php
@@ -90,7 +90,7 @@ class PropertyInfoCacheExtractorTest extends AbstractPropertyInfoExtractorTest
      */
     public function testNestedExtractorWithoutGetTypeImplementation(string $property, ?Type $expectedType)
     {
-        $propertyInfoCacheExtractor = new PropertyInfoCacheExtractor(new class() implements PropertyInfoExtractorInterface {
+        $propertyInfoCacheExtractor = new PropertyInfoCacheExtractor(new class implements PropertyInfoExtractorInterface {
             private PropertyTypeExtractorInterface $propertyTypeExtractor;
 
             public function __construct()
@@ -136,7 +136,7 @@ class PropertyInfoCacheExtractorTest extends AbstractPropertyInfoExtractorTest
         }
     }
 
-    public function provideNestedExtractorWithoutGetTypeImplementationData()
+    public static function provideNestedExtractorWithoutGetTypeImplementationData()
     {
         yield ['bar', Type::string()];
         yield ['baz', Type::int()];

--- a/src/Symfony/Component/PropertyInfo/Tests/PropertyInfoExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/PropertyInfoExtractorTest.php
@@ -30,7 +30,7 @@ class PropertyInfoExtractorTest extends AbstractPropertyInfoExtractorTest
      */
     public function testNestedExtractorWithoutGetTypeImplementation(string $property, ?Type $expectedType)
     {
-        $propertyInfoExtractor = new PropertyInfoExtractor([], [new class() implements PropertyTypeExtractorInterface {
+        $propertyInfoExtractor = new PropertyInfoExtractor([], [new class implements PropertyTypeExtractorInterface {
             private PropertyTypeExtractorInterface $propertyTypeExtractor;
 
             public function __construct()
@@ -51,7 +51,7 @@ class PropertyInfoExtractorTest extends AbstractPropertyInfoExtractorTest
         }
     }
 
-    public function provideNestedExtractorWithoutGetTypeImplementationData()
+    public static function provideNestedExtractorWithoutGetTypeImplementationData()
     {
         yield ['bar', Type::string()];
         yield ['baz', Type::int()];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Non-static data providers are deprecated. Fabbot also raised two formatting problems in the same files on anonymous class instanciation, so this PR also fixes them.