### PR TITLE
[Messenger] Add options to specify SQS queue attributes and tags

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.3
+---
+
+ * Add new `queue_attributes` and `queue_tags` options for SQS queue creation
+
 7.2
 ---
 

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
@@ -46,6 +46,8 @@ class Connection
         'endpoint' => 'https://sqs.eu-west-1.amazonaws.com',
         'region' => 'eu-west-1',
         'queue_name' => 'messages',
+        'queue_attributes' => null,
+        'queue_tags' => null,
         'account' => null,
         'sslmode' => null,
         'debug' => null,
@@ -89,6 +91,8 @@ class Connection
      * * endpoint: absolute URL to the SQS service (Default: https://sqs.eu-west-1.amazonaws.com)
      * * region: name of the AWS region (Default: eu-west-1)
      * * queue_name: name of the queue (Default: messages)
+     * * queue_attributes: attributes of the queue, array<QueueAttributeName::*, string>
+     * * queue_tags: tags of the queue, array<string, string>
      * * account: identifier of the AWS account
      * * access_key: AWS access key
      * * secret_key: AWS secret key
@@ -132,6 +136,8 @@ class Connection
             'visibility_timeout' => null !== $options['visibility_timeout'] ? (int) $options['visibility_timeout'] : null,
             'auto_setup' => filter_var($options['auto_setup'], \FILTER_VALIDATE_BOOL),
             'queue_name' => (string) $options['queue_name'],
+            'queue_attributes' => $options['queue_attributes'],
+            'queue_tags' => $options['queue_tags'],
         ];
 
         $clientConfiguration = [
@@ -278,12 +284,14 @@ class Connection
             throw new InvalidArgumentException(\sprintf('The Amazon SQS queue "%s" does not exist (or you don\'t have permissions on it), and can\'t be created when an account is provided.', $this->configuration['queue_name']));
         }
 
-        $parameters = ['QueueName' => $this->configuration['queue_name']];
+        $parameters = [
+            'QueueName' => $this->configuration['queue_name'],
+            'Attributes' => $this->configuration['queue_attributes'],
+            'tags' => $this->configuration['queue_tags'],
+        ];
 
         if (self::isFifoQueue($this->configuration['queue_name'])) {
-            $parameters['Attributes'] = [
-                'FifoQueue' => 'true',
-            ];
+            $parameters['Attributes'][QueueAttributeName::FIFO_QUEUE] = 'true';
         }
 
         $this->client->createQueue($parameters);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        |
| License       | MIT

When automatically creating SQS queue, the new options `queue_attributes` and `queue_tags` can be used to specify queue attributes and cost allocation tags as per [SQS CreateQueue API](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_CreateQueue.html)

Usage example:
```
$queueName = 'queueName.fifo';
$queueAttributes = [
    QueueAttributeName::MESSAGE_RETENTION_PERIOD => '900',
    QueueAttributeName::MAXIMUM_MESSAGE_SIZE => '1024',
];
$queueTags = ['tag1' => 'value1', 'tag2' => 'value2'];

$connection = new Connection(['queue_name' => $queueName, 'queue_attributes' => $queueAttributes, 'queue_tags' => $queueTags], $client);
```