### PR TITLE
[Mailer][Mime] add support for external template engine to mail

### DIFF
--- a/src/Symfony/Component/Mime/CHANGELOG.md
+++ b/src/Symfony/Component/Mime/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.3
+---
+  * Add `ExternalTemplatedEmail`
+
+
 7.0
 ---
 

--- a/src/Symfony/Component/Mime/ExternalTemplatedEmail.php
+++ b/src/Symfony/Component/Mime/ExternalTemplatedEmail.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mime;
+
+use Symfony\Component\Mime\Exception\LogicException;
+
+class ExternalTemplatedEmail extends Email
+{
+    private ?string $templateId = null;
+    private array $context = [];
+    private ?string $locale = null;
+
+    public function ensureValidity(): void
+    {
+        if (null === $this->getTemplateId()) {
+            throw new LogicException('The template ID is required.');
+        }
+
+        if ('1' === $this->getHeaders()->getHeaderBody('X-Unsent')) {
+            throw new LogicException('Cannot send messages marked as "draft".');
+        }
+
+        Message::ensureValidity();
+    }
+
+    public function templateId(?string $templateId): static
+    {
+        $this->templateId = $templateId;
+
+        return $this;
+    }
+
+    public function getTemplateId(): ?string
+    {
+        return $this->templateId;
+    }
+
+    /**
+     * @return $this
+     */
+    public function locale(?string $locale): static
+    {
+        $this->locale = $locale;
+
+        return $this;
+    }
+
+    public function getLocale(): ?string
+    {
+        return $this->locale;
+    }
+
+    /**
+     * @return $this
+     */
+    public function context(array $context): static
+    {
+        $this->context = $context;
+
+        return $this;
+    }
+
+    public function getContext(): array
+    {
+        return $this->context;
+    }
+
+    /**
+     * @internal
+     */
+    public function __serialize(): array
+    {
+        return [$this->context, parent::__serialize(), $this->locale];
+    }
+
+    /**
+     * @internal
+     */
+    public function __unserialize(array $data): void
+    {
+        [$this->context, $parentData] = $data;
+        $this->locale = $data[2] ?? null;
+
+        parent::__unserialize($parentData);
+    }
+}

--- a/src/Symfony/Component/Mime/Tests/ExternalTemplatedEmailTest.php
+++ b/src/Symfony/Component/Mime/Tests/ExternalTemplatedEmailTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mime\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mime\ExternalTemplatedEmail;
+
+class ExternalTemplatedEmailTest extends TestCase
+{
+    public function testTemplateId()
+    {
+        $e = new ExternalTemplatedEmail();
+        $e->templateId('template_id');
+        $this->assertSame('template_id', $e->getTemplateId());
+    }
+
+    public function testContext()
+    {
+        $e = new ExternalTemplatedEmail();
+        $e->context(['foo' => 'bar']);
+        $this->assertSame(['foo' => 'bar'], $e->getContext());
+    }
+
+    public function testLocale()
+    {
+        $e = new ExternalTemplatedEmail();
+        $e->locale('fr');
+        $this->assertSame('fr', $e->getLocale());
+    }
+
+    public function testInvalidTemplateIdExternalTemplatedEmail()
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('The template ID is required.');
+
+        (new ExternalTemplatedEmail())->ensureValidity();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? |no
| Issues        | 
| License       | MIT

There are several mailer services (mailjet, brevo, mailgun,etc..) that allow to design templates directly using their platform.
Currently the mailer component cannot manage this, it's mandatory to manage the rendering before the "send" function

This implementation allow to support that kind of flow.

If this is accepted, I will manage to update existing mailing transport to also support ExternalTemplatedEmail.

here is an exemple of usage 
```php
$email = (new ExternalTemplatedEmail())
    ->from('from@example.com')
    ->to('to@dpaas.fr')
    ->templateId('my_template_id')
    ->context([
        'first_name' => 'My FirstName',
    ]);

$this->mailer->send($email);
```


