### PR TITLE
[PropertyInfo] Deprecate `Type`

### DIFF
--- a/UPGRADE-7.3.md
+++ b/UPGRADE-7.3.md
@@ -44,6 +44,11 @@ DependencyInjection
 
  * Deprecate `ContainerBuilder::getAutoconfiguredAttributes()` in favor of the `getAttributeAutoconfigurators()` method.
 
+DoctrineBridge
+--------------
+
+ * Deprecate the `DoctrineExtractor::getTypes()` method, use `DoctrineExtractor::getType()` instead
+
 FrameworkBundle
 ---------------
 
@@ -75,6 +80,13 @@ OptionsResolver
       // ...
   });
   ```
+
+PropertyInfo
+-------
+
+ * Deprecate the `Type` class, use `Symfony\Component\TypeInfo\Type` class from `symfony/type-info` instead
+ * Deprecate the `PropertyTypeExtractorInterface::getTypes()` method, use `PropertyTypeExtractorInterface::getType()` instead
+ * Deprecate the `ConstructorArgumentTypeExtractorInterface::getTypesFromConstructor()` method, use `ConstructorArgumentTypeExtractorInterface::getTypeFromConstructor()` instead
 
 Security
 --------

--- a/UPGRADE-7.3.md
+++ b/UPGRADE-7.3.md
@@ -82,7 +82,7 @@ OptionsResolver
   ```
 
 PropertyInfo
--------
+------------
 
  * Deprecate the `Type` class, use `Symfony\Component\TypeInfo\Type` class from `symfony/type-info` instead
  * Deprecate the `PropertyTypeExtractorInterface::getTypes()` method, use `PropertyTypeExtractorInterface::getType()` instead

--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Reset the manager registry using native lazy objects when applicable
+ * Deprecate the `DoctrineExtractor::getTypes()` method, use `DoctrineExtractor::getType()` instead
 
 7.2
 ---

--- a/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
+++ b/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
@@ -161,8 +161,13 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
         };
     }
 
+    /**
+     * @deprecated since Symfony 7.3, use "getType" instead
+     */
     public function getTypes(string $class, string $property, array $context = []): ?array
     {
+        trigger_deprecation('symfony/property-info', '7.3', 'The "%s()" method is deprecated, use "%s::getType()" instead.', __METHOD__, self::class);
+
         if (null === $metadata = $this->getMetadata($class)) {
             return null;
         }

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
@@ -30,6 +30,7 @@ use Symfony\Bridge\Doctrine\Tests\PropertyInfo\Fixtures\DoctrineRelation;
 use Symfony\Bridge\Doctrine\Tests\PropertyInfo\Fixtures\DoctrineWithEmbedded;
 use Symfony\Bridge\Doctrine\Tests\PropertyInfo\Fixtures\EnumInt;
 use Symfony\Bridge\Doctrine\Tests\PropertyInfo\Fixtures\EnumString;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\PropertyInfo\Type as LegacyType;
 use Symfony\Component\TypeInfo\Type;
 
@@ -38,6 +39,8 @@ use Symfony\Component\TypeInfo\Type;
  */
 class DoctrineExtractorTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     private function createExtractor(): DoctrineExtractor
     {
         $config = ORMSetup::createConfiguration(true);
@@ -108,15 +111,24 @@ class DoctrineExtractorTest extends TestCase
     }
 
     /**
+     * @group legacy
+     *
      * @dataProvider legacyTypesProvider
      */
     public function testExtractLegacy(string $property, ?array $type = null)
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor::getTypes()" method is deprecated, use "Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor::getType()" instead.');
+
         $this->assertEquals($type, $this->createExtractor()->getTypes(DoctrineDummy::class, $property, []));
     }
 
+    /**
+     * @group legacy
+     */
     public function testExtractWithEmbeddedLegacy()
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor::getTypes()" method is deprecated, use "Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor::getType()" instead.');
+
         $expectedTypes = [new LegacyType(
             LegacyType::BUILTIN_TYPE_OBJECT,
             false,
@@ -132,8 +144,13 @@ class DoctrineExtractorTest extends TestCase
         $this->assertEquals($expectedTypes, $actualTypes);
     }
 
+    /**
+     * @group legacy
+     */
     public function testExtractEnumLegacy()
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor::getTypes()" method is deprecated, use "Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor::getType()" instead.');
+
         $this->assertEquals([new LegacyType(LegacyType::BUILTIN_TYPE_OBJECT, false, EnumString::class)], $this->createExtractor()->getTypes(DoctrineEnum::class, 'enumString', []));
         $this->assertEquals([new LegacyType(LegacyType::BUILTIN_TYPE_OBJECT, false, EnumInt::class)], $this->createExtractor()->getTypes(DoctrineEnum::class, 'enumInt', []));
         $this->assertNull($this->createExtractor()->getTypes(DoctrineEnum::class, 'enumStringArray', []));
@@ -141,6 +158,9 @@ class DoctrineExtractorTest extends TestCase
         $this->assertNull($this->createExtractor()->getTypes(DoctrineEnum::class, 'enumCustom', []));
     }
 
