### PR TITLE
[Console] fix progress bar messing output in section when there is an EOL

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -486,12 +486,21 @@ final class ProgressBar
                 if ($this->output instanceof ConsoleSectionOutput) {
                     $messageLines = explode("\n", $this->previousMessage);
                     $lineCount = \count($messageLines);
+
+                    $lastLineWithoutDecoration = Helper::removeDecoration($this->output->getFormatter(), end($messageLines) ?? '');
+
+                    // When the last previous line is empty (without formatting) it is already cleared by the section output, so we don't need to clear it again
+                    if ('' === $lastLineWithoutDecoration) {
+                        --$lineCount;
+                    }
+
                     foreach ($messageLines as $messageLine) {
                         $messageLineLength = Helper::width(Helper::removeDecoration($this->output->getFormatter(), $messageLine));
                         if ($messageLineLength > $this->terminal->getWidth()) {
                             $lineCount += floor($messageLineLength / $this->terminal->getWidth());
                         }
                     }
+
                     $this->output->clear($lineCount);
                 } else {
                     $lineCount = substr_count($this->previousMessage, "\n");

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -416,6 +416,81 @@ class ProgressBarTest extends TestCase
         );
     }
 
+    public function testOverwriteWithSectionOutputAndEol()
+    {
+        $sections = [];
+        $stream = $this->getOutputStream(true);
+        $output = new ConsoleSectionOutput($stream->getStream(), $sections, $stream->getVerbosity(), $stream->isDecorated(), new OutputFormatter());
+
+        $bar = new ProgressBar($output, 50, 0);
+        $bar->setFormat('[%bar%] %percent:3s%%' . PHP_EOL . '%message%' . PHP_EOL);
+        $bar->setMessage('');
+        $bar->start();
+        $bar->display();
+        $bar->setMessage('Doing something...');
+        $bar->advance();
+        $bar->setMessage('Doing something foo...');
+        $bar->advance();
+
+        rewind($output->getStream());
+        $this->assertEquals(escapeshellcmd(
+            '[>---------------------------]   0%'.\PHP_EOL.\PHP_EOL.
+            "\x1b[2A\x1b[0J".'[>---------------------------]   2%'.\PHP_EOL. 'Doing something...' . \PHP_EOL .
+            "\x1b[2A\x1b[0J".'[=>--------------------------]   4%'.\PHP_EOL. 'Doing something foo...' . \PHP_EOL),
+            escapeshellcmd(stream_get_contents($output->getStream()))
+        );
+    }
+
+    public function testOverwriteWithSectionOutputAndEolWithEmptyMessage()
+    {
+        $sections = [];
+        $stream = $this->getOutputStream(true);
+        $output = new ConsoleSectionOutput($stream->getStream(), $sections, $stream->getVerbosity(), $stream->isDecorated(), new OutputFormatter());
+
+        $bar = new ProgressBar($output, 50, 0);
+        $bar->setFormat('[%bar%] %percent:3s%%' . PHP_EOL . '%message%');
+        $bar->setMessage('Start');
+        $bar->start();
+        $bar->display();
+        $bar->setMessage('');
+        $bar->advance();
+        $bar->setMessage('Doing something...');
+        $bar->advance();
+
+        rewind($output->getStream());
+        $this->assertEquals(escapeshellcmd(
+            '[>---------------------------]   0%'.\PHP_EOL.'Start'.\PHP_EOL.
+            "\x1b[2A\x1b[0J".'[>---------------------------]   2%'.\PHP_EOL .
+            "\x1b[1A\x1b[0J".'[=>--------------------------]   4%'.\PHP_EOL. 'Doing something...' . \PHP_EOL),
+            escapeshellcmd(stream_get_contents($output->getStream()))
+        );
+    }
+
+    public function testOverwriteWithSectionOutputAndEolWithEmptyMessageComment()
+    {
+        $sections = [];
+        $stream = $this->getOutputStream(true);
+        $output = new ConsoleSectionOutput($stream->getStream(), $sections, $stream->getVerbosity(), $stream->isDecorated(), new OutputFormatter());
+
+        $bar = new ProgressBar($output, 50, 0);
+        $bar->setFormat('[%bar%] %percent:3s%%' . PHP_EOL . '<comment>%message%</comment>');
+        $bar->setMessage('Start');
+        $bar->start();
+        $bar->display();
+        $bar->setMessage('');
+        $bar->advance();
+        $bar->setMessage('Doing something...');
+        $bar->advance();
+
+        rewind($output->getStream());
+        $this->assertEquals(escapeshellcmd(
+            '[>---------------------------]   0%'.\PHP_EOL."\x1b[33mStart\x1b[39m".\PHP_EOL.
+            "\x1b[2A\x1b[0J".'[>---------------------------]   2%'.\PHP_EOL .
+            "\x1b[1A\x1b[0J".'[=>--------------------------]   4%'.\PHP_EOL. "\x1b[33mDoing something...\x1b[39m" . \PHP_EOL),
+            escapeshellcmd(stream_get_contents($output->getStream()))
+        );
+    }
+
     public function testOverwriteWithAnsiSectionOutput()
     {
         // output has 43 visible characters plus 2 invisible ANSI characters


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | https://github.com/symfony/symfony/issues/52446
| License       | MIT

This fix the progress bar making the output erase previous line when there is an EOL at the end of it
