### PR TITLE
[RFC][Validator] Allow to set the translation domain or disable translations on a per-constraint level

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
  * Add support for multiple fields containing nested constraints in `Composite` constraints
  * Add the `stopOnFirstError` option to the `Unique` constraint to validate all elements
  * Add support for closures in the `When` constraint
+ * Add `translationDomain` to all constraints; setting it to `false` disables translations for the particular constraint
 
 7.2
 ---

--- a/src/Symfony/Component/Validator/Constraints/NotBlank.php
+++ b/src/Symfony/Component/Validator/Constraints/NotBlank.php
@@ -31,6 +31,9 @@ class NotBlank extends Constraint
     ];
 
     public string $message = 'This value should not be blank.';
+
+    public string|false|null $translationDomain = null;
+
     public bool $allowNull = false;
     /** @var callable|null */
     public $normalizer;
@@ -41,7 +44,7 @@ class NotBlank extends Constraint
      * @param string[]|null            $groups
      */
     #[HasNamedArguments]
-    public function __construct(?array $options = null, ?string $message = null, ?bool $allowNull = null, ?callable $normalizer = null, ?array $groups = null, mixed $payload = null)
+    public function __construct(?array $options = null, ?string $message = null, ?bool $allowNull = null, ?callable $normalizer = null, ?array $groups = null, mixed $payload = null, string|false|null $translationDomain = null)
     {
         if (\is_array($options)) {
             trigger_deprecation('symfony/validator', '7.3', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
@@ -50,6 +53,7 @@ class NotBlank extends Constraint
         parent::__construct($options ?? [], $groups, $payload);
 
         $this->message = $message ?? $this->message;
+        $this->translationDomain = $translationDomain ?? $this->translationDomain;
         $this->allowNull = $allowNull ?? $this->allowNull;
         $this->normalizer = $normalizer ?? $this->normalizer;
 

--- a/src/Symfony/Component/Validator/Constraints/NotBlankValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NotBlankValidator.php
@@ -39,6 +39,7 @@ class NotBlankValidator extends ConstraintValidator
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ value }}', $this->formatValue($value))
                 ->setCode(NotBlank::IS_BLANK_ERROR)
+                ->setOrDisableTranslationDomain($constraint->translationDomain)
                 ->addViolation();
         }
     }

--- a/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\Constraint\IsInstanceOf;
 use PHPUnit\Framework\Constraint\IsNull;
 use PHPUnit\Framework\Constraint\LogicalOr;
 use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\GroupSequence;
@@ -60,6 +61,8 @@ abstract class ConstraintValidatorTestCase extends TestCase
     protected string $propertyPath;
     protected Constraint $constraint;
     protected ?string $defaultTimezone = null;
+
+    private TranslatorInterface&MockObject $translator;
 
     private string $defaultLocale;
     private array $expectedViolations;
@@ -122,14 +125,14 @@ abstract class ConstraintValidatorTestCase extends TestCase
 
     protected function createContext()
     {
-        $translator = $this->createMock(TranslatorInterface::class);
-        $translator->expects($this->any())->method('trans')->willReturnArgument(0);
+        $this->translator = $this->createMock(TranslatorInterface::class);
+        $this->translator->expects($this->any())->method('trans')->willReturnArgument(0);
         $validator = $this->createMock(ValidatorInterface::class);
         $validator->expects($this->any())
             ->method('validate')
             ->willReturnCallback(fn () => $this->expectedViolations[$this->call++] ?? new ConstraintViolationList());
 
-        $context = new ExecutionContext($validator, $this->root, $translator);
+        $context = new ExecutionContext($validator, $this->root, $this->translator);
         $context->setGroup($this->group);
         $context->setNode($this->value, $this->object, $this->metadata, $this->propertyPath);
         $context->setConstraint($this->constraint);
@@ -275,6 +278,14 @@ abstract class ConstraintValidatorTestCase extends TestCase
         $this->expectedViolations[] = $context->getViolations();
 
         return $context->getViolations();
+    }
+
+    protected function expectTranslationDomain(string $translationDomain)
+    {
+        $this->translator
+            ->expects($this->atLeastOnce())
+            ->method('trans')
+            ->with($this->anything(), $this->anything(), $translationDomain, $this->anything());
     }
 
     protected function assertNoViolation()

