### PR TITLE
replace `assertEmpty()` with stricter assertions

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/DoctrineLoaderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/DoctrineLoaderTest.php
@@ -210,7 +210,7 @@ class DoctrineLoaderTest extends TestCase
         $this->assertSame(AutoMappingStrategy::DISABLED, $classMetadata->getAutoMappingStrategy());
 
         $maxLengthMetadata = $classMetadata->getPropertyMetadata('maxLength');
-        $this->assertEmpty($maxLengthMetadata);
+        $this->assertSame([], $maxLengthMetadata);
 
         /** @var PropertyMetadata[] $autoMappingExplicitlyEnabledMetadata */
         $autoMappingExplicitlyEnabledMetadata = $classMetadata->getPropertyMetadata('autoMappingExplicitlyEnabled');

--- a/src/Symfony/Bridge/PhpUnit/Tests/Metadata/AttributeReaderTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/Metadata/AttributeReaderTest.php
@@ -71,7 +71,7 @@ final class AttributeReaderTest extends TestCase
         $reader = new AttributeReader();
         $cacheRef = new \ReflectionProperty(AttributeReader::class, 'cache');
 
-        self::assertEmpty($cacheRef->getValue($reader));
+        self::assertSame([], $cacheRef->getValue($reader));
 
         $reader->forClass(FooBar::class, TimeSensitive::class);
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractLayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractLayoutTestCase.php
@@ -1592,7 +1592,7 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
         $form->get('date')->addError(new FormError('[trans]Error![/trans]'));
         $view = $form->createView();
 
-        $this->assertEmpty($this->renderErrors($view));
+        $this->assertSame('', $this->renderErrors($view));
         $this->assertNotEmpty($this->renderErrors($view['date']));
     }
 
@@ -2213,7 +2213,7 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
         $form->get('time')->addError(new FormError('[trans]Error![/trans]'));
         $view = $form->createView();
 
-        $this->assertEmpty($this->renderErrors($view));
+        $this->assertSame('', $this->renderErrors($view));
         $this->assertNotEmpty($this->renderErrors($view['time']));
     }
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/DumpExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/DumpExtensionTest.php
@@ -142,6 +142,6 @@ class DumpExtensionTest extends TestCase
             'Custom dumper should be used to dump data.'
         );
 
-        $this->assertEmpty($output, 'Dumper output should be ignored.');
+        $this->assertSame('', $output, 'Dumper output should be ignored.');
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -796,7 +796,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
             \ARRAY_FILTER_USE_KEY
         );
 
-        $this->assertEmpty($messengerDefinitions);
+        $this->assertSame([], $messengerDefinitions);
         $this->assertFalse($container->hasDefinition('console.command.messenger_consume_messages'));
         $this->assertFalse($container->hasDefinition('console.command.messenger_debug'));
         $this->assertFalse($container->hasDefinition('console.command.messenger_stop_workers'));
@@ -1941,7 +1941,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
 
         $container = $this->createContainer(['kernel.debug' => false]);
         (new FrameworkExtension())->load([['annotations' => false, 'http_method_override' => false, 'handle_all_throwables' => true, 'php_errors' => ['log' => true]]], $container);
-        $this->assertEmpty($container->getDefinition('config_cache_factory')->getArguments());
+        $this->assertSame([], $container->getDefinition('config_cache_factory')->getArguments());
     }
 
     public function testLoggerAwareRegistration()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ApiAttributesTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ApiAttributesTest.php
@@ -34,7 +34,7 @@ class ApiAttributesTest extends AbstractWebTestCase
         if ($expectedResponse) {
             self::assertJsonStringEqualsJsonString($expectedResponse, $response->getContent());
         } else {
-            self::assertEmpty($response->getContent());
+            self::assertSame('', $response->getContent());
         }
         self::assertSame($expectedStatusCode, $response->getStatusCode());
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
@@ -54,7 +54,7 @@ class SecurityDataCollectorTest extends TestCase
         $this->assertFalse($collector->supportsRoleHierarchy());
         $this->assertCount(0, $collector->getRoles());
         $this->assertCount(0, $collector->getInheritedRoles());
-        $this->assertEmpty($collector->getUser());
+        $this->assertSame('', $collector->getUser());
         $this->assertNull($collector->getFirewall());
     }
 
@@ -73,7 +73,7 @@ class SecurityDataCollectorTest extends TestCase
         $this->assertTrue($collector->supportsRoleHierarchy());
         $this->assertCount(0, $collector->getRoles());
         $this->assertCount(0, $collector->getInheritedRoles());
-        $this->assertEmpty($collector->getUser());
+        $this->assertSame('', $collector->getUser());
         $this->assertNull($collector->getFirewall());
     }
 
@@ -425,7 +425,7 @@ class SecurityDataCollectorTest extends TestCase
 
         $dataCollector->collect(new Request(), new Response());
 
-        $this->assertEmpty($dataCollector->getVoters());
+        $this->assertSame([], $dataCollector->getVoters());
     }
 
     public static function provideRoles(): array

--- a/src/Symfony/Component/Asset/Tests/Context/NullContextTest.php
+++ b/src/Symfony/Component/Asset/Tests/Context/NullContextTest.php
@@ -20,7 +20,7 @@ class NullContextTest extends TestCase
     {
         $nullContext = new NullContext();
 
-        $this->assertEmpty($nullContext->getBasePath());
+        $this->assertSame('', $nullContext->getBasePath());
     }
 
     public function testIsSecure()

--- a/src/Symfony/Component/Asset/Tests/Context/RequestStackContextTest.php
+++ b/src/Symfony/Component/Asset/Tests/Context/RequestStackContextTest.php
@@ -22,7 +22,7 @@ class RequestStackContextTest extends TestCase
     {
         $requestStackContext = new RequestStackContext(new RequestStack());
 
-        $this->assertEmpty($requestStackContext->getBasePath());
+        $this->assertSame('', $requestStackContext->getBasePath());
     }
 
     public function testGetBasePathSet()

--- a/src/Symfony/Component/Asset/Tests/VersionStrategy/EmptyVersionStrategyTest.php
+++ b/src/Symfony/Component/Asset/Tests/VersionStrategy/EmptyVersionStrategyTest.php
@@ -21,7 +21,7 @@ class EmptyVersionStrategyTest extends TestCase
         $emptyVersionStrategy = new EmptyVersionStrategy();
         $path = 'test-path';
 
-        $this->assertEmpty($emptyVersionStrategy->getVersion($path));
+        $this->assertSame('', $emptyVersionStrategy->getVersion($path));
     }
 
     public function testApplyVersion()

--- a/src/Symfony/Component/BrowserKit/Tests/AbstractBrowserTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/AbstractBrowserTest.php
@@ -642,10 +642,10 @@ class AbstractBrowserTest extends TestCase
             $client->request('POST', 'http://www.example.com/foo/foobar', $parameters, $files, $server, $content);
 
             $this->assertSame('http://www.example.com/redirected', $client->getRequest()->getUri(), '->followRedirect() follows a redirect with POST method on response code: '.$code.'.');
-            $this->assertEmpty($client->getRequest()->getParameters(), '->followRedirect() drops parameters with POST method on response code: '.$code.'.');
-            $this->assertEmpty($client->getRequest()->getFiles(), '->followRedirect() drops files with POST method on response code: '.$code.'.');
+            $this->assertSame([], $client->getRequest()->getParameters(), '->followRedirect() drops parameters with POST method on response code: '.$code.'.');
+            $this->assertSame([], $client->getRequest()->getFiles(), '->followRedirect() drops files with POST method on response code: '.$code.'.');
             $this->assertArrayHasKey('X_TEST_FOO', $client->getRequest()->getServer(), '->followRedirect() keeps $_SERVER with POST method on response code: '.$code.'.');
-            $this->assertEmpty($client->getRequest()->getContent(), '->followRedirect() drops content with POST method on response code: '.$code.'.');
+            $this->assertNull($client->getRequest()->getContent(), '->followRedirect() drops content with POST method on response code: '.$code.'.');
             $this->assertSame('GET', $client->getRequest()->getMethod(), '->followRedirect() drops request method to GET on response code: '.$code.'.');
         }
     }

--- a/src/Symfony/Component/BrowserKit/Tests/CookieJarTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/CookieJarTest.php
@@ -247,6 +247,6 @@ class CookieJarTest extends TestCase
         $cookieJar->set(new Cookie('foo', 'bar', null, '/', '.example.com'));
 
         $this->assertEquals(['foo' => 'bar'], $cookieJar->allValues('http://www.example.com'));
-        $this->assertEmpty($cookieJar->allValues('http://wwwexample.com'));
+        $this->assertSame([], $cookieJar->allValues('http://wwwexample.com'));
     }
 }

--- a/src/Symfony/Component/Cache/Tests/Adapter/DoctrineDbalAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/DoctrineDbalAdapterTest.php
@@ -117,7 +117,7 @@ class DoctrineDbalAdapterTest extends AdapterTestCase
         $adapter = new DoctrineDbalAdapter($connection);
         $adapter->configureSchema($schema, $connection, fn () => true);
         $table = $schema->getTable('cache_items');
