### PR TITLE
[VarExporter] Fix lazy objects with hooked properties

### DIFF
--- a/src/Symfony/Component/VarExporter/Internal/Hydrator.php
+++ b/src/Symfony/Component/VarExporter/Internal/Hydrator.php
@@ -287,6 +287,8 @@ class Hydrator
 
             if (\ReflectionProperty::IS_PROTECTED & $flags) {
                 $propertyScopes["\0*\0$name"] = $propertyScopes[$name];
+            } elseif (\PHP_VERSION_ID >= 80400 && $property->getHooks()) {
+                $propertyScopes[$name][] = true;
             }
         }
 

--- a/src/Symfony/Component/VarExporter/ProxyHelper.php
+++ b/src/Symfony/Component/VarExporter/ProxyHelper.php
@@ -58,6 +58,37 @@ final class ProxyHelper
                 throw new LogicException(sprintf('Cannot generate lazy ghost: class "%s" extends "%s" which is internal.', $class->name, $parent->name));
             }
         }
+
+        $hooks = '';
+        $propertyScopes = Hydrator::$propertyScopes[$class->name] ??= Hydrator::getPropertyScopes($class->name);
+        foreach ($propertyScopes as $name => $scope) {
+            if (!isset($scope[4]) || ($p = $scope[3])->isVirtual()) {
+                continue;
+            }
+
+            $type = self::exportType($p);
+            $hooks .= "\n        public {$type} \${$name} {\n";
+
+            foreach ($p->getHooks() as $hook => $method) {
+                if ($method->isFinal()) {
+                    throw new LogicException(sprintf('Cannot generate lazy ghost: hook "%s::%s()" is final.', $class->name, $method->name));
+                }
+
+                if ('get' === $hook) {
+                    $ref = ($method->returnsReference() ? '&' : '');
+                    $hooks .= "            {$ref}get { \$this->initializeLazyObject(); return parent::\${$name}::get(); }\n";
+                } elseif ('set' === $hook) {
+                    $parameters = self::exportParameters($method, true);
+                    $arg = '$'.$method->getParameters()[0]->name;
+                    $hooks .= "            set({$parameters}) { \$this->initializeLazyObject(); parent::\${$name}::set({$arg}); }\n";
+                } else {
+                    throw new LogicException(sprintf('Cannot generate lazy ghost: hook "%s::%s()" is not supported.', $class->name, $method->name));
+                }
+            }
+
+            $hooks .= "        }\n";
+        }
+
         $propertyScopes = self::exportPropertyScopes($class->name);
 
         return <<<EOPHP
@@ -66,7 +97,7 @@ final class ProxyHelper
                 use \Symfony\Component\VarExporter\LazyGhostTrait;
 
                 private const LAZY_OBJECT_PROPERTY_SCOPES = {$propertyScopes};
-            }
+            {$hooks}}
 
             // Help opcache.preload discover always-needed symbols
             class_exists(\Symfony\Component\VarExporter\Internal\Hydrator::class);
@@ -95,14 +126,74 @@ final class ProxyHelper
             throw new LogicException(sprintf('Cannot generate lazy proxy with PHP < 8.3: class "%s" is readonly.', $class->name));
         }
 
+        $hookedProperties = [];
+        if (\PHP_VERSION_ID >= 80400 && $class) {
+            $propertyScopes = Hydrator::$propertyScopes[$class->name] ??= Hydrator::getPropertyScopes($class->name);
+            foreach ($propertyScopes as $name => $scope) {
+                if (isset($scope[4]) && !($p = $scope[3])->isVirtual()) {
+                    $hookedProperties[$name] = [$p, $p->getHooks()];
+                }
+            }
+        }
+
         $methodReflectors = [$class?->getMethods(\ReflectionMethod::IS_PUBLIC | \ReflectionMethod::IS_PROTECTED) ?? []];
         foreach ($interfaces as $interface) {
             if (!$interface->isInterface()) {
                 throw new LogicException(sprintf('Cannot generate lazy proxy: "%s" is not an interface.', $interface->name));
             }
             $methodReflectors[] = $interface->getMethods();
+
+            if (\PHP_VERSION_ID >= 80400 && !$class) {
+                foreach ($interface->getProperties() as $p) {
+                    $hookedProperties[$p->name] ??= [$p, []];
+                    $hookedProperties[$p->name][1] += $p->getHooks();
+                }
+            }
         }
-        $methodReflectors = array_merge(...$methodReflectors);
+
+        $hooks = '';
+        foreach ($hookedProperties as $name => [$p, $methods]) {
+            $type = self::exportType($p);
+            $hooks .= "\n        public {$type} \${$p->name} {\n";
+
+            foreach ($methods as $hook => $method) {
+                if ($method->isFinal()) {
+                    throw new LogicException(sprintf('Cannot generate lazy proxy: hook "%s::%s()" is final.', $class->name, $method->name));
+                }
+
+                if ('get' === $hook) {
+                    $ref = ($method->returnsReference() ? '&' : '');
+                    $hooks .= <<<EOPHP
+                                {$ref}get {
+                                    if (isset(\$this->lazyObjectState)) {
+                                        return (\$this->lazyObjectState->realInstance ??= (\$this->lazyObjectState->initializer)())->{$p->name};
+                                    }
+
+                                    return parent::\${$p->name}::get();
+                                }
+
+                    EOPHP;
+                } elseif ('set' === $hook) {
+                    $parameters = self::exportParameters($method, true);
+                    $arg = '$'.$method->getParameters()[0]->name;
+                    $hooks .= <<<EOPHP
+                                set({$parameters}) {
+                                    if (isset(\$this->lazyObjectState)) {
+                                        \$this->lazyObjectState->realInstance ??= (\$this->lazyObjectState->initializer)();
+                                        \$this->lazyObjectState->realInstance->{$p->name} = {$arg};
+                                    }
+
+                                    parent::\${$p->name}::set({$arg});
+                                }
+
+                    EOPHP;
+                } else {
+                    throw new LogicException(sprintf('Cannot generate lazy proxy: hook "%s::%s()" is not supported.', $class->name, $method->name));
+                }
+            }
+
+            $hooks .= "        }\n";
+        }
 
         $extendsInternalClass = false;
         if ($parent = $class) {
@@ -112,6 +203,7 @@ final class ProxyHelper
         }
         $methodsHaveToBeProxied = $extendsInternalClass;
         $methods = [];
