### PR TITLE
[Messenger] Allow to close the transport connection

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 7.3
 ---
 
+ * Implement the `CloseableTransportInterface` to allow closing the transport
  * Add new `queue_attributes` and `queue_tags` options for SQS queue creation
 
 7.2

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsTransport.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsTransport.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Messenger\Bridge\AmazonSqs\Transport;
 use AsyncAws\Core\Exception\Http\HttpException;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\TransportException;
+use Symfony\Component\Messenger\Transport\CloseableTransportInterface;
 use Symfony\Component\Messenger\Transport\Receiver\KeepaliveReceiverInterface;
 use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
 use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
@@ -27,7 +28,7 @@ use Symfony\Contracts\Service\ResetInterface;
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>
  */
-class AmazonSqsTransport implements TransportInterface, KeepaliveReceiverInterface, SetupableTransportInterface, MessageCountAwareInterface, ResetInterface
+class AmazonSqsTransport implements TransportInterface, KeepaliveReceiverInterface, SetupableTransportInterface, CloseableTransportInterface, MessageCountAwareInterface, ResetInterface
 {
     private SerializerInterface $serializer;
 
@@ -89,6 +90,11 @@ class AmazonSqsTransport implements TransportInterface, KeepaliveReceiverInterfa
         } catch (HttpException $e) {
             throw new TransportException($e->getMessage(), 0, $e);
         }
+    }
+
+    public function close(): void
+    {
+        $this->reset();
     }
 
     private function getReceiver(): MessageCountAwareInterface&ReceiverInterface

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/composer.json
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/composer.json
@@ -19,7 +19,7 @@
         "php": ">=8.2",
         "async-aws/core": "^1.7",
         "async-aws/sqs": "^1.0|^2.0",
-        "symfony/messenger": "^7.2",
+        "symfony/messenger": "^7.3",
         "symfony/service-contracts": "^2.5|^3",
         "psr/log": "^1|^2|^3"
     },

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 7.1
 ---
 
+* Implement the `CloseableTransportInterface` to allow closing the AMQP connection
  * Add option `delay[arguments]` in the transport definition
 
 6.0

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpTransport.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpTransport.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Messenger\Bridge\Amqp\Transport;
 
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Transport\CloseableTransportInterface;
 use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
 use Symfony\Component\Messenger\Transport\Receiver\QueueReceiverInterface;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
@@ -22,7 +23,7 @@ use Symfony\Component\Messenger\Transport\TransportInterface;
 /**
  * @author Nicolas Grekas <p@tchwork.com>
  */
-class AmqpTransport implements QueueReceiverInterface, TransportInterface, SetupableTransportInterface, MessageCountAwareInterface
+class AmqpTransport implements QueueReceiverInterface, TransportInterface, SetupableTransportInterface, CloseableTransportInterface, MessageCountAwareInterface
 {
     private SerializerInterface $serializer;
     private AmqpReceiver $receiver;
@@ -68,6 +69,11 @@ class AmqpTransport implements QueueReceiverInterface, TransportInterface, Setup
     public function getMessageCount(): int
     {
         return $this->getReceiver()->getMessageCount();
+    }
+
+    public function close(): void
+    {
+        $this->connection->clear();
     }
 
     private function getReceiver(): AmqpReceiver

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -551,7 +551,7 @@ class Connection
         }
     }
 
-    private function clear(): void
+    public function clear(): void
     {
         unset($this->amqpChannel, $this->amqpExchange, $this->amqpDelayExchange);
         $this->amqpQueues = [];

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/composer.json
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.2",
         "ext-amqp": "*",
-        "symfony/messenger": "^6.4|^7.0"
+        "symfony/messenger": "^7.3"
     },
     "require-dev": {
         "symfony/event-dispatcher": "^6.4|^7.0",

--- a/src/Symfony/Component/Messenger/Bridge/Redis/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 7.3
 ---
 
+ * Implement the `CloseableTransportInterface` to allow closing the Redis connection
  * Implement the `KeepaliveReceiverInterface` to enable asynchronously notifying Redis that the job is still being processed, in order to avoid timeouts
 
 6.3

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisTransport.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisTransport.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Messenger\Bridge\Redis\Transport;
 
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Transport\CloseableTransportInterface;
 use Symfony\Component\Messenger\Transport\Receiver\KeepaliveReceiverInterface;
 use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
@@ -23,7 +24,7 @@ use Symfony\Component\Messenger\Transport\TransportInterface;
  * @author Alexander Schranz <alexander@sulu.io>
  * @author Antoine Bluchet <soyuka@gmail.com>
  */
-class RedisTransport implements TransportInterface, KeepaliveReceiverInterface, SetupableTransportInterface, MessageCountAwareInterface
+class RedisTransport implements TransportInterface, KeepaliveReceiverInterface, SetupableTransportInterface, CloseableTransportInterface, MessageCountAwareInterface
 {
     private SerializerInterface $serializer;
     private RedisReceiver $receiver;
@@ -69,6 +70,11 @@ class RedisTransport implements TransportInterface, KeepaliveReceiverInterface, 
     public function getMessageCount(): int
     {
         return $this->getReceiver()->getMessageCount();
+    }
+
+    public function close(): void
+    {
+        $this->connection->close();
     }
 
     private function getReceiver(): RedisReceiver

--- a/src/Symfony/Component/Messenger/Bridge/Redis/composer.json
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.2",
         "ext-redis": "*",
-        "symfony/messenger": "^7.2"
+        "symfony/messenger": "^7.3"
     },
     "require-dev": {
         "symfony/property-access": "^6.4|^7.0",

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 7.3
 ---
 
+ * Add `CloseableTransportInterface` to allow closing the transport
  * Add `SentForRetryStamp` that identifies whether a failed message was sent for retry
  * Add `Symfony\Component\Messenger\Middleware\DeduplicateMiddleware` and `Symfony\Component\Messenger\Stamp\DeduplicateStamp`
 

--- a/src/Symfony/Component/Messenger/Transport/CloseableTransportInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/CloseableTransportInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Transport;
+
+interface CloseableTransportInterface
+{
+    public function close(): void;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #53543 
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

~~1. Implemented the possibility to make messenger transports resettable~~
~~2. Implemented reset Redis connection for Redis messenger transport~~

~~This feature may lead to decreased performance for messenger consumers (because connection will be resetted between processing messages).~~

~~One way to resolve it that I found - add configuration for resettable transports - aka "reset connection on kernel reset: true/false". For consumers it can be configured via env var to be "false", but for web "true".~~

----

**UPD 2025-02-27**: According to the feedback, I changed the implementation to another one to help with our use case.

Implemented a way to close messenger transport from the application, to allow free resources for long-running processes (like a long-running webserver)