### PR TITLE
[TypeInfo] rewrite tests to not fail when self/parent are resolved at compile time

### DIFF
--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/ReflectionExtractableDummyUsingTrait.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/ReflectionExtractableDummyUsingTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Tests\Fixtures;
+
+class ReflectionExtractableDummyUsingTrait
+{
+    use ReflectionExtractableTrait;
+}

--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/ReflectionExtractableTrait.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/ReflectionExtractableTrait.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Tests\Fixtures;
+
+trait ReflectionExtractableTrait
+{
+    public self $self;
+
+    public function getSelf(): self
+    {
+        return $this;
+    }
+
+    public function setSelf(self $self): void
+    {
+        $this->self = $self;
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Tests/TypeResolver/ReflectionParameterTypeResolverTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeResolver/ReflectionParameterTypeResolverTest.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\TypeInfo\Tests\TypeResolver;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\TypeInfo\Exception\UnsupportedException;
 use Symfony\Component\TypeInfo\Tests\Fixtures\ReflectionExtractableDummy;
+use Symfony\Component\TypeInfo\Tests\Fixtures\ReflectionExtractableDummyUsingTrait;
+use Symfony\Component\TypeInfo\Tests\Fixtures\ReflectionExtractableTrait;
 use Symfony\Component\TypeInfo\Type;
 use Symfony\Component\TypeInfo\TypeContext\TypeContextFactory;
 use Symfony\Component\TypeInfo\TypeResolver\ReflectionParameterTypeResolver;
@@ -71,15 +73,29 @@ class ReflectionParameterTypeResolverTest extends TestCase
         $this->assertEquals(Type::nullable(Type::int()), $this->resolver->resolve($reflectionParameter));
     }
 
-    public function testCreateTypeContextOrUseProvided()
+    public function testResolveSelfFromClassWithoutContext()
     {
         $reflectionClass = new \ReflectionClass(ReflectionExtractableDummy::class);
         $reflectionParameter = $reflectionClass->getMethod('setSelf')->getParameters()[0];
 
         $this->assertEquals(Type::object(ReflectionExtractableDummy::class), $this->resolver->resolve($reflectionParameter));
+    }
 
-        $typeContext = (new TypeContextFactory())->createFromClassName(self::class);
+    public function testResolveSelfFromTraitWithoutContext()
+    {
+        $reflectionClass = new \ReflectionClass(ReflectionExtractableTrait::class);
+        $reflectionParameter = $reflectionClass->getMethod('setSelf')->getParameters()[0];
 
-        $this->assertEquals(Type::object(self::class), $this->resolver->resolve($reflectionParameter, $typeContext));
+        $this->assertEquals(Type::object(ReflectionExtractableTrait::class), $this->resolver->resolve($reflectionParameter));
+    }
+
+    public function testResolveSelfFromTraitWithClassContext()
+    {
+        $reflectionClass = new \ReflectionClass(ReflectionExtractableTrait::class);
+        $reflectionParameter = $reflectionClass->getMethod('setSelf')->getParameters()[0];
+
+        $typeContext = (new TypeContextFactory())->createFromClassName(ReflectionExtractableDummyUsingTrait::class);
+
+        $this->assertEquals(Type::object(ReflectionExtractableDummyUsingTrait::class), $this->resolver->resolve($reflectionParameter, $typeContext));
     }
 }

--- a/src/Symfony/Component/TypeInfo/Tests/TypeResolver/ReflectionPropertyTypeResolverTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeResolver/ReflectionPropertyTypeResolverTest.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\TypeInfo\Tests\TypeResolver;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\TypeInfo\Exception\UnsupportedException;
 use Symfony\Component\TypeInfo\Tests\Fixtures\ReflectionExtractableDummy;
+use Symfony\Component\TypeInfo\Tests\Fixtures\ReflectionExtractableDummyUsingTrait;
+use Symfony\Component\TypeInfo\Tests\Fixtures\ReflectionExtractableTrait;
 use Symfony\Component\TypeInfo\Type;
 use Symfony\Component\TypeInfo\TypeContext\TypeContextFactory;
 use Symfony\Component\TypeInfo\TypeResolver\ReflectionPropertyTypeResolver;
