### PR TITLE
[Form] Introduce `choice_help` option to `ChoiceType`

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -90,6 +90,9 @@
             </optgroup>
         {%- else -%}
             <option value="{{ choice.value }}"{% if choice.attr %}{% with { attr: choice.attr } %}{{ block('attributes') }}{% endwith %}{% endif %}{% if not render_preferred_choices|default(false) and choice is selectedchoice(value) %} selected="selected"{% endif %}>{{ choice_translation_domain is same as(false) ? choice.label : choice.label|trans(choice.labelTranslationParameters, choice_translation_domain) }}</option>
+            {% if choice.help is defined and choice.help is not none %}
+                <option disabled>{{ choice.help != '' ? (choice_translation_domain is same as(false) ? choice.help : choice.help|trans({}, choice_translation_domain)) }}</option>
+            {% endif %}
         {%- endif -%}
     {% endfor %}
 {%- endblock choice_widget_options -%}

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add support for displaying nested options in DebugCommand
+ * Add a `choice_help` option to `ChoiceType`
 
 7.2
 ---

--- a/src/Symfony/Component/Form/ChoiceList/ChoiceList.php
+++ b/src/Symfony/Component/Form/ChoiceList/ChoiceList.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Form\ChoiceList;
 use Symfony\Component\Form\ChoiceList\Factory\Cache\ChoiceAttr;
 use Symfony\Component\Form\ChoiceList\Factory\Cache\ChoiceFieldName;
 use Symfony\Component\Form\ChoiceList\Factory\Cache\ChoiceFilter;
+use Symfony\Component\Form\ChoiceList\Factory\Cache\ChoiceHelp;
 use Symfony\Component\Form\ChoiceList\Factory\Cache\ChoiceLabel;
 use Symfony\Component\Form\ChoiceList\Factory\Cache\ChoiceLoader;
 use Symfony\Component\Form\ChoiceList\Factory\Cache\ChoiceTranslationParameters;
@@ -105,6 +106,17 @@ final class ChoiceList
     public static function attr(FormTypeInterface|FormTypeExtensionInterface $formType, callable|array $attr, mixed $vary = null): ChoiceAttr
     {
         return new ChoiceAttr($formType, $attr, $vary);
+    }
+
+    /**
+     * Decorates a "choice_help" option to make it cacheable.
+     *
+     * @param callable|array $help Any pseudo callable or array to create help option from a choice
+     * @param mixed          $vary Dynamic data used to compute a unique hash when caching the option
+     */
+    public static function help(FormTypeInterface|FormTypeExtensionInterface $formType, callable|array $help, mixed $vary = null): ChoiceHelp
+    {
+        return new ChoiceHelp($formType, $help, $vary);
     }
 
     /**

--- a/src/Symfony/Component/Form/ChoiceList/Factory/Cache/ChoiceHelp.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/Cache/ChoiceHelp.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\ChoiceList\Factory\Cache;
+
+use Symfony\Component\Form\FormTypeExtensionInterface;
+use Symfony\Component\Form\FormTypeInterface;
+
+/**
+ * A cacheable wrapper for any {@see FormTypeInterface} or {@see FormTypeExtensionInterface}
+ * which configures a "choice_help" option.
+ *
+ * @internal
+ *
+ * @author Santiago San Martin <sanmartindev@gmail.com>
+ */
+final class ChoiceHelp extends AbstractStaticOption
+{
+}

--- a/src/Symfony/Component/Form/ChoiceList/Factory/CachingFactoryDecorator.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/CachingFactoryDecorator.php
@@ -143,7 +143,7 @@ class CachingFactoryDecorator implements ChoiceListFactoryInterface, ResetInterf
         return $this->lists[$hash];
     }
 
-    public function createView(ChoiceListInterface $list, mixed $preferredChoices = null, mixed $label = null, mixed $index = null, mixed $groupBy = null, mixed $attr = null, mixed $labelTranslationParameters = [], bool $duplicatePreferredChoices = true): ChoiceListView
+    public function createView(ChoiceListInterface $list, mixed $preferredChoices = null, mixed $label = null, mixed $index = null, mixed $groupBy = null, mixed $attr = null, mixed $labelTranslationParameters = [], bool $duplicatePreferredChoices = true, mixed $help = null): ChoiceListView
     {
         $cache = true;
 
@@ -177,6 +177,12 @@ class CachingFactoryDecorator implements ChoiceListFactoryInterface, ResetInterf
             $cache = false;
         }
 
