### PR TITLE
[Serializer] Add `defaultType` to `DiscriminatorMap`

### DIFF
--- a/src/Symfony/Component/Serializer/Attribute/DiscriminatorMap.php
+++ b/src/Symfony/Component/Serializer/Attribute/DiscriminatorMap.php
@@ -22,12 +22,14 @@ class DiscriminatorMap
     /**
      * @param string                      $typeProperty The property holding the type discriminator
      * @param array<string, class-string> $mapping      The mapping between types and classes (i.e. ['admin_user' => AdminUser::class])
+     * @param ?string                     $defaultType  The fallback value if nothing specified by $typeProperty
      *
      * @throws InvalidArgumentException
      */
     public function __construct(
         private readonly string $typeProperty,
         private readonly array $mapping,
+        private readonly ?string $defaultType = null,
     ) {
         if (!$typeProperty) {
             throw new InvalidArgumentException(\sprintf('Parameter "typeProperty" given to "%s" cannot be empty.', static::class));
@@ -35,6 +37,10 @@ class DiscriminatorMap
 
         if (!$mapping) {
             throw new InvalidArgumentException(\sprintf('Parameter "mapping" given to "%s" cannot be empty.', static::class));
+        }
+
+        if (null !== $this->defaultType && !\array_key_exists($this->defaultType, $this->mapping)) {
+            throw new InvalidArgumentException(\sprintf('Default type "%s" given to "%s" must be present in "mapping" types.', $this->defaultType, static::class));
         }
     }
 
@@ -46,6 +52,11 @@ class DiscriminatorMap
     public function getMapping(): array
     {
         return $this->mapping;
+    }
+
+    public function getDefaultType(): ?string
+    {
+        return $this->defaultType;
     }
 }
 

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Deprecate the `CompiledClassMetadataFactory` and `CompiledClassMetadataCacheWarmer` classes
  * Register `NormalizerInterface` and `DenormalizerInterface` aliases for named serializers
  * Add `NumberNormalizer` to normalize `BcMath\Number` and `GMP` as `string`
+ * Add `defaultType` to `DiscriminatorMap`
 
 7.2
 ---

