### PR TITLE
[Yaml] Add the `Yaml::DUMP_FORCE_DOUBLE_QUOTES_ON_VALUES` flag to enforce double quotes around string values

### DIFF
--- a/src/Symfony/Component/Yaml/CHANGELOG.md
+++ b/src/Symfony/Component/Yaml/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add compact nested mapping support by using the `Yaml::DUMP_COMPACT_NESTED_MAPPING` flag
+ * Add the `Yaml::DUMP_FORCE_DOUBLE_QUOTES_ON_VALUES` flag to enforce double quotes around string values
 
 7.2
 ---

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -173,6 +173,7 @@ class Inline
             case self::isBinaryString($value):
                 return '!!binary '.base64_encode($value);
             case Escaper::requiresDoubleQuoting($value):
+            case Yaml::DUMP_FORCE_DOUBLE_QUOTES_ON_VALUES & $flags:
                 return Escaper::escapeWithDoubleQuotes($value);
             case Escaper::requiresSingleQuoting($value):
                 $singleQuoted = Escaper::escapeWithSingleQuotes($value);
@@ -242,12 +243,13 @@ class Inline
     private static function dumpHashArray(array|\ArrayObject|\stdClass $value, int $flags): string
     {
         $output = [];
+        $keyFlags = $flags &~ Yaml::DUMP_FORCE_DOUBLE_QUOTES_ON_VALUES;
         foreach ($value as $key => $val) {
             if (\is_int($key) && Yaml::DUMP_NUMERIC_KEY_AS_STRING & $flags) {
                 $key = (string) $key;
             }
 
-            $output[] = \sprintf('%s: %s', self::dump($key, $flags), self::dump($val, $flags));
+            $output[] = \sprintf('%s: %s', self::dump($key, $keyFlags), self::dump($val, $flags));
         }
 
         return \sprintf('{ %s }', implode(', ', $output));

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -911,6 +911,87 @@ YAML;
     }
 
     /**
+     * @dataProvider getForceQuotesOnValuesData
+     */
+    public function testCanForceQuotesOnValues(array $input, string $expected)
+    {
+        $this->assertSame($expected, $this->dumper->dump($input, 0, 0, Yaml::DUMP_FORCE_DOUBLE_QUOTES_ON_VALUES));
+    }
+
+    public function getForceQuotesOnValuesData(): iterable
+    {
+        yield 'empty string' => [
+            ['foo' => ''],
+            '{ foo: \'\' }',
+        ];
+
+        yield 'double quote' => [
+            ['foo' => '"'],
+            '{ foo: "\"" }',
+        ];
+
+        yield 'single quote' => [
+            ['foo' => "'"],
+            '{ foo: "\'" }',
+        ];
+
+        yield 'line break' => [
+            ['foo' => "line\nbreak"],
+            '{ foo: "line\nbreak" }',
+        ];
+
+        yield 'tab character' => [
+            ['foo' => "tab\tcharacter"],
+            '{ foo: "tab\tcharacter" }',
+        ];
+
+        yield 'backslash' => [
+            ['foo' => "back\\slash"],
+            '{ foo: "back\\\\slash" }',
+        ];
+
+        yield 'colon' => [
+            ['foo' => 'colon: value'],
+            '{ foo: "colon: value" }',
+        ];
+
+        yield 'dash' => [
+            ['foo' => '- dash'],
+            '{ foo: "- dash" }',
+        ];
+
+        yield 'numeric' => [
+            ['foo' => 23],
+            '{ foo: 23 }',
+        ];
+
+        yield 'boolean' => [
+            ['foo' => true],
+            '{ foo: true }',
+        ];
+
+        yield 'null' => [
+            ['foo' => null],
+            '{ foo: null }',
+        ];
+
+        yield 'nested' => [
+            ['foo' => ['bar' => 'bat', 'baz' => 23]],
+            '{ foo: { bar: "bat", baz: 23 } }',
+        ];
+
+        yield 'mix of values' => [
+            ['foo' => 'bat', 'bar' => 23, 'baz' => true, 'qux' => "line\nbreak"],
+            '{ foo: "bat", bar: 23, baz: true, qux: "line\nbreak" }',
+        ];
+
+        yield 'special YAML characters' => [
+            ['foo' => 'colon: value', 'bar' => '- dash', 'baz' => '? question', 'qux' => '# hash'],
+            '{ foo: "colon: value", bar: "- dash", baz: "? question", qux: "# hash" }',
+        ];
+    }
+
+    /**
      * @dataProvider getNumericKeyData
      */
     public function testDumpInlineNumericKeyAsString(array $input, bool $inline, int $flags, string $expected)

--- a/src/Symfony/Component/Yaml/Yaml.php
+++ b/src/Symfony/Component/Yaml/Yaml.php
@@ -37,6 +37,7 @@ class Yaml
     public const DUMP_NUMERIC_KEY_AS_STRING = 4096;
     public const DUMP_NULL_AS_EMPTY = 8192;
     public const DUMP_COMPACT_NESTED_MAPPING = 16384;
+    public const DUMP_FORCE_DOUBLE_QUOTES_ON_VALUES = 32768;
 
     /**
      * Parses a YAML file into a PHP value.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #59680
| License       | MIT

In some scenarios, quoting even safe values is encouraged by various inspectors, for example PHPStorm inspectors will mark it with a warning when used in Kubernetes `ConfigMap` dump.

This option allows forcing the quotes even when technically not required, see #59680 for an example.