### PR TITLE
[Cache] remove legacy "redis_sentinel" option (it was replaced "sentinel")

### DIFF
--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -46,7 +46,6 @@ trait RedisTrait
         'retry_interval' => 0,
         'tcp_keepalive' => 0,
         'lazy' => null,
-        'redis_sentinel' => null,
         'cluster' => false,
         'sentinel' => null,
         'relay_cluster_context' => [],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT