### PR TITLE
[Console] Add option to control progress bar visibility

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -978,6 +978,8 @@ class Application implements ResetInterface
             }
         }
 
+        $output->setProgressBarVisibility(!$input->hasParameterOption('--no-progress', true));
+
         if (0 > $shellVerbosity) {
             $input->setInteractive(false);
         }
@@ -1137,6 +1139,7 @@ class Application implements ResetInterface
             new InputOption('--version', '-V', InputOption::VALUE_NONE, 'Display this application version'),
             new InputOption('--ansi', '', InputOption::VALUE_NEGATABLE, 'Force (or disable --no-ansi) ANSI output', null),
             new InputOption('--no-interaction', '-n', InputOption::VALUE_NONE, 'Do not ask any interactive question'),
+            new InputOption('--no-progress', null, InputOption::VALUE_NONE, 'Disable the progress bar output during the execution of the command'),
         ]);
     }
 

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG
  * Add support for `LockableTrait` in invokable commands
  * Deprecate returning a non-integer value from a `\Closure` function set via `Command::setCode()`
  * Mark `#[AsCommand]` attribute as `@final`
+ * Add `--no-progress` option to the commands
 
 7.2
 ---

--- a/src/Symfony/Component/Console/Descriptor/ReStructuredTextDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/ReStructuredTextDescriptor.php
@@ -223,6 +223,7 @@ class ReStructuredTextDescriptor extends Descriptor
             'version',
             'ansi',
             'no-interaction',
