### PR TITLE
[Config] Make ifFalse() consistent between value and closure based checks

### DIFF
--- a/src/Symfony/Component/Config/Definition/Builder/ExprBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ExprBuilder.php
@@ -76,7 +76,7 @@ class ExprBuilder
      */
     public function ifFalse(?\Closure $closure = null): static
     {
-        $this->ifPart = $closure ?? static fn ($v) => false === $v;
+        $this->ifPart = $closure ? static fn ($v) => !$closure($v) : static fn ($v) => false === $v;
         $this->allowedTypes = self::TYPE_ANY;
 
         return $this;

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/ExprBuilderTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/ExprBuilderTest.php
@@ -43,7 +43,19 @@ class ExprBuilderTest extends TestCase
         $this->assertFinalizedValueIs('new_value', $test);
 
         $test = $this->getTestBuilder()
+            ->ifTrue(fn () => 1)
+            ->then($this->returnClosure('new_value'))
+        ->end();
+        $this->assertFinalizedValueIs('new_value', $test);
+
+        $test = $this->getTestBuilder()
             ->ifTrue(fn () => false)
+            ->then($this->returnClosure('new_value'))
+        ->end();
+        $this->assertFinalizedValueIs('value', $test);
+
+        $test = $this->getTestBuilder()
+            ->ifTrue(fn () => 0)
             ->then($this->returnClosure('new_value'))
         ->end();
         $this->assertFinalizedValueIs('value', $test);
@@ -58,16 +70,28 @@ class ExprBuilderTest extends TestCase
         $this->assertFinalizedValueIs('new_value', $test, ['key' => false]);
 
         $test = $this->getTestBuilder()
-            ->ifFalse(fn () => true)
+            ->ifFalse(fn ($v) => 'value' === $v)
+            ->then($this->returnClosure('new_value'))
+        ->end();
+        $this->assertFinalizedValueIs('value', $test);
+
+        $test = $this->getTestBuilder()
+            ->ifFalse(fn ($v) => 1)
+            ->then($this->returnClosure('new_value'))
+        ->end();
+        $this->assertFinalizedValueIs('value', $test);
+
+        $test = $this->getTestBuilder()
+            ->ifFalse(fn ($v) => 'other_value' === $v)
             ->then($this->returnClosure('new_value'))
         ->end();
         $this->assertFinalizedValueIs('new_value', $test);
 
         $test = $this->getTestBuilder()
-            ->ifFalse(fn () => false)
+            ->ifFalse(fn ($v) => 0)
             ->then($this->returnClosure('new_value'))
-        ->end();
-        $this->assertFinalizedValueIs('value', $test);
+            ->end();
+        $this->assertFinalizedValueIs('new_value', $test);
     }
 
     public function testIfStringExpression()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix  https://github.com/symfony/symfony/pull/59325
| License       | MIT

I noticed the Config/ExpBuilder got a nice new ifFalse in Symfony 7.3.
But I think its implementation is confusing.

The behavior for `ifTrue()` was:
- If no closure is provided: if the actual value is `true` execute the then part
- If a closure is provided: if it returns `true` execute the then part

The behavior for `ifFalse()` is prior to this PR is:
- If no closure is provided: if the actual value is `false` execute the then part
- If a closure is provided: if it returns **`true`** execute the then part

With this PR it becomes:
- If no closure is provided: if the actual value is `false` execute the then part
- If a closure is provided: if it returns **`false`** execute the then part

Rationale, I think people (me included) would not expect these to be both be valid or invalid with the same input:
`$expr->ifTrue(self::valueIsNotValid(...))->thenInvalid()`
`$expr->ifFalse(self::valueIsNotValid(...))->thenInvalid()`

They/I expect to have to change it to a test for valid values (rather than invalid ones):
`$expr->ifFalse(self::valueIsValid(...))->thenInvalid()`