### PR TITLE
[RateLimiter] Add `RateLimiterBuilder`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add the `doctrine.orm.entity` tag to auto-excluded `#[Entity]` and `#[MappedSuperclass]` classes to allow discovering them
+ * Add `framework.rate_limiter.builder` option
  * Add the `cache.adapter.pdo_tag_aware` cache pool adapter
  * Register the `web_link.json_linkset_serializer`, `web_link.json_linkset_parser`, `web_link.link_template_header_serializer` and `web_link.link_template_header_parser` services
  * Add `framework.asset_mapper.importmap_integrity_algorithms` option to add integrity metadata to importmaps

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -2797,9 +2797,13 @@ class Configuration implements ConfigurationInterface
                         ->then(static function ($v) {
                             if (!isset($v['limiters']) && !isset($v['limiter'])) {
                                 $v = ['limiters' => $v];
-                                if (\array_key_exists('enabled', $v['limiters'])) {
-                                    $v['enabled'] = $v['limiters']['enabled'];
-                                    unset($v['limiters']['enabled']);
+
+                                // hoist back the keys the shorthand would otherwise read as limiter names
+                                foreach (['enabled', 'builder'] as $key) {
+                                    if (\array_key_exists($key, $v['limiters'])) {
+                                        $v[$key] = $v['limiters'][$key];
+                                        unset($v['limiters'][$key]);
+                                    }
                                 }
                             }
 
@@ -2807,6 +2811,24 @@ class Configuration implements ConfigurationInterface
                         })
                     ->end()
                     ->children()
+                        ->arrayNode('builder')
+                            ->info('Configuration for the RateLimiterBuilder service.')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->scalarNode('lock_factory')
+                                    ->info('The service ID of the lock factory to use with the RateLimiterBuilder.')
+                                    ->defaultValue('auto')
+                                ->end()
+                                ->scalarNode('cache_pool')
+                                    ->info('The cache pool to use with RateLimiterBuilder.')
+                                    ->defaultValue('cache.rate_limiter')
+                                ->end()
+                                ->scalarNode('storage_service')
+                                    ->info('The service ID of a custom storage implementation, this precedes any configured "cache_pool".')
+                                    ->defaultNull()
+                                ->end()
+                            ->end()
+                        ->end()
                         ->arrayNode('limiters', 'limiter')
                             ->useAttributeAsKey('name')
                             ->arrayPrototype()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -166,6 +166,7 @@ use Symfony\Component\PropertyInfo\PropertyListExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\RateLimiter\CompoundRateLimiterFactory;
 use Symfony\Component\RateLimiter\LimiterInterface;
+use Symfony\Component\RateLimiter\RateLimiterBuilder;
 use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
 use Symfony\Component\RateLimiter\Storage\CacheStorage;
 use Symfony\Component\RemoteEvent\Attribute\AsRemoteEventConsumer;
@@ -3721,6 +3722,38 @@ class FrameworkExtension extends Extension
             ;
 
             $container->registerAliasForArgument($limiterId, RateLimiterFactoryInterface::class, $name.'.limiter', $name);
+        }
+
+        if (class_exists(RateLimiterBuilder::class)) {
+            $builderConfig = $config['builder'];
+
+            if ('auto' === $builderConfig['lock_factory']) {
+                $builderConfig['lock_factory'] = $this->isInitializedConfigEnabled('lock') ? 'lock.factory' : null;
+            }
+
+            $builder = $container->getDefinition('limiter_builder');
+
+            if (null === $storageId = $builderConfig['storage_service']) {
+                $container->register($storageId = 'limiter_builder.storage', CacheStorage::class)->addArgument(new Reference($builderConfig['cache_pool']));
+            }
+
+            $builder->replaceArgument(0, new Reference($storageId));
+
+            if ($builderConfig['lock_factory']) {
+                if (!interface_exists(LockInterface::class)) {
+                    throw new LogicException('Rate Limiter Builder requires the Lock component to be installed. Try running "composer require symfony/lock".');
+                }
+
+                if (!$this->isInitializedConfigEnabled('lock')) {
+                    throw new LogicException('Rate Limiter Builder requires the Lock component to be configured.');
+                }
+
+                $builder->replaceArgument(1, new Reference($builderConfig['lock_factory']));
+            }
+
+            $container->setAlias(RateLimiterBuilder::class, 'limiter_builder');
+        } else {
+            $container->removeDefinition('limiter_builder');
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/rate_limiter.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/rate_limiter.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Component\HttpKernel\EventListener\RateLimitAttributeListener;
+use Symfony\Component\RateLimiter\RateLimiterBuilder;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
 
 return static function (ContainerConfigurator $container) {
@@ -31,5 +32,11 @@ return static function (ContainerConfigurator $container) {
         ->set('rate_limiter.attribute_listener', RateLimitAttributeListener::class)
             ->tag('kernel.event_subscriber')
             ->args([tagged_locator('rate_limiter', 'name')])
+
+        ->set('limiter_builder', RateLimiterBuilder::class)
+            ->args([
+                abstract_arg('storage'),
+                null,
+            ])
     ;
 };

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -52,6 +52,34 @@ class ConfigurationTest extends TestCase
         $this->assertEquals(self::getBundleDefaultConfig(), $config);
     }
 
+    public function testRateLimiterBuilderIsNotReadAsALimiterName()
+    {
+        $processor = new Processor();
+        $config = $processor->processConfiguration(new Configuration(true), [[
+            // no "limiters" key: the shorthand below would otherwise read "builder" as a limiter name
+            'rate_limiter' => [
+                'builder' => ['cache_pool' => 'my.pool'],
+            ],
+        ]]);
+
+        $this->assertSame([], $config['rate_limiter']['limiters']);
+        $this->assertSame('my.pool', $config['rate_limiter']['builder']['cache_pool']);
+    }
+
+    public function testRateLimiterBuilderCanBeConfiguredAlongsideLimiters()
+    {
+        $processor = new Processor();
+        $config = $processor->processConfiguration(new Configuration(true), [[
+            'rate_limiter' => [
+                'limiters' => ['foo' => ['policy' => 'fixed_window', 'limit' => 5, 'interval' => '1 minute']],
+                'builder' => ['cache_pool' => 'my.pool'],
+            ],
+        ]]);
+
+        $this->assertSame(['foo'], array_keys($config['rate_limiter']['limiters']));
+        $this->assertSame('my.pool', $config['rate_limiter']['builder']['cache_pool']);
+    }
+
     public function testTranslatorProviderDomainsCanBeKeyed()
     {
         $processor = new Processor();
@@ -1334,6 +1362,11 @@ class ConfigurationTest extends TestCase
             'rate_limiter' => [
                 'enabled' => !class_exists(FullStack::class) && class_exists(TokenBucketLimiter::class),
                 'limiters' => [],
+                'builder' => [
+                    'lock_factory' => 'auto',
+                    'cache_pool' => 'cache.rate_limiter',
+                    'storage_service' => null,
+                ],
             ],
             'uid' => [
                 'enabled' => !class_exists(FullStack::class) && class_exists(UuidFactory::class),

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/PhpFrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/PhpFrameworkExtensionTest.php
@@ -24,6 +24,7 @@ use Symfony\Component\Mailer\Bridge\Brevo\Webhook\BrevoRequestParser;
 use Symfony\Component\Mailer\Bridge\Postmark\Webhook\PostmarkRequestParser;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 use Symfony\Component\RateLimiter\CompoundRateLimiterFactory;
+use Symfony\Component\RateLimiter\RateLimiterBuilder;
 use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Workflow\Definition;
@@ -533,6 +534,134 @@ class PhpFrameworkExtensionTest extends FrameworkExtensionTestCase
             [...PostmarkRequestParser::PROVIDER_IPS, '127.0.0.1'],
             $container->getDefinition('mailer.webhook.request_parser.postmark')->getArgument('$allowedIPs')
         );
+    }
+
+    public function testRateLimiterBuilderDefault()
+    {
+        if (!class_exists(RateLimiterBuilder::class)) {
+            $this->markTestSkipped('RateLimiterBuilder is not available.');
+        }
+
+        $container = $this->createContainerFromClosure(static function (ContainerBuilder $container) {
+            $container->loadFromExtension('framework', [
+                'rate_limiter' => true,
+            ]);
+        });
+
+        $this->assertSame('cache.rate_limiter', (string) $container->getDefinition('limiter_builder.storage')->getArgument(0));
+
+        $builder = $container->getDefinition('limiter_builder');
+        $this->assertSame('limiter_builder.storage', (string) $builder->getArgument(0));
+        $this->assertNull($builder->getArgument(1));
+
+        $this->assertSame('limiter_builder', (string) $container->getAlias(RateLimiterBuilder::class));
+    }
+
+    public function testRateLimiterBuilderDefaultWithLock()
+    {
+        if (!class_exists(RateLimiterBuilder::class)) {
+            $this->markTestSkipped('RateLimiterBuilder is not available.');
+        }
+
+        $container = $this->createContainerFromClosure(static function (ContainerBuilder $container) {
+            $container->loadFromExtension('framework', [
+                'lock' => true,
+                'rate_limiter' => true,
+            ]);
+        });
+
+        $builder = $container->getDefinition('limiter_builder');
+        $this->assertSame('lock.factory', (string) $builder->getArgument(1));
+    }
+
+    public function testRateLimiterBuilderWithCustomCachePool()
+    {
+        if (!class_exists(RateLimiterBuilder::class)) {
+            $this->markTestSkipped('RateLimiterBuilder is not available.');
+        }
+
+        $container = $this->createContainerFromClosure(static function (ContainerBuilder $container) {
+            $container->loadFromExtension('framework', [
+                'rate_limiter' => [
+                    'builder' => ['cache_pool' => 'cache.app'],
+                ],
+            ]);
+        });
+
+        $this->assertSame('cache.app', (string) $container->getDefinition('limiter_builder.storage')->getArgument(0));
+        $this->assertSame('limiter_builder.storage', (string) $container->getDefinition('limiter_builder')->getArgument(0));
+    }
+
+    public function testRateLimiterBuilderWithCustomStorageService()
+    {
+        if (!class_exists(RateLimiterBuilder::class)) {
+            $this->markTestSkipped('RateLimiterBuilder is not available.');
+        }
+
+        $container = $this->createContainerFromClosure(static function (ContainerBuilder $container) {
+            $container->loadFromExtension('framework', [
+                'rate_limiter' => [
+                    'builder' => ['storage_service' => 'my.storage'],
+                ],
+            ]);
+        });
+
+        $this->assertFalse($container->hasDefinition('limiter_builder.storage'));
+        $this->assertSame('my.storage', (string) $container->getDefinition('limiter_builder')->getArgument(0));
+    }
+
+    public function testRateLimiterBuilderWithCustomLockFactory()
+    {
+        if (!class_exists(RateLimiterBuilder::class)) {
+            $this->markTestSkipped('RateLimiterBuilder is not available.');
+        }
+
+        $container = $this->createContainerFromClosure(static function (ContainerBuilder $container) {
+            $container->loadFromExtension('framework', [
+                'lock' => true,
+                'rate_limiter' => [
+                    'builder' => ['lock_factory' => 'my.lock_factory'],
+                ],
+            ]);
+        });
+
+        $this->assertSame('my.lock_factory', (string) $container->getDefinition('limiter_builder')->getArgument(1));
+    }
+
+    public function testRateLimiterBuilderLockCanBeDisabledWhileLockIsEnabled()
+    {
+        if (!class_exists(RateLimiterBuilder::class)) {
+            $this->markTestSkipped('RateLimiterBuilder is not available.');
+        }
+
+        $container = $this->createContainerFromClosure(static function (ContainerBuilder $container) {
+            $container->loadFromExtension('framework', [
+                'lock' => true,
+                'rate_limiter' => [
+                    'builder' => ['lock_factory' => null],
+                ],
+            ]);
+        });
+
+        $this->assertNull($container->getDefinition('limiter_builder')->getArgument(1));
+    }
+
+    public function testRateLimiterBuilderThrowsWhenLockIsNotConfigured()
+    {
+        if (!class_exists(RateLimiterBuilder::class)) {
+            $this->markTestSkipped('RateLimiterBuilder is not available.');
+        }
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Rate Limiter Builder requires the Lock component to be configured.');
+
+        $this->createContainerFromClosure(static function (ContainerBuilder $container) {
+            $container->loadFromExtension('framework', [
+                'rate_limiter' => [
+                    'builder' => ['lock_factory' => 'lock.factory'],
+                ],
+            ]);
+        });
     }
 }
 

