### PR TITLE
[Console] Add support for invokable commands in `LockableTrait`

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Add support for help definition via `AsCommand` attribute
  * Deprecate methods `Command::getDefaultName()` and `Command::getDefaultDescription()` in favor of the `#[AsCommand]` attribute
  * Add support for Markdown format in `Table`
+ * Add support for `LockableTrait` in invokable commands
 
 7.2
 ---

--- a/src/Symfony/Component/Console/Tests/Fixtures/FooLock4InvokableCommand.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/FooLock4InvokableCommand.php
@@ -1,0 +1,22 @@
+<?php
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\LockableTrait;
+
+#[AsCommand(name: 'foo:lock4')]
+class FooLock4InvokableCommand
+{
+    use LockableTrait;
+
+    public function __invoke(): int
+    {
+        if (!$this->lock()) {
+            return Command::FAILURE;
+        }
+
+        $this->release();
+
+        return Command::SUCCESS;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This enables invokable commands to use `LockableTrait` without extending the `Command` class:
```php
use Symfony\Component\Console\Command\LockableTrait;

#[AsCommand(name: 'foo:lock')]
class FooLockCommand
{
    use LockableTrait;

    public function __invoke(): int
    {
        if (!$this->lock()) {
            return Command::FAILURE;
        }

        // exclusive logic starts here...

        $this->release();

        return Command::SUCCESS;
    }
}
```
Ref: https://symfony.com/doc/current/console/lockable_trait.html