### PR TITLE
[Validator] fix translation in spanish

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.es.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.es.xlf
@@ -52,7 +52,7 @@
             </trans-unit>
             <trans-unit id="108">
                 <source>Please enter a valid date.</source>
-                <target>Por favor, ingrese una fecha valida.</target>
+                <target>Por favor, ingrese una fecha válida.</target>
             </trans-unit>
             <trans-unit id="109">
                 <source>Please select a valid file.</source>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT

Fix translation inconsistency

Changed `valida` to `válida` to align with RAE guidelines.