### PR TITLE
[Messenger] Exclude AsMessenger attribute from services WIP

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
    for auto-configuration of classes excluded from the service container
  * Accept multiple auto-configuration callbacks for the same attribute class
  * Leverage native lazy objects when possible for lazy services
+ * Class attributes `#[AsMessage]` and `#[Entity]` are now automatically excluded as services injection, like `#[Exclude]` does
 
 7.2
 ---

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Utils/ObjectAsMessage.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Utils/ObjectAsMessage.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Utils;
+
+use Symfony\Component\Messenger\Attribute\AsMessage;
+
+#[AsMessage]
+class ObjectAsMessage
+{
+}

--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -20,6 +20,7 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\OutOfBoundsException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Messenger\Attribute\AsMessage;
 use Symfony\Component\Messenger\Handler\HandlerDescriptor;
 use Symfony\Component\Messenger\Handler\HandlersLocator;
 use Symfony\Component\Messenger\TraceableMessageBus;
@@ -50,6 +51,7 @@ class MessengerPass implements CompilerPassInterface
             $this->registerReceivers($container, $busIds);
         }
         $this->registerHandlers($container, $busIds);
+        $this->excludeMessagesFromServices($container);
     }
 
     private function registerHandlers(ContainerBuilder $container, array $busIds): void
@@ -387,5 +389,13 @@ class MessengerPass implements CompilerPassInterface
 
             return $definition->getClass();
         }
+    }
+
+    private function excludeMessagesFromServices(ContainerBuilder $container): void
+    {
+        $container->registerAttributeForAutoconfiguration(
+            AsMessage::class,
+            static fn (ChildDefinition $definition) => $definition->addTag('container.excluded')
+        );
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
@@ -23,6 +23,7 @@ use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\Utils\ObjectAsMessage;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpReceiver;
 use Symfony\Component\Messenger\Command\ConsumeMessagesCommand;
@@ -383,6 +384,16 @@ class MessengerPassTest extends TestCase
             DummyMessage::class,
             [$abstractHandlerId]
         );
+    }
+
+    public function testRegisterClassesWithExcludedAttributes()
+    {
+        $container = $this->getContainerBuilder();
+        $container->register(ObjectAsMessage::class);
+
+        (new MessengerPass())->process($container);
+
+        $this->assertSame(true, $container->getDefinition(ObjectAsMessage::class)->hasTag('container.excluded')); //false I miss something
     }
 
     public function testThrowsExceptionIfTheHandlerClassDoesNotExist()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

As I wanted to auto exclude from services some classes based on their attributes (like messenger messages or doctrine entities), in order to simplify default config/services.yaml->services. App/.exclude configuration, and after some discussions with Sir Grekas, it seems that it can be achieved directly from the components' repositories, and by tagging the given attributes to the container's config.

I'm a bit stuck here, as:
- My test doesn't pass here as I'm not sure how should I articulate it,
- I'm not sure my changes will be fired when anyone will use the component,

Any advice or tips would be appreciated to finish this! Sorry for my maybe naive questions