### PR TITLE
[Mailer] fix multiple transports default injection

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2660,7 +2660,6 @@ class FrameworkExtension extends Extension
         }
         $transports = $config['dsn'] ? ['main' => $config['dsn']] : $config['transports'];
         $container->getDefinition('mailer.transports')->setArgument(0, $transports);
-        $container->getDefinition('mailer.default_transport')->setArgument(0, current($transports));
 
         $mailer = $container->getDefinition('mailer.mailer');
         if (false === $messageBus = $config['message_bus']) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer.php
@@ -46,10 +46,7 @@ return static function (ContainerConfigurator $container) {
             ])
 
         ->set('mailer.default_transport', TransportInterface::class)
-            ->factory([service('mailer.transport_factory'), 'fromString'])
-            ->args([
-                abstract_arg('env(MAILER_DSN)'),
-            ])
+        ->alias('mailer.default_transport', 'mailer.transports')
         ->alias(TransportInterface::class, 'mailer.default_transport')
 
         ->set('mailer.messenger.message_handler', MessageHandler::class)

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -2103,8 +2103,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->assertTrue($container->hasAlias('mailer'));
         $this->assertTrue($container->hasDefinition('mailer.transports'));
         $this->assertSame($expectedTransports, $container->getDefinition('mailer.transports')->getArgument(0));
-        $this->assertTrue($container->hasDefinition('mailer.default_transport'));
-        $this->assertSame(current($expectedTransports), $container->getDefinition('mailer.default_transport')->getArgument(0));
+        $this->assertTrue($container->hasAlias('mailer.default_transport'));
         $this->assertTrue($container->hasDefinition('mailer.envelope_listener'));
         $l = $container->getDefinition('mailer.envelope_listener');
         $this->assertSame('sender@example.org', $l->getArgument(0));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #46372
| License       | MIT


As discussed here https://github.com/symfony/symfony/discussions/46372
If multiple mailer transports are configured and you try to inject the TransportInterface as a service, only the first one gets injected and not all the Transports. Therefore, X-Transport headers do not work. 
