### PR TITLE
[Validator] Add support for closures in `When`

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Add support for the `otherwise` option in the `When` constraint
  * Add support for multiple fields containing nested constraints in `Composite` constraints
  * Add the `stopOnFirstError` option to the `Unique` constraint to validate all elements
+ * Add support for closures in the `When` constraint
 
 7.2
 ---

--- a/src/Symfony/Component/Validator/Constraints/When.php
+++ b/src/Symfony/Component/Validator/Constraints/When.php
@@ -25,13 +25,13 @@ use Symfony\Component\Validator\Exception\LogicException;
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class When extends Composite
 {
-    public string|Expression $expression;
+    public string|Expression|\Closure $expression;
     public array|Constraint $constraints = [];
     public array $values = [];
     public array|Constraint $otherwise = [];
 
     /**
-     * @param string|Expression|array<string,mixed> $expression  The condition to evaluate, written with the ExpressionLanguage syntax
+     * @param string|Expression|array<string,mixed>|\Closure(object): bool $expression The condition to evaluate, either as a closure or using the ExpressionLanguage syntax
      * @param Constraint[]|Constraint|null          $constraints One or multiple constraints that are applied if the expression returns true
      * @param array<string,mixed>|null              $values      The values of the custom variables used in the expression (defaults to [])
      * @param string[]|null                         $groups
@@ -39,7 +39,7 @@ class When extends Composite
      * @param Constraint[]|Constraint               $otherwise   One or multiple constraints that are applied if the expression returns false
      */
     #[HasNamedArguments]
-    public function __construct(string|Expression|array $expression, array|Constraint|null $constraints = null, ?array $values = null, ?array $groups = null, $payload = null, ?array $options = null, array|Constraint $otherwise = [])
+    public function __construct(string|Expression|array|\Closure $expression, array|Constraint|null $constraints = null, ?array $values = null, ?array $groups = null, $payload = null, ?array $options = null, array|Constraint $otherwise = [])
     {
         if (!class_exists(ExpressionLanguage::class)) {
             throw new LogicException(\sprintf('The "symfony/expression-language" component is required to use the "%s" constraint. Try running "composer require symfony/expression-language".', __CLASS__));

--- a/src/Symfony/Component/Validator/Constraints/WhenValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/WhenValidator.php
@@ -35,7 +35,11 @@ final class WhenValidator extends ConstraintValidator
         $variables['this'] = $context->getObject();
         $variables['context'] = $context;
 
-        $result = $this->getExpressionLanguage()->evaluate($constraint->expression, $variables);
+        if ($constraint->expression instanceof \Closure) {
+            $result = ($constraint->expression)($context->getObject());
+        } else {
+            $result = $this->getExpressionLanguage()->evaluate($constraint->expression, $variables);
+        }
 
         if ($result) {
             $context->getValidator()->inContext($context)

--- a/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/WhenTestWithClosure.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/WhenTestWithClosure.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints\Fixtures;
+
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\NotNull;
+use Symfony\Component\Validator\Constraints\When;
+
+#[When(expression: static function () {
+        return true;
+    }, constraints: new NotNull()
+)]
+class WhenTestWithClosure
+{
+    #[When(expression: static function () {
+        return true;
+    }, constraints: [
+        new NotNull(),
+        new NotBlank(),
+    ])]
+    private $foo;
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/WhenValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/WhenValidatorTest.php
@@ -40,6 +40,34 @@ final class WhenValidatorTest extends ConstraintValidatorTestCase
         ));
     }
 
+    public function testConstraintsAreExecutedWhenClosureIsTrue()
+    {
+        $constraints = [
+            new NotNull(),
+            new NotBlank(),
+        ];
+
+        $this->expectValidateValue(0, 'Foo', $constraints);
+
+        $this->validator->validate('Foo', new When(
+            expression: static fn () => true,
+            constraints: $constraints,
+        ));
+    }
+
+    public function testClosureTakesSubject()
+    {
+        $subject = new \stdClass();
+        $this->setObject($subject);
+
+        $this->validator->validate($subject, new When(
+            expression: static function ($closureSubject) use ($subject) {
+                self::assertSame($subject, $closureSubject);
+            },
+            constraints: new NotNull(),
+        ));
+    }
+
     public function testConstraintIsExecuted()
     {
         $constraint = new NotNull();
@@ -60,6 +88,20 @@ final class WhenValidatorTest extends ConstraintValidatorTestCase
 
         $this->validator->validate('Foo', new When(
             expression: 'false',
+            constraints: $constraint,
+            otherwise: $otherwise,
+        ));
+    }
+
+    public function testOtherwiseIsExecutedWhenClosureReturnsFalse()
+    {
+        $constraint = new NotNull();
+        $otherwise = new Length(exactly: 10);
+
+        $this->expectValidateValue(0, 'Foo', [$otherwise]);
+
+        $this->validator->validate('Foo', new When(
+            expression: static fn () => false,
             constraints: $constraint,
             otherwise: $otherwise,
         ));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Closures can be used instead of Expressions in the `When` constraint since PHP 8.5, like in this example:

```php
use Symfony\Component\Validator\Constraints\NotBlank;
use Symfony\Component\Validator\Constraints\NotNull;
use Symfony\Component\Validator\Constraints\When;

class BlogPost
{
    #[When(expression: static function (BlogPost $subject) {
        return $subject->published && !$subject->draft;
    }, constraints: [
        new NotNull(),
        new NotBlank(),
    ])]
    public ?string $content;

    public bool $published;

    public bool $draft;
}
```