+            'no-progress',
         ];
         $nonDefaultOptions = [];
         foreach ($definition->getOptions() as $option) {

--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -502,6 +502,9 @@ final class ProgressBar
      */
     private function overwrite(string $message): void
     {
+        if ($this->output->isHiddenProgressBar()) {
+            return;
+        }
         if ($this->previousMessage === $message) {
             return;
         }

--- a/src/Symfony/Component/Console/Output/ConsoleOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleOutput.php
@@ -82,6 +82,18 @@ class ConsoleOutput extends StreamOutput implements ConsoleOutputInterface
         $this->stderr->setVerbosity($level);
     }
 
+    public function setHiddenOptions(array $hiddenOptions): void
+    {
+        parent::setHiddenOptions($hiddenOptions);
+        $this->stderr->setHiddenOptions($hiddenOptions);
+    }
+
+    public function setProgressBarVisibility(bool $visible): void
+    {
+        parent::setProgressBarVisibility($visible);
+        $this->stderr->setProgressBarVisibility($visible);
+    }
+
     public function getErrorOutput(): OutputInterface
     {
         return $this->stderr;

--- a/src/Symfony/Component/Console/Output/NullOutput.php
+++ b/src/Symfony/Component/Console/Output/NullOutput.php
@@ -82,6 +82,26 @@ class NullOutput implements OutputInterface
         return false;
     }
 
+    public function setHiddenOptions(array $hiddenOptions): void
+    {
+        // do nothing
+    }
+
+    public function getHiddenOptions(): array
+    {
+        return [];
+    }
+
+    public function setProgressBarVisibility(bool $visible): void
+    {
+        // do nothing
+    }
+
+    public function isHiddenProgressBar(): bool
+    {
+        return false;
+    }
+
     public function writeln(string|iterable $messages, int $options = self::OUTPUT_NORMAL): void
     {
         // do nothing

--- a/src/Symfony/Component/Console/Output/Output.php
+++ b/src/Symfony/Component/Console/Output/Output.php
@@ -32,6 +32,9 @@ abstract class Output implements OutputInterface
 {
     private int $verbosity;
     private OutputFormatterInterface $formatter;
+    private array $hiddenOptions = [
+        self::HIDDEN_PROGRESS_BAR => false,
+    ];
 
     /**
      * @param int|null                      $verbosity The verbosity level (one of the VERBOSITY constants in OutputInterface)
@@ -98,6 +101,26 @@ abstract class Output implements OutputInterface
     public function isDebug(): bool
     {
         return self::VERBOSITY_DEBUG <= $this->verbosity;
+    }
+
+    public function setHiddenOptions(array $hiddenOptions): void
+    {
+        $this->hiddenOptions = $hiddenOptions;
+    }
+
+    public function getHiddenOptions(): array
+    {
+        return $this->hiddenOptions;
+    }
+
+    public function setProgressBarVisibility(bool $visible): void
+    {
+        $this->hiddenOptions[self::HIDDEN_PROGRESS_BAR] = !$visible;
+    }
+
+    public function isHiddenProgressBar(): bool
+    {
+        return $this->hiddenOptions[self::HIDDEN_PROGRESS_BAR] ?? false;
     }
 
     public function writeln(string|iterable $messages, int $options = self::OUTPUT_NORMAL): void

--- a/src/Symfony/Component/Console/Output/OutputInterface.php
+++ b/src/Symfony/Component/Console/Output/OutputInterface.php
@@ -33,6 +33,8 @@ interface OutputInterface
     public const OUTPUT_RAW = 2;
     public const OUTPUT_PLAIN = 4;
 
+    public const HIDDEN_PROGRESS_BAR = 'progress_bar';
+
     /**
      * Writes a message to the output.
      *
@@ -100,4 +102,24 @@ interface OutputInterface
      * Returns current output formatter instance.
      */
     public function getFormatter(): OutputFormatterInterface;
+
+    /**
+     * Sets the hiddenOptions of the output.
+     */
+    public function setHiddenOptions(array $hiddenOptions): void;
+
+    /**
+     * Gets the current hiddenOptions of the output.
+     */
+    public function getHiddenOptions(): array;
+
+    /**
+     * Sets the visibility of the progress bar.
+     */
+    public function setProgressBarVisibility(bool $visible): void;
+
+    /**
+     * Checks if the progress bar is hidden.
+     */
+    public function isHiddenProgressBar(): bool;
 }

--- a/src/Symfony/Component/Console/Style/OutputStyle.php
+++ b/src/Symfony/Component/Console/Style/OutputStyle.php
@@ -104,6 +104,26 @@ abstract class OutputStyle implements OutputInterface, StyleInterface
         return $this->output->isDebug();
     }
 
+    public function setHiddenOptions(array $hiddenOptions): void
+    {
+        $this->output->setHiddenOptions($hiddenOptions);
+    }
+
+    public function getHiddenOptions(): array
+    {
+        return $this->output->getHiddenOptions();
+    }
+
+    public function setProgressBarVisibility(bool $visible): void
+    {
+        $this->output->setProgressBarVisibility($visible);
+    }
+
+    public function isHiddenProgressBar(): bool
+    {
+        return $this->output->isHiddenProgressBar();
+    }
+
     protected function getErrorOutput(): OutputInterface
     {
         if (!$this->output instanceof ConsoleOutputInterface) {

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -1113,6 +1113,9 @@ class ApplicationTest extends TestCase
         $tester->run(['command' => 'help', '-h' => true], ['decorated' => false]);
         $this->assertStringEqualsFile(self::$fixturesPath.'/application_run5.txt', $tester->getDisplay(true), '->run() displays the help if -h is passed');
 
+        $tester->run(['--no-progress' => true]);
+        $this->assertFalse($tester->getOutput()->isDecorated(), '->run() Disable the progress bar output during the execution of the command');
+
         $application = new Application();
         $application->setAutoExit(false);
         $application->setCatchExceptions(false);

--- a/src/Symfony/Component/Console/Tests/Command/CompleteCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CompleteCommandTest.php
@@ -119,9 +119,9 @@ class CompleteCommandTest extends TestCase
 
     public static function provideCompleteCommandInputDefinitionInputs()
     {
-        yield 'definition' => [['bin/console', 'hello', '-'], ['--help', '--silent', '--quiet', '--verbose', '--version', '--ansi', '--no-ansi', '--no-interaction']];
+        yield 'definition' => [['bin/console', 'hello', '-'], ['--help', '--silent', '--quiet', '--verbose', '--version', '--ansi', '--no-ansi', '--no-interaction', '--no-progress']];
         yield 'custom' => [['bin/console', 'hello'], ['Fabien', 'Robin', 'Wouter']];
-        yield 'definition-aliased' => [['bin/console', 'ahoy', '-'], ['--help', '--silent', '--quiet', '--verbose', '--version', '--ansi', '--no-ansi', '--no-interaction']];
+        yield 'definition-aliased' => [['bin/console', 'ahoy', '-'], ['--help', '--silent', '--quiet', '--verbose', '--version', '--ansi', '--no-ansi', '--no-interaction', '--no-progress']];
         yield 'custom-aliased' => [['bin/console', 'ahoy'], ['Fabien', 'Robin', 'Wouter']];
     }
 

--- a/src/Symfony/Component/Console/Tests/Command/ListCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/ListCommandTest.php
@@ -85,6 +85,7 @@ Options:
   -V, --version         Display this application version
       --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
   -n, --no-interaction  Do not ask any interactive question
+      --no-progress     Disable the progress bar output during the execution of the command
   -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 
 Available commands:

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.json
@@ -127,6 +127,15 @@
                         "is_multiple": false,
                         "description": "The API version of the completion script",
                         "default": null
+                    },
+                    "no-progress": {
+                        "name": "--no-progress",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Disable the progress bar output during the execution of the command",
+                        "default": false
                     }
                 }
             }