--- a/src/Symfony/Component/Serializer/Mapping/ClassDiscriminatorMapping.php
+++ b/src/Symfony/Component/Serializer/Mapping/ClassDiscriminatorMapping.php
@@ -22,6 +22,7 @@ class ClassDiscriminatorMapping
     public function __construct(
         private readonly string $typeProperty,
         private array $typesMapping = [],
+        private readonly ?string $defaultType = null,
     ) {
         uasort($this->typesMapping, static function (string $a, string $b): int {
             if (is_a($a, $b, true)) {
@@ -60,5 +61,10 @@ class ClassDiscriminatorMapping
     public function getTypesMapping(): array
     {
         return $this->typesMapping;
+    }
+
+    public function getDefaultType(): ?string
+    {
+        return $this->defaultType;
     }
 }

--- a/src/Symfony/Component/Serializer/Mapping/Factory/ClassMetadataFactoryCompiler.php
+++ b/src/Symfony/Component/Serializer/Mapping/Factory/ClassMetadataFactoryCompiler.php
@@ -55,6 +55,7 @@ EOF;
             $classDiscriminatorMapping = $classMetadata->getClassDiscriminatorMapping() ? [
                 $classMetadata->getClassDiscriminatorMapping()->getTypeProperty(),
                 $classMetadata->getClassDiscriminatorMapping()->getTypesMapping(),
+                $classMetadata->getClassDiscriminatorMapping()->getDefaultType(),
             ] : null;
 
             $compiled .= \sprintf("\n'%s' => %s,", $classMetadata->getName(), VarExporter::export([

--- a/src/Symfony/Component/Serializer/Mapping/Loader/AttributeLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AttributeLoader.php
@@ -59,7 +59,7 @@ class AttributeLoader implements LoaderInterface
 
         foreach ($this->loadAttributes($reflectionClass) as $attribute) {
             match (true) {
-                $attribute instanceof DiscriminatorMap => $classMetadata->setClassDiscriminatorMapping(new ClassDiscriminatorMapping($attribute->getTypeProperty(), $attribute->getMapping())),
+                $attribute instanceof DiscriminatorMap => $classMetadata->setClassDiscriminatorMapping(new ClassDiscriminatorMapping($attribute->getTypeProperty(), $attribute->getMapping(), $attribute->getDefaultType())),
                 $attribute instanceof Groups => $classGroups = $attribute->getGroups(),
                 $attribute instanceof Context => $classContextAttribute = $attribute,
                 default => null,

--- a/src/Symfony/Component/Serializer/Mapping/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/XmlFileLoader.php
@@ -107,7 +107,8 @@ class XmlFileLoader extends FileLoader
 
                 $classMetadata->setClassDiscriminatorMapping(new ClassDiscriminatorMapping(
                     (string) $xml->{'discriminator-map'}->attributes()->{'type-property'},
-                    $mapping
+                    $mapping,
+                    $xml->{'discriminator-map'}->attributes()->{'default-type'} ?? null
                 ));
             }
 

--- a/src/Symfony/Component/Serializer/Mapping/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/YamlFileLoader.php
@@ -133,7 +133,8 @@ class YamlFileLoader extends FileLoader
 
             $classMetadata->setClassDiscriminatorMapping(new ClassDiscriminatorMapping(
                 $yaml['discriminator_map']['type_property'],
-                $yaml['discriminator_map']['mapping']
+                $yaml['discriminator_map']['mapping'],
+                $yaml['discriminator_map']['default_type'] ?? null
             ));
         }
 

--- a/src/Symfony/Component/Serializer/Mapping/Loader/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd
@@ -47,6 +47,7 @@
             <xsd:element name="mapping" type="discriminator-map-mapping" maxOccurs="unbounded" />
         </xsd:choice>
         <xsd:attribute name="type-property" type="xsd:string" use="required" />
+        <xsd:attribute name="default-type" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:complexType name="discriminator-map-mapping">

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -1179,7 +1179,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             return $class;
         }
 
-        if (null === $type = $data[$mapping->getTypeProperty()] ?? null) {
+        if (null === $type = $data[$mapping->getTypeProperty()] ?? $mapping->getDefaultType()) {
             throw NotNormalizableValueException::createForUnexpectedDataType(\sprintf('Type property "%s" not found for the abstract object "%s".', $mapping->getTypeProperty(), $class), null, ['string'], isset($context['deserialization_path']) ? $context['deserialization_path'].'.'.$mapping->getTypeProperty() : $mapping->getTypeProperty(), false);
         }
 

--- a/src/Symfony/Component/Serializer/Tests/Attribute/DiscriminatorMapTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Attribute/DiscriminatorMapTest.php
@@ -40,9 +40,16 @@ class DiscriminatorMapTest extends TestCase
         new DiscriminatorMap(typeProperty: '', mapping: ['foo' => 'FooClass']);
     }
 
-    public function testExceptionWitEmptyMappingProperty()
+    public function testExceptionWithEmptyMappingProperty()
     {
         $this->expectException(InvalidArgumentException::class);
         new DiscriminatorMap(typeProperty: 'type', mapping: []);
+    }
+
+    public function testExceptionWithMissingDefaultTypeInMapping()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf('Default type "bar" given to "%s" must be present in "mapping" types.', DiscriminatorMap::class));
+        new DiscriminatorMap(typeProperty: 'type', mapping: ['foo' => 'FooClass'], defaultType: 'bar');
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/AbstractDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/AbstractDummy.php
@@ -17,7 +17,7 @@ use Symfony\Component\Serializer\Attribute\DiscriminatorMap;
     'first' => AbstractDummyFirstChild::class,
     'second' => AbstractDummySecondChild::class,
     'third' => AbstractDummyThirdChild::class,
-])]
+], defaultType: 'third')]
 abstract class AbstractDummy
 {
     public $foo;

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.xml
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.xml
@@ -35,7 +35,7 @@
     </class>
 
     <class name="Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummy">
-        <discriminator-map type-property="type">
+        <discriminator-map type-property="type" default-type="second">
             <mapping type="first" class="Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummyFirstChild" />
             <mapping type="second" class="Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummySecondChild" />
         </discriminator-map>

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.yml
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.yml
@@ -32,6 +32,7 @@
     mapping:
       first: 'Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummyFirstChild'
       second: 'Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummySecondChild'
+    default_type: first
   attributes:
     foo: ~
 'Symfony\Component\Serializer\Tests\Fixtures\Attributes\IgnoreDummy':

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Factory/ClassMetadataFactoryCompilerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Factory/ClassMetadataFactoryCompilerTest.php
@@ -15,6 +15,10 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryCompiler;
 use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummyFirstChild;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummySecondChild;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummyThirdChild;
 use Symfony\Component\Serializer\Tests\Fixtures\Attributes\MaxDepthDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Attributes\SerializedNameDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Attributes\SerializedPathDummy;
@@ -40,6 +44,7 @@ final class ClassMetadataFactoryCompilerTest extends TestCase
         $classMetatadataFactory = new ClassMetadataFactory(new AttributeLoader());
 
         $dummyMetadata = $classMetatadataFactory->getMetadataFor(Dummy::class);
+        $abstractDummyMetadata = $classMetatadataFactory->getMetadataFor(AbstractDummy::class);
         $maxDepthDummyMetadata = $classMetatadataFactory->getMetadataFor(MaxDepthDummy::class);
         $serializedNameDummyMetadata = $classMetatadataFactory->getMetadataFor(SerializedNameDummy::class);
         $serializedPathDummyMetadata = $classMetatadataFactory->getMetadataFor(SerializedPathDummy::class);
@@ -47,6 +52,7 @@ final class ClassMetadataFactoryCompilerTest extends TestCase
 
         $code = (new ClassMetadataFactoryCompiler())->compile([
             $dummyMetadata,
+            $abstractDummyMetadata,
             $maxDepthDummyMetadata,
             $serializedNameDummyMetadata,
             $serializedPathDummyMetadata,
@@ -56,7 +62,7 @@ final class ClassMetadataFactoryCompilerTest extends TestCase
         file_put_contents($this->dumpPath, $code);
         $compiledMetadata = require $this->dumpPath;
 
-        $this->assertCount(5, $compiledMetadata);
+        $this->assertCount(6, $compiledMetadata);
 
         $this->assertArrayHasKey(Dummy::class, $compiledMetadata);
         $this->assertEquals([
@@ -68,6 +74,22 @@ final class ClassMetadataFactoryCompilerTest extends TestCase
             ],
             null,
         ], $compiledMetadata[Dummy::class]);
+
+        $this->assertArrayHasKey(AbstractDummy::class, $compiledMetadata);
+        $this->assertEquals([
+            [
+                'foo' => [[], null, null, null],
+            ],
+            [
+                'type',
+                [
+                    'first' => AbstractDummyFirstChild::class,
+                    'second' => AbstractDummySecondChild::class,
+                    'third' => AbstractDummyThirdChild::class,
+                ],
+                'third',
+            ],
+        ], $compiledMetadata[AbstractDummy::class]);
 
         $this->assertArrayHasKey(MaxDepthDummy::class, $compiledMetadata);
         $this->assertEquals([

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AttributeLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AttributeLoaderTest.php
@@ -85,7 +85,7 @@ class AttributeLoaderTest extends TestCase
             'first' => AbstractDummyFirstChild::class,
             'second' => AbstractDummySecondChild::class,
             'third' => AbstractDummyThirdChild::class,
-        ]));
+        ], 'third'));
 
         $expected->addAttributeMetadata(new AttributeMetadata('foo'));
         $expected->getReflectionClass();

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/XmlFileLoaderTest.php
@@ -109,7 +109,7 @@ class XmlFileLoaderTest extends TestCase
         $expected = new ClassMetadata(AbstractDummy::class, new ClassDiscriminatorMapping('type', [
             'first' => AbstractDummyFirstChild::class,
             'second' => AbstractDummySecondChild::class,
-        ]));
+        ], 'second'));
 
         $expected->addAttributeMetadata(new AttributeMetadata('foo'));
 

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/YamlFileLoaderTest.php
@@ -126,7 +126,7 @@ class YamlFileLoaderTest extends TestCase
         $expected = new ClassMetadata(AbstractDummy::class, new ClassDiscriminatorMapping('type', [
             'first' => AbstractDummyFirstChild::class,
             'second' => AbstractDummySecondChild::class,
-        ]));
+        ], 'first'));
 
         $expected->addAttributeMetadata(new AttributeMetadata('foo'));
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | N/A
| License       | MIT

I thought it would be nice to have a default type value for the discriminator map of the serializer.

For instance with this configuration:
```php
#[DiscriminatorMap(
    typeProperty: 'type',
    mapping: [
        'article' => Article::class,
        'video' => Video::class,
    ],
    defaultType: 'article'
)]
abstract class Element
{
    public string $product;
}

final class Article extends Element
{
    public string $title;
}

final class Video extends Element
{
    public int $duration;
}
```
It would deserialize to an `Article` with this data:
```json
{
    "product": "desk",
    "title": "PHP devs love Symfony"
}
```
And to a `Video` with this:
```json
{
    "product": "desk",
    "duration": 8765,
    "type": "video"
}
```