### PR TITLE
[Security] improve VoteObject adding extraData for give more possibilities to AccessDecicsionStrategy

### DIFF
--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -89,6 +89,7 @@ Security
  * Deprecate `AbstractListener::__invoke`
  * Deprecate `LazyFirewallContext::__invoke()`
  * Deprecate `PersistentTokenInterface::getClass()` and `RememberMeDetails::getUserFqcn()`, the user FQCN will be removed from the remember-me cookie in 8.0
+ * Add argument `$accessDecision` to `AccessDecisionStrategyInterface::decide()`;
 
 Serializer
 ----------

--- a/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
@@ -71,7 +71,8 @@ final class AccessDecisionManager implements AccessDecisionManagerInterface
 
         try {
             return $accessDecision->isGranted = $this->strategy->decide(
-                $this->collectResults($token, $attributes, $object, $accessDecision)
+                $this->collectResults($token, $attributes, $object, $accessDecision),
+                $accessDecision,
             );
         } finally {
             array_pop($this->accessDecisionStack);

--- a/src/Symfony/Component/Security/Core/Authorization/Strategy/AccessDecisionStrategyInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Strategy/AccessDecisionStrategyInterface.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Security\Core\Authorization\Strategy;
 
+use Symfony\Component\Security\Core\Authorization\AccessDecision;
+
 /**
  * A strategy for turning a stream of votes into a final decision.
  *
@@ -20,6 +22,7 @@ interface AccessDecisionStrategyInterface
 {
     /**
      * @param \Traversable<int> $results
+     * @param ?AccessDecision   $accessDecision
      */
-    public function decide(\Traversable $results): bool;
+    public function decide(\Traversable $results/* , ?AccessDecision $accessDecision = null */): bool;
 }

--- a/src/Symfony/Component/Security/Core/Authorization/Strategy/AffirmativeStrategy.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Strategy/AffirmativeStrategy.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Security\Core\Authorization\Strategy;
 
+use Symfony\Component\Security\Core\Authorization\AccessDecision;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
 /**
@@ -29,7 +30,7 @@ final class AffirmativeStrategy implements AccessDecisionStrategyInterface, \Str
     ) {
     }
 
-    public function decide(\Traversable $results): bool
+    public function decide(\Traversable $results, ?AccessDecision $accessDecision = null): bool
     {
         $deny = 0;
         foreach ($results as $result) {

--- a/src/Symfony/Component/Security/Core/Authorization/Strategy/ConsensusStrategy.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Strategy/ConsensusStrategy.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Security\Core\Authorization\Strategy;
 
+use Symfony\Component\Security\Core\Authorization\AccessDecision;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
 /**
@@ -38,7 +39,7 @@ final class ConsensusStrategy implements AccessDecisionStrategyInterface, \Strin
     ) {
     }
 
-    public function decide(\Traversable $results): bool
+    public function decide(\Traversable $results, ?AccessDecision $accessDecision = null): bool
     {
         $grant = 0;
         $deny = 0;

--- a/src/Symfony/Component/Security/Core/Authorization/Strategy/PriorityStrategy.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Strategy/PriorityStrategy.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Security\Core\Authorization\Strategy;
 
+use Symfony\Component\Security\Core\Authorization\AccessDecision;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
 /**
@@ -30,7 +31,7 @@ final class PriorityStrategy implements AccessDecisionStrategyInterface, \String
     ) {
     }
 
-    public function decide(\Traversable $results): bool
+    public function decide(\Traversable $results, ?AccessDecision $accessDecision = null): bool
     {
         foreach ($results as $result) {
             if (VoterInterface::ACCESS_GRANTED === $result) {

--- a/src/Symfony/Component/Security/Core/Authorization/Strategy/UnanimousStrategy.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Strategy/UnanimousStrategy.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Security\Core\Authorization\Strategy;
 
+use Symfony\Component\Security\Core\Authorization\AccessDecision;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
 /**
@@ -29,7 +30,7 @@ final class UnanimousStrategy implements AccessDecisionStrategyInterface, \Strin
     ) {
     }
 
-    public function decide(\Traversable $results): bool
+    public function decide(\Traversable $results, ?AccessDecision $accessDecision = null): bool
     {
         $grant = 0;
         foreach ($results as $result) {

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/Vote.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/Vote.php
@@ -28,6 +28,11 @@ class Vote
      */
     public array $reasons = [];
 
+    /**
+     * @var array<string, mixed>
+     */
+    public array $extraData = [];
+
     public function addReason(string $reason): void
     {
         $this->reasons[] = $reason;

--- a/src/Symfony/Component/Security/Core/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Core/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 
  * Add `MermaidDumper` to dump Role Hierarchy graphs in the Mermaid.js flowchart format
  * Deprecate `PersistentTokenInterface::getClass()`, the user class will be removed from the remember-me cookie in 8.0
+ * Add `extraData` property to `Vote` objects
+ * Add argument `$accessDecision` to `AccessDecisionStrategyInterface`
 
 7.3
 ---

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/AccessDecisionManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/AccessDecisionManagerTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Security\Core\Tests\Authorization;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecision;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManager;
 use Symfony\Component\Security\Core\Authorization\Strategy\AccessDecisionStrategyInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\CacheableVoterInterface;
@@ -40,7 +41,7 @@ class AccessDecisionManagerTest extends TestCase
         ];
 
         $strategy = new class implements AccessDecisionStrategyInterface {
-            public function decide(\Traversable $results): bool
+            public function decide(\Traversable $results, ?AccessDecision $accessDecision = null): bool
             {
                 $i = 0;
                 foreach ($results as $result) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

In continuation of https://github.com/symfony/symfony/pull/58107 and https://github.com/symfony/symfony/pull/59771, add ExtraData in VoteObject and pass it to AccessDecicsionStrategy Object to allow the decision to be refined.

ExtraData can be an array or an object, and AccessDecicsionStrategy can get it to get the final decision.

In 7.2, voter can only respond abstain / allow or deny, but what if we want more choices, per example a ponderable vote ? 

With this PR, it allow to put somme data in the new VoteObject as : 

```php
/** ScoreData.php */

/** MyVoter.php */

    public function vote(TokenInterface $token, mixed $subject, array $attributes, ?Vote $vote = null) : int
    {
        $vote->result = 1;
        $vote->reasons[] = 'is Admin';
        $vote->extraData['score'] = 10;

        return $vote->result;
    }
```
we need also a custom strategy to take this score into account : 

```php
/** MyStrategy.php */

public function decide(\Traversable $results, $accessDecision = null): bool
    {
        $score = 0;

        foreach ($results as $key => $result) {
            $vote = $accessDecision->votes[$key];  // <==

            if(array_key_exists('score', $vote->extraData)) {
                $score += $vote->extraData['score'];
            } else {
                $score += $vote->result;
            }
        }

        $accessDecision->result = $score;

        if ($score > 0) {
            return true;
        }

        if ($score< 0) {
            return false;
        }


        return $this->allowIfAllAbstainDecisions;
    }
```

AccessDecision contains Vote objects and we can read our score from it.