### PR TITLE
[Console] Deprecate returning a non-int value from a `\Closure` function set via `Command::setCode()`

### DIFF
--- a/UPGRADE-7.3.md
+++ b/UPGRADE-7.3.md
@@ -16,7 +16,7 @@ AssetMapper
 Console
 -------
 
- * Omitting parameter types in callables configured via `Command::setCode()` method is deprecated
+ * Omitting parameter types or returning a non-integer value from a `\Closure` set via `Command::setCode()` method is deprecated
 
    Before:
 
@@ -32,8 +32,10 @@ Console
    use Symfony\Component\Console\Input\InputInterface;
    use Symfony\Component\Console\Output\OutputInterface;
 
-   $command->setCode(function (InputInterface $input, OutputInterface $output) {
+   $command->setCode(function (InputInterface $input, OutputInterface $output): int {
        // ...
+
+       return 0;
    });
    ```
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
@@ -135,7 +135,11 @@ class ApplicationTest extends TestCase
         $kernel
             ->method('getBundles')
             ->willReturn([$this->createBundleMock(
-                [(new Command('fine'))->setCode(function (InputInterface $input, OutputInterface $output) { $output->write('fine'); })]
+                [(new Command('fine'))->setCode(function (InputInterface $input, OutputInterface $output): int {
+                    $output->write('fine');
+
+                    return 0;
+                })]
             )]);
         $kernel
             ->method('getContainer')
@@ -163,7 +167,11 @@ class ApplicationTest extends TestCase
         $kernel
             ->method('getBundles')
             ->willReturn([$this->createBundleMock(
-                [(new Command(null))->setCode(function (InputInterface $input, OutputInterface $output) { $output->write('fine'); })]
+                [(new Command(null))->setCode(function (InputInterface $input, OutputInterface $output): int {
+                    $output->write('fine');
+
+                    return 0;
+                })]
             )]);
         $kernel
             ->method('getContainer')
@@ -193,7 +201,11 @@ class ApplicationTest extends TestCase
         $kernel
             ->method('getBundles')
             ->willReturn([$this->createBundleMock(
-                [(new Command('fine'))->setCode(function (InputInterface $input, OutputInterface $output) { $output->write('fine'); })]
+                [(new Command('fine'))->setCode(function (InputInterface $input, OutputInterface $output): int {
+                    $output->write('fine');
+
+                    return 0;
+                })]
             )]);
         $kernel
             ->method('getContainer')

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
  * Deprecate methods `Command::getDefaultName()` and `Command::getDefaultDescription()` in favor of the `#[AsCommand]` attribute
  * Add support for Markdown format in `Table`
  * Add support for `LockableTrait` in invokable commands
+ * Deprecate returning a non-integer value from a `\Closure` function set via `Command::setCode()`
 
 7.2
 ---

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -347,7 +347,7 @@ class Command
      */
     public function setCode(callable $code): static
     {
-        $this->code = new InvokableCommand($this, $code, triggerDeprecations: true);
+        $this->code = new InvokableCommand($this, $code);
 
         return $this;
     }

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -196,8 +196,10 @@ class ApplicationTest extends TestCase
 
     public function testRegisterAmbiguous()
     {
-        $code = function (InputInterface $input, OutputInterface $output) {
+        $code = function (InputInterface $input, OutputInterface $output): int {
             $output->writeln('It works!');
+
+            return 0;
         };
 
         $application = new Application();
@@ -1275,7 +1277,9 @@ class ApplicationTest extends TestCase
             ->register('foo')
             ->setAliases(['f'])
             ->setDefinition([new InputOption('survey', 'e', InputOption::VALUE_REQUIRED, 'My option with a shortcut.')])
-            ->setCode(function (InputInterface $input, OutputInterface $output) {})
+            ->setCode(function (InputInterface $input, OutputInterface $output): int {
+                return 0;
+            })
         ;
 
         $input = new ArrayInput(['command' => 'foo']);
@@ -1298,7 +1302,9 @@ class ApplicationTest extends TestCase
         $application
             ->register('foo')
             ->setDefinition([$def])
-            ->setCode(function (InputInterface $input, OutputInterface $output) {})
+            ->setCode(function (InputInterface $input, OutputInterface $output): int {
+                return 0;
+            })
         ;
 
         $input = new ArrayInput(['command' => 'foo']);
@@ -1435,8 +1441,10 @@ class ApplicationTest extends TestCase
         $application->setAutoExit(false);
         $application->setDispatcher($this->getDispatcher());
 
-        $application->register('foo')->setCode(function (InputInterface $input, OutputInterface $output) {
+        $application->register('foo')->setCode(function (InputInterface $input, OutputInterface $output): int {
             $output->write('foo.');
+
+            return 0;
         });
 
         $tester = new ApplicationTester($application);
@@ -1491,8 +1499,10 @@ class ApplicationTest extends TestCase
         $application->setDispatcher($dispatcher);
         $application->setAutoExit(false);
 
-        $application->register('foo')->setCode(function (InputInterface $input, OutputInterface $output) {
+        $application->register('foo')->setCode(function (InputInterface $input, OutputInterface $output): int {
             $output->write('foo.');
+
+            return 0;
         });
 
         $tester = new ApplicationTester($application);
@@ -1559,8 +1569,10 @@ class ApplicationTest extends TestCase
         $application->setDispatcher($dispatcher);
         $application->setAutoExit(false);
 
-        $application->register('foo')->setCode(function (InputInterface $input, OutputInterface $output) {
+        $application->register('foo')->setCode(function (InputInterface $input, OutputInterface $output): int {
             $output->write('foo.');
+
+            return 0;
         });
 
         $tester = new ApplicationTester($application);
@@ -1671,8 +1683,10 @@ class ApplicationTest extends TestCase
         $application->setDispatcher($this->getDispatcher(true));
         $application->setAutoExit(false);
 
-        $application->register('foo')->setCode(function (InputInterface $input, OutputInterface $output) {
+        $application->register('foo')->setCode(function (InputInterface $input, OutputInterface $output): int {
             $output->write('foo.');
+
+            return 0;
         });
 
         $tester = new ApplicationTester($application);
@@ -1698,8 +1712,10 @@ class ApplicationTest extends TestCase
         $application->setDispatcher($dispatcher);
         $application->setAutoExit(false);
 
-        $application->register('foo')->setCode(function (InputInterface $input, OutputInterface $output) {
+        $application->register('foo')->setCode(function (InputInterface $input, OutputInterface $output): int {
             $output->write('foo.');
+
+            return 0;
         });
 
         $tester = new ApplicationTester($application);
@@ -1728,8 +1744,10 @@ class ApplicationTest extends TestCase
         $application->setDispatcher($dispatcher);
         $application->setAutoExit(false);
 
-        $application->register('foo')->setCode(function (InputInterface $input, OutputInterface $output) {
+        $application->register('foo')->setCode(function (InputInterface $input, OutputInterface $output): int {
             $output->write('foo.');
+
+            return 0;
         });
 
         $tester = new ApplicationTester($application);
@@ -1858,12 +1876,12 @@ class ApplicationTest extends TestCase
             'foo:bar' => function () use (&$loaded) {
                 $loaded['foo:bar'] = true;
 
-                return (new Command('foo:bar'))->setCode(function () {});
+                return (new Command('foo:bar'))->setCode(function (): int { return 0; });
             },
             'foo' => function () use (&$loaded) {
                 $loaded['foo'] = true;
 
-                return (new Command('foo'))->setCode(function () {});
+                return (new Command('foo'))->setCode(function (): int { return 0; });
             },
         ]));
 
@@ -1934,8 +1952,10 @@ class ApplicationTest extends TestCase
         $application->setAutoExit(false);
         $application->setCatchExceptions(false);
 
-        $application->register('foo')->setCode(function (InputInterface $input, OutputInterface $output) {
+        $application->register('foo')->setCode(function (InputInterface $input, OutputInterface $output): int {
             $output->write('foo.');
+
+            return 0;
         });
 
         $tester = new ApplicationTester($application);

--- a/src/Symfony/Component/Console/Tests/Command/InvokableCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/InvokableCommandTest.php
@@ -34,7 +34,9 @@ class InvokableCommandTest extends TestCase
             #[Argument] string $lastName = '',
             #[Argument(description: 'Short argument description')] string $bio = '',
             #[Argument(suggestedValues: [self::class, 'getSuggestedRoles'])] array $roles = ['ROLE_USER'],
-        ) {});
+        ): int {
+            return 0;
+        });
 
         $nameInputArgument = $command->getDefinition()->getArgument('first-name');
         self::assertSame('first-name', $nameInputArgument->getName());
@@ -75,7 +77,9 @@ class InvokableCommandTest extends TestCase
             #[Option(shortcut: 'v')] bool $verbose = false,
             #[Option(description: 'User groups')] array $groups = [],
             #[Option(suggestedValues: [self::class, 'getSuggestedRoles'])] array $roles = ['ROLE_USER'],
-        ) {});
+        ): int {
+            return 0;
+        });
 
         $timeoutInputOption = $command->getDefinition()->getOption('idle');
         self::assertSame('idle', $timeoutInputOption->getName());
@@ -138,6 +142,19 @@ class InvokableCommandTest extends TestCase
         $command->getDefinition();
     }
 
+    public function testInvalidReturnType()
+    {
+        $command = new Command('foo');
+        $command->setCode(new class {
+            public function __invoke() {}
+        });
+
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('The command "foo" must return an integer value in the "__invoke" method, but "null" was returned.');
+
+        $command->run(new ArrayInput([]), new NullOutput());
+    }
+
     /**
      * @dataProvider provideInputArguments
      */
@@ -149,11 +166,13 @@ class InvokableCommandTest extends TestCase
             #[Argument] ?string $b,
             #[Argument] string $c = '',
             #[Argument] array $d = [],
-        ) use ($expected) {
+        ) use ($expected): int {
             $this->assertSame($expected[0], $a);
             $this->assertSame($expected[1], $b);
             $this->assertSame($expected[2], $c);
             $this->assertSame($expected[3], $d);
+
+            return 0;
         });
 
         $command->run(new ArrayInput($parameters), new NullOutput());
@@ -176,10 +195,12 @@ class InvokableCommandTest extends TestCase
             #[Option] bool $a = true,
             #[Option] bool $b = false,
             #[Option] ?bool $c = null,
-        ) use ($expected) {
+        ) use ($expected): int {
             $this->assertSame($expected[0], $a);
             $this->assertSame($expected[1], $b);
             $this->assertSame($expected[2], $c);
+
+            return 0;
         });
 
         $command->run(new ArrayInput($parameters), new NullOutput());
@@ -202,10 +223,12 @@ class InvokableCommandTest extends TestCase
             #[Option] ?string $a = null,
             #[Option] ?string $b = 'b',
             #[Option] ?array $c = [],
-        ) use ($expected) {
+        ) use ($expected): int {
             $this->assertSame($expected[0], $a);
             $this->assertSame($expected[1], $b);
             $this->assertSame($expected[2], $c);
+
+            return 0;
         });
 
         $command->run(new ArrayInput($parameters), new NullOutput());

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_0.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_0.php
@@ -5,7 +5,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 //Ensure has single blank line at start when using block element
-return function (InputInterface $input, OutputInterface $output) {
+return function (InputInterface $input, OutputInterface $output): int {
     $output = new SymfonyStyle($input, $output);
     $output->caution('Lorem ipsum dolor sit amet');
+
+    return 0;
 };

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_1.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_1.php
@@ -5,9 +5,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 //Ensure has single blank line between titles and blocks
-return function (InputInterface $input, OutputInterface $output) {
+return function (InputInterface $input, OutputInterface $output): int {
     $output = new SymfonyStyle($input, $output);
     $output->title('Title');
     $output->warning('Lorem ipsum dolor sit amet');
     $output->title('Title');
+
+    return 0;
 };

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_10.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_10.php
@@ -5,7 +5,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 //Ensure that all lines are aligned to the begin of the first line in a very long line block
-return function (InputInterface $input, OutputInterface $output) {
+return function (InputInterface $input, OutputInterface $output): int {
     $output = new SymfonyStyle($input, $output);
     $output->block(
         'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum',
@@ -14,4 +14,6 @@ return function (InputInterface $input, OutputInterface $output) {
         'X ',
         true
     );
+
+    return 0;
 };

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_11.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_11.php
@@ -5,8 +5,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 // ensure long words are properly wrapped in blocks
-return function (InputInterface $input, OutputInterface $output) {
+return function (InputInterface $input, OutputInterface $output): int {
     $word = 'Lopadotemachoselachogaleokranioleipsanodrimhypotrimmatosilphioparaomelitokatakechymenokichlepikossyphophattoperisteralektryonoptekephalliokigklopeleiolagoiosiraiobaphetraganopterygon';
     $sfStyle = new SymfonyStyle($input, $output);
     $sfStyle->block($word, 'CUSTOM', 'fg=white;bg=blue', ' § ', false);
+
+    return 0;
 };

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_12.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_12.php
@@ -5,9 +5,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 // ensure that all lines are aligned to the begin of the first one and start with '//' in a very long line comment
-return function (InputInterface $input, OutputInterface $output) {
+return function (InputInterface $input, OutputInterface $output): int {
     $output = new SymfonyStyle($input, $output);
     $output->comment(
         'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum'
     );
+
+    return 0;
 };

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_13.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_13.php
@@ -5,10 +5,12 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 // ensure that nested tags have no effect on the color of the '//' prefix
-return function (InputInterface $input, OutputInterface $output) {
+return function (InputInterface $input, OutputInterface $output): int {
     $output->setDecorated(true);
     $output = new SymfonyStyle($input, $output);
     $output->comment(
         'Árvíztűrőtükörfúrógép 🎼 Lorem ipsum dolor sit <comment>💕 amet, consectetur adipisicing elit, sed do eiusmod tempor incididu labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</comment> Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum'
     );
+
+    return 0;
 };

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_14.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_14.php
@@ -5,7 +5,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 // ensure that block() behaves properly with a prefix and without type
-return function (InputInterface $input, OutputInterface $output) {
+return function (InputInterface $input, OutputInterface $output): int {
     $output = new SymfonyStyle($input, $output);
     $output->block(
         'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum',
@@ -14,4 +14,6 @@ return function (InputInterface $input, OutputInterface $output) {
         '$ ',
         true
     );
+
+    return 0;
 };

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_15.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_15.php
@@ -5,10 +5,12 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 // ensure that block() behaves properly with a type and without prefix
-return function (InputInterface $input, OutputInterface $output) {
+return function (InputInterface $input, OutputInterface $output): int {
     $output = new SymfonyStyle($input, $output);
     $output->block(
         'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum',
         'TEST'
     );
+
+    return 0;
 };

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_16.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_16.php
@@ -5,11 +5,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 // ensure that block() output is properly formatted (even padding lines)
-return function (InputInterface $input, OutputInterface $output) {
+return function (InputInterface $input, OutputInterface $output): int {
     $output->setDecorated(true);
     $output = new SymfonyStyle($input, $output);
     $output->success(
         'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum',
         'TEST'
     );
+
+    return 0;
 };

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_17.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_17.php
@@ -5,9 +5,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 //Ensure symfony style helper methods handle trailing backslashes properly when decorating user texts
-return function (InputInterface $input, OutputInterface $output) {
+return function (InputInterface $input, OutputInterface $output): int {
     $output = new SymfonyStyle($input, $output);
 
     $output->title('Title ending with \\');
     $output->section('Section ending with \\');
+
+    return 0;
 };

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_18.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_18.php
@@ -5,7 +5,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-return function (InputInterface $input, OutputInterface $output) {
+return function (InputInterface $input, OutputInterface $output): int {
     $output = new SymfonyStyle($input, $output);
 
     $output->definitionList(
@@ -15,4 +15,6 @@ return function (InputInterface $input, OutputInterface $output) {
         new TableSeparator(),
         ['foo2' => 'bar2']
     );
+
+    return 0;
 };

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_19.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_19.php
@@ -5,7 +5,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 //Ensure formatting tables when using multiple headers with TableCell
-return function (InputInterface $input, OutputInterface $output) {
+return function (InputInterface $input, OutputInterface $output): int {
     $output = new SymfonyStyle($input, $output);
     $output->horizontalTable(['a', 'b', 'c', 'd'], [[1, 2, 3], [4, 5], [7, 8, 9]]);
+
+    return 0;
 };

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_2.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_2.php
@@ -5,7 +5,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 //Ensure has single blank line between blocks
-return function (InputInterface $input, OutputInterface $output) {
+return function (InputInterface $input, OutputInterface $output): int {
     $output = new SymfonyStyle($input, $output);
     $output->warning('Warning');
     $output->caution('Caution');
@@ -14,4 +14,6 @@ return function (InputInterface $input, OutputInterface $output) {
     $output->note('Note');
     $output->info('Info');
     $output->block('Custom block', 'CUSTOM', 'fg=white;bg=green', 'X ', true);
+
+    return 0;
 };

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_20.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_20.php
@@ -5,9 +5,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 // Ensure that closing tag is applied once
-return function (InputInterface $input, OutputInterface $output) {
+return function (InputInterface $input, OutputInterface $output): int {
     $output->setDecorated(true);
     $output = new SymfonyStyle($input, $output);
     $output->write('<question>do you want <comment>something</>');
     $output->writeln('?</>');
+
+    return 0;
 };

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_21.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_21.php
@@ -5,9 +5,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 //Ensure texts with emojis don't make longer lines than expected
-return function (InputInterface $input, OutputInterface $output) {
+return function (InputInterface $input, OutputInterface $output): int {
     $output = new SymfonyStyle($input, $output);
     $output->success('Lorem ipsum dolor sit amet');
     $output->success('Lorem ipsum dolor sit amet with one emoji 🎉');
     $output->success('Lorem ipsum dolor sit amet with so many of them 👩‍🌾👩‍🌾👩‍🌾👩‍🌾👩‍🌾');
+
+    return 0;
 };

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_22.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_22.php
@@ -5,7 +5,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 // ensure that nested tags have no effect on the color of the '//' prefix
-return function (InputInterface $input, OutputInterface $output) {
+return function (InputInterface $input, OutputInterface $output): int {
     $output->setDecorated(true);
     $output = new SymfonyStyle($input, $output);
     $output->block(
@@ -16,4 +16,6 @@ return function (InputInterface $input, OutputInterface $output) {
         false,
         false
     );
+
+    return 0;
 };

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_23.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_23.php
@@ -4,7 +4,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-return function (InputInterface $input, OutputInterface $output) {
+return function (InputInterface $input, OutputInterface $output): int {
     $output = new SymfonyStyle($input, $output);
     $output->text('Hello');
+
+    return 0;
 };

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_3.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_3.php
@@ -5,8 +5,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 //Ensure has single blank line between two titles
-return function (InputInterface $input, OutputInterface $output) {
+return function (InputInterface $input, OutputInterface $output): int {
     $output = new SymfonyStyle($input, $output);
     $output->title('First title');
     $output->title('Second title');
+
+    return 0;
 };

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_4.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_4.php
@@ -5,7 +5,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 //Ensure has single blank line after any text and a title
-return function (InputInterface $input, OutputInterface $output) {
+return function (InputInterface $input, OutputInterface $output): int {
     $output = new SymfonyStyle($input, $output);
 
     $output->write('Lorem ipsum dolor sit amet');
@@ -31,4 +31,6 @@ return function (InputInterface $input, OutputInterface $output) {
     $output->writeln('Lorem ipsum dolor sit amet');
     $output->newLine(2); //Should append an extra blank line
     $output->title('Fifth title');
+
+    return 0;
 };

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_4_with_iterators.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_4_with_iterators.php
@@ -5,7 +5,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 //Ensure has single blank line after any text and a title
-return function (InputInterface $input, OutputInterface $output) {
+return function (InputInterface $input, OutputInterface $output): int {
     $output = new SymfonyStyle($input, $output);
 
     $output->write('Lorem ipsum dolor sit amet');
@@ -31,4 +31,6 @@ return function (InputInterface $input, OutputInterface $output) {
     $output->writeln('Lorem ipsum dolor sit amet');
     $output->newLine(2); //Should append an extra blank line
     $output->title('Fifth title');
+
+    return 0;
 };

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_5.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_5.php
@@ -5,7 +5,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 //Ensure has proper line ending before outputting a text block like with SymfonyStyle::listing() or SymfonyStyle::text()
-return function (InputInterface $input, OutputInterface $output) {
+return function (InputInterface $input, OutputInterface $output): int {
     $output = new SymfonyStyle($input, $output);
 
     $output->writeln('Lorem ipsum dolor sit amet');
@@ -34,4 +34,6 @@ return function (InputInterface $input, OutputInterface $output) {
         'Lorem ipsum dolor sit amet',
         'consectetur adipiscing elit',
     ]);
+
+    return 0;
 };

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_6.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_6.php
@@ -5,7 +5,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 //Ensure has proper blank line after text block when using a block like with SymfonyStyle::success
-return function (InputInterface $input, OutputInterface $output) {
+return function (InputInterface $input, OutputInterface $output): int {
     $output = new SymfonyStyle($input, $output);
 
     $output->listing([
@@ -13,4 +13,6 @@ return function (InputInterface $input, OutputInterface $output) {
         'consectetur adipiscing elit',
     ]);
     $output->success('Lorem ipsum dolor sit amet');
+
+    return 0;
 };

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_7.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_7.php
@@ -5,11 +5,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 //Ensure questions do not output anything when input is non-interactive
-return function (InputInterface $input, OutputInterface $output) {
+return function (InputInterface $input, OutputInterface $output): int {
     $output = new SymfonyStyle($input, $output);
     $output->title('Title');
     $output->askHidden('Hidden question');
     $output->choice('Choice question with default', ['choice1', 'choice2'], 'choice1');
     $output->confirm('Confirmation with yes default', true);
     $output->text('Duis aute irure dolor in reprehenderit in voluptate velit esse');
+
+    return 0;
 };

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_8.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_8.php
@@ -6,7 +6,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 //Ensure formatting tables when using multiple headers with TableCell
-return function (InputInterface $input, OutputInterface $output) {
+return function (InputInterface $input, OutputInterface $output): int {
     $headers = [
         [new TableCell('Main table title', ['colspan' => 3])],
         ['ISBN', 'Title', 'Author'],
@@ -23,4 +23,6 @@ return function (InputInterface $input, OutputInterface $output) {
 
     $output = new SymfonyStyle($input, $output);
     $output->table($headers, $rows);
+
+    return 0;
 };

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_9.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_9.php
@@ -5,7 +5,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 //Ensure that all lines are aligned to the begin of the first line in a multi-line block
-return function (InputInterface $input, OutputInterface $output) {
+return function (InputInterface $input, OutputInterface $output): int {
     $output = new SymfonyStyle($input, $output);
     $output->block(['Custom block', 'Second custom block line'], 'CUSTOM', 'fg=white;bg=green', 'X ', true);
+
+    return 0;
 };

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/interactive_command_1.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/interactive_command_1.php
@@ -5,7 +5,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 //Ensure that questions have the expected outputs
-return function (InputInterface $input, OutputInterface $output) {
+return function (InputInterface $input, OutputInterface $output): int {
     $output = new SymfonyStyle($input, $output);
     $stream = fopen('php://memory', 'r+', false);
 
@@ -16,4 +16,6 @@ return function (InputInterface $input, OutputInterface $output) {
     $output->ask('What\'s your name?');
     $output->ask('How are you?');
     $output->ask('Where do you come from?');
+
+    return 0;
 };

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/progress/command_progress_iterate.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/progress/command_progress_iterate.php
@@ -5,7 +5,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 // progressIterate
-return function (InputInterface $input, OutputInterface $output) {
+return function (InputInterface $input, OutputInterface $output): int {
     $style = new SymfonyStyle($input, $output);
 
     foreach ($style->progressIterate(\range(1, 10)) as $step) {
@@ -13,4 +13,6 @@ return function (InputInterface $input, OutputInterface $output) {
     }
 
     $style->writeln('end of progressbar');
+
+    return 0;
 };

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_signalable.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_signalable.php
@@ -23,7 +23,7 @@ require $vendor.'/vendor/autoload.php';
         exit(0);
     }
 })
-    ->setCode(function(InputInterface $input, OutputInterface $output) {
+    ->setCode(function(InputInterface $input, OutputInterface $output): int {
         $this->getHelper('question')
              ->ask($input, $output, new ChoiceQuestion('😊', ['y']));
 

--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -777,7 +777,7 @@ EOD;
         $application = new Application();
         $application->setAutoExit(false);
         $application->register('question')
-            ->setCode(function (InputInterface $input, OutputInterface $output) use (&$tries) {
+            ->setCode(function (InputInterface $input, OutputInterface $output) use (&$tries): int {
                 $question = new Question('This is a promptable question');
                 $question->setValidator(function ($value) use (&$tries) {
                     ++$tries;

--- a/src/Symfony/Component/Console/Tests/Tester/ApplicationTesterTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/ApplicationTesterTest.php
@@ -31,8 +31,10 @@ class ApplicationTesterTest extends TestCase
         $this->application->setAutoExit(false);
         $this->application->register('foo')
             ->addArgument('foo')
-            ->setCode(function (OutputInterface $output) {
+            ->setCode(function (OutputInterface $output): int {
                 $output->writeln('foo');
+
+                return 0;
             })
         ;
 
@@ -67,11 +69,13 @@ class ApplicationTesterTest extends TestCase
     {
         $application = new Application();
         $application->setAutoExit(false);
-        $application->register('foo')->setCode(function (InputInterface $input, OutputInterface $output) {
+        $application->register('foo')->setCode(function (InputInterface $input, OutputInterface $output): int {
             $helper = new QuestionHelper();
             $helper->ask($input, $output, new Question('Q1'));
             $helper->ask($input, $output, new Question('Q2'));
             $helper->ask($input, $output, new Question('Q3'));
+
+            return 0;
         });
         $tester = new ApplicationTester($application);
 
@@ -93,8 +97,10 @@ class ApplicationTesterTest extends TestCase
         $application->setAutoExit(false);
         $application->register('foo')
             ->addArgument('foo')
-            ->setCode(function (OutputInterface $output) {
+            ->setCode(function (OutputInterface $output): int {
                 $output->getErrorOutput()->write('foo');
+
+                return 0;
             })
         ;
 

--- a/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
@@ -34,7 +34,11 @@ class CommandTesterTest extends TestCase
         $this->command = new Command('foo');
         $this->command->addArgument('command');
         $this->command->addArgument('foo');
-        $this->command->setCode(function (OutputInterface $output) { $output->writeln('foo'); });
+        $this->command->setCode(function (OutputInterface $output): int {
+            $output->writeln('foo');
+
+            return 0;
+        });
 
         $this->tester = new CommandTester($this->command);
         $this->tester->execute(['foo' => 'bar'], ['interactive' => false, 'decorated' => false, 'verbosity' => Output::VERBOSITY_VERBOSE]);
@@ -94,7 +98,11 @@ class CommandTesterTest extends TestCase
         $application->setAutoExit(false);
 
         $command = new Command('foo');
-        $command->setCode(function (OutputInterface $output) { $output->writeln('foo'); });
+        $command->setCode(function (OutputInterface $output): int {
+            $output->writeln('foo');
+
+            return 0;
+        });
 
         $application->add($command);
 
@@ -114,11 +122,13 @@ class CommandTesterTest extends TestCase
 
         $command = new Command('foo');
         $command->setHelperSet(new HelperSet([new QuestionHelper()]));
-        $command->setCode(function (InputInterface $input, OutputInterface $output) use ($questions, $command) {
+        $command->setCode(function (InputInterface $input, OutputInterface $output) use ($questions, $command): int {
             $helper = $command->getHelper('question');
             $helper->ask($input, $output, new Question($questions[0]));
             $helper->ask($input, $output, new Question($questions[1]));
             $helper->ask($input, $output, new Question($questions[2]));
+
+            return 0;
         });
 
         $tester = new CommandTester($command);
@@ -139,11 +149,13 @@ class CommandTesterTest extends TestCase
 
         $command = new Command('foo');
         $command->setHelperSet(new HelperSet([new QuestionHelper()]));
-        $command->setCode(function (InputInterface $input, OutputInterface $output) use ($questions, $command) {
+        $command->setCode(function (InputInterface $input, OutputInterface $output) use ($questions, $command): int {
             $helper = $command->getHelper('question');
             $helper->ask($input, $output, new Question($questions[0], 'Bobby'));
             $helper->ask($input, $output, new Question($questions[1], 'Fine'));
             $helper->ask($input, $output, new Question($questions[2], 'France'));
+
+            return 0;
         });
 
         $tester = new CommandTester($command);
@@ -164,12 +176,14 @@ class CommandTesterTest extends TestCase
 
         $command = new Command('foo');
         $command->setHelperSet(new HelperSet([new QuestionHelper()]));
-        $command->setCode(function (InputInterface $input, OutputInterface $output) use ($questions, $command) {
+        $command->setCode(function (InputInterface $input, OutputInterface $output) use ($questions, $command): int {
             $helper = $command->getHelper('question');
             $helper->ask($input, $output, new ChoiceQuestion('choice', ['a', 'b']));
             $helper->ask($input, $output, new Question($questions[0]));
             $helper->ask($input, $output, new Question($questions[1]));
             $helper->ask($input, $output, new Question($questions[2]));
+
+            return 0;
         });
 
         $tester = new CommandTester($command);
@@ -191,12 +205,14 @@ class CommandTesterTest extends TestCase
 
         $command = new Command('foo');
         $command->setHelperSet(new HelperSet([new QuestionHelper()]));
-        $command->setCode(function (InputInterface $input, OutputInterface $output) use ($questions, $command) {
+        $command->setCode(function (InputInterface $input, OutputInterface $output) use ($questions, $command): int {
             $helper = $command->getHelper('question');
             $helper->ask($input, $output, new ChoiceQuestion('choice', ['a', 'b']));
             $helper->ask($input, $output, new Question($questions[0]));
             $helper->ask($input, $output, new Question($questions[1]));
             $helper->ask($input, $output, new Question($questions[2]));
+
+            return 0;
         });
 
         $tester = new CommandTester($command);
@@ -216,11 +232,13 @@ class CommandTesterTest extends TestCase
         ];
 
         $command = new Command('foo');
-        $command->setCode(function (InputInterface $input, OutputInterface $output) use ($questions) {
+        $command->setCode(function (InputInterface $input, OutputInterface $output) use ($questions): int {
             $io = new SymfonyStyle($input, $output);
             $io->ask($questions[0]);
             $io->ask($questions[1]);
             $io->ask($questions[2]);
+
+            return 0;
         });
 
         $tester = new CommandTester($command);
@@ -235,8 +253,10 @@ class CommandTesterTest extends TestCase
         $command = new Command('foo');
         $command->addArgument('command');
         $command->addArgument('foo');
-        $command->setCode(function (OutputInterface $output) {
+        $command->setCode(function (OutputInterface $output): int {
             $output->getErrorOutput()->write('foo');
+
+            return 0;
         });
 
         $tester = new CommandTester($command);

--- a/src/Symfony/Component/Console/Tests/phpt/uses_stdin_as_interactive_input.phpt
+++ b/src/Symfony/Component/Console/Tests/phpt/uses_stdin_as_interactive_input.phpt
@@ -17,9 +17,11 @@ require $vendor.'/vendor/autoload.php';
 
 (new Application())
     ->register('app')
-    ->setCode(function(InputInterface $input, OutputInterface $output) {
+    ->setCode(function(InputInterface $input, OutputInterface $output): int {
         $output->writeln((new QuestionHelper())->ask($input, $output, new Question('Foo?', 'foo')));
         $output->writeln((new QuestionHelper())->ask($input, $output, new Question('Bar?', 'bar')));
+
+        return 0;
     })
     ->getApplication()
     ->setDefaultCommand('app', true)

--- a/src/Symfony/Component/Console/composer.json
+++ b/src/Symfony/Component/Console/composer.json
@@ -43,7 +43,8 @@
         "symfony/dotenv": "<6.4",
         "symfony/event-dispatcher": "<6.4",
         "symfony/lock": "<6.4",
-        "symfony/process": "<6.4"
+        "symfony/process": "<6.4",
+        "symfony/runtime": "<7.3"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Console\\": "" },

--- a/src/Symfony/Component/Runtime/Tests/phpt/application.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/application.php
@@ -18,8 +18,10 @@ require __DIR__.'/autoload.php';
 
 return function (array $context) {
     $command = new Command('go');
-    $command->setCode(function (InputInterface $input, OutputInterface $output) use ($context) {
+    $command->setCode(function (InputInterface $input, OutputInterface $output) use ($context): int {
         $output->write('OK Application '.$context['SOME_VAR']);
+
+        return 0;
     });
 
     $app = new Application();

--- a/src/Symfony/Component/Runtime/Tests/phpt/command.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/command.php
@@ -19,7 +19,9 @@ require __DIR__.'/autoload.php';
 return function (Command $command, InputInterface $input, OutputInterface $output, array $context) {
     $command->addOption('hello', 'e', InputOption::VALUE_REQUIRED, 'How should I greet?', 'OK');
 
-    return $command->setCode(function () use ($input, $output, $context) {
+    return $command->setCode(function () use ($input, $output, $context): int {
         $output->write($input->getOption('hello').' Command '.$context['SOME_VAR']);
+
+        return 0;
     });
 };

--- a/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload_command_debug_exists_0_to_1.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload_command_debug_exists_0_to_1.php
@@ -20,6 +20,8 @@ $_SERVER['APP_RUNTIME_OPTIONS'] = [
 
 require __DIR__.'/autoload.php';
 
-return static fn (Command $command, OutputInterface $output, array $context): Command => $command->setCode(static function () use ($output, $context): void {
+return static fn (Command $command, OutputInterface $output, array $context): Command => $command->setCode(static function () use ($output, $context): int {
     $output->writeln($context['DEBUG_ENABLED']);
+
+    return 0;
 });

--- a/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload_command_debug_exists_1_to_0.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload_command_debug_exists_1_to_0.php
@@ -20,6 +20,8 @@ $_SERVER['APP_RUNTIME_OPTIONS'] = [
 
 require __DIR__.'/autoload.php';
 
-return static fn (Command $command, OutputInterface $output, array $context): Command => $command->setCode(static function () use ($output, $context): void {
+return static fn (Command $command, OutputInterface $output, array $context): Command => $command->setCode(static function () use ($output, $context): int {
     $output->writeln($context['DEBUG_MODE']);
+
+    return 0;
 });

--- a/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload_command_env_exists.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload_command_env_exists.php
@@ -20,6 +20,8 @@ $_SERVER['APP_RUNTIME_OPTIONS'] = [
 
 require __DIR__.'/autoload.php';
 
-return static fn (Command $command, OutputInterface $output, array $context): Command => $command->setCode(static function () use ($output, $context): void {
+return static fn (Command $command, OutputInterface $output, array $context): Command => $command->setCode(static function () use ($output, $context): int {
     $output->writeln($context['ENV_MODE']);
+
+    return 0;
 });

--- a/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload_command_no_debug.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload_command_no_debug.php
@@ -19,6 +19,8 @@ $_SERVER['APP_RUNTIME_OPTIONS'] = [
 
 require __DIR__.'/autoload.php';
 
-return static fn (Command $command, OutputInterface $output, array $context): Command => $command->setCode(static function () use ($output, $context): void {
+return static fn (Command $command, OutputInterface $output, array $context): Command => $command->setCode(static function () use ($output, $context): int {
     $output->writeln($context['DEBUG_ENABLED']);
+
+    return 0;
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | -
| License       | MIT

This adds a missing log entry about a deprecation introduced [here](https://github.com/symfony/symfony/pull/59340), and also deprecates returning a `null` value for `\Closure` code (which was allowed before) and throwing a `\TypeError` for the new invokable command, making this consistent with the `Command::execute(): int` method.