### PR TITLE
[DependencyInjection] Rename "exclude tag" to "resource tag"

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -765,24 +765,24 @@ class FrameworkExtension extends Extension
         }
 
         $container->registerForAutoconfiguration(CompilerPassInterface::class)
-            ->addExcludeTag('container.excluded.compiler_pass');
+            ->addResourceTag('container.excluded.compiler_pass');
         $container->registerForAutoconfiguration(TestCase::class)
-            ->addExcludeTag('container.excluded.test_case');
+            ->addResourceTag('container.excluded.test_case');
         $container->registerAttributeForAutoconfiguration(AsMessage::class, static function (ChildDefinition $definition) {
-            $definition->addExcludeTag('container.excluded.messenger.message');
+            $definition->addResourceTag('container.excluded.messenger.message');
         });
         $container->registerAttributeForAutoconfiguration(Entity::class, static function (ChildDefinition $definition) {
-            $definition->addExcludeTag('container.excluded.doctrine.entity');
+            $definition->addResourceTag('container.excluded.doctrine.entity');
         });
         $container->registerAttributeForAutoconfiguration(Embeddable::class, static function (ChildDefinition $definition) {
-            $definition->addExcludeTag('container.excluded.doctrine.embeddable');
+            $definition->addResourceTag('container.excluded.doctrine.embeddable');
         });
         $container->registerAttributeForAutoconfiguration(MappedSuperclass::class, static function (ChildDefinition $definition) {
-            $definition->addExcludeTag('container.excluded.doctrine.mapped_superclass');
+            $definition->addResourceTag('container.excluded.doctrine.mapped_superclass');
         });
 
         $container->registerAttributeForAutoconfiguration(JsonStreamable::class, static function (ChildDefinition $definition, JsonStreamable $attribute) {
-            $definition->addExcludeTag('json_streamer.streamable', [
+            $definition->addResourceTag('json_streamer.streamable', [
                 'object' => $attribute->asObject,
                 'list' => $attribute->asList,
             ]);

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -7,7 +7,7 @@ CHANGELOG
  * Make `#[AsTaggedItem]` repeatable
  * Support `@>` as a shorthand for `!service_closure` in yaml files
  * Don't skip classes with private constructor when autodiscovering
- * Add `Definition::addExcludeTag()` and `ContainerBuilder::findExcludedServiceIds()`
+ * Add `Definition::addResourceTag()` and `ContainerBuilder::findTaggedResourceIds()`
    for auto-configuration of classes excluded from the service container
  * Leverage native lazy objects when possible for lazy services
 

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1356,9 +1356,9 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      *
      *  Example:
      *
-     *      $container->register('foo')->addExcludeTag('my.tag', ['hello' => 'world'])
+     *      $container->register('foo')->addResourceTag('my.tag', ['hello' => 'world'])
      *
-     *      $serviceIds = $container->findExcludedServiceIds('my.tag');
+     *      $serviceIds = $container->findTaggedResourceIds('my.tag');
      *      foreach ($serviceIds as $serviceId => $tags) {
      *          foreach ($tags as $tag) {
      *              echo $tag['hello'];
@@ -1367,14 +1367,14 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      *
      * @return array<string, array> An array of tags with the tagged service as key, holding a list of attribute arrays
      */
-    public function findExcludedServiceIds(string $tagName): array
+    public function findTaggedResourceIds(string $tagName): array
     {
         $this->usedTags[] = $tagName;
         $tags = [];
         foreach ($this->getDefinitions() as $id => $definition) {
             if ($definition->hasTag($tagName)) {
                 if (!$definition->hasTag('container.excluded')) {
-                    throw new InvalidArgumentException(\sprintf('The service "%s" tagged "%s" is missing the "container.excluded" tag.', $id, $tagName));
+                    throw new InvalidArgumentException(\sprintf('The resource "%s" tagged "%s" is missing the "container.excluded" tag.', $id, $tagName));
                 }
                 $tags[$id] = $definition->getTag($tagName);
             }

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -456,13 +456,13 @@ class Definition
     }
 
     /**
-     * Adds a tag to the definition and marks it as excluded.
+     * Adds a "resource" tag to the definition and marks it as excluded.
      *
-     * These definitions should be processed using {@see ContainerBuilder::findExcludedServiceIds()}
+     * These definitions should be processed using {@see ContainerBuilder::findTaggedResourceIds()}
      *
      * @return $this
      */
-    public function addExcludeTag(string $name, array $attributes = []): static
+    public function addResourceTag(string $name, array $attributes = []): static
     {
         return $this->addTag($name, $attributes)
             ->addTag('container.excluded', ['source' => \sprintf('by tag "%s"', $name)])

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -1095,21 +1095,21 @@ class ContainerBuilderTest extends TestCase
         $builder->findTaggedServiceIds('foo', true);
     }
 
-    public function testFindExcludedServiceIds()
+    public function testFindTaggedResourceIds()
     {
         $builder = new ContainerBuilder();
         $builder->register('myservice', 'Bar\FooClass')
             ->addTag('foo', ['foo' => 'foo'])
             ->addTag('bar', ['bar' => 'bar'])
             ->addTag('foo', ['foofoo' => 'foofoo'])
-            ->addExcludeTag('container.excluded');
+            ->addResourceTag('container.excluded');
 
         $expected = ['myservice' => [['foo' => 'foo'], ['foofoo' => 'foofoo']]];
-        $this->assertSame($expected, $builder->findExcludedServiceIds('foo'));
-        $this->assertSame([], $builder->findExcludedServiceIds('foofoo'));
+        $this->assertSame($expected, $builder->findTaggedResourceIds('foo'));
+        $this->assertSame([], $builder->findTaggedResourceIds('foofoo'));
     }
 
-    public function testFindExcludedServiceIdsThrowsWhenNotExcluded()
+    public function testFindTaggedResourceIdsThrowsWhenNotExcluded()
     {
         $builder = new ContainerBuilder();
         $builder->register('myservice', 'Bar\FooClass')
@@ -1118,8 +1118,8 @@ class ContainerBuilderTest extends TestCase
             ->addTag('foo', ['foofoo' => 'foofoo']);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The service "myservice" tagged "foo" is missing the "container.excluded" tag.');
-        $builder->findExcludedServiceIds('foo', true);
+        $this->expectExceptionMessage('The resource "myservice" tagged "foo" is missing the "container.excluded" tag.');
+        $builder->findTaggedResourceIds('foo');
     }
 
     public function testFindUnusedTags()

--- a/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
@@ -258,10 +258,10 @@ class DefinitionTest extends TestCase
         ], $def->getTags(), '->getTags() returns all tags');
     }
 
-    public function testAddExcludeTag()
+    public function testAddResourceTag()
     {
         $def = new Definition('stdClass');
-        $def->addExcludeTag('foo', ['bar' => true]);
+        $def->addResourceTag('foo', ['bar' => true]);
 
         $this->assertSame([['bar' => true]], $def->getTag('foo'));
         $this->assertTrue($def->isAbstract());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Follow up to #59704
| License       | MIT

I find `$definition->addExcludedTag('app.model')` and `$containerBuilder->findExcludedServiceIds('app.model')` unintuitive. If feels like your excluding something from the DI container but in fact, your registering it, but in a "different way". The fact that it's an excluded service is just a side-effect. This is especially weird when the tag has attributes (`$definition->addExcludedTag('app.model', ['connection' => 'default'])`).

Totally open for a name other than "resource".