### PR TITLE
[FrameworkBundle] Auto-exclude DI extensions, test cases, entities and messenger messages

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG
  * Add support for signal plain name in the `messenger.stop_worker_on_signals` configuration
  * Deprecate the `framework.validation.cache` option
  * Add `--method` option to the `debug:router` command
+ * Auto-exclude DI extensions, test cases, entities and messenger messages
 
 7.2
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
@@ -165,6 +165,7 @@ trait MicroKernelTrait
                     ->setPublic(true)
                 ;
             }
+            $container->setAlias($kernelClass, 'kernel')->setPublic(true);
 
             $kernelDefinition = $container->getDefinition('kernel');
             $kernelDefinition->addTag('routing.route_loader');
@@ -197,8 +198,6 @@ trait MicroKernelTrait
                 $kernelLoader->registerAliasesForSinglyImplementedInterfaces();
                 AbstractConfigurator::$valuePreProcessor = $valuePreProcessor;
             }
-
-            $container->setAlias($kernelClass, 'kernel')->setPublic(true);
         });
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

So that we can remove the exclude lines from the default recipe.