### PR TITLE
[DependencyInjection] Fix phpdoc for $configurator in Autoconfigure attribute

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/Autoconfigure.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/Autoconfigure.php
@@ -28,7 +28,7 @@ class Autoconfigure
      * @param bool|null                                               $shared       Whether to declare the service as shared
      * @param bool|null                                               $autowire     Whether to declare the service as autowired
      * @param array<string, mixed>|null                               $properties   The properties to define when creating the service
-     * @param array<class-string, string>|string|null                 $configurator A PHP function, reference or an array containing a class/Reference and a method to call after the service is fully initialized
+     * @param array{string, string}|string|null                       $configurator A PHP function, reference or an array containing a class/reference and a method to call after the service is fully initialized
      * @param string|null                                             $constructor  The public static method to use to instantiate the service
      */
     public function __construct(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony/issues/59821
| License       | MIT

Since SF7.1, in Autoconfigure attribute, the $configurator phpdoc seems wrong : 

` * @param array<class-string, string>|string|null                 $configurator A PHP function, reference or an array containing a class/Reference and a method to call after the service is fully initialized`

The doc is asking for a class-string **key** and a string **value**. However, this is not always the case because the first parameter could be a service, like `@foo` which is not a class-string. Moreover, the second parameter should not be empty.
