### PR TITLE
[Validator] Don't skip `WhenTest` case after fix merge in `php-src`

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Constraints/WhenTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/WhenTest.php
@@ -118,8 +118,6 @@ final class WhenTest extends TestCase
      */
     public function testAttributesWithClosure()
     {
-        $this->markTestSkipped('Requires https://github.com/php/php-src/issues/17851 to be fixed');
-
         $loader = new AttributeLoader();
         $metadata = new ClassMetadata(WhenTestWithClosure::class);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Revert skip being introduced in https://github.com/symfony/symfony/pull/59895 after the fix of https://github.com/php/php-src/issues/17851.