+    /**
+     * @group legacy
+     */
     public static function legacyTypesProvider(): array
     {
         // DBAL 4 has a special fallback strategy for BINGINT (int -> string)
@@ -240,8 +260,13 @@ class DoctrineExtractorTest extends TestCase
         $this->assertNull($this->createExtractor()->getProperties('Not\Exist'));
     }
 
+    /**
+     * @group legacy
+     */
     public function testGetTypesCatchExceptionLegacy()
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor::getTypes()" method is deprecated, use "Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor::getType()" instead.');
+
         $this->assertNull($this->createExtractor()->getTypes('Not\Exist', 'baz'));
     }
 

--- a/src/Symfony/Component/PropertyInfo/CHANGELOG.md
+++ b/src/Symfony/Component/PropertyInfo/CHANGELOG.md
@@ -6,6 +6,9 @@ CHANGELOG
 
  * Add support for `non-positive-int`, `non-negative-int` and `non-zero-int` PHPStan types to `PhpStanExtractor`
  * Add `PropertyDescriptionExtractorInterface` to `PhpStanExtractor`
+ * Deprecate the `Type` class, use `Symfony\Component\TypeInfo\Type` class from `symfony/type-info` instead
+ * Deprecate the `PropertyTypeExtractorInterface::getTypes()` method, use `PropertyTypeExtractorInterface::getType()` instead
+ * Deprecate the `ConstructorArgumentTypeExtractorInterface::getTypesFromConstructor()` method, use `ConstructorArgumentTypeExtractorInterface::getTypeFromConstructor()` instead
 
 7.1
 ---

--- a/src/Symfony/Component/PropertyInfo/Extractor/ConstructorArgumentTypeExtractorInterface.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ConstructorArgumentTypeExtractorInterface.php
@@ -24,6 +24,8 @@ interface ConstructorArgumentTypeExtractorInterface
     /**
      * Gets types of an argument from constructor.
      *
+     * @deprecated since Symfony 7.3, use "getTypeFromConstructor" instead
+     *
      * @return LegacyType[]|null
      */
     public function getTypesFromConstructor(string $class, string $property): ?array;

--- a/src/Symfony/Component/PropertyInfo/Extractor/ConstructorExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ConstructorExtractor.php
@@ -40,8 +40,13 @@ final class ConstructorExtractor implements PropertyTypeExtractorInterface
         return null;
     }
 
