### PR TITLE
[DependencyInjection] Defer check for circular references instead of skipping them

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckCircularReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckCircularReferencesPass.php
@@ -28,6 +28,7 @@ class CheckCircularReferencesPass implements CompilerPassInterface
 {
     private array $currentPath;
     private array $checkedNodes;
+    private array $checkedLazyNodes;
 
     /**
      * Checks the ContainerBuilder object for circular references.
@@ -59,22 +60,36 @@ class CheckCircularReferencesPass implements CompilerPassInterface
             $node = $edge->getDestNode();
             $id = $node->getId();
 
-            if (empty($this->checkedNodes[$id])) {
-                // Don't check circular references for lazy edges
-                if (!$node->getValue() || (!$edge->isLazy() && !$edge->isWeak())) {
-                    $searchKey = array_search($id, $this->currentPath);
-                    $this->currentPath[] = $id;
+            if (!empty($this->checkedNodes[$id])) {
+                continue;
+            }
 
-                    if (false !== $searchKey) {
-                        throw new ServiceCircularReferenceException($id, \array_slice($this->currentPath, $searchKey));
-                    }
+            $isLeaf = !!$node->getValue();
+            $isConcrete = !$edge->isLazy() && !$edge->isWeak();
 
-                    $this->checkOutEdges($node->getOutEdges());
+            // Skip already checked lazy services if they are still lazy. Will not gain any new information.
+            if (!empty($this->checkedLazyNodes[$id]) && (!$isLeaf || !$isConcrete)) {
+                continue;
+            }
+
+            // Process concrete references, otherwise defer check circular references for lazy edges.
+            if (!$isLeaf || $isConcrete) {
+                $searchKey = array_search($id, $this->currentPath);
+                $this->currentPath[] = $id;
+
+                if (false !== $searchKey) {
+                    throw new ServiceCircularReferenceException($id, \array_slice($this->currentPath, $searchKey));
                 }
 
+                $this->checkOutEdges($node->getOutEdges());
+
                 $this->checkedNodes[$id] = true;
-                array_pop($this->currentPath);
+                unset($this->checkedLazyNodes[$id]);
+            } else {
+                $this->checkedLazyNodes[$id] = true;
             }
+
+            array_pop($this->currentPath);
         }
     }
 }


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT

Allow Dependency injection to check for circular references for lazy services, if they ever appear as "non-lazy" later during the compilation.
The issue happens when one of injected references happen to be in a service locator and injected into another service.