### PR TITLE
[Cache] Enable namespace-based invalidation by prefixing keys with backend-native namespace separators

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "psr/http-message": "^1.0|^2.0",
         "psr/link": "^1.1|^2.0",
         "psr/log": "^1|^2|^3",
-        "symfony/contracts": "^3.5",
+        "symfony/contracts": "^3.6",
         "symfony/polyfill-ctype": "~1.8",
         "symfony/polyfill-intl-grapheme": "~1.0",
         "symfony/polyfill-intl-icu": "~1.0",
@@ -218,7 +218,7 @@
             "url": "src/Symfony/Contracts",
             "options": {
                 "versions": {
-                    "symfony/contracts": "3.5.x-dev"
+                    "symfony/contracts": "3.6.x-dev"
                 }
             }
         },

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -208,6 +208,7 @@ use Symfony\Component\Yaml\Command\LintCommand as BaseYamlLintCommand;
 use Symfony\Component\Yaml\Yaml;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\CallbackInterface;
+use Symfony\Contracts\Cache\NamespacedPoolInterface;
 use Symfony\Contracts\Cache\TagAwareCacheInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -2576,6 +2577,10 @@ class FrameworkExtension extends Extension
                 $container->registerAliasForArgument($tagAwareId, TagAwareCacheInterface::class, $pool['name'] ?? $name);
                 $container->registerAliasForArgument($name, CacheInterface::class, $pool['name'] ?? $name);
                 $container->registerAliasForArgument($name, CacheItemPoolInterface::class, $pool['name'] ?? $name);
+
+                if (interface_exists(NamespacedPoolInterface::class)) {
+                    $container->registerAliasForArgument($name, NamespacedPoolInterface::class, $pool['name'] ?? $name);
+                }
             }
 
             $definition->setPublic($pool['public']);

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/cache.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/cache.html.twig
@@ -93,7 +93,7 @@
                                     <tr>
                                         <td class="font-normal text-small text-muted nowrap">{{ loop.index }}</td>
                                         <td class="nowrap">{{ '%0.2f'|format((call.end - call.start) * 1000) }} ms</td>
-                                        <td class="nowrap">{{ call.name }}()</td>
+                                        <td class="nowrap">{{ call.name }}({{ call.namespace|default('') }})</td>
                                         <td>{{ profiler_dump(call.value.result, maxDepth=2) }}</td>
                                     </tr>
                                 {% endfor %}

--- a/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
@@ -19,11 +19,12 @@ use Symfony\Component\Cache\ResettableInterface;
 use Symfony\Component\Cache\Traits\AbstractAdapterTrait;
 use Symfony\Component\Cache\Traits\ContractsTrait;
 use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\NamespacedPoolInterface;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
  */
