### PR TITLE
[Cache] Fix missing cache data in profiler

### DIFF
--- a/src/Symfony/Component/Cache/DataCollector/CacheDataCollector.php
+++ b/src/Symfony/Component/Cache/DataCollector/CacheDataCollector.php
@@ -60,6 +60,7 @@ class CacheDataCollector extends DataCollector implements LateDataCollectorInter
 
         $this->data['instances']['statistics'] = $this->calculateStatistics();
         $this->data['total']['statistics'] = $this->calculateTotalStatistics();
+        $this->data['instances']['calls'] = $this->cloneVar($this->data['instances']['calls']);
     }
 
     public function getName(): string

--- a/src/Symfony/Component/Cache/Tests/DataCollector/CacheDataCollectorTest.php
+++ b/src/Symfony/Component/Cache/Tests/DataCollector/CacheDataCollectorTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\Cache\Adapter\TraceableAdapter;
 use Symfony\Component\Cache\DataCollector\CacheDataCollector;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\VarDumper\Cloner\Data;
 
 class CacheDataCollectorTest extends TestCase
 {
@@ -122,6 +123,7 @@ class CacheDataCollectorTest extends TestCase
         $this->assertEquals($stats[self::INSTANCE_NAME]['hits'], 0, 'hits');
         $this->assertEquals($stats[self::INSTANCE_NAME]['misses'], 1, 'misses');
         $this->assertEquals($stats[self::INSTANCE_NAME]['calls'], 1, 'calls');
+        $this->assertInstanceOf(Data::class, $collector->getCalls());
     }
 
     private function getCacheDataCollectorStatisticsFromEvents(array $traceableAdapterEvents)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  6.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Issues        | Fix #59838
| License       | MIT

There was a problem with the rebase on PR https://github.com/symfony/symfony/pull/59841 
I added the fix and a test to check it