@@ -229,6 +238,15 @@
                         "is_value_required": false,
                         "is_multiple": false,
                         "description": "Tail the completion debug log",
+                        "default": false
+                    },
+                    "no-progress": {
+                        "name": "--no-progress",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Disable the progress bar output during the execution of the command",
                         "default": false
                     }
                 }
@@ -341,6 +359,15 @@
                         "is_value_required": false,
                         "is_multiple": false,
                         "description": "Do not ask any interactive question",
+                        "default": false
+                    },
+                    "no-progress": {
+                        "name": "--no-progress",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Disable the progress bar output during the execution of the command",
                         "default": false
                     }
                 }
@@ -462,6 +489,15 @@
                         "is_value_required": false,
                         "is_multiple": false,
                         "description": "To skip describing commands' arguments",
+                        "default": false
+                    },
+                    "no-progress": {
+                        "name": "--no-progress",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Disable the progress bar output during the execution of the command",
                         "default": false
                     }
                 }

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.md
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.md
@@ -108,6 +108,16 @@ Do not ask any interactive question
 * Is negatable: no
 * Default: `false`
 
+#### `--no-progress`
+
+Disable the progress bar output during the execution of the command
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
 `help`
 ------
 
@@ -222,6 +232,16 @@ Force (or disable --no-ansi) ANSI output
 #### `--no-interaction|-n`
 
 Do not ask any interactive question
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--no-progress`
+
+Disable the progress bar output during the execution of the command
 
 * Accept value: no
 * Is value required: no
@@ -359,6 +379,16 @@ Force (or disable --no-ansi) ANSI output
 #### `--no-interaction|-n`
 
 Do not ask any interactive question
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--no-progress`
+
+Disable the progress bar output during the execution of the command
 
 * Accept value: no
 * Is value required: no

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.txt
@@ -10,6 +10,7 @@ Console Tool
   <info>-V, --version</info>         Display this application version
   <info>    --ansi|--no-ansi</info>  Force (or disable --no-ansi) ANSI output
   <info>-n, --no-interaction</info>  Do not ask any interactive question
+  <info>    --no-progress</info>     Disable the progress bar output during the execution of the command
   <info>-v|vv|vvv, --verbose</info>  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 
 <comment>Available commands:</comment>

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.xml
@@ -53,6 +53,9 @@
         <option name="--no-interaction" shortcut="-n" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not ask any interactive question</description>
         </option>
