### PR TITLE
[Serializer] Fix code skipped by premature return

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2004,23 +2004,21 @@ class FrameworkExtension extends Extension
             $container->setParameter('serializer.default_context', $defaultContext);
         }
 
-        if (!$container->hasDefinition('serializer.normalizer.object')) {
-            return;
+        if ($container->hasDefinition('serializer.normalizer.object')) {
+            $arguments = $container->getDefinition('serializer.normalizer.object')->getArguments();
+            $context = $arguments[6] ?? $defaultContext;
+
+            if (isset($config['circular_reference_handler']) && $config['circular_reference_handler']) {
+                $context += ['circular_reference_handler' => new Reference($config['circular_reference_handler'])];
+                $container->getDefinition('serializer.normalizer.object')->setArgument(5, null);
+            }
+
+            if ($config['max_depth_handler'] ?? false) {
+                $context += ['max_depth_handler' => new Reference($config['max_depth_handler'])];
+            }
+
+            $container->getDefinition('serializer.normalizer.object')->setArgument(6, $context);
         }
-
-        $arguments = $container->getDefinition('serializer.normalizer.object')->getArguments();
-        $context = $arguments[6] ?? $defaultContext;
-
-        if (isset($config['circular_reference_handler']) && $config['circular_reference_handler']) {
-            $context += ['circular_reference_handler' => new Reference($config['circular_reference_handler'])];
-            $container->getDefinition('serializer.normalizer.object')->setArgument(5, null);
-        }
-
-        if ($config['max_depth_handler'] ?? false) {
-            $context += ['max_depth_handler' => new Reference($config['max_depth_handler'])];
-        }
-
-        $container->getDefinition('serializer.normalizer.object')->setArgument(6, $context);
 
         $container->getDefinition('serializer.normalizer.property')->setArgument(5, $defaultContext);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The problem with the current code is the early return:
https://github.com/symfony/symfony/blob/c9ed7620fb00e8e7db89fe724cabd0bd43cec0dc/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php#L2007-L2009

Some code after the return is not related to the object normalizer, and should therefor not be skipped:
https://github.com/symfony/symfony/blob/c9ed7620fb00e8e7db89fe724cabd0bd43cec0dc/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php#L2025-L2026

This PR replaces the early return by wrapping the code related to the object normalizer inside the `if` block to prevent any future mistakes.

Probably easier to review with [whitespace changes hidden](https://github.com/symfony/symfony/pull/60025/files?diff=unified&w=1).