### PR TITLE
[Routing] Add `MONGODB_ID` to requirement patterns

### DIFF
--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Allow aliases and deprecations in `#[Route]` attribute
+ * Add the `Requirement::MONGODB_ID` constant to validate MongoDB ObjectIDs in hexadecimal format
 
 7.2
 ---

--- a/src/Symfony/Component/Routing/Requirement/Requirement.php
+++ b/src/Symfony/Component/Routing/Requirement/Requirement.php
@@ -20,6 +20,7 @@ enum Requirement
     public const CATCH_ALL = '.+';
     public const DATE_YMD = '[0-9]{4}-(?:0[1-9]|1[012])-(?:0[1-9]|[12][0-9]|(?<!02-)3[01])'; // YYYY-MM-DD
     public const DIGITS = '[0-9]+';
+    public const MONGODB_ID = '[0-9a-f]{24}';
     public const POSITIVE_INT = '[1-9][0-9]*';
     public const UID_BASE32 = '[0-9A-HJKMNP-TV-Z]{26}';
     public const UID_BASE58 = '[1-9A-HJ-NP-Za-km-z]{22}';

--- a/src/Symfony/Component/Routing/Tests/Requirement/RequirementTest.php
+++ b/src/Symfony/Component/Routing/Tests/Requirement/RequirementTest.php
@@ -138,6 +138,32 @@ class RequirementTest extends TestCase
     }
 
     /**
+     * @testWith    ["67c8b7d295c70befc3070bf2"]
+     *              ["000000000000000000000000"]
+     */
+    public function testMongoDbIdOK(string $id)
+    {
+        $this->assertMatchesRegularExpression(
+            (new Route('/{id}', [], ['id' => Requirement::MONGODB_ID]))->compile()->getRegex(),
+            '/'.$id,
+        );
+    }
+
+    /**
+     * @testWith    ["67C8b7D295C70BEFC3070BF2"]
+     *              ["67c8b7d295c70befc3070bg2"]
+     *              ["67c8b7d295c70befc3070bf2a"]
+     *              ["67c8b7d295c70befc3070bf"]
+     */
+    public function testMongoDbIdKO(string $id)
+    {
+        $this->assertDoesNotMatchRegularExpression(
+            (new Route('/{id}', [], ['id' => Requirement::MONGODB_ID]))->compile()->getRegex(),
+            '/'.$id,
+        );
+    }
+
+    /**
      * @testWith    ["1"]
      *              ["42"]
      *              ["42198"]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

The [MongoDB ObjectID](https://www.mongodb.com/docs/manual/reference/method/ObjectId/) is a 12-bytes binary value represented as an hexadecimal string of 24 characters.

They are used by default in Doctrine MongoDB ODM.