### PR TITLE
[WebProfilerBundle] Twig template macro arguments default values

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
@@ -411,7 +411,7 @@
     </div>
 {% endblock %}
 
-{% macro set_handler(controller, route, method) %}
+{% macro set_handler(controller, route = false, method = false) %}
     {% if controller.class is defined -%}
         {%- if method|default(false) %}<span class="sf-toolbar-status sf-toolbar-redirection-method">{{ method }}</span>{% endif -%}
         {%- set link = controller.file|file_link(controller.line) %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no
| Issues        | -
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Fixes the following error:

> request.CRITICAL: Uncaught PHP Exception Twig\Error\SyntaxError: "An exception has been thrown during the compilation of a template ("User Warning: Too few arguments (1) for macro 'set_handler' (at /var/www/pimcore/vendor/symfony/web-profiler-bundle/Resources/views/Collector/request.html.twig:28)")."