### PR TITLE
[FrameworkBundle] fix autowiring `RateLimiterFactoryInterface`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -9,7 +9,7 @@ CHANGELOG
  * Add JsonStreamer services and configuration
  * Add new `framework.property_info.with_constructor_extractor` option to allow enabling or disabling the constructor extractor integration
  * Deprecate the `--show-arguments` option of the `container:debug` command, as arguments are now always shown
- * Add `RateLimiterFactoryInterface` as an alias of the `limiter` service
+ * Add autowiring alias for `RateLimiterFactoryInterface`
  * Add `framework.validation.disable_translation` option
  * Add support for signal plain name in the `messenger.stop_worker_on_signals` configuration
  * Deprecate the `framework.validation.cache` option

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -151,6 +151,7 @@ use Symfony\Component\PropertyInfo\PropertyListExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\RateLimiter\LimiterInterface;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
 use Symfony\Component\RateLimiter\Storage\CacheStorage;
 use Symfony\Component\RemoteEvent\Attribute\AsRemoteEventConsumer;
 use Symfony\Component\RemoteEvent\RemoteEvent;
@@ -3201,6 +3202,10 @@ class FrameworkExtension extends Extension
             $limiter->replaceArgument(0, $limiterConfig);
 
             $container->registerAliasForArgument($limiterId, RateLimiterFactory::class, $name.'.limiter');
+
+            if (interface_exists(RateLimiterFactoryInterface::class)) {
+                $container->registerAliasForArgument($limiterId, RateLimiterFactoryInterface::class, $name.'.limiter');
+            }
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/rate_limiter.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/rate_limiter.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Component\RateLimiter\RateLimiterFactory;
-use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
@@ -28,9 +27,4 @@ return static function (ContainerConfigurator $container) {
                 null,
             ])
     ;
-
-    if (interface_exists(RateLimiterFactoryInterface::class)) {
-        $container->services()
-            ->alias(RateLimiterFactoryInterface::class, 'limiter');
-    }
 };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix bug in #58939
| License       | MIT

Fixes a small bug from #58939. Confirmed with @alexandre-daubois this was the intention.