### PR TITLE
[HttpFoundation] Add SessionHasFlashMessage test constraint

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -17,6 +17,7 @@ CHANGELOG
  * Enable mocking non-shared services in tests
  * Add support for setting `mock_response_factory` per scoped HTTP client
  * Add `ConsoleCommandAssertionsTrait` to `KernelTestCase` for running a command and asserting the result
+ * Add `assertSessionHasFlashMessage()` to `BrowserKitAssertionsTrait`
  * Add `framework.html_sanitizer.sanitizers.*.default_action` config option
  * Deprecate parameters `router.request_context.scheme` and `router.request_context.host`;
    use the `router.request_context.base_url` parameter or the `framework.router.default_uri` config option instead

--- a/src/Symfony/Bundle/FrameworkBundle/Test/BrowserKitAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/BrowserKitAssertionsTrait.php
@@ -180,6 +180,11 @@ trait BrowserKitAssertionsTrait
         self::assertThat(self::getRequest(), $constraint, $message);
     }
 
+    public static function assertSessionHasFlashMessage(string $messageType, string|array $messages = ''): void
+    {
+        static::assertThat(self::getRequest(), new ResponseConstraint\SessionHasFlashMessage($messageType, $messages));
+    }
+
     public static function assertThatForResponse(Constraint $constraint, string $message = ''): void
     {
         try {

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add `BinaryFileResponse::shouldDeleteFileAfterSend()`
  * Deprecate setting public properties of `Request` and `Response` objects directly; use setters or constructor arguments instead
+ * Add `SessionHasFlashMessage` test constraint
 
 8.0
 ---

--- a/src/Symfony/Component/HttpFoundation/Test/Constraint/SessionHasFlashMessage.php
+++ b/src/Symfony/Component/HttpFoundation/Test/Constraint/SessionHasFlashMessage.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Test\Constraint;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\FlashBagAwareSessionInterface;
+
+final class SessionHasFlashMessage extends Constraint
+{
+    public function __construct(
+        private readonly string $messageType,
+        private readonly mixed $messages,
+    ) {
+    }
+
+    public function toString(): string
+    {
+        return \sprintf('session has flash message of type "%s" containing: %s', $this->messageType, implode(', ', $this->getExpectedMessages()));
+    }
+
+    protected function getExpectedMessages(): array
+    {
+        return \is_array($this->messages) ? $this->messages : [(string) $this->messages];
+    }
+
+    protected function matches(mixed $other): bool
+    {
+        if (!$other instanceof Request) {
+            return false;
+        }
+
+        if (!$other->hasSession()) {
+            return false;
+        }
+
+        $session = $other->getSession();
+
+        if (!$session instanceof FlashBagAwareSessionInterface) {
+            return false;
+        }
+
+        $flashbag = $session->getFlashBag();
+        $flashMessages = $flashbag->peek($this->messageType);
+        $expectedMessages = $this->getExpectedMessages();
+
+        return array_any($flashMessages, static fn (mixed $message) => \in_array($message, $expectedMessages, true));
+    }
+
+    protected function failureDescription(mixed $other): string
+    {
+        if (!$other instanceof Request) {
+            return 'because the constraint was not configured with a Request object';
+        }
+
+        $message = $this->toString();
+
+        if (!$other->hasSession()) {
+            return $message.', because the Request does not have a Session';
+        }
+
+        $session = $other->getSession();
+        if (!$session instanceof FlashBagAwareSessionInterface) {
+            return $message.', because the Session does not have a FlashBag';
+        }
+
+        return $message;
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/SessionHasFlashMessageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/SessionHasFlashMessageTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Tests\Test\Constraint;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\HttpFoundation\Test\Constraint\SessionHasFlashMessage;
+
+class SessionHasFlashMessageTest extends TestCase
+{
+    #[DataProvider('provideMessages')]
+    public function testSuccessfulCase(string|array $flashMessages)
+    {
+        $request = new Request();
+        $session = new Session(new MockArraySessionStorage());
+        $request->setSession($session);
+
+        $session->getFlashBag()->set('foo', 'bar');
+
+        $constraint = new SessionHasFlashMessage('foo', $flashMessages);
+        $this->assertTrue($constraint->evaluate($request, '', true));
+    }
+
+    #[DataProvider('provideMessages')]
+    public function testNoMessage(string|array $flashMessages)
+    {
+        $request = new Request();
+        $session = new Session(new MockArraySessionStorage());
+        $request->setSession($session);
+
+        $constraint = new SessionHasFlashMessage('foo', $flashMessages);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Failed asserting that session has flash message of type "foo" containing: %s.',
+            \is_string($flashMessages) ? $flashMessages : implode(', ', $flashMessages),
+        ));
+
+        $constraint->evaluate($request);
+    }
+
+    #[DataProvider('provideMessages')]
+    public function testNoSession(string|array $flashMessages)
+    {
+        $request = new Request();
+
+        $constraint = new SessionHasFlashMessage('foo', $flashMessages);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Failed asserting that session has flash message of type "foo" containing: %s, because the Request does not have a Session.',
+            \is_string($flashMessages) ? $flashMessages : implode(', ', $flashMessages),
+        ));
+
+        $constraint->evaluate($request);
+    }
+
+    #[DataProvider('provideMessages')]
+    public function testNoFlashBag(string|array $flashMessages)
+    {
+        $request = new Request();
+        $session = $this->createStub(SessionInterface::class);
+        $request->setSession($session);
+
+        $constraint = new SessionHasFlashMessage('foo', $flashMessages);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Failed asserting that session has flash message of type "foo" containing: %s, because the Session does not have a FlashBag',
+            \is_string($flashMessages) ? $flashMessages : implode(', ', $flashMessages),
+        ));
+
+        $constraint->evaluate($request);
+    }
+
+    public static function provideMessages(): iterable
+    {
+        yield ['bar'];
+        yield [['bar', 'baz']];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

Eases the checks on the Session, to avoid the user having to do the checks themselves.

Before:
```php
$request = $client->getRequest();
self::assertTrue($request->hasSession());
$session = $request->getSession();
self::assertInstanceOf(FlashBagAwareSessionInterface::class, $session);
$flashbag = $session->getFlashBag();
self::assertContains($message, $flashbag->peek($messageType));
```

After:
```php
self::assertSessionHasFlashMessage($messageType, $message);
```