+        $methodReflectors = array_merge(...$methodReflectors);
 
         foreach ($methodReflectors as $method) {
             if ('__get' !== strtolower($method->name) || 'mixed' === ($type = self::exportType($method) ?? 'mixed')) {
@@ -228,7 +320,7 @@ final class ProxyHelper
                 {$lazyProxyTraitStatement}
 
                 private const LAZY_OBJECT_PROPERTY_SCOPES = {$propertyScopes};
-            {$body}}
+            {$hooks}{$body}}
 
             // Help opcache.preload discover always-needed symbols
             class_exists(\Symfony\Component\VarExporter\Internal\Hydrator::class);
@@ -238,7 +330,7 @@ final class ProxyHelper
             EOPHP;
     }
 
-    public static function exportSignature(\ReflectionFunctionAbstract $function, bool $withParameterTypes = true, ?string &$args = null): string
+    public static function exportParameters(\ReflectionFunctionAbstract $function, bool $withParameterTypes = true, ?string &$args = null): string
     {
         $byRefIndex = 0;
         $args = '';
@@ -268,8 +360,15 @@ final class ProxyHelper
             $args = implode(', ', $args);
         }
 
+        return implode(', ', $parameters);
+    }
+
+    public static function exportSignature(\ReflectionFunctionAbstract $function, bool $withParameterTypes = true, ?string &$args = null): string
+    {
+        $parameters = self::exportParameters($function, $withParameterTypes, $args);
+
         $signature = 'function '.($function->returnsReference() ? '&' : '')
-            .($function->isClosure() ? '' : $function->name).'('.implode(', ', $parameters).')';
+            .($function->isClosure() ? '' : $function->name).'('.$parameters.')';
 
         if ($function instanceof \ReflectionMethod) {
             $signature = ($function->isPublic() ? 'public ' : ($function->isProtected() ? 'protected ' : 'private '))

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/Hooked.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/Hooked.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarExporter\Tests\Fixtures;
+
+class Hooked
+{
+    public int $notBacked {
+        get { return 123; }
+        set { throw \LogicException('Cannot set value.'); }
+    }
+
+    public int $backed {
+        get { return $this->backed ??= 234; }
+        set { $this->backed = $value; }
+    }
+}

--- a/src/Symfony/Component/VarExporter/Tests/LazyProxyTraitTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/LazyProxyTraitTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\VarExporter\Exception\LogicException;
 use Symfony\Component\VarExporter\LazyProxyTrait;
 use Symfony\Component\VarExporter\ProxyHelper;
+use Symfony\Component\VarExporter\Tests\Fixtures\Hooked;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\FinalPublicClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\ReadOnlyClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\StringMagicGetClass;
@@ -296,6 +297,33 @@ class LazyProxyTraitTest extends TestCase
         $output = $serializer->normalize($object);
 
         $this->assertSame(['property' => 'property', 'method' => 'method'], $output);
+    }
+
+    /**
+     * @requires PHP 8.4
+     */
+    public function testPropertyHooks()
+    {
+        $initialized = false;
+        $object = $this->createLazyProxy(Hooked::class, function () use (&$initialized) {
+            $initialized = true;
+            return new Hooked();
+        });
+
+        $this->assertSame(123, $object->notBacked);
+        $this->assertFalse($initialized);
+        $this->assertSame(234, $object->backed);
+        $this->assertTrue($initialized);
+
+        $initialized = false;
+        $object = $this->createLazyProxy(Hooked::class, function () use (&$initialized) {
+            $initialized = true;
+            return new Hooked();
+        });
+
+        $object->backed = 345;
+        $this->assertTrue($initialized);
+        $this->assertSame(345, $object->backed);
     }
 
     /**

--- a/src/Symfony/Component/VarExporter/Tests/ProxyHelperTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/ProxyHelperTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\VarExporter\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\VarExporter\Exception\LogicException;
 use Symfony\Component\VarExporter\ProxyHelper;
+use Symfony\Component\VarExporter\Tests\Fixtures\Hooked;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\Php82NullStandaloneReturnType;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\StringMagicGetClass;
 
@@ -244,6 +245,17 @@ class ProxyHelperTest extends TestCase
         self::assertStringContainsString(
             'public function foo(): null',
             ProxyHelper::generateLazyProxy(new \ReflectionClass(Php82NullStandaloneReturnType::class))
+        );
+    }
+
+    /**
+     * @requires PHP 8.4
+     */
+    public function testPropertyHooks()
+    {
+        self::assertStringContainsString(
+            "[parent::class, 'backed', null, 4 => true]",
+            ProxyHelper::generateLazyProxy(new \ReflectionClass(Hooked::class))
         );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59153
| License       | MIT

With hook proxies when needed so that lazy objects are fully compatible with non-final hooks.