### PR TITLE
[TypeInfo] Add `CollectionType::mergeCollectionValueTypes()`

### DIFF
--- a/src/Symfony/Component/TypeInfo/CHANGELOG.md
+++ b/src/Symfony/Component/TypeInfo/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Deprecate constructing a `CollectionType` instance as a list that is not an array
  * Deprecate the third `$asList` argument of `TypeFactoryTrait::iterable()`, use `TypeFactoryTrait::list()` instead
  * Add type alias support in `TypeContext` and `StringTypeResolver`
+ * Add `CollectionType::mergeCollectionValueTypes()` method
 
 7.2
 ---

--- a/src/Symfony/Component/TypeInfo/Tests/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/CollectionTypeTest.php
@@ -134,4 +134,26 @@ class CollectionTypeTest extends TestCase
         $this->expectUserDeprecationMessage('Since symfony/type-info 7.3: Creating a "Symfony\Component\TypeInfo\Type\CollectionType" that is a list and not an array is deprecated and will throw a "Symfony\Component\TypeInfo\Exception\InvalidArgumentException" in 8.0.');
         new CollectionType(Type::generic(Type::builtin(TypeIdentifier::ITERABLE), Type::bool()), isList: true);
     }
+
+    public function testMergeCollectionValueTypes()
+    {
+        $this->assertEquals(Type::int(), CollectionType::mergeCollectionValueTypes([Type::int()]));
+        $this->assertEquals(Type::union(Type::int(), Type::string()), CollectionType::mergeCollectionValueTypes([Type::int(), Type::string()]));
+
+        $this->assertEquals(Type::mixed(), CollectionType::mergeCollectionValueTypes([Type::int(), Type::mixed()]));
+
+        $this->assertEquals(Type::union(Type::int(), Type::true()), CollectionType::mergeCollectionValueTypes([Type::int(), Type::true()]));
+        $this->assertEquals(Type::bool(), CollectionType::mergeCollectionValueTypes([Type::true(), Type::false(), Type::true()]));
+
+        $this->assertEquals(Type::union(Type::object(\Stringable::class), Type::object(\Countable::class)), CollectionType::mergeCollectionValueTypes([Type::object(\Stringable::class), Type::object(\Countable::class)]));
+        $this->assertEquals(Type::object(), CollectionType::mergeCollectionValueTypes([Type::object(\Stringable::class), Type::object()]));
+    }
+
+    public function testCannotMergeEmptyCollectionValueTypes()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The $types cannot be empty.');
+
+        CollectionType::mergeCollectionValueTypes([]);
+    }
 }

--- a/src/Symfony/Component/TypeInfo/Tests/TypeFactoryTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeFactoryTest.php
@@ -227,6 +227,7 @@ class TypeFactoryTest extends TestCase
         // object
         yield [Type::object(\DateTimeImmutable::class), new \DateTimeImmutable()];
         yield [Type::object(), new \stdClass()];
+        yield [Type::list(Type::object()), [new \stdClass(), new \DateTimeImmutable()]];
 
         // collection
         $arrayAccess = new class implements \ArrayAccess {

--- a/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
+++ b/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
@@ -391,44 +391,24 @@ trait TypeFactoryTrait
             /** @var list<BuiltinType<TypeIdentifier::INT>|BuiltinType<TypeIdentifier::STRING>> $keyTypes */
             $keyTypes = [];
 
-            /** @var list<Type|null> $valueTypes */
+            /** @var list<Type> $valueTypes */
             $valueTypes = [];
 
             $i = 0;
 
             foreach ($value as $k => $v) {
                 $keyTypes[] = self::fromValue($k);
-                $keyTypes = array_unique($keyTypes);
-
                 $valueTypes[] = self::fromValue($v);
-                $valueTypes = array_unique($valueTypes);
             }
 
-            if ([] !== $keyTypes) {
-                $keyTypes = array_values($keyTypes);
+            if ($keyTypes) {
+                $keyTypes = array_values(array_unique($keyTypes));
                 $keyType = \count($keyTypes) > 1 ? self::union(...$keyTypes) : $keyTypes[0];
-
-                $valueType = null;
-                foreach ($valueTypes as &$v) {
-                    if ($v->isIdentifiedBy(TypeIdentifier::MIXED)) {
-                        $valueType = Type::mixed();
-
-                        break;
-                    }
-
-                    if ($v->isIdentifiedBy(TypeIdentifier::TRUE, TypeIdentifier::FALSE)) {
-                        $v = Type::bool();
-                    }
-                }
-
-                if (!$valueType) {
-                    $valueTypes = array_values(array_unique($valueTypes));
-                    $valueType = \count($valueTypes) > 1 ? self::union(...$valueTypes) : $valueTypes[0];
-                }
             } else {
                 $keyType = Type::union(Type::int(), Type::string());
-                $valueType = Type::mixed();
             }
+
+            $valueType = $valueTypes ? CollectionType::mergeCollectionValueTypes($valueTypes) : Type::mixed();
 
             return self::collection($type, $valueType, $keyType, \is_array($value) && array_is_list($value));
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

At the moment, when calling the following code:
```php
$type = Type::fromValue([new \stdClass(), new \DateTimeImmutable()]);
```
used to throw an exception saying: `Cannot create union with both "object" and class type.`. This PR fixes that, allowing the method to return the proper `Type::list(Type::object())`.

It also creates the `CollectionType::mergeCollectionValueTypes()` method to encapsulate this logic (as it'll be used in future PRs).




