### PR TITLE
Fix PHP warning in GetSetMethodNormalizer when a "set()" method is defined

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -118,6 +118,7 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
         return !$method->isStatic()
             && !$method->getAttributes(Ignore::class)
             && 0 < $method->getNumberOfParameters()
+            && 3 < \strlen($method->name)
             && str_starts_with($method->name, 'set')
             && !ctype_lower($method->name[3])
             ;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Fix: Add length check for setter method detection in
src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
