### PR TITLE
[DoctrineBridge] fix tests with Doctrine ORM 3.4+ on PHP < 8.4

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/SingleIntIdEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/SingleIntIdEntity.php
@@ -16,7 +16,7 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\Id;
 
-#[Entity]
+#[Entity(repositoryClass: SingleIntIdEntityRepository::class)]
 class SingleIntIdEntity
 {
     #[Column(type: Types::JSON, nullable: true)]

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/SingleIntIdEntityRepository.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/SingleIntIdEntityRepository.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
+
+use Doctrine\ORM\EntityRepository;
+
+class SingleIntIdEntityRepository extends EntityRepository
+{
+    public $result = null;
+
+    public function findByCustom()
+    {
+        return $this->result;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

The solution implemented in #59887 does no longer work on PHP < 8.4 with the changes made in doctrine/orm#11853.