### PR TITLE
[TypeInfo] add TypeFactoryTrait::arrayKey()

### DIFF
--- a/src/Symfony/Component/TypeInfo/CHANGELOG.md
+++ b/src/Symfony/Component/TypeInfo/CHANGELOG.md
@@ -5,7 +5,7 @@ CHANGELOG
 ---
 
  * Add `Type::accepts()` method
- * Add `TypeFactoryTrait::fromValue()` method
+ * Add the `TypeFactoryTrait::fromValue()`, `TypeFactoryTrait::arrayShape()`, and `TypeFactoryTrait::arrayKey()` methods
  * Deprecate constructing a `CollectionType` instance as a list that is not an array
  * Deprecate the third `$asList` argument of `TypeFactoryTrait::iterable()`, use `TypeFactoryTrait::list()` instead
  * Add type alias support in `TypeContext` and `StringTypeResolver`

--- a/src/Symfony/Component/TypeInfo/Tests/Type/ArrayShapeTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/ArrayShapeTypeTest.php
@@ -59,7 +59,7 @@ class ArrayShapeTypeTest extends TestCase
             1 => ['type' => Type::bool(), 'optional' => false],
             'foo' => ['type' => Type::bool(), 'optional' => false],
         ]);
-        $this->assertEquals(Type::union(Type::int(), Type::string()), $type->getCollectionKeyType());
+        $this->assertEquals(Type::arrayKey(), $type->getCollectionKeyType());
     }
 
     public function testGetCollectionValueType()
@@ -134,7 +134,7 @@ class ArrayShapeTypeTest extends TestCase
 
         $type = new ArrayShapeType(
             shape: ['foo' => ['type' => Type::bool()]],
-            extraKeyType: Type::union(Type::int(), Type::string()),
+            extraKeyType: Type::arrayKey(),
             extraValueType: Type::mixed(),
         );
         $this->assertSame("array{'foo': bool, ...}", (string) $type);