+        if ($help instanceof Cache\ChoiceHelp) {
+            $help = $help->getOption();
+        } elseif ($help) {
+            $cache = false;
+        }
+
         if ($labelTranslationParameters instanceof Cache\ChoiceTranslationParameters) {
             $labelTranslationParameters = $labelTranslationParameters->getOption();
         } elseif ([] !== $labelTranslationParameters) {
@@ -193,10 +199,11 @@ class CachingFactoryDecorator implements ChoiceListFactoryInterface, ResetInterf
                 $attr,
                 $labelTranslationParameters,
                 $duplicatePreferredChoices,
+                $help,
             );
         }
 
-        $hash = self::generateHash([$list, $preferredChoices, $label, $index, $groupBy, $attr, $labelTranslationParameters, $duplicatePreferredChoices]);
+        $hash = self::generateHash([$list, $preferredChoices, $label, $index, $groupBy, $attr, $labelTranslationParameters, $duplicatePreferredChoices, $help]);
 
         if (!isset($this->views[$hash])) {
             $this->views[$hash] = $this->decoratedFactory->createView(
@@ -208,6 +215,7 @@ class CachingFactoryDecorator implements ChoiceListFactoryInterface, ResetInterf
                 $attr,
                 $labelTranslationParameters,
                 $duplicatePreferredChoices,
+                $help
             );
         }
 

--- a/src/Symfony/Component/Form/ChoiceList/Factory/ChoiceListFactoryInterface.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/ChoiceListFactoryInterface.php
@@ -80,6 +80,7 @@ interface ChoiceListFactoryInterface
      * @param bool                $duplicatePreferredChoices  Whether the preferred choices should be duplicated
      *                                                        on top of the list and in their original position
      *                                                        or only in the top of the list
+     * @param array|callable|null $help                       The callable generating the helps
      */
-    public function createView(ChoiceListInterface $list, array|callable|null $preferredChoices = null, callable|false|null $label = null, ?callable $index = null, ?callable $groupBy = null, array|callable|null $attr = null, array|callable $labelTranslationParameters = [], bool $duplicatePreferredChoices = true): ChoiceListView;
+    public function createView(ChoiceListInterface $list, array|callable|null $preferredChoices = null, callable|false|null $label = null, ?callable $index = null, ?callable $groupBy = null, array|callable|null $attr = null, array|callable $labelTranslationParameters = [], bool $duplicatePreferredChoices = true, array|callable|null $help = null): ChoiceListView;
 }

--- a/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php
@@ -52,7 +52,7 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
         return new LazyChoiceList($loader, $value);
     }
 
-    public function createView(ChoiceListInterface $list, array|callable|null $preferredChoices = null, callable|false|null $label = null, ?callable $index = null, ?callable $groupBy = null, array|callable|null $attr = null, array|callable $labelTranslationParameters = [], bool $duplicatePreferredChoices = true): ChoiceListView
+    public function createView(ChoiceListInterface $list, array|callable|null $preferredChoices = null, callable|false|null $label = null, ?callable $index = null, ?callable $groupBy = null, array|callable|null $attr = null, array|callable $labelTranslationParameters = [], bool $duplicatePreferredChoices = true, array|callable|null $help = null): ChoiceListView
     {
         $preferredViews = [];
         $preferredViewsOrder = [];
@@ -94,6 +94,7 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
                     $preferredViewsOrder,
                     $otherViews,
                     $duplicatePreferredChoices,
+                    $help
                 );
             }
 
@@ -133,6 +134,7 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
                 $preferredViewsOrder,
                 $otherViews,
                 $duplicatePreferredChoices,
+                $help
             );
         }
 
@@ -141,7 +143,7 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
         return new ChoiceListView($otherViews, $preferredViews);
     }
 
