### PR TITLE
Extract no type `@param` annotation with `PhpStanExtractor`

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
@@ -16,6 +16,8 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\InvalidTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
 use PHPStan\PhpDocParser\Lexer\Lexer;
 use PHPStan\PhpDocParser\Parser\ConstExprParser;
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
@@ -206,7 +208,7 @@ final class PhpStanExtractor implements PropertyTypeExtractorInterface, Construc
         $types = [];
 
         foreach ($docNode->getTagsByName($tag) as $tagDocNode) {
-            if ($tagDocNode->value instanceof InvalidTagValueNode) {
+            if (!$tagDocNode->value instanceof ParamTagValueNode && !$tagDocNode->value instanceof ReturnTagValueNode && !$tagDocNode->value instanceof VarTagValueNode) {
                 continue;
             }
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
@@ -694,6 +694,7 @@ class PhpStanExtractorTest extends TestCase
         yield 'stat' => ['stat'];
         yield 'foo' => ['foo'];
         yield 'bar' => ['bar'];
+        yield 'baz' => ['baz'];
     }
 
     /**

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/InvalidDummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/InvalidDummy.php
@@ -47,4 +47,11 @@ class InvalidDummy
     {
         return 'bar';
     }
+
+    /**
+     * @param $baz
+     */
+    public function setBaz($baz)
+    {
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59923
| License       | MIT
