### PR TITLE
[TwigBridge] Fix compatibility with Twig 3.21

### DIFF
--- a/src/Symfony/Bridge/Twig/TokenParser/DumpTokenParser.php
+++ b/src/Symfony/Bridge/Twig/TokenParser/DumpTokenParser.php
@@ -14,6 +14,7 @@ namespace Symfony\Bridge\Twig\TokenParser;
 use Symfony\Bridge\Twig\Node\DumpNode;
 use Twig\Node\Expression\Variable\LocalVariable;
 use Twig\Node\Node;
+use Twig\Node\Nodes;
 use Twig\Token;
 use Twig\TokenParser\AbstractTokenParser;
 
@@ -34,11 +35,26 @@ final class DumpTokenParser extends AbstractTokenParser
     {
         $values = null;
         if (!$this->parser->getStream()->test(Token::BLOCK_END_TYPE)) {
-            $values = $this->parser->getExpressionParser()->parseMultitargetExpression();
+            $values = method_exists($this->parser, 'parseExpression') ?
+                $this->parseMultitargetExpression() :
+                $this->parser->getExpressionParser()->parseMultitargetExpression();
         }
         $this->parser->getStream()->expect(Token::BLOCK_END_TYPE);
 
         return new DumpNode(class_exists(LocalVariable::class) ? new LocalVariable(null, $token->getLine()) : $this->parser->getVarName(), $values, $token->getLine(), $this->getTag());
+    }
+
+    private function parseMultitargetExpression(): Node
+    {
+        $targets = [];
+        while (true) {
+            $targets[] = $this->parser->parseExpression();
+            if (!$this->parser->getStream()->nextIf(Token::PUNCTUATION_TYPE, ',')) {
+                break;
+            }
+        }
+
+        return new Nodes($targets);
     }
 
     public function getTag(): string

--- a/src/Symfony/Bridge/Twig/TokenParser/FormThemeTokenParser.php
+++ b/src/Symfony/Bridge/Twig/TokenParser/FormThemeTokenParser.php
@@ -29,12 +29,16 @@ final class FormThemeTokenParser extends AbstractTokenParser
         $lineno = $token->getLine();
         $stream = $this->parser->getStream();
 
-        $form = $this->parser->getExpressionParser()->parseExpression();
+        $parseExpression = method_exists($this->parser, 'parseExpression')
+            ? $this->parser->parseExpression(...)
+            : $this->parser->getExpressionParser()->parseExpression(...);
+
+        $form = $parseExpression();
         $only = false;
 
         if ($this->parser->getStream()->test(Token::NAME_TYPE, 'with')) {
             $this->parser->getStream()->next();
-            $resources = $this->parser->getExpressionParser()->parseExpression();
+            $resources = $parseExpression();
 
             if ($this->parser->getStream()->nextIf(Token::NAME_TYPE, 'only')) {
                 $only = true;
@@ -42,7 +46,7 @@ final class FormThemeTokenParser extends AbstractTokenParser
         } else {
             $resources = new ArrayExpression([], $stream->getCurrent()->getLine());
             do {
-                $resources->addElement($this->parser->getExpressionParser()->parseExpression());
+                $resources->addElement($parseExpression());
             } while (!$stream->test(Token::BLOCK_END_TYPE));
         }
 

--- a/src/Symfony/Bridge/Twig/TokenParser/StopwatchTokenParser.php
+++ b/src/Symfony/Bridge/Twig/TokenParser/StopwatchTokenParser.php
@@ -38,7 +38,9 @@ final class StopwatchTokenParser extends AbstractTokenParser
         $stream = $this->parser->getStream();
 
         // {% stopwatch 'bar' %}
-        $name = $this->parser->getExpressionParser()->parseExpression();
+        $name = method_exists($this->parser, 'parseExpression') ?
+            $this->parser->parseExpression() :
+            $this->parser->getExpressionParser()->parseExpression();
 
         $stream->expect(Token::BLOCK_END_TYPE);
 

--- a/src/Symfony/Bridge/Twig/TokenParser/TransDefaultDomainTokenParser.php
+++ b/src/Symfony/Bridge/Twig/TokenParser/TransDefaultDomainTokenParser.php
@@ -25,7 +25,9 @@ final class TransDefaultDomainTokenParser extends AbstractTokenParser
 {
     public function parse(Token $token): Node
     {
-        $expr = $this->parser->getExpressionParser()->parseExpression();
+        $expr = method_exists($this->parser, 'parseExpression') ?
+            $this->parser->parseExpression() :
+            $this->parser->getExpressionParser()->parseExpression();
 
         $this->parser->getStream()->expect(Token::BLOCK_END_TYPE);
 

--- a/src/Symfony/Bridge/Twig/TokenParser/TransTokenParser.php
+++ b/src/Symfony/Bridge/Twig/TokenParser/TransTokenParser.php
@@ -36,29 +36,33 @@ final class TransTokenParser extends AbstractTokenParser
         $vars = new ArrayExpression([], $lineno);
         $domain = null;
         $locale = null;
+        $parseExpression = method_exists($this->parser, 'parseExpression')
+            ? $this->parser->parseExpression(...)
+            : $this->parser->getExpressionParser()->parseExpression(...);
+
         if (!$stream->test(Token::BLOCK_END_TYPE)) {
             if ($stream->test('count')) {
                 // {% trans count 5 %}
                 $stream->next();
-                $count = $this->parser->getExpressionParser()->parseExpression();
+                $count = $parseExpression();
             }
 
             if ($stream->test('with')) {
                 // {% trans with vars %}
                 $stream->next();
-                $vars = $this->parser->getExpressionParser()->parseExpression();
+                $vars = $parseExpression();
             }
 
             if ($stream->test('from')) {
                 // {% trans from "messages" %}
                 $stream->next();
-                $domain = $this->parser->getExpressionParser()->parseExpression();
+                $domain = $parseExpression();
             }
 
             if ($stream->test('into')) {
                 // {% trans into "fr" %}
                 $stream->next();
-                $locale = $this->parser->getExpressionParser()->parseExpression();
+                $locale = $parseExpression();
             } elseif (!$stream->test(Token::BLOCK_END_TYPE)) {
                 throw new SyntaxError('Unexpected token. Twig was looking for the "with", "from", or "into" keyword.', $stream->getCurrent()->getLine(), $stream->getSourceContext());
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`Parser::getExpressionParser()` is deprecated since Twig 3.21.