### PR TITLE
[MonologBridge] Make `ConsoleHandler` not handle messages at SILENT verbosity

### DIFF
--- a/src/Symfony/Bridge/Monolog/Handler/ConsoleHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/ConsoleHandler.php
@@ -167,6 +167,8 @@ final class ConsoleHandler extends AbstractProcessingHandler implements EventSub
         $verbosity = $this->output->getVerbosity();
         if (isset($this->verbosityLevelMap[$verbosity])) {
             $this->setLevel($this->verbosityLevelMap[$verbosity]);
+        } elseif (\defined('\Symfony\Component\Console\Output\OutputInterface::VERBOSITY_SILENT') && OutputInterface::VERBOSITY_SILENT === $verbosity) {
+            return false;
         } else {
             $this->setLevel(Level::Debug);
         }

--- a/src/Symfony/Bridge/Monolog/Tests/Handler/ConsoleHandlerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/ConsoleHandlerTest.php
@@ -101,6 +101,58 @@ class ConsoleHandlerTest extends TestCase
         ];
     }
 
+    /**
+     * @dataProvider provideHandleOrBubbleSilentTests
+     */
+    public function testHandleOrBubbleSilent(int $verbosity, Level $level, bool $isHandling, bool $isWriting, array $map = [])
+    {
+        $output = $this->createMock(OutputInterface::class);
+        $output
+            ->expects($this->atLeastOnce())
+            ->method('getVerbosity')
+            ->willReturn($verbosity)
+        ;
+        $handler = new ConsoleHandler($output, false, $map);
+        $this->assertSame($isHandling, $handler->isHandling(RecordFactory::create($level)), '->isHandling returns correct value depending on console verbosity and log level');
+
+        // check that the handler actually outputs the record if it handles it at verbosity above SILENT
+        $levelName = Logger::getLevelName($level);
+        $levelName = \sprintf('%-9s', $levelName);
+
+        $realOutput = $this->getMockBuilder(Output::class)->onlyMethods(['doWrite'])->getMock();
+        $realOutput->setVerbosity($verbosity);
+        $log = "16:21:54 $levelName [app] My info message\n";
+        $realOutput
+            ->expects($isWriting ? $this->once() : $this->never())
+            ->method('doWrite')
+            ->with($log, false);
+        $handler = new ConsoleHandler($realOutput, false, $map);
+
+        $infoRecord = RecordFactory::create($level, 'My info message', 'app', datetime: new \DateTimeImmutable('2013-05-29 16:21:54'));
+        $this->assertSame($isHandling, $handler->handle($infoRecord), 'The handler bubbled correctly when it did not output the message.');
+    }
+
+    public static function provideHandleOrBubbleSilentTests(): array
+    {
+        // The VERBOSITY_SILENT const is not defined for Console below 7.2, but in that case, the code behaves as before
+        if (!\defined('\Symfony\Component\Console\Output\OutputInterface::VERBOSITY_SILENT')) {
+            return [
+                [OutputInterface::VERBOSITY_NORMAL, Level::Warning, true, true],
+                [OutputInterface::VERBOSITY_NORMAL, Level::Info, false, false],
+            ];
+        }
+
+        return [
+            [OutputInterface::VERBOSITY_SILENT, Level::Warning, false, false],
+            [OutputInterface::VERBOSITY_NORMAL, Level::Warning, true, true],
+            [OutputInterface::VERBOSITY_NORMAL, Level::Info, false, false],
+            [OutputInterface::VERBOSITY_SILENT, Level::Warning, true, false, [OutputInterface::VERBOSITY_SILENT => Level::Warning]],
+            [OutputInterface::VERBOSITY_SILENT, Level::Warning, false, false, [OutputInterface::VERBOSITY_SILENT => Level::Error]],
+            [OutputInterface::VERBOSITY_SILENT, Level::Emergency, false, false],
+            [OutputInterface::VERBOSITY_SILENT, Level::Emergency, true, false, [OutputInterface::VERBOSITY_SILENT => Level::Emergency]],
+        ];
+    }
+
     public function testVerbosityChanged()
     {
         $output = $this->createMock(OutputInterface::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes 
| New feature?  | no
| Deprecations? | no
| Issues        | #53632
| License       | MIT

<details><summary>Original description</summary>
<p>
Adding a new constructor parameter to ConsoleHandler to let it bubble messages when the output is set at Silent verbosity level (like when using `--silent` in the CLI).

Messages are dropped by the ConsoleHandler down the line because of the verbosity, but they are considered as handled and so bubbling is interrupted if the handler is set with `$bubble = false`. The use-case is to have the messages being either printed by the ConsoleHandler (and so seen by the person running the CLI) or sent to the logging system by the next handlers, but not both.
Tweaking the `$verbosityLevelMap` is not perfect because EMERGENCY level can never be marked as not handled.

With this change, the behaviour is more consistent between Silent and Quiet verbosity levels.
</p>
</details> 

Messages are dropped by the ConsoleHandler down the line because of the verbosity, but they are considered as handled and so bubbling is interrupted if the handler is set with `$bubble = false`. The use-case is to have the messages being either printed by the ConsoleHandler (and so seen by the person running the CLI) or sent to the logging system by the next handlers, but not both.

By not handling messages when the ConsoleHandler verbosity is set to silent, the behaviour is more consistent between, Silent and all the other verbosity levels.