### PR TITLE
[HttpCache][WIP] Use RFC9211 Cache-Status

### DIFF
--- a/src/Symfony/Component/HttpFoundation/HeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderBag.php
@@ -29,6 +29,8 @@ class HeaderBag implements \IteratorAggregate, \Countable, \Stringable
     protected array $headers = [];
     protected array $cacheControl = [];
 
+    protected array $cacheStatus = [];
+
     public function __construct(array $headers = [])
     {
         foreach ($headers as $key => $values) {

--- a/src/Symfony/Component/HttpFoundation/HeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderBag.php
@@ -28,7 +28,6 @@ class HeaderBag implements \IteratorAggregate, \Countable, \Stringable
      */
     protected array $headers = [];
     protected array $cacheControl = [];
-
     protected array $cacheStatus = [];
 
     public function __construct(array $headers = [])

--- a/src/Symfony/Component/HttpFoundation/HeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderBag.php
@@ -29,6 +29,8 @@ class HeaderBag implements \IteratorAggregate, \Countable, \Stringable
     protected array $headers = [];
     protected array $cacheControl = [];
 
+    protected array $cacheStatus = [];
+
     public function __construct(array $headers = [])
     {
         foreach ($headers as $key => $values) {
@@ -150,6 +152,10 @@ class HeaderBag implements \IteratorAggregate, \Countable, \Stringable
         if ('cache-control' === $key) {
             $this->cacheControl = $this->parseCacheControl(implode(', ', $this->headers[$key]));
         }
+
+        if ('cache-status' === $key) {
+            $this->cacheStatus = $this->parseCacheStatus(implode('; ', $this->headers[$key]));
+        }
     }
 
     /**
@@ -179,6 +185,10 @@ class HeaderBag implements \IteratorAggregate, \Countable, \Stringable
 
         if ('cache-control' === $key) {
             $this->cacheControl = [];
+        }
+
+        if ('cache-status' === $key) {
+            $this->cacheStatus = [];
         }
     }
 
@@ -211,11 +221,29 @@ class HeaderBag implements \IteratorAggregate, \Countable, \Stringable
     }
 
     /**
+     * Adds a custom Cache-Status directive.
+     */
+    public function addCacheStatusDirective(string $key, bool|string $value = true): void
+    {
+        $this->cacheStatus[$key] = $value;
+
+        $this->set('Cache-Status', $this->getCacheStatusHeader());
+    }
+
+    /**
      * Returns true if the Cache-Control directive is defined.
      */
     public function hasCacheControlDirective(string $key): bool
     {
         return \array_key_exists($key, $this->cacheControl);
+    }
+
+    /**
+     * Returns true if the Cache-Status directive is defined.
+     */
+    public function hasCacheStatusDirective(string $key): bool
+    {
+        return \array_key_exists($key, $this->cacheStatus);
     }
 
     /**
@@ -261,12 +289,29 @@ class HeaderBag implements \IteratorAggregate, \Countable, \Stringable
         return HeaderUtils::toString($this->cacheControl, ',');
     }
 
+    protected function getCacheStatusHeader(): string
+    {
+        ksort($this->cacheStatus);
+
+        return HeaderUtils::toString($this->cacheStatus, ';');
+    }
+
     /**
      * Parses a Cache-Control HTTP header.
      */
     protected function parseCacheControl(string $header): array
     {
         $parts = HeaderUtils::split($header, ',=');
+
+        return HeaderUtils::combine($parts);
+    }
+
+    /**
+     * Parses a Cache-Status HTTP header.
+     */
+    protected function parseCacheStatus(string $header): array
+    {
+        $parts = HeaderUtils::split($header, ';=');
 
         return HeaderUtils::combine($parts);
     }

--- a/src/Symfony/Component/HttpFoundation/HeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderBag.php
@@ -28,7 +28,6 @@ class HeaderBag implements \IteratorAggregate, \Countable, \Stringable
      */
     protected array $headers = [];
     protected array $cacheControl = [];
-    protected array $cacheStatus = [];
 
     public function __construct(array $headers = [])
     {

--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -341,6 +341,8 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
             return $this->fetch($request, $catch);
         }
 
+        $entry->headers->set('Cache-Status', 'SymfonyCache, hit; ttl='.$entry->getTtl());
+
         if (!$this->isFreshEnough($request, $entry)) {
             $this->record($request, 'stale');
 
@@ -351,6 +353,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
             return $this->validate($request, $entry, $catch);
         }
 
+        $this->record($request, 'hit');
         $this->record($request, 'fresh');
 
         $entry->headers->set('Age', $entry->getAge());

--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -341,8 +341,6 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
             return $this->fetch($request, $catch);
         }
 
-        $entry->headers->set('Cache-Status', 'SymfonyCache, hit; ttl='.$entry->getTtl());
-
         if (!$this->isFreshEnough($request, $entry)) {
             $this->record($request, 'stale');
 
@@ -353,7 +351,6 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
             return $this->validate($request, $entry, $catch);
         }
 
-        $this->record($request, 'hit');
         $this->record($request, 'fresh');
 
         $entry->headers->set('Age', $entry->getAge());

--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -338,13 +338,19 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
         if (null === $entry) {
             $this->record($request, 'miss');
 
-            return $this->fetch($request, $catch);
+            $response = $this->fetch($request, $catch);
+            $response->headers->addCacheStatusDirective('X-Symfony-Cache');
+            $response->headers->addCacheStatusDirective('fwd', 'uri-miss');
+
+            return $response;
         }
 
         if (!$this->isFreshEnough($request, $entry)) {
             $this->record($request, 'stale');
+            $response = $this->validate($request, $entry, $catch);
+            $response->headers->addCacheStatusDirective('fwd','stale');
 
-            return $this->validate($request, $entry, $catch);
+            return $response;
         }
 
         if ($entry->headers->hasCacheControlDirective('no-cache')) {
@@ -354,6 +360,10 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
         $this->record($request, 'fresh');
 
         $entry->headers->set('Age', $entry->getAge());
+        $entry->headers->addCacheStatusDirective('X-Symfony-Cache');
+        $entry->headers->addCacheStatusDirective('hit');
+        $entry->headers->addCacheStatusDirective('ttl', $entry->getTTL());
+
 
         return $entry;
     }
@@ -393,6 +403,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
 
         if (304 == $response->getStatusCode()) {
             $this->record($request, 'valid');
+            $response->headers->addCacheStatusDirective('fwd', '304');
 
             // return the response and not the cache entry if the response is valid but not cached
             $etag = $response->getEtag();

--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -348,7 +348,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
         if (!$this->isFreshEnough($request, $entry)) {
             $this->record($request, 'stale');
             $response = $this->validate($request, $entry, $catch);
-            $response->headers->addCacheStatusDirective('fwd','stale');
+            $response->headers->addCacheStatusDirective('fwd', 'stale');
 
             return $response;
         }
@@ -363,7 +363,6 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
         $entry->headers->addCacheStatusDirective('X-Symfony-Cache');
         $entry->headers->addCacheStatusDirective('hit');
         $entry->headers->addCacheStatusDirective('ttl', $entry->getTTL());
-
 
         return $entry;
     }

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
@@ -634,11 +634,24 @@ class HttpCacheTest extends HttpCacheTestCase
         $this->assertLessThan(2, strtotime($this->responses[0]->headers->get('Date')) - strtotime($this->response->headers->get('Date')));
         $this->assertGreaterThan(0, $this->response->headers->get('Age'));
         $this->assertNotNull($this->response->headers->get('X-Content-Digest'));
-        $this->assertNotNull($this->response->headers->get('Cache-Status'));
-        $this->assertTraceContains('hit');
         $this->assertTraceContains('fresh');
         $this->assertTraceNotContains('store');
         $this->assertEquals('Hello World', $this->response->getContent());
+    }
+
+    public function testHitsCachedResponseAndHasCacheStatusHeader()
+    {
+        $time = \DateTimeImmutable::createFromFormat('U', time() - 5);
+        $this->setNextResponse(200, ['Date' => $time->format(\DATE_RFC2822), 'Cache-Control' => 'public, max-age=10']);
+
+        $this->request('GET', '/');
+        $this->assertHttpKernelIsCalled();
+
+        $this->request('GET', '/');
+        $this->assertHttpKernelIsNotCalled();
+
+        $this->assertNotNull($this->response->headers->get('Cache-Status'));
+        $this->assertTrue($this->response->headers->hasCacheStatusDirective('hit'));
     }
 
     public function testDegradationWhenCacheLocked()

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
@@ -126,7 +126,6 @@ class HttpCacheTest extends HttpCacheTestCase
 
             $this->assertHttpKernelIsCalled();
             $this->assertResponseOk();
-
             $this->assertTraceContains('invalidate');
             $this->assertTraceContains('pass');
         }

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
@@ -126,6 +126,7 @@ class HttpCacheTest extends HttpCacheTestCase
 
             $this->assertHttpKernelIsCalled();
             $this->assertResponseOk();