+        <option name="--no-progress" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Disable the progress bar output during the execution of the command</description>
+        </option>
       </options>
     </command>
     <command id="completion" name="completion" hidden="0">
@@ -94,6 +97,9 @@
         </option>
         <option name="--no-interaction" shortcut="-n" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not ask any interactive question</description>
+        </option>
+        <option name="--no-progress" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Disable the progress bar output during the execution of the command</description>
         </option>
       </options>
     </command>
@@ -152,6 +158,9 @@
         </option>
         <option name="--no-interaction" shortcut="-n" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not ask any interactive question</description>
+        </option>
+        <option name="--no-progress" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Disable the progress bar output during the execution of the command</description>
         </option>
       </options>
     </command>
@@ -217,6 +226,9 @@
         </option>
         <option name="--no-interaction" shortcut="-n" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not ask any interactive question</description>
+        </option>
+        <option name="--no-progress" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Disable the progress bar output during the execution of the command</description>
         </option>
       </options>
     </command>

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.json
@@ -131,6 +131,15 @@
                         "is_multiple": false,
                         "description": "The API version of the completion script",
                         "default": null
+                    },
+                    "no-progress": {
+                        "name": "--no-progress",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Disable the progress bar output during the execution of the command",
+                        "default": false
                     }
                 }
             }
@@ -233,6 +242,15 @@
                         "is_value_required": false,
                         "is_multiple": false,
                         "description": "Tail the completion debug log",
+                        "default": false
+                    },
+                    "no-progress": {
+                        "name": "--no-progress",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Disable the progress bar output during the execution of the command",
                         "default": false
                     }
                 }
@@ -345,6 +363,15 @@
                         "is_value_required": false,
                         "is_multiple": false,
                         "description": "Do not ask any interactive question",
+                        "default": false
+                    },
+                    "no-progress": {
+                        "name": "--no-progress",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Disable the progress bar output during the execution of the command",
                         "default": false
                     }
                 }
@@ -467,6 +494,15 @@
                         "is_multiple": false,
                         "description": "To skip describing commands' arguments",
                         "default": false
+                    },
+                    "no-progress": {
+                        "name": "--no-progress",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Disable the progress bar output during the execution of the command",
+                        "default": false
                     }
                 }
             }
@@ -554,6 +590,15 @@
                         "is_value_required": false,
                         "is_multiple": false,
                         "description": "Do not ask any interactive question",
+                        "default": false
+                    },
+                    "no-progress": {
+                        "name": "--no-progress",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Disable the progress bar output during the execution of the command",
                         "default": false
                     }
                 }
@@ -660,6 +705,15 @@
                         "is_multiple": false,
                         "description": "Do not ask any interactive question",
                         "default": false
+                    },
+                    "no-progress": {
+                        "name": "--no-progress",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Disable the progress bar output during the execution of the command",
+                        "default": false
                     }
                 }
             }
@@ -745,6 +799,15 @@
                         "is_value_required": false,
                         "is_multiple": false,
                         "description": "Do not ask any interactive question",
+                        "default": false
+                    },
+                    "no-progress": {
+                        "name": "--no-progress",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Disable the progress bar output during the execution of the command",
                         "default": false
                     }
                 }
@@ -833,6 +896,15 @@
                         "is_value_required": false,
                         "is_multiple": false,
                         "description": "Do not ask any interactive question",
+                        "default": false
+                    },
+                    "no-progress": {
+                        "name": "--no-progress",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Disable the progress bar output during the execution of the command",
                         "default": false
                     }
                 }

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.md
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.md
@@ -121,6 +121,16 @@ Do not ask any interactive question
 * Is negatable: no
 * Default: `false`
 
+#### `--no-progress`
+
+Disable the progress bar output during the execution of the command
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
 `help`
 ------
 