-    private static function addChoiceView($choice, string $value, $label, array $keys, &$index, $attr, $labelTranslationParameters, ?callable $isPreferred, array &$preferredViews, array &$preferredViewsOrder, array &$otherViews, bool $duplicatePreferredChoices): void
+    private static function addChoiceView($choice, string $value, $label, array $keys, &$index, $attr, $labelTranslationParameters, ?callable $isPreferred, array &$preferredViews, array &$preferredViewsOrder, array &$otherViews, bool $duplicatePreferredChoices, mixed $help): void
     {
         // $value may be an integer or a string, since it's stored in the array
         // keys. We want to guarantee it's a string though.
@@ -175,7 +177,8 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
             \is_callable($attr) ? $attr($choice, $key, $value) : ($attr[$key] ?? []),
             // The label translation parameters may be a callable or a mapping from choice indices
             // to nested arrays
-            \is_callable($labelTranslationParameters) ? $labelTranslationParameters($choice, $key, $value) : ($labelTranslationParameters[$key] ?? [])
+            \is_callable($labelTranslationParameters) ? $labelTranslationParameters($choice, $key, $value) : ($labelTranslationParameters[$key] ?? []),
+            \is_callable($help) ? $help($choice, $key, $value) : ($help[$key] ?? null),
         );
 
         // $isPreferred may be null if no choices are preferred
@@ -191,7 +194,7 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
         }
     }
 
-    private static function addChoiceViewsFromStructuredValues(array $values, $label, array $choices, array $keys, &$index, $attr, $labelTranslationParameters, ?callable $isPreferred, array &$preferredViews, array &$preferredViewsOrder, array &$otherViews, bool $duplicatePreferredChoices): void
+    private static function addChoiceViewsFromStructuredValues(array $values, $label, array $choices, array $keys, &$index, $attr, $labelTranslationParameters, ?callable $isPreferred, array &$preferredViews, array &$preferredViewsOrder, array &$otherViews, bool $duplicatePreferredChoices, mixed $help): void
     {
         foreach ($values as $key => $value) {
             if (null === $value) {
@@ -216,6 +219,7 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
                     $preferredViewsOrder,
                     $otherViewsForGroup,
                     $duplicatePreferredChoices,
+                    $help
                 );
 
                 if (\count($preferredViewsForGroup) > 0) {
@@ -243,11 +247,12 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
                 $preferredViewsOrder,
                 $otherViews,
                 $duplicatePreferredChoices,
+                $help,
             );
         }
     }
 
-    private static function addChoiceViewsGroupedByCallable(callable $groupBy, $choice, string $value, $label, array $keys, &$index, $attr, $labelTranslationParameters, ?callable $isPreferred, array &$preferredViews, array &$preferredViewsOrder, array &$otherViews, bool $duplicatePreferredChoices): void
+    private static function addChoiceViewsGroupedByCallable(callable $groupBy, $choice, string $value, $label, array $keys, &$index, $attr, $labelTranslationParameters, ?callable $isPreferred, array &$preferredViews, array &$preferredViewsOrder, array &$otherViews, bool $duplicatePreferredChoices, mixed $help): void
     {
         $groupLabels = $groupBy($choice, $keys[$value], $value);
 
@@ -266,6 +271,7 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
                 $preferredViewsOrder,
                 $otherViews,
                 $duplicatePreferredChoices,
+                $help,
             );
 
             return;
@@ -297,6 +303,7 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
                 $preferredViewsOrder[$groupLabel],
                 $otherViews[$groupLabel]->choices,
                 $duplicatePreferredChoices,
+                $help,
             );
         }
     }

--- a/src/Symfony/Component/Form/ChoiceList/Factory/PropertyAccessDecorator.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/PropertyAccessDecorator.php
@@ -109,7 +109,7 @@ class PropertyAccessDecorator implements ChoiceListFactoryInterface
         return $this->decoratedFactory->createListFromLoader($loader, $value, $filter);
     }
 
-    public function createView(ChoiceListInterface $list, mixed $preferredChoices = null, mixed $label = null, mixed $index = null, mixed $groupBy = null, mixed $attr = null, mixed $labelTranslationParameters = [], bool $duplicatePreferredChoices = true): ChoiceListView
+    public function createView(ChoiceListInterface $list, mixed $preferredChoices = null, mixed $label = null, mixed $index = null, mixed $groupBy = null, mixed $attr = null, mixed $labelTranslationParameters = [], bool $duplicatePreferredChoices = true, mixed $help = null): ChoiceListView
     {
         $accessor = $this->propertyAccessor;
 
@@ -167,6 +167,14 @@ class PropertyAccessDecorator implements ChoiceListFactoryInterface
             $attr = static fn ($choice) => $accessor->getValue($choice, $attr);
         }
 
