### PR TITLE
[OptionsResolver] Added OptionsResolverIntrospector::getNestedClosures() method

### DIFF
--- a/src/Symfony/Component/OptionsResolver/CHANGELOG.md
+++ b/src/Symfony/Component/OptionsResolver/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Support union type in `OptionResolver::setAllowedTypes()` method
  * Add `OptionsResolver::setOptions()` and `OptionConfigurator::options()` methods
  * Deprecate defining nested options via `setDefault()`, use `setOptions()` instead
+ * Add `OptionsResolverIntrospector::getNestedClosures()` method
 
 6.4
 ---

--- a/src/Symfony/Component/OptionsResolver/Debug/OptionsResolverIntrospector.php
+++ b/src/Symfony/Component/OptionsResolver/Debug/OptionsResolverIntrospector.php
@@ -59,6 +59,16 @@ class OptionsResolverIntrospector
     }
 
     /**
+     * @return \Closure[]
+     *
+     * @throws NoConfigurationException on no configured closures
+     */
+    public function getNestedClosures(string $option): array
+    {
+        return ($this->get)('nested', $option, \sprintf('No lazy closures were set for the "%s" option.', $option));
+    }
+
+    /**
      * @return string[]
      *
      * @throws NoConfigurationException on no configured types

--- a/src/Symfony/Component/OptionsResolver/Tests/Debug/OptionsResolverIntrospectorTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/Debug/OptionsResolverIntrospectorTest.php
@@ -90,6 +90,37 @@ class OptionsResolverIntrospectorTest extends TestCase
         $debug->getLazyClosures('foo');
     }
 
+    public function testGetNestedClosures()
+    {
+        $resolver = new OptionsResolver();
+        $closures = [];
+        $resolver->setOptions($option = 'foo', $closures[] = function (OptionsResolver $nestedResolver) {});
+
+        $debug = new OptionsResolverIntrospector($resolver);
+        $this->assertSame($closures, $debug->getNestedClosures($option));
+    }
+
+    public function testGetNestedClosuresThrowsOnNoConfiguredValue()
+    {
+        $this->expectException(NoConfigurationException::class);
+        $this->expectExceptionMessage('No lazy closures were set for the "foo" option.');
+        $resolver = new OptionsResolver();
+        $resolver->setDefined($option = 'foo');
+
+        $debug = new OptionsResolverIntrospector($resolver);
+        $debug->getNestedClosures($option);
+    }
+
+    public function testGetNestedClosuresThrowsOnNotDefinedOption()
+    {
+        $this->expectException(UndefinedOptionsException::class);
+        $this->expectExceptionMessage('The option "foo" does not exist.');
+        $resolver = new OptionsResolver();
+
+        $debug = new OptionsResolverIntrospector($resolver);
+        $debug->getNestedClosures('foo');
+    }
+
     public function testGetAllowedTypes()
     {
         $resolver = new OptionsResolver();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

The purpose of this PR is to add a missing feature to `OptionsResolverIntrospector` class. It does not have any method to introspect nested options at the moment.