### PR TITLE
[Lock] Add `LockKeyNormalizer`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -118,6 +118,7 @@ use Symfony\Component\JsonStreamer\ValueTransformer\ValueTransformerInterface;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\LockInterface;
 use Symfony\Component\Lock\PersistingStoreInterface;
+use Symfony\Component\Lock\Serializer\LockKeyNormalizer;
 use Symfony\Component\Lock\Store\StoreFactory;
 use Symfony\Component\Mailer\Bridge as MailerBridge;
 use Symfony\Component\Mailer\Command\MailerTestCommand;
@@ -2258,6 +2259,11 @@ class FrameworkExtension extends Extension
     private function registerLockConfiguration(array $config, ContainerBuilder $container, PhpFileLoader $loader): void
     {
         $loader->load('lock.php');
+
+        // BC layer Lock < 7.4
+        if (!interface_exists(DenormalizerInterface::class) || !class_exists(LockKeyNormalizer::class)) {
+            $container->removeDefinition('serializer.normalizer.lock_key');
+        }
 
         foreach ($config['resources'] as $resourceName => $resourceStores) {
             if (0 === \count($resourceStores)) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/lock.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/lock.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\Serializer\LockKeyNormalizer;
 use Symfony\Component\Lock\Store\CombinedStore;
 use Symfony\Component\Lock\Strategy\ConsensusStrategy;
 
@@ -26,5 +27,8 @@ return static function (ContainerConfigurator $container) {
             ->args([abstract_arg('Store')])
             ->call('setLogger', [service('logger')->ignoreOnInvalid()])
             ->tag('monolog.logger', ['channel' => 'lock'])
+
+        ->set('serializer.normalizer.lock_key', LockKeyNormalizer::class)
+            ->tag('serializer.normalizer', ['built_in' => true, 'priority' => -880])
     ;
 };

--- a/src/Symfony/Component/Lock/CHANGELOG.md
+++ b/src/Symfony/Component/Lock/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+ * Add `LockKeyNormalizer`
+
 7.3
 ---
 

--- a/src/Symfony/Component/Lock/Key.php
+++ b/src/Symfony/Component/Lock/Key.php
@@ -89,6 +89,13 @@ final class Key
         return null !== $this->expiringTime && $this->expiringTime <= microtime(true);
     }
 
+    public function __unserialize(array $data): void
+    {
+        $this->resource = $data['resource'];
+        $this->expiringTime = $data['expiringTime'];
+        $this->state = $data['state'];
+    }
+
     public function __serialize(): array
     {
         if (!$this->serializable) {

--- a/src/Symfony/Component/Lock/Serializer/LockKeyNormalizer.php
+++ b/src/Symfony/Component/Lock/Serializer/LockKeyNormalizer.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock\Serializer;
+
+use Symfony\Component\Lock\Key;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * Normalize {@see Key} instance to transfer an acquired lock between processes.
+ *
+ * @author Valtteri R <valtzu@gmail.com>
+ */
+final class LockKeyNormalizer implements NormalizerInterface, DenormalizerInterface
+{
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Key::class => true];
+    }
+
+    /**
+     * @param Key $data
+     */
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array
+    {
+        return $data->__serialize();
+    }
+
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Key;
+    }
+
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): Key
+    {
+        $key = (new \ReflectionClass(Key::class))->newInstanceWithoutConstructor();
+        $key->__unserialize($data);
+
+        return $key;
+    }
+
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return Key::class === $type;
+    }
+}

--- a/src/Symfony/Component/Lock/Tests/Serializer/LockKeyNormalizerTest.php
+++ b/src/Symfony/Component/Lock/Tests/Serializer/LockKeyNormalizerTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock\Tests\Serializer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Lock\Exception\UnserializableKeyException;
+use Symfony\Component\Lock\Key;
+use Symfony\Component\Lock\Serializer\LockKeyNormalizer;
+
+class LockKeyNormalizerTest extends TestCase
+{
+    public function testNormalizeAndDenormalize()
+    {
+        $key = new Key(__METHOD__);
+        $key->reduceLifetime(1);
+        $key->setState('foo', 'bar');
+        $normalizer = new LockKeyNormalizer();
+
+        $copy = $normalizer->denormalize($normalizer->normalize($key), Key::class);
+        $this->assertSame($key->getState('foo'), $copy->getState('foo'));
+        $this->assertEqualsWithDelta($key->getRemainingLifetime(), $copy->getRemainingLifetime(), 0.001);
+    }
+
+    public function testNormalizingUnserializableLockThrows()
+    {
+        $key = new Key(__METHOD__);
+        $key->markUnserializable();
+        $normalizer = new LockKeyNormalizer();
+
+        $this->expectException(UnserializableKeyException::class);
+        $normalizer->normalize($key);
+    }
+}

--- a/src/Symfony/Component/Lock/composer.json
+++ b/src/Symfony/Component/Lock/composer.json
@@ -21,7 +21,8 @@
     },
     "require-dev": {
         "doctrine/dbal": "^3.6|^4",
-        "predis/predis": "^1.1|^2.0"
+        "predis/predis": "^1.1|^2.0",
+        "symfony/serializer": "^6.4|^7.0"
     },
     "conflict": {
         "doctrine/dbal": "<3.6",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

[The Lock documentation](https://symfony.com/doc/7.3/components/lock.html#serializing-locks) mentions that the lock keys are serializable – however, it seems that's the case only if you're using native php serializer.

I'm proposing to add `LockKeyNormalizer` to make the example in the docs work the same when using Symfony Serializer too.