### PR TITLE
[Translation] remove deprecated libxml_disable_entity_loader function

### DIFF
--- a/src/Symfony/Component/Translation/Util/XliffUtils.php
+++ b/src/Symfony/Component/Translation/Util/XliffUtils.php
@@ -61,18 +61,19 @@ class XliffUtils
     {
         $xliffVersion = static::getVersionNumber($dom);
         $internalErrors = libxml_use_internal_errors(true);
-        if ($shouldEnable = self::shouldEnableEntityLoader()) {
+        /*if ($shouldEnable = self::shouldEnableEntityLoader()) {
             $disableEntities = libxml_disable_entity_loader(false);
-        }
-        try {
-            $isValid = @$dom->schemaValidateSource(self::getSchema($xliffVersion));
-            if (!$isValid) {
-                return self::getXmlErrors($internalErrors);
-            }
+        }*/
+        /*try {
+
         } finally {
             if ($shouldEnable) {
                 libxml_disable_entity_loader($disableEntities);
             }
+        }*/
+        $isValid = @$dom->schemaValidateSource(self::getSchema($xliffVersion));
+        if (!$isValid) {
+            return self::getXmlErrors($internalErrors);
         }
 
         $dom->normalizeDocument();
@@ -83,7 +84,7 @@ class XliffUtils
         return [];
     }
 
-    private static function shouldEnableEntityLoader(): bool
+    /*private static function shouldEnableEntityLoader(): bool
     {
         static $dom, $schema;
         if (null === $dom) {
@@ -106,7 +107,7 @@ class XliffUtils
         }
 
         return !@$dom->schemaValidateSource($schema);
-    }
+    }*/
 
     public static function getErrorsAsString(array $xmlErrors): string
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | yes <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT

Hello, this function is deprecated since PHP 8.0.0: [https://www.php.net/manual/en/function.libxml-disable-entity-loader.php](https://www.php.net/manual/en/function.libxml-disable-entity-loader.php)
![Capture d'écran 2025-03-23 112159](https://github.com/user-attachments/assets/3b3068b8-c2c2-4bd1-87d4-4fc7b8015a64)

At the moment, I just comment the unused function `shouldEnableEntityLoader` but before finalize this PR, I need your comment about this. There are no replacement for `libxml_disable_entity_loader` PHP function. Have you any idea to replace it or we don't need this for PHP 8.2 ?

Thanks.

I see another PR for this in Sf4: [https://github.com/symfony/symfony/pull/37790/files](https://github.com/symfony/symfony/pull/37790/files)

**TODO**
- Remove comments
- Update UPGRADE-*.md and src/**/CHANGELOG.md files
