### PR TITLE
[Messenger] Improve return type of `HandlerDescriptor::getHandler()`

### DIFF
--- a/src/Symfony/Component/Messenger/Handler/HandlerDescriptor.php
+++ b/src/Symfony/Component/Messenger/Handler/HandlerDescriptor.php
@@ -47,7 +47,7 @@ final class HandlerDescriptor
         }
     }
 
-    public function getHandler(): callable
+    public function getHandler(): \Closure
     {
         return $this->handler;
     }

--- a/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php
@@ -139,7 +139,7 @@ class HandleMessageMiddleware implements MiddlewareInterface
         return false;
     }
 
-    private function callHandler(callable $handler, object $message, ?Acknowledger $ack, ?HandlerArgumentsStamp $handlerArgumentsStamp): mixed
+    private function callHandler(\Closure $handler, object $message, ?Acknowledger $ack, ?HandlerArgumentsStamp $handlerArgumentsStamp): mixed
     {
         $arguments = [$message];
         if (null !== $ack) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | n/a
| License       | MIT

Explanation is given in the individual commit messages. I'm repeating them here for visibility:

A return type of `callable` is not particularly useful, since it does not
actually guarantee that the returned value is callable by the caller. It only
guarantees that it is callable by the callee as seen in this example:

```php
class Foo {
    public function bar(): callable
    {
        return [self::class, 'baz'];
    }

    private static function baz(): void
    {
        echo __METHOD__;
    }
}

$foo = new Foo();
$cb = $foo->bar();
$cb();
```

Since `HandlerDescriptor::$handler` is already typed `\Closure` and since the
class is `final`, we can simply adjust the return type to `\Closure`.

---------------


Since the previous commit this is guaranteed to be a `\Closure`. A microbenchmark using:

```php
function closure_(\Closure $f) {
    $f('abc');
}

function callable_(callable $f) {
    $f('abc');
}

for ($i = 0; $i < 10000000; $i++) {
    callable_(strrev(...));
}
```

Indicates that using `\Closure` as the parameter type is roughly 10% faster:

    Benchmark 1: php callable.php
      Time (mean ± σ):     708.4 ms ±   5.8 ms    [User: 696.4 ms, System: 11.5 ms]
      Range (min … max):   699.5 ms … 715.7 ms    10 runs

    Benchmark 2: php closure.php
      Time (mean ± σ):     647.1 ms ±  21.0 ms    [User: 633.2 ms, System: 13.2 ms]
      Range (min … max):   626.7 ms … 683.7 ms    10 runs

    Summary
      php closure.php ran
        1.09 ± 0.04 times faster than php callable.php