### PR TITLE
[Form] Keep submitted values when `keep_as_list` option of collection type is enabled

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
@@ -213,7 +213,7 @@ class ResizeFormListener implements EventSubscriberInterface
             foreach ($formReindex as $index => $child) {
                 $form->add($index, $this->type, array_replace([
                     'property_path' => '['.$index.']',
-                ], $this->options));
+                ], $this->options, ['data' => $child->getData()]));
                 $data[$index] = $child->getData();
             }
         }

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
@@ -257,7 +257,7 @@ class FormTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
     {
         $formMetadata = new ClassMetadata(Form::class);
         $authorMetadata = (new ClassMetadata(Author::class))
-            ->addPropertyConstraint('firstName', new NotBlank());
+            ->addPropertyConstraint('firstName', new Length(1));
         $organizationMetadata = (new ClassMetadata(Organization::class))
             ->addPropertyConstraint('authors', new Valid());
         $metadataFactory = $this->createMock(MetadataFactoryInterface::class);
@@ -301,22 +301,22 @@ class FormTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
         $form->submit([
             'authors' => [
                 0 => [
-                    'firstName' => '', // Fires a Not Blank Error
+                    'firstName' => 'foobar', // Fires a Length Error
                     'lastName' => 'lastName1',
                 ],
                 // key "1" could be missing if we add 4 blank form entries and then remove it.
                 2 => [
-                    'firstName' => '', // Fires a Not Blank Error
+                    'firstName' => 'barfoo', // Fires a Length Error
                     'lastName' => 'lastName3',
                 ],
                 3 => [
-                    'firstName' => '', // Fires a Not Blank Error
+                    'firstName' => 'barbaz', // Fires a Length Error
                     'lastName' => 'lastName3',
                 ],
             ],
         ]);
 
-        // Form does have 3 not blank errors
+        // Form does have 3 length errors
         $errors = $form->getErrors(true);
         $this->assertCount(3, $errors);
 
@@ -328,12 +328,15 @@ class FormTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
         ];
 
         $this->assertTrue($form->get('authors')->has('0'));
+        $this->assertSame('foobar', $form->get('authors')->get('0')->getData()->firstName);
         $this->assertContains('data.authors[0].firstName', $errorPaths);
 
         $this->assertTrue($form->get('authors')->has('1'));
+        $this->assertSame('barfoo', $form->get('authors')->get('1')->getData()->firstName);
         $this->assertContains('data.authors[1].firstName', $errorPaths);
 
         $this->assertTrue($form->get('authors')->has('2'));
+        $this->assertSame('barbaz', $form->get('authors')->get('2')->getData()->firstName);
         $this->assertContains('data.authors[2].firstName', $errorPaths);
 
         $this->assertFalse($form->get('authors')->has('3'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #57430 
| License       | MIT

When the `keep_as_list` option of `CollectionType` is true, its entries lose their values when re-displaying the form with submitted data.

This fix only concerns the 2nd point of the [linked issue](https://github.com/symfony/symfony/issues/57430#issuecomment-2470078792).
