### PR TITLE
[DependencyInjection] Optimize findTaggedServiceIds

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1340,8 +1340,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      */
     public function findTaggedServiceIds(string $name, bool $throwOnAbstract = false): array
     {
-        if (!$throwOnAbstract)
-        {
+        if (!$throwOnAbstract) {
             return $this->tagCache->findTaggedServiceIds($name);
         }
         $this->usedTags[] = $name;

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -425,8 +425,7 @@ class Definition
     public function setTags(array $tags): static
     {
         $this->tags = $tags;
-        if (isset($this->tagCache))
-        {
+        if (isset($this->tagCache)) {
             $this->tagCache->setTags($this->id, $tags);
         }
 
@@ -457,8 +456,7 @@ class Definition
     public function addTag(string $name, array $attributes = []): static
     {
         $this->tags[$name][] = $attributes;
-        if (isset($this->tagCache))
-        {
+        if (isset($this->tagCache)) {
             $this->tagCache->addTag($this->id, $name, $attributes);
         }
 
@@ -495,8 +493,7 @@ class Definition
     public function clearTag(string $name): static
     {
         unset($this->tags[$name]);
-        if (isset($this->tagCache))
-        {
+        if (isset($this->tagCache)) {
             $this->tagCache->clearTag($this->id, $name);
         }
 
@@ -511,8 +508,7 @@ class Definition
     public function clearTags(): static
     {
         $this->tags = [];
-        if (isset($this->tagCache))
-        {
+        if (isset($this->tagCache)) {
             $this->tagCache->clearTags($this->id);
         }
 

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -44,6 +44,8 @@ class Definition
     private array $changes = [];
     private array $bindings = [];
     private array $errors = [];
+    private string $id;
+    private TagCache $tagCache;
 
     protected array $arguments = [];
 
@@ -423,6 +425,10 @@ class Definition
     public function setTags(array $tags): static
     {
         $this->tags = $tags;
+        if (isset($this->tagCache))
+        {
+            $this->tagCache->setTags($this->id, $tags);
+        }
 
         return $this;
     }
@@ -451,6 +457,10 @@ class Definition
     public function addTag(string $name, array $attributes = []): static
     {
         $this->tags[$name][] = $attributes;
+        if (isset($this->tagCache))
+        {
+            $this->tagCache->addTag($this->id, $name, $attributes);
+        }
 
         return $this;
     }
@@ -485,6 +495,10 @@ class Definition
     public function clearTag(string $name): static
     {
         unset($this->tags[$name]);
+        if (isset($this->tagCache))
+        {
+            $this->tagCache->clearTag($this->id, $name);
+        }
 
         return $this;
     }
@@ -497,6 +511,10 @@ class Definition
     public function clearTags(): static
     {
         $this->tags = [];
+        if (isset($this->tagCache))
+        {
+            $this->tagCache->clearTags($this->id);
+        }
 
         return $this;
     }
@@ -820,4 +838,12 @@ class Definition
     {
         return (bool) $this->errors;
     }
+
+    public function setupTagCache($id, TagCache $tagCache): static
+    {
+        $this->id = $id;
+        $this->tagCache = $tagCache->setTags($this->id, $this->getTags());
+        return $this;
+    }
+
 }

--- a/src/Symfony/Component/DependencyInjection/TagCache.php
+++ b/src/Symfony/Component/DependencyInjection/TagCache.php
@@ -20,9 +20,14 @@ class TagCache
     public function setTags(string $id, array $tags): static
     {
         $this->clearTags($id);
-        foreach ($tags as $name => $attributes) {
-            $this->addTag($id, $name, $attributes);
+        foreach ($tags as $key => $value) {
+            if (is_array($value)) {
+                $this->addTag($id, $key, $value);
+            } else {
+                $this->addTag($id, $value);
+            }
         }
+
         return $this;
     }
 
@@ -40,8 +45,7 @@ class TagCache
 
     public function clearTags(string $id): void
     {
-        foreach ($this->names[$id] ?? [] as $name)
-        {
+        foreach ($this->names[$id] ?? [] as $name) {
             unset($this->tags[$name][$id]);
         }
         unset($this->names[$id]);

--- a/src/Symfony/Component/DependencyInjection/TagCache.php
+++ b/src/Symfony/Component/DependencyInjection/TagCache.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony package.
  *
- * (c) Karoly Negyesi <karoly@negyesi.net>
+ * (c) Fabien Potencier <fabien@symfony.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -21,7 +21,7 @@ class TagCache
     {
         $this->clearTags($id);
         foreach ($tags as $key => $value) {
-            if (is_array($value)) {
+            if (\is_array($value)) {
                 $this->addTag($id, $key, $value);
             } else {
                 $this->addTag($id, $value);
@@ -55,5 +55,4 @@ class TagCache
     {
         return $this->tags[$name] ?? [];
     }
-
 }

--- a/src/Symfony/Component/DependencyInjection/TagCache.php
+++ b/src/Symfony/Component/DependencyInjection/TagCache.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Karoly Negyesi <karoly@negyesi.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection;
+
+class TagCache
+{
+
+    private array $tags = [];
+    private array $names = [];
+
+    public function setTags(string $id, array $tags): static
+    {
+        $this->clearTags($id);
+        foreach ($tags as $name => $attributes) {
+            $this->addTag($id, $name, $attributes);
+        }
+        return $this;
+    }
+
+    public function addTag(string $id, string $name, array $attributes = []): void
+    {
+        $this->tags[$name][$id][] = $attributes;
+        $this->names[$id][] = $name;
+    }
+
+    public function clearTag(string $id, string $name): void
+    {
+        unset($this->tags[$name][$id]);
+        $this->names[$id] = array_diff($this->names[$id] ?? [], [$name]);
+    }
+
+    public function clearTags(string $id): void
+    {
+        foreach ($this->names[$id] ?? [] as $name)
+        {
+            unset($this->tags[$name][$id]);
+        }
+        unset($this->names[$id]);
+    }
+
+    public function findTaggedServiceIds(string $name): array
+    {
+        return $this->tags[$name] ?? [];
+    }
+
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | none
| License       | MIT

By storing each tag as it is added to a definition in a tag cache object `findTaggedServiceIds` does not need to iterate every definition in the container.