### PR TITLE
[VarExporter] Leverage native lazy objects

### DIFF
--- a/UPGRADE-7.3.md
+++ b/UPGRADE-7.3.md
@@ -196,3 +196,10 @@ VarDumper
 
  * Deprecate `ResourceCaster::castCurl()`, `ResourceCaster::castGd()` and `ResourceCaster::castOpensslX509()`
  * Mark all casters as `@internal`
+
+VarExporter
+-----------
+
+ * Deprecate using `ProxyHelper::generateLazyProxy()` when native lazy proxies can be used - the method should be used to generate abstraction-based lazy decorators only
+ * Deprecate `LazyGhostTrait` and `LazyProxyTrait`, use native lazy objects instead
+ * Deprecate `ProxyHelper::generateLazyGhost()`, use native lazy objects instead

--- a/src/Symfony/Bridge/Doctrine/Tests/Security/User/EntityUserProviderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Security/User/EntityUserProviderTest.php
@@ -136,6 +136,9 @@ class EntityUserProviderTest extends TestCase
         $provider->refreshUser($user2);
     }
 
+    /**
+     * @group legacy
+     */
     public function testSupportProxy()
     {
         $em = DoctrineTestHelper::createTestEntityManager();
@@ -202,6 +205,9 @@ class EntityUserProviderTest extends TestCase
         $provider->upgradePassword($user, 'foobar');
     }
 
+    /**
+     * @group legacy
+     */
     public function testRefreshedUserProxyIsLoaded()
     {
         $em = DoctrineTestHelper::createTestEntityManager();

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
@@ -223,6 +223,9 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         yield 'Named arguments' => [new UniqueEntity(message: 'myMessage', fields: ['name'], em: 'foo')];
     }
 
+    /**
+     * @group legacy
+     */
     public function testValidateEntityWithPrivatePropertyAndProxyObject()
     {
         $entity = new SingleIntIdWithPrivateNameEntity(1, 'Foo');

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -2036,7 +2036,11 @@ PHP
 
         $dumper = new PhpDumper($container);
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/lazy_autowire_attribute_with_intersection.php', $dumper->dump());
+        if (\PHP_VERSION_ID >= 80400) {
+            $this->assertStringEqualsFile(self::$fixturesPath.'/php/lazy_autowire_attribute_with_intersection.php', $dumper->dump());
+        } else {
+            $this->assertStringEqualsFile(self::$fixturesPath.'/php/legacy_lazy_autowire_attribute_with_intersection.php', $dumper->dump());
+        }
     }
 
     public function testCallableAdapterConsumer()

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/legacy_lazy_autowire_attribute_with_intersection.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/legacy_lazy_autowire_attribute_with_intersection.php
@@ -74,16 +74,21 @@ class ProjectServiceContainer extends Container
 
 class objectProxy1fd6daa implements \Symfony\Component\DependencyInjection\Tests\Compiler\AInterface, \Symfony\Component\DependencyInjection\Tests\Compiler\IInterface, \Symfony\Component\VarExporter\LazyObjectInterface
 {
-    use \Symfony\Component\VarExporter\Internal\LazyDecoratorTrait;
+    use \Symfony\Component\VarExporter\LazyProxyTrait;
 
     private const LAZY_OBJECT_PROPERTY_SCOPES = [];
 
     public function initializeLazyObject(): \Symfony\Component\DependencyInjection\Tests\Compiler\AInterface&\Symfony\Component\DependencyInjection\Tests\Compiler\IInterface
     {
-        return $this->lazyObjectState->realInstance;
+        if ($state = $this->lazyObjectState ?? null) {
+            return $state->realInstance ??= ($state->initializer)();
+        }
+
+        return $this;
     }
 }
 
 // Help opcache.preload discover always-needed symbols
 class_exists(\Symfony\Component\VarExporter\Internal\Hydrator::class);
 class_exists(\Symfony\Component\VarExporter\Internal\LazyObjectRegistry::class);
+class_exists(\Symfony\Component\VarExporter\Internal\LazyObjectState::class);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_dedup_lazy.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_dedup_lazy.php
@@ -66,7 +66,7 @@ class ProjectServiceContainer extends Container
     protected static function getBazService($container, $lazyLoad = true)
     {
         if (true === $lazyLoad) {
-            return $container->services['baz'] = new \ReflectionClass('stdClass')->newLazyProxy(static fn () => self::getBazService($container, false));
+            return $container->services['baz'] = $container->createProxy('stdClassProxyAa01f12', static fn () => \stdClassProxyAa01f12::createLazyProxy(static fn () => self::getBazService($container, false)));
         }
 
         return \foo_bar();
@@ -80,7 +80,7 @@ class ProjectServiceContainer extends Container
     protected static function getBuzService($container, $lazyLoad = true)
     {
         if (true === $lazyLoad) {
-            return $container->services['buz'] = new \ReflectionClass('stdClass')->newLazyProxy(static fn () => self::getBuzService($container, false));
+            return $container->services['buz'] = $container->createProxy('stdClassProxyAa01f12', static fn () => \stdClassProxyAa01f12::createLazyProxy(static fn () => self::getBuzService($container, false)));
         }
 
         return \foo_bar();
@@ -100,3 +100,14 @@ class ProjectServiceContainer extends Container
         return $lazyLoad;
     }
 }
