### PR TITLE
[TypeInfo] Fix create union with nullable type

### DIFF
--- a/src/Symfony/Component/TypeInfo/Tests/TypeFactoryTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeFactoryTest.php
@@ -205,5 +205,9 @@ class TypeFactoryTest extends TestCase
             new NullableType(new UnionType(new BuiltinType(TypeIdentifier::INT), new BuiltinType(TypeIdentifier::STRING))),
             Type::nullable(Type::union(Type::int(), Type::string(), Type::null())),
         );
+        $this->assertEquals(
+            new NullableType(new UnionType(new BuiltinType(TypeIdentifier::INT), new BuiltinType(TypeIdentifier::STRING))),
+            Type::union(Type::nullable(Type::int()), Type::string()),
+        );
     }
 }

--- a/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
+++ b/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
@@ -266,6 +266,13 @@ trait TypeFactoryTrait
         $isNullable = fn (Type $type): bool => $type instanceof BuiltinType && TypeIdentifier::NULL === $type->getTypeIdentifier();
 
         foreach ($types as $type) {
+            if ($type instanceof NullableType) {
+                $nullableUnion = true;
+                $unionTypes[] = $type->getWrappedType();
+
+                continue;
+            }
+
             if ($type instanceof UnionType) {
                 foreach ($type->getTypes() as $unionType) {
                     if ($isNullable($type)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Fix the creation of a union type with a nullable type, such as
```php
Type::union(Type::nullable(Type::int()), Type::string());

// it will be handled the same as:
Type::nullable(Type::int(), Type::string())
Type::union(Type::int(), Type::string(), Type::null())
```