+        if (\is_string($help)) {
+            $help = new PropertyPath($help);
+        }
+
+        if ($help instanceof PropertyPathInterface) {
+            $help = static fn ($choice) => $accessor->getValue($choice, $help);
+        }
+
         if (\is_string($labelTranslationParameters)) {
             $labelTranslationParameters = new PropertyPath($labelTranslationParameters);
         }
@@ -184,6 +192,7 @@ class PropertyAccessDecorator implements ChoiceListFactoryInterface
             $attr,
             $labelTranslationParameters,
             $duplicatePreferredChoices,
+            $help
         );
     }
 }

--- a/src/Symfony/Component/Form/ChoiceList/View/ChoiceView.php
+++ b/src/Symfony/Component/Form/ChoiceList/View/ChoiceView.php
@@ -28,6 +28,7 @@ class ChoiceView
      * @param string|TranslatableInterface|false $label                      The label displayed to humans; pass false to discard the label
      * @param array                              $attr                       Additional attributes for the HTML tag
      * @param array                              $labelTranslationParameters Additional parameters used to translate the label
+     * @param ?string                            $help                       Additional helps for the options
      */
     public function __construct(
         public mixed $data,
@@ -35,6 +36,7 @@ class ChoiceView
         public string|TranslatableInterface|false $label,
         public array $attr = [],
         public array $labelTranslationParameters = [],
+        public ?string $help = null,
     ) {
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -16,6 +16,7 @@ use Symfony\Component\Form\ChoiceList\ChoiceListInterface;
 use Symfony\Component\Form\ChoiceList\Factory\Cache\ChoiceAttr;
 use Symfony\Component\Form\ChoiceList\Factory\Cache\ChoiceFieldName;
 use Symfony\Component\Form\ChoiceList\Factory\Cache\ChoiceFilter;
+use Symfony\Component\Form\ChoiceList\Factory\Cache\ChoiceHelp;
 use Symfony\Component\Form\ChoiceList\Factory\Cache\ChoiceLabel;
 use Symfony\Component\Form\ChoiceList\Factory\Cache\ChoiceLoader;
 use Symfony\Component\Form\ChoiceList\Factory\Cache\ChoiceTranslationParameters;
@@ -358,6 +359,7 @@ class ChoiceType extends AbstractType
             'choice_name' => null,
             'choice_value' => null,
             'choice_attr' => null,
+            'choice_help' => null,
             'choice_translation_parameters' => [],
             'preferred_choices' => [],
             'separator' => '-------------------',
@@ -391,6 +393,7 @@ class ChoiceType extends AbstractType
         $resolver->setAllowedTypes('choice_name', ['null', 'callable', 'string', PropertyPath::class, ChoiceFieldName::class]);
         $resolver->setAllowedTypes('choice_value', ['null', 'callable', 'string', PropertyPath::class, ChoiceValue::class]);
         $resolver->setAllowedTypes('choice_attr', ['null', 'array', 'callable', 'string', PropertyPath::class, ChoiceAttr::class]);
+        $resolver->setAllowedTypes('choice_help', ['null', 'array', \Traversable::class, 'callable', 'string', PropertyPath::class, ChoiceHelp::class]);
         $resolver->setAllowedTypes('choice_translation_parameters', ['null', 'array', 'callable', ChoiceTranslationParameters::class]);
         $resolver->setAllowedTypes('placeholder_attr', ['array']);
         $resolver->setAllowedTypes('preferred_choices', ['array', \Traversable::class, 'callable', 'string', PropertyPath::class, PreferredChoice::class]);
@@ -483,6 +486,7 @@ class ChoiceType extends AbstractType
             $options['choice_attr'],
             $options['choice_translation_parameters'],
             $options['duplicate_preferred_choices'],
+            $options['choice_help'],
         );
     }
 }

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Factory/CachingFactoryDecoratorTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Factory/CachingFactoryDecoratorTest.php
@@ -354,6 +354,82 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->assertEquals(new ChoiceListView(), $view2);
     }
 
