### PR TITLE
[VarDumper] Don't make `CurlCasterTest` response status dependant

### DIFF
--- a/src/Symfony/Component/VarDumper/Tests/Caster/CurlCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/CurlCasterTest.php
@@ -32,7 +32,8 @@ class CurlCasterTest extends TestCase
 CurlHandle {
   url: "http://example.com/"
   content_type: "text/html"
-  http_code: 200%A
+  http_code: %d
+%A
 }
 EODUMP, $ch);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This test sometimes fail because http://example.com/ returns a status code 400 instead of 200, making the CI red randomly. I think this test success should not depend on the status code, the goal is only to check if the data is properly formatted.