+    /**
+     * @deprecated since Symfony 7.3, use "getType" instead
+     */
     public function getTypes(string $class, string $property, array $context = []): ?array
     {
+        trigger_deprecation('symfony/property-info', '7.3', 'The "%s()" method is deprecated, use "%s::getType()" instead.', __METHOD__, self::class);
+
         foreach ($this->extractors as $extractor) {
             $value = $extractor->getTypesFromConstructor($class, $property);
             if (null !== $value) {

--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -118,8 +118,13 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
         return '' === $contents ? null : $contents;
     }
 
+    /**
+     * @deprecated since Symfony 7.3, use "getType" instead
+     */
     public function getTypes(string $class, string $property, array $context = []): ?array
     {
+        trigger_deprecation('symfony/property-info', '7.3', 'The "%s()" method is deprecated, use "%s::getType()" instead.', __METHOD__, self::class);
+
         /** @var DocBlock $docBlock */
         [$docBlock, $source, $prefix] = $this->findDocBlock($class, $property);
         if (!$docBlock) {
@@ -171,8 +176,13 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
         return [new LegacyType(LegacyType::BUILTIN_TYPE_ARRAY, false, null, true, new LegacyType(LegacyType::BUILTIN_TYPE_INT), $types[0])];
     }
 
+    /**
+     * @deprecated since Symfony 7.3, use "getTypeFromConstructor" instead
+     */
     public function getTypesFromConstructor(string $class, string $property): ?array
     {
+        trigger_deprecation('symfony/property-info', '7.3', 'The "%s()" method is deprecated, use "%s::getTypeFromConstructor()" instead.', __METHOD__, self::class);
+
         $docBlock = $this->getDocBlockFromConstructor($class, $property);
 
         if (!$docBlock) {

--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
@@ -95,8 +95,13 @@ final class PhpStanExtractor implements PropertyDescriptionExtractorInterface, P
         $this->typeContextFactory = new TypeContextFactory($this->stringTypeResolver);
     }
 
+    /**
+     * @deprecated since Symfony 7.3, use "getType" instead
+     */
     public function getTypes(string $class, string $property, array $context = []): ?array
     {
+        trigger_deprecation('symfony/property-info', '7.3', 'The "%s()" method is deprecated, use "%s::getType()" instead.', __METHOD__, self::class);
+
         /** @var PhpDocNode|null $docNode */
         [$docNode, $source, $prefix, $declaringClass] = $this->getDocBlock($class, $property);
         if (null === $docNode) {
@@ -168,10 +173,14 @@ final class PhpStanExtractor implements PropertyDescriptionExtractorInterface, P
     }
 
     /**
+     * @deprecated since Symfony 7.3, use "getTypeFromConstructor" instead
+     *
      * @return LegacyType[]|null
      */
     public function getTypesFromConstructor(string $class, string $property): ?array
     {
+        trigger_deprecation('symfony/property-info', '7.3', 'The "%s()" method is deprecated, use "%s::getTypeFromConstructor()" instead.', __METHOD__, self::class);
+
         if (null === $tagDocNode = $this->getDocBlockFromConstructor($class, $property)) {
             return null;
         }

--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -155,8 +155,13 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
         return $properties ? array_values($properties) : null;
     }
 
+    /**
+     * @deprecated since Symfony 7.3, use "getType" instead
+     */
     public function getTypes(string $class, string $property, array $context = []): ?array
     {
+        trigger_deprecation('symfony/property-info', '7.3', 'The "%s()" method is deprecated, use "%s::getType()" instead.', __METHOD__, self::class);
+
         if ($fromMutator = $this->extractFromMutator($class, $property)) {
             return $fromMutator;
         }
@@ -180,10 +185,14 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
     }
 
     /**
+     * @deprecated since Symfony 7.3, use "getTypeFromConstructor" instead
+     *
      * @return LegacyType[]|null
      */
     public function getTypesFromConstructor(string $class, string $property): ?array
     {
+        trigger_deprecation('symfony/property-info', '7.3', 'The "%s()" method is deprecated, use "%s::getTypeFromConstructor()" instead.', __METHOD__, self::class);
+
         try {
             $reflection = new \ReflectionClass($class);
         } catch (\ReflectionException) {

--- a/src/Symfony/Component/PropertyInfo/PropertyInfoCacheExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyInfoCacheExtractor.php
@@ -95,8 +95,13 @@ class PropertyInfoCacheExtractor implements PropertyInfoExtractorInterface, Prop
         return $this->arrayCache[$key] = $value;
     }
 
+    /**
+     * @deprecated since Symfony 7.3, use "getType" instead
+     */
     public function getTypes(string $class, string $property, array $context = []): ?array
     {
+        trigger_deprecation('symfony/property-info', '7.3', 'The "%s()" method is deprecated, use "%s::getType()" instead.', __METHOD__, self::class);
+
         return $this->extract('getTypes', [$class, $property, $context]);
     }
 

--- a/src/Symfony/Component/PropertyInfo/PropertyInfoExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyInfoExtractor.php
@@ -75,8 +75,13 @@ class PropertyInfoExtractor implements PropertyInfoExtractorInterface, PropertyI
         return null;
     }
 
+    /**
+     * @deprecated since Symfony 7.3, use "getType" instead
+     */
     public function getTypes(string $class, string $property, array $context = []): ?array
     {
+        trigger_deprecation('symfony/property-info', '7.3', 'The "%s()" method is deprecated, use "%s::getType()" instead.', __METHOD__, self::class);
+
         return $this->extract($this->typeExtractors, 'getTypes', [$class, $property, $context]);
     }
 

--- a/src/Symfony/Component/PropertyInfo/PropertyTypeExtractorInterface.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyTypeExtractorInterface.php
@@ -26,6 +26,8 @@ interface PropertyTypeExtractorInterface
     /**
      * Gets types of a property.
      *
+     * @deprecated since Symfony 7.3, use "getType" instead
+     *
      * @return LegacyType[]|null
      */
     public function getTypes(string $class, string $property, array $context = []): ?array;

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ConstructorExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ConstructorExtractorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\PropertyInfo\Tests\Extractor;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\PropertyInfo\Extractor\ConstructorExtractor;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyExtractor;
 use Symfony\Component\PropertyInfo\Type as LegacyType;
@@ -22,6 +23,8 @@ use Symfony\Component\TypeInfo\Type;
  */
 class ConstructorExtractorTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     private ConstructorExtractor $extractor;
 
     protected function setUp(): void
@@ -50,6 +53,8 @@ class ConstructorExtractorTest extends TestCase
      */
     public function testGetTypes()
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\ConstructorExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\ConstructorExtractor::getType()" instead.');
+
         $this->assertEquals([new LegacyType(LegacyType::BUILTIN_TYPE_STRING)], $this->extractor->getTypes('Foo', 'bar', []));
     }
 
@@ -58,6 +63,8 @@ class ConstructorExtractorTest extends TestCase
      */
     public function testGetTypesIfNoExtractors()
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\ConstructorExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\ConstructorExtractor::getType()" instead.');
+
         $extractor = new ConstructorExtractor([]);
         $this->assertNull($extractor->getTypes('Foo', 'bar', []));
     }

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\PropertyInfo\Tests\Extractor;
 
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use phpDocumentor\Reflection\DocBlock;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
@@ -34,6 +35,8 @@ use Symfony\Component\TypeInfo\Type\NullableType;
  */
 class PhpDocExtractorTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     private PhpDocExtractor $extractor;
 
     protected function setUp(): void
@@ -48,6 +51,8 @@ class PhpDocExtractorTest extends TestCase
      */
     public function testExtractLegacy($property, ?array $type, $shortDescription, $longDescription)
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor::getType()" instead.');
+
         $this->assertEquals($type, $this->extractor->getTypes(Dummy::class, $property));
         $this->assertSame($shortDescription, $this->extractor->getShortDescription(Dummy::class, $property));
         $this->assertSame($longDescription, $this->extractor->getLongDescription(Dummy::class, $property));
@@ -71,6 +76,8 @@ class PhpDocExtractorTest extends TestCase
      */
     public function testParamTagTypeIsOmittedLegacy()
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor::getType()" instead.');
+
         $this->assertNull($this->extractor->getTypes(OmittedParamTagTypeDocBlock::class, 'omittedType'));
     }
 
@@ -90,6 +97,8 @@ class PhpDocExtractorTest extends TestCase
      */
     public function testInvalidLegacy($property, $shortDescription, $longDescription)
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor::getType()" instead.');
+
         $this->assertNull($this->extractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\InvalidDummy', $property));
         $this->assertSame($shortDescription, $this->extractor->getShortDescription('Symfony\Component\PropertyInfo\Tests\Fixtures\InvalidDummy', $property));
         $this->assertSame($longDescription, $this->extractor->getLongDescription('Symfony\Component\PropertyInfo\Tests\Fixtures\InvalidDummy', $property));
@@ -100,6 +109,8 @@ class PhpDocExtractorTest extends TestCase
      */
     public function testEmptyParamAnnotationLegacy()
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor::getType()" instead.');
+
         $this->assertNull($this->extractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\InvalidDummy', 'foo'));
         $this->assertSame('Foo.', $this->extractor->getShortDescription('Symfony\Component\PropertyInfo\Tests\Fixtures\InvalidDummy', 'foo'));
         $this->assertNull($this->extractor->getLongDescription('Symfony\Component\PropertyInfo\Tests\Fixtures\InvalidDummy', 'foo'));
@@ -112,6 +123,8 @@ class PhpDocExtractorTest extends TestCase
      */
     public function testExtractTypesWithNoPrefixesLegacy($property, ?array $type = null)
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor::getType()" instead.');
+
         $noPrefixExtractor = new PhpDocExtractor(null, [], [], []);
 
         $this->assertEquals($type, $noPrefixExtractor->getTypes(Dummy::class, $property));
@@ -240,6 +253,8 @@ class PhpDocExtractorTest extends TestCase
      */
     public function testExtractTypesWithCustomPrefixesLegacy($property, ?array $type = null)
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor::getType()" instead.');
+
         $customExtractor = new PhpDocExtractor(null, ['add', 'remove'], ['is', 'can']);
 
         $this->assertEquals($type, $customExtractor->getTypes(Dummy::class, $property));
@@ -356,6 +371,8 @@ class PhpDocExtractorTest extends TestCase
      */
     public function testDocBlockFallbackLegacy($property, $types)
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor::getType()" instead.');
+
         $this->assertEquals($types, $this->extractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\DockBlockFallback', $property));
     }
 
@@ -366,6 +383,8 @@ class PhpDocExtractorTest extends TestCase
      */
     public function testPropertiesDefinedByTraitsLegacy(string $property, LegacyType $type)
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor::getType()" instead.');
+
         $this->assertEquals([$type], $this->extractor->getTypes(DummyUsingTrait::class, $property));
     }
 
@@ -388,6 +407,8 @@ class PhpDocExtractorTest extends TestCase
      */
     public function testMethodsDefinedByTraitsLegacy(string $property, LegacyType $type)
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor::getType()" instead.');
+
         $this->assertEquals([$type], $this->extractor->getTypes(DummyUsingTrait::class, $property));
     }
 
@@ -410,6 +431,8 @@ class PhpDocExtractorTest extends TestCase
      */
     public function testPropertiesStaticTypeLegacy(string $class, string $property, LegacyType $type)
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor::getType()" instead.');
+
         $this->assertEquals([$type], $this->extractor->getTypes($class, $property));
     }
 
@@ -428,6 +451,8 @@ class PhpDocExtractorTest extends TestCase
      */
     public function testPropertiesParentTypeLegacy(string $class, string $property, ?array $types)
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor::getType()" instead.');
+
         $this->assertEquals($types, $this->extractor->getTypes($class, $property));
     }
 