@@ -235,6 +245,16 @@ Force (or disable --no-ansi) ANSI output
 #### `--no-interaction|-n`
 
 Do not ask any interactive question
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--no-progress`
+
+Disable the progress bar output during the execution of the command
 
 * Accept value: no
 * Is value required: no
@@ -379,6 +399,16 @@ Do not ask any interactive question
 * Is negatable: no
 * Default: `false`
 
+#### `--no-progress`
+
+Disable the progress bar output during the execution of the command
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
 `descriptor:command1`
 ---------------------
 
@@ -457,6 +487,16 @@ Force (or disable --no-ansi) ANSI output
 #### `--no-interaction|-n`
 
 Do not ask any interactive question
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--no-progress`
+
+Disable the progress bar output during the execution of the command
 
 * Accept value: no
 * Is value required: no
@@ -565,6 +605,16 @@ Do not ask any interactive question
 * Is negatable: no
 * Default: `false`
 
+#### `--no-progress`
+
+Disable the progress bar output during the execution of the command
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
 `descriptor:command4`
 ---------------------
 
@@ -640,6 +690,16 @@ Force (or disable --no-ansi) ANSI output
 #### `--no-interaction|-n`
 
 Do not ask any interactive question
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--no-progress`
+
+Disable the progress bar output during the execution of the command
 
 * Accept value: no
 * Is value required: no

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.txt
@@ -10,6 +10,7 @@ My Symfony application <info>v1.0</info>
   <info>-V, --version</info>         Display this application version
   <info>    --ansi|--no-ansi</info>  Force (or disable --no-ansi) ANSI output
   <info>-n, --no-interaction</info>  Do not ask any interactive question
+  <info>    --no-progress</info>     Disable the progress bar output during the execution of the command
   <info>-v|vv|vvv, --verbose</info>  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 
 <comment>Available commands:</comment>

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.xml
@@ -53,6 +53,9 @@
         <option name="--no-interaction" shortcut="-n" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not ask any interactive question</description>
         </option>
+        <option name="--no-progress" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Disable the progress bar output during the execution of the command</description>
+        </option>
       </options>
     </command>
     <command id="completion" name="completion" hidden="0">
@@ -94,6 +97,9 @@
         </option>
         <option name="--no-interaction" shortcut="-n" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not ask any interactive question</description>
+        </option>
+        <option name="--no-progress" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Disable the progress bar output during the execution of the command</description>
         </option>
       </options>
     </command>
@@ -152,6 +158,9 @@
         </option>
         <option name="--no-interaction" shortcut="-n" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not ask any interactive question</description>
+        </option>
+        <option name="--no-progress" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Disable the progress bar output during the execution of the command</description>
         </option>
       </options>
     </command>
@@ -218,6 +227,9 @@
         <option name="--no-interaction" shortcut="-n" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not ask any interactive question</description>
         </option>
+        <option name="--no-progress" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Disable the progress bar output during the execution of the command</description>
+        </option>
       </options>
     </command>
     <command id="descriptor:command1" name="descriptor:command1" hidden="0">
@@ -253,6 +265,9 @@
         </option>
         <option name="--no-interaction" shortcut="-n" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not ask any interactive question</description>
+        </option>
+        <option name="--no-progress" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Disable the progress bar output during the execution of the command</description>
         </option>
       </options>
     </command>
@@ -298,6 +313,9 @@
         <option name="--no-interaction" shortcut="-n" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not ask any interactive question</description>
         </option>
+        <option name="--no-progress" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Disable the progress bar output during the execution of the command</description>
+        </option>
       </options>
     </command>
     <command id="descriptor:command3" name="descriptor:command3" hidden="1">
@@ -331,6 +349,9 @@
         </option>
         <option name="--no-interaction" shortcut="-n" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not ask any interactive question</description>
+        </option>
+        <option name="--no-progress" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Disable the progress bar output during the execution of the command</description>
         </option>
       </options>
     </command>
@@ -367,6 +388,9 @@
         </option>
         <option name="--no-interaction" shortcut="-n" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not ask any interactive question</description>
+        </option>
+        <option name="--no-progress" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Disable the progress bar output during the execution of the command</description>
         </option>
       </options>
     </command>

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_filtered_namespace.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_filtered_namespace.txt
@@ -10,6 +10,7 @@ My Symfony application <info>v1.0</info>
   <info>-V, --version</info>         Display this application version
   <info>    --ansi|--no-ansi</info>  Force (or disable --no-ansi) ANSI output
   <info>-n, --no-interaction</info>  Do not ask any interactive question
+  <info>    --no-progress</info>     Disable the progress bar output during the execution of the command
   <info>-v|vv|vvv, --verbose</info>  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 
 <comment>Available commands for the "command4" namespace:</comment>

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_mbstring.md
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_mbstring.md
@@ -112,6 +112,16 @@ Do not ask any interactive question
 * Is negatable: no
 * Default: `false`
 
+#### `--no-progress`
+
+Disable the progress bar output during the execution of the command
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
 `help`
 ------
 
@@ -226,6 +236,16 @@ Force (or disable --no-ansi) ANSI output
 #### `--no-interaction|-n`
 
 Do not ask any interactive question
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--no-progress`
+
+Disable the progress bar output during the execution of the command
 
 * Accept value: no
 * Is value required: no
