### PR TITLE
[Console] Fixed support for Kernel as command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/KernelCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/KernelCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Kernel;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(name: 'kernel:hello')]
+final class KernelCommand extends MinimalKernel
+{
+    public function __invoke(OutputInterface $output): int
+    {
+        $output->write('Hello Kernel!');
+
+        return 0;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
@@ -13,7 +13,11 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Kernel;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\ClosureLoader;
@@ -150,6 +154,23 @@ class MicroKernelTraitTest extends TestCase
         $response = $kernel->handle($request, HttpKernelInterface::MAIN_REQUEST, false);
 
         $this->assertSame('Hello World!', $response->getContent());
+    }
+
+    public function testKernelCommand()
+    {
+        if (!property_exists(AsCommand::class, 'help')) {
+            $this->markTestSkipped('Invokable command no available.');
+        }
+
+        $kernel = $this->kernel = new KernelCommand('kernel_command');
+        $application = new Application($kernel);
+
+        $input = new ArrayInput(['command' => 'kernel:hello']);
+        $output = new BufferedOutput();
+
+        $this->assertTrue($application->has('kernel:hello'));
+        $this->assertSame(0, $application->doRun($input, $output));
+        $this->assertSame('Hello Kernel!', $output->fetch());
     }
 
     public function testDefaultKernel()

--- a/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
+++ b/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
@@ -39,7 +39,6 @@ class AddConsoleCommandPass implements CompilerPassInterface
 
         foreach ($commandServices as $id => $tags) {
             $definition = $container->getDefinition($id);
-            $definition->addTag('container.no_preload');
             $class = $container->getParameterBag()->resolveValue($definition->getClass());
 
             if (!$r = $container->getReflectionClass($class)) {
@@ -57,6 +56,8 @@ class AddConsoleCommandPass implements CompilerPassInterface
             } else {
                 $invokableRef = null;
             }
+
+            $definition->addTag('container.no_preload');
 
             /** @var AsCommand|null $attribute */
             $attribute = ($r->getAttributes(AsCommand::class)[0] ?? null)?->newInstance();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Currently, registering the Kernel as a command (see the example here: https://github.com/symfony/symfony/pull/59340#issuecomment-2567140159) results in an error:
```
Undefined array key "kernel"
```
I added the test case that highlights the issue and the fix (adding the `'container.no_preload'` tag to the invokable service is incorrect, as it is not the command service).