### PR TITLE
[Process] Use a pipe for stderr in pty mode to avoid mixed output between stdout and stderr

### DIFF
--- a/src/Symfony/Component/Process/Pipes/UnixPipes.php
+++ b/src/Symfony/Component/Process/Pipes/UnixPipes.php
@@ -74,7 +74,7 @@ class UnixPipes extends AbstractPipes
             return [
                 ['pty'],
                 ['pty'],
-                ['pty'],
+                ['pipe', 'w'], // stderr needs to be in a pipe to correctly split error and output, since PHP will use the same stream for both
             ];
         }
 

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -540,6 +540,20 @@ class ProcessTest extends TestCase
         $this->assertNull($process->getExitCodeText());
     }
 
+    public function testStderrNotMixedWithStdout()
+    {
+        if (!Process::isPtySupported()) {
+            $this->markTestSkipped('PTY is not supported on this operating system.');
+        }
+
+        $process = $this->getProcess('echo "foo" && echo "bar" >&2');
+        $process->setPty(true);
+        $process->run();
+
+        $this->assertSame("foo\r\n", $process->getOutput());
+        $this->assertSame("bar\n", $process->getErrorOutput());
+    }
+
     public function testPTYCommand()
     {
         if (!Process::isPtySupported()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Issues        | Fix https://github.com/symfony/symfony/issues/59927
| License       | MIT

This PR split the stderr in a pipe to correctly split stdout / stderr when using `->setPty`

When using `pty` for pipes, PHP will only open only one pty and share the "same" fd for all pipes (it use dup but the original fd is the same)

Which means there is a possibility than stdout goes to stderr (or vice versa) when using `pty` for both stdout and stderr.

I did not make a test as this behavior is erratic and happens under other conditions that are hard to find (see related issue to see reproducer, we have to do some iterations before it happens)