### PR TITLE
[FrameworkBundle] Autoconfigure ORM attributes only if not done by DoctrineBundle

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -771,15 +771,19 @@ class FrameworkExtension extends Extension
         $container->registerAttributeForAutoconfiguration(AsMessage::class, static function (ChildDefinition $definition) {
             $definition->addExcludeTag('container.excluded.messenger.message');
         });
-        $container->registerAttributeForAutoconfiguration(Entity::class, static function (ChildDefinition $definition) {
-            $definition->addExcludeTag('container.excluded.doctrine.entity');
-        });
-        $container->registerAttributeForAutoconfiguration(Embeddable::class, static function (ChildDefinition $definition) {
-            $definition->addExcludeTag('container.excluded.doctrine.embeddable');
-        });
-        $container->registerAttributeForAutoconfiguration(MappedSuperclass::class, static function (ChildDefinition $definition) {
-            $definition->addExcludeTag('container.excluded.doctrine.mapped_superclass');
-        });
+
+        // DoctrineBundle autoconfigures attributes since version 2.14.0
+        if (!array_key_exists(Entity::class, $container->getAutoconfiguredAttributes())) {
+            $container->registerAttributeForAutoconfiguration(Entity::class, static function (ChildDefinition $definition) {
+                $definition->addExcludeTag('container.excluded.doctrine.entity');
+            });
+            $container->registerAttributeForAutoconfiguration(Embeddable::class, static function (ChildDefinition $definition) {
+                $definition->addExcludeTag('container.excluded.doctrine.embeddable');
+            });
+            $container->registerAttributeForAutoconfiguration(MappedSuperclass::class, static function (ChildDefinition $definition) {
+                $definition->addExcludeTag('container.excluded.doctrine.mapped_superclass');
+            });
+        }
 
         $container->registerAttributeForAutoconfiguration(JsonStreamable::class, static function (ChildDefinition $definition, JsonStreamable $attribute) {
             $definition->addExcludeTag('json_streamer.streamable', [

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -21,7 +21,7 @@
         "ext-xml": "*",
         "symfony/cache": "^6.4|^7.0",
         "symfony/config": "^7.3",
-        "symfony/dependency-injection": "^7.2",
+        "symfony/dependency-injection": "^7.3",
         "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/error-handler": "^7.3",
         "symfony/event-dispatcher": "^6.4|^7.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix https://github.com/doctrine/DoctrineBundle/pull/1868#issuecomment-2730726691
| License       | MIT

An attribute cannot have multiple autoconfiguration callbacks registered. By excluding classes with the `#[Entity]` and other ORM attributes in both FrameworkBundle (https://github.com/symfony/symfony/pull/59987) and DoctrineBundle (https://github.com/doctrine/DoctrineBundle/pull/1868), the following exception is thrown:
> Symfony\Component\DependencyInjection\Exception\InvalidArgumentException: "Doctrine\ORM\Mapping\Embeddable" has already been autoconfigured and merge() does not support merging autoconfiguration for the same attribute.

