### PR TITLE
[TypeInfo] Add `ArrayShapeType::$sealed`

### DIFF
--- a/src/Symfony/Component/TypeInfo/Tests/TypeFactoryTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeFactoryTest.php
@@ -210,6 +210,16 @@ class TypeFactoryTest extends TestCase
     {
         $this->assertEquals(new ArrayShapeType(['foo' => ['type' => Type::bool(), 'optional' => true]]), Type::arrayShape(['foo' => ['type' => Type::bool(), 'optional' => true]]));
         $this->assertEquals(new ArrayShapeType(['foo' => ['type' => Type::bool(), 'optional' => false]]), Type::arrayShape(['foo' => Type::bool()]));
+        $this->assertEquals(new ArrayShapeType(
+            shape: ['foo' => ['type' => Type::bool(), 'optional' => false]],
+            extraKeyType: Type::union(Type::int(), Type::string()),
+            extraValueType: Type::mixed(),
+        ), Type::arrayShape(['foo' => Type::bool()], sealed: false));
+        $this->assertEquals(new ArrayShapeType(
+            shape: ['foo' => ['type' => Type::bool(), 'optional' => false]],
+            extraKeyType: Type::string(),
+            extraValueType: Type::bool(),
+        ), Type::arrayShape(['foo' => Type::bool()], extraKeyType: Type::string(), extraValueType: Type::bool()));
     }
 
     /**

--- a/src/Symfony/Component/TypeInfo/Tests/TypeResolver/StringTypeResolverTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeResolver/StringTypeResolverTest.php
@@ -76,6 +76,9 @@ class StringTypeResolverTest extends TestCase
         // array shape
         yield [Type::arrayShape(['foo' => Type::true(), 1 => Type::false()]), 'array{foo: true, 1: false}'];
         yield [Type::arrayShape(['foo' => ['type' => Type::bool(), 'optional' => true]]), 'array{foo?: bool}'];
+        yield [Type::arrayShape(['foo' => Type::bool()], sealed: false), 'array{foo: bool, ...}'];
+        yield [Type::arrayShape(['foo' => Type::bool()], extraKeyType: Type::int(), extraValueType: Type::string()), 'array{foo: bool, ...<int, string>}'];
+        yield [Type::arrayShape(['foo' => Type::bool()], extraValueType: Type::int()), 'array{foo: bool, ...<int>}'];
 
         // object shape
         yield [Type::object(), 'object{foo: true, bar: false}'];

--- a/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
+++ b/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
@@ -198,13 +198,22 @@ trait TypeFactoryTrait
     /**
      * @param array<array{type: Type, optional?: bool}|Type> $shape
      */
-    public static function arrayShape(array $shape): ArrayShapeType
+    public static function arrayShape(array $shape, bool $sealed = true, ?Type $extraKeyType = null, ?Type $extraValueType = null): ArrayShapeType
     {
-        return new ArrayShapeType(array_map(static function (array|Type $item): array {
+        $shape = array_map(static function (array|Type $item): array {
             return $item instanceof Type
                 ? ['type' => $item, 'optional' => false]
                 : ['type' => $item['type'], 'optional' => $item['optional'] ?? false];
-        }, $shape));
+        }, $shape);
+
+        if ($extraKeyType || $extraValueType) {
+            $sealed = false;
+        }
+
+        $extraKeyType ??= !$sealed ? Type::union(Type::int(), Type::string()) : null;
+        $extraValueType ??= !$sealed ? Type::mixed() : null;
+
+        return new ArrayShapeType($shape, $extraKeyType, $extraValueType);
     }
 
     /**

--- a/src/Symfony/Component/TypeInfo/TypeResolver/StringTypeResolver.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/StringTypeResolver.php
@@ -110,7 +110,12 @@ final class StringTypeResolver implements TypeResolverInterface
                 ];
             }
 
-            return Type::arrayShape($shape);
+            return Type::arrayShape(
+                $shape,
+                $node->sealed,
+                $node->unsealedType?->keyType ? $this->getTypeFromNode($node->unsealedType->keyType, $typeContext) : null,
+                $node->unsealedType?->valueType ? $this->getTypeFromNode($node->unsealedType->valueType, $typeContext) : null,
+            );
         }
 
         if ($node instanceof ObjectShapeNode) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

Implement sealed syntax for array shape type, as suggested in https://github.com/symfony/symfony/pull/59827#discussion_r1994316860.