+
             $this->assertTraceContains('invalidate');
             $this->assertTraceContains('pass');
         }
@@ -634,6 +635,8 @@ class HttpCacheTest extends HttpCacheTestCase
         $this->assertLessThan(2, strtotime($this->responses[0]->headers->get('Date')) - strtotime($this->response->headers->get('Date')));
         $this->assertGreaterThan(0, $this->response->headers->get('Age'));
         $this->assertNotNull($this->response->headers->get('X-Content-Digest'));
+        $this->assertNotNull($this->response->headers->get('Cache-Status'));
+        $this->assertTraceContains('hit');
         $this->assertTraceContains('fresh');
         $this->assertTraceNotContains('store');
         $this->assertEquals('Hello World', $this->response->getContent());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch       | 8.1 <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        |  #58985 
| License       | MIT

This PR is intended to answer #58985 by using Cache-Status as described [here](https://www.rfc-editor.org/rfc/rfc9211.html). 

Usage
--

To help debugging HTTP requests and responses from caches. This HTTP RFC introduces a new cache header, the "Cache-Status". The Cache Status header should indicate how the cache handled the request. Basically this new header reports if there was a hit, a miss or a forward to origin and add details on how the cache actually managed the request.

Examples
--
Examples here are provided directly from the RFC. 

The following is an example of a minimal cache hit:

`Cache-Status: ExampleCache; hit`

However, a polite cache will give some more information, e.g.:

`Cache-Status: ExampleCache; hit; ttl=376`

A stale hit just has negative freshness, as in this example:

`Cache-Status: ExampleCache; hit; ttl=-412`

Whereas this is an example of a complete miss:

`Cache-Status: ExampleCache; fwd=uri-miss`

This is an example of a miss that successfully validated on the backend server:

`Cache-Status: ExampleCache; fwd=stale; fwd-status=304`

This is an example of a miss that was collapsed with another request:

`Cache-Status: ExampleCache; fwd=uri-miss; collapsed`

This is an example of a miss that the cache attempted to collapse, but couldn't:

`Cache-Status: ExampleCache; fwd=uri-miss; collapsed=?0`


<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
