### PR TITLE
[Mailer] [Amazon] Support for custom headers in ses+api

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/CHANGELOG.md
@@ -1,7 +1,7 @@
 CHANGELOG
 =========
 
-7.2
+7.3
 ---
 
 * Add support for custom headers in ses+api


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | 
| License       | MIT

Updated the CHANGELOG to reflect the addition of custom headers support in the Amazon SES API mailer. This change will be available starting from version 7.3 instead of 7.2 as per #58761.