### PR TITLE
[Security] Fix typos in OIDC methods

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/OidcTokenHandlerFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/OidcTokenHandlerFactory.php
@@ -71,7 +71,7 @@ class OidcTokenHandlerFactory implements TokenHandlerFactoryInterface
                 ->replaceArgument(0, $config['encryption']['keyset']);
 
             $tokenHandlerDefinition->addMethodCall(
-                'enabledJweSupport',
+                'enableJweSupport',
                 [
                     $keyset,
                     $algorithmManager,

--- a/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenHandler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenHandler.php
@@ -71,14 +71,14 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface
         }
     }
 
-    public function enabledJweSupport(JWKSet $decryptionKeyset, AlgorithmManager $decryptionAlgorithms, bool $enforceEncryption): void
+    public function enableJweSupport(JWKSet $decryptionKeyset, AlgorithmManager $decryptionAlgorithms, bool $enforceEncryption): void
     {
         $this->decryptionKeyset = $decryptionKeyset;
         $this->decryptionAlgorithms = $decryptionAlgorithms;
         $this->enforceEncryption = $enforceEncryption;
     }
 
-    public function enabledDiscovery(CacheInterface $cache, HttpClientInterface $client, string $oidcConfigurationCacheKey, string $oidcJWKSetCacheKey): void
+    public function enableDiscovery(CacheInterface $cache, HttpClientInterface $client, string $oidcConfigurationCacheKey, string $oidcJWKSetCacheKey): void
     {
         $this->discoveryCache = $cache;
         $this->discoveryClient = $client;

--- a/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcUserInfoTokenHandler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcUserInfoTokenHandler.php
@@ -37,7 +37,7 @@ final class OidcUserInfoTokenHandler implements AccessTokenHandlerInterface
     ) {
     }
 
-    public function enabledDiscovery(CacheInterface $cache, string $oidcConfigurationCacheKey): void
+    public function enableDiscovery(CacheInterface $cache, string $oidcConfigurationCacheKey): void
     {
         $this->discoveryCache = $cache;
         $this->oidcConfigurationCacheKey = $oidcConfigurationCacheKey;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| License       | MIT

Related to recently merged [OIDC discovery](https://github.com/symfony/symfony/pull/54932), the DI is configured to call `enableDiscovery` method but it does not exist – but there is `enabledDiscovery`.

Let's drop the extra `d`, and the same for `enabledJweSupport` too.