### PR TITLE
[DomCrawler] Bug #43921  Check for null parent nodes in the case of orphaned branches

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -431,7 +431,7 @@ class Crawler implements \Countable, \IteratorAggregate
 
         $domNode = $this->getNode(0);
 
-        while (\XML_ELEMENT_NODE === $domNode->nodeType) {
+        while (null !== $domNode && \XML_ELEMENT_NODE === $domNode->nodeType) {
             $node = $this->createSubCrawler($domNode);
             if ($node->matches($selector)) {
                 return $node;

--- a/src/Symfony/Component/DomCrawler/Tests/AbstractCrawlerTestCase.php
+++ b/src/Symfony/Component/DomCrawler/Tests/AbstractCrawlerTestCase.php
@@ -1031,6 +1031,29 @@ HTML;
         $this->assertNull($notFound);
     }
 
+    public function testClosestWithOrphanedNode()
+    {
+        $html = <<<'HTML'
+<html lang="en">
+<body>
+    <div id="foo" class="newFoo ok">
+        <div class="lorem1 ko"></div>
+    </div>
+</body>
+</html>
+HTML;
+
+        $crawler = $this->createCrawler($this->getDoctype().$html);
+        $foo = $crawler->filter('#foo');
+
+        $fooNode = $foo->getNode(0);
+
+        $fooNode->parentNode->replaceChild($fooNode->ownerDocument->createElement('ol'), $fooNode);
+
+        $body = $foo->closest('body');
+        $this->assertNull($body);
+    }
+
     public function testOuterHtml()
     {
         $html = <<<'HTML'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch       | 7.2
| Bug fix      | yes
| New feature  | no
| Deprecations | no
| Issues        | Fix #43921
| License       | MIT

This simple fix checks for null parent nodes when traversing the DOM tree when calling the `closest()` function.  Instead of failing, the function will return null instead.  This bring it into alignment with how the `ancestors()` function behaves (not failing on null parent nodes).

Null parent nodes can occur when a DOM branch is orphaned due to manipulations on the document, and this is a perfectly normal scenario.

Unit tests added that checks for this specific bug.

This fix should not break any backward compatibility.