### PR TITLE
[Security] Enhancing CAS authentication handling by extracting user attributes

### DIFF
--- a/src/Symfony/Component/Security/Http/AccessToken/Cas/Cas2Handler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/Cas/Cas2Handler.php
@@ -50,7 +50,23 @@ final class Cas2Handler implements AccessTokenHandlerInterface
         $xml = new \SimpleXMLElement($response->getContent(), 0, false, $this->prefix, true);
 
         if (isset($xml->authenticationSuccess)) {
-            return new UserBadge((string) $xml->authenticationSuccess->user);
+            $userIdentifier = (string) $xml->authenticationSuccess->user;
+            $attributes = [];
+            if (isset($xml->authenticationSuccess->attributes)) {
+                // Extract all attributes without using namespace
+                foreach ($xml->authenticationSuccess->attributes->children($this->prefix, true) as $child) {
+                    $key = $child->getName();
+                    if (isset($attributes[$key])) {
+                        if (!\is_array($attributes[$key])) {
+                            $attributes[$key] = [$attributes[$key]];
+                        }
+                        $attributes[$key][] = (string) $child;
+                    } else {
+                        $attributes[$key] = (string) $child;
+                    }
+                }
+            }        
+            return new UserBadge($userIdentifier, null, $attributes);
         }
 
         if (isset($xml->authenticationFailure)) {

--- a/src/Symfony/Component/Security/Http/AccessToken/Cas/Cas2Handler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/Cas/Cas2Handler.php
@@ -65,7 +65,7 @@ final class Cas2Handler implements AccessTokenHandlerInterface
                         $attributes[$key] = (string) $child;
                     }
                 }
-            }        
+            }
             return new UserBadge($userIdentifier, null, $attributes);
         }
 

--- a/src/Symfony/Component/Security/Http/Tests/AccessToken/Cas/Cas2HandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessToken/Cas/Cas2HandlerTest.php
@@ -25,13 +25,17 @@ final class Cas2HandlerTest extends TestCase
     public function testWithValidTicket()
     {
         $response = new MockResponse(<<<BODY
-                <cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>
-                    <cas:authenticationSuccess>
-                        <cas:user>lobster</cas:user>
-                        <cas:proxyGrantingTicket>PGTIOU-84678-8a9d</cas:proxyGrantingTicket>
-                    </cas:authenticationSuccess>
-                </cas:serviceResponse>
-            BODY
+            <cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>
+                <cas:authenticationSuccess>
+                    <cas:user>lobster</cas:user>
+                    <cas:proxyGrantingTicket>PGTIOU-84678-8a9d</cas:proxyGrantingTicket>
+                    <cas:attributes>
+                        <cas:email>lobster@example.com</cas:email>
+                        <cas:role>ROLE_USER</cas:role>
+                    </cas:attributes>
+                </cas:authenticationSuccess>
+            </cas:serviceResponse>
+        BODY
         );
 
         $httpClient = new MockHttpClient([$response]);
@@ -40,7 +44,64 @@ final class Cas2HandlerTest extends TestCase
 
         $cas2Handler = new Cas2Handler(requestStack: $requestStack, validationUrl: 'https://www.example.com/cas', client: $httpClient);
         $userbadge = $cas2Handler->getUserBadgeFrom('PGTIOU-84678-8a9d');
-        $this->assertEquals(new UserBadge('lobster'), $userbadge);
+        $this->assertEquals(new UserBadge('lobster', null, [
+            'email' => 'lobster@example.com',
+            'role' => 'ROLE_USER',
+        ]), $userbadge);        
+    }
+
+    public function testWithNoAttributes()
+    {
+        $response = new MockResponse(<<<BODY
+            <cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>
+                <cas:authenticationSuccess>
+                    <cas:user>lobster</cas:user>
+                    <cas:proxyGrantingTicket>PGTIOU-84678-8a9d</cas:proxyGrantingTicket>
+                </cas:authenticationSuccess>
+            </cas:serviceResponse>
+        BODY
+        );
+
+        $httpClient = new MockHttpClient([$response]);
+        $requestStack = new RequestStack();
+        $requestStack->push(new Request(['ticket' => 'PGTIOU-84678-8a9d']));
+
+        $cas2Handler = new Cas2Handler(requestStack: $requestStack, validationUrl: 'https://www.example.com/cas', client: $httpClient);
+        $userbadge = $cas2Handler->getUserBadgeFrom('PGTIOU-84678-8a9d');
+        $this->assertEquals(new UserBadge('lobster', null, []), $userbadge);
+    }
+
+    public function testWithMultipleAffiliations()
+    {
+        $response = new MockResponse(<<<BODY
+            <cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>
+                <cas:authenticationSuccess>
+                    <cas:user>lobster</cas:user>
+                    <cas:proxyGrantingTicket>PGTIOU-84678-8a9d</cas:proxyGrantingTicket>
+                    <cas:attributes>
+                        <cas:firstname>John</cas:firstname>
+                        <cas:lastname>Doe</cas:lastname>
+                        <cas:email>jdoe@example.org</cas:email>
+                        <cas:affiliation>staff</cas:affiliation>
+                        <cas:affiliation>faculty</cas:affiliation>
+                    </cas:attributes>
+                </cas:authenticationSuccess>
+            </cas:serviceResponse>
+        BODY
+        );
+
+        $httpClient = new MockHttpClient([$response]);
+        $requestStack = new RequestStack();
+        $requestStack->push(new Request(['ticket' => 'PGTIOU-84678-8a9d']));
+
+        $cas2Handler = new Cas2Handler(requestStack: $requestStack, validationUrl: 'https://www.example.com/cas', client: $httpClient);
+        $userbadge = $cas2Handler->getUserBadgeFrom('PGTIOU-84678-8a9d');
+        $this->assertEquals(new UserBadge('lobster', null, [
+            'firstname' => 'John',
+            'lastname' => 'Doe',
+            'email' => 'jdoe@example.org',
+            'affiliation' => ['staff', 'faculty'],
+        ]), $userbadge);
     }
 
     public function testWithInvalidTicket()