+    public function testCreateViewSameHelps()
+    {
+        $help = ['a' => 'c'];
+        $list = new ArrayChoiceList([]);
+        $view1 = $this->factory->createView($list, null, null, null, null, null, [], true, $help);
+        $view2 = $this->factory->createView($list, null, null, null, null, null, [], true, $help);
+
+        $this->assertNotSame($view1, $view2);
+        $this->assertEquals(new ChoiceListView(), $view1);
+        $this->assertEquals(new ChoiceListView(), $view2);
+    }
+
+    public function testCreateViewSameHelpsUseCache()
+    {
+        $help = ['a' => 'c'];
+        $type = new FormType();
+        $list = new ArrayChoiceList([]);
+        $view1 = $this->factory->createView($list, null, null, null, null, null, [], true, ChoiceList::help($type, $help));
+        $view2 = $this->factory->createView($list, null, null, null, null, null, [], true, ChoiceList::help($type, ['a']));
+
+        $this->assertSame($view1, $view2);
+        $this->assertEquals(new ChoiceListView(), $view1);
+        $this->assertEquals(new ChoiceListView(), $view2);
+    }
+
+    public function testCreateViewDifferentHelps()
+    {
+        $help1 = ['a' => 'c'];
+        $help2 = ['b' => 'd'];
+        $list = new ArrayChoiceList([]);
+        $view1 = $this->factory->createView($list, null, null, null, null, null, [], true, $help1);
+        $view2 = $this->factory->createView($list, null, null, null, null, null, [], true, $help2);
+
+        $this->assertNotSame($view1, $view2);
+        $this->assertEquals(new ChoiceListView(), $view1);
+        $this->assertEquals(new ChoiceListView(), $view2);
+    }
+
+    public function testCreateViewSameHelpsClosure()
+    {
+        $help = function () {};
+        $list = new ArrayChoiceList([]);
+        $view1 = $this->factory->createView($list, null, null, null, null, null, [], true, $help);
+        $view2 = $this->factory->createView($list, null, null, null, null, null, [], true, $help);
+
+        $this->assertNotSame($view1, $view2);
+        $this->assertEquals(new ChoiceListView(), $view1);
+        $this->assertEquals(new ChoiceListView(), $view2);
+    }
+
+    public function testCreateViewSameHelpsClosureUseCache()
+    {
+        $helpCallback = function () {};
+        $type = new FormType();
+        $list = new ArrayChoiceList([]);
+        $view1 = $this->factory->createView($list, null, null, null, null, null, [], true, ChoiceList::help($type, $helpCallback));
+        $view2 = $this->factory->createView($list, null, null, null, null, null, [], true, ChoiceList::help($type, function () {}));
+
+        $this->assertSame($view1, $view2);
+        $this->assertEquals(new ChoiceListView(), $view1);
+        $this->assertEquals(new ChoiceListView(), $view2);
+    }
+
+    public function testCreateViewDifferentHelpsClosure()
+    {
+        $help1 = function () {};
+        $help2 = function () {};
+        $list = new ArrayChoiceList([]);
+        $view1 = $this->factory->createView($list, null, null, null, null, null, [], true, $help1);
+        $view2 = $this->factory->createView($list, null, null, null, null, null, [], true, $help2);
+
+        $this->assertNotSame($view1, $view2);
+        $this->assertEquals(new ChoiceListView(), $view1);
+        $this->assertEquals(new ChoiceListView(), $view2);
+    }
+
     public function testCreateViewSameLabelClosure()
     {
         $labels = function () {};

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Factory/DefaultChoiceListFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Factory/DefaultChoiceListFactoryTest.php
@@ -69,6 +69,11 @@ class DefaultChoiceListFactoryTest extends TestCase
         return $object->attr;
     }
 
