### PR TITLE
[ObjectMapper] mapping on target (reverse-side mapping)

### DIFF
--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -298,7 +298,7 @@ final class ObjectMapper implements ObjectMapperInterface
         }
 
         foreach ($refl->getProperties() as $property) {
-            if ($this->metadataFactory->create($source, $property)) {
+            if ($this->metadataFactory->create($source, $property->getName())) {
                 return $refl;
             }
         }

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MapTargetToSource/A.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MapTargetToSource/A.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MapTargetToSource;
+
+class A
+{
+    public function __construct(public string $source)
+    {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MapTargetToSource/B.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MapTargetToSource/B.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MapTargetToSource;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(source: A::class)]
+class B
+{
+    public function __construct(#[Map(source: 'source')] public string $target)
+    {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -38,6 +38,8 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\AToBMapper;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\MapStructMapperMetadataFactory;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\Source;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\Target;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MapTargetToSource\A as MapTargetToSourceA;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MapTargetToSource\B as MapTargetToSourceB;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargets\A as MultipleTargetsA;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargets\C as MultipleTargetsC;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\Recursion\AB;
@@ -261,5 +263,14 @@ final class ObjectMapperTest extends TestCase
         $metadata->method('create')->with($u)->willReturn([new Mapping(target: ClassWithoutTarget::class, transform: fn () => new \stdClass())]);
         $mapper = new ObjectMapper($metadata);
         $mapper->map($u);
+    }
+
+    public function testMapTargetToSource()
+    {
+        $a = new MapTargetToSourceA('str');
+        $mapper = new ObjectMapper();
+        $b = $mapper->map($a, MapTargetToSourceB::class);
+        $this->assertInstanceOf(MapTargetToSourceB::class, $b);
+        $this->assertSame('str', $b->target);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60058
| License       | MIT

This allows to configure mapping on the target instead of the source:

```php
<?php

#[Map(target: self::class, source: A::class)]
class B
{
    public function __construct(#[Map(source: 'source')] public string $target)
    {
    }
}
```
