### PR TITLE
Release v7.2.5

### DIFF
--- a/CHANGELOG-7.2.md
+++ b/CHANGELOG-7.2.md
@@ -7,6 +7,29 @@ in 7.2 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v7.2.0...v7.2.1
 
+* 7.2.5 (2025-03-28)
+
+ * bug #60054 [Form] Use duplicate_preferred_choices to set value of ChoiceType (aleho)
+ * bug #60026 [Serializer] Fix ObjectNormalizer default context with named serializers (HypeMC)
+ * bug #60030 [Cache][DoctrineBridge][HttpFoundation][Lock][Messenger] use `Table::addPrimaryKeyConstraint()` with Doctrine DBAL 4.3+ (xabbuh)
+ * bug #59844 [TypeInfo] Fix `isSatisfiedBy` not traversing type tree (mtarld)
+ * bug #59858 Update `JsDelivrEsmResolver::IMPORT_REGEX` to support dynamic imports (natepage)
+ * bug #60019 [HttpKernel] Fix `TraceableEventDispatcher` when the `Stopwatch` service has been reset (lyrixx)
+ * bug #59975 [HttpKernel] Only remove `E_WARNING` from error level during kernel init (fritzmg)
+ * bug #59988 [FrameworkBundle] Remove redundant `name` attribute from `default_context` (HypeMC)
+ * bug #59963 [TypeInfo] Fix ``@var`` tag reading for promoted properties (mtarld)
+ * bug #59949 [Process] Use a pipe for stderr in pty mode to avoid mixed output between stdout and stderr (joelwurtz)
+ * bug #59940 [Cache] Fix missing cache data in profiler (dcmbrs)
+ * bug #59965 [VarExporter] Fix support for hooks and asymmetric visibility (nicolas-grekas)
+ * bug #59924 Extract no type ``@param`` annotation with `PhpStanExtractor` (thomasdubuffet)
+ * bug #59908 [Messenger] Reduce keepalive request noise (ro0NL)
+ * bug #59874 [Console] fix progress bar messing output in section when there is an EOL (joelwurtz)
+ * bug #59888 [PhpUnitBridge] don't trigger "internal" deprecations for PHPUnit Stub objects (xabbuh)
+ * bug #59830 [Yaml] drop comments while lexing unquoted strings (xabbuh)
+ * bug #59884 [VarExporter] Fix support for asymmetric visibility (nicolas-grekas)
+ * bug #59881 [VarExporter] Fix support for abstract properties (nicolas-grekas)
+ * bug #59841 [Cache] fix cache data collector on late collect (dcmbrs)
+
 * 7.2.4 (2025-02-26)
 
  * bug #59198 [Messenger] Filter out non-consumable receivers when registering `ConsumeMessagesCommand` (wazum)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -73,12 +73,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     private static array $freshCache = [];
 
-    public const VERSION = '7.2.5-DEV';
+    public const VERSION = '7.2.5';
     public const VERSION_ID = 70205;
     public const MAJOR_VERSION = 7;
     public const MINOR_VERSION = 2;
     public const RELEASE_VERSION = 5;
-    public const EXTRA_VERSION = 'DEV';
+    public const EXTRA_VERSION = '';
 
     public const END_OF_MAINTENANCE = '07/2025';
     public const END_OF_LIFE = '07/2025';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v7.2.4...v7.2.5)

 * bug #60054 [Form] Use duplicate_preferred_choices to set value of ChoiceType (@aleho)
 * bug #60026 [Serializer] Fix ObjectNormalizer default context with named serializers (@HypeMC)
 * bug #60030 [Cache][DoctrineBridge][HttpFoundation][Lock][Messenger] use `Table::addPrimaryKeyConstraint()` with Doctrine DBAL 4.3+ (@xabbuh)
 * bug #59844 [TypeInfo] Fix `isSatisfiedBy` not traversing type tree (@mtarld)
 * bug #59858 Update `JsDelivrEsmResolver::IMPORT_REGEX` to support dynamic imports (@natepage)
 * bug #60019 [HttpKernel] Fix `TraceableEventDispatcher` when the `Stopwatch` service has been reset (@lyrixx)
 * bug #59975 [HttpKernel] Only remove `E_WARNING` from error level during kernel init (@fritzmg)
 * bug #59988 [FrameworkBundle] Remove redundant `name` attribute from `default_context` (@HypeMC)
 * bug #59963 [TypeInfo] Fix ``@var`` tag reading for promoted properties (@mtarld)
 * bug #59949 [Process] Use a pipe for stderr in pty mode to avoid mixed output between stdout and stderr (@joelwurtz)
 * bug #59940 [Cache] Fix missing cache data in profiler (@dcmbrs)
 * bug #59965 [VarExporter] Fix support for hooks and asymmetric visibility (@nicolas-grekas)
 * bug #59924 Extract no type ``@param`` annotation with `PhpStanExtractor` (@thomasdubuffet)
 * bug #59908 [Messenger] Reduce keepalive request noise (@ro0NL)
 * bug #59874 [Console] fix progress bar messing output in section when there is an EOL (@joelwurtz)
 * bug #59888 [PhpUnitBridge] don't trigger "internal" deprecations for PHPUnit Stub objects (@xabbuh)
 * bug #59830 [Yaml] drop comments while lexing unquoted strings (@xabbuh)
 * bug #59884 [VarExporter] Fix support for asymmetric visibility (@nicolas-grekas)
 * bug #59881 [VarExporter] Fix support for abstract properties (@nicolas-grekas)
 * bug #59841 [Cache] fix cache data collector on late collect (@dcmbrs)