--- a/src/Symfony/Component/Validator/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Validator/Tests/Command/DebugCommandTest.php
@@ -55,7 +55,8 @@ Symfony\Component\Validator\Tests\Dummy\DummyClassOne
 |               |                                                    |                        |   "allowNull" => false,                                    |
 |               |                                                    |                        |   "message" => "This value should not be blank.",          |
 |               |                                                    |                        |   "normalizer" => null,                                    |
-|               |                                                    |                        |   "payload" => null                                        |
+|               |                                                    |                        |   "payload" => null,                                       |
+|               |                                                    |                        |   "translationDomain" => null                              |
 |               |                                                    |                        | ]                                                          |
 | email         | property options                                   |                        | [                                                          |
 |               |                                                    |                        |   "cascadeStrategy" => "None",                             |
@@ -111,7 +112,8 @@ Symfony\Component\Validator\Tests\Dummy\DummyClassOne
 |               |                                                    |                        |   "allowNull" => false,                                    |
 |               |                                                    |                        |   "message" => "This value should not be blank.",          |
 |               |                                                    |                        |   "normalizer" => null,                                    |
-|               |                                                    |                        |   "payload" => null                                        |
+|               |                                                    |                        |   "payload" => null,                                       |
+|               |                                                    |                        |   "translationDomain" => null                              |
 |               |                                                    |                        | ]                                                          |
 | email         | property options                                   |                        | [                                                          |
 |               |                                                    |                        |   "cascadeStrategy" => "None",                             |
@@ -153,7 +155,8 @@ Symfony\Component\Validator\Tests\Dummy\DummyClassTwo
 |               |                                                    |                        |   "allowNull" => false,                                    |
 |               |                                                    |                        |   "message" => "This value should not be blank.",          |
 |               |                                                    |                        |   "normalizer" => null,                                    |
-|               |                                                    |                        |   "payload" => null                                        |
+|               |                                                    |                        |   "payload" => null,                                       |
+|               |                                                    |                        |   "translationDomain" => null                              |
 |               |                                                    |                        | ]                                                          |
 | email         | property options                                   |                        | [                                                          |
 |               |                                                    |                        |   "cascadeStrategy" => "None",                             |

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotBlankValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotBlankValidatorTest.php
@@ -55,6 +55,15 @@ class NotBlankValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
+    public function testTranslationDomain()
+    {
+        $constraint = new NotBlank(translationDomain: 'my_domain');
+
+        $this->expectTranslationDomain('my_domain');
+
+        $this->validator->validate(null, $constraint);
+    }
+
     public function testBlankIsInvalid()
     {
         $constraint = new NotBlank(message: 'myMessage');

--- a/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilder.php
+++ b/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilder.php
@@ -83,6 +83,16 @@ class ConstraintViolationBuilder implements ConstraintViolationBuilderInterface
         return $this;
     }
 
+    /**
+     * @return $this
+     */
+    public function setOrDisableTranslationDomain(string|false|null $translationDomain): static
+    {
+        $this->translationDomain = $translationDomain;
+
+        return $this;
+    }
+
     public function setInvalidValue(mixed $invalidValue): static
     {
         $this->invalidValue = $invalidValue;

--- a/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilderInterface.php
+++ b/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilderInterface.php
@@ -20,6 +20,8 @@ namespace Symfony\Component\Validator\Violation;
  * execution context.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @method $this setOrDisableTranslationDomain(string|false|null $translationDomain)
  */
 interface ConstraintViolationBuilderInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

This PR builds upon the work in #48852 and makes it possible to specify the translation domain for validation constraints on a per-constraint level. This can happen either when using the constraint as an attribute, or when creating constraint instances e. g. when building a form.

```php
   $formBuilder
            ->add('some_field', TextType::class, [
                'label' => 'Something',
                'constraints' => [new NotBlank(['message' => 'standard.notblank.message', 'translation_domain' => 'my_special_domain'])],
            ])
            ->add('other_field', TextType::class, [
                'label' => 'Elsething',
                'constraints' => [new NotBlank(['message' => 'Use this text as-is, do not attempt to translate', 'translation_domain' => false])],
            ]);
```

The setting works similar to the `translation_domain` option for form types. Setting it to `false` disables translations (for that constraint) altogether.

#### TODO

- [ ] Add documentation PR
- [ ] Apply enhancement to all constraints once we agree on the basics; for now, it's just `NotBlank`
- [ ] Add tests
- [ ] Update src/Symfony/Component/Translation/Extractor/Visitor/ConstraintVisitor.php