### PR TITLE
[DependencyInjection] Allow autowiring references from other containers

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -458,46 +458,49 @@ class AutowirePass extends AbstractRecursivePass
 
         $name = $target = (array_filter($reference->getAttributes(), static fn ($a) => $a instanceof Target)[0] ?? null)?->name;
 
-        if (null !== $name ??= $reference->getName()) {
-            if ($this->container->has($alias = $type.' $'.$name) && !$this->container->findDefinition($alias)->isAbstract()) {
-                return new TypedReference($alias, $type, $reference->getInvalidBehavior());
-            }
+        foreach ($this->container->getContainers() as $container) {
 
-            if (null !== ($alias = $this->getCombinedAlias($type, $name)) && !$this->container->findDefinition($alias)->isAbstract()) {
-                return new TypedReference($alias, $type, $reference->getInvalidBehavior());
-            }
+            if (null !== $name ??= $reference->getName()) {
+                if ($container->has($alias = $type.' $'.$name) && !$container->findDefinition($alias)->isAbstract()) {
+                    return new TypedReference($alias, $type, $reference->getInvalidBehavior());
+                }
 
-            $parsedName = (new Target($name))->getParsedName();
+                if (null !== ($alias = $this->getCombinedAlias($type, $name)) && !$container->findDefinition($alias)->isAbstract()) {
+                    return new TypedReference($alias, $type, $reference->getInvalidBehavior());
+                }
 
-            if ($this->container->has($alias = $type.' $'.$parsedName) && !$this->container->findDefinition($alias)->isAbstract()) {
-                return new TypedReference($alias, $type, $reference->getInvalidBehavior());
-            }
+                $parsedName = (new Target($name))->getParsedName();
 
-            if (null !== ($alias = $this->getCombinedAlias($type, $parsedName)) && !$this->container->findDefinition($alias)->isAbstract()) {
-                return new TypedReference($alias, $type, $reference->getInvalidBehavior());
-            }
+                if ($container->has($alias = $type.' $'.$parsedName) && !$container->findDefinition($alias)->isAbstract()) {
+                    return new TypedReference($alias, $type, $reference->getInvalidBehavior());
+                }
 
-            if (($this->container->has($n = $name) && !$this->container->findDefinition($n)->isAbstract())
-                || ($this->container->has($n = $parsedName) && !$this->container->findDefinition($n)->isAbstract())
-            ) {
-                foreach ($this->container->getAliases() as $id => $alias) {
-                    if ($n === (string) $alias && str_starts_with($id, $type.' $')) {
-                        return new TypedReference($n, $type, $reference->getInvalidBehavior());
+                if (null !== ($alias = $this->getCombinedAlias($type, $parsedName)) && !$container->findDefinition($alias)->isAbstract()) {
+                    return new TypedReference($alias, $type, $reference->getInvalidBehavior());
+                }
+
+                if (($container->has($n = $name) && !$container->findDefinition($n)->isAbstract())
+                    || ($container->has($n = $parsedName) && !$container->findDefinition($n)->isAbstract())
+                ) {
+                    foreach ($container->getAliases() as $id => $alias) {
+                        if ($n === (string) $alias && str_starts_with($id, $type.' $')) {
+                            return new TypedReference($n, $type, $reference->getInvalidBehavior());
+                        }
                     }
+                }
+
+                if (null !== $target) {
+                    return null;
                 }
             }
 
-            if (null !== $target) {
-                return null;
+            if ($container->has($type) && !$container->findDefinition($type)->isAbstract()) {
+                return new TypedReference($type, $type, $reference->getInvalidBehavior());
             }
-        }
 
-        if ($this->container->has($type) && !$this->container->findDefinition($type)->isAbstract()) {
-            return new TypedReference($type, $type, $reference->getInvalidBehavior());
-        }
-
-        if (null !== ($alias = $this->getCombinedAlias($type)) && !$this->container->findDefinition($alias)->isAbstract()) {
-            return new TypedReference($alias, $type, $reference->getInvalidBehavior());
+            if (null !== ($alias = $this->getCombinedAlias($type)) && !$container->findDefinition($alias)->isAbstract()) {
+                return new TypedReference($alias, $type, $reference->getInvalidBehavior());
+            }
         }
 
         return null;
@@ -747,4 +750,5 @@ class AutowirePass extends AbstractRecursivePass
 
         return $alias;
     }
+
 }

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -56,7 +56,7 @@ use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class ContainerBuilder extends Container implements TaggedContainerInterface
+class ContainerBuilder extends Container implements TaggedContainerInterface, DefinitionFinderContainerInterface
 {
     /**
      * @var array<string, ExtensionInterface>
@@ -157,12 +157,18 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
         'mixed' => true,
     ];
 
+    /**
+     * @var \Symfony\Component\DependencyInjection\DefinitionFinderContainerInterface[]
+     */
+    private array $containers;
+
     public function __construct(?ParameterBagInterface $parameterBag = null)
     {
         parent::__construct($parameterBag);
 
         $this->trackResources = interface_exists(ResourceInterface::class);
         $this->setDefinition('service_container', (new Definition(ContainerInterface::class))->setSynthetic(true)->setPublic(true));
+        $this->containers = [$this];
     }
 
     /**
@@ -1806,5 +1812,39 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
         }
 
         return $this->pathsInVendor[$path] = false;
+    }
+
+    /**
+     * Adds a container
+     *
+     * @param DefinitionFinderContainerInterface $container
+     *
+     * @return $this
+     */
+    public function addContainer(DefinitionFinderContainerInterface $container): static
+    {
+        $this->containers[] = $container;
+        return $this;
+    }
+
+    /**
+     * Resets the list of containers.
+     *
+     * @return $this
+     */
+    public function resetContainers(): static
+    {
+        $this->containers = [$this];
+        return $this;
+    }
+
+    /**
+     * Returns an array of containers.
+     *
+     * @return array<int, DefinitionFinderContainerInterface>
+     */
+    public function getContainers(): array
+    {
+        return $this->containers;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/DefinitionFinderContainerInterface.php
+++ b/src/Symfony/Component/DependencyInjection/DefinitionFinderContainerInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection;
+
+/**
+ * Interface for containers which know how to find the definition of services.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+interface DefinitionFinderContainerInterface extends ContainerInterface
+{
+    /**
+     * Returns definition for a service id.
+     *
+     * @param string $id The service id
+     */
+    public function findDefinition(string $id): Definition;
+
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

Drupal would greatly benefit from the ability to have autowired references across multiple containers. I would, of course, prefer to keep this within Drupal but since everything in AutowirePass is private, I can't do that so I am submitting this for upstream inclusion. It doesn't do anything at all until addContainers is called.

Please consider this or perhaps allow opening up AutowirePass for extension so that this is not necessary.