@@ -444,11 +469,18 @@ class PhpDocExtractorTest extends TestCase
      */
     public function testUnknownPseudoTypeLegacy()
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor::getType()" instead.');
+
         $this->assertEquals([new LegacyType(LegacyType::BUILTIN_TYPE_OBJECT, false, 'scalar')], $this->extractor->getTypes(PseudoTypeDummy::class, 'unknownPseudoType'));
     }
 
+    /**
+     * @group legacy
+     */
     public function testGenericInterface()
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor::getType()" instead.');
+
         $this->assertNull($this->extractor->getTypes(Dummy::class, 'genericInterface'));
     }
 
@@ -459,6 +491,8 @@ class PhpDocExtractorTest extends TestCase
      */
     public function testExtractConstructorTypesLegacy($property, ?array $type = null)
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor::getTypesFromConstructor()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor::getTypeFromConstructor()" instead.');
+
         $this->assertEquals($type, $this->extractor->getTypesFromConstructor('Symfony\Component\PropertyInfo\Tests\Fixtures\ConstructorDummy', $property));
     }
 
@@ -481,6 +515,8 @@ class PhpDocExtractorTest extends TestCase
      */
     public function testPseudoTypesLegacy($property, array $type)
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor::getType()" instead.');
+
         $this->assertEquals($type, $this->extractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\PseudoTypesDummy', $property));
     }
 