@@ -370,6 +390,16 @@ Do not ask any interactive question
 * Is negatable: no
 * Default: `false`
 
+#### `--no-progress`
+
+Disable the progress bar output during the execution of the command
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
 `descriptor:åèä`
 ----------------
 
@@ -464,6 +494,16 @@ Force (or disable --no-ansi) ANSI output
 #### `--no-interaction|-n`
 
 Do not ask any interactive question
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
+* Default: `false`
+
+#### `--no-progress`
+
+Disable the progress bar output during the execution of the command
 
 * Accept value: no
 * Is value required: no

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_mbstring.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_mbstring.txt
@@ -10,6 +10,7 @@ MbString åpplicätion
   <info>-V, --version</info>         Display this application version
   <info>    --ansi|--no-ansi</info>  Force (or disable --no-ansi) ANSI output
   <info>-n, --no-interaction</info>  Do not ask any interactive question
+  <info>    --no-progress</info>     Disable the progress bar output during the execution of the command
   <info>-v|vv|vvv, --verbose</info>  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 
 <comment>Available commands:</comment>

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_run1.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_run1.txt
@@ -10,6 +10,7 @@ Options:
   -V, --version         Display this application version
       --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
   -n, --no-interaction  Do not ask any interactive question
+      --no-progress     Disable the progress bar output during the execution of the command
   -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 
 Available commands:

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_run2.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_run2.txt
@@ -17,6 +17,7 @@ Options:
   -V, --version         Display this application version
       --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
   -n, --no-interaction  Do not ask any interactive question
+      --no-progress     Disable the progress bar output during the execution of the command
   -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 
 Help:

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_run3.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_run3.txt
@@ -17,6 +17,7 @@ Options:
   -V, --version         Display this application version
       --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
   -n, --no-interaction  Do not ask any interactive question
+      --no-progress     Disable the progress bar output during the execution of the command
   -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 
 Help:

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_run5.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_run5.txt
@@ -16,6 +16,7 @@ Options:
   -V, --version         Display this application version
       --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
   -n, --no-interaction  Do not ask any interactive question
+      --no-progress     Disable the progress bar output during the execution of the command
   -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 
 Help:

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -52,6 +52,22 @@ class ProgressBarTest extends TestCase
         );
     }
 
