### PR TITLE
[Messenger][Process] add `fromShellCommandline` to `RunProcessMessage`

### DIFF
--- a/src/Symfony/Component/Process/CHANGELOG.md
+++ b/src/Symfony/Component/Process/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+
+7.3
+---
+
+ * Add `RunProcessMessage::fromShellCommandline()` to instantiate a Process via the fromShellCommandline method
+
 7.1
 ---
 

--- a/src/Symfony/Component/Process/Messenger/RunProcessMessage.php
+++ b/src/Symfony/Component/Process/Messenger/RunProcessMessage.php
@@ -16,6 +16,8 @@ namespace Symfony\Component\Process\Messenger;
  */
 class RunProcessMessage implements \Stringable
 {
+    public ?string $commandLine = null;
+
     public function __construct(
         public readonly array $command,
         public readonly ?string $cwd = null,
@@ -27,6 +29,19 @@ class RunProcessMessage implements \Stringable
 
     public function __toString(): string
     {
-        return implode(' ', $this->command);
+        return $this->commandLine ?? implode(' ', $this->command);
+    }
+
+    /**
+     * Create a process message instance that will instantiate a Process using the fromShellCommandline method.
+     *
+     * @see Process::fromShellCommandline
+     */
+    public static function fromShellCommandline(string $command, ?string $cwd = null, ?array $env = null, mixed $input = null, ?float $timeout = 60): self
+    {
+        $message = new self([], $cwd, $env, $input, $timeout);
+        $message->commandLine = $command;
+
+        return $message;
     }
 }

--- a/src/Symfony/Component/Process/Messenger/RunProcessMessageHandler.php
+++ b/src/Symfony/Component/Process/Messenger/RunProcessMessageHandler.php
@@ -22,7 +22,10 @@ final class RunProcessMessageHandler
 {
     public function __invoke(RunProcessMessage $message): RunProcessContext
     {
-        $process = new Process($message->command, $message->cwd, $message->env, $message->input, $message->timeout);
+        $process = match ($message->commandLine) {
+            null => new Process($message->command, $message->cwd, $message->env, $message->input, $message->timeout),
+            default => Process::fromShellCommandline($message->commandLine, $message->cwd, $message->env, $message->input, $message->timeout),
+        };
 
         try {
             return new RunProcessContext($message, $process->mustRun());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        |
| License       | MIT

The `RunProcess::fromShellCommandline()` method can be useful when using pipes or redirection.
This feature allow the use of this method when using a RunProcessMessage.