@@ -506,6 +542,8 @@ class PhpDocExtractorTest extends TestCase
      */
     public function testExtractPromotedPropertyLegacy(string $property, ?array $types)
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor::getType()" instead.');
+
         $this->assertEquals($types, $this->extractor->getTypes(Php80Dummy::class, $property));
     }
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\PropertyInfo\Tests\Extractor;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Clazz;
@@ -48,6 +49,8 @@ require_once __DIR__.'/../Fixtures/Extractor/DummyNamespace.php';
  */
 class PhpStanExtractorTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     private PhpStanExtractor $extractor;
     private PhpDocExtractor $phpDocExtractor;
 
@@ -64,6 +67,8 @@ class PhpStanExtractorTest extends TestCase
      */
     public function testExtractLegacy($property, ?array $type = null)
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor::getType()" instead.');
+
         $this->assertEquals($type, $this->extractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', $property));
     }
 
@@ -72,6 +77,8 @@ class PhpStanExtractorTest extends TestCase
      */
     public function testParamTagTypeIsOmittedLegacy()
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor::getType()" instead.');
+
         $this->assertNull($this->extractor->getTypes(PhpStanOmittedParamTagTypeDocBlock::class, 'omittedType'));
     }
 
@@ -92,6 +99,8 @@ class PhpStanExtractorTest extends TestCase
      */
     public function testInvalidLegacy($property)
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor::getType()" instead.');
+
         $this->assertNull($this->extractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\InvalidDummy', $property));
     }
 
