### PR TITLE
[Runtime] Make project_dir configurable

### DIFF
--- a/src/Symfony/Component/Runtime/CHANGELOG.md
+++ b/src/Symfony/Component/Runtime/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add automatic detection of FrankenPHP worker mode in `SymfonyRuntime`
  * Expose the runtime class in `$_SERVER['APP_RUNTIME']`
  * Expose the runtime options in `$_SERVER['APP_RUNTIME_OPTIONS']`
+ * Make `project_dir` configurable in `composer.json`
 
 6.4
 ---

--- a/src/Symfony/Component/Runtime/Internal/ComposerPlugin.php
+++ b/src/Symfony/Component/Runtime/Internal/ComposerPlugin.php
@@ -74,7 +74,7 @@ class ComposerPlugin implements PluginInterface, EventSubscriberInterface
             }
         }
 
-        $projectDir = $fs->makePathRelative($projectDir, $vendorDir);
+        $projectDir = $fs->makePathRelative(realpath($projectDir.'/'.($extra['project_dir'] ?? '')), $vendorDir);
         $nestingLevel = 0;
 
         while (str_starts_with($projectDir, '../')) {
@@ -91,7 +91,7 @@ class ComposerPlugin implements PluginInterface, EventSubscriberInterface
 
         $runtimeClass = $extra['class'] ?? SymfonyRuntime::class;
 
-        unset($extra['class'], $extra['autoload_template']);
+        unset($extra['class'], $extra['autoload_template'], $extra['project_dir']);
 
         $code = strtr(file_get_contents($autoloadTemplate), [
             '%project_dir%' => $projectDir,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #59954
| License       | MIT

this would allow a `composer.json` file at `/alternative/location/composer.json` be configured with

```json
  "extra": {
    "runtime": {
      "project_dir": "/../../"
    }
  }
```
while using

```shell
COMPOSER=/alternative/location/composer.json composer update
```

generate a `autoload_runtime.php` with the following `project_dir`

```php
$runtime = new $runtime(($_SERVER['APP_RUNTIME_OPTIONS'] ?? $_ENV['APP_RUNTIME_OPTIONS'] ?? []) + [
  'project_dir' => dirname(__DIR__, 1),
]);
```

i did not meddle with the autoload template discovery as that's currently already configurable and would introduce a bc break. also it makes sense in a way that every config value is relative to the composer.json file itself
