### PR TITLE
[DoctrineBridge] add new `DatePointType` Doctrine type

### DIFF
--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Reset the manager registry using native lazy objects when applicable
  * Deprecate the `DoctrineExtractor::getTypes()` method, use `DoctrineExtractor::getType()` instead
+ * Add support for `Symfony\Component\Clock\DatePoint` as `DatePointType` Doctrine type
 
 7.2
 ---

--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterDatePointTypePass.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterDatePointTypePass.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass;
+
+use Symfony\Bridge\Doctrine\Types\DatePointType;
+use Symfony\Component\Clock\DatePoint;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class RegisterDatePointTypePass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!class_exists(DatePoint::class)) {
+            return;
+        }
+
+        if (!$container->hasParameter('doctrine.dbal.connection_factory.types')) {
+            return;
+        }
+
+        $types = $container->getParameter('doctrine.dbal.connection_factory.types');
+
+        $types['date_point'] ??= ['class' => DatePointType::class];
+
+        $container->setParameter('doctrine.dbal.connection_factory.types', $types);
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterDatePointTypePassTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterDatePointTypePassTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\DependencyInjection\CompilerPass;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\RegisterDatePointTypePass;
+use Symfony\Bridge\Doctrine\Types\DatePointType;
+use Symfony\Component\Clock\DatePoint;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class RegisterDatePointTypePassTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!class_exists(DatePoint::class)) {
+            self::markTestSkipped('The DatePoint class is not available.');
+        }
+    }
+
+    public function testRegistered()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('doctrine.dbal.connection_factory.types', ['foo' => 'bar']);
+        (new RegisterDatePointTypePass())->process($container);
+
+        $expected = [
+            'foo' => 'bar',
+            'date_point' => ['class' => DatePointType::class],
+        ];
+        $this->assertSame($expected, $container->getParameter('doctrine.dbal.connection_factory.types'));
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Types/DatePointTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Types/DatePointTypeTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MariaDBPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Doctrine\Types\DatePointType;
+use Symfony\Component\Clock\DatePoint;
+
+final class DatePointTypeTest extends TestCase
+{
+    private DatePointType $type;
+
+    public static function setUpBeforeClass(): void
+    {
+        $name = DatePointType::NAME;
+        if (Type::hasType($name)) {
+            Type::overrideType($name, DatePointType::class);
+        } else {
+            Type::addType($name, DatePointType::class);
+        }
+    }
+
+    protected function setUp(): void
+    {
+        if (!class_exists(DatePoint::class)) {
+            self::markTestSkipped('The DatePoint class is not available.');
+        }
+        $this->type = Type::getType(DatePointType::NAME);
+    }
+
+    public function testDatePointConvertsToDatabaseValue()
+    {
+        $datePoint = new DatePoint('2025-03-03 12:13:14');
+
+        $expected = $datePoint->format('Y-m-d H:i:s');
+        $actual = $this->type->convertToDatabaseValue($datePoint, new PostgreSQLPlatform());
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testDatePointConvertsToPHPValue()
+    {
+        $datePoint = new DatePoint();
+        $actual = $this->type->convertToPHPValue($datePoint, new SqlitePlatform());
+
+        $this->assertSame($datePoint, $actual);
+    }
+
+    public function testNullConvertsToPHPValue()
+    {
+        $actual = $this->type->convertToPHPValue(null, new SqlitePlatform());
+
+        $this->assertNull($actual);
+    }
+
+    public function testDateTimeImmutableConvertsToPHPValue()
+    {
+        $format = 'Y-m-d H:i:s';
+        $dateTime = new \DateTimeImmutable('2025-03-03 12:13:14');
+        $actual = $this->type->convertToPHPValue($dateTime, new SqlitePlatform());
+        $expected = DatePoint::createFromInterface($dateTime);
+
+        $this->assertSame($expected->format($format), $actual->format($format));
+    }
+
+    public function testGetName()
+    {
+        $this->assertSame('date_point', $this->type->getName());
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Types/DatePointType.php
+++ b/src/Symfony/Bridge/Doctrine/Types/DatePointType.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\DateTimeImmutableType;
+use Symfony\Component\Clock\DatePoint;
+
+final class DatePointType extends DateTimeImmutableType
+{
+    public const NAME = 'date_point';
+
+    /**
+      * @param T $value
+      *
+      * @return (T is null ? null : DatePoint)
+      *
+      * @template T
+      */
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?DatePoint
+    {
+        if (null === $value || $value instanceof DatePoint) {
+            return $value;
+        }
+
+        $value = parent::convertToPHPValue($value, $platform);
+
+        return DatePoint::createFromInterface($value);
+    }
+
+    public function getName(): string
+    {
+        return self::NAME;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #59889
| License       | MIT

Add a new DoctrineType for the DatePoint class.
Please take a look at the issue mentioned above for more details.