### PR TITLE
[HttpKernel] Add `target="_blank"` to the doc link on the default page

### DIFF
--- a/src/Symfony/Component/HttpKernel/Resources/welcome.html.php
+++ b/src/Symfony/Component/HttpKernel/Resources/welcome.html.php
@@ -265,7 +265,7 @@ SVG;
                     <strong>Next Step</strong>
                     <?php echo $renderNextStepIconSvg; ?>
                     <span>
-                        <a href="https://symfony.com/doc/<?php echo $docVersion; ?>/page_creation.html">Create your first page</a>
+                        <a target="_blank" href="https://symfony.com/doc/<?php echo $docVersion; ?>/page_creation.html">Create your first page</a>
                         to replace this placeholder page.
                     </span>
                 </p>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | no
| License       | MIT

The link for `debug-mode` opens in a new tab, but the link for `page-creation` does not. Let's make both open in new tabs.