### PR TITLE
[TwigBridge] Add Twig `field_id()` form helper

### DIFF
--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `is_granted_for_user()` Twig function
+ * Add `field_id()` Twig form helper function
 
 7.2
 ---

--- a/src/Symfony/Bridge/Twig/Extension/FormExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/FormExtension.php
@@ -62,6 +62,7 @@ final class FormExtension extends AbstractExtension
             new TwigFunction('csrf_token', [FormRenderer::class, 'renderCsrfToken']),
             new TwigFunction('form_parent', 'Symfony\Bridge\Twig\Extension\twig_get_form_parent'),
             new TwigFunction('field_name', $this->getFieldName(...)),
+            new TwigFunction('field_id', $this->getFieldId(...)),
             new TwigFunction('field_value', $this->getFieldValue(...)),
             new TwigFunction('field_label', $this->getFieldLabel(...)),
             new TwigFunction('field_help', $this->getFieldHelp(...)),
@@ -91,6 +92,11 @@ final class FormExtension extends AbstractExtension
         $view->setRendered();
 
         return $view->vars['full_name'];
+    }
+
+    public function getFieldId(FormView $view): string
+    {
+        return $view->vars['id'];
     }
 
     public function getFieldValue(FormView $view): string|array

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionFieldHelpersTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionFieldHelpersTest.php
@@ -119,6 +119,12 @@ class FormExtensionFieldHelpersTest extends FormIntegrationTestCase
         $this->assertTrue($this->view->children['username']->isRendered());
     }
 
+    public function testFieldId()
+    {
+        $this->assertSame('register_username', $this->rawExtension->getFieldId($this->view->children['username']));
+        $this->assertSame('register_choice_multiple', $this->rawExtension->getFieldId($this->view->children['choice_multiple']));
+    }
+
     public function testFieldValue()
     {
         $this->assertSame('tgalopin', $this->rawExtension->getFieldValue($this->view->children['username']));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Hello, I thought it would be nice to have a twig `field_id(form.myField)` helper instead of using the `{{ form.task.vars.id }}` as stated in the official documentation. https://symfony.com/doc/current/form/form_customization.html#form-rendering-variables