### PR TITLE
[Form] Use duplicate_preferred_choices to set value of ChoiceType

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -85,7 +85,7 @@
                 {{- block('choice_widget_options') -}}
             </optgroup>
         {%- else -%}
-            <option value="{{ choice.value }}"{% if choice.attr %}{% with { attr: choice.attr } %}{{ block('attributes') }}{% endwith %}{% endif %}{% if not render_preferred_choices|default(false) and choice is selectedchoice(value) %} selected="selected"{% endif %}>{{ choice_translation_domain is same as(false) ? choice.label : choice.label|trans(choice.labelTranslationParameters, choice_translation_domain) }}</option>
+            <option value="{{ choice.value }}"{% if choice.attr %}{% with { attr: choice.attr } %}{{ block('attributes') }}{% endwith %}{% endif %}{% if (not render_preferred_choices|default(false) or not (duplicate_preferred_choices ?? true)) and choice is selectedchoice(value) %} selected="selected"{% endif %}>{{ choice_translation_domain is same as(false) ? choice.label : choice.label|trans(choice.labelTranslationParameters, choice_translation_domain) }}</option>
         {%- endif -%}
     {% endfor %}
 {%- endblock choice_widget_options -%}

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractDivLayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractDivLayoutTestCase.php
@@ -856,6 +856,56 @@ abstract class AbstractDivLayoutTestCase extends AbstractLayoutTestCase
         );
     }
 
+    public function testSingleChoiceWithoutDuplicatePreferredIsSelected()
+    {
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&d', [
+            'choices' => ['Choice&A' => '&a', 'Choice&B' => '&b', 'Choice&C' => '&c', 'Choice&D' => '&d'],
+            'preferred_choices' => ['&b', '&d'],
+            'duplicate_preferred_choices' => false,
+            'multiple' => false,
+            'expanded' => false,
+        ]);
+
+        $this->assertWidgetMatchesXpath($form->createView(), ['separator' => '-- sep --'],
+            '/select
+    [@name="name"]
+    [
+        ./option[@value="&d"][@selected="selected"]
+        /following-sibling::option[@disabled="disabled"][.="-- sep --"]
+        /following-sibling::option[@value="&a"][not(@selected)]
+        /following-sibling::option[@value="&c"][not(@selected)]
+    ]
+    [count(./option)=5]
+'
+        );
+    }
+
+    public function testSingleChoiceWithoutDuplicateNotPreferredIsSelected()
+    {
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&d', [
+            'choices' => ['Choice&A' => '&a', 'Choice&B' => '&b', 'Choice&C' => '&c', 'Choice&D' => '&d'],
+            'preferred_choices' => ['&b', '&d'],
+            'duplicate_preferred_choices' => true,
+            'multiple' => false,
+            'expanded' => false,
+        ]);
+
+        $this->assertWidgetMatchesXpath($form->createView(), ['separator' => '-- sep --'],
+            '/select
+    [@name="name"]
+    [
+        ./option[@value="&d"][not(@selected)]
+        /following-sibling::option[@disabled="disabled"][.="-- sep --"]
+        /following-sibling::option[@value="&a"][not(@selected)]
+        /following-sibling::option[@value="&b"][not(@selected)]
+        /following-sibling::option[@value="&c"][not(@selected)]
+        /following-sibling::option[@value="&d"][@selected="selected"]
+    ]
+    [count(./option)=7]
+'
+        );
+    }
+
     public function testFormEndWithRest()
     {
         $view = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType')

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -281,6 +281,8 @@ class ChoiceType extends AbstractType
      */
     public function finishView(FormView $view, FormInterface $form, array $options)
     {
+        $view->vars['duplicate_preferred_choices'] = $options['duplicate_preferred_choices'];
+
         if ($options['expanded']) {
             // Radio buttons should have the same name as the parent
             $childName = $view->vars['full_name'];


### PR DESCRIPTION
When the preferred choices are not duplicated an option has to be selected in the group of preferred choices.

Closes #58561

| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58561
| License       | MIT

When the preferred choices are not duplicated an option has to be selected in the group of preferred choices.