### PR TITLE
[FrameworkBundle] Disable the keys normalization of the CSRF form field attributes

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -250,6 +250,7 @@ class Configuration implements ConfigurationInterface
                                 ->scalarNode('field_name')->defaultValue('_token')->end()
                                 ->arrayNode('field_attr')
                                     ->performNoDeepMerging()
+                                    ->normalizeKeys(false)
                                     ->scalarPrototype()->end()
                                     ->defaultValue(['data-controller' => 'csrf-protection'])
                                 ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -699,6 +699,22 @@ class ConfigurationTest extends TestCase
         $this->assertSame([], $config['serializer']['default_context'] ?? []);
     }
 
+    public function testFormCsrfProtectionFieldAttrDoNotNormalizeKeys()
+    {
+        $processor = new Processor();
+        $config = $processor->processConfiguration(new Configuration(false), [
+            [
+                'form' => [
+                    'csrf_protection' => [
+                        'field_attr' => ['data-example-attr' => 'value'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertSame(['data-example-attr' => 'value'], $config['form']['csrf_protection']['field_attr'] ?? []);
+    }
+
     protected static function getBundleDefaultConfig()
     {
         return [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

The form.csrf_protection.field_attr configuration node value should remain as-is when defined. The default behavior of the configuration component is to normalize keys, but in that specific cases, keys becomes HTML attributes and therefore should not be changed. This commit fix that behaviour for the specific node.

**Given**

```yaml
framework:
    form:
        csrf_protection:
            field_attr: { 'data-example-attr': 'value }
```

**Before this patch**

```php
['field_attr' = ['data_example_attr' => 'value']]
```

**After this patch**

```php
['field_attr' = ['data-example-attr' => 'value']]
```