### PR TITLE
[AssetMapper] Removing `asnyc` from `<script>` tag of es-module-shims

### DIFF
--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapRenderer.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapRenderer.php
@@ -125,7 +125,7 @@ class ImportMapRenderer
             }
 
             $output .= <<<HTML
-                <script async$scriptAttributes>
+                <script$scriptAttributes>
                 if (!HTMLScriptElement.supports || !HTMLScriptElement.supports('importmap')) (function () {
                     const script = document.createElement('script');
                     script.src = '{$this->escapeAttributeValue($polyfillPath, \ENT_NOQUOTES)}';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | none
| License       | MIT

https://validator.w3.org/nu/ is saying:
> Error: Element `script` must not have attribute `async` unless attribute `src` is also specified or unless attribute `type` is specified with value `module`.

I don't know why `async` was added in the first place; and I don't have an old browser to test. Just wanted to make you aware that the current implementation looks invalid.