+    public function testMultipleStartWithHiddenProgressBar()
+    {
+        $output = $this->getOutputStream();
+        $output->setProgressBarVisibility(false);
+        $bar = new ProgressBar($output, 0, 0);
+        $bar->start();
+        $bar->advance();
+        $bar->start();
+
+        rewind($output->getStream());
+        $this->assertEquals(
+            '',
+            stream_get_contents($output->getStream())
+        );
+    }
+
     public function testAdvance()
     {
         $bar = new ProgressBar($output = $this->getOutputStream(), 0, 0);
@@ -62,6 +78,21 @@ class ProgressBarTest extends TestCase
         $this->assertEquals(
             '    0 [>---------------------------]'.
             $this->generateOutput('    1 [->--------------------------]'),
+            stream_get_contents($output->getStream())
+        );
+    }
+
+    public function testAdvanceWithHiddenProgressBar()
+    {
+        $output = $this->getOutputStream();
+        $output->setProgressBarVisibility(false);
+        $bar = new ProgressBar($output, 0, 0);
+        $bar->start();
+        $bar->advance();
+
+        rewind($output->getStream());
+        $this->assertEquals(
+            '',
             stream_get_contents($output->getStream())
         );
     }
@@ -1338,6 +1369,34 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
             $this->generateOutput("1/3\nABC\nFoo").
             $this->generateOutput("2/3\nA\nFoo").
             $this->generateOutput("3/3\nA\nFoo"),
+            stream_get_contents($output->getStream())
+        );
+    }
+
+    public function testMultiLineFormatIsFullyClearedWithHiddenProgressBar()
+    {
+        $output = $this->getOutputStream();
+        $output->setProgressBarVisibility(false);
+        $bar = new ProgressBar($output, 3);
+        $bar->setFormat("%current%/%max%\n%message%\nFoo");
+
+        $bar->setMessage('1234567890');
+        $bar->start();
+        $bar->display();
+
+        $bar->setMessage('ABC');
+        $bar->advance();
+        $bar->display();
+
+        $bar->setMessage('A');
+        $bar->advance();
+        $bar->display();
+
+        $bar->finish();
+
+        rewind($output->getStream());
+        $this->assertEquals(
+            '',
             stream_get_contents($output->getStream())
         );
     }

--- a/src/Symfony/Component/Console/Tests/Output/ConsoleOutputTest.php
+++ b/src/Symfony/Component/Console/Tests/Output/ConsoleOutputTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\Output;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class ConsoleOutputTest extends TestCase
 {
@@ -47,5 +48,21 @@ class ConsoleOutputTest extends TestCase
         $output = new ConsoleOutput();
         $output->setVerbosity(Output::VERBOSITY_VERBOSE);
         $this->assertSame(Output::VERBOSITY_VERBOSE, $output->getVerbosity());
+    }
+
+    public function testSetHiddenOptions()
+    {
+        $output = new ConsoleOutput();
+        $output->setHiddenOptions([
+            OutputInterface::HIDDEN_PROGRESS_BAR => true,
+        ]);
+        $this->assertSame([OutputInterface::HIDDEN_PROGRESS_BAR => true], $output->getHiddenOptions());
+    }
+
+    public function testSetProgressBarVisibility()
+    {
+        $output = new ConsoleOutput();
+        $output->setProgressBarVisibility(false);
+        $this->assertTrue($output->isHiddenProgressBar());
     }
 }

--- a/src/Symfony/Component/Console/Tests/Output/NullOutputTest.php
+++ b/src/Symfony/Component/Console/Tests/Output/NullOutputTest.php
@@ -99,4 +99,34 @@ class NullOutputTest extends TestCase
         $output = new NullOutput();
         $this->assertFalse($output->isDebug());
     }
