### PR TITLE
[ObjectMapper] Condition to target a specific class 

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/ObjectMapper/TransformCallable.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/ObjectMapper/TransformCallable.php
@@ -18,7 +18,7 @@ use Symfony\Component\ObjectMapper\TransformCallableInterface;
  */
 final class TransformCallable implements TransformCallableInterface
 {
-    public function __invoke(mixed $value, object $object): mixed
+    public function __invoke(mixed $value, object $source, ?object $target): mixed
     {
         return 'transformed';
     }

--- a/src/Symfony/Component/ObjectMapper/Condition/TargetClass.php
+++ b/src/Symfony/Component/ObjectMapper/Condition/TargetClass.php
@@ -9,17 +9,26 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ServiceLocator;
+namespace Symfony\Component\ObjectMapper\Condition;
 
 use Symfony\Component\ObjectMapper\ConditionCallableInterface;
 
 /**
- * @implements ConditionCallableInterface<A>
+ * @template T of object
+ *
+ * @implements ConditionCallableInterface<object, T>
  */
-class ConditionCallable implements ConditionCallableInterface
+final class TargetClass implements ConditionCallableInterface
 {
+    /**
+     * @param class-string<T> $className
+     */
+    public function __construct(private readonly string $className)
+    {
+    }
+
     public function __invoke(mixed $value, object $source, ?object $target): bool
     {
-        return 'ok' === $value;
+        return $target instanceof $this->className;
     }
 }

--- a/src/Symfony/Component/ObjectMapper/ConditionCallableInterface.php
+++ b/src/Symfony/Component/ObjectMapper/ConditionCallableInterface.php
@@ -15,6 +15,7 @@ namespace Symfony\Component\ObjectMapper;
  * Service used by "Map::if".
  *
  * @template T of object
+ * @template T2 of object
  *
  * @experimental
  *
@@ -25,6 +26,7 @@ interface ConditionCallableInterface
     /**
      * @param mixed $value  The value being mapped
      * @param T     $source The object we're working on
+     * @param T2|null $target The target we're mapping to
      */
-    public function __invoke(mixed $value, object $source): bool;
+    public function __invoke(mixed $value, object $source, ?object $target): bool;
 }

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MultipleTargetProperty/A.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MultipleTargetProperty/A.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+use Symfony\Component\ObjectMapper\Condition\TargetClass;
+
+#[Map(target: B::class)]
+#[Map(target: C::class)]
+class A
+{
+    #[Map(target: 'foo', transform: 'strtoupper', if: new TargetClass(B::class))]
+    #[Map(target: 'bar')]
+    public string $something = 'test';
+
+    public string $doesNotExistInTargetB = 'foo';
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MultipleTargetProperty/B.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MultipleTargetProperty/B.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty;
+
+class B
+{
+    public string $foo;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MultipleTargetProperty/C.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MultipleTargetProperty/C.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty;
+
+class C
+{
+    public string $foo = 'donotmap';
+    public string $bar;
+    public string $doesNotExistInTargetB;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ServiceLocator/TransformCallable.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ServiceLocator/TransformCallable.php
@@ -18,7 +18,7 @@ use Symfony\Component\ObjectMapper\TransformCallableInterface;
  */
 class TransformCallable implements TransformCallableInterface
 {
-    public function __invoke(mixed $value, object $object): mixed
+    public function __invoke(mixed $value, object $source, ?object $target): mixed
     {
         return "transformed$value";
     }

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -40,6 +40,9 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\Source;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\Target;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapTargetToSource\A as MapTargetToSourceA;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapTargetToSource\B as MapTargetToSourceB;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty\A as MultipleTargetPropertyA;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty\B as MultipleTargetPropertyB;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty\C as MultipleTargetPropertyC;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargets\A as MultipleTargetsA;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargets\C as MultipleTargetsC;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\Recursion\AB;
@@ -272,5 +275,20 @@ final class ObjectMapperTest extends TestCase
         $b = $mapper->map($a, MapTargetToSourceB::class);
         $this->assertInstanceOf(MapTargetToSourceB::class, $b);
         $this->assertSame('str', $b->target);
+    }
+
+    public function testMultipleTargetMapProperty()
+    {
+        $u = new MultipleTargetPropertyA();
+
+        $mapper = new ObjectMapper();
+        $b = $mapper->map($u, MultipleTargetPropertyB::class);
+        $this->assertInstanceOf(MultipleTargetPropertyB::class, $b);
+        $this->assertEquals($b->foo, 'TEST');
+        $c = $mapper->map($u, MultipleTargetPropertyC::class);
+        $this->assertInstanceOf(MultipleTargetPropertyC::class, $c);
+        $this->assertEquals($c->bar, 'test');
+        $this->assertEquals($c->foo, 'donotmap');
+        $this->assertEquals($c->doesNotExistInTargetB, 'foo');
     }
 }

--- a/src/Symfony/Component/ObjectMapper/TransformCallableInterface.php
+++ b/src/Symfony/Component/ObjectMapper/TransformCallableInterface.php
@@ -15,6 +15,7 @@ namespace Symfony\Component\ObjectMapper;
  * Service used by "Map::transform".
  *
  * @template T of object
+ * @template T2 of object
  *
  * @experimental
  *
@@ -25,6 +26,7 @@ interface TransformCallableInterface
     /**
      * @param mixed $value  The value being mapped
      * @param T     $source The object we're working on
+     * @param T2|null $target The target we're mapping to
      */
-    public function __invoke(mixed $value, object $source): mixed;
+    public function __invoke(mixed $value, object $source, ?object $target): mixed;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

We want to be able to choose which property to map according to the target. Here `foo` is mapped to `B` only when the target is `B`. If `C` has a `foo` property it won't be mapped as we only map to `bar`.

```php
use Symfony\Component\ObjectMapper\Attribute\Map;
use Symfony\Component\ObjectMapper\TargetClass;

#[Map(target: B::class)]
#[Map(target: C::class)]
class A
{
    #[Map(target: 'foo', transform: 'strtoupper', if: new TargetClass(B::class))]
    #[Map(target: 'bar')]
    public string $something = 'test';

    public string $doesNotExistInTargetB = 'foo';
}
```

This is a good alternative to groups as we can have one class that has multiple representation. 