+
+class stdClassProxyAa01f12 extends \stdClass implements \Symfony\Component\VarExporter\LazyObjectInterface
+{
+    use \Symfony\Component\VarExporter\Internal\LazyDecoratorTrait;
+
+    private const LAZY_OBJECT_PROPERTY_SCOPES = [];
+}
+
+// Help opcache.preload discover always-needed symbols
+class_exists(\Symfony\Component\VarExporter\Internal\Hydrator::class);
+class_exists(\Symfony\Component\VarExporter\Internal\LazyObjectRegistry::class);

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/LazyResettableService.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/LazyResettableService.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\HttpKernel\Tests\Fixtures;
 
-class LazyResettableService
+class LazyResettableService extends \stdClass
 {
     public static $counter = 0;
 

--- a/src/Symfony/Component/VarExporter/CHANGELOG.md
+++ b/src/Symfony/Component/VarExporter/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+7.3
+---
+
+ * Deprecate using `ProxyHelper::generateLazyProxy()` when native lazy proxies can be used - the method should be used to generate abstraction-based lazy decorators only
+ * Deprecate `LazyGhostTrait` and `LazyProxyTrait`, use native lazy objects instead
+ * Deprecate `ProxyHelper::generateLazyGhost()`, use native lazy objects instead
+
 7.2
 ---
 

--- a/src/Symfony/Component/VarExporter/Internal/LazyDecoratorTrait.php
+++ b/src/Symfony/Component/VarExporter/Internal/LazyDecoratorTrait.php
@@ -1,0 +1,158 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarExporter\Internal;
+
+use Symfony\Component\Serializer\Attribute\Ignore;
+use Symfony\Component\VarExporter\Internal\LazyObjectRegistry as Registry;
+
+/**
+ * @internal
+ */
+trait LazyDecoratorTrait
+{
+    #[Ignore]
+    private readonly LazyObjectState $lazyObjectState;
+
+    /**
+     * Creates a lazy-loading decorator.
+     *
+     * @param \Closure():object $initializer Returns the proxied object
+     * @param static|null       $instance
+     */
+    public static function createLazyProxy(\Closure $initializer, ?object $instance = null): static
+    {
+        $class = $instance ? $instance::class : static::class;
+
+        if (self::class === $class && \defined($class.'::LAZY_OBJECT_PROPERTY_SCOPES')) {
+            Hydrator::$propertyScopes[$class] ??= $class::LAZY_OBJECT_PROPERTY_SCOPES;
+        }
+
+        $instance ??= (Registry::$classReflectors[$class] ??= ($r = new \ReflectionClass($class))->hasProperty('lazyObjectState')
+            ? $r
+            : throw new \LogicException('Cannot create a lazy proxy for a non-decorator object.')
+        )->newInstanceWithoutConstructor();
+
+        $state = $instance->lazyObjectState ??= new LazyObjectState();
+        $state->initializer = null;
+        unset($state->realInstance);
+
+        foreach (Registry::$classResetters[$class] ??= Registry::getClassResetters($class) as $reset) {
+            $reset($instance, []);
+        }
+        $state->initializer = $initializer;
+
+        return $instance;
+    }
+
+    public function __construct(...$args)
+    {
+        self::createLazyProxy(static fn () => new parent(...$args), $this);
+    }
+
+    public function __destruct()
+    {
+    }
+
+    #[Ignore]
+    public function isLazyObjectInitialized(bool $partial = false): bool
+    {
+        return isset($this->lazyObjectState->realInstance);
+    }
+
+    public function initializeLazyObject(): parent
+    {
+        return $this->lazyObjectState->realInstance;
+    }
+
+    public function resetLazyObject(): bool
+    {
+        if (!isset($this->lazyObjectState->initializer)) {
+            return false;
+        }
+        unset($this->lazyObjectState->realInstance);
+
+        return true;
+    }
+
+    public function &__get($name): mixed
+    {
+        $instance = $this->lazyObjectState->realInstance;
+        $class = $this::class;
+
+        $propertyScopes = Hydrator::$propertyScopes[$class] ??= Hydrator::getPropertyScopes($class);
+        $notByRef = 0;
+
+        if ([, , , $access] = $propertyScopes[$name] ?? null) {
+            $notByRef = $access & Hydrator::PROPERTY_NOT_BY_REF || ($access >> 2) & \ReflectionProperty::IS_PRIVATE_SET;
+        }
+
+        if ($notByRef || 2 !== ((Registry::$parentMethods[$class] ??= Registry::getParentMethods($class))['get'] ?: 2)) {
+            $value = $instance->$name;
+
+            return $value;
+        }
+
+        try {
+            return $instance->$name;
+        } catch (\Error $e) {
+            if (\Error::class !== $e::class || !str_starts_with($e->getMessage(), 'Cannot access uninitialized non-nullable property')) {
+                throw $e;
+            }
+
+            try {
+                $instance->$name = [];
+
+                return $instance->$name;
+            } catch (\Error) {
+                if (preg_match('/^Cannot access uninitialized non-nullable property ([^ ]++) by reference$/', $e->getMessage(), $matches)) {
+                    throw new \Error('Typed property '.$matches[1].' must not be accessed before initialization', $e->getCode(), $e->getPrevious());
+                }
+
+                throw $e;
+            }
+        }
+    }
+
+    public function __set($name, $value): void
+    {
+        $this->lazyObjectState->realInstance->$name = $value;
+    }
+
+    public function __isset($name): bool
+    {
+        return isset($this->lazyObjectState->realInstance->$name);
+    }
+
+    public function __unset($name): void
+    {
+        if ($this->lazyObjectState->initializer) {
+            unset($this->lazyObjectState->realInstance->$name);
+        }
+    }
+
+    public function __serialize(): array
+    {
+        return [$this->lazyObjectState->realInstance];
+    }
+
+    public function __unserialize($data): void
+    {
+        $this->lazyObjectState = new LazyObjectState();
+        $this->lazyObjectState->realInstance = $data[0];
+    }
+
+    public function __clone(): void
+    {
+        $this->lazyObjectState->realInstance; // initialize lazy object
+        $this->lazyObjectState = clone $this->lazyObjectState;
+    }
+}

--- a/src/Symfony/Component/VarExporter/Internal/Registry.php
+++ b/src/Symfony/Component/VarExporter/Internal/Registry.php
@@ -58,7 +58,7 @@ class Registry
     {
         $reflector = self::$reflectors[$class] ??= self::getClassReflector($class, true, false);
 
-        return self::$factories[$class] = [$reflector, 'newInstanceWithoutConstructor'](...);
+        return self::$factories[$class] = $reflector->newInstanceWithoutConstructor(...);
     }
 
     public static function getClassReflector($class, $instantiableWithoutConstructor = false, $cloneable = null)

--- a/src/Symfony/Component/VarExporter/LazyGhostTrait.php
+++ b/src/Symfony/Component/VarExporter/LazyGhostTrait.php
@@ -17,6 +17,13 @@ use Symfony\Component\VarExporter\Internal\LazyObjectRegistry as Registry;
 use Symfony\Component\VarExporter\Internal\LazyObjectState;
 use Symfony\Component\VarExporter\Internal\LazyObjectTrait;
 
+if (\PHP_VERSION_ID >= 80400) {
+    trigger_deprecation('symfony/var-exporter', '7.3', 'The "%s" trait is deprecated, use native lazy objects instead.', LazyGhostTrait::class);
+}
+
+/**
+ * @deprecated since Symfony 7.3, use native lazy objects instead
+ */
 trait LazyGhostTrait
 {
     use LazyObjectTrait;

--- a/src/Symfony/Component/VarExporter/LazyProxyTrait.php
+++ b/src/Symfony/Component/VarExporter/LazyProxyTrait.php
@@ -18,6 +18,13 @@ use Symfony\Component\VarExporter\Internal\LazyObjectRegistry as Registry;
 use Symfony\Component\VarExporter\Internal\LazyObjectState;
 use Symfony\Component\VarExporter\Internal\LazyObjectTrait;
 
+if (\PHP_VERSION_ID >= 80400) {
+    trigger_deprecation('symfony/var-exporter', '7.3', 'The "%s" trait is deprecated, use native lazy objects instead.', LazyProxyTrait::class);
+}
+
+/**
+ * @deprecated since Symfony 7.3, use native lazy objects instead
+ */
 trait LazyProxyTrait
 {
     use LazyObjectTrait;
@@ -38,11 +45,12 @@ trait LazyProxyTrait
             Registry::$classReflectors[$class] ??= new \ReflectionClass($class);
             $instance ??= Registry::$classReflectors[$class]->newInstanceWithoutConstructor();
             Registry::$defaultProperties[$class] ??= (array) $instance;
-            Registry::$classResetters[$class] ??= Registry::getClassResetters($class);
 
             if (self::class === $class && \defined($class.'::LAZY_OBJECT_PROPERTY_SCOPES')) {
                 Hydrator::$propertyScopes[$class] ??= $class::LAZY_OBJECT_PROPERTY_SCOPES;
             }
+
+            Registry::$classResetters[$class] ??= Registry::getClassResetters($class);
         } else {
             $instance ??= Registry::$classReflectors[$class]->newInstanceWithoutConstructor();
         }
@@ -290,10 +298,6 @@ trait LazyProxyTrait
         }
 
         $this->lazyObjectState = clone $this->lazyObjectState;
-
-        if (isset($this->lazyObjectState->realInstance)) {
-            $this->lazyObjectState->realInstance = clone $this->lazyObjectState->realInstance;
-        }
     }
 
     public function __serialize(): array

