### PR TITLE
[Notifier][Ntfy] fix description

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Ntfy/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Ntfy/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "symfony/ntfy-notifier",
     "type": "symfony-notifier-bridge",
-    "description": "Symfony Ntyf Notifier Bridge",
+    "description": "Symfony Ntfy Notifier Bridge",
     "keywords": ["ntfy", "notifier"],
     "homepage": "https://symfony.com",
     "license": "MIT",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Fix an ntfy vs. nfty typo in composer.json description field.

Initially reported by Cyril Brulebois on https://bugs.debian.org/1095786.