--- a/src/Symfony/Component/TypeInfo/Tests/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/CollectionTypeTest.php
@@ -50,7 +50,7 @@ class CollectionTypeTest extends TestCase
     public function testGetCollectionKeyType()
     {
         $type = new CollectionType(Type::builtin(TypeIdentifier::ARRAY));
-        $this->assertEquals(Type::union(Type::int(), Type::string()), $type->getCollectionKeyType());
+        $this->assertEquals(Type::arrayKey(), $type->getCollectionKeyType());
 
         $type = new CollectionType(Type::generic(Type::builtin(TypeIdentifier::ARRAY), Type::bool()));
         $this->assertEquals(Type::int(), $type->getCollectionKeyType());

--- a/src/Symfony/Component/TypeInfo/Tests/TypeFactoryTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeFactoryTest.php
@@ -212,7 +212,7 @@ class TypeFactoryTest extends TestCase
         $this->assertEquals(new ArrayShapeType(['foo' => ['type' => Type::bool(), 'optional' => false]]), Type::arrayShape(['foo' => Type::bool()]));
         $this->assertEquals(new ArrayShapeType(
             shape: ['foo' => ['type' => Type::bool(), 'optional' => false]],
-            extraKeyType: Type::union(Type::int(), Type::string()),
+            extraKeyType: Type::arrayKey(),
             extraValueType: Type::mixed(),
         ), Type::arrayShape(['foo' => Type::bool()], sealed: false));
         $this->assertEquals(new ArrayShapeType(
@@ -220,6 +220,11 @@ class TypeFactoryTest extends TestCase
             extraKeyType: Type::string(),
             extraValueType: Type::bool(),
         ), Type::arrayShape(['foo' => Type::bool()], extraKeyType: Type::string(), extraValueType: Type::bool()));
+    }
+
+    public function testCreateArrayKey()
+    {
+        $this->assertEquals(new UnionType(Type::int(), Type::string()), Type::arrayKey());
     }
 
     /**
@@ -275,7 +280,7 @@ class TypeFactoryTest extends TestCase
         yield [Type::dict(Type::bool()), ['a' => true, 'b' => false]];
         yield [Type::array(Type::string()), [1 => 'foo', 'bar' => 'baz']];
         yield [Type::array(Type::nullable(Type::bool()), Type::int()), [1 => true, 2 => null, 3 => false]];
-        yield [Type::collection(Type::object(\ArrayIterator::class), Type::mixed(), Type::union(Type::int(), Type::string())), new \ArrayIterator()];
+        yield [Type::collection(Type::object(\ArrayIterator::class), Type::mixed(), Type::arrayKey()), new \ArrayIterator()];
         yield [Type::collection(Type::object(\Generator::class), Type::string(), Type::int()), (fn (): iterable => yield 'string')()];
         yield [Type::collection(Type::object($arrayAccess::class)), $arrayAccess];
     }

--- a/src/Symfony/Component/TypeInfo/Tests/TypeResolver/StringTypeResolverTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeResolver/StringTypeResolverTest.php
@@ -137,7 +137,7 @@ class StringTypeResolverTest extends TestCase
         yield [Type::never(), 'never-return'];
         yield [Type::never(), 'never-returns'];
         yield [Type::never(), 'no-return'];
-        yield [Type::union(Type::int(), Type::string()), 'array-key'];
+        yield [Type::arrayKey(), 'array-key'];
         yield [Type::union(Type::int(), Type::float(), Type::string(), Type::bool()), 'scalar'];
         yield [Type::union(Type::int(), Type::float()), 'number'];
         yield [Type::union(Type::int(), Type::float(), Type::string()), 'numeric'];

--- a/src/Symfony/Component/TypeInfo/Type/ArrayShapeType.php
+++ b/src/Symfony/Component/TypeInfo/Type/ArrayShapeType.php
@@ -49,7 +49,7 @@ final class ArrayShapeType extends CollectionType
             $keyTypes = array_values(array_unique($keyTypes));
             $keyType = \count($keyTypes) > 1 ? self::union(...$keyTypes) : $keyTypes[0];
         } else {
-            $keyType = Type::union(Type::int(), Type::string());
+            $keyType = Type::arrayKey();
         }
 
         $valueType = $valueTypes ? CollectionType::mergeCollectionValueTypes($valueTypes) : Type::mixed();

--- a/src/Symfony/Component/TypeInfo/Type/CollectionType.php
+++ b/src/Symfony/Component/TypeInfo/Type/CollectionType.php
@@ -117,7 +117,7 @@ class CollectionType extends Type implements WrappingTypeInterface
 
     public function getCollectionKeyType(): Type
     {
-        $defaultCollectionKeyType = self::union(self::int(), self::string());
+        $defaultCollectionKeyType = self::arrayKey();
 
         if ($this->type instanceof GenericType) {
             return match (\count($this->type->getVariableTypes())) {

--- a/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
+++ b/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
@@ -153,7 +153,7 @@ trait TypeFactoryTrait
     public static function collection(BuiltinType|ObjectType|GenericType $type, ?Type $value = null, ?Type $key = null, bool $asList = false): CollectionType
     {
         if (!$type instanceof GenericType && (null !== $value || null !== $key)) {
-            $type = self::generic($type, $key ?? self::union(self::int(), self::string()), $value ?? self::mixed());
+            $type = self::generic($type, $key ?? self::arrayKey(), $value ?? self::mixed());
         }
 
         return new CollectionType($type, $asList);
@@ -210,10 +210,15 @@ trait TypeFactoryTrait
             $sealed = false;
         }
 
-        $extraKeyType ??= !$sealed ? Type::union(Type::int(), Type::string()) : null;
+        $extraKeyType ??= !$sealed ? Type::arrayKey() : null;
         $extraValueType ??= !$sealed ? Type::mixed() : null;
 
         return new ArrayShapeType($shape, $extraKeyType, $extraValueType);
+    }
+
+    public static function arrayKey(): UnionType
+    {
+        return self::union(self::int(), self::string());
     }
 
     /**
@@ -434,7 +439,7 @@ trait TypeFactoryTrait
                 $keyTypes = array_values(array_unique($keyTypes));
                 $keyType = \count($keyTypes) > 1 ? self::union(...$keyTypes) : $keyTypes[0];
             } else {
-                $keyType = Type::union(Type::int(), Type::string());
+                $keyType = Type::arrayKey();
             }
 
             $valueType = $valueTypes ? CollectionType::mergeCollectionValueTypes($valueTypes) : Type::mixed();

--- a/src/Symfony/Component/TypeInfo/TypeResolver/StringTypeResolver.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/StringTypeResolver.php
@@ -171,7 +171,7 @@ final class StringTypeResolver implements TypeResolverInterface
                 'iterable' => Type::iterable(),
                 'mixed' => Type::mixed(),
                 'null' => Type::null(),
-                'array-key' => Type::union(Type::int(), Type::string()),
+                'array-key' => Type::arrayKey(),
                 'scalar' => Type::union(Type::int(), Type::float(), Type::string(), Type::bool()),
                 'number' => Type::union(Type::int(), Type::float()),
                 'numeric' => Type::union(Type::int(), Type::float(), Type::string()),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

reading the latest PRs about array shapes I wondered if it wouldn't be useful to have a dedicated method for the array key types supported by PHP
