### PR TITLE
[Console] Table counts wrong number of padding symbols in `renderCell()` method when cell contain unicode variant selector

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -1278,7 +1278,7 @@ class Application implements ResetInterface
 
             foreach (preg_split('//u', $m[0]) as $char) {
                 // test if $char could be appended to current line
-                if (mb_strwidth($line.$char, 'utf8') <= $width) {
+                if (Helper::width($line.$char) <= $width) {
                     $line .= $char;
                     continue;
                 }

--- a/src/Symfony/Component/Console/Helper/Helper.php
+++ b/src/Symfony/Component/Console/Helper/Helper.php
@@ -48,7 +48,9 @@ abstract class Helper implements HelperInterface
         $string ??= '';
 
         if (preg_match('//u', $string)) {
-            return (new UnicodeString($string))->width(false);
+            $string = preg_replace('/[\p{Cc}\x7F]++/u', '', $string, -1, $count);
+
+            return (new UnicodeString($string))->width(false) + $count;
         }
 
         if (false === $encoding = mb_detect_encoding($string, null, true)) {

--- a/src/Symfony/Component/Console/Helper/Table.php
+++ b/src/Symfony/Component/Console/Helper/Table.php
@@ -564,10 +564,7 @@ class Table
         }
 
         // str_pad won't work properly with multi-byte strings, we need to fix the padding
-        if (false !== $encoding = mb_detect_encoding($cell, null, true)) {
-            $width += \strlen($cell) - mb_strwidth($cell, $encoding);
-        }
-
+        $width += \strlen($cell) - Helper::width($cell) - substr_count($cell, "\0");
         $style = $this->getColumnStyle($column);
 
         if ($cell instanceof TableSeparator) {

--- a/src/Symfony/Component/Console/Tests/Helper/TableTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableTest.php
@@ -1294,9 +1294,9 @@ TABLE
                 'footer',
                 'default',
                 <<<'TABLE'
-+---------------+---- Multiline
++---------------+--- Multiline
 header
-here -+------------------+
+here +------------------+
 | ISBN          | Title                    | Author           |
 +---------------+--------------------------+------------------+
 | 99921-58-10-7 | Divine Comedy            | Dante Alighieri  |
@@ -2075,6 +2075,38 @@ TABLE
 └───────┴───────┘
 
 TABLE,
+            $this->getOutputContent($output)
+        );
+    }
+
+    public function testGithubIssue60038WidthOfCellWithEmoji()
+    {
+        $table = (new Table($output = $this->getOutputStream()))
+            ->setHeaderTitle('Test Title')
+            ->setHeaders(['Title', 'Author'])
+            ->setRows([
+                ["🎭 💫 ☯"." Divine Comedy", "Dante Alighieri"],
+                // the snowflake (e2 9d 84 ef b8 8f) has a variant selector
+                ["👑 ❄️  🗡"." Game of Thrones", "George R.R. Martin"],
+                // the snowflake in text style (e2 9d 84 ef b8 8e) has a variant selector
+                ["❄︎❄︎❄︎ snowflake in text style ❄︎❄︎❄︎", ""],
+                ["And a very long line to show difference in previous lines", ""],
+            ])
+        ;
+        $table->render();
+
+        $this->assertSame(<<<TABLE
++---------------------------------- Test Title -------------+--------------------+
+| Title                                                     | Author             |
++-----------------------------------------------------------+--------------------+
+| 🎭 💫 ☯ Divine Comedy                                     | Dante Alighieri    |
+| 👑 ❄️  🗡 Game of Thrones                                   | George R.R. Martin |
+| ❄︎❄︎❄︎ snowflake in text style ❄︎❄︎❄︎                           |                    |
+| And a very long line to show difference in previous lines |                    |
++-----------------------------------------------------------+--------------------+
+
+TABLE
+            ,
             $this->getOutputContent($output)
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? |no
| Issues        | Fix #60038
| License       | MIT

When rendering a table in console and use emojis then width of columns could be wrong calculated.