### PR TITLE
[Notifier] do not implement JsonSerializable in MatrixOptions

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Matrix/MatrixOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Matrix/MatrixOptions.php
@@ -16,7 +16,7 @@ use Symfony\Component\Notifier\Message\MessageOptionsInterface;
 /**
  * @author Frank Schulze <frank@akiber.de>
  */
-final class MatrixOptions implements MessageOptionsInterface, \JsonSerializable
+final class MatrixOptions implements MessageOptionsInterface
 {
     public function __construct(
         private array $options = [],
@@ -31,10 +31,5 @@ final class MatrixOptions implements MessageOptionsInterface, \JsonSerializable
     public function getRecipientId(): ?string
     {
         return $this->options['recipient_id'] ?? null;
-    }
-
-    public function jsonSerialize(): mixed
-    {
-        return $this->options;
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Matrix/Tests/MatrixOptionsTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Matrix/Tests/MatrixOptionsTest.php
@@ -33,14 +33,4 @@ class MatrixOptionsTest extends TestCase
         ]);
         $this->assertSame('@testuser:matrix.io', $options->getRecipientId());
     }
-
-    public function testJsonSerialize()
-    {
-        $options = new MatrixOptions([
-            'recipient_id' => '@testuser:matrix.io',
-            'msgtype' => 'm.text',
-            'format' => 'org.matrix.custom.html',
-        ]);
-        $this->assertSame(['recipient_id' => '@testuser:matrix.io', 'msgtype' => 'm.text', 'format' => 'org.matrix.custom.html'], $options->jsonSerialize());
-    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony/pull/59377#discussion_r1908300678
| License       | MIT
