### PR TITLE
[TypeInfo] require `phpstan/phpdoc-parser` to fully support sealed array shapes

### DIFF
--- a/src/Symfony/Component/TypeInfo/composer.json
+++ b/src/Symfony/Component/TypeInfo/composer.json
@@ -30,7 +30,10 @@
         "symfony/deprecation-contracts": "^2.5|^3"
     },
     "require-dev": {
-        "phpstan/phpdoc-parser": "^1.0|^2.0"
+        "phpstan/phpdoc-parser": "^1.30|^2.0"
+    },
+    "conflict": {
+        "phpstan/phpdoc-parser": "<1.30"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\TypeInfo\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT