### PR TITLE
[DependencyInjection] Enable multiple attribute autoconfiguration callbacks on the same class

### DIFF
--- a/UPGRADE-7.3.md
+++ b/UPGRADE-7.3.md
@@ -39,6 +39,11 @@ Console
 
  * Deprecate methods `Command::getDefaultName()` and `Command::getDefaultDescription()` in favor of the `#[AsCommand]` attribute
 
+DependencyInjection
+-------------------
+
+ * Deprecate `ContainerBuilder::getAutoconfiguredAttributes()` in favor of the `getAttributeAutoconfigurators()` method.
+
 FrameworkBundle
 ---------------
 

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Don't skip classes with private constructor when autodiscovering
  * Add `Definition::addResourceTag()` and `ContainerBuilder::findTaggedResourceIds()`
    for auto-configuration of classes excluded from the service container
+ * Accept multiple auto-configuration callbacks for the same attribute class
  * Leverage native lazy objects when possible for lazy services
 
 7.2

--- a/src/Symfony/Component/DependencyInjection/Compiler/AttributeAutoconfigurationPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AttributeAutoconfigurationPass.php
@@ -31,49 +31,51 @@ final class AttributeAutoconfigurationPass extends AbstractRecursivePass
 
     public function process(ContainerBuilder $container): void
     {
-        if (!$container->getAutoconfiguredAttributes()) {
+        if (!$container->getAttributeAutoconfigurators()) {
             return;
         }
 
-        foreach ($container->getAutoconfiguredAttributes() as $attributeName => $callable) {
-            $callableReflector = new \ReflectionFunction($callable(...));
-            if ($callableReflector->getNumberOfParameters() <= 2) {
-                $this->classAttributeConfigurators[$attributeName] = $callable;
-                continue;
-            }
-
-            $reflectorParameter = $callableReflector->getParameters()[2];
-            $parameterType = $reflectorParameter->getType();
-            $types = [];
-            if ($parameterType instanceof \ReflectionUnionType) {
-                foreach ($parameterType->getTypes() as $type) {
-                    $types[] = $type->getName();
+        foreach ($container->getAttributeAutoconfigurators() as $attributeName => $callables) {
+            foreach ($callables as $callable) {
+                $callableReflector = new \ReflectionFunction($callable(...));
+                if ($callableReflector->getNumberOfParameters() <= 2) {
+                    $this->classAttributeConfigurators[$attributeName][] = $callable;
+                    continue;
                 }
-            } elseif ($parameterType instanceof \ReflectionNamedType) {
-                $types[] = $parameterType->getName();
-            } else {
-                throw new LogicException(\sprintf('Argument "$%s" of attribute autoconfigurator should have a type, use one or more of "\ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\Reflector" in "%s" on line "%d".', $reflectorParameter->getName(), $callableReflector->getFileName(), $callableReflector->getStartLine()));
-            }
 
-            try {
-                $attributeReflector = new \ReflectionClass($attributeName);
-            } catch (\ReflectionException) {
-                continue;
-            }
-
-            $targets = $attributeReflector->getAttributes(\Attribute::class)[0] ?? 0;
-            $targets = $targets ? $targets->getArguments()[0] ?? -1 : 0;
-
-            foreach (['class', 'method', 'property', 'parameter'] as $symbol) {
-                if (['Reflector'] !== $types) {
-                    if (!\in_array('Reflection'.ucfirst($symbol), $types, true)) {
-                        continue;
+                $reflectorParameter = $callableReflector->getParameters()[2];
+                $parameterType = $reflectorParameter->getType();
+                $types = [];
+                if ($parameterType instanceof \ReflectionUnionType) {
+                    foreach ($parameterType->getTypes() as $type) {
+                        $types[] = $type->getName();
                     }
-                    if (!($targets & \constant('Attribute::TARGET_'.strtoupper($symbol)))) {
-                        throw new LogicException(\sprintf('Invalid type "Reflection%s" on argument "$%s": attribute "%s" cannot target a '.$symbol.' in "%s" on line "%d".', ucfirst($symbol), $reflectorParameter->getName(), $attributeName, $callableReflector->getFileName(), $callableReflector->getStartLine()));
-                    }
+                } elseif ($parameterType instanceof \ReflectionNamedType) {
+                    $types[] = $parameterType->getName();
+                } else {
+                    throw new LogicException(\sprintf('Argument "$%s" of attribute autoconfigurator should have a type, use one or more of "\ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\Reflector" in "%s" on line "%d".', $reflectorParameter->getName(), $callableReflector->getFileName(), $callableReflector->getStartLine()));
                 }
-                $this->{$symbol.'AttributeConfigurators'}[$attributeName] = $callable;
+
+                try {
+                    $attributeReflector = new \ReflectionClass($attributeName);
+                } catch (\ReflectionException) {
+                    continue;
+                }
+
+                $targets = $attributeReflector->getAttributes(\Attribute::class)[0] ?? 0;
+                $targets = $targets ? $targets->getArguments()[0] ?? -1 : 0;
+
+                foreach (['class', 'method', 'property', 'parameter'] as $symbol) {
+                    if (['Reflector'] !== $types) {
+                        if (!\in_array('Reflection' . ucfirst($symbol), $types, true)) {
+                            continue;
+                        }
+                        if (!($targets & \constant('Attribute::TARGET_' . strtoupper($symbol)))) {
+                            throw new LogicException(\sprintf('Invalid type "Reflection%s" on argument "$%s": attribute "%s" cannot target a ' . $symbol . ' in "%s" on line "%d".', ucfirst($symbol), $reflectorParameter->getName(), $attributeName, $callableReflector->getFileName(), $callableReflector->getStartLine()));
+                        }
+                    }
+                    $this->{$symbol . 'AttributeConfigurators'}[$attributeName][] = $callable;
+                }
             }
         }
 
@@ -94,13 +96,7 @@ final class AttributeAutoconfigurationPass extends AbstractRecursivePass
         $instanceof = $value->getInstanceofConditionals();
         $conditionals = $instanceof[$classReflector->getName()] ?? new ChildDefinition('');
 
-        if ($this->classAttributeConfigurators) {
-            foreach ($classReflector->getAttributes() as $attribute) {
-                if ($configurator = $this->findConfigurator($this->classAttributeConfigurators, $attribute->getName())) {
-                    $configurator($conditionals, $attribute->newInstance(), $classReflector);
-                }
-            }
-        }
+        $this->callConfigurators($this->classAttributeConfigurators, $conditionals, $classReflector);
 
         if ($this->parameterAttributeConfigurators) {
             try {
@@ -111,11 +107,7 @@ final class AttributeAutoconfigurationPass extends AbstractRecursivePass
 
             if ($constructorReflector) {
                 foreach ($constructorReflector->getParameters() as $parameterReflector) {
-                    foreach ($parameterReflector->getAttributes() as $attribute) {
-                        if ($configurator = $this->findConfigurator($this->parameterAttributeConfigurators, $attribute->getName())) {
-                            $configurator($conditionals, $attribute->newInstance(), $parameterReflector);
-                        }
-                    }
+                    $this->callConfigurators($this->parameterAttributeConfigurators, $conditionals, $parameterReflector);
                 }
             }
         }
@@ -126,22 +118,10 @@ final class AttributeAutoconfigurationPass extends AbstractRecursivePass
                     continue;
                 }
 
-                if ($this->methodAttributeConfigurators) {
-                    foreach ($methodReflector->getAttributes() as $attribute) {
-                        if ($configurator = $this->findConfigurator($this->methodAttributeConfigurators, $attribute->getName())) {
-                            $configurator($conditionals, $attribute->newInstance(), $methodReflector);
-                        }
-                    }
-                }
+                $this->callConfigurators($this->methodAttributeConfigurators, $conditionals, $methodReflector);
 
-                if ($this->parameterAttributeConfigurators) {
-                    foreach ($methodReflector->getParameters() as $parameterReflector) {
-                        foreach ($parameterReflector->getAttributes() as $attribute) {
-                            if ($configurator = $this->findConfigurator($this->parameterAttributeConfigurators, $attribute->getName())) {
-                                $configurator($conditionals, $attribute->newInstance(), $parameterReflector);
-                            }
-                        }
-                    }
+                foreach ($methodReflector->getParameters() as $parameterReflector) {
+                    $this->callConfigurators($this->parameterAttributeConfigurators, $conditionals, $parameterReflector);
                 }
             }
         }
@@ -152,11 +132,7 @@ final class AttributeAutoconfigurationPass extends AbstractRecursivePass
                     continue;
                 }
 
-                foreach ($propertyReflector->getAttributes() as $attribute) {
-                    if ($configurator = $this->findConfigurator($this->propertyAttributeConfigurators, $attribute->getName())) {
-                        $configurator($conditionals, $attribute->newInstance(), $propertyReflector);
-                    }
-                }
+                $this->callConfigurators($this->propertyAttributeConfigurators, $conditionals, $propertyReflector);
             }
         }
 
@@ -169,18 +145,36 @@ final class AttributeAutoconfigurationPass extends AbstractRecursivePass
     }
 
     /**
+     * Call all the configurators for the given attribute.
+     *
+     * @param array<class-string, callable[]> $configurators
+     */
+    private function callConfigurators(array &$configurators, ChildDefinition $conditionals, \ReflectionClass|\ReflectionMethod|\ReflectionParameter|\ReflectionProperty $reflector): void
+    {
+        if (!$configurators) {
+            return;
+        }
+
+        foreach ($reflector->getAttributes() as $attribute) {
+            foreach ($this->findConfigurators($configurators, $attribute->getName()) as $configurator) {
+                $configurator($conditionals, $attribute->newInstance(), $reflector);
+            }
+        }
+    }
+
+    /**
      * Find the first configurator for the given attribute name, looking up the class hierarchy.
      */
-    private function findConfigurator(array &$configurators, string $attributeName): ?callable
+    private function findConfigurators(array &$configurators, string $attributeName): array
     {
         if (\array_key_exists($attributeName, $configurators)) {
             return $configurators[$attributeName];
         }
 
         if (class_exists($attributeName) && $parent = get_parent_class($attributeName)) {
-            return $configurators[$attributeName] = self::findConfigurator($configurators, $parent);
+            return $configurators[$attributeName] = $this->findConfigurators($configurators, $parent);
         }
 
-        return $configurators[$attributeName] = null;
+        return $configurators[$attributeName] = [];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | yes
| Issues        | Fix https://github.com/doctrine/DoctrineBundle/pull/1868#issuecomment-2730726691
| License       | MIT

Replace https://github.com/symfony/symfony/pull/60001

By having a list of callables for each attributes, we can enable merging definitions each having an autoconfiguration for the same attribute class. This is the case with the `#[Entity]` attribute in DoctrineBundle and FrameworkBundle.

I have to deprecate `ContainerBuilder::getAutoconfiguredAttributes()` as its return type is `array<class-string, callable>`; so I added a new method `getAttributeAutoconfigurations` that returns `array<class-string, callable[]>` in  in order to use reflection on each callable in the compiler pass.