### PR TITLE
[TypeInfo] Fix `@var` tag reading for promoted properties

### DIFF
--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithPhpDoc.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithPhpDoc.php
@@ -11,9 +11,18 @@ final class DummyWithPhpDoc
 
     /**
      * @param bool $promoted
+     * @param bool $promotedVarAndParam
      */
     public function __construct(
         public mixed $promoted,
+        /**
+         * @var string
+         */
+        public mixed $promotedVar,
+        /**
+         * @var string
+         */
+        public mixed $promotedVarAndParam,
     ) {
     }
 

--- a/src/Symfony/Component/TypeInfo/Tests/TypeResolver/PhpDocAwareReflectionTypeResolverTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeResolver/PhpDocAwareReflectionTypeResolverTest.php
@@ -29,6 +29,8 @@ class PhpDocAwareReflectionTypeResolverTest extends TestCase
 
         $this->assertEquals(Type::array(Type::object(Dummy::class)), $resolver->resolve($reflection->getProperty('arrayOfDummies')));
         $this->assertEquals(Type::bool(), $resolver->resolve($reflection->getProperty('promoted')));
+        $this->assertEquals(Type::string(), $resolver->resolve($reflection->getProperty('promotedVar')));
+        $this->assertEquals(Type::string(), $resolver->resolve($reflection->getProperty('promotedVarAndParam')));
         $this->assertEquals(Type::object(Dummy::class), $resolver->resolve($reflection->getMethod('getNextDummy')));
         $this->assertEquals(Type::object(Dummy::class), $resolver->resolve($reflection->getMethod('getNextDummy')->getParameters()[0]));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59959
| License       | MIT

Read either `@param` and `@var` tags for promoted properties.