### PR TITLE
[Notifier] [Bluesky] Return the record CID as additional info

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Bluesky/BlueskyTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Bluesky/BlueskyTransport.php
@@ -124,7 +124,8 @@ final class BlueskyTransport extends AbstractTransport
 
         if (200 === $statusCode) {
             $content = $response->toArray();
-            $sentMessage = new SentMessage($message, (string) $this);
+
+            $sentMessage = new SentMessage($message, (string) $this, ['cid' => $content['cid']]);
             $sentMessage->setMessageId($content['uri']);
 
             return $sentMessage;

--- a/src/Symfony/Component/Notifier/Bridge/Bluesky/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Bluesky/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add option to attach a website preview card
+ * Add `cid` info into returned `SentMessage`
 
 7.2
 ---

--- a/src/Symfony/Component/Notifier/Bridge/Bluesky/Tests/BlueskyTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Bluesky/Tests/BlueskyTransportTest.php
@@ -338,6 +338,7 @@ final class BlueskyTransportTest extends TransportTestCase
         $message = $transport->send(new ChatMessage('Hello!'));
 
         $this->assertSame($recordUri, $message->getMessageId());
+        $this->assertSame($recordCid, $message->getInfo('cid'));
     }
 
     public static function sendMessageWithEmbedDataProvider(): iterable

--- a/src/Symfony/Component/Notifier/Bridge/Bluesky/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Bluesky/composer.json
@@ -24,7 +24,7 @@
         "psr/log": "^1|^2|^3",
         "symfony/clock": "^6.4|^7.0",
         "symfony/http-client": "^6.4|^7.0",
-        "symfony/notifier": "^7.2",
+        "symfony/notifier": "^7.3",
         "symfony/string": "^6.4|^7.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Some Bluesky API operations (like replies and quotes) require "strong references", which is the combination of the `uri` and the `cid` (See https://docs.bsky.app/docs/advanced-guides/posts#replies-quote-posts-and-embeds).

After the changes made in #59742, we should also return the `cid` as additional info.