### PR TITLE
[HttpKernel] Only remove `E_WARNING` from error level during kernel init

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -407,7 +407,8 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
         $cachePath = $cache->getPath();
 
         // Silence E_WARNING to ignore "include" failures - don't use "@" to prevent silencing fatal errors
-        $errorLevel = error_reporting(\E_ALL ^ \E_WARNING);
+        $errorLevel = error_reporting();
+        error_reporting($errorLevel & ~\E_WARNING);
 
         try {
             if (is_file($cachePath) && \is_object($this->container = include $cachePath)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59139
| License       | MIT

This fixes #59139 as mentioned in https://github.com/symfony/symfony/issues/59139#issuecomment-2674252840.

With PHP 8.4 there can currently be a huge console output spam showing the

> Implicitly marking parameter as nullable is deprecated, the explicit nullable type must be used instead

deprecation, depending on your installed packages. This is caused by the kernel completely overriding the PHP error level within `initializeContainer()`, which will cause _everything_ to be shown (except warnings) that is triggered during `include`.

The kernel should always adhere to the `error_reporting` level set by the environment - thus this PR fixes this issue by only removing the `E_WARNING` level from the `error_reporting` level when trying to silence the include failures while including the cache path during kernel init.