+
+    public function testSetHiddenOptions()
+    {
+        $output = new NullOutput();
+        $output->setHiddenOptions([
+            OutputInterface::HIDDEN_PROGRESS_BAR => false,
+        ]);
+        $this->assertIsArray($output->getHiddenOptions());
+        $this->assertCount(0, $output->getHiddenOptions());
+    }
+
+    public function testGetHiddenOptions()
+    {
+        $output = new NullOutput();
+        $this->assertIsArray($output->getHiddenOptions());
+        $this->assertCount(0, $output->getHiddenOptions());
+    }
+
+    public function testSetProgressBarVisibility()
+    {
+        $output = new NullOutput();
+        $output->setProgressBarVisibility(true);
+        $this->assertFalse($output->isHiddenProgressBar());
+    }
+
+    public function testIsHiddenProgressBar()
+    {
+        $output = new NullOutput();
+        $this->assertFalse($output->isHiddenProgressBar());
+    }
 }

--- a/src/Symfony/Component/Console/Tests/Output/OutputTest.php
+++ b/src/Symfony/Component/Console/Tests/Output/OutputTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Console\Tests\Output;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Output\Output;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class OutputTest extends TestCase
 {
@@ -72,6 +73,35 @@ class OutputTest extends TestCase
         $output = new TestOutput(Output::VERBOSITY_QUIET);
         $output->writeln('foo');
         $this->assertEquals('', $output->output, '->writeln() outputs nothing if verbosity is set to VERBOSITY_QUIET');
+    }
+
+    public function testSetGetHiddenOptions()
+    {
+        $output = new TestOutput();
+        $hiddenOptions = [
+            OutputInterface::HIDDEN_PROGRESS_BAR => false,
+        ];
+
+        $this->assertSame($hiddenOptions, $output->getHiddenOptions());
+
+        $hiddenOptions = [
+            OutputInterface::HIDDEN_PROGRESS_BAR => true,
+        ];
+
+        $output->setHiddenOptions($hiddenOptions);
+
+        $this->assertSame($hiddenOptions, $output->getHiddenOptions());
+    }
+
+    public function testIsHiddenProgressBar()
+    {
+        $output = new TestOutput();
+
+        $this->assertFalse($output->isHiddenProgressBar());
+
+        $output->setProgressBarVisibility(false);
+
+        $this->assertTrue($output->isHiddenProgressBar());
     }
 
     public function testWriteAnArrayOfMessages()

--- a/src/Symfony/Component/Console/Tests/phpt/single_application/help_name.phpt
+++ b/src/Symfony/Component/Console/Tests/phpt/single_application/help_name.phpt
@@ -34,4 +34,5 @@ Options:
   -V, --version         Display this application version
       --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
   -n, --no-interaction  Do not ask any interactive question
+      --no-progress     Disable the progress bar output during the execution of the command
   -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

--- a/src/Symfony/Component/Runtime/Tests/phpt/command_list.phpt
+++ b/src/Symfony/Component/Runtime/Tests/phpt/command_list.phpt
@@ -28,6 +28,7 @@ Options:
   -V, --version         Display this application version
       --ansi%A
   -n, --no-interaction  Do not ask any interactive question
+      --no-progress     Disable the progress bar output during the execution of the command
   -e, --env=ENV         The Environment name. [default: "prod"]
       --no-debug        Switches off debug mode.
   -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Feature #45596 
| License       | MIT

Hello :wave:

I’ve been working on a feature for the linked issue in this PR, which adds a new option `--no-progress`. This option allows the user to disable the display of the progress bar in the output.

To address this, I considered two possible solutions. The first one was to introduce a new verbosity level, but I didn't find it entirely appropriate since, based on the issue description, the goal is to simply toggle the visibility of the progress bar, regardless of the verbosity level.

The second solution I came up with was to create an array called `hiddenOptions`, which provides a simple way to manage and hide specific functionalities (like the progress bar) when needed.

I’ve also included example images showcasing the current behavior with this change.

Example without new option:
![Screenshot from 2025-03-16 23-15-57](https://github.com/user-attachments/assets/4681a30f-3d64-47ba-82bb-21986615b6cf)


Example with new option:
![Screenshot from 2025-03-16 23-17-13](https://github.com/user-attachments/assets/b7ba4e21-7c57-44e6-9b8d-fca7db7343a0)