--- a/src/Symfony/Component/VarExporter/ProxyHelper.php
+++ b/src/Symfony/Component/VarExporter/ProxyHelper.php
@@ -13,7 +13,9 @@ namespace Symfony\Component\VarExporter;
 
 use Symfony\Component\VarExporter\Exception\LogicException;
 use Symfony\Component\VarExporter\Internal\Hydrator;
+use Symfony\Component\VarExporter\Internal\LazyDecoratorTrait;
 use Symfony\Component\VarExporter\Internal\LazyObjectRegistry;
+use Symfony\Component\VarExporter\LazyProxyTrait;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
@@ -23,10 +25,15 @@ final class ProxyHelper
     /**
      * Helps generate lazy-loading ghost objects.
      *
+     * @deprecated since Symfony 7.3, use native lazy objects instead
+     *
      * @throws LogicException When the class is incompatible with ghost objects
      */
     public static function generateLazyGhost(\ReflectionClass $class): string
     {
+        if (\PHP_VERSION_ID >= 80400) {
+            trigger_deprecation('symfony/var-exporter', '7.3', 'Using ProxyHelper::generateLazyGhost() is deprecated, use native lazy objects instead.');
+        }
         if (\PHP_VERSION_ID < 80300 && $class->isReadOnly()) {
             throw new LogicException(\sprintf('Cannot generate lazy ghost with PHP < 8.3: class "%s" is readonly.', $class->name));
         }
@@ -94,7 +101,7 @@ final class ProxyHelper
                 }
             }
 
