### PR TITLE
[Security] Add methods param in IsCsrfTokenValid attribute

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -16,6 +16,7 @@ CHANGELOG
  * Add `--method` option to the `debug:router` command
  * Auto-exclude DI extensions, test cases, entities and messenger messages
  * Add DI alias from `ServicesResetterInterface` to `services_resetter`
+ * Add `methods` argument in `#[IsCsrfTokenValid]` attribute
 
 7.2
 ---

--- a/src/Symfony/Component/Security/Http/Attribute/IsCsrfTokenValid.php
+++ b/src/Symfony/Component/Security/Http/Attribute/IsCsrfTokenValid.php
@@ -26,6 +26,12 @@ final class IsCsrfTokenValid
          * Sets the key of the request that contains the actual token value that should be validated.
          */
         public ?string $tokenKey = '_token',
+
+        /**
+         * Sets the available http methods that can be used to validate the token.
+         * If not set, the token will be validated for all methods.
+         */
+        public array|string $methods = [],
     ) {
     }
 }

--- a/src/Symfony/Component/Security/Http/EventListener/IsCsrfTokenValidAttributeListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/IsCsrfTokenValidAttributeListener.php
@@ -45,6 +45,11 @@ final class IsCsrfTokenValidAttributeListener implements EventSubscriberInterfac
 
         foreach ($attributes as $attribute) {
             $id = $this->getTokenId($attribute->id, $request, $arguments);
+            $methods = \array_map('strtoupper', (array) $attribute->methods);
+
+            if ($methods && !\in_array($request->getMethod(), $methods, true)) {
+                continue;
+            }
 
             if (!$this->csrfTokenManager->isTokenValid(new CsrfToken($id, $request->getPayload()->getString($attribute->tokenKey)))) {
                 throw new InvalidCsrfTokenException('Invalid CSRF token.');

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/IsCsrfTokenValidAttributeListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/IsCsrfTokenValidAttributeListenerTest.php
@@ -206,4 +206,141 @@ class IsCsrfTokenValidAttributeListenerTest extends TestCase
         $listener = new IsCsrfTokenValidAttributeListener($csrfTokenManager);
         $listener->onKernelControllerArguments($event);
     }
+
+    public function testIsCsrfTokenValidCalledCorrectlyWithDeleteMethod()
+    {
+        $request = new Request(request: ['_token' => 'bar']);
+        $request->setMethod('DELETE');
+
+        $csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $csrfTokenManager->expects($this->once())
+            ->method('isTokenValid')
+            ->with(new CsrfToken('foo', 'bar'))
+            ->willReturn(true);
+
+        $event = new ControllerArgumentsEvent(
+            $this->createMock(HttpKernelInterface::class),
+            [new IsCsrfTokenValidAttributeMethodsController(), 'withDeleteMethod'],
+            [],
+            $request,
+            null
+        );
+
+        $listener = new IsCsrfTokenValidAttributeListener($csrfTokenManager);
+        $listener->onKernelControllerArguments($event);
+    }
+
+    public function testIsCsrfTokenValidIgnoredWithNonMatchingMethod()
+    {
+        $request = new Request(request: ['_token' => 'bar']);
+        $request->setMethod('POST');
+
+        $csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $csrfTokenManager->expects($this->never())
+            ->method('isTokenValid')
+            ->with(new CsrfToken('foo', 'bar'));
+
+        $event = new ControllerArgumentsEvent(
+            $this->createMock(HttpKernelInterface::class),
+            [new IsCsrfTokenValidAttributeMethodsController(), 'withDeleteMethod'],
+            [],
+            $request,
+            null
+        );
+
+        $listener = new IsCsrfTokenValidAttributeListener($csrfTokenManager);
+        $listener->onKernelControllerArguments($event);
+    }
+
+    public function testIsCsrfTokenValidCalledCorrectlyWithGetOrPostMethodWithGetMethod()
+    {
+        $request = new Request(request: ['_token' => 'bar']);
+        $request->setMethod('GET');
+
+        $csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $csrfTokenManager->expects($this->once())
+            ->method('isTokenValid')
+            ->with(new CsrfToken('foo', 'bar'))
+            ->willReturn(true);
+
+        $event = new ControllerArgumentsEvent(
+            $this->createMock(HttpKernelInterface::class),
+            [new IsCsrfTokenValidAttributeMethodsController(), 'withGetOrPostMethod'],
+            [],
+            $request,
+            null
+        );
+
+        $listener = new IsCsrfTokenValidAttributeListener($csrfTokenManager);
+        $listener->onKernelControllerArguments($event);
+    }
+
+    public function testIsCsrfTokenValidNoIgnoredWithGetOrPostMethodWithPutMethod()
+    {
+        $request = new Request(request: ['_token' => 'bar']);
+        $request->setMethod('PUT');
+
+        $csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $csrfTokenManager->expects($this->never())
+            ->method('isTokenValid')
+            ->with(new CsrfToken('foo', 'bar'));
+
+        $event = new ControllerArgumentsEvent(
+            $this->createMock(HttpKernelInterface::class),
+            [new IsCsrfTokenValidAttributeMethodsController(), 'withGetOrPostMethod'],
+            [],
+            $request,
+            null
+        );
+
+        $listener = new IsCsrfTokenValidAttributeListener($csrfTokenManager);
+        $listener->onKernelControllerArguments($event);
+    }
+
+    public function testIsCsrfTokenValidCalledCorrectlyWithInvalidTokenKeyAndPostMethod()
+    {
+        $this->expectException(InvalidCsrfTokenException::class);
+
+        $request = new Request(request: ['_token' => 'bar']);
+        $request->setMethod('POST');
+
+        $csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $csrfTokenManager->expects($this->once())
+            ->method('isTokenValid')
+            ->withAnyParameters()
+            ->willReturn(false);
+
+        $event = new ControllerArgumentsEvent(
+            $this->createMock(HttpKernelInterface::class),
+            [new IsCsrfTokenValidAttributeMethodsController(), 'withPostMethodAndInvalidTokenKey'],
+            [],
+            $request,
+            null
+        );
+
+        $listener = new IsCsrfTokenValidAttributeListener($csrfTokenManager);
+        $listener->onKernelControllerArguments($event);
+    }
+
+    public function testIsCsrfTokenValidIgnoredWithInvalidTokenKeyAndUnavailableMethod()
+    {
+        $request = new Request(request: ['_token' => 'bar']);
+        $request->setMethod('PUT');
+
+        $csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $csrfTokenManager->expects($this->never())
+            ->method('isTokenValid')
+            ->withAnyParameters();
+
+        $event = new ControllerArgumentsEvent(
+            $this->createMock(HttpKernelInterface::class),
+            [new IsCsrfTokenValidAttributeMethodsController(), 'withPostMethodAndInvalidTokenKey'],
+            [],
+            $request,
+            null
+        );
+
+        $listener = new IsCsrfTokenValidAttributeListener($csrfTokenManager);
+        $listener->onKernelControllerArguments($event);
+    }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Fixtures/IsCsrfTokenValidAttributeMethodsController.php
+++ b/src/Symfony/Component/Security/Http/Tests/Fixtures/IsCsrfTokenValidAttributeMethodsController.php
@@ -44,4 +44,19 @@ class IsCsrfTokenValidAttributeMethodsController
     public function withInvalidTokenKey()
     {
     }
+
+    #[IsCsrfTokenValid('foo', methods: 'DELETE')]
+    public function withDeleteMethod()
+    {
+    }
+
+    #[IsCsrfTokenValid('foo', methods: ['GET', 'POST'])]
+    public function withGetOrPostMethod()
+    {
+    }
+
+    #[IsCsrfTokenValid('foo', tokenKey: 'invalid_token_key', methods: ['POST'])]
+    public function withPostMethodAndInvalidTokenKey()
+    {
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

I use a controller action to show a confirmation message for delete entity, i think it could be usefull to add 'methods' param in `#[IsCsrfTokenValid]` attribute.

```php
#[Route('/delete/{id}', name: 'delete', methods: ['GET', 'DELETE'], requirements: ['id' => Requirement::UUID])]
public function delete(Request $request, User $user, UserManager $userManager): Response
{
    if ($request->isMethod('DELETE') && $this->isCsrfTokenValid('delete'.$user->getId(), $request->request->get('_token'))) {
        $userManager->remove($user);

        return $this->redirectToRoute('admin_user_index');
    }

    return $this->render('/admin/user/delete.html.twig', [
        'entity' => $user,
    ]);
}
```

```php
#[Route('/delete/{id}', name: 'delete', methods: ['GET', 'DELETE'], requirements: ['id' => Requirement::UUID])]
#[IsCsrfTokenValid(new Expression('"delete" ~ args["user"].getId()'), methods: ['DELETE'])]
public function delete(Request $request, User $user, UserManager $userManager): Response
{
    if ($request->isMethod('DELETE')) {
        $userManager->remove($user);

        return $this->redirectToRoute('admin_user_index');
    }

    return $this->render('/admin/user/delete.html.twig', [
        'entity' => $user,
    ]);
}
```

The `isCsrfTokenValid`function is ignored if request method is not settings in param.

What do you think about this ? 
