### PR TITLE
[Translation] check empty notes

### DIFF
--- a/src/Symfony/Component/Translation/Dumper/XliffFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/XliffFileDumper.php
@@ -176,7 +176,7 @@ class XliffFileDumper extends FileDumper
             $metadata = $messages->getMetadata($source, $domain);
 
             // Add notes section
-            if ($this->hasMetadataArrayInfo('notes', $metadata)) {
+            if ($this->hasMetadataArrayInfo('notes', $metadata) && $metadata['notes']) {
                 $notesElement = $dom->createElement('notes');
                 foreach ($metadata['notes'] as $note) {
                     $n = $dom->createElement('note');

--- a/src/Symfony/Component/Translation/Tests/Dumper/XliffFileDumperTest.php
+++ b/src/Symfony/Component/Translation/Tests/Dumper/XliffFileDumperTest.php
@@ -147,4 +147,40 @@ class XliffFileDumperTest extends TestCase
             $dumper->formatCatalogue($catalogue, 'messages', ['default_locale' => 'fr_FR'])
         );
     }
+
+    public function testFormatCatalogueXliff2WithSegmentAttributes()
+    {
+        $catalogue = new MessageCatalogue('en_US');
+        $catalogue->add([
+            'foo' => 'bar',
+            'key' => '',
+        ]);
+        $catalogue->setMetadata('foo', ['segment-attributes' => ['state' => 'translated']]);
+        $catalogue->setMetadata('key', ['segment-attributes' => ['state' => 'translated', 'subState' => 'My Value']]);
+
+        $dumper = new XliffFileDumper();
+
+        $this->assertStringEqualsFile(
+            __DIR__.'/../Fixtures/resources-2.0-segment-attributes.xlf',
+            $dumper->formatCatalogue($catalogue, 'messages', ['default_locale' => 'fr_FR', 'xliff_version' => '2.0'])
+        );
+    }
+
+    public function testEmptyMetadataNotes()
+    {
+        $catalogue = new MessageCatalogue('en_US');
+        $catalogue->add([
+            'empty' => 'notes',
+            'full' => 'notes',
+        ]);
+        $catalogue->setMetadata('empty', ['notes' => []]);
+        $catalogue->setMetadata('full', ['notes' => [['category' => 'file-source', 'priority' => 1, 'content' => 'test/path/to/translation/Example.1.html.twig:27']]]);
+
+        $dumper = new XliffFileDumper();
+
+        $this->assertStringEqualsFile(
+            __DIR__.'/../Fixtures/resources-2.0-empty-notes.xlf',
+            $dumper->formatCatalogue($catalogue, 'messages', ['default_locale' => 'fr_FR', 'xliff_version' => '2.0'])
+        );
+    }
 }

--- a/src/Symfony/Component/Translation/Tests/Fixtures/resources-2.0-empty-notes.xlf
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/resources-2.0-empty-notes.xlf
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="fr-FR" trgLang="en-US">
+  <file id="messages.en_US">
+    <unit id="Ll7LrI6" name="empty">
+      <segment>
+        <source>empty</source>
+        <target>notes</target>
+      </segment>
+    </unit>
+    <unit id="hU8PAYC" name="full">
+      <notes>
+        <note category="file-source" priority="1">test/path/to/translation/Example.1.html.twig:27</note>
+      </notes>
+      <segment>
+        <source>full</source>
+        <target>notes</target>
+      </segment>
+    </unit>
+  </file>
+</xliff>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Issues        | --
| License       | MIT

In the case of notes, an empty array is always stored in the metadata. The is_iterable condition always returns true even if notes is empty and there is no location info. When notes are loaded within a translation, translations containing <notes/> will crash.