-            $hooks .= "        }\n";
+            $hooks .= "    }\n";
         }
 
         $propertyScopes = self::exportPropertyScopes($class->name, $propertyScopes);
@@ -116,7 +123,7 @@ final class ProxyHelper
     }
 
     /**
-     * Helps generate lazy-loading virtual proxies.
+     * Helps generate lazy-loading decorators.
      *
      * @param \ReflectionClass[] $interfaces
      *
@@ -130,39 +137,49 @@ final class ProxyHelper
         if ($class?->isFinal()) {
             throw new LogicException(\sprintf('Cannot generate lazy proxy: class "%s" is final.', $class->name));
         }
-        if (\PHP_VERSION_ID < 80300 && $class?->isReadOnly()) {
-            throw new LogicException(\sprintf('Cannot generate lazy proxy with PHP < 8.3: class "%s" is readonly.', $class->name));
+        if (\PHP_VERSION_ID < 80400) {
+            return self::generateLegacyLazyProxy($class, $interfaces);
+        }
+
+        if ($class && !$class->isAbstract()) {
+            $parent = $class;
+            do {
+                $extendsInternalClass = $parent->isInternal();
+            } while (!$extendsInternalClass && $parent = $parent->getParentClass());
+
+            if (!$extendsInternalClass) {
+                trigger_deprecation('symfony/var-exporter', '7.3', 'Generating lazy proxy for class "%s" is deprecated; leverage native lazy objects instead.', $class->name);
+                // throw new LogicException(\sprintf('Cannot generate lazy proxy: leverage native lazy objects instead for class "%s".', $class->name));
+            }
         }
 
         $propertyScopes = $class ? Hydrator::$propertyScopes[$class->name] ??= Hydrator::getPropertyScopes($class->name) : [];
         $abstractProperties = [];
         $hookedProperties = [];
-        if (\PHP_VERSION_ID >= 80400 && $class) {
-            foreach ($propertyScopes as $key => [$scope, $name, , $access]) {
-                $propertyScopes[$k = "\0$scope\0$name"] ?? $propertyScopes[$k = "\0*\0$name"] ?? $k = $name;
-                $flags = $access >> 2;
+        foreach ($propertyScopes as $key => [$scope, $name, , $access]) {
+            $propertyScopes[$k = "\0$scope\0$name"] ?? $propertyScopes[$k = "\0*\0$name"] ?? $k = $name;
+            $flags = $access >> 2;
 
-                if ($k !== $key) {
-                    continue;
-                }
-
-                if ($flags & \ReflectionProperty::IS_ABSTRACT) {
-                    $abstractProperties[$name] = $propertyScopes[$k][4] ?? Hydrator::$propertyScopes[$class->name][$k][4] = new \ReflectionProperty($scope, $name);
-                    continue;
-                }
-                $abstractProperties[$name] = false;
-
-                if (!($access & Hydrator::PROPERTY_HAS_HOOKS) || $flags & \ReflectionProperty::IS_VIRTUAL) {
-                    continue;
-                }
-
-                if ($flags & (\ReflectionProperty::IS_FINAL | \ReflectionProperty::IS_PRIVATE)) {
-                    throw new LogicException(\sprintf('Cannot generate lazy proxy: property "%s::$%s" is final or private(set).', $class->name, $name));
-                }
-
-                $p = $propertyScopes[$k][4] ?? Hydrator::$propertyScopes[$class->name][$k][4] = new \ReflectionProperty($scope, $name);
-                $hookedProperties[$name] = [$p, $p->getHooks()];
+            if ($k !== $key || $flags & \ReflectionProperty::IS_PRIVATE) {
+                continue;
             }
+
+            if ($flags & \ReflectionProperty::IS_ABSTRACT) {
+                $abstractProperties[$name] = $propertyScopes[$k][4] ?? Hydrator::$propertyScopes[$class->name][$k][4] = new \ReflectionProperty($scope, $name);
+                continue;
+            }
+            $abstractProperties[$name] = false;
+
+            if (!($access & Hydrator::PROPERTY_HAS_HOOKS)) {
+                continue;
+            }
+
+            if ($flags & \ReflectionProperty::IS_FINAL) {
+                throw new LogicException(\sprintf('Cannot generate lazy proxy: property "%s::$%s" is final.', $class->name, $name));
+            }
+
+            $p = $propertyScopes[$k][4] ?? Hydrator::$propertyScopes[$class->name][$k][4] = new \ReflectionProperty($scope, $name);
+            $hookedProperties[$name] = [$p, $p->getHooks()];
         }
 
         $methodReflectors = [$class?->getMethods(\ReflectionMethod::IS_PUBLIC | \ReflectionMethod::IS_PROTECTED) ?? []];
@@ -172,12 +189,10 @@ final class ProxyHelper
             }
             $methodReflectors[] = $interface->getMethods();
 
-            if (\PHP_VERSION_ID >= 80400) {
-                foreach ($interface->getProperties() as $p) {
-                    $abstractProperties[$p->name] ??= $p;
-                    $hookedProperties[$p->name] ??= [$p, []];
-                    $hookedProperties[$p->name][1] += $p->getHooks();
-                }
+            foreach ($interface->getProperties() as $p) {
+                $abstractProperties[$p->name] ??= $p;
+                $hookedProperties[$p->name] ??= [$p, []];
+                $hookedProperties[$p->name][1] += $p->getHooks();
             }
         }
 
@@ -192,6 +207,9 @@ final class ProxyHelper
         }
 
         foreach ($hookedProperties as $name => [$p, $methods]) {
+            if ($abstractProperties[$p->name] ?? false) {
+                continue;
+            }
             $type = self::exportType($p);
             $hooks .= "\n    "
                 .($p->isProtected() ? 'protected' : 'public')
@@ -203,11 +221,7 @@ final class ProxyHelper
                     $ref = ($method->returnsReference() ? '&' : '');
                     $hooks .= <<<EOPHP
                             {$ref}get {
-                                if (isset(\$this->lazyObjectState)) {
-                                    return (\$this->lazyObjectState->realInstance ??= (\$this->lazyObjectState->initializer)())->{$p->name};
-                                }
-
-                                return parent::\${$p->name}::get();
+                                return \$this->lazyObjectState->realInstance->{$p->name};
                             }
 
                     EOPHP;
@@ -216,12 +230,7 @@ final class ProxyHelper
                     $arg = '$'.$method->getParameters()[0]->name;
                     $hooks .= <<<EOPHP
                             set({$parameters}) {
-                                if (isset(\$this->lazyObjectState)) {
-                                    \$this->lazyObjectState->realInstance ??= (\$this->lazyObjectState->initializer)();
-                                    \$this->lazyObjectState->realInstance->{$p->name} = {$arg};
-                                }
-
-                                parent::\${$p->name}::set({$arg});
+                                \$this->lazyObjectState->realInstance->{$p->name} = {$arg};
                             }
 
                     EOPHP;
@@ -231,6 +240,154 @@ final class ProxyHelper
             }
 
             $hooks .= "    }\n";
+        }
+
+        $methods = [];
+        $methodReflectors = array_merge(...$methodReflectors);
+
+        foreach ($methodReflectors as $method) {
+            if ('__get' !== strtolower($method->name) || 'mixed' === ($type = self::exportType($method) ?? 'mixed')) {
+                continue;
+            }
+            $trait = new \ReflectionMethod(LazyDecoratorTrait::class, '__get');
+            $body = \array_slice(file($trait->getFileName()), $trait->getStartLine() - 1, $trait->getEndLine() - $trait->getStartLine());
+            $body[0] = str_replace('): mixed', '): '.$type, $body[0]);
+            $methods['__get'] = strtr(implode('', $body).'    }', [
+                'Hydrator' => '\\'.Hydrator::class,
+                'Registry' => '\\'.LazyObjectRegistry::class,
+            ]);
+            break;
+        }
+
+        foreach ($methodReflectors as $method) {
+            if (($method->isStatic() && !$method->isAbstract()) || isset($methods[$lcName = strtolower($method->name)])) {
+                continue;
+            }
+            if ($method->isFinal()) {
+                throw new LogicException(\sprintf('Cannot generate lazy proxy: method "%s::%s()" is final.', $class->name, $method->name));
+            }
+            if (method_exists(LazyDecoratorTrait::class, $method->name)) {
+                continue;
+            }
+
+            $signature = self::exportSignature($method, true, $args);
+
+            if ($method->isStatic()) {
+                $body = "        throw new \BadMethodCallException('Cannot forward abstract method \"{$method->class}::{$method->name}()\".');";
+            } elseif (str_ends_with($signature, '): never') || str_ends_with($signature, '): void')) {
+                $body = <<<EOPHP
+                        \$this->lazyObjectState->realInstance->{$method->name}({$args});
+                EOPHP;
+            } else {
+                $mayReturnThis = false;
+                foreach (preg_split('/[()|&]++/', self::exportType($method) ?? 'static') as $type) {
+                    if (\in_array($type = ltrim($type, '?'), ['static', 'object'], true)) {
+                        $mayReturnThis = true;
+                        break;
+                    }
+                    foreach ([$class, ...$interfaces] as $r) {
+                        if ($r && is_a($r->name, $type, true)) {
+                            $mayReturnThis = true;
+                            break 2;
+                        }
+                    }
+                }
+
+                if ($method->returnsReference() || !$mayReturnThis) {
+                    $body = <<<EOPHP
+                            return \$this->lazyObjectState->realInstance->{$method->name}({$args});
+                    EOPHP;
+                } else {
+                    $body = <<<EOPHP
+                            \${0} = \$this->lazyObjectState->realInstance;
+                            \${1} = \${0}->{$method->name}({$args});
+
+                            return match (true) {
+                                \${1} === \${0} => \$this,
+                                !\${1} instanceof \${0} || !\${0} instanceof \${1} => \${1},
+                                null !== \$this->lazyObjectState->cloneInstance =& \${1} => clone \$this,
+                            };
+                    EOPHP;
+                }
+            }
+            $methods[$lcName] = "    {$signature}\n    {\n{$body}\n    }";
+        }
+
+        $types = $interfaces = array_unique(array_column($interfaces, 'name'));
+        $interfaces[] = LazyObjectInterface::class;
+        $interfaces = implode(', \\', $interfaces);
+        $parent = $class ? ' extends \\'.$class->name : '';
+        array_unshift($types, $class ? 'parent' : '');
+        $type = ltrim(implode('&\\', $types), '&');
+
+        if (!$class) {
+            $trait = new \ReflectionMethod(LazyDecoratorTrait::class, 'initializeLazyObject');
+            $body = \array_slice(file($trait->getFileName()), $trait->getStartLine() - 1, $trait->getEndLine() - $trait->getStartLine());
+            $body[0] = str_replace('): parent', '): '.$type, $body[0]);
+            $methods = ['initializeLazyObject' => implode('', $body).'    }'] + $methods;
+        }
+        $body = $methods ? "\n".implode("\n\n", $methods)."\n" : '';
+        $propertyScopes = $class ? self::exportPropertyScopes($class->name, $propertyScopes) : '[]';
+        $lazyProxyTraitStatement = [];
+
+        if (
+            $class?->hasMethod('__unserialize')
+            && !$class->getMethod('__unserialize')->getParameters()[0]->getType()
+        ) {
+            // fix contravariance type problem when $class declares a `__unserialize()` method without typehint.
+            $lazyProxyTraitStatement[] = '__unserialize as private __doUnserialize;';
+
+            $body .= <<<EOPHP
+
+                    public function __unserialize(\$data): void
+                    {
+                        \$this->__doUnserialize(\$data);
+                    }
+
+                EOPHP;
+        }
+
+        if ($lazyProxyTraitStatement) {
+            $lazyProxyTraitStatement = implode("\n        ", $lazyProxyTraitStatement);
+            $lazyProxyTraitStatement = <<<EOPHP
+            use \Symfony\Component\VarExporter\Internal\LazyDecoratorTrait {
+                    {$lazyProxyTraitStatement}
+                }
+            EOPHP;
+        } else {
+            $lazyProxyTraitStatement = <<<EOPHP
+            use \Symfony\Component\VarExporter\Internal\LazyDecoratorTrait;
+            EOPHP;
+        }
+
+        return <<<EOPHP
+            {$parent} implements \\{$interfaces}
+            {
+                {$lazyProxyTraitStatement}
+
+                private const LAZY_OBJECT_PROPERTY_SCOPES = {$propertyScopes};
+            {$hooks}{$body}}
+
+            // Help opcache.preload discover always-needed symbols
+            class_exists(\Symfony\Component\VarExporter\Internal\Hydrator::class);
+            class_exists(\Symfony\Component\VarExporter\Internal\LazyObjectRegistry::class);
+
+            EOPHP;
+    }
+
+    private static function generateLegacyLazyProxy(?\ReflectionClass $class, array $interfaces): string
+    {
+        if (\PHP_VERSION_ID < 80300 && $class?->isReadOnly()) {
+            throw new LogicException(\sprintf('Cannot generate lazy proxy with PHP < 8.3: class "%s" is readonly.', $class->name));
+        }
+
+        $propertyScopes = $class ? Hydrator::$propertyScopes[$class->name] ??= Hydrator::getPropertyScopes($class->name) : [];
+        $methodReflectors = [$class?->getMethods(\ReflectionMethod::IS_PUBLIC | \ReflectionMethod::IS_PROTECTED) ?? []];
+        foreach ($interfaces as $interface) {
+            if (!$interface->isInterface()) {
+                throw new LogicException(\sprintf('Cannot generate lazy proxy: "%s" is not an interface.', $interface->name));
+            }
+            $methodReflectors[] = $interface->getMethods();
         }
 
         $extendsInternalClass = false;
@@ -358,7 +515,7 @@ final class ProxyHelper
                 {$lazyProxyTraitStatement}
 
                 private const LAZY_OBJECT_PROPERTY_SCOPES = {$propertyScopes};
-            {$hooks}{$body}}
+            {$body}}
 
             // Help opcache.preload discover always-needed symbols
             class_exists(\Symfony\Component\VarExporter\Internal\Hydrator::class);

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyGhost/RegularClass.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyGhost/RegularClass.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost;
 
-class RegularClass
+class RegularClass extends \stdClass
 {
     public function __construct(
         public int $foo,

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyProxy/AsymmetricVisibility.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyProxy/AsymmetricVisibility.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy;
 
-class AsymmetricVisibility
+class AsymmetricVisibility extends \stdClass
 {
     public function __construct(
         public private(set) int $foo,

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyProxy/ConcreteReadOnlyClass.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyProxy/ConcreteReadOnlyClass.php
@@ -11,15 +11,6 @@
 
 namespace Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy;
 
-class Hooked extends \stdClass
+readonly class ConcreteReadOnlyClass extends ReadOnlyClass
 {
-    public int $notBacked {
-        get { return 123; }
-        set { throw \LogicException('Cannot set value.'); }
-    }
-
-    public int $backed {
-        get { return $this->backed ??= 234; }
-        set { $this->backed = $value; }
-    }
 }

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyProxy/FinalPublicClass.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyProxy/FinalPublicClass.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy;
 
-class FinalPublicClass
+class FinalPublicClass extends \stdClass
 {
     private $count = 0;
 

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyProxy/Php82NullStandaloneReturnType.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyProxy/Php82NullStandaloneReturnType.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy;
 
-class Php82NullStandaloneReturnType
+class Php82NullStandaloneReturnType extends \stdClass
 {
     public function foo(): null
     {

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyProxy/ReadOnlyClass.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyProxy/ReadOnlyClass.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy;
 
-readonly class ReadOnlyClass
+abstract readonly class ReadOnlyClass
 {
     public function __construct(
         public int $foo,

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyProxy/StringMagicGetClass.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyProxy/StringMagicGetClass.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy;
 
-class StringMagicGetClass
+class StringMagicGetClass extends \stdClass
 {
     public function __get(string $name): string
     {

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyProxy/TestClass.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyProxy/TestClass.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy;
 
 #[\AllowDynamicProperties]
-class TestClass
+class TestClass extends \stdClass
 {
     public function __construct(
         protected \stdClass $dep,

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/SimpleObject.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/SimpleObject.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\VarExporter\Tests\Fixtures;
 
-class SimpleObject
+class SimpleObject extends \stdClass
 {
     public function getMethod(): string
     {

--- a/src/Symfony/Component/VarExporter/Tests/LegacyLazyGhostTraitTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/LegacyLazyGhostTraitTest.php
@@ -28,7 +28,10 @@ use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\AsymmetricVisibility;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\Hooked;
 use Symfony\Component\VarExporter\Tests\Fixtures\SimpleObject;
 
-class LazyGhostTraitTest extends TestCase
+/**
+ * @group legacy
+ */
+class LegacyLazyGhostTraitTest extends TestCase
 {
     public function testGetPublic()
     {

--- a/src/Symfony/Component/VarExporter/Tests/LegacyLazyProxyTraitTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/LegacyLazyProxyTraitTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarExporter\Tests;
+
+use Symfony\Component\VarExporter\LazyProxyTrait;
+use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\FinalPublicClass;
+use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\TestClass;
+use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\TestOverwritePropClass;
+
+/**
+ * @requires PHP < 8.4
+ *
+ * @group legacy
+ */
+class LegacyLazyProxyTraitTest extends LazyProxyTraitTest
+{
+    public function testLazyDecoratorClass()
+    {
+        $obj = new class extends TestClass {
+            use LazyProxyTrait {
+                createLazyProxy as private;
+            }
+
+            public function __construct()
+            {
+                self::createLazyProxy(fn () => new TestClass((object) ['foo' => 123]), $this);
+            }
+        };
+
+        $this->assertSame(['foo' => 123], (array) $obj->getDep());
+    }
+
+    public function testFinalPublicClass()
+    {
+        $proxy = $this->createLazyProxy(FinalPublicClass::class, fn () => new FinalPublicClass());
+
+        $this->assertSame(1, $proxy->increment());
+        $this->assertSame(2, $proxy->increment());
+        $this->assertSame(1, $proxy->decrement());
+    }
+
+    public function testOverwritePropClass()
+    {
+        $proxy = $this->createLazyProxy(TestOverwritePropClass::class, fn () => new TestOverwritePropClass('123', 5));
+
+        $this->assertSame('123', $proxy->getDep());
+        $this->assertSame(1, $proxy->increment());
+    }
+}

--- a/src/Symfony/Component/VarExporter/Tests/LegacyProxyHelperTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/LegacyProxyHelperTest.php
@@ -1,0 +1,200 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarExporter\Tests;
+
+use Symfony\Component\VarExporter\Exception\LogicException;
+use Symfony\Component\VarExporter\ProxyHelper;
+use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\Php82NullStandaloneReturnType;
+use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\StringMagicGetClass;
+
+/**
+ * @requires PHP < 8.4
+ *
+ * @group legacy
+ */
+class LegacyProxyHelperTest extends ProxyHelperTest
+{
+    public function testGenerateLazyProxy()
+    {
+        $expected = <<<'EOPHP'
+         extends \Symfony\Component\VarExporter\Tests\TestForProxyHelper implements \Symfony\Component\VarExporter\LazyObjectInterface
+        {
+            use \Symfony\Component\VarExporter\LazyProxyTrait;
+
+            private const LAZY_OBJECT_PROPERTY_SCOPES = [];
+
+            public function foo1(): ?\Symfony\Component\VarExporter\Tests\Bar
+            {
+                if (isset($this->lazyObjectState)) {
+                    return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->foo1(...\func_get_args());
+                }
+
+                return parent::foo1(...\func_get_args());
+            }
+
+            public function foo4(\Symfony\Component\VarExporter\Tests\Bar|string $b, &$d): void
+            {
+                if (isset($this->lazyObjectState)) {
+                    ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->foo4($b, $d, ...\array_slice(\func_get_args(), 2));
+                } else {
+                    parent::foo4($b, $d, ...\array_slice(\func_get_args(), 2));
+                }
+            }
+
+            protected function foo7()
+            {
+                if (isset($this->lazyObjectState)) {
+                    return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->foo7(...\func_get_args());
+                }
+
+                return throw new \BadMethodCallException('Cannot forward abstract method "Symfony\Component\VarExporter\Tests\TestForProxyHelper::foo7()".');
+            }
+        }
+
+        // Help opcache.preload discover always-needed symbols
+        class_exists(\Symfony\Component\VarExporter\Internal\Hydrator::class);
+        class_exists(\Symfony\Component\VarExporter\Internal\LazyObjectRegistry::class);
+        class_exists(\Symfony\Component\VarExporter\Internal\LazyObjectState::class);
+
+        EOPHP;
+
+        $this->assertSame($expected, ProxyHelper::generateLazyProxy(new \ReflectionClass(TestForProxyHelper::class)));
+    }
+
+    public function testGenerateLazyProxyForInterfaces()
+    {
+        $expected = <<<'EOPHP'
+         implements \Symfony\Component\VarExporter\Tests\TestForProxyHelperInterface1, \Symfony\Component\VarExporter\Tests\TestForProxyHelperInterface2, \Symfony\Component\VarExporter\LazyObjectInterface
+        {
+            use \Symfony\Component\VarExporter\LazyProxyTrait;
+
+            private const LAZY_OBJECT_PROPERTY_SCOPES = [];
+
+            public function initializeLazyObject(): \Symfony\Component\VarExporter\Tests\TestForProxyHelperInterface1&\Symfony\Component\VarExporter\Tests\TestForProxyHelperInterface2
+            {
+                if ($state = $this->lazyObjectState ?? null) {
+                    return $state->realInstance ??= ($state->initializer)();
+                }
+
+                return $this;
+            }
+
+            public function foo1(): ?\Symfony\Component\VarExporter\Tests\Bar
+            {
+                if (isset($this->lazyObjectState)) {
+                    return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->foo1(...\func_get_args());
+                }
+
+                return throw new \BadMethodCallException('Cannot forward abstract method "Symfony\Component\VarExporter\Tests\TestForProxyHelperInterface1::foo1()".');
+            }
+
+            public function foo2(?\Symfony\Component\VarExporter\Tests\Bar $b, ...$d): \Symfony\Component\VarExporter\Tests\TestForProxyHelperInterface2
+            {
+                if (isset($this->lazyObjectState)) {
+                    return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->foo2(...\func_get_args());
+                }
+
+                return throw new \BadMethodCallException('Cannot forward abstract method "Symfony\Component\VarExporter\Tests\TestForProxyHelperInterface2::foo2()".');
+            }
+
+            public static function foo3(): string
+            {
+                throw new \BadMethodCallException('Cannot forward abstract method "Symfony\Component\VarExporter\Tests\TestForProxyHelperInterface2::foo3()".');
+            }
+        }
+
+        // Help opcache.preload discover always-needed symbols
+        class_exists(\Symfony\Component\VarExporter\Internal\Hydrator::class);
+        class_exists(\Symfony\Component\VarExporter\Internal\LazyObjectRegistry::class);
+        class_exists(\Symfony\Component\VarExporter\Internal\LazyObjectState::class);
+
+        EOPHP;
+
+        $this->assertSame($expected, ProxyHelper::generateLazyProxy(null, [new \ReflectionClass(TestForProxyHelperInterface1::class), new \ReflectionClass(TestForProxyHelperInterface2::class)]));
+    }
+
+    public static function classWithUnserializeMagicMethodProvider(): iterable
+    {
+        yield 'not type hinted __unserialize method' => [new class {
+            public function __unserialize($array): void
+            {
+            }
+        }, <<<'EOPHP'
+        implements \Symfony\Component\VarExporter\LazyObjectInterface
+        {
+            use \Symfony\Component\VarExporter\LazyProxyTrait {
+                __unserialize as private __doUnserialize;
+            }
+
+            private const LAZY_OBJECT_PROPERTY_SCOPES = [];
+
+            public function __unserialize($data): void
+            {
+                $this->__doUnserialize($data);
+            }
+        }
+        EOPHP];
+
+        yield 'type hinted __unserialize method' => [new class {
+            public function __unserialize(array $array): void
+            {
+            }
+        }, <<<'EOPHP'
+        implements \Symfony\Component\VarExporter\LazyObjectInterface
+        {
+            use \Symfony\Component\VarExporter\LazyProxyTrait;
+
+            private const LAZY_OBJECT_PROPERTY_SCOPES = [];
+        }
+        EOPHP];
+    }
+
+    public function testAttributes()
+    {
+        $expected = <<<'EOPHP'
+
+            public function foo(#[\SensitiveParameter] $a): int
+            {
+                if (isset($this->lazyObjectState)) {
+                    return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->foo(...\func_get_args());
+                }
+
+                return parent::foo(...\func_get_args());
+            }
+        }
+
+        EOPHP;
+
+        $class = new \ReflectionClass(new class {
+            #[SomeAttribute]
+            public function foo(#[\SensitiveParameter, AnotherAttribute] $a): int
+            {
+            }
+        });
+
+        $this->assertStringContainsString($expected, ProxyHelper::generateLazyProxy($class));
+    }
+
+    public function testCannotGenerateGhostForStringMagicGet()
+    {
+        $this->expectException(LogicException::class);
+        ProxyHelper::generateLazyGhost(new \ReflectionClass(StringMagicGetClass::class));
+    }
+
+    public function testNullStandaloneReturnType()
+    {
+        self::assertStringContainsString(
+            'public function foo(): null',
+            ProxyHelper::generateLazyProxy(new \ReflectionClass(Php82NullStandaloneReturnType::class))
+        );
+    }
+}

--- a/src/Symfony/Component/VarExporter/composer.json
+++ b/src/Symfony/Component/VarExporter/composer.json
@@ -16,7 +16,8 @@
         }
     ],
     "require": {
-        "php": ">=8.2"
+        "php": ">=8.2",
+        "symfony/deprecation-contracts": "^2.5|^3"
     },
     "require-dev": {
         "symfony/property-access": "^6.4|^7.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Let's leverage native lazy objects.

Instead of keeping/updating LazyGhostTrait and LazyProxyTrait, I'm deprecating them in favor of using native lazy proxies directly.

There is one use case that is not covered by native lazy objects: lazy decorators - aka lazy proxies built against an interface or an internal class. For this use case, we keep `ProxyHelper::generateLazyProxy()`.