--- a/src/Symfony/Component/RateLimiter/CHANGELOG.md
+++ b/src/Symfony/Component/RateLimiter/CHANGELOG.md
@@ -5,6 +5,8 @@ CHANGELOG
 ---
 
  * Add `RateLimitExceededEvent`
+ * Add `RateLimiterBuilder`
+ * Allow `\DateInterval` for the `interval` and `rate.interval` options of `RateLimiterFactory`
 
 8.1
 ---

--- a/src/Symfony/Component/RateLimiter/RateLimiterBuilder.php
+++ b/src/Symfony/Component/RateLimiter/RateLimiterBuilder.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\RateLimiter;
+
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\RateLimiter\Storage\StorageInterface;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class RateLimiterBuilder
+{
+    public function __construct(
+        private StorageInterface $storage,
+        private ?LockFactory $lockFactory = null,
+    ) {
+    }
+
+    /**
+     * @param string               $id       Unique identifier for the rate limiter
+     * @param int                  $limit    Maximum allowed hits for the passed interval
+     * @param \DateInterval|string $interval If string, must be a number followed by "second",
+     *                                       "minute", "hour", "day", "week" or "month" (or their
+     *                                       plural equivalent)
+     */
+    public function slidingWindow(string $id, int $limit, \DateInterval|string $interval): RateLimiterFactoryInterface
+    {
+        return $this->factory([
+            'id' => $id,
+            'policy' => 'sliding_window',
+            'limit' => $limit,
+            'interval' => $interval,
+        ]);
+    }
+
+    /**
+     * @param string                         $id       Unique identifier for the rate limiter
+     * @param int                            $limit    Maximum allowed hits for the passed interval
+     * @param \DateInterval|string           $interval If string, must be a number followed by "second",
+     *                                                 "minute", "hour", "day", "week" or "month" (or their
+     *                                                 plural equivalent)
+     * @param \DateTimeInterface|string|null $anchorAt Align the window to a calendar starting at this datetime
+     *                                                 instead of the first hit; requires an "$interval" of at
+     *                                                 least one month. Timezone-less strings are parsed as UTC.
+     */
+    public function fixedWindow(string $id, int $limit, \DateInterval|string $interval, \DateTimeInterface|string|null $anchorAt = null): RateLimiterFactoryInterface
+    {
+        return $this->factory([
+            'id' => $id,
+            'policy' => 'fixed_window',
+            'limit' => $limit,
+            'interval' => $interval,
+            'anchor_at' => $anchorAt,
+        ]);
+    }
+
+    /**
+     * @param string               $id       Unique identifier for the rate limiter
+     * @param int                  $limit    Maximum allowed hits in a burst
+     * @param \DateInterval|string $interval Interval at which "$amount" tokens are added back
+     * @param int                  $amount   Number of tokens added back per "$interval"
+     */
+    public function tokenBucket(string $id, int $limit, \DateInterval|string $interval, int $amount = 1): RateLimiterFactoryInterface
+    {
+        return $this->factory([
+            'id' => $id,
+            'policy' => 'token_bucket',
+            'limit' => $limit,
+            'rate' => [
+                'interval' => $interval,
+                'amount' => $amount,
+            ],
+        ]);
+    }
+
+    public function compound(RateLimiterFactoryInterface ...$factories): RateLimiterFactoryInterface
+    {
+        return new CompoundRateLimiterFactory($factories);
+    }
+
+    public function noop(): RateLimiterFactoryInterface
+    {
+        return $this->factory([
+            'id' => 'noop',
+            'policy' => 'no_limit',
+        ]);
+    }
+
+    private function factory(array $config): RateLimiterFactory
+    {
+        return new RateLimiterFactory($config, $this->storage, $this->lockFactory);
+    }
+}