@@ -102,6 +111,8 @@ class PhpStanExtractorTest extends TestCase
      */
     public function testExtractTypesWithNoPrefixesLegacy($property, ?array $type = null)
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor::getType()" instead.');
+
         $noPrefixExtractor = new PhpStanExtractor([], [], []);
 
         $this->assertEquals($type, $noPrefixExtractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', $property));
@@ -218,6 +229,8 @@ class PhpStanExtractorTest extends TestCase
      */
     public function testExtractTypesWithCustomPrefixesLegacy($property, ?array $type = null)
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor::getType()" instead.');
+
         $customExtractor = new PhpStanExtractor(['add', 'remove'], ['is', 'can']);
 
         $this->assertEquals($type, $customExtractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', $property));
@@ -321,6 +334,8 @@ class PhpStanExtractorTest extends TestCase
      */
     public function testDocBlockFallbackLegacy($property, $types)
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor::getType()" instead.');
+
         $this->assertEquals($types, $this->extractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\DockBlockFallback', $property));
     }
 
@@ -331,6 +346,8 @@ class PhpStanExtractorTest extends TestCase
      */
     public function testPropertiesDefinedByTraitsLegacy(string $property, LegacyType $type)
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor::getType()" instead.');
+
         $this->assertEquals([$type], $this->extractor->getTypes(DummyUsingTrait::class, $property));
     }
 
@@ -351,6 +368,8 @@ class PhpStanExtractorTest extends TestCase
      */
     public function testPropertiesStaticTypeLegacy(string $class, string $property, LegacyType $type)
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor::getType()" instead.');
+
         $this->assertEquals([$type], $this->extractor->getTypes($class, $property));
     }
 
@@ -369,6 +388,8 @@ class PhpStanExtractorTest extends TestCase
      */
     public function testPropertiesParentTypeLegacy(string $class, string $property, ?array $types)
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor::getType()" instead.');
+
         $this->assertEquals($types, $this->extractor->getTypes($class, $property));
     }
 
@@ -387,6 +408,8 @@ class PhpStanExtractorTest extends TestCase
      */
     public function testExtractConstructorTypesLegacy($property, ?array $type = null)
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor::getTypesFromConstructor()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor::getTypeFromConstructor()" instead.');
+
         $this->assertEquals($type, $this->extractor->getTypesFromConstructor('Symfony\Component\PropertyInfo\Tests\Fixtures\ConstructorDummy', $property));
     }
 
@@ -397,6 +420,8 @@ class PhpStanExtractorTest extends TestCase
      */
     public function testExtractConstructorTypesReturnNullOnEmptyDocBlockLegacy($property)
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor::getTypesFromConstructor()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor::getTypeFromConstructor()" instead.');
+
         $this->assertNull($this->extractor->getTypesFromConstructor(ConstructorDummyWithoutDocBlock::class, $property));
     }
 
@@ -418,6 +443,8 @@ class PhpStanExtractorTest extends TestCase
      */
     public function testExtractorUnionTypesLegacy(string $property, ?array $types)
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor::getType()" instead.');
+
         $this->assertEquals($types, $this->extractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\DummyUnionType', $property));
     }
 
@@ -441,6 +468,8 @@ class PhpStanExtractorTest extends TestCase
      */
     public function testPseudoTypesLegacy($property, array $type)
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor::getType()" instead.');
+
         $this->assertEquals($type, $this->extractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\PhpStanPseudoTypesDummy', $property));
     }
 
@@ -477,6 +506,8 @@ class PhpStanExtractorTest extends TestCase
      */
     public function testDummyNamespaceLegacy()
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor::getType()" instead.');
+
         $this->assertEquals(
             [new LegacyType(LegacyType::BUILTIN_TYPE_OBJECT, false, 'Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy')],
             $this->extractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\DummyNamespace', 'dummy')
@@ -488,6 +519,8 @@ class PhpStanExtractorTest extends TestCase
      */
     public function testDummyNamespaceWithPropertyLegacy()
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor::getType()" instead.');
+
         $phpStanTypes = $this->extractor->getTypes(\B\Dummy::class, 'property');
         $phpDocTypes = $this->phpDocExtractor->getTypes(\B\Dummy::class, 'property');
 
@@ -502,6 +535,8 @@ class PhpStanExtractorTest extends TestCase
      */
     public function testExtractorIntRangeTypeLegacy(string $property, ?array $types)
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor::getType()" instead.');
+
         $this->assertEquals($types, $this->extractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\IntRangeDummy', $property));
     }
 
@@ -521,6 +556,8 @@ class PhpStanExtractorTest extends TestCase
      */
     public function testExtractPhp80TypeLegacy(string $class, $property, ?array $type = null)
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor::getType()" instead.');
+
         $this->assertEquals($type, $this->extractor->getTypes($class, $property, []));
     }
 