-        $this->assertEmpty($table->getColumns(), 'The table was not overwritten');
+        $this->assertSame([], $table->getColumns(), 'The table was not overwritten');
     }
 
     /**

--- a/src/Symfony/Component/Config/Tests/Definition/PrototypedArrayNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/PrototypedArrayNodeTest.php
@@ -24,7 +24,7 @@ class PrototypedArrayNodeTest extends TestCase
         $node = new PrototypedArrayNode('root');
         $prototype = new ArrayNode(null, $node);
         $node->setPrototype($prototype);
-        $this->assertEmpty($node->getDefaultValue());
+        $this->assertSame([], $node->getDefaultValue());
     }
 
     public function testGetDefaultValueReturnsDefaultValueForPrototypes()

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -291,7 +291,7 @@ class ApplicationTest extends TestCase
         $tester = new ApplicationTester($application);
         $tester->run(['-h' => true, '-q' => true], ['decorated' => false]);
 
-        $this->assertEmpty($tester->getDisplay(true));
+        $this->assertSame('', $tester->getDisplay(true));
     }
 
     public function testGetInvalidCommand()

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/DecoratorServicePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/DecoratorServicePassTest.php
@@ -197,7 +197,7 @@ class DecoratorServicePassTest extends TestCase
 
         $this->process($container);
 
-        $this->assertEmpty($container->getDefinition('baz.inner')->getTags());
+        $this->assertSame([], $container->getDefinition('baz.inner')->getTags());
         $this->assertEquals(['bar' => ['attr' => 'baz'], 'foobar' => ['attr' => 'bar'], 'container.decorator' => [['id' => 'foo', 'inner' => 'baz.inner']]], $container->getDefinition('baz')->getTags());
     }
 
@@ -220,7 +220,7 @@ class DecoratorServicePassTest extends TestCase
 
         $this->process($container);
 
-        $this->assertEmpty($container->getDefinition('deco1')->getTags());
+        $this->assertSame([], $container->getDefinition('deco1')->getTags());
         $this->assertEquals(['bar' => ['attr' => 'baz'], 'container.decorator' => [['id' => 'foo', 'inner' => 'deco1.inner']]], $container->getDefinition('deco2')->getTags());
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/PassConfigTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/PassConfigTest.php
@@ -45,10 +45,10 @@ class PassConfigTest extends TestCase
         $config->setOptimizationPasses([]);
         $config->setRemovingPasses([]);
 
-        $this->assertEmpty($config->getBeforeOptimizationPasses());
-        $this->assertEmpty($config->getAfterRemovingPasses());
-        $this->assertEmpty($config->getBeforeRemovingPasses());
-        $this->assertEmpty($config->getOptimizationPasses());
-        $this->assertEmpty($config->getRemovingPasses());
+        $this->assertSame([], $config->getBeforeOptimizationPasses());
+        $this->assertSame([], $config->getAfterRemovingPasses());
+        $this->assertSame([], $config->getBeforeRemovingPasses());
+        $this->assertSame([], $config->getOptimizationPasses());
+        $this->assertSame([], $config->getRemovingPasses());
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInstanceofConditionalsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInstanceofConditionalsPassTest.php
@@ -39,7 +39,7 @@ class ResolveInstanceofConditionalsPassTest extends TestCase
 
         $parent = '.instanceof.'.parent::class.'.0.foo';
         $def = $container->getDefinition('foo');
-        $this->assertEmpty($def->getInstanceofConditionals());
+        $this->assertSame([], $def->getInstanceofConditionals());
         $this->assertInstanceOf(ChildDefinition::class, $def);
         $this->assertTrue($def->isAutowired());
         $this->assertSame($parent, $def->getParent());
@@ -266,10 +266,10 @@ class ResolveInstanceofConditionalsPassTest extends TestCase
 
         $abstract = $container->getDefinition('.abstract.instanceof.bar');
 
-        $this->assertEmpty($abstract->getArguments());
-        $this->assertEmpty($abstract->getMethodCalls());
+        $this->assertSame([], $abstract->getArguments());
+        $this->assertSame([], $abstract->getMethodCalls());
         $this->assertNull($abstract->getDecoratedService());
-        $this->assertEmpty($abstract->getTags());
+        $this->assertSame([], $abstract->getTags());
         $this->assertTrue($abstract->isAbstract());
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -1150,7 +1150,7 @@ class ContainerBuilderTest extends TestCase
         $container->setResourceTracking(false);
         $container->addObjectResource(new \BarClass());
 
-        $this->assertEmpty($container->getResources(), 'No resources get registered without resource tracking');
+        $this->assertSame([], $container->getResources(), 'No resources get registered without resource tracking');
 
         $container->setResourceTracking(true);
         $container->addObjectResource(new \BarClass());
@@ -1173,7 +1173,7 @@ class ContainerBuilderTest extends TestCase
         $container->setResourceTracking(false);
         $r1 = $container->getReflectionClass('BarClass');
 
-        $this->assertEmpty($container->getResources(), 'No resources get registered without resource tracking');
+        $this->assertSame([], $container->getResources(), 'No resources get registered without resource tracking');
 
         $container->setResourceTracking(true);
         $r2 = $container->getReflectionClass('BarClass');
@@ -1213,7 +1213,7 @@ class ContainerBuilderTest extends TestCase
     {
         $container = new ContainerBuilder();
 
-        $this->assertEmpty($container->getResources(), 'No resources get registered without resource tracking');
+        $this->assertSame([], $container->getResources(), 'No resources get registered without resource tracking');
 
         $container->register('foo', 'BarClass')->setPublic(true);
         $container->getDefinition('foo')->setLazy(true);
@@ -1372,7 +1372,7 @@ class ContainerBuilderTest extends TestCase
         $container = new ContainerBuilder();
 
         $configs = $container->getExtensionConfig('foo');
-        $this->assertEmpty($configs);
+        $this->assertSame([], $configs);
 
         $first = ['foo' => 'bar'];
         $container->prependExtensionConfig('foo', $first);

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -986,7 +986,7 @@ class PhpDumperTest extends TestCase
             }
         }
 
-        $this->assertEmpty(iterator_to_array($lazyContext->lazyEmptyValues));
+        $this->assertSame([], iterator_to_array($lazyContext->lazyEmptyValues));
     }
 
     public function testNormalizedId()

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -850,7 +850,7 @@ class YamlFileLoaderTest extends TestCase
         $anonymous = $container->getDefinition((string) $args['foo']);
         $this->assertEquals('Anonymous', $anonymous->getClass());
         $this->assertFalse($anonymous->isPublic());
-        $this->assertEmpty($anonymous->getInstanceofConditionals());
+        $this->assertSame([], $anonymous->getInstanceofConditionals());
 
         $this->assertFalse($container->has('Bar'));
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/EnvPlaceholderParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/EnvPlaceholderParameterBagTest.php
@@ -66,7 +66,7 @@ class EnvPlaceholderParameterBagTest extends TestCase
         // initialize placeholder only in second bag
         $secondBag->get($parameter);
 
-        $this->assertEmpty($firstBag->getEnvPlaceholders());
+        $this->assertSame([], $firstBag->getEnvPlaceholders());
 
         $firstBag->mergeEnvPlaceholders($secondBag);
         $mergedPlaceholders = $firstBag->getEnvPlaceholders();

--- a/src/Symfony/Component/DomCrawler/Tests/Html5ParserCrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Html5ParserCrawlerTest.php
@@ -43,7 +43,7 @@ class Html5ParserCrawlerTest extends AbstractCrawlerTestCase
     {
         $crawler = $this->createCrawler();
         $crawler->addHtmlContent($content);
-        self::assertEmpty($crawler->filterXPath('//h1')->text(), '->addHtmlContent failed as expected');
+        self::assertSame('', $crawler->filterXPath('//h1')->text(), '->addHtmlContent failed as expected');
     }
 
     public function testHtml5ParserNotSameAsNativeParserForSpecificHtml()

--- a/src/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
@@ -182,7 +182,7 @@ class TraceableEventDispatcherTest extends TestCase
     {
         $tdispatcher = new TraceableEventDispatcher(new EventDispatcher(), new Stopwatch());
         $events = $tdispatcher->getOrphanedEvents();
-        $this->assertEmpty($events);
+        $this->assertSame([], $events);
     }
 
     public function testItReturnsOrphanedEventsAfterDispatch()
@@ -200,7 +200,7 @@ class TraceableEventDispatcherTest extends TestCase
         $tdispatcher->addListener('foo', function () {});
         $tdispatcher->dispatch(new Event(), 'foo');
         $events = $tdispatcher->getOrphanedEvents();
-        $this->assertEmpty($events);
+        $this->assertSame([], $events);
     }
 
     public function testLogger()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -878,7 +878,7 @@ class ChoiceTypeTest extends BaseTypeTestCase
 
         $this->assertSame('b', $form->getData());
         $this->assertSame('b', $form->getViewData());
-        $this->assertEmpty($form->getExtraData());
+        $this->assertSame([], $form->getExtraData());
         $this->assertTrue($form->isSynchronized());
 
         $this->assertFalse($form[0]->getData());
@@ -906,7 +906,7 @@ class ChoiceTypeTest extends BaseTypeTestCase
 
         $this->assertNull($form->getData());
         $this->assertSame('foobar', $form->getViewData());
-        $this->assertEmpty($form->getExtraData());
+        $this->assertSame([], $form->getExtraData());
         $this->assertFalse($form->isSynchronized());
 
         $this->assertFalse($form[0]->getData());
@@ -934,7 +934,7 @@ class ChoiceTypeTest extends BaseTypeTestCase
 
         $this->assertSame('b', $form->getData());
         $this->assertSame('b', $form->getViewData());
-        $this->assertEmpty($form->getExtraData());
+        $this->assertSame([], $form->getExtraData());
         $this->assertTrue($form->isSynchronized());
 
         $this->assertFalse($form['placeholder']->getData());
@@ -964,7 +964,7 @@ class ChoiceTypeTest extends BaseTypeTestCase
 
         $this->assertNull($form->getData());
         $this->assertSame('foobar', $form->getViewData());
-        $this->assertEmpty($form->getExtraData());
+        $this->assertSame([], $form->getExtraData());
         $this->assertFalse($form->isSynchronized());
 
         $this->assertFalse($form[0]->getData());
@@ -1348,7 +1348,7 @@ class ChoiceTypeTest extends BaseTypeTestCase
 
         $this->assertSame(['a', 'c'], $form->getData());
         $this->assertSame(['a', 'c'], $form->getViewData());
-        $this->assertEmpty($form->getExtraData());
+        $this->assertSame([], $form->getExtraData());
         $this->assertTrue($form->isSynchronized());
 
         $this->assertTrue($form[0]->getData());
@@ -1375,7 +1375,7 @@ class ChoiceTypeTest extends BaseTypeTestCase
 
         $this->assertNull($form->getData());
         $this->assertSame('foobar', $form->getViewData());
-        $this->assertEmpty($form->getExtraData());
+        $this->assertSame([], $form->getExtraData());
         $this->assertFalse($form->isSynchronized());
 
         $this->assertFalse($form[0]->getData());
@@ -1402,7 +1402,7 @@ class ChoiceTypeTest extends BaseTypeTestCase
 
         $this->assertSame(['a'], $form->getData());
         $this->assertSame(['a'], $form->getViewData());
-        $this->assertEmpty($form->getExtraData());
+        $this->assertSame([], $form->getExtraData());
         $this->assertFalse($form->isValid());
 
         $this->assertTrue($form[0]->getData());

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ColorTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ColorTypeTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
 use Symfony\Component\Form\Extension\Core\Type\ColorType;
 use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormErrorIterator;
 
 final class ColorTypeTest extends BaseTypeTestCase
 {
@@ -30,7 +31,8 @@ final class ColorTypeTest extends BaseTypeTestCase
 
         $form->submit($submittedValue);
 
-        $this->assertEmpty($form->getErrors());
+        $this->assertInstanceOf(FormErrorIterator::class, $form->getErrors());
+        $this->assertCount(0, $form->getErrors());
     }
 
     public static function validationShouldPassProvider(): array

--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/EventListener/CsrfValidationListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/EventListener/CsrfValidationListenerTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\Extension\Core\DataMapper\DataMapper;
 use Symfony\Component\Form\Extension\Csrf\EventListener\CsrfValidationListener;
 use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Form\FormErrorIterator;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormFactoryBuilder;
 use Symfony\Component\Form\FormFactoryInterface;
@@ -65,7 +66,8 @@ class CsrfValidationListenerTest extends TestCase
         $validation = new CsrfValidationListener('csrf', $this->tokenManager, 'unknown', 'Invalid.');
         $validation->preSubmit($event);
 
-        $this->assertNotEmpty($this->form->getErrors());
+        $this->assertInstanceOf(FormErrorIterator::class, $this->form->getErrors());
+        $this->assertGreaterThan(0, count($this->form->getErrors()));
     }
 
     public function testMaxPostSizeExceeded()
@@ -74,7 +76,8 @@ class CsrfValidationListenerTest extends TestCase
         $validation = new CsrfValidationListener('csrf', $this->tokenManager, 'unknown', 'Error message', null, null, new ServerParamsPostMaxSizeExceeded());
 
         $validation->preSubmit($event);
-        $this->assertEmpty($this->form->getErrors());
+        $this->assertInstanceOf(FormErrorIterator::class, $this->form->getErrors());
+        $this->assertCount(0, $this->form->getErrors());
     }
 }
 

--- a/src/Symfony/Component/Form/Tests/FormBuilderTest.php
+++ b/src/Symfony/Component/Form/Tests/FormBuilderTest.php
@@ -173,8 +173,8 @@ class FormBuilderTest extends TestCase
         $children = $reflClass->getProperty('children');
         $unresolvedChildren = $reflClass->getProperty('unresolvedChildren');
 
-        $this->assertEmpty($children->getValue($config));
-        $this->assertEmpty($unresolvedChildren->getValue($config));
+        $this->assertSame([], $children->getValue($config));
+        $this->assertSame([], $unresolvedChildren->getValue($config));
     }
 
     public function testGetButtonBuilderBeforeExplicitlyResolvingAllChildren()

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -253,7 +253,7 @@ class ParameterBagTest extends TestCase
             'array' => ['bang'],
         ]);
 
-        $this->assertEmpty($bag->filter('nokey'), '->filter() should return empty by default if no key is found');
+        $this->assertSame('', $bag->filter('nokey'), '->filter() should return empty by default if no key is found');
 
         $this->assertEquals('0123', $bag->filter('digits', '', \FILTER_SANITIZE_NUMBER_INT), '->filter() gets a value of parameter as integer filtering out invalid characters');
 

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
@@ -127,7 +127,7 @@ class ResponseTest extends ResponseTestCase
         ob_start();
         $modified->sendContent();
         $string = ob_get_clean();
-        $this->assertEmpty($string);
+        $this->assertSame('', $string);
     }
 
     public function testIsSuccessful()

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
@@ -352,7 +352,7 @@ class PdoSessionHandlerTest extends TestCase
         $pdoSessionHandler = new PdoSessionHandler($this->getMemorySqlitePdo());
         $pdoSessionHandler->configureSchema($schema, fn () => true);
         $table = $schema->getTable('sessions');
-        $this->assertEmpty($table->getColumns(), 'The table was not overwritten');
+        $this->assertSame([], $table->getColumns(), 'The table was not overwritten');
     }
 
     public static function provideUrlDsnPairs()

--- a/src/Symfony/Component/HttpFoundation/Tests/StreamedResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/StreamedResponseTest.php
@@ -133,7 +133,7 @@ class StreamedResponseTest extends TestCase
         ob_start();
         $modified->sendContent();
         $string = ob_get_clean();
-        $this->assertEmpty($string);
+        $this->assertSame('', $string);
     }
 
     public function testSendInformationalResponse()

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/TraceableValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/TraceableValueResolverTest.php
@@ -32,7 +32,7 @@ class TraceableValueResolverTest extends TestCase
         foreach ($iterable as $index => $resolved) {
             $event = $stopwatch->getEvent(ResolverStub::class.'::resolve');
             $this->assertTrue($event->isStarted());
-            $this->assertEmpty($event->getPeriods());
+            $this->assertSame([], $event->getPeriods());
             switch ($index) {
                 case 0:
                     $this->assertEquals('first', $resolved);

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/UploadedFileValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/UploadedFileValueResolverTest.php
@@ -85,7 +85,7 @@ class UploadedFileValueResolverTest extends TestCase
         $resolver->onKernelControllerArguments($event);
         $data = $event->getArguments()[0];
 
-        $this->assertEmpty($data);
+        $this->assertSame([], $data);
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/DumpDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/DumpDataCollectorTest.php
@@ -79,7 +79,7 @@ class DumpDataCollectorTest extends TestCase
         // Collect doesn't re-trigger dump
         ob_start();
         $collector->collect(new Request(), new Response());
-        $this->assertEmpty(ob_get_clean());
+        $this->assertSame('', ob_get_clean());
         $this->assertStringMatchesFormat('%a;a:%d:{i:0;a:6:{s:4:"data";%c:39:"Symfony\Component\VarDumper\Cloner\Data":%a', serialize($collector));
     }
 
@@ -157,7 +157,7 @@ EOTXT;
 
         ob_start();
         $collector->__destruct();
-        $this->assertEmpty(ob_get_clean());
+        $this->assertSame('', ob_get_clean());
     }
 
     public function testNullContentTypeWithNoDebugEnv()
@@ -175,6 +175,6 @@ EOTXT;
 
         ob_start();
         $collector->__destruct();
-        $this->assertEmpty(ob_get_clean());
+        $this->assertSame('', ob_get_clean());
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/AddAnnotatedClassesToCachePassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/AddAnnotatedClassesToCachePassTest.php
@@ -36,33 +36,33 @@ class AddAnnotatedClassesToCachePassTest extends TestCase
 
         $this->assertSame('Foo\\Bar', $expand(['Foo\\'], ['\\Foo\\Bar'])[0]);
         $this->assertSame('Foo\\Bar\\Acme', $expand(['Foo\\'], ['\\Foo\\Bar\\Acme'])[0]);
-        $this->assertEmpty($expand(['Foo\\'], ['\\Foo']));
+        $this->assertSame([], $expand(['Foo\\'], ['\\Foo']));
 
         $this->assertSame('Acme\\Foo\\Bar', $expand(['**\\Foo\\'], ['\\Acme\\Foo\\Bar'])[0]);
-        $this->assertEmpty($expand(['**\\Foo\\'], ['\\Foo\\Bar']));
-        $this->assertEmpty($expand(['**\\Foo\\'], ['\\Acme\\Foo']));
-        $this->assertEmpty($expand(['**\\Foo\\'], ['\\Foo']));
+        $this->assertSame([], $expand(['**\\Foo\\'], ['\\Foo\\Bar']));
+        $this->assertSame([], $expand(['**\\Foo\\'], ['\\Acme\\Foo']));
+        $this->assertSame([], $expand(['**\\Foo\\'], ['\\Foo']));
 
         $this->assertSame('Acme\\Foo', $expand(['**\\Foo'], ['\\Acme\\Foo'])[0]);
-        $this->assertEmpty($expand(['**\\Foo'], ['\\Acme\\Foo\\AcmeBundle']));
-        $this->assertEmpty($expand(['**\\Foo'], ['\\Acme\\FooBar\\AcmeBundle']));
+        $this->assertSame([], $expand(['**\\Foo'], ['\\Acme\\Foo\\AcmeBundle']));
+        $this->assertSame([], $expand(['**\\Foo'], ['\\Acme\\FooBar\\AcmeBundle']));
 
         $this->assertSame('Foo\\Acme\\Bar', $expand(['Foo\\*\\Bar'], ['\\Foo\\Acme\\Bar'])[0]);
-        $this->assertEmpty($expand(['Foo\\*\\Bar'], ['\\Foo\\Acme\\Bundle\\Bar']));
+        $this->assertSame([], $expand(['Foo\\*\\Bar'], ['\\Foo\\Acme\\Bundle\\Bar']));
 
         $this->assertSame('Foo\\Acme\\Bar', $expand(['Foo\\**\\Bar'], ['\\Foo\\Acme\\Bar'])[0]);
         $this->assertSame('Foo\\Acme\\Bundle\\Bar', $expand(['Foo\\**\\Bar'], ['\\Foo\\Acme\\Bundle\\Bar'])[0]);
 
         $this->assertSame('Acme\\Bar', $expand(['*\\Bar'], ['\\Acme\\Bar'])[0]);
-        $this->assertEmpty($expand(['*\\Bar'], ['\\Bar']));
-        $this->assertEmpty($expand(['*\\Bar'], ['\\Foo\\Acme\\Bar']));
+        $this->assertSame([], $expand(['*\\Bar'], ['\\Bar']));
+        $this->assertSame([], $expand(['*\\Bar'], ['\\Foo\\Acme\\Bar']));
 
         $this->assertSame('Foo\\Acme\\Bar', $expand(['**\\Bar'], ['\\Foo\\Acme\\Bar'])[0]);
         $this->assertSame('Foo\\Acme\\Bundle\\Bar', $expand(['**\\Bar'], ['\\Foo\\Acme\\Bundle\\Bar'])[0]);
-        $this->assertEmpty($expand(['**\\Bar'], ['\\Bar']));
+        $this->assertSame([], $expand(['**\\Bar'], ['\\Bar']));
 
         $this->assertSame('Foo\\Bar', $expand(['Foo\\*'], ['\\Foo\\Bar'])[0]);
-        $this->assertEmpty($expand(['Foo\\*'], ['\\Foo\\Acme\\Bar']));
+        $this->assertSame([], $expand(['Foo\\*'], ['\\Foo\\Acme\\Bar']));
 
         $this->assertSame('Foo\\Bar', $expand(['Foo\\**'], ['\\Foo\\Bar'])[0]);
         $this->assertSame('Foo\\Acme\\Bar', $expand(['Foo\\**'], ['\\Foo\\Acme\\Bar'])[0]);

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
@@ -277,7 +277,7 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
         $pass->process($container);
 
         $locator = $container->getDefinition((string) $resolver->getArgument(0))->getArgument(0);
-        $this->assertEmpty(array_keys($locator));
+        $this->assertSame([], array_keys($locator));
     }
 
     public function testControllersAreMadePublic()
@@ -440,7 +440,7 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
         $pass->process($container);
 
         $locator = $container->getDefinition((string) $resolver->getArgument(0))->getArgument(0);
-        $this->assertEmpty(array_keys($locator), 'enum typed argument is ignored');
+        $this->assertSame([], array_keys($locator), 'enum typed argument is ignored');
     }
 
     public function testBindWithTarget()
@@ -480,7 +480,7 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
         (new RegisterControllerArgumentLocatorsPass())->process($container);
 
         $locator = $container->getDefinition((string) $resolver->getArgument(0))->getArgument(0);
-        $this->assertEmpty(array_keys($locator), 'Response typed argument is ignored');
+        $this->assertSame([], array_keys($locator), 'Response typed argument is ignored');
     }
 
     public function testAutowireAttribute()

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/SessionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/SessionListenerTest.php
@@ -896,8 +896,8 @@ class SessionListenerTest extends TestCase
 
         (new SessionListener($container, true))->reset();
 
-        $this->assertEmpty($_SESSION);
-        $this->assertEmpty(session_id());
+        $this->assertSame([], $_SESSION);
+        $this->assertSame('', session_id());
         $this->assertSame(\PHP_SESSION_NONE, session_status());
     }
 
@@ -917,8 +917,8 @@ class SessionListenerTest extends TestCase
 
         (new SessionListener($container, true))->reset();
 
-        $this->assertEmpty($_SESSION);
-        $this->assertEmpty(session_id());
+        $this->assertSame([], $_SESSION);
+        $this->assertSame('', session_id());
         $this->assertSame(\PHP_SESSION_NONE, session_status());
     }
 

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
@@ -97,7 +97,7 @@ class InlineFragmentRendererTest extends TestCase
 
         $strategy = new InlineFragmentRenderer($kernel, $dispatcher);
 
-        $this->assertEmpty($strategy->render('/', $request, ['ignore_errors' => true])->getContent());
+        $this->assertSame('', $strategy->render('/', $request, ['ignore_errors' => true])->getContent());
     }
 
     public function testRenderExceptionIgnoreErrorsWithAlt()

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
@@ -195,7 +195,7 @@ class HttpCacheTest extends HttpCacheTestCase
         $this->assertHttpKernelIsCalled();
         $this->assertEquals(304, $this->response->getStatusCode());
         $this->assertEquals('', $this->response->headers->get('Content-Type'));
-        $this->assertEmpty($this->response->getContent());
+        $this->assertSame('', $this->response->getContent());
         $this->assertTraceContains('miss');
         $this->assertTraceContains('store');
     }
@@ -209,7 +209,7 @@ class HttpCacheTest extends HttpCacheTestCase
         $this->assertEquals(304, $this->response->getStatusCode());
         $this->assertEquals('', $this->response->headers->get('Content-Type'));
         $this->assertTrue($this->response->headers->has('ETag'));
-        $this->assertEmpty($this->response->getContent());
+        $this->assertSame('', $this->response->getContent());
         $this->assertTraceContains('miss');
         $this->assertTraceContains('store');
     }
@@ -1281,7 +1281,7 @@ class HttpCacheTest extends HttpCacheTestCase
 
         $this->request('HEAD', '/', [], [], true);
 
-        $this->assertEmpty($this->response->getContent());
+        $this->assertSame('', $this->response->getContent());
         $this->assertEquals(100, $this->response->getTtl());
     }
 
@@ -1510,7 +1510,7 @@ class HttpCacheTest extends HttpCacheTestCase
 
         // The response has been assembled from expiration and validation based resources
         // This can neither be cached nor revalidated, so it should be private/no cache
-        $this->assertEmpty($this->response->getContent());
+        $this->assertSame('', $this->response->getContent());
         $this->assertNull($this->response->getTtl());
         $this->assertTrue($this->response->headers->hasCacheControlDirective('private'));
         $this->assertTrue($this->response->headers->hasCacheControlDirective('no-cache'));
@@ -1568,7 +1568,7 @@ class HttpCacheTest extends HttpCacheTestCase
         // in decimal number of OCTETs, sent to the recipient or, in the case of the HEAD
         // method, the size of the entity-body that would have been sent had the request
         // been a GET."
-        $this->assertEmpty($this->response->getContent());
+        $this->assertSame('', $this->response->getContent());
         $this->assertEquals(12, $this->response->headers->get('Content-Length'));
     }
 
@@ -1692,7 +1692,7 @@ class HttpCacheTest extends HttpCacheTestCase
         $this->setNextResponses($responses);
 
         $this->request('HEAD', '/', [], [], true);
-        $this->assertEmpty($this->response->getContent());
+        $this->assertSame('', $this->response->getContent());
         $this->assertNull($this->response->getETag());
         $this->assertNull($this->response->getLastModified());
     }

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/StoreTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/StoreTest.php
@@ -40,7 +40,7 @@ class StoreTest extends TestCase
 
     public function testReadsAnEmptyArrayWithReadWhenNothingCachedAtKey()
     {
-        $this->assertEmpty($this->getStoreMetadata('/nothing'));
+        $this->assertSame([], $this->getStoreMetadata('/nothing'));
     }
 
     public function testUnlockFileThatDoesExist()
@@ -65,7 +65,7 @@ class StoreTest extends TestCase
         $this->assertNotEmpty($metadata);
 
         $this->assertTrue($this->store->purge('/foo'));
-        $this->assertEmpty($this->getStoreMetadata($request));
+        $this->assertSame([], $this->getStoreMetadata($request));
 
         // cached content should be kept after purging
         $path = $this->store->getPath($metadata[0][1]['x-content-digest'][0]);
@@ -291,7 +291,7 @@ class StoreTest extends TestCase
         $this->assertNotEmpty($this->getStoreMetadata($request));
 
         $this->assertTrue($this->store->purge('https://example.com/foo'));
-        $this->assertEmpty($this->getStoreMetadata($request));
+        $this->assertSame([], $this->getStoreMetadata($request));
     }
 
     public function testPurgeHttpAndHttps()
@@ -306,8 +306,8 @@ class StoreTest extends TestCase
         $this->assertNotEmpty($this->getStoreMetadata($requestHttps));
 
         $this->assertTrue($this->store->purge('http://example.com/foo'));
-        $this->assertEmpty($this->getStoreMetadata($requestHttp));
-        $this->assertEmpty($this->getStoreMetadata($requestHttps));
+        $this->assertSame([], $this->getStoreMetadata($requestHttp));
+        $this->assertSame([], $this->getStoreMetadata($requestHttps));
     }
 
     public function testDoesNotStorePrivateHeaders()

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/FileProfilerStorageTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/FileProfilerStorageTest.php
@@ -292,7 +292,7 @@ class FileProfilerStorageTest extends TestCase
 
         $this->storage->purge();
 
-        $this->assertEmpty($this->storage->read('token'), '->purge() removes all data stored by profiler');
+        $this->assertNull($this->storage->read('token'), '->purge() removes all data stored by profiler');
         $this->assertCount(0, $this->storage->find('127.0.0.1', '', 10, 'GET'), '->purge() removes all items from index');
     }
 

--- a/src/Symfony/Component/Intl/Tests/LanguagesTest.php
+++ b/src/Symfony/Component/Intl/Tests/LanguagesTest.php
@@ -1725,7 +1725,7 @@ class LanguagesTest extends ResourceBundleTestCase
         sort($languages);
 
         $this->assertNotEmpty($languages);
-        $this->assertEmpty(array_diff($languages, self::LANGUAGES));
+        $this->assertSame([], array_diff($languages, self::LANGUAGES));
 
         foreach (Languages::getAlpha3Names($displayLocale) as $alpha3Code => $name) {
             $alpha2Code = self::ALPHA3_TO_ALPHA2[$alpha3Code] ?? null;
@@ -1928,7 +1928,7 @@ class LanguagesTest extends ResourceBundleTestCase
         sort($languages);
 
         $this->assertNotEmpty($languages);
-        $this->assertEmpty(array_diff($languages, self::ALPHA3_CODES));
+        $this->assertSame([], array_diff($languages, self::ALPHA3_CODES));
 
         foreach (Languages::getNames($displayLocale) as $alpha2Code => $name) {
             $alpha3Code = self::ALPHA2_TO_ALPHA3[$alpha2Code] ?? (3 === \strlen($alpha2Code) ? $alpha2Code : null);

--- a/src/Symfony/Component/Intl/Tests/LocalesTest.php
+++ b/src/Symfony/Component/Intl/Tests/LocalesTest.php
@@ -46,7 +46,7 @@ class LocalesTest extends ResourceBundleTestCase
         // We can't assert on exact list of locale, as there's too many variations.
         // The best we can do is to make sure getNames() returns a subset of what getLocales() returns.
         $this->assertNotEmpty($locales);
-        $this->assertEmpty(array_diff($locales, static::getLocales()));
+        $this->assertSame([], array_diff($locales, static::getLocales()));
     }
 
     public function testGetNamesDefaultLocale()

--- a/src/Symfony/Component/Intl/Tests/ScriptsTest.php
+++ b/src/Symfony/Component/Intl/Tests/ScriptsTest.php
@@ -254,7 +254,7 @@ class ScriptsTest extends ResourceBundleTestCase
         // We can't assert on exact list of scripts, as there's too many variations between locales.
         // The best we can do is to make sure getNames() returns a subset of what getScripts() returns.
         $this->assertNotEmpty($scripts);
-        $this->assertEmpty(array_diff($scripts, self::$scripts));
+        $this->assertSame([], array_diff($scripts, self::$scripts));
     }
 
     public function testGetNamesDefaultLocale()

--- a/src/Symfony/Component/Intl/Tests/TimezonesTest.php
+++ b/src/Symfony/Component/Intl/Tests/TimezonesTest.php
@@ -473,7 +473,7 @@ class TimezonesTest extends ResourceBundleTestCase
         sort($zones);
 
         $this->assertNotEmpty($zones);
-        $this->assertEmpty(array_diff($zones, self::ZONES));
+        $this->assertSame([], array_diff($zones, self::ZONES));
     }
 
     public function testGetNamesDefaultLocale()

--- a/src/Symfony/Component/Lock/Tests/Store/DoctrineDbalStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/DoctrineDbalStoreTest.php
@@ -300,6 +300,6 @@ class DoctrineDbalStoreTest extends AbstractStoreTestCase
         $someFunction = fn () => true;
         $dbalStore->configureSchema($schema, $someFunction);
         $table = $schema->getTable('lock_keys');
-        $this->assertEmpty($table->getColumns(), 'The table was not overwritten');
+        $this->assertSame([], $table->getColumns(), 'The table was not overwritten');
     }
 }

--- a/src/Symfony/Component/Mailer/Tests/EventListener/MessengerTransportListenerTest.php
+++ b/src/Symfony/Component/Mailer/Tests/EventListener/MessengerTransportListenerTest.php
@@ -29,7 +29,7 @@ class MessengerTransportListenerTest extends TestCase
         $message = new Message(new Headers());
         $event = new MessageEvent($message, $envelope, 'smtp', true);
         $l->onMessage($event);
-        $this->assertEmpty($event->getStamps());
+        $this->assertSame([], $event->getStamps());
     }
 
     public function testMessengerTransportStampViaHeader()

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpExtIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpExtIntegrationTest.php
@@ -72,7 +72,7 @@ class AmqpExtIntegrationTest extends TestCase
         $envelope = $envelopes[0];
         $this->assertEquals($second->getMessage(), $envelope->getMessage());
 
-        $this->assertEmpty(iterator_to_array($receiver->get()));
+        $this->assertSame([], iterator_to_array($receiver->get()));
     }
 
     public function testRetryAndDelay()

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/ConnectionTest.php
@@ -803,7 +803,7 @@ class ConnectionTest extends TestCase
         $connection = new Connection([], $driverConnection);
         $connection->configureSchema($schema, $driverConnection, fn () => true);
         $table = $schema->getTable('messenger_messages');
-        $this->assertEmpty($table->getColumns(), 'The table was not overwritten');
+        $this->assertSame([], $table->getColumns(), 'The table was not overwritten');
     }
 
     /**

--- a/src/Symfony/Component/Messenger/Tests/EnvelopeTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EnvelopeTest.php
@@ -47,7 +47,7 @@ class EnvelopeTest extends TestCase
 
         $envelope = $envelope->withoutAll(ReceivedStamp::class);
 
-        $this->assertEmpty($envelope->all(ReceivedStamp::class));
+        $this->assertSame([], $envelope->all(ReceivedStamp::class));
         $this->assertCount(1, $envelope->all(DelayStamp::class));
     }
 
@@ -70,14 +70,14 @@ class EnvelopeTest extends TestCase
         $this->assertEquals($envelope, $envelope2);
 
         $envelope3 = $envelope2->withoutStampsOfType(ReceivedStamp::class);
-        $this->assertEmpty($envelope3->all(ReceivedStamp::class));
+        $this->assertSame([], $envelope3->all(ReceivedStamp::class));
 
         $envelope4 = $envelope3->withoutStampsOfType(DummyImplementsFooBarStamp::class);
-        $this->assertEmpty($envelope4->all(DummyImplementsFooBarStamp::class));
-        $this->assertEmpty($envelope4->all(DummyExtendsFooBarStamp::class));
+        $this->assertSame([], $envelope4->all(DummyImplementsFooBarStamp::class));
+        $this->assertSame([], $envelope4->all(DummyExtendsFooBarStamp::class));
 
         $envelope5 = $envelope3->withoutStampsOfType(DummyFooBarStampInterface::class);
-        $this->assertEmpty($envelope5->all());
+        $this->assertSame([], $envelope5->all());
     }
 
     public function testWithoutStampsOfTypeWithNonExistentStampClass()

--- a/src/Symfony/Component/Messenger/Tests/FailureIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Tests/FailureIntegrationTest.php
@@ -152,7 +152,7 @@ class FailureIntegrationTest extends TestCase
         $this->assertSame(0, $transport2HandlerThatWorks->getTimesCalled());
         // one handler failed and the message is retried (resent to transport1)
         $this->assertCount(1, $transport1->getMessagesWaitingToBeReceived());
-        $this->assertEmpty($failureTransport->getMessagesWaitingToBeReceived());
+        $this->assertSame([], $failureTransport->getMessagesWaitingToBeReceived());
 
         /*
          * Receive the message for a (final) retry
@@ -210,9 +210,9 @@ class FailureIntegrationTest extends TestCase
         // transport1 handler called for the first time
         $this->assertSame(1, $transport2HandlerThatWorks->getTimesCalled());
         // all transport should be empty
-        $this->assertEmpty($transport1->getMessagesWaitingToBeReceived());
-        $this->assertEmpty($transport2->getMessagesWaitingToBeReceived());
-        $this->assertEmpty($failureTransport->getMessagesWaitingToBeReceived());
+        $this->assertSame([], $transport1->getMessagesWaitingToBeReceived());
+        $this->assertSame([], $transport2->getMessagesWaitingToBeReceived());
+        $this->assertSame([], $failureTransport->getMessagesWaitingToBeReceived());
 
         /*
          * Dispatch the original message again
@@ -225,7 +225,7 @@ class FailureIntegrationTest extends TestCase
         $transport1HandlerThatFails->setShouldThrow(false);
         $runWorker('the_failure_transport');
         // the failure transport is empty because it worked
-        $this->assertEmpty($failureTransport->getMessagesWaitingToBeReceived());
+        $this->assertSame([], $failureTransport->getMessagesWaitingToBeReceived());
     }
 
     public function testMultipleFailedTransportsWithoutGlobalFailureTransport()

--- a/src/Symfony/Component/Messenger/Tests/Transport/InMemory/InMemoryTransportTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/InMemory/InMemoryTransportTest.php
@@ -177,9 +177,9 @@ class InMemoryTransportTest extends TestCase
 
         $this->transport->reset();
 
-        $this->assertEmpty($this->transport->get(), 'Should be empty after reset');
-        $this->assertEmpty($this->transport->getAcknowledged(), 'Should be empty after reset');
-        $this->assertEmpty($this->transport->getRejected(), 'Should be empty after reset');
-        $this->assertEmpty($this->transport->getSent(), 'Should be empty after reset');
+        $this->assertSame([], $this->transport->get(), 'Should be empty after reset');
+        $this->assertSame([], $this->transport->getAcknowledged(), 'Should be empty after reset');
+        $this->assertSame([], $this->transport->getRejected(), 'Should be empty after reset');
+        $this->assertSame([], $this->transport->getSent(), 'Should be empty after reset');
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Transport/Receiver/SingleMessageReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Receiver/SingleMessageReceiverTest.php
@@ -28,7 +28,7 @@ class SingleMessageReceiverTest extends TestCase
         $this->assertCount(1, $received);
         $this->assertSame($received[0], $envelope);
 
-        $this->assertEmpty($receiver->get());
+        $this->assertSame([], $receiver->get());
     }
 
     public function testCallsAreForwarded()

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -1585,7 +1585,7 @@ class OptionsResolverTest extends TestCase
             Assert::fail('Should not be called.');
         });
 
-        $this->assertEmpty($this->resolver->resolve());
+        $this->assertSame([], $this->resolver->resolve());
     }
 
     public function testAddNormalizerReturnsThis()
@@ -1768,7 +1768,7 @@ class OptionsResolverTest extends TestCase
 
         $this->resolver->clear();
 
-        $this->assertEmpty($this->resolver->resolve());
+        $this->assertSame([], $this->resolver->resolve());
     }
 
     public function testClearLazyOption()
@@ -1829,7 +1829,7 @@ class OptionsResolverTest extends TestCase
         $this->resolver->setNormalizer('foo2', fn (Options $options) => '');
 
         $this->resolver->clear();
-        $this->assertEmpty($this->resolver->resolve());
+        $this->assertSame([], $this->resolver->resolve());
     }
 
     public function testArrayAccess()

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -422,7 +422,7 @@ class ProcessTest extends TestCase
 
         $p->run();
         $p->clearErrorOutput();
-        $this->assertEmpty($p->getErrorOutput());
+        $this->assertSame('', $p->getErrorOutput());
     }
 
     /**
@@ -475,7 +475,7 @@ class ProcessTest extends TestCase
 
         $p->run();
         $p->clearOutput();
-        $this->assertEmpty($p->getOutput());
+        $this->assertSame('', $p->getOutput());
     }
 
     public function testZeroAsOutput()

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -832,7 +832,7 @@ class PropertyAccessorTest extends TestCase
         $this->propertyAccessor->setValue($object, 'email', 'test@email.com');
 
         self::assertEquals('test@email.com', $object->getEmail());
-        self::assertEmpty($object->getEmails());
+        self::assertSame([], $object->getEmails());
     }
 
     public function testWriteToPluralPropertyWhileSingularOneExists()

--- a/src/Symfony/Component/Scheduler/Tests/Messenger/SchedulerTransportTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Messenger/SchedulerTransportTest.php
@@ -46,7 +46,7 @@ class SchedulerTransportTest extends TestCase
             $this->assertSame('id'.$i + 1, $stamp->messageContext->id);
         }
 
-        $this->assertEmpty($messages);
+        $this->assertSame([], $messages);
     }
 
     public function testAddsStampToInnerRedispatchMessageEnvelope()

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
@@ -368,13 +368,13 @@ class ContextListenerTest extends TestCase
         $httpKernel = $this->createMock(HttpKernelInterface::class);
 
         $listener = new ContextListener($tokenStorage, [], 'session', null, $dispatcher, null, $tokenStorage->getToken(...));
-        $this->assertEmpty($dispatcher->getListeners());
+        $this->assertSame([], $dispatcher->getListeners());
 
         $listener(new RequestEvent($httpKernel, $request, HttpKernelInterface::MAIN_REQUEST));
         $this->assertNotEmpty($dispatcher->getListeners());
 
         $listener->onKernelResponse(new ResponseEvent($httpKernel, $request, HttpKernelInterface::MAIN_REQUEST, new Response()));
-        $this->assertEmpty($dispatcher->getListeners());
+        $this->assertSame([], $dispatcher->getListeners());
     }
 
     /**

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ExceptionListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ExceptionListenerTest.php
@@ -166,7 +166,7 @@ class ExceptionListenerTest extends TestCase
         $this->assertNotEmpty($dispatcher->getListeners());
 
         $listener->unregister($dispatcher);
-        $this->assertEmpty($dispatcher->getListeners());
+        $this->assertSame([], $dispatcher->getListeners());
     }
 
     public static function getAccessDeniedExceptionProvider()

--- a/src/Symfony/Component/Serializer/Tests/Attribute/ContextTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Attribute/ContextTest.php
@@ -50,9 +50,9 @@ class ContextTest extends TestCase
         $context = new Context(['foo' => 'bar']);
 
         self::assertSame(['foo' => 'bar'], $context->getContext());
-        self::assertEmpty($context->getNormalizationContext());
-        self::assertEmpty($context->getDenormalizationContext());
-        self::assertEmpty($context->getGroups());
+        self::assertSame([], $context->getNormalizationContext());
+        self::assertSame([], $context->getDenormalizationContext());
+        self::assertSame([], $context->getGroups());
     }
 
     public function testAsContextArg()
@@ -60,9 +60,9 @@ class ContextTest extends TestCase
         $context = new Context(context: ['foo' => 'bar']);
 
         self::assertSame(['foo' => 'bar'], $context->getContext());
-        self::assertEmpty($context->getNormalizationContext());
-        self::assertEmpty($context->getDenormalizationContext());
-        self::assertEmpty($context->getGroups());
+        self::assertSame([], $context->getNormalizationContext());
+        self::assertSame([], $context->getDenormalizationContext());
+        self::assertSame([], $context->getGroups());
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Tests/DataCollector/SerializerDataCollectorTest.php
+++ b/src/Symfony/Component/Serializer/Tests/DataCollector/SerializerDataCollectorTest.php
@@ -373,17 +373,17 @@ class SerializerDataCollectorTest extends TestCase
         $this->assertSame('default', $collectedData['normalize'][0]['name']);
         $this->assertSame('ObjectNormalizer', $collectedData['normalize'][0]['normalizer']['class']);
 
-        $this->assertEmpty($collectedData['encode']);
-        $this->assertEmpty($collectedData['deserialize']);
-        $this->assertEmpty($collectedData['denormalize']);
-        $this->assertEmpty($collectedData['decode']);
+        $this->assertSame([], $collectedData['encode']);
+        $this->assertSame([], $collectedData['deserialize']);
+        $this->assertSame([], $collectedData['denormalize']);
+        $this->assertSame([], $collectedData['decode']);
 
         $this->assertSame(4, $dataCollector->getHandledCount('api'));
 
         $collectedData = $dataCollector->getData('api');
 
-        $this->assertEmpty($collectedData['serialize']);
-        $this->assertEmpty($collectedData['normalize']);
+        $this->assertSame([], $collectedData['serialize']);
+        $this->assertSame([], $collectedData['normalize']);
 
         $this->assertSame('api', $collectedData['encode'][0]['name']);
         $this->assertSame('JsonEncoder', $collectedData['encode'][0]['encoder']['class']);

--- a/src/Symfony/Component/Serializer/Tests/DependencyInjection/SerializerPassTest.php
+++ b/src/Symfony/Component/Serializer/Tests/DependencyInjection/SerializerPassTest.php
@@ -567,7 +567,7 @@ class SerializerPassTest extends TestCase
         $serializerPass = new SerializerPass();
         $serializerPass->process($container);
 
-        $this->assertEmpty($definition->getBindings());
+        $this->assertSame([], $definition->getBindings());
 
         $bindings = $container->getDefinition('n1.api')->getBindings();
         $this->assertArrayHasKey('array $defaultContext', $bindings);

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -199,8 +199,7 @@ class ObjectNormalizerTest extends TestCase
             'xml'
         );
 
-        $this->assertIsArray($obj->bar);
-        $this->assertEmpty($obj->bar);
+        $this->assertSame([], $obj->bar);
     }
 
     public function testDenormalizeWithObject()

--- a/src/Symfony/Component/Translation/Tests/DataCollector/TranslationDataCollectorTest.php
+++ b/src/Symfony/Component/Translation/Tests/DataCollector/TranslationDataCollectorTest.php
@@ -147,7 +147,7 @@ class TranslationDataCollectorTest extends TestCase
         $dataCollector->reset();
 
         $this->assertNull($dataCollector->getLocale());
-        $this->assertEmpty($dataCollector->getFallbackLocales());
+        $this->assertSame([], $dataCollector->getFallbackLocales());
     }
 
     private function getTranslator()

--- a/src/Symfony/Component/Validator/Test/CompoundConstraintTestCase.php
+++ b/src/Symfony/Component/Validator/Test/CompoundConstraintTestCase.php
@@ -102,7 +102,8 @@ abstract class CompoundConstraintTestCase extends TestCase
             next($expectedViolations);
         }
 
-        $this->assertEmpty(
+        $this->assertSame(
+            [],
             $failedToAssertViolations,
             \sprintf('Expected violation(s) for constraint(s) %s to be raised by compound.',
                 implode(', ', array_map(fn ($violation) => ($violation->getConstraint())::class, $failedToAssertViolations))

--- a/src/Symfony/Component/Validator/Tests/Constraints/WhenTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/WhenTest.php
@@ -61,7 +61,7 @@ final class WhenTest extends TestCase
                 groups: ['Default', 'WhenTestWithAttributes'],
             ),
         ], $classConstraint->constraints);
-        self::assertEmpty($classConstraint->otherwise);
+        self::assertSame([], $classConstraint->otherwise);
 
         [$fooConstraint] = $metadata->properties['foo']->getConstraints();
 
@@ -71,7 +71,7 @@ final class WhenTest extends TestCase
             new NotNull(groups: ['Default', 'WhenTestWithAttributes']),
             new NotBlank(groups: ['Default', 'WhenTestWithAttributes']),
         ], $fooConstraint->constraints);
-        self::assertEmpty($fooConstraint->otherwise);
+        self::assertSame([], $fooConstraint->otherwise);
         self::assertSame(['Default', 'WhenTestWithAttributes'], $fooConstraint->groups);
 
         [$barConstraint] = $metadata->properties['bar']->getConstraints();
@@ -82,7 +82,7 @@ final class WhenTest extends TestCase
             new NotNull(groups: ['foo']),
             new NotBlank(groups: ['foo']),
         ], $barConstraint->constraints);
-        self::assertEmpty($barConstraint->otherwise);
+        self::assertSame([], $barConstraint->otherwise);
         self::assertSame(['foo'], $barConstraint->groups);
 
         [$quxConstraint] = $metadata->properties['qux']->getConstraints();
@@ -90,7 +90,7 @@ final class WhenTest extends TestCase
         self::assertInstanceOf(When::class, $quxConstraint);
         self::assertSame('true', $quxConstraint->expression);
         self::assertEquals([new NotNull(groups: ['foo'])], $quxConstraint->constraints);
-        self::assertEmpty($quxConstraint->otherwise);
+        self::assertSame([], $quxConstraint->otherwise);
         self::assertSame(['foo'], $quxConstraint->groups);
 
         [$bazConstraint] = $metadata->getters['baz']->getConstraints();
@@ -101,7 +101,7 @@ final class WhenTest extends TestCase
             new NotNull(groups: ['Default', 'WhenTestWithAttributes']),
             new NotBlank(groups: ['Default', 'WhenTestWithAttributes']),
         ], $bazConstraint->constraints);
-        self::assertEmpty($bazConstraint->otherwise);
+        self::assertSame([], $bazConstraint->otherwise);
         self::assertSame(['Default', 'WhenTestWithAttributes'], $bazConstraint->groups);
 
         [$quuxConstraint] = $metadata->properties['quux']->getConstraints();
@@ -135,7 +135,7 @@ final class WhenTest extends TestCase
                 groups: ['Default', 'WhenTestWithClosure'],
             ),
         ], $classConstraint->constraints);
-        self::assertEmpty($classConstraint->otherwise);
+        self::assertSame([], $classConstraint->otherwise);
 
         [$fooConstraint] = $metadata->properties['foo']->getConstraints();
 
@@ -145,7 +145,7 @@ final class WhenTest extends TestCase
             new NotNull(groups: ['Default', 'WhenTestWithClosure']),
             new NotBlank(groups: ['Default', 'WhenTestWithClosure']),
         ], $fooConstraint->constraints);
-        self::assertEmpty($fooConstraint->otherwise);
+        self::assertSame([], $fooConstraint->otherwise);
         self::assertSame(['Default', 'WhenTestWithClosure'], $fooConstraint->groups);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/PropertyInfoLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/PropertyInfoLoaderTest.php
@@ -214,7 +214,7 @@ class PropertyInfoLoaderTest extends TestCase
         $this->assertInstanceOf(Iban::class, $alreadyPartiallyMappedCollectionConstraints[0]->constraints[1]);
 
         $readOnlyMetadata = $classMetadata->getPropertyMetadata('readOnly');
-        $this->assertEmpty($readOnlyMetadata);
+        $this->assertSame([], $readOnlyMetadata);
 
         /** @var PropertyMetadata[] $noAutoMappingMetadata */
         $noAutoMappingMetadata = $classMetadata->getPropertyMetadata('noAutoMapping');
