### PR TITLE
[Validator] Fix docblock of `All` constraint constructor

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/All.php
+++ b/src/Symfony/Component/Validator/Constraints/All.php
@@ -25,8 +25,8 @@ class All extends Composite
     public array|Constraint $constraints = [];
 
     /**
-     * @param array<Constraint>|array<string,mixed>|null $constraints
-     * @param string[]|null                              $groups
+     * @param array<Constraint>|array<string,mixed>|Constraint|null $constraints
+     * @param string[]|null                                         $groups
      */
     public function __construct(mixed $constraints = null, ?array $groups = null, mixed $payload = null)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Single constraints can be provided to `All` (as shown in the the `AllValidatorTest`), but PHPStan currently complains as the docblock doesn't permit it.