### PR TITLE
[Messenger] Add `--class-filter` option to the `messenger:failed:remove` command

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add `CloseableTransportInterface` to allow closing the transport
  * Add `SentForRetryStamp` that identifies whether a failed message was sent for retry
  * Add `Symfony\Component\Messenger\Middleware\DeduplicateMiddleware` and `Symfony\Component\Messenger\Stamp\DeduplicateStamp`
+ * Add `--class-filter` option to the `messenger:failed:remove` command
 
 7.2
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR adds the `--class-filter` to the `messenger:failed:remove` command which is already available on `messenger:failed:show` command.  
It will yield the message ids that match the given class and use it as if it were passed as the `id` argument in the command so the `--force` and `--show-messages` can work with this filter.
When using the filter, the command will prompt for confirmation before removing the messages.

Example output:

```
$ bin/console messenger:failed:remove --class-filter="App\Message\MyMessage"

 There is 16 messages to remove. Do you want to continue? (yes/no) [yes]:
```

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