@@ -543,6 +580,8 @@ class PhpStanExtractorTest extends TestCase
      */
     public function testAllowPrivateAccessLegacy(bool $allowPrivateAccess, array $expectedTypes)
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor::getType()" instead.');
+
         $extractor = new PhpStanExtractor(allowPrivateAccess: $allowPrivateAccess);
         $this->assertEquals(
             $expectedTypes,
@@ -559,12 +598,16 @@ class PhpStanExtractorTest extends TestCase
     }
 
     /**
+     * @group legacy
+     *
      * @param list<LegacyType> $expectedTypes
      *
      * @dataProvider legacyGenericsProvider
      */
     public function testGenericsLegacy(string $property, array $expectedTypes)
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor::getType()" instead.');
+
         $this->assertEquals($expectedTypes, $this->extractor->getTypes(DummyGeneric::class, $property));
     }
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\PropertyInfo\Tests\Extractor;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\PropertyReadInfo;
 use Symfony\Component\PropertyInfo\PropertyWriteInfo;
@@ -42,6 +43,8 @@ use Symfony\Component\TypeInfo\Type\NullableType;
  */
 class ReflectionExtractorTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     private ReflectionExtractor $extractor;
 
     protected function setUp(): void
@@ -227,6 +230,8 @@ class ReflectionExtractorTest extends TestCase
      */
     public function testExtractorsLegacy($property, ?array $type = null)
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor::getType()" instead.');
+
         $this->assertEquals($type, $this->extractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', $property, []));
     }
 
@@ -256,6 +261,8 @@ class ReflectionExtractorTest extends TestCase
      */
     public function testExtractPhp7TypeLegacy(string $class, string $property, ?array $type = null)
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor::getType()" instead.');
+
         $this->assertEquals($type, $this->extractor->getTypes($class, $property, []));
     }
 
@@ -279,6 +286,8 @@ class ReflectionExtractorTest extends TestCase
      */
     public function testExtractPhp71TypeLegacy($property, ?array $type = null)
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor::getType()" instead.');
+
         $this->assertEquals($type, $this->extractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\Php71Dummy', $property, []));
     }
 
@@ -300,6 +309,8 @@ class ReflectionExtractorTest extends TestCase
      */
     public function testExtractPhp80TypeLegacy(string $property, ?array $type = null)
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor::getType()" instead.');
+
         $this->assertEquals($type, $this->extractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\Php80Dummy', $property, []));
     }
 
@@ -324,6 +335,8 @@ class ReflectionExtractorTest extends TestCase
      */
     public function testExtractPhp81TypeLegacy(string $property, ?array $type = null)
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor::getType()" instead.');
+
         $this->assertEquals($type, $this->extractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\Php81Dummy', $property, []));
     }
 
@@ -347,6 +360,8 @@ class ReflectionExtractorTest extends TestCase
      */
     public function testExtractPhp82TypeLegacy(string $property, ?array $type = null)
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor::getType()" instead.');
+
         $this->assertEquals($type, $this->extractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\Php82Dummy', $property, []));
     }
 
@@ -368,6 +383,8 @@ class ReflectionExtractorTest extends TestCase
      */
     public function testExtractWithDefaultValueLegacy($property, $type)
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor::getType()" instead.');
+
         $this->assertEquals($type, $this->extractor->getTypes(DefaultValue::class, $property, []));
     }
 
@@ -511,6 +528,8 @@ class ReflectionExtractorTest extends TestCase
      */
     public function testExtractTypeConstructorLegacy(string $class, string $property, ?array $type = null)
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor::getType()" instead.');
+
         /* Check that constructor extractions works by default, and if passed in via context.
            Check that null is returned if constructor extraction is disabled */
         $this->assertEquals($type, $this->extractor->getTypes($class, $property, []));
