### PR TITLE
[Messenger] Use newer version of Beanstalkd bridge library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -144,7 +144,7 @@
         "monolog/monolog": "^3.0",
         "nikic/php-parser": "^4.18|^5.0",
         "nyholm/psr7": "^1.0",
-        "pda/pheanstalk": "^4.0",
+        "pda/pheanstalk": "^5.1|^7.0",
         "php-http/discovery": "^1.15",
         "php-http/httplug": "^1.0|^2.0",
         "phpdocumentor/reflection-docblock": "^5.2",

--- a/src/Symfony/Component/Messenger/Bridge/Beanstalkd/composer.json
+++ b/src/Symfony/Component/Messenger/Bridge/Beanstalkd/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=8.2",
-        "pda/pheanstalk": "^4.0",
+        "pda/pheanstalk": "^5.1|^7.0",
         "symfony/messenger": "^7.3"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Currently, the Beanstalkd bridge supports version 4 of `pda/pheanstalk`, which is no longer maintained. The latest version is v7, and the actively maintained versions appear to be v5 and v7. Version 7 was released just a week after v6, and from what I can tell, v6 is not supported as no patch versions have ever been released for it.

This PR bumps support to the maintained versions. I've split it into two commits to make reviewing easier:

1. The first commit upgrades the library version and updates the code for compatibility.  
2. The second commit adds a reconnect mechanism. Version 4 had a [built-in one](https://github.com/pheanstalk/pheanstalk/blob/1459f2f62dddfe28902e0584708417dddd79bd70/src/Pheanstalk.php#L366-L376), which was removed in v5+. This commit reimplements that logic in the `Connection` class.

I'm not sure which version of Symfony this should target. It's not exactly a new feature, but the changes are significant.