### PR TITLE
[Mime] use address for body at `PathHeader`

### DIFF
--- a/src/Symfony/Component/Mime/Header/PathHeader.php
+++ b/src/Symfony/Component/Mime/Header/PathHeader.php
@@ -57,6 +57,6 @@ final class PathHeader extends AbstractHeader
 
     public function getBodyAsString(): string
     {
-        return '<'.$this->address->toString().'>';
+        return '<'.$this->address->getEncodedAddress().'>';
     }
 }

--- a/src/Symfony/Component/Mime/Tests/Header/HeadersTest.php
+++ b/src/Symfony/Component/Mime/Tests/Header/HeadersTest.php
@@ -346,4 +346,12 @@ class HeadersTest extends TestCase
         $this->expectException(\LogicException::class);
         $headers->setHeaderParameter('Content-Disposition', 'name', 'foo');
     }
+
+    public function testPathHeaderHasNoName()
+    {
+        $headers = new Headers();
+
+        $headers->addPathHeader('Return-Path', new Address('some@path', 'any ignored name'));
+        $this->assertSame('<some@path>', $headers->get('Return-Path')->getBodyAsString());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

We noticed, that ReturnPath has wrong content in EML if any library is forcing key=>value.
Setting it to `mail@example.com`, results into `<"mail@example.com" <mail@example.com>>` after stringify it which is not compliant: `Email \"\"mail@example.com"<mail@example.com\" does not comply with addr-spec of RFC 2822.`