### PR TITLE
[FrameworkBundle] Enable controller service with `#[Route]` attribute

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -19,6 +19,8 @@ CHANGELOG
  * Add DI alias from `ServicesResetterInterface` to `services_resetter`
  * Add `methods` argument in `#[IsCsrfTokenValid]` attribute
  * Allow configuring the logging channel per type of exceptions
+ * Enable service argument resolution on classes that use the `#[Route]` attribute,
+   the `#[AsController]` attribute is no longer required
 
 7.2
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -164,6 +164,7 @@ use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
 use Symfony\Component\RateLimiter\Storage\CacheStorage;
 use Symfony\Component\RemoteEvent\Attribute\AsRemoteEventConsumer;
 use Symfony\Component\RemoteEvent\RemoteEvent;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Scheduler\Attribute\AsCronTask;
 use Symfony\Component\Scheduler\Attribute\AsPeriodicTask;
 use Symfony\Component\Scheduler\Attribute\AsSchedule;
@@ -429,7 +430,7 @@ class FrameworkExtension extends Extension
             }
             $loggers[$exception['log_channel']] = new Reference('monolog.logger.'.$exception['log_channel'], ContainerInterface::NULL_ON_INVALID_REFERENCE);
         }
-        
+
         $exceptionListener
             ->replaceArgument(3, $config['exceptions'])
             ->setArgument(4, $loggers)
@@ -737,6 +738,9 @@ class FrameworkExtension extends Extension
             $definition->addTag('kernel.event_listener', $tagAttributes);
         });
         $container->registerAttributeForAutoconfiguration(AsController::class, static function (ChildDefinition $definition, AsController $attribute): void {
+            $definition->addTag('controller.service_arguments');
+        });
+        $container->registerAttributeForAutoconfiguration(Route::class, static function (ChildDefinition $definition, Route $attribute, \ReflectionClass|\ReflectionMethod $reflection): void {
             $definition->addTag('controller.service_arguments');
         });
         $container->registerAttributeForAutoconfiguration(AsRemoteEventConsumer::class, static function (ChildDefinition $definition, AsRemoteEventConsumer $attribute): void {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

The `#[AsController]` attribute has 2 purposes:
- Add the tag `controller.service_argument` that configures the service and service argument injection ([RegisterControllerArgumentLocatorsPass](https://github.com/symfony/symfony/blob/79ea49c772ce4b39f414cde5648ad347c3bbcfd7/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php#L56))
- Allow the class in the controller resolver ([#52471](https://github.com/symfony/symfony/pull/52471))

In this PR, I propose to add the tag `argument_resolver.service` on services when the class has the `#[Route]` attribute. Removing the need for `#[AsController]` on classes that use the `#[Route]` attribute. 
I assume that if there is a route, it is a controller.

Diff (from the [docs](https://symfony.com/doc/7.2/controller/service.html)):
```diff
  namespace App\Controller;

  use Symfony\Component\HttpFoundation\Response;
- use Symfony\Component\HttpKernel\Attribute\AsController;
  use Symfony\Component\Routing\Attribute\Route;

- #[AsController]
  class HelloController
  {
      #[Route('/hello', name: 'hello', methods: ['GET'])]
      public function index(): Response
      {
          // ...
      }
  }
```