+    public function getHelp($object)
+    {
+        return $object->help;
+    }
+
     public function getLabelTranslationParameters($object)
     {
         return $object->labelTranslationParameters;
@@ -93,10 +98,10 @@ class DefaultChoiceListFactoryTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->obj1 = (object) ['label' => 'A', 'index' => 'w', 'value' => 'a', 'preferred' => false, 'group' => 'Group 1', 'attr' => [], 'labelTranslationParameters' => []];
-        $this->obj2 = (object) ['label' => 'B', 'index' => 'x', 'value' => 'b', 'preferred' => true, 'group' => 'Group 1', 'attr' => ['attr1' => 'value1'], 'labelTranslationParameters' => []];
-        $this->obj3 = (object) ['label' => 'C', 'index' => 'y', 'value' => 1, 'preferred' => true, 'group' => 'Group 2', 'attr' => ['attr2' => 'value2'], 'labelTranslationParameters' => []];
-        $this->obj4 = (object) ['label' => 'D', 'index' => 'z', 'value' => 2, 'preferred' => false, 'group' => 'Group 2', 'attr' => [], 'labelTranslationParameters' => ['%placeholder1%' => 'value1']];
+        $this->obj1 = (object) ['label' => 'A', 'index' => 'w', 'value' => 'a', 'preferred' => false, 'group' => 'Group 1', 'attr' => [], 'labelTranslationParameters' => [], 'help' => null];
+        $this->obj2 = (object) ['label' => 'B', 'index' => 'x', 'value' => 'b', 'preferred' => true, 'group' => 'Group 1', 'attr' => ['attr1' => 'value1'], 'labelTranslationParameters' => [], 'help' => 'help1'];
+        $this->obj3 = (object) ['label' => 'C', 'index' => 'y', 'value' => 1, 'preferred' => true, 'group' => 'Group 2', 'attr' => ['attr2' => 'value2'], 'labelTranslationParameters' => [], 'help' => 'help2'];
+        $this->obj4 = (object) ['label' => 'D', 'index' => 'z', 'value' => 2, 'preferred' => false, 'group' => 'Group 2', 'attr' => [], 'labelTranslationParameters' => ['%placeholder1%' => 'value1'], 'help' => null];
         $this->list = new ArrayChoiceList(['A' => $this->obj1, 'B' => $this->obj2, 'C' => $this->obj3, 'D' => $this->obj4]);
         $this->factory = new DefaultChoiceListFactory();
     }
@@ -713,6 +718,116 @@ class DefaultChoiceListFactoryTest extends TestCase
         $this->assertFlatViewWithAttr($view);
     }
 
