### PR TITLE
[HttpKernel] Add UnauthorizedHttpException to HttpException::fromStatusCode

### DIFF
--- a/src/Symfony/Component/HttpKernel/Exception/HttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/HttpException.php
@@ -32,6 +32,7 @@ class HttpException extends \RuntimeException implements HttpExceptionInterface
     {
         return match ($statusCode) {
             400 => new BadRequestHttpException($message, $previous, $code, $headers),
+            401 => new UnauthorizedHttpException($message, $previous, $code, $headers),
             403 => new AccessDeniedHttpException($message, $previous, $code, $headers),
             404 => new NotFoundHttpException($message, $previous, $code, $headers),
             406 => new NotAcceptableHttpException($message, $previous, $code, $headers),

--- a/src/Symfony/Component/HttpKernel/Exception/HttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/HttpException.php
@@ -32,7 +32,7 @@ class HttpException extends \RuntimeException implements HttpExceptionInterface
     {
         return match ($statusCode) {
             400 => new BadRequestHttpException($message, $previous, $code, $headers),
-            401 => new UnauthorizedHttpException($message, $previous, $code, $headers),
+            401 => new UnauthorizedHttpException('', $message, $previous, $code, $headers),
             403 => new AccessDeniedHttpException($message, $previous, $code, $headers),
             404 => new NotFoundHttpException($message, $previous, $code, $headers),
             406 => new NotAcceptableHttpException($message, $previous, $code, $headers),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #... 
| License       | MIT

Added missing (?) status code to HttpException::fromStatusCode

https://github.com/symfony/symfony/blob/7.3/src/Symfony/Component/HttpKernel/Tests/Exception/HttpExceptionTest.php#L80 Already presented in tests, not in code
