### PR TITLE
Enable `JSON_PRESERVE_ZERO_FRACTION` in `jsonRequest` method

### DIFF
--- a/src/Symfony/Component/BrowserKit/AbstractBrowser.php
+++ b/src/Symfony/Component/BrowserKit/AbstractBrowser.php
@@ -170,7 +170,7 @@ abstract class AbstractBrowser
      */
     public function jsonRequest(string $method, string $uri, array $parameters = [], array $server = [], bool $changeHistory = true): Crawler
     {
-        $content = json_encode($parameters);
+        $content = json_encode($parameters, \JSON_PRESERVE_ZERO_FRACTION);
 
         $this->setServerParameter('CONTENT_TYPE', 'application/json');
         $this->setServerParameter('HTTP_ACCEPT', 'application/json');

--- a/src/Symfony/Component/BrowserKit/Tests/AbstractBrowserTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/AbstractBrowserTest.php
@@ -67,12 +67,12 @@ class AbstractBrowserTest extends TestCase
     public function testJsonRequest()
     {
         $client = $this->getBrowser();
-        $client->jsonRequest('GET', 'http://example.com/', ['param' => 1], [], true);
+        $client->jsonRequest('GET', 'http://example.com/', ['param' => 1, 'float' => 10.0], [], true);
         $this->assertSame('application/json', $client->getRequest()->getServer()['CONTENT_TYPE']);
         $this->assertSame('application/json', $client->getRequest()->getServer()['HTTP_ACCEPT']);
         $this->assertFalse($client->getServerParameter('CONTENT_TYPE', false));
         $this->assertFalse($client->getServerParameter('HTTP_ACCEPT', false));
-        $this->assertSame('{"param":1}', $client->getRequest()->getContent());
+        $this->assertSame('{"param":1,"float":10.0}', $client->getRequest()->getContent());
     }
 
     public function testGetRequestWithIpAsHttpHost()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Updated the jsonRequest method to use JSON_PRESERVE_ZERO_FRACTION when encoding parameters. 
This avoid unintended cast to int.

Test case:

```
$this->browser->jsonRequest('GET', 'url', ['cost' => 10.0]);
```

"cost" will be cast to int `10`