### PR TITLE
[ErrorHandler][FrameworkBundle] Add support for selecting the appropriate error renderer based on the `APP_RUNTIME_MODE`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -19,6 +19,7 @@ CHANGELOG
  * Add `framework.allowed_http_method_override` option
  * Initialize `router.request_context`'s `_locale` parameter to `%kernel.default_locale%`
  * Deprecate `ConfigBuilderCacheWarmer`, return PHP arrays from your config instead
+ * Add support for selecting the appropriate error renderer based on the `APP_RUNTIME_MODE` env var
 
 7.3
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/ErrorHandler/ErrorRenderer/RuntimeModeErrorRendererSelector.php
+++ b/src/Symfony/Bundle/FrameworkBundle/ErrorHandler/ErrorRenderer/RuntimeModeErrorRendererSelector.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\ErrorHandler\ErrorRenderer;
+
+use Symfony\Component\ErrorHandler\ErrorRenderer\ErrorRendererInterface;
+
+/**
+ * @internal
+ *
+ * @author Yonel Ceruto <open@yceruto.dev>
+ */
+final class RuntimeModeErrorRendererSelector
+{
+    /**
+     * @param \Closure(): ErrorRendererInterface $htmlErrorRenderer
+     * @param \Closure(): ErrorRendererInterface $cliErrorRenderer
+     */
+    public static function select(bool $isWebMode, \Closure $htmlErrorRenderer, \Closure $cliErrorRenderer): ErrorRendererInterface
+    {
+        return ($isWebMode ? $htmlErrorRenderer : $cliErrorRenderer)();
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/error_renderer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/error_renderer.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Symfony\Bundle\FrameworkBundle\ErrorHandler\ErrorRenderer\RuntimeModeErrorRendererSelector;
+use Symfony\Component\ErrorHandler\ErrorRenderer\CliErrorRenderer;
+use Symfony\Component\ErrorHandler\ErrorRenderer\ErrorRendererInterface;
 use Symfony\Component\ErrorHandler\ErrorRenderer\HtmlErrorRenderer;
 
 return static function (ContainerConfigurator $container) {
@@ -32,7 +35,19 @@ return static function (ContainerConfigurator $container) {
                 service('logger')->nullOnInvalid(),
             ])
 
+        ->set('error_handler.error_renderer.cli', CliErrorRenderer::class)
+
+        ->set('error_handler.error_renderer.default', ErrorRendererInterface::class)
+            ->factory([RuntimeModeErrorRendererSelector::class, 'select'])
+            ->args([
+                param('kernel.runtime_mode.web'),
+                service_closure('error_renderer.html'),
+                service_closure('error_renderer.cli'),
+            ])
+
         ->alias('error_renderer.html', 'error_handler.error_renderer.html')
-        ->alias('error_renderer', 'error_renderer.html')
+        ->alias('error_renderer.cli', 'error_handler.error_renderer.cli')
+        ->alias('error_renderer.default', 'error_handler.error_renderer.default')
+        ->alias('error_renderer', 'error_renderer.default')
     ;
 };

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Bundle\FrameworkBundle\CacheWarmer\SerializerCacheWarmer;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
+use Symfony\Component\ErrorHandler\ErrorRenderer\ErrorRendererInterface;
 use Symfony\Component\ErrorHandler\ErrorRenderer\HtmlErrorRenderer;
 use Symfony\Component\ErrorHandler\ErrorRenderer\SerializerErrorRenderer;
 use Symfony\Component\PropertyInfo\Extractor\SerializerExtractor;
@@ -218,7 +219,10 @@ return static function (ContainerConfigurator $container) {
                 inline_service()
                     ->factory([SerializerErrorRenderer::class, 'getPreferredFormat'])
                     ->args([service('request_stack')]),
-                service('error_renderer.html'),
+                inline_service(ErrorRendererInterface::class)
+                    ->factory([\Closure::class, 'fromCallable'])
+                    ->args([service('error_renderer.default'), 'render'])
+                    ->lazy(),
                 inline_service()
                     ->factory([HtmlErrorRenderer::class, 'isDebug'])
                     ->args([service('request_stack'), param('kernel.debug')]),

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ErrorHandlerWebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ErrorHandlerWebTestCase.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
+
+class ErrorHandlerWebTestCase extends AbstractWebTestCase
+{
+    public function testHtmlErrorResponseOnCliContext()
+    {
+        $client = self::createClient(['test_case' => 'ErrorHandler', 'root_config' => 'config.yml', 'debug' => false]);
+        $client->request('GET', '/_error/500.html');
+
+        self::assertResponseStatusCodeSame(500, $client->getResponse()->getStatusCode());
+        self::assertStringContainsString('<!DOCTYPE html>', $client->getResponse()->getContent());
+        self::assertStringContainsString('Oops! An Error Occurred', $client->getResponse()->getContent());
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ApiAttributesTest/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ApiAttributesTest/config.yml
@@ -1,6 +1,9 @@
 imports:
     - { resource: ../config/default.yml }
 
+parameters:
+    kernel.runtime_mode.web: true
+
 framework:
     serializer:
         enabled: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ErrorHandler/bundles.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ErrorHandler/bundles.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+
+return [
+    new FrameworkBundle(),
+];

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ErrorHandler/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ErrorHandler/config.yml
@@ -1,0 +1,5 @@
+imports:
+    - { resource: ../config/default.yml }
+
+parameters:
+    kernel.runtime_mode.web: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ErrorHandler/routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ErrorHandler/routing.yml
@@ -1,0 +1,3 @@
+_errors:
+    resource: "@FrameworkBundle/Resources/config/routing/errors.xml"
+    prefix:   /_error


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Alternative approach to https://github.com/symfony/symfony/pull/58456 (same goal), using a factory selector to pick the correct error renderer based on the runtime mode (`APP_RUNTIME_MODE`). One advantage of this solution is that it works even if `TwigBundle` is not installed as the selector/decider doesn't depend on it.

![image](https://github.com/user-attachments/assets/79e4212c-1a65-4515-ab02-a64dc1218890)