### PR TITLE
[Form] Add input with `string` value in `MoneyType`

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add support for displaying nested options in DebugCommand
+ * Add support for strings as data for the `MoneyType`
 
 7.2
 ---

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformer.php
@@ -70,7 +70,7 @@ class MoneyToLocalizedStringTransformer extends NumberToLocalizedStringTransform
         if (null !== $value) {
             $value = (string) ($value * $this->divisor);
 
-            if ('float' === $this->input) {
+            if ('integer' !== $this->input) {
                 return (float) $value;
             }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/MoneyType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/MoneyType.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Form\Extension\Core\Type;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Exception\LogicException;
 use Symfony\Component\Form\Extension\Core\DataTransformer\MoneyToLocalizedStringTransformer;
+use Symfony\Component\Form\Extension\Core\DataTransformer\StringToFloatTransformer;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
@@ -38,6 +39,10 @@ class MoneyType extends AbstractType
                 $options['input'],
             ))
         ;
+
+        if ('string' === $options['input']) {
+            $builder->addModelTransformer(new StringToFloatTransformer($options['scale']));
+        }
     }
 
     public function buildView(FormView $view, FormInterface $form, array $options): void
@@ -77,7 +82,7 @@ class MoneyType extends AbstractType
 
         $resolver->setAllowedTypes('html5', 'bool');
 
-        $resolver->setAllowedValues('input', ['float', 'integer']);
+        $resolver->setAllowedValues('input', ['float', 'integer', 'string']);
 
         $resolver->setNormalizer('grouping', static function (Options $options, $value) {
             if ($value && $options['html5']) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #59710 
| License       | MIT
| Doc PR        | [#20768](https://github.com/symfony/symfony-docs/pull/20768)

Related to the issue, add the possibility to configure the property `input` with the value `string` to avoid some unnecessary update with Doctrine.
