### PR TITLE
[Stopwatch] Fix StopWatchEvent never throws InvalidArgumentException

### DIFF
--- a/src/Symfony/Component/Stopwatch/StopwatchEvent.php
+++ b/src/Symfony/Component/Stopwatch/StopwatchEvent.php
@@ -39,8 +39,6 @@ class StopwatchEvent
      * @param string|null $category      The event category or null to use the default
      * @param bool        $morePrecision If true, time is stored as float to keep the original microsecond precision
      * @param string|null $name          The event name or null to define the name as default
-     *
-     * @throws \InvalidArgumentException When the raw time is not valid
      */
     public function __construct(float $origin, ?string $category = null, bool $morePrecision = false, ?string $name = null)
     {
@@ -207,8 +205,6 @@ class StopwatchEvent
 
     /**
      * Formats a time.
-     *
-     * @throws \InvalidArgumentException When the raw time is not valid
      */
     private function formatTime(float $time): float
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Where was old [commit](https://github.com/symfony/symfony/commit/416a2a46df52717280e04be0c301b7e608bea828#diff-c71d0fac870b79a4782783376e3bdc8f73e5d0c4427bd45711f4d112f71e76feR172) where `InvalidArgumentException` really thrown, but it is no longer needed now.