-abstract class AbstractAdapter implements AdapterInterface, CacheInterface, LoggerAwareInterface, ResettableInterface
+abstract class AbstractAdapter implements AdapterInterface, CacheInterface, NamespacedPoolInterface, LoggerAwareInterface, ResettableInterface
 {
     use AbstractAdapterTrait;
     use ContractsTrait;
@@ -37,7 +38,19 @@ abstract class AbstractAdapter implements AdapterInterface, CacheInterface, Logg
 
     protected function __construct(string $namespace = '', int $defaultLifetime = 0)
     {
-        $this->namespace = '' === $namespace ? '' : CacheItem::validateKey($namespace).static::NS_SEPARATOR;
+        if ('' !== $namespace) {
+            if (str_contains($namespace, static::NS_SEPARATOR)) {
+                if (str_contains($namespace, static::NS_SEPARATOR.static::NS_SEPARATOR)) {
+                    throw new InvalidArgumentException(\sprintf('Cache namespace "%s" contains empty sub-namespace.', $namespace));
+                }
+                CacheItem::validateKey(str_replace(static::NS_SEPARATOR, '', $namespace));
+            } else {
+                CacheItem::validateKey($namespace);
+            }
+            $this->namespace = $namespace.static::NS_SEPARATOR;
+        }
+        $this->rootNamespace = $this->namespace;
+
         $this->defaultLifetime = $defaultLifetime;
         if (null !== $this->maxIdLength && \strlen($namespace) > $this->maxIdLength - 24) {
             throw new InvalidArgumentException(\sprintf('Namespace must be %d chars max, %d given ("%s").', $this->maxIdLength - 24, \strlen($namespace), $namespace));
@@ -118,7 +131,7 @@ abstract class AbstractAdapter implements AdapterInterface, CacheInterface, Logg
             return MemcachedAdapter::createConnection($dsn, $options);
         }
         if (str_starts_with($dsn, 'couchbase:')) {
-            if (class_exists('CouchbaseBucket') && CouchbaseBucketAdapter::isSupported()) {
+            if (class_exists(\CouchbaseBucket::class) && CouchbaseBucketAdapter::isSupported()) {
                 return CouchbaseBucketAdapter::createConnection($dsn, $options);
             }
 
@@ -159,7 +172,7 @@ abstract class AbstractAdapter implements AdapterInterface, CacheInterface, Logg
                     $v = $values[$id];
                     $type = get_debug_type($v);
                     $message = \sprintf('Failed to save key "{key}" of type %s%s', $type, $e instanceof \Exception ? ': '.$e->getMessage() : '.');
-                    CacheItem::log($this->logger, $message, ['key' => substr($id, \strlen($this->namespace)), 'exception' => $e instanceof \Exception ? $e : null, 'cache-adapter' => get_debug_type($this)]);
+                    CacheItem::log($this->logger, $message, ['key' => substr($id, \strlen($this->rootNamespace)), 'exception' => $e instanceof \Exception ? $e : null, 'cache-adapter' => get_debug_type($this)]);
                 }
             } else {
                 foreach ($values as $id => $v) {
@@ -182,7 +195,7 @@ abstract class AbstractAdapter implements AdapterInterface, CacheInterface, Logg
                 $ok = false;
                 $type = get_debug_type($v);
                 $message = \sprintf('Failed to save key "{key}" of type %s%s', $type, $e instanceof \Exception ? ': '.$e->getMessage() : '.');
-                CacheItem::log($this->logger, $message, ['key' => substr($id, \strlen($this->namespace)), 'exception' => $e instanceof \Exception ? $e : null, 'cache-adapter' => get_debug_type($this)]);
+                CacheItem::log($this->logger, $message, ['key' => substr($id, \strlen($this->rootNamespace)), 'exception' => $e instanceof \Exception ? $e : null, 'cache-adapter' => get_debug_type($this)]);
             }
         }
 

--- a/src/Symfony/Component/Cache/Adapter/AbstractTagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/AbstractTagAwareAdapter.php
@@ -17,6 +17,7 @@ use Symfony\Component\Cache\Exception\InvalidArgumentException;
 use Symfony\Component\Cache\ResettableInterface;
 use Symfony\Component\Cache\Traits\AbstractAdapterTrait;
 use Symfony\Component\Cache\Traits\ContractsTrait;
+use Symfony\Contracts\Cache\NamespacedPoolInterface;
 use Symfony\Contracts\Cache\TagAwareCacheInterface;
 
 /**
@@ -30,16 +31,33 @@ use Symfony\Contracts\Cache\TagAwareCacheInterface;
  *
  * @internal
  */
-abstract class AbstractTagAwareAdapter implements TagAwareAdapterInterface, TagAwareCacheInterface, LoggerAwareInterface, ResettableInterface
+abstract class AbstractTagAwareAdapter implements TagAwareAdapterInterface, TagAwareCacheInterface, AdapterInterface, NamespacedPoolInterface, LoggerAwareInterface, ResettableInterface
 {
     use AbstractAdapterTrait;
     use ContractsTrait;
+
+    /**
+     * @internal
+     */
+    protected const NS_SEPARATOR = ':';
 
     private const TAGS_PREFIX = "\1tags\1";
 
     protected function __construct(string $namespace = '', int $defaultLifetime = 0)
     {
-        $this->namespace = '' === $namespace ? '' : CacheItem::validateKey($namespace).':';
+        if ('' !== $namespace) {
+            if (str_contains($namespace, static::NS_SEPARATOR)) {
+                if (str_contains($namespace, static::NS_SEPARATOR.static::NS_SEPARATOR)) {
+                    throw new InvalidArgumentException(\sprintf('Cache namespace "%s" contains empty sub-namespace.', $namespace));
+                }
+                CacheItem::validateKey(str_replace(static::NS_SEPARATOR, '', $namespace));
+            } else {
+                CacheItem::validateKey($namespace);
+            }
+            $this->namespace = $namespace.static::NS_SEPARATOR;
+        }
+        $this->rootNamespace = $this->namespace;
+
         $this->defaultLifetime = $defaultLifetime;
         if (null !== $this->maxIdLength && \strlen($namespace) > $this->maxIdLength - 24) {
             throw new InvalidArgumentException(\sprintf('Namespace must be %d chars max, %d given ("%s").', $this->maxIdLength - 24, \strlen($namespace), $namespace));
@@ -70,7 +88,7 @@ abstract class AbstractTagAwareAdapter implements TagAwareAdapterInterface, TagA
             CacheItem::class
         );
         self::$mergeByLifetime ??= \Closure::bind(
-            static function ($deferred, &$expiredIds, $getId, $tagPrefix, $defaultLifetime) {
+            static function ($deferred, &$expiredIds, $getId, $tagPrefix, $defaultLifetime, $rootNamespace) {
                 $byLifetime = [];
                 $now = microtime(true);
                 $expiredIds = [];
@@ -102,10 +120,10 @@ abstract class AbstractTagAwareAdapter implements TagAwareAdapterInterface, TagA
                     $value['tag-operations'] = ['add' => [], 'remove' => []];
                     $oldTags = $item->metadata[CacheItem::METADATA_TAGS] ?? [];
                     foreach (array_diff_key($value['tags'], $oldTags) as $addedTag) {
-                        $value['tag-operations']['add'][] = $getId($tagPrefix.$addedTag);
+                        $value['tag-operations']['add'][] = $getId($tagPrefix.$addedTag, $rootNamespace);
                     }
                     foreach (array_diff_key($oldTags, $value['tags']) as $removedTag) {
-                        $value['tag-operations']['remove'][] = $getId($tagPrefix.$removedTag);
+                        $value['tag-operations']['remove'][] = $getId($tagPrefix.$removedTag, $rootNamespace);
                     }
                     $value['tags'] = array_keys($value['tags']);
 
@@ -168,7 +186,7 @@ abstract class AbstractTagAwareAdapter implements TagAwareAdapterInterface, TagA
     public function commit(): bool
     {
         $ok = true;
-        $byLifetime = (self::$mergeByLifetime)($this->deferred, $expiredIds, $this->getId(...), self::TAGS_PREFIX, $this->defaultLifetime);
+        $byLifetime = (self::$mergeByLifetime)($this->deferred, $expiredIds, $this->getId(...), self::TAGS_PREFIX, $this->defaultLifetime, $this->rootNamespace);
         $retry = $this->deferred = [];
 
         if ($expiredIds) {
@@ -195,7 +213,7 @@ abstract class AbstractTagAwareAdapter implements TagAwareAdapterInterface, TagA
                     $v = $values[$id];
                     $type = get_debug_type($v);
                     $message = \sprintf('Failed to save key "{key}" of type %s%s', $type, $e instanceof \Exception ? ': '.$e->getMessage() : '.');
-                    CacheItem::log($this->logger, $message, ['key' => substr($id, \strlen($this->namespace)), 'exception' => $e instanceof \Exception ? $e : null, 'cache-adapter' => get_debug_type($this)]);
+                    CacheItem::log($this->logger, $message, ['key' => substr($id, \strlen($this->rootNamespace)), 'exception' => $e instanceof \Exception ? $e : null, 'cache-adapter' => get_debug_type($this)]);
                 }
             } else {
                 foreach ($values as $id => $v) {
@@ -219,7 +237,7 @@ abstract class AbstractTagAwareAdapter implements TagAwareAdapterInterface, TagA
                 $ok = false;
                 $type = get_debug_type($v);
                 $message = \sprintf('Failed to save key "{key}" of type %s%s', $type, $e instanceof \Exception ? ': '.$e->getMessage() : '.');
-                CacheItem::log($this->logger, $message, ['key' => substr($id, \strlen($this->namespace)), 'exception' => $e instanceof \Exception ? $e : null, 'cache-adapter' => get_debug_type($this)]);
+                CacheItem::log($this->logger, $message, ['key' => substr($id, \strlen($this->rootNamespace)), 'exception' => $e instanceof \Exception ? $e : null, 'cache-adapter' => get_debug_type($this)]);
             }
         }
 
@@ -244,7 +262,7 @@ abstract class AbstractTagAwareAdapter implements TagAwareAdapterInterface, TagA
         try {
             foreach ($this->doDeleteYieldTags(array_values($ids)) as $id => $tags) {
                 foreach ($tags as $tag) {
-                    $tagData[$this->getId(self::TAGS_PREFIX.$tag)][] = $id;
+                    $tagData[$this->getId(self::TAGS_PREFIX.$tag, $this->rootNamespace)][] = $id;
                 }
             }
         } catch (\Exception) {
@@ -283,7 +301,7 @@ abstract class AbstractTagAwareAdapter implements TagAwareAdapterInterface, TagA
 
         $tagIds = [];
         foreach (array_unique($tags) as $tag) {
-            $tagIds[] = $this->getId(self::TAGS_PREFIX.$tag);
+            $tagIds[] = $this->getId(self::TAGS_PREFIX.$tag, $this->rootNamespace);
         }
 
         try {

--- a/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php
@@ -335,17 +335,17 @@ class DoctrineDbalAdapter extends AbstractAdapter implements PruneableInterface
     /**
      * @internal
      */
-    protected function getId(mixed $key): string
+    protected function getId(mixed $key, ?string $namespace = null): string
     {
         if ('pgsql' !== $this->platformName ??= $this->getPlatformName()) {
-            return parent::getId($key);
+            return parent::getId($key, $namespace);
         }
 
         if (str_contains($key, "\0") || str_contains($key, '%') || !preg_match('//u', $key)) {
             $key = rawurlencode($key);
         }
 
-        return parent::getId($key);
+        return parent::getId($key, $namespace);
     }
 
     private function getPlatformName(): string

--- a/src/Symfony/Component/Cache/Adapter/NullAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/NullAdapter.php
@@ -14,11 +14,12 @@ namespace Symfony\Component\Cache\Adapter;
 use Psr\Cache\CacheItemInterface;
 use Symfony\Component\Cache\CacheItem;
 use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\NamespacedPoolInterface;
 
 /**
  * @author Titouan Galopin <galopintitouan@gmail.com>
  */
-class NullAdapter implements AdapterInterface, CacheInterface
+class NullAdapter implements AdapterInterface, CacheInterface, NamespacedPoolInterface
 {
     private static \Closure $createCacheItem;
 
@@ -92,6 +93,11 @@ class NullAdapter implements AdapterInterface, CacheInterface
     public function delete(string $key): bool
     {
         return $this->deleteItem($key);
+    }
+
+    public function withSubNamespace(string $namespace): static
+    {
+        return clone $this;
     }
 
     private function generateItems(array $keys): \Generator

--- a/src/Symfony/Component/Cache/Adapter/PdoAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/PdoAdapter.php
@@ -348,17 +348,17 @@ class PdoAdapter extends AbstractAdapter implements PruneableInterface
     /**
      * @internal
      */
-    protected function getId(mixed $key): string
+    protected function getId(mixed $key, ?string $namespace = null): string
     {
         if ('pgsql' !== $this->getDriver()) {
-            return parent::getId($key);
+            return parent::getId($key, $namespace);
         }
 
         if (str_contains($key, "\0") || str_contains($key, '%') || !preg_match('//u', $key)) {
             $key = rawurlencode($key);
         }
 
-        return parent::getId($key);
+        return parent::getId($key, $namespace);
     }
 
     private function getConnection(): \PDO

--- a/src/Symfony/Component/Cache/Adapter/RedisTagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/RedisTagAwareAdapter.php
@@ -159,7 +159,7 @@ EOLUA;
 
         foreach ($results as $id => $result) {
             if ($result instanceof \RedisException || $result instanceof \Relay\Exception || $result instanceof ErrorInterface) {
-                CacheItem::log($this->logger, 'Failed to delete key "{key}": '.$result->getMessage(), ['key' => substr($id, \strlen($this->namespace)), 'exception' => $result]);
+                CacheItem::log($this->logger, 'Failed to delete key "{key}": '.$result->getMessage(), ['key' => substr($id, \strlen($this->rootNamespace)), 'exception' => $result]);
 
                 continue;
             }

--- a/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
@@ -16,9 +16,11 @@ use Psr\Cache\InvalidArgumentException;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Symfony\Component\Cache\CacheItem;
+use Symfony\Component\Cache\Exception\BadMethodCallException;
 use Symfony\Component\Cache\PruneableInterface;
 use Symfony\Component\Cache\ResettableInterface;
 use Symfony\Component\Cache\Traits\ContractsTrait;
+use Symfony\Contracts\Cache\NamespacedPoolInterface;
 use Symfony\Contracts\Cache\TagAwareCacheInterface;
 
 /**
@@ -33,7 +35,7 @@ use Symfony\Contracts\Cache\TagAwareCacheInterface;
  * @author Nicolas Grekas <p@tchwork.com>
  * @author Sergey Belyshkin <sbelyshkin@gmail.com>
  */
-class TagAwareAdapter implements TagAwareAdapterInterface, TagAwareCacheInterface, PruneableInterface, ResettableInterface, LoggerAwareInterface
+class TagAwareAdapter implements TagAwareAdapterInterface, TagAwareCacheInterface, NamespacedPoolInterface, PruneableInterface, ResettableInterface, LoggerAwareInterface
 {
     use ContractsTrait;
     use LoggerAwareTrait;
@@ -275,6 +277,23 @@ class TagAwareAdapter implements TagAwareAdapterInterface, TagAwareCacheInterfac
         (self::$setTagVersions)($items, array_combine($tagVersions, $tagVersions));
 
         return $ok;
+    }
+
+    /**
+     * @throws BadMethodCallException When the item pool is not a NamespacedPoolInterface
+     */
+    public function withSubNamespace(string $namespace): static
+    {
+        if (!$this->pool instanceof NamespacedPoolInterface) {
+            throw new BadMethodCallException(\sprintf('Cannot call "%s::withSubNamespace()": this class doesn\'t implement "%s".', get_debug_type($this->pool), NamespacedPoolInterface::class));
+        }
+
+        $knownTagVersions = &$this->knownTagVersions; // ensures clones share the same array
+        $clone = clone $this;
+        $clone->deferred = [];
+        $clone->pool = $this->pool->withSubNamespace($namespace);
+
+        return $clone;
     }
 
     public function prune(): bool

--- a/src/Symfony/Component/Cache/CHANGELOG.md
+++ b/src/Symfony/Component/Cache/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add support for `\Relay\Cluster` in `RedisAdapter`
  * Add support for `valkey:` / `valkeys:` schemes
+ * Add support for namespace-based invalidation
  * Rename options "redis_cluster" and "redis_sentinel" to "cluster" and "sentinel" respectively
 
 7.2

--- a/src/Symfony/Component/Cache/Exception/BadMethodCallException.php
+++ b/src/Symfony/Component/Cache/Exception/BadMethodCallException.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Exception;
+
+use Psr\Cache\CacheException as Psr6CacheInterface;
+use Psr\SimpleCache\CacheException as SimpleCacheInterface;
+
+if (interface_exists(SimpleCacheInterface::class)) {
+    class BadMethodCallException extends \BadMethodCallException implements Psr6CacheInterface, SimpleCacheInterface
+    {
+    }
+} else {
+    class BadMethodCallException extends \BadMethodCallException implements Psr6CacheInterface
+    {
+    }
+}

--- a/src/Symfony/Component/Cache/Tests/Adapter/PhpArrayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PhpArrayAdapterTest.php
@@ -57,6 +57,8 @@ class PhpArrayAdapterTest extends AdapterTestCase
 
         'testDefaultLifeTime' => 'PhpArrayAdapter does not allow configuring a default lifetime.',
         'testPrune' => 'PhpArrayAdapter just proxies',
+
+        'testNamespaces' => 'PhpArrayAdapter does not support namespaces.',
     ];
 
     protected static string $file;

--- a/src/Symfony/Component/Cache/Tests/Adapter/PhpArrayAdapterWithFallbackTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PhpArrayAdapterWithFallbackTest.php
@@ -28,6 +28,8 @@ class PhpArrayAdapterWithFallbackTest extends AdapterTestCase
         'testDeleteItemInvalidKeys' => 'PhpArrayAdapter does not throw exceptions on invalid key.',
         'testDeleteItemsInvalidKeys' => 'PhpArrayAdapter does not throw exceptions on invalid key.',
         'testPrune' => 'PhpArrayAdapter just proxies',
+
+        'testNamespaces' => 'PhpArrayAdapter does not support namespaces.',
     ];
 
     protected static string $file;

--- a/src/Symfony/Component/Cache/Tests/Adapter/TagAwareTestTrait.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/TagAwareTestTrait.php
@@ -183,4 +183,27 @@ trait TagAwareTestTrait
         $cacheItem = $pool->getItem('test');
         $this->assertTrue($cacheItem->isHit());
     }
+
+    public function testNamespacesAndTags()
+    {
+        $pool = $this->createCachePool();
+        $pool->clear();
+
+        $item = $pool->getItem('foo');
+        $item->tag('baz');
+        $pool->save($item);
+
+        $derived = $pool->withSubNamespace('derived');
+        $item = $derived->getItem('bar');
+        $item->tag('baz');
+        $derived->save($item);
+
+        $this->assertTrue($pool->getItem('foo')->isHit());
+        $this->assertTrue($derived->getItem('bar')->isHit());
+
+        $pool->invalidateTags(['baz']);
+
+        $this->assertFalse($pool->getItem('foo')->isHit());
+        $this->assertFalse($derived->getItem('bar')->isHit());
+    }
 }

--- a/src/Symfony/Component/Cache/Tests/Psr16CacheProxyTest.php
+++ b/src/Symfony/Component/Cache/Tests/Psr16CacheProxyTest.php
@@ -45,12 +45,12 @@ class Psr16CacheProxyTest extends SimpleCacheTest
     public function testProxy()
     {
         $pool = new ArrayAdapter();
-        $cache = new Psr16Cache(new ProxyAdapter($pool, 'my-namespace.'));
+        $cache = new Psr16Cache(new ProxyAdapter($pool, 'my-namespace'));
 
         $this->assertNull($cache->get('some-key'));
         $this->assertTrue($cache->set('some-other-key', 'value'));
 
-        $item = $pool->getItem('my-namespace.some-other-key', 'value');
+        $item = $pool->withSubNamespace('my-namespace')->getItem('some-other-key', 'value');
         $this->assertTrue($item->isHit());
         $this->assertSame('value', $item->get());
     }

--- a/src/Symfony/Component/Cache/Traits/AbstractAdapterTrait.php
+++ b/src/Symfony/Component/Cache/Traits/AbstractAdapterTrait.php
@@ -35,6 +35,7 @@ trait AbstractAdapterTrait
      */
     private static \Closure $mergeByLifetime;
 
+    private readonly string $rootNamespace;
     private string $namespace = '';
     private int $defaultLifetime;
     private string $namespaceVersion = '';
@@ -106,15 +107,16 @@ trait AbstractAdapterTrait
     {
         $this->deferred = [];
         if ($cleared = $this->versioningIsEnabled) {
+            $rootNamespace = $this->rootNamespace ??= $this->namespace;
             if ('' === $namespaceVersionToClear = $this->namespaceVersion) {
-                foreach ($this->doFetch([static::NS_SEPARATOR.$this->namespace]) as $v) {
+                foreach ($this->doFetch([static::NS_SEPARATOR.$rootNamespace]) as $v) {
                     $namespaceVersionToClear = $v;
                 }
             }
-            $namespaceToClear = $this->namespace.$namespaceVersionToClear;
+            $namespaceToClear = $rootNamespace.$namespaceVersionToClear;
             $namespaceVersion = self::formatNamespaceVersion(mt_rand());
             try {
-                $e = $this->doSave([static::NS_SEPARATOR.$this->namespace => $namespaceVersion], 0);
+                $e = $this->doSave([static::NS_SEPARATOR.$rootNamespace => $namespaceVersion], 0);
             } catch (\Exception $e) {
             }
             if (true !== $e && [] !== $e) {
@@ -247,6 +249,16 @@ trait AbstractAdapterTrait
         return true;
     }
 
+    public function withSubNamespace(string $namespace): static
+    {
+        $this->rootNamespace ??= $this->namespace;
+
+        $clone = clone $this;
+        $clone->namespace .= CacheItem::validateKey($namespace).static::NS_SEPARATOR;
+
+        return $clone;
+    }
+
     /**
      * Enables/disables versioning of items.
      *
@@ -318,19 +330,24 @@ trait AbstractAdapterTrait
     /**
      * @internal
      */
-    protected function getId(mixed $key): string
+    protected function getId(mixed $key, ?string $namespace = null): string
     {
-        if ($this->versioningIsEnabled && '' === $this->namespaceVersion) {
+        $namespace ??= $this->namespace;
+
+        if ('' !== $this->namespaceVersion) {
+            $namespace .= $this->namespaceVersion;
+        } elseif ($this->versioningIsEnabled) {
+            $rootNamespace = $this->rootNamespace ??= $this->namespace;
             $this->ids = [];
             $this->namespaceVersion = '1'.static::NS_SEPARATOR;
             try {
-                foreach ($this->doFetch([static::NS_SEPARATOR.$this->namespace]) as $v) {
+                foreach ($this->doFetch([static::NS_SEPARATOR.$rootNamespace]) as $v) {
                     $this->namespaceVersion = $v;
                 }
                 $e = true;
                 if ('1'.static::NS_SEPARATOR === $this->namespaceVersion) {
                     $this->namespaceVersion = self::formatNamespaceVersion(time());
-                    $e = $this->doSave([static::NS_SEPARATOR.$this->namespace => $this->namespaceVersion], 0);
+                    $e = $this->doSave([static::NS_SEPARATOR.$rootNamespace => $this->namespaceVersion], 0);
                 }
             } catch (\Exception $e) {
             }
@@ -338,25 +355,34 @@ trait AbstractAdapterTrait
                 $message = 'Failed to save the new namespace'.($e instanceof \Exception ? ': '.$e->getMessage() : '.');
                 CacheItem::log($this->logger, $message, ['exception' => $e instanceof \Exception ? $e : null, 'cache-adapter' => get_debug_type($this)]);
             }
+
+            $namespace .= $this->namespaceVersion;
         }
 
         if (\is_string($key) && isset($this->ids[$key])) {
-            return $this->namespace.$this->namespaceVersion.$this->ids[$key];
-        }
-        \assert('' !== CacheItem::validateKey($key));
-        $this->ids[$key] = $key;
+            $id = $this->ids[$key];
+        } else {
+            \assert('' !== CacheItem::validateKey($key));
+            $this->ids[$key] = $key;
 
-        if (\count($this->ids) > 1000) {
-            $this->ids = \array_slice($this->ids, 500, null, true); // stop memory leak if there are many keys
-        }
+            if (\count($this->ids) > 1000) {
+                $this->ids = \array_slice($this->ids, 500, null, true); // stop memory leak if there are many keys
+            }
 
-        if (null === $this->maxIdLength) {
-            return $this->namespace.$this->namespaceVersion.$key;
-        }
-        if (\strlen($id = $this->namespace.$this->namespaceVersion.$key) > $this->maxIdLength) {
+            if (null === $this->maxIdLength) {
+                return $namespace.$key;
+            }
+            if (\strlen($id = $namespace.$key) <= $this->maxIdLength) {
+                return $id;
+            }
+
             // Use xxh128 to favor speed over security, which is not an issue here
             $this->ids[$key] = $id = substr_replace(base64_encode(hash('xxh128', $key, true)), static::NS_SEPARATOR, -(\strlen($this->namespaceVersion) + 2));
-            $id = $this->namespace.$this->namespaceVersion.$id;
+        }
+        $id = $namespace.$id;
+
+        if (null !== $this->maxIdLength && \strlen($id) > $this->maxIdLength) {
+            return base64_encode(hash('xxh128', $id, true));
         }
 
         return $id;

--- a/src/Symfony/Component/Cache/composer.json
+++ b/src/Symfony/Component/Cache/composer.json
@@ -24,7 +24,7 @@
         "php": ">=8.2",
         "psr/cache": "^2.0|^3.0",
         "psr/log": "^1.1|^2|^3",
-        "symfony/cache-contracts": "^2.5|^3",
+        "symfony/cache-contracts": "^3.6",
         "symfony/deprecation-contracts": "^2.5|^3.0",
         "symfony/service-contracts": "^2.5|^3",
         "symfony/var-exporter": "^6.4|^7.0"

--- a/src/Symfony/Contracts/CHANGELOG.md
+++ b/src/Symfony/Contracts/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Make `HttpClientTestCase` and `TranslatorTest` compatible with PHPUnit 10+
+ * Add `NamespacedPoolInterface` to support namespace-based invalidation
 
 3.5
 ---

--- a/src/Symfony/Contracts/Cache/NamespacedPoolInterface.php
+++ b/src/Symfony/Contracts/Cache/NamespacedPoolInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Contracts\Cache;
+
+use Psr\Cache\InvalidArgumentException;
+
+/**
+ * Enables namespace-based invalidation by prefixing keys with backend-native namespace separators.
+ *
+ * Note that calling `withSubNamespace()` MUST NOT mutate the pool, but return a new instance instead.
+ *
+ * When tags are used, they MUST ignore sub-namespaces.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+interface NamespacedPoolInterface
+{
+    /**
+     * @throws InvalidArgumentException If the namespace contains characters found in ItemInterface's RESERVED_CHARACTERS
+     */
+    public function withSubNamespace(string $namespace): static;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #45599
| License       | MIT

This PR adds a `NamespacedPoolInterface` that describes how one can add namespace prefixes to cache pool keys.

This solves #45599 by allowing to use the `:` separator for Redis:
```php
$cache->withSubNamespace('some-prefix')->get($key, fn () => ...);
```

Most importantly, this enables namespace-based cache invalidation, typically with namespaces generated by hashing some context.