### PR TITLE
[TypeInfo] Fix `isSatisfiedBy` not traversing type tree

### DIFF
--- a/src/Symfony/Component/TypeInfo/Tests/TypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeTest.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\TypeInfo\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\Type\CollectionType;
+use Symfony\Component\TypeInfo\Type\UnionType;
 use Symfony\Component\TypeInfo\TypeIdentifier;
 
 class TypeTest extends TestCase
@@ -33,5 +35,13 @@ class TypeTest extends TestCase
         $this->assertTrue(Type::nullable(Type::int())->isNullable());
 
         $this->assertFalse(Type::int()->isNullable());
+    }
+
+    public function testIsSatisfiedBy()
+    {
+        $this->assertTrue(Type::union(Type::int(), Type::string())->isSatisfiedBy(fn (Type $t): bool => 'int' === (string) $t));
+        $this->assertTrue(Type::union(Type::int(), Type::string())->isSatisfiedBy(fn (Type $t): bool => $t instanceof UnionType));
+        $this->assertTrue(Type::list(Type::int())->isSatisfiedBy(fn (Type $t): bool => $t instanceof CollectionType && 'int' === (string) $t->getCollectionValueType()));
+        $this->assertFalse(Type::list(Type::int())->isSatisfiedBy(fn (Type $t): bool => 'int' === (string) $t));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Previously, `Type::isSatisfiedBy` was not traversing the type tree, which means that:
```php
$specification = static fn (Type $type): bool => $type instanceof ObjectType;

return Type::collection(Type::object(Foo::class))->isSatisfiedBy($specification);
```
was unexpectedly returning `false`.
This PR fixes it.
