### PR TITLE
[Notifier][Bluesky] Add support for tag facets

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Bluesky/BlueskyTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Bluesky/BlueskyTransport.php
@@ -21,8 +21,6 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SentMessage;
 use Symfony\Component\Notifier\Transport\AbstractTransport;
-use Symfony\Component\String\AbstractString;
-use Symfony\Component\String\ByteString;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
@@ -33,6 +31,9 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class BlueskyTransport extends AbstractTransport
 {
+    private const TAG_MAX_BYTES = 640;
+    private const TAG_MAX_GRAPHEMES = 64;
+
     private array $authSession = [];
     private ClockInterface $clock;
 
@@ -172,11 +173,10 @@ final class BlueskyTransport extends AbstractTransport
     private function parseFacets(string $input): array
     {
         $facets = [];
-        $text = new ByteString($input);
 
         // regex based on: https://bluesky.com/specs/handle#handle-identifier-syntax
         $regex = '#[$|\W](@([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)#';
-        foreach ($this->getMatchAndPosition($text, $regex) as $match) {
+        foreach ($this->getMatchAndPosition($input, $regex) as $match) {
             $response = $this->client->request('GET', \sprintf('https://%s/xrpc/com.atproto.identity.resolveHandle', $this->getEndpoint()), [
                 'query' => [
                     'handle' => ltrim($match['match'], '@'),
@@ -214,7 +214,7 @@ final class BlueskyTransport extends AbstractTransport
         // partial/naive URL regex based on: https://stackoverflow.com/a/3809435
         // tweaked to disallow some trailing punctuation
         $regex = ';[$|\W](https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*[-a-zA-Z0-9@%_\+~#//=])?);';
-        foreach ($this->getMatchAndPosition($text, $regex) as $match) {
+        foreach ($this->getMatchAndPosition($input, $regex) as $match) {
             $facets[] = [
                 'index' => [
                     'byteStart' => $match['start'],
@@ -229,32 +229,54 @@ final class BlueskyTransport extends AbstractTransport
             ];
         }
 
+        // tag regex based on: https://github.com/bluesky-social/atproto/blob/main/packages/api/src/rich-text/detection.ts
+        // a tag needs at least one character that is neither a digit nor punctuation, and trailing punctuation is left out
+        $regex = '/(?:^|\s)([#＃][^\s]*[^\s\d\p{P}][^\s\p{P}]*)/u';
+        foreach ($this->getMatchAndPosition($input, $regex) as $match) {
+            // the marker is "#" or the fullwidth "＃", which is 3 bytes
+            $tag = preg_replace('/^[#＃]/u', '', $match['match']);
+
+            // the lexicon caps the tag at 640 bytes and 64 graphemes; emitting a longer one makes the whole post fail
+            if (self::TAG_MAX_BYTES < \strlen($tag) || self::TAG_MAX_GRAPHEMES < preg_match_all('/\X/u', $tag)) {
+                continue;
+            }
+
+            $facets[] = [
+                'index' => [
+                    'byteStart' => $match['start'],
+                    'byteEnd' => $match['end'],
+                ],
+                'features' => [
+                    [
+                        '$type' => 'app.bsky.richtext.facet#tag',
+                        'tag' => $tag,
+                    ],
+                ],
+            ];
+        }
+
+        usort($facets, static fn (array $a, array $b) => $a['index']['byteStart'] <=> $b['index']['byteStart']);
+
         return $facets;
     }
 
-    private function getMatchAndPosition(AbstractString $text, string $regex): array
+    /**
+     * @return list<array{start: int, end: int, match: string}>
+     */
+    private function getMatchAndPosition(string $text, string $regex): array
     {
-        $output = [];
-        $handled = [];
-        $matches = $text->match($regex, \PREG_PATTERN_ORDER);
-        if ([] === $matches) {
-            return $output;
+        // preg_* work on bytes, so the captured offsets already are the byte offsets facets are indexed by
+        if (!preg_match_all($regex, $text, $matches, \PREG_OFFSET_CAPTURE)) {
+            return [];
         }
 
-        $length = $text->length();
-        foreach ($matches[1] as $match) {
-            if (isset($handled[$match])) {
-                continue;
-            }
-            $handled[$match] = true;
-            $end = -1;
-            while (null !== $start = $text->indexOf($match, min($length, $end + 1))) {
-                $output[] = [
-                    'start' => $start,
-                    'end' => $end = $start + (new ByteString($match))->length(),
-                    'match' => $match,
-                ];
-            }
+        $output = [];
+        foreach ($matches[1] as [$match, $start]) {
+            $output[] = [
+                'start' => $start,
+                'end' => $start + \strlen($match),
+                'match' => $match,
+            ];
         }
 
         return $output;

--- a/src/Symfony/Component/Notifier/Bridge/Bluesky/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Bluesky/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add support for hashtag facets
+
 7.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Bluesky/Tests/BlueskyTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Bluesky/Tests/BlueskyTransportTest.php
@@ -239,6 +239,136 @@ final class BlueskyTransportTest extends TransportTestCase
         $this->assertEquals($expected, $output);
     }
 
+    public function testParseFacetsHashTags()
+    {
+        // "#123" gets no facet: a tag needs at least one character that is neither a digit nor punctuation
+        $input = 'Salut #test #123 #テスト http://bsky.app';
+        $expected = [
+            [
+                'index' => ['byteStart' => 6, 'byteEnd' => 11],
+                'features' => [
+                    ['$type' => 'app.bsky.richtext.facet#tag', 'tag' => 'test'],
+                ],
+            ],
+            [
+                'index' => ['byteStart' => 17, 'byteEnd' => 27],
+                'features' => [
+                    ['$type' => 'app.bsky.richtext.facet#tag', 'tag' => 'テスト'],
+                ],
+            ],
+            [
+                'index' => ['byteStart' => 28, 'byteEnd' => 43],
+                'features' => [
+                    ['$type' => 'app.bsky.richtext.facet#link', 'uri' => 'http://bsky.app'],
+                ],
+            ],
+        ];
+        $output = $this->parseFacets($input);
+        $this->assertEquals($expected, $output);
+    }
+
+    public function testParseFacetsHashTagWithEmoji()
+    {
+        $input = '💩💩💩 #tag';
+        $expected = [
+            [
+                'index' => ['byteStart' => 13, 'byteEnd' => 17],
+                'features' => [
+                    ['$type' => 'app.bsky.richtext.facet#tag', 'tag' => 'tag'],
+                ],
+            ],
+        ];
+        $output = $this->parseFacets($input);
+        $this->assertEquals($expected, $output);
+    }
+
+    public function testParseFacetsHashTagsSharingAPrefixDoNotOverlap()
+    {
+        $input = '#php #php8 #php84';
+        $expected = [
+            [
+                'index' => ['byteStart' => 0, 'byteEnd' => 4],
+                'features' => [
+                    ['$type' => 'app.bsky.richtext.facet#tag', 'tag' => 'php'],
+                ],
+            ],
+            [
+                'index' => ['byteStart' => 5, 'byteEnd' => 10],
+                'features' => [
+                    ['$type' => 'app.bsky.richtext.facet#tag', 'tag' => 'php8'],
+                ],
+            ],
+            [
+                'index' => ['byteStart' => 11, 'byteEnd' => 17],
+                'features' => [
+                    ['$type' => 'app.bsky.richtext.facet#tag', 'tag' => 'php84'],
+                ],
+            ],
+        ];
+        $output = $this->parseFacets($input);
+        $this->assertEquals($expected, $output);
+    }
+
+    public function testParseFacetsHashTagInsideUrlIsNotATag()
+    {
+        $input = 'go http://bsky.app#fragment #fragment';
+        $expected = [
+            [
+                'index' => ['byteStart' => 3, 'byteEnd' => 27],
+                'features' => [
+                    ['$type' => 'app.bsky.richtext.facet#link', 'uri' => 'http://bsky.app#fragment'],
+                ],
+            ],
+            [
+                'index' => ['byteStart' => 28, 'byteEnd' => 37],
+                'features' => [
+                    ['$type' => 'app.bsky.richtext.facet#tag', 'tag' => 'fragment'],
+                ],
+            ],
+        ];
+        $output = $this->parseFacets($input);
+        $this->assertEquals($expected, $output);
+    }
+
+    public function testParseFacetsUrlsSharingAPrefixDoNotOverlap()
+    {
+        $input = 'a https://ex.com b https://ex.com/x';
+        $expected = [
+            [
+                'index' => ['byteStart' => 2, 'byteEnd' => 16],
+                'features' => [
+                    ['$type' => 'app.bsky.richtext.facet#link', 'uri' => 'https://ex.com'],
+                ],
+            ],
+            [
+                'index' => ['byteStart' => 19, 'byteEnd' => 35],
+                'features' => [
+                    ['$type' => 'app.bsky.richtext.facet#link', 'uri' => 'https://ex.com/x'],
+                ],
+            ],
+        ];
+        $output = $this->parseFacets($input);
+        $this->assertEquals($expected, $output);
+    }
+
+    public function testParseFacetsHashTagBoundaries()
+    {
+        $input = '#foo_bar #foo-bar ＃fullwidth #tag. #ab😀cd';
+        $output = $this->parseFacets($input);
+
+        $this->assertSame(
+            ['foo_bar', 'foo-bar', 'fullwidth', 'tag', 'ab😀cd'],
+            array_map(static fn (array $facet) => $facet['features'][0]['tag'], $output),
+        );
+    }
+
+    public function testParseFacetsHashTagTooLongIsSkipped()
+    {
+        $this->assertSame([], $this->parseFacets('ok #'.str_repeat('a', 641)));
+        $this->assertSame([], $this->parseFacets('ok #'.str_repeat('é', 65)));
+        $this->assertNotSame([], $this->parseFacets('ok #'.str_repeat('a', 64)));
+    }
+
     /**
      * Example from https://github.com/bluesky-social/atproto-website/blob/main/examples/create_bsky_post.py.
      */

--- a/src/Symfony/Component/Notifier/Bridge/Bluesky/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Bluesky/composer.json
@@ -24,8 +24,7 @@
         "psr/log": "^1|^2|^3",
         "symfony/clock": "^7.4|^8.0",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0",
-        "symfony/string": "^7.4|^8.0"
+        "symfony/notifier": "^7.4|^8.0"
     },
     "require-dev": {
         "symfony/mime": "^7.4|^8.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        |
| License       | MIT

Bluesky posts have no markup. A post record declares byte ranges of its text as rich text through facets, and the client is responsible for producing them. `BlueskyTransport` already emits `app.bsky.richtext.facet#mention` and `#link`, so handles and URLs are clickable, but a `#hashtag` was left as plain text: not clickable, and not attached to the tag feed. Links are detected client side by the app, tags are not, so the facet is the only way to get one.

This adds a third pass emitting `app.bsky.richtext.facet#tag`. No configuration and no new public API: send a `ChatMessage` containing hashtags and they become tags.

```php
$chatter->send(new ChatMessage('Released today #symfony #php'));
```

What counts as a tag follows the reference client:

* the marker is `#` or the fullwidth `＃`, at the start of the text or after whitespace
* the tag needs at least one character that is neither a digit nor punctuation, so `#123` produces no facet, matching bsky.app
* letters, digits, `_`, `-` and emoji are all part of the tag, so `#foo_bar` is the tag `foo_bar`, not `foo`
* trailing punctuation is left out, so `#tag.` at the end of a sentence is the tag `tag`
* the byte range includes the `#`, the tag value does not
* a tag over the lexicon limits of 640 bytes or 64 graphemes is skipped, since emitting it would make the whole post fail

Facet ranges are indexed by UTF-8 byte offset and the protocol forbids them from overlapping. Offsets now come from the regex match itself, and the returned facets are sorted by `byteStart`.

For symfony-docs: nothing to configure, this is automatic for every Bluesky chat message. Worth documenting that hashtags in the message body become Bluesky tags, that `#123` and over-long hashtags are deliberately left as plain text, and that a `#` inside a URL is not treated as a tag.