--- a/src/Symfony/Component/Security/Http/Tests/AccessToken/Cas/Cas2HandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessToken/Cas/Cas2HandlerTest.php
@@ -47,7 +47,7 @@ final class Cas2HandlerTest extends TestCase
         $this->assertEquals(new UserBadge('lobster', null, [
             'email' => 'lobster@example.com',
             'role' => 'ROLE_USER',
-        ]), $userbadge);        
+        ]), $userbadge);
     }
 
     public function testWithNoAttributes()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

### Description

This pull request enhances the CAS authentication process by extracting user attributes from the CAS response and passing them to the `UserBadge`. This ensures that additional information, such as email or roles, can be accessed within authentication workflows.

### Changes

- **[`src/Symfony/Component/Security/Http/AccessToken/Cas/Cas2Handler.php`](diffhunk://#diff-ef4a573bbad3de612fbf9f1756e04b8e48c72074c7d45ffdf7a5a2a9c5785539L53-R62)**  
  - Updated `getUserBadgeFrom` to extract attributes from the CAS response.  
  - Attributes are now passed to the `UserBadge` constructor, making them available in authentication logic.  

### Test Updates

- **[`src/Symfony/Component/Security/Http/Tests/AccessToken/Cas/Cas2HandlerTest.php`](diffhunk://#diff-88574bff6bccc5479ea323f44863d6feddd4aaddeeae10e1225e57343a3ae584R32-R35)**  
  - Updated `testWithValidTicket` to include attributes in the CAS response.  
  - Validates that `UserBadge` correctly includes and retains these attributes.  

### Why?

- Provides better integration with Symfony’s security system.  
- Ensures CAS user attributes (like email and roles) are available in authentication workflows.  
- Improves maintainability by aligning with how attributes are handled in OIDC authentication.  

✅ **Tests updated and verified**  
✅ **No backward compatibility breaks**  

Let me know if any adjustments are needed! 🚀
