### PR TITLE
Add default values to set_handler macro

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
@@ -411,7 +411,7 @@
     </div>
 {% endblock %}
 
-{% macro set_handler(controller, route, method) %}
+{% macro set_handler(controller, route = false, method = false) %}
     {% if controller.class is defined -%}
         {%- if method|default(false) %}<span class="sf-toolbar-status sf-toolbar-redirection-method">{{ method }}</span>{% endif -%}
         {%- set link = controller.file|file_link(controller.line) %}


### PR DESCRIPTION
Note: I need to rebase this on the 6.4 branch and update changelog, please allow me some time to do that. :) 

---

| Q             | A
| ------------- | ---
| Branch?       | 7.3 for features / 6.4, 7.1, and 7.2 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no
| Issues        | -
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Fixes the following error:

> request.CRITICAL: Uncaught PHP Exception Twig\Error\SyntaxError: "An exception has been thrown during the compilation of a template ("User Warning: Too few arguments (1) for macro 'set_handler' (at /var/www/pimcore/vendor/symfony/web-profiler-bundle/Resources/views/Collector/request.html.twig:28)")."