### PR TITLE
[Mailer][TwigBridge] Revert "Add support for translatable objects"

### DIFF
--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -6,7 +6,6 @@ CHANGELOG
 
  * Add `is_granted_for_user()` Twig function
  * Add `field_id()` Twig form helper function
- * Add `TemplatedEmail::getTranslatableSubject()` method
 
 7.2
 ---

--- a/src/Symfony/Bridge/Twig/Mime/TemplatedEmail.php
+++ b/src/Symfony/Bridge/Twig/Mime/TemplatedEmail.php
@@ -100,7 +100,7 @@ class TemplatedEmail extends Email
      */
     public function __serialize(): array
     {
-        return [$this->htmlTemplate, $this->textTemplate, $this->context, parent::__serialize(),  $this->locale];
+        return [$this->htmlTemplate, $this->textTemplate, $this->context, parent::__serialize(), $this->locale];
     }
 
     /**

--- a/src/Symfony/Bridge/Twig/Mime/TemplatedEmail.php
+++ b/src/Symfony/Bridge/Twig/Mime/TemplatedEmail.php
@@ -18,28 +18,10 @@ use Symfony\Component\Mime\Email;
  */
 class TemplatedEmail extends Email
 {
-    private string|\Stringable|null $subject = null;
     private ?string $htmlTemplate = null;
     private ?string $textTemplate = null;
     private ?string $locale = null;
     private array $context = [];
-
-    /**
-     * @return $this
-     */
-    public function subject(string|\Stringable $subject): static
-    {
-        parent::subject($subject);
-
-        $this->subject = $subject;
-
-        return $this;
-    }
-
-    public function getTranslatableSubject(): string|\Stringable|null
-    {
-        return $this->subject;
-    }
 
     /**
      * @return $this
@@ -118,7 +100,7 @@ class TemplatedEmail extends Email
      */
     public function __serialize(): array
     {
-        return [$this->htmlTemplate, $this->textTemplate, $this->context, parent::__serialize(), $this->locale, $this->subject];
+        return [$this->htmlTemplate, $this->textTemplate, $this->context, parent::__serialize(),  $this->locale];
     }
 
     /**
@@ -128,7 +110,6 @@ class TemplatedEmail extends Email
     {
         [$this->htmlTemplate, $this->textTemplate, $this->context, $parentData] = $data;
         $this->locale = $data[4] ?? null;
-        $this->subject = $data[5] ?? null;
 
         parent::__unserialize($parentData);
     }

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/mailer.php
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/mailer.php
@@ -18,11 +18,7 @@ use Symfony\Component\Mime\BodyRendererInterface;
 return static function (ContainerConfigurator $container) {
     $container->services()
         ->set('twig.mailer.message_listener', MessageListener::class)
-            ->args([
-                null,
-                service('twig.mime_body_renderer'),
-                '$translator' => service('translator')->ignoreOnInvalid(),
-            ])
+            ->args([null, service('twig.mime_body_renderer')])
             ->tag('kernel.event_subscriber')
 
         ->set('twig.mime_body_renderer', BodyRenderer::class)

--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -9,7 +9,6 @@ CHANGELOG
  * Add DSN param `source_ip` to allow binding to a (specific) IPv4 or IPv6 address.
  * Add DSN param `require_tls` to enforce use of TLS/STARTTLS
  * Add `DkimSignedMessageListener`, `SmimeEncryptedMessageListener`, and `SmimeSignedMessageListener`
- * Add support for translatable subject in `TemplatedEmail`
 
 7.2
 ---

--- a/src/Symfony/Component/Mailer/EventListener/MessageListener.php
+++ b/src/Symfony/Component/Mailer/EventListener/MessageListener.php
@@ -122,7 +122,7 @@ class MessageListener implements EventSubscriberInterface
 
     private function translateSubject(Message $message): void
     {
-        if (!$message instanceof TemplatedEmail || !$this->translator || !method_exists(TemplatedEmail::class, 'getTranslatableSubject') || !$message->getTranslatableSubject() instanceof TranslatableMessage) {
+        if (!$message instanceof TemplatedEmail || !$this->translator || !$message->getTranslatableSubject() instanceof TranslatableMessage) {
             return;
         }
 

--- a/src/Symfony/Component/Mailer/EventListener/MessageListener.php
+++ b/src/Symfony/Component/Mailer/EventListener/MessageListener.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Mailer\EventListener;
 
-use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Mailer\Event\MessageEvent;
 use Symfony\Component\Mailer\Exception\InvalidArgumentException;
@@ -20,11 +19,9 @@ use Symfony\Component\Mime\BodyRendererInterface;
 use Symfony\Component\Mime\Header\Headers;
 use Symfony\Component\Mime\Header\MailboxListHeader;
 use Symfony\Component\Mime\Message;
-use Symfony\Component\Translation\TranslatableMessage;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
- * Manipulates the headers, subject, and the body of a Message.
+ * Manipulates the headers and the body of a Message.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
@@ -48,7 +45,6 @@ class MessageListener implements EventSubscriberInterface
         private ?Headers $headers = null,
         private ?BodyRendererInterface $renderer = null,
         array $headerRules = self::DEFAULT_RULES,
-        private ?TranslatorInterface $translator = null,
     ) {
         foreach ($headerRules as $headerName => $rule) {
             $this->addHeaderRule($headerName, $rule);
@@ -72,7 +68,6 @@ class MessageListener implements EventSubscriberInterface
         }
 
         $this->setHeaders($message);
-        $this->translateSubject($message);
         $this->renderMessage($message);
     }
 
@@ -118,15 +113,6 @@ class MessageListener implements EventSubscriberInterface
                     }
             }
         }
-    }
-
-    private function translateSubject(Message $message): void
-    {
-        if (!$message instanceof TemplatedEmail || !$this->translator || !$message->getTranslatableSubject() instanceof TranslatableMessage) {
-            return;
-        }
-
-        $message->subject($message->getTranslatableSubject()->trans($this->translator, $message->getLocale()));
     }
 
     private function renderMessage(Message $message): void

--- a/src/Symfony/Component/Mailer/Tests/EventListener/MessageListenerTest.php
+++ b/src/Symfony/Component/Mailer/Tests/EventListener/MessageListenerTest.php
@@ -120,10 +120,6 @@ class MessageListenerTest extends TestCase
 
     public function testTranslatableSubject()
     {
-        if (!method_exists(TemplatedEmail::class, 'getTranslatableSubject')) {
-            $this->markTestSkipped('symfony/twig-bridge 7.3 or higher required');
-        }
-
         $message = new TemplatedEmail();
         $message->subject(new TranslatableMessage('hello.world'));
         $listener = new MessageListener(translator: new class implements TranslatorInterface {

--- a/src/Symfony/Component/Mailer/Tests/EventListener/MessageListenerTest.php
+++ b/src/Symfony/Component/Mailer/Tests/EventListener/MessageListenerTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Mailer\Tests\EventListener;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Event\MessageEvent;
 use Symfony\Component\Mailer\EventListener\MessageListener;
@@ -21,8 +20,6 @@ use Symfony\Component\Mime\Header\Headers;
 use Symfony\Component\Mime\Header\MailboxListHeader;
 use Symfony\Component\Mime\Header\UnstructuredHeader;
 use Symfony\Component\Mime\Message;
-use Symfony\Component\Translation\TranslatableMessage;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 class MessageListenerTest extends TestCase
 {
@@ -116,26 +113,5 @@ class MessageListenerTest extends TestCase
             'Foo' => MessageListener::HEADER_REPLACE,
         ];
         yield 'Capitalized header rule (case-insensitive), replace if set' => [$initialHeaders, $defaultHeaders, $defaultHeaders, $rules];
-    }
-
-    public function testTranslatableSubject()
-    {
-        $message = new TemplatedEmail();
-        $message->subject(new TranslatableMessage('hello.world'));
-        $listener = new MessageListener(translator: new class implements TranslatorInterface {
-            public function trans(string $id, array $parameters = [], ?string $domain = null, ?string $locale = null): string
-            {
-                return 'Hello World';
-            }
-
-            public function getLocale(): string
-            {
-                return 'en';
-            }
-        });
-        $event = new MessageEvent($message, new Envelope(new Address('sender@example.com'), [new Address('recipient@example.com')]), 'smtp');
-        $listener->onMessage($event);
-
-        $this->assertSame('Hello World', $message->getSubject());
     }
 }

--- a/src/Symfony/Component/Mailer/composer.json
+++ b/src/Symfony/Component/Mailer/composer.json
@@ -21,7 +21,7 @@
         "psr/event-dispatcher": "^1",
         "psr/log": "^1|^2|^3",
         "symfony/event-dispatcher": "^6.4|^7.0",
-        "symfony/mime": "^7.2",
+        "symfony/mime": "^7.3",
         "symfony/service-contracts": "^2.5|^3"
     },
     "require-dev": {

--- a/src/Symfony/Component/Mailer/composer.json
+++ b/src/Symfony/Component/Mailer/composer.json
@@ -21,14 +21,13 @@
         "psr/event-dispatcher": "^1",
         "psr/log": "^1|^2|^3",
         "symfony/event-dispatcher": "^6.4|^7.0",
-        "symfony/mime": "^7.3",
+        "symfony/mime": "^7.2",
         "symfony/service-contracts": "^2.5|^3"
     },
     "require-dev": {
         "symfony/console": "^6.4|^7.0",
         "symfony/http-client": "^6.4|^7.0",
         "symfony/messenger": "^6.4|^7.0",
-        "symfony/translation": "^6.4|^7.0",
         "symfony/twig-bridge": "^6.4|^7.0"
     },
     "conflict": {

--- a/src/Symfony/Component/Mime/Email.php
+++ b/src/Symfony/Component/Mime/Email.php
@@ -58,9 +58,9 @@ class Email extends Message
     /**
      * @return $this
      */
-    public function subject(string|\Stringable $subject): static
+    public function subject(string $subject): static
     {
-        return $this->setHeaderBody('Text', 'Subject', (string) $subject);
+        return $this->setHeaderBody('Text', 'Subject', $subject);
     }
 
     public function getSubject(): ?string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Reverts #60047 & #59967
| License       | MIT

#59967 introduced a BC break so we need to revert and find another solution.
