### PR TITLE
[Messenger] Reduce keepalive request noise

### DIFF
--- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
@@ -290,7 +290,7 @@ EOF
         }
 
         if (\SIGALRM === $signal) {
-            $this->logger?->info('Sending keepalive request.', ['transport_names' => $this->worker->getMetadata()->getTransportNames()]);
+            $this->logger?->debug('Sending keepalive request.', ['transport_names' => $this->worker->getMetadata()->getTransportNames()]);
 
             $this->worker->keepalive($this->getApplication()->getAlarmInterval());
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

Currently `messenger:consume --keepalive` creates a lot of noise (INFO log every 5 sec by default).

```
13:34:59 INFO      [messenger] Sending keepalive request.
13:35:04 INFO      [messenger] Sending keepalive request.
```

I propose to use DEBUG instead. We can also remove this log, since there's already a keepalive log per message ID: https://github.com/symfony/symfony/blob/8b008510a48adba218d6358a3ab52141daacbaa8/src/Symfony/Component/Messenger/Worker.php#L303-L306

cc @HypeMC 