### PR TITLE
[Notifier] [BlueSky] Change the value returned as the message ID

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Bluesky/BlueskyTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Bluesky/BlueskyTransport.php
@@ -105,7 +105,7 @@ final class BlueskyTransport extends AbstractTransport
         if (200 === $statusCode) {
             $content = $response->toArray();
             $sentMessage = new SentMessage($message, (string) $this);
-            $sentMessage->setMessageId($content['cid']);
+            $sentMessage->setMessageId($content['uri']);
 
             return $sentMessage;
         }

--- a/src/Symfony/Component/Notifier/Bridge/Bluesky/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Bluesky/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add option to attach a media
+ * [BC Break] Change the returned message ID from record's 'cid' to 'uri'
 
 7.1
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | #59739
| License       | MIT

Some BlueSky API actions require both the `cid` and the `uri` (see https://docs.bsky.app/docs/tutorials/like-repost) so we might re-add the `cid` to SentMessage's `info` in Symfony 7.3.