### PR TITLE
[Routing] Add alias in `{foo:bar}` syntax in route parameter

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
@@ -117,7 +117,14 @@ class RouterListener implements EventSubscriberInterface
                 $attributes = [];
 
                 foreach ($parameters as $parameter => $value) {
-                    $attribute = $mapping[$parameter] ?? $parameter;
+                    if (!isset($mapping[$parameter])) {
+                        $attribute = $parameter;
+                    } elseif (\is_array($mapping[$parameter])) {
+                        [$attribute, $parameter] = $mapping[$parameter];
+                        $mappedAttributes[$attribute] = '';
+                    } else {
+                        $attribute = $mapping[$parameter];
+                    }
 
                     if (!isset($mappedAttributes[$attribute])) {
                         $attributes[$attribute] = $value;

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
@@ -323,5 +323,49 @@ class RouterListenerTest extends TestCase
                 ],
             ],
         ];
+
+        yield [
+            [
+                'conference' => ['slug' => 'vienna-2024'],
+            ],
+            [
+                'slug' => 'vienna-2024',
+                '_route_mapping' => [
+                    'slug' => [
+                        'conference',
+                        'slug',
+                    ],
+                ],
+            ],
+        ];
+
+        yield [
+            [
+                'article' => [
+                    'id' => 'abc123',
+                    'date' => '2024-04-24',
+                    'slug' => 'symfony-rocks',
+                ],
+            ],
+            [
+                'id' => 'abc123',
+                'date' => '2024-04-24',
+                'slug' => 'symfony-rocks',
+                '_route_mapping' => [
+                    'id' => [
+                        'article',
+                        'id'
+                    ],
+                    'date' => [
+                        'article',
+                        'date',
+                    ],
+                    'slug' => [
+                        'article',
+                        'slug',
+                    ],
+                ],
+            ],
+        ];
     }
 }

--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -418,15 +418,15 @@ class Route implements \Serializable
 
         $mapping = $this->getDefault('_route_mapping') ?? [];
 
-        $pattern = preg_replace_callback('#\{(!?)([\w\x80-\xFF]++)(:[\w\x80-\xFF]++)?(<.*?>)?(\?[^\}]*+)?\}#', function ($m) use (&$mapping) {
-            if (isset($m[5][0])) {
-                $this->setDefault($m[2], '?' !== $m[5] ? substr($m[5], 1) : null);
+        $pattern = preg_replace_callback('#\{(!?)([\w\x80-\xFF]++)(:([\w\x80-\xFF]++)(\.[\w\x80-\xFF]++)?)?(<.*?>)?(\?[^\}]*+)?\}#', function ($m) use (&$mapping) {
+            if (isset($m[7][0])) {
+                $this->setDefault($m[2], '?' !== $m[6] ? substr($m[7], 1) : null);
+            }
+            if (isset($m[6][0])) {
+                $this->setRequirement($m[2], substr($m[6], 1, -1));
             }
             if (isset($m[4][0])) {
-                $this->setRequirement($m[2], substr($m[4], 1, -1));
-            }
-            if (isset($m[3][0])) {
-                $mapping[$m[2]] = substr($m[3], 1);
+                $mapping[$m[2]] = isset($m[5][0]) ? [$m[4], substr($m[5], 1)] : $mapping[$m[2]] = [$m[4], $m[2]];
             }
 
             return '{'.$m[1].$m[2].'}';

--- a/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
@@ -1011,7 +1011,30 @@ class UrlMatcherTest extends TestCase
             '_route' => 'a',
             'slug' => 'vienna-2024',
             '_route_mapping' => [
-                'slug' => 'conference',
+                'slug' => [
+                    'conference',
+                    'slug',
+                ],
+            ],
+        ];
+        $this->assertEquals($expected, $matcher->match('/conference/vienna-2024'));
+    }
+
+    public function testMappingwithAlias()
+    {
+        $collection = new RouteCollection();
+        $collection->add('a', new Route('/conference/{conferenceSlug:conference.slug}'));
+
+        $matcher = $this->getUrlMatcher($collection);
+
+        $expected = [
+            '_route' => 'a',
+            'conferenceSlug' => 'vienna-2024',
+            '_route_mapping' => [
+                'conferenceSlug' => [
+                    'conference',
+                    'slug',
+                ],
             ],
         ];
         $this->assertEquals($expected, $matcher->match('/conference/vienna-2024'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

Since https://github.com/symfony/symfony/pull/54720 we can/have to write route parameters with "destination" as slug:bar, 


but if we have two properties with same name example : 

`/search-book/{name:author}/{name:category}`

we get the error message : Route pattern "/search-book/{name}/{name}" cannot reference variable name "name" more than once.

Actually to prevent this error we have to use MapEntity as : 

```php
    public function bookSearch(
        #[MapEntity(mapping: ['authorName' => 'name'])]
        Author $author,
        #[MapEntity(mapping: ['categoryName' => 'name'])]
        Category $category): Response
    {
```
	
and we have to remove Mapped Route Parameters : 

`#[Route('/search-book/{authorName}/{categoryName}')`


This PR proposal is to remove MapEntity attributes and keep Mapped Route Parameters by adding an alias on it : 

`/search-book/{authorName:author.name}/{categoryName:category.name}`

With that, EntityValueResolver will search name in author Entity and name in Category Entity.

We can have url with : `{{ path('bookSearch', {authorName: 'KING', categoryName: 'Horror'}) }}`