@@ -52,15 +54,29 @@ class ReflectionPropertyTypeResolverTest extends TestCase
         $this->assertEquals(Type::int(), $this->resolver->resolve($reflectionProperty));
     }
 
-    public function testCreateTypeContextOrUseProvided()
+    public function testResolveSelfFromClassWithoutContext()
     {
         $reflectionClass = new \ReflectionClass(ReflectionExtractableDummy::class);
         $reflectionProperty = $reflectionClass->getProperty('self');
 
         $this->assertEquals(Type::object(ReflectionExtractableDummy::class), $this->resolver->resolve($reflectionProperty));
+    }
 
-        $typeContext = (new TypeContextFactory())->createFromClassName(self::class);
+    public function testResolveSelfFromTraitWithoutContext()
+    {
+        $reflectionClass = new \ReflectionClass(ReflectionExtractableTrait::class);
+        $reflectionProperty = $reflectionClass->getProperty('self');
 
-        $this->assertEquals(Type::object(self::class), $this->resolver->resolve($reflectionProperty, $typeContext));
+        $this->assertEquals(Type::object(ReflectionExtractableTrait::class), $this->resolver->resolve($reflectionProperty));
+    }
+
+    public function testResolveSelfFromTraitWithClassContext()
+    {
+        $reflectionClass = new \ReflectionClass(ReflectionExtractableTrait::class);
+        $reflectionProperty = $reflectionClass->getProperty('self');
+
+        $typeContext = (new TypeContextFactory())->createFromClassName(ReflectionExtractableDummyUsingTrait::class);
+
+        $this->assertEquals(Type::object(ReflectionExtractableDummyUsingTrait::class), $this->resolver->resolve($reflectionProperty, $typeContext));
     }
 }

--- a/src/Symfony/Component/TypeInfo/Tests/TypeResolver/ReflectionReturnTypeResolverTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeResolver/ReflectionReturnTypeResolverTest.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\TypeInfo\Tests\TypeResolver;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\TypeInfo\Exception\UnsupportedException;
 use Symfony\Component\TypeInfo\Tests\Fixtures\ReflectionExtractableDummy;
+use Symfony\Component\TypeInfo\Tests\Fixtures\ReflectionExtractableDummyUsingTrait;
+use Symfony\Component\TypeInfo\Tests\Fixtures\ReflectionExtractableTrait;
 use Symfony\Component\TypeInfo\Type;
 use Symfony\Component\TypeInfo\TypeContext\TypeContextFactory;
 use Symfony\Component\TypeInfo\TypeResolver\ReflectionReturnTypeResolver;
@@ -62,15 +64,29 @@ class ReflectionReturnTypeResolverTest extends TestCase
         $this->assertEquals(Type::int(), $this->resolver->resolve($reflectionFunction));
     }
 
-    public function testCreateTypeContextOrUseProvided()
+    public function testResolveSelfFromClassWithoutContext()
     {
         $reflectionClass = new \ReflectionClass(ReflectionExtractableDummy::class);
         $reflectionFunction = $reflectionClass->getMethod('getSelf');
 
         $this->assertEquals(Type::object(ReflectionExtractableDummy::class), $this->resolver->resolve($reflectionFunction));
+    }
 
-        $typeContext = (new TypeContextFactory())->createFromClassName(self::class);
+    public function testResolveSelfFromTraitWithoutContext()
+    {
+        $reflectionClass = new \ReflectionClass(ReflectionExtractableTrait::class);
+        $reflectionFunction = $reflectionClass->getMethod('getSelf');
 
-        $this->assertEquals(Type::object(self::class), $this->resolver->resolve($reflectionFunction, $typeContext));
+        $this->assertEquals(Type::object(ReflectionExtractableTrait::class), $this->resolver->resolve($reflectionFunction));
+    }
+
+    public function testResolveSelfFromTraitWithClassContext()
+    {
+        $reflectionClass = new \ReflectionClass(ReflectionExtractableTrait::class);
+        $reflectionFunction = $reflectionClass->getMethod('getSelf');
+
+        $typeContext = (new TypeContextFactory())->createFromClassName(ReflectionExtractableDummyUsingTrait::class);
+
+        $this->assertEquals(Type::object(ReflectionExtractableDummyUsingTrait::class), $this->resolver->resolve($reflectionFunction, $typeContext));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

see php/php-src#17755