+    public function testCreateViewFlatHelpsAsArray()
+    {
+        $view = $this->factory->createView(
+            $this->list,
+            [$this->obj2, $this->obj3],
+            null, // label
+            null, // index
+            null, // group
+            [], // attr
+            [], // labelTranslationParameters
+            true, // duplicatePreferredChoices
+            [
+                'B' => 'help1',
+                'C' => 'help2',
+            ]
+        );
+
+        $this->assertFlatViewWithHelps($view);
+    }
+
+    public function testCreateViewFlatHelpsEmpty()
+    {
+        $view = $this->factory->createView(
+            $this->list,
+            [$this->obj2, $this->obj3],
+            null, // label
+            null, // index
+            null, // group
+            []
+        );
+
+        $this->assertFlatView($view);
+    }
+
+    public function testCreateViewFlatHelpsAsCallable()
+    {
+        $view = $this->factory->createView(
+            $this->list,
+            [$this->obj2, $this->obj3],
+            null, // label
+            null, // index
+            null, // group
+            [], // attr
+            [], // labelTranslationParameters
+            true, // duplicatePreferredChoices
+            $this->getHelp(...)
+        );
+
+        $this->assertFlatViewWithHelps($view);
+    }
+
+    public function testCreateViewFlatHelpsAsClosure()
+    {
+        $view = $this->factory->createView(
+            $this->list,
+            [$this->obj2, $this->obj3],
+            null, // label
+            null, // index
+            null, // group
+            [], // attr
+            [], // labelTranslationParameters
+            true, // duplicatePreferredChoices
+            fn ($object) => $object->help
+        );
+
+        $this->assertFlatViewWithHelps($view);
+    }
+
+    public function testCreateViewFlatHelpsClosureReceivesKey()
+    {
+        $view = $this->factory->createView(
+            $this->list,
+            [$this->obj2, $this->obj3],
+            null, // label
+            null, // index
+            null, // group
+            [], // attr
+            [], // labelTranslationParameters
+            true, // duplicatePreferredChoices
+            fn ($object, $key) => match ($key) {
+                'B' => 'help1',
+                'C' => 'help2',
+                default => null,
+            }
+        );
+
+        $this->assertFlatViewWithHelps($view);
+    }
+
+    public function testCreateViewFlatHelpsClosureReceivesValue()
+    {
+        $view = $this->factory->createView(
+            $this->list,
+            [$this->obj2, $this->obj3],
+            null, // label
+            null, // index
+            null, // group
+            [], // attr
+            [], // labelTranslationParameters
+            true, // duplicatePreferredChoices
+            fn ($object, $key, $value) => match ($value) {
+                '1' => 'help1',
+                '2' => 'help2',
+                default => null,
+            }
+        );
+
+        $this->assertFlatViewWithHelps($view);
+    }
+
     public function testPassTranslatableMessageAsLabelDoesntCastItToString()
     {
         $view = $this->factory->createView(
@@ -940,6 +1055,49 @@ class DefaultChoiceListFactoryTest extends TestCase
                     '2',
                     'C',
                     ['attr2' => 'value2']
+                ),
+            ]
+        ), $view);
+    }
+
+    private function assertFlatViewWithHelps($view)
+    {
+        $this->assertEquals(new ChoiceListView(
+            [
+                0 => new ChoiceView($this->obj1, '0', 'A'),
+                1 => new ChoiceView(
+                    $this->obj2,
+                    '1',
+                    'B',
+                    [],
+                    [],
+                    'help1'
+                ),
+                2 => new ChoiceView(
+                    $this->obj3,
+                    '2',
+                    'C',
+                    [],
+                    [],
+                    'help2'
+                ),
+                3 => new ChoiceView($this->obj4, '3', 'D'),
+            ], [
+                1 => new ChoiceView(
+                    $this->obj2,
+                    '1',
+                    'B',
+                    [],
+                    [],
+                    'help1'
+                ),
+                2 => new ChoiceView(
+                    $this->obj3,
+                    '2',
+                    'C',
+                    [],
+                    [],
+                    'help2'
                 ),
             ]
         ), $view);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -1837,6 +1837,12 @@ class ChoiceTypeTest extends BaseTypeTestCase
                 ['attr3' => 'value3'],
                 ['attr4' => 'value4'],
             ],
