### PR TITLE
[FrameworkBundle] Remove redundant `name` attribute from `default_context`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1196,7 +1196,6 @@ class Configuration implements ConfigurationInterface
                         ->end()
                         ->arrayNode('default_context')
                             ->normalizeKeys(false)
-                            ->useAttributeAsKey('name')
                             ->validate()
                                 ->ifTrue(fn () => $this->debug && class_exists(JsonParser::class))
                                 ->then(fn (array $v) => $v + [JsonDecode::DETAILED_ERROR_MESSAGES => true])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes?
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This was initially merged into v7.1 in #53657. However, after seeing @wouterj's [comment](https://github.com/symfony/symfony/pull/53657#issuecomment-2495496835) (which I missed earlier), I opened this PR to see if we might want to reconsider this as a bug after all.