@@ -549,6 +568,8 @@ class ReflectionExtractorTest extends TestCase
      */
     public function testTypedPropertiesLegacy()
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor::getType()" instead.');
+
         $this->assertEquals([new LegacyType(LegacyType::BUILTIN_TYPE_OBJECT, false, Dummy::class)], $this->extractor->getTypes(Php74Dummy::class, 'dummy'));
         $this->assertEquals([new LegacyType(LegacyType::BUILTIN_TYPE_BOOL, true)], $this->extractor->getTypes(Php74Dummy::class, 'nullableBoolProp'));
         $this->assertEquals([new LegacyType(LegacyType::BUILTIN_TYPE_ARRAY, false, null, true, new LegacyType(LegacyType::BUILTIN_TYPE_INT), new LegacyType(LegacyType::BUILTIN_TYPE_STRING))], $this->extractor->getTypes(Php74Dummy::class, 'stringCollection'));
@@ -687,6 +708,8 @@ class ReflectionExtractorTest extends TestCase
      */
     public function testExtractConstructorTypesLegacy(string $property, ?array $type = null)
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor::getTypesFromConstructor()" method is deprecated, use "Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor::getTypeFromConstructor()" instead.');
+
         $this->assertEquals($type, $this->extractor->getTypesFromConstructor('Symfony\Component\PropertyInfo\Tests\Fixtures\ConstructorDummy', $property));
     }
 

--- a/src/Symfony/Component/PropertyInfo/Tests/PropertyInfoCacheExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/PropertyInfoCacheExtractorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\PropertyInfo\Tests;
 
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoCacheExtractor;
@@ -25,6 +26,8 @@ use Symfony\Component\TypeInfo\Type;
  */
 class PropertyInfoCacheExtractorTest extends AbstractPropertyInfoExtractorTest
 {
+    use ExpectDeprecationTrait;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -55,6 +58,8 @@ class PropertyInfoCacheExtractorTest extends AbstractPropertyInfoExtractorTest
      */
     public function testGetTypes()
     {
+        $this->expectDeprecation('Since symfony/property-info 7.3: The "Symfony\Component\PropertyInfo\PropertyInfoCacheExtractor::getTypes()" method is deprecated, use "Symfony\Component\PropertyInfo\PropertyInfoCacheExtractor::getType()" instead.');
+
         parent::testGetTypes();
         parent::testGetTypes();
     }

--- a/src/Symfony/Component/PropertyInfo/Type.php
+++ b/src/Symfony/Component/PropertyInfo/Type.php
@@ -11,10 +11,14 @@
 
 namespace Symfony\Component\PropertyInfo;
 
+trigger_deprecation('symfony/property-info', '7.3', 'The "%s" class is deprecated. Use "%s" class from "symfony/type-info" instead.', Type::class, \Symfony\Component\TypeInfo\Type::class);
+
 /**
  * Type value object (immutable).
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @deprecated since Symfony 7.3, use "Symfony\Component\TypeInfo\Type" class from "symfony/type-info" instead
  *
  * @final
  */

--- a/src/Symfony/Component/PropertyInfo/Util/PhpDocTypeHelper.php
+++ b/src/Symfony/Component/PropertyInfo/Util/PhpDocTypeHelper.php
@@ -41,10 +41,14 @@ final class PhpDocTypeHelper
     /**
      * Creates a {@see LegacyType} from a PHPDoc type.
      *
+     * @deprecated since Symfony 7.3, use "getType" instead
+     *
      * @return LegacyType[]
      */
     public function getTypes(DocType $varType): array
     {
+        trigger_deprecation('symfony/property-info', '7.3', 'The "%s()" method is deprecated, use "%s::getType()" instead.', __METHOD__, self::class);
+
         if ($varType instanceof ConstExpression) {
             // It's safer to fall back to other extractors here, as resolving const types correctly is not easy at the moment
             return [];

--- a/src/Symfony/Component/PropertyInfo/composer.json
+++ b/src/Symfony/Component/PropertyInfo/composer.json
@@ -24,6 +24,7 @@
     ],
     "require": {
         "php": ">=8.2",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/string": "^6.4|^7.0",
         "symfony/type-info": "~7.1.9|^7.2.2"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        |
| License       | MIT

A new attempt to https://github.com/symfony/symfony/pull/53160, now that `symfony/type-info` is not experimental anymore.

Deprecates:
- `Type` class in favor of the `Type` class of `symfony/type-info`
- `PropertyTypeExtractorInterface::getTypes()` in favor of the `PropertyTypeExtractorInterface::getType()` method
- `ConstructorArgumentTypeExtractorInterface::getTypesFromConstructor()` in favor of the `ConstructorArgumentTypeExtractorInterface::getTypeFromConstructor()` method

The work for upgrading dependent packages has begun already:
- https://github.com/api-platform/core/pull/6979
- https://github.com/symfony/ux/pull/2607