+            'choice_help' => [
+                'help1',
+                'help2',
+                'help3',
+                'help4',
+            ],
             'choice_translation_parameters' => [
                 ['%placeholder1%' => 'value1'],
                 ['%placeholder2%' => 'value2'],
@@ -1847,10 +1853,10 @@ class ChoiceTypeTest extends BaseTypeTestCase
             ->createView();
 
         $this->assertEquals([
-            new ChoiceView($obj1, 'a', 'A', ['attr1' => 'value1'], ['%placeholder1%' => 'value1']),
-            new ChoiceView($obj2, 'b', 'B', ['attr2' => 'value2'], ['%placeholder2%' => 'value2']),
-            new ChoiceView($obj3, 'c', 'C', ['attr3' => 'value3'], ['%placeholder3%' => 'value3']),
-            new ChoiceView($obj4, 'd', 'D', ['attr4' => 'value4'], ['%placeholder4%' => 'value4']),
+            new ChoiceView($obj1, 'a', 'A', ['attr1' => 'value1'], ['%placeholder1%' => 'value1'], 'help1'),
+            new ChoiceView($obj2, 'b', 'B', ['attr2' => 'value2'], ['%placeholder2%' => 'value2'], 'help2'),
+            new ChoiceView($obj3, 'c', 'C', ['attr3' => 'value3'], ['%placeholder3%' => 'value3'], 'help3'),
+            new ChoiceView($obj4, 'd', 'D', ['attr4' => 'value4'], ['%placeholder4%' => 'value4'], 'help4'),
         ], $view->vars['choices']);
     }
 

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.json
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.json
@@ -5,6 +5,7 @@
         "own": [
             "choice_attr",
             "choice_filter",
+            "choice_help",
             "choice_label",
             "choice_lazy",
             "choice_loader",

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.txt
@@ -7,24 +7,24 @@ Symfony\Component\Form\Extension\Core\Type\ChoiceType (Block prefix: "choice")
  ------------------------------- -------------------- ------------------------------ ----------------------- 
   choice_attr                     FormType             FormType                       FormTypeCsrfExtension  
   choice_filter                  -------------------- ------------------------------ ----------------------- 
-  choice_label                    compound             action                         csrf_field_name        
-  choice_lazy                     data_class           allow_file_upload              csrf_message           
-  choice_loader                   empty_data           attr                           csrf_protection        
-  choice_name                     error_bubbling       attr_translation_parameters    csrf_token_id          
-  choice_translation_domain       invalid_message      auto_initialize                csrf_token_manager     
-  choice_translation_parameters   trim                 block_name                                            
-  choice_value                                         block_prefix                                          
-  choices                                              by_reference                                          
-  duplicate_preferred_choices                          data                                                  
-  expanded                                             disabled                                              
-  group_by                                             form_attr                                             
-  multiple                                             getter                                                
-  placeholder                                          help                                                  
-  placeholder_attr                                     help_attr                                             
-  preferred_choices                                    help_html                                             
-  separator                                            help_translation_parameters                           
-  separator_html                                       inherit_data                                          
-                                                       invalid_message_parameters                            
+  choice_help                     compound             action                         csrf_field_name        
+  choice_label                    data_class           allow_file_upload              csrf_message           
+  choice_lazy                     empty_data           attr                           csrf_protection        
+  choice_loader                   error_bubbling       attr_translation_parameters    csrf_token_id          
+  choice_name                     invalid_message      auto_initialize                csrf_token_manager     
+  choice_translation_domain       trim                 block_name                                            
+  choice_translation_parameters                        block_prefix                                          
+  choice_value                                         by_reference                                          
+  choices                                              data                                                  
+  duplicate_preferred_choices                          disabled                                              
+  expanded                                             form_attr                                             
+  group_by                                             getter                                                
+  multiple                                             help                                                  
+  placeholder                                          help_attr                                             
+  placeholder_attr                                     help_html                                             
+  preferred_choices                                    help_translation_parameters                           
+  separator                                            inherit_data                                          
+  separator_html                                       invalid_message_parameters                            
                                                        is_empty_callback                                     
                                                        label                                                 
                                                        label_attr                                            


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Feature #50823
| License       | MIT

Hello :vulcan_salute:,

This PR addresses one of the two requested solutions mentioned in the linked issue. The two solutions discussed in the issue are:
1. Add a **choice_help** option to allow providing a help message for each choice.
2. Allow adding HTML to the choices.

In this PR, I have implemented the solution for the first request. I plan to address the second request in a future PR, as I believe both options are valuable. However, to minimize the risk of conflicts, I prefer to introduce them one at a time

Here is a small example showing how to use the new **choice_help** functionality.

```php
// array
$builder->add('isAttending', ChoiceType::class, [
                'choices' => [
                    'Fruits' => [
                        'Apple' => 1,
                        'Banana' => 2,
                        'Durian' => 3,
                    ]
                ],
                'choice_help' => [
                    'Apple' => 'choice.apple',
                    'Banana' => 'Yellow',
                    'Durian' => 'Green',
                ],
                'choice_translation_domain' => true
            ]);

// callable
$builder->add('isAttending', ChoiceType::class, [
                'choices' => [
                    'Fruits' => [
                        'Apple' => 1,
                        'Banana' => 2,
                        'Durian' => 3,
                    ]
                ],
                'choice_help' => function ($choice, string $key, mixed $value): string {
                    return \sprintf('help-%s', $key);
                }
            ]);

// with cache
$builder->add('isAttending', ChoiceType::class, [
                'choices' => [
                    'Fruits' => [
                        'Apple' => 1,
                        'Banana' => 2,
                        'Durian' => 3,
                    ]
                ],
                'choice_help' => ChoiceList::help($this, function ($choice, string $key, mixed $value): string {
                    return $key . '-help';
                }),
            ]);
```

Additionally, I’m providing an image without any CSS showing how the **choice_help** option would look.

![Screenshot from 2025-03-15 19-28-18](https://github.com/user-attachments/assets/966a96cc-a8b5-4d46-b5fe-5ddb276e0739)