--- a/src/Symfony/Component/RateLimiter/RateLimiterFactory.php
+++ b/src/Symfony/Component/RateLimiter/RateLimiterFactory.php
@@ -41,6 +41,10 @@ final class RateLimiterFactory implements RateLimiterFactoryInterface
 
     public function create(?string $key = null): LimiterInterface
     {
+        if ('no_limit' === $this->config['policy']) {
+            return new NoLimiter();
+        }
+
         $id = $this->config['id'].'-'.$key;
         $lock = $this->lockFactory?->createLock($id);
 
@@ -48,14 +52,17 @@ final class RateLimiterFactory implements RateLimiterFactoryInterface
             'token_bucket' => new TokenBucketLimiter($id, $this->config['limit'], $this->config['rate'], $this->storage, $lock),
             'fixed_window' => new FixedWindowLimiter($id, $this->config['limit'], $this->config['interval'], $this->storage, $lock, $this->config['anchor_at']),
             'sliding_window' => new SlidingWindowLimiter($id, $this->config['limit'], $this->config['interval'], $this->storage, $lock),
-            'no_limit' => new NoLimiter(),
             default => throw new \LogicException(\sprintf('Limiter policy "%s" does not exists, it must be either "token_bucket", "sliding_window", "fixed_window" or "no_limit".', $this->config['policy'])),
         };
     }
 
     private static function configureOptions(OptionsResolver $options): void
     {
-        $intervalNormalizer = static function (Options $options, string $interval): \DateInterval {
+        $intervalNormalizer = static function (Options $options, \DateInterval|string $interval): \DateInterval {
+            if ($interval instanceof \DateInterval) {
+                return $interval;
+            }
+
             // Create DateTimeImmutable from unix timestamp, so the default timezone is ignored and we don't need to
             // deal with quirks happening when modifying dates using a timezone with DST.
             $now = \DateTimeImmutable::createFromFormat('U', (string) time());
@@ -80,12 +87,12 @@ final class RateLimiterFactory implements RateLimiterFactoryInterface
                 ->allowedValues('token_bucket', 'fixed_window', 'sliding_window', 'no_limit')
 
             ->define('limit')->allowedTypes('int')
-            ->define('interval')->allowedTypes('string')->normalize($intervalNormalizer)
+            ->define('interval')->allowedTypes('string', \DateInterval::class)->normalize($intervalNormalizer)
             ->define('rate')
                 ->options(static function (OptionsResolver $rate) use ($intervalNormalizer) {
                     $rate
                         ->define('amount')->allowedTypes('int')->default(1)
-                        ->define('interval')->allowedTypes('string')->normalize($intervalNormalizer)
+                        ->define('interval')->allowedTypes('string', \DateInterval::class)->normalize($intervalNormalizer)
                     ;
                 })
                 ->normalize(static function (Options $options, $value) {

--- a/src/Symfony/Component/RateLimiter/Tests/RateLimiterBuilderTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/RateLimiterBuilderTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\RateLimiter\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\Store\InMemoryStore;
+use Symfony\Component\RateLimiter\CompoundLimiter;
+use Symfony\Component\RateLimiter\CompoundRateLimiterFactory;
+use Symfony\Component\RateLimiter\Policy\FixedWindowLimiter;
+use Symfony\Component\RateLimiter\Policy\NoLimiter;
+use Symfony\Component\RateLimiter\Policy\SlidingWindowLimiter;
+use Symfony\Component\RateLimiter\Policy\TokenBucketLimiter;
+use Symfony\Component\RateLimiter\RateLimiterBuilder;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
+use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
+
+class RateLimiterBuilderTest extends TestCase
+{
+    public function testCreateMethodsReturnFactories()
+    {
+        $builder = new RateLimiterBuilder(new InMemoryStorage());
+
+        $this->assertInstanceOf(RateLimiterFactoryInterface::class, $builder->slidingWindow('foo', 5, '1 minute'));
+        $this->assertInstanceOf(RateLimiterFactoryInterface::class, $builder->fixedWindow('foo', 5, '1 minute'));
+        $this->assertInstanceOf(RateLimiterFactoryInterface::class, $builder->tokenBucket('foo', 5, '1 hour', 2));
+        $this->assertInstanceOf(RateLimiterFactoryInterface::class, $builder->noop());
+        $this->assertInstanceOf(CompoundRateLimiterFactory::class, $builder->compound($builder->noop()));
+    }
+
+    public function testFactoriesCreateExpectedLimiters()
+    {
+        $builder = new RateLimiterBuilder(new InMemoryStorage());
+
+        $this->assertInstanceOf(SlidingWindowLimiter::class, $builder->slidingWindow('foo', 5, '1 minute')->create());
+        $this->assertInstanceOf(FixedWindowLimiter::class, $builder->fixedWindow('foo', 5, '1 minute')->create());
+        $this->assertInstanceOf(TokenBucketLimiter::class, $builder->tokenBucket('foo', 5, '1 hour', 2)->create());
+        $this->assertInstanceOf(NoLimiter::class, $builder->noop()->create());
+        $this->assertInstanceOf(CompoundLimiter::class, $builder->compound($builder->noop())->create());
+    }
+
+    public function testAcceptsDateInterval()
+    {
+        $builder = new RateLimiterBuilder(new InMemoryStorage());
+        $interval = new \DateInterval('PT1M');
+
+        $this->assertInstanceOf(SlidingWindowLimiter::class, $builder->slidingWindow('foo', 5, $interval)->create());
+        $this->assertInstanceOf(FixedWindowLimiter::class, $builder->fixedWindow('foo', 5, $interval)->create());
+        $this->assertInstanceOf(TokenBucketLimiter::class, $builder->tokenBucket('foo', 5, $interval)->create());
+    }
+
+    #[DataProvider('anchorProvider')]
+    public function testFixedWindowCanBeAnchoredToACalendar(\DateTimeInterface|string $anchorAt)
+    {
+        $builder = new RateLimiterBuilder(new InMemoryStorage());
+        $limiter = $builder->fixedWindow('foo', 2, '1 month', $anchorAt)->create('key');
+        $limiter->consume(2);
+
+        // the window resets on the calendar boundary, not one month after the first hit
+        $this->assertSame('01 00:00:00', $limiter->consume()->getRetryAfter()->format('d H:i:s'));
+    }
+
+    public static function anchorProvider()
+    {
+        yield 'string' => ['2024-01-01 00:00:00'];
+        yield 'DateTimeImmutable' => [new \DateTimeImmutable('2024-01-01 00:00:00')];
+    }
+
+    public function testLockIsCreatedPerKey()
+    {
+        $lockFactory = new LockFactory(new InMemoryStore());
+        $builder = new RateLimiterBuilder(new InMemoryStorage(), $lockFactory);
+        $factory = $builder->slidingWindow('foo', 5, '1 minute');
+
+        $first = $factory->create('a');
+        $first->consume();
+
+        // a second key must not contend with the first one's lock
+        $factory->create('b')->consume();
+
+        $this->assertInstanceOf(SlidingWindowLimiter::class, $first);
+    }
+}

--- a/src/Symfony/Component/RateLimiter/Tests/RateLimiterFactoryTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/RateLimiterFactoryTest.php
@@ -66,6 +66,26 @@ class RateLimiterFactoryTest extends TestCase
             'policy' => 'no_limit',
             'id' => 'test',
         ]];
+        yield 'fixed_window with a DateInterval' => [FixedWindowLimiter::class, [
+            'policy' => 'fixed_window',
+            'id' => 'test',
+            'limit' => 5,
+            'interval' => new \DateInterval('PT5S'),
+        ]];
+        yield 'sliding_window with a DateInterval' => [SlidingWindowLimiter::class, [
+            'policy' => 'sliding_window',
+            'id' => 'test',
+            'limit' => 5,
+            'interval' => new \DateInterval('PT5S'),
+        ]];
+        yield 'token_bucket with a DateInterval' => [TokenBucketLimiter::class, [
+            'policy' => 'token_bucket',
+            'id' => 'test',
+            'limit' => 5,
+            'rate' => [
+                'interval' => new \DateInterval('PT5S'),
+            ],
+        ]];
     }
 
     #[DataProvider('invalidConfigProvider')]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony/issues/51401#issuecomment-2754958638
| License       | MIT

Configuring a rate limiter today means one `framework.rate_limiter.limiters` entry per limiter, each injected individually. When a service needs many one-off limiters, or when the limits are only known at runtime, that does not fit. `RateLimiterBuilder` closes the gap: inject one service and build limiter factories on the fly.

```php
use Symfony\Component\RateLimiter\RateLimiterBuilder;

class ApiController extends AbstractController
{
    public function registerUser(Request $request, RateLimiterBuilder $limiterBuilder): Response
    {
        $limiter = $limiterBuilder
            ->slidingWindow(id: 'register', limit: 10, interval: '10 minutes')
            ->create($request->getClientIp());

        // ...
    }
}
```

Every method returns a `RateLimiterFactoryInterface`, so `create($key)` stays the single entry point and the per-key lock comes from the factory, exactly as for configured limiters:

- `slidingWindow(string $id, int $limit, \DateInterval|string $interval)`
- `fixedWindow(string $id, int $limit, \DateInterval|string $interval, \DateTimeInterface|string|null $anchorAt = null)`, where `$anchorAt` aligns the window to a calendar instead of the first hit
- `tokenBucket(string $id, int $limit, \DateInterval|string $interval, int $amount = 1)`
- `compound(RateLimiterFactoryInterface ...$factories)`
- `noop()`, a factory of `NoLimiter`, to disable limiting conditionally

String intervals accept the same units as the configuration (`'10 minutes'`, ...). `\DateInterval` is accepted too; that also works for the `interval` and `rate.interval` options of `RateLimiterFactory` itself now.

FrameworkBundle registers the `limiter_builder` service when the RateLimiter component is installed and `framework.rate_limiter` is enabled, autowirable by class name. Configuration, all optional:

```yaml
framework:
    rate_limiter:
        builder:
            lock_factory: auto      # "auto" uses lock.factory when framework.lock is enabled; null disables locking
            cache_pool: cache.rate_limiter
            storage_service: null   # a StorageInterface service id; takes precedence over cache_pool
```

Points for the documentation:
- the `$id` is the storage namespace: two limiters built with the same id and storage share their state, which also allows sharing state with a configured limiter on purpose;
- state lives in the `cache.rate_limiter` pool by default, like configured limiters;
- in the shorthand syntax (`rate_limiter: { name: {...} }`), `builder` is a reserved key; a limiter named `builder` needs the explicit `limiters:` form.
