### PR TITLE
[TypeInfo] Add type alias support

### DIFF
--- a/src/Symfony/Component/TypeInfo/CHANGELOG.md
+++ b/src/Symfony/Component/TypeInfo/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add `TypeFactoryTrait::fromValue()` method
  * Deprecate constructing a `CollectionType` instance as a list that is not an array
  * Deprecate the third `$asList` argument of `TypeFactoryTrait::iterable()`, use `TypeFactoryTrait::list()` instead
+ * Add type alias support in `TypeContext` and `StringTypeResolver`
 
 7.2
 ---

--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/AbstractDummy.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/AbstractDummy.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\TypeInfo\Tests\Fixtures;
 
 abstract class AbstractDummy

--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/Dummy.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/Dummy.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\TypeInfo\Tests\Fixtures;
 
 final class Dummy extends AbstractDummy

--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyBackedEnum.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyBackedEnum.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\TypeInfo\Tests\Fixtures;
 
 enum DummyBackedEnum: string

--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyCollection.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyCollection.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\TypeInfo\Tests\Fixtures;
 
 final class DummyCollection implements \IteratorAggregate

--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyEnum.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyEnum.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\TypeInfo\Tests\Fixtures;
 
 enum DummyEnum

--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyExtendingStdClass.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyExtendingStdClass.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\TypeInfo\Tests\Fixtures;
 
 final class DummyExtendingStdClass extends \stdClass

--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithPhpDoc.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithPhpDoc.php
@@ -1,13 +1,31 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\TypeInfo\Tests\Fixtures;
 
+/**
+ * @phpstan-type CustomInt = int
+ * @psalm-type PsalmCustomInt = int
+ */
 final class DummyWithPhpDoc
 {
     /**
      * @var array<Dummy>
      */
     public mixed $arrayOfDummies = [];
+
+    /**
+     * @var CustomInt
+     */
+    public mixed $aliasedInt;
 
     /**
      * @param bool $promoted

--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithTemplates.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithTemplates.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\TypeInfo\Tests\Fixtures;
 
 /**

--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithTypeAliases.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithTypeAliases.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Tests\Fixtures;
+
+/**
+ * @phpstan-type CustomString = string
+ * @phpstan-import-type CustomInt from DummyWithPhpDoc
+ * @phpstan-import-type CustomInt from DummyWithPhpDoc as AliasedCustomInt
+ *
+ * @psalm-type PsalmCustomString = string
+ * @psalm-import-type PsalmCustomInt from DummyWithPhpDoc
+ * @psalm-import-type PsalmCustomInt from DummyWithPhpDoc as PsalmAliasedCustomInt
+ */
+final class DummyWithTypeAliases
+{
+    /**
+     * @var CustomString
+     */
+    public mixed $localAlias;
+
+    /**
+     * @var CustomInt
+     */
+    public mixed $externalAlias;
+
+    /**
+     * @var AliasedCustomInt
+     */
+    public mixed $aliasedExternalAlias;
+
+    /**
+     * @var PsalmCustomString
+     */
+    public mixed $psalmLocalAlias;
+
+    /**
+     * @var PsalmCustomInt
+     */
+    public mixed $psalmExternalAlias;
+
+    /**
+     * @var PsalmAliasedCustomInt
+     */
+    public mixed $psalmOtherAliasedExternalAlias;
+}
+
+/**
+ * @phpstan-import-type Invalid from DummyWithTypeAliases
+ */
+final class DummyWithInvalidTypeAliasImport
+{
+}

--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithUses.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithUses.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\TypeInfo\Tests\Fixtures;
 
 use Symfony\Component\TypeInfo\Type;

--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/ReflectionExtractableDummy.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/ReflectionExtractableDummy.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\TypeInfo\Tests\Fixtures;
 
 final class ReflectionExtractableDummy extends AbstractDummy

--- a/src/Symfony/Component/TypeInfo/Tests/TypeResolver/StringTypeResolverTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeResolver/StringTypeResolverTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\TypeInfo\Tests\Fixtures\DummyBackedEnum;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyCollection;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyEnum;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithTemplates;
+use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithTypeAliases;
 use Symfony\Component\TypeInfo\Type;
 use Symfony\Component\TypeInfo\TypeContext\TypeContext;
 use Symfony\Component\TypeInfo\TypeContext\TypeContextFactory;
@@ -175,6 +176,10 @@ class StringTypeResolverTest extends TestCase
         yield [Type::collection(Type::object(\IteratorAggregate::class), Type::string()), \IteratorAggregate::class.'<string>'];
         yield [Type::collection(Type::object(\IteratorAggregate::class), Type::bool(), Type::string()), \IteratorAggregate::class.'<string, bool>'];
         yield [Type::collection(Type::object(DummyCollection::class), Type::bool(), Type::string()), DummyCollection::class.'<string, bool>'];
+
+        // type aliases
+        yield [Type::int(), 'CustomInt', $typeContextFactory->createFromClassName(DummyWithTypeAliases::class)];
+        yield [Type::string(), 'CustomString', $typeContextFactory->createFromClassName(DummyWithTypeAliases::class)];
     }
 
     public function testCannotResolveNonStringType()

--- a/src/Symfony/Component/TypeInfo/TypeContext/TypeContext.php
+++ b/src/Symfony/Component/TypeInfo/TypeContext/TypeContext.php
@@ -33,6 +33,7 @@ final class TypeContext
     /**
      * @param array<string, string> $uses
      * @param array<string, Type>   $templates
+     * @param array<string, Type>   $typeAliases
      */
     public function __construct(
         public readonly string $calledClassName,
@@ -40,6 +41,7 @@ final class TypeContext
         public readonly ?string $namespace = null,
         public readonly array $uses = [],
         public readonly array $templates = [],
+        public readonly array $typeAliases = [],
     ) {
     }
 

--- a/src/Symfony/Component/TypeInfo/TypeResolver/StringTypeResolver.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/StringTypeResolver.php
@@ -275,6 +275,10 @@ final class StringTypeResolver implements TypeResolverInterface
             return Type::template($identifier, $typeContext->templates[$identifier]);
         }
 
+        if (isset($typeContext?->typeAliases[$identifier])) {
+            return $typeContext->typeAliases[$identifier];
+        }
+
         throw new \DomainException(\sprintf('Unhandled "%s" identifier.', $identifier));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

Add type aliasing support in `TypeContext` and `StringTypeResolver`, which enables the read of `@phpstan-type` and `@phpstan-import-type`.

With this PR, the following code will be properly understood by TypeInfo (before, it used to throw an `UnhandledException`):
```php
/**
 * @phpstan-type TypeAlias = array<string, list<bool>>
 */
final class Dummy
{
    /**
     * @var TypeAlias
     */
    public mixed $aliasedType;
}
```
