### PR TITLE
[Twig] Remove support for Twig 2.x extra versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -158,9 +158,9 @@
         "symfony/runtime": "self.version",
         "symfony/security-acl": "~2.8|~3.0",
         "symfony/webpack-encore-bundle": "^1.0|^2.0",
-        "twig/cssinliner-extra": "^2.12|^3",
-        "twig/inky-extra": "^2.12|^3",
-        "twig/markdown-extra": "^2.12|^3",
+        "twig/cssinliner-extra": "^3",
+        "twig/inky-extra": "^3",
+        "twig/markdown-extra": "^3",
         "web-token/jwt-library": "^3.3.2|^4.0"
     },
     "conflict": {

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -51,9 +51,9 @@
         "symfony/expression-language": "^6.4|^7.0",
         "symfony/web-link": "^6.4|^7.0",
         "symfony/workflow": "^6.4|^7.0",
-        "twig/cssinliner-extra": "^2.12|^3",
-        "twig/inky-extra": "^2.12|^3",
-        "twig/markdown-extra": "^2.12|^3"
+        "twig/cssinliner-extra": "^3",
+        "twig/inky-extra": "^3",
+        "twig/markdown-extra": "^3"
     },
     "conflict": {
         "phpdocumentor/reflection-docblock": "<3.2.2",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | n/a
| License       | MIT

As we only support Twig 3+, I don't a good reason not to do the same for the Twig extra packages.