@@ -298,7 +298,7 @@ class PropertyInfoLoaderTest extends TestCase
 
         /** @var ClassMetadata $classMetadata */
         $classMetadata = $validator->getMetadataFor(new PropertyInfoLoaderNoAutoMappingEntity());
-        $this->assertEmpty($classMetadata->getPropertyMetadata('string'));
+        $this->assertSame([], $classMetadata->getPropertyMetadata('string'));
         $this->assertCount(2, $classMetadata->getPropertyMetadata('autoMappingExplicitlyEnabled')[0]->constraints);
         $this->assertSame(AutoMappingStrategy::ENABLED, $classMetadata->getPropertyMetadata('autoMappingExplicitlyEnabled')[0]->getAutoMappingStrategy());
     }

--- a/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
@@ -734,7 +734,7 @@ class WorkflowTest extends TestCase
         });
         $workflow = new Workflow($definition, new MethodMarkingStore(), $eventDispatcher, 'workflow_name');
 
-        $this->assertEmpty($workflow->getEnabledTransitions($subject));
+        $this->assertSame([], $workflow->getEnabledTransitions($subject));
 
         $subject->setMarking(['d' => 1]);
         $transitions = $workflow->getEnabledTransitions($subject);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

In the code we are strict about not using `empty()`. In my opinion it makes sense to be equally strict with our assertions. But I'd like to gather some feedback first before updating all places.
