### PR TITLE
[FrameworkBundle][Serializer] Allow setting `$objectClassResolver` via configuration

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -21,6 +21,7 @@ CHANGELOG
  * Allow configuring the logging channel per type of exceptions
  * Enable service argument resolution on classes that use the `#[Route]` attribute,
    the `#[AsController]` attribute is no longer required
+ * Add `framework.serializer.object_class_resolver` option
 
 7.2
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1172,6 +1172,13 @@ class Configuration implements ConfigurationInterface
                 ->defaultValue([])
                 ->prototype('variable')->end()
         ;
+        $objectClassResolver = fn () => (new NodeBuilder())
+            ->variableNode('object_class_resolver')
+                ->validate()
+                    ->ifTrue(fn ($v) => !\is_string($v) && !\is_callable($v))
+                    ->thenInvalid('The "object_class_resolver" parameter must be a string or a callable.')
+                ->end()
+        ;
 
         $rootNode
             ->children()
@@ -1182,6 +1189,7 @@ class Configuration implements ConfigurationInterface
                     ->children()
                         ->booleanNode('enable_attributes')->{class_exists(FullStack::class) ? 'defaultFalse' : 'defaultTrue'}()->end()
                         ->scalarNode('name_converter')->end()
+                        ->append($objectClassResolver())
                         ->scalarNode('circular_reference_handler')->end()
                         ->scalarNode('max_depth_handler')->end()
                         ->arrayNode('mapping')
@@ -1199,6 +1207,7 @@ class Configuration implements ConfigurationInterface
                             ->arrayPrototype()
                                 ->children()
                                     ->scalarNode('name_converter')->end()
+                                    ->append($objectClassResolver())
                                     ->append($defaultContextNode())
                                     ->booleanNode('include_built_in_normalizers')
                                         ->info('Whether to include the built-in normalizers')

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2070,6 +2070,10 @@ class FrameworkExtension extends Extension
             $container->setParameter('serializer.default_context', $defaultContext);
         }
 
+        if ($config['object_class_resolver'] ?? false) {
+            $container->setParameter('.serializer.object_class_resolver', $config['object_class_resolver']);
+        }
+
         if ($config['circular_reference_handler'] ?? false) {
             $container->setParameter('.serializer.circular_reference_handler', $config['circular_reference_handler']);
         }

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Register `NormalizerInterface` and `DenormalizerInterface` aliases for named serializers
  * Add `NumberNormalizer` to normalize `BcMath\Number` and `GMP` as `string`
  * Add `defaultType` to `DiscriminatorMap`
+ * Support setting `$objectClassResolver` via `SerializerPass`
 
 7.2
 ---

--- a/src/Symfony/Component/Serializer/DependencyInjection/SerializerPass.php
+++ b/src/Symfony/Component/Serializer/DependencyInjection/SerializerPass.php
@@ -19,6 +19,7 @@ use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Serializer\Debug\TraceableEncoder;
 use Symfony\Component\Serializer\Debug\TraceableNormalizer;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
@@ -73,6 +74,10 @@ class SerializerPass implements CompilerPassInterface
             ? $container->getParameter('.serializer.max_depth_handler') : null;
 
         $this->bindDefaultContext($container, array_merge($normalizers, $encoders), $defaultContext, $circularReferenceHandler, $maxDepthHandler);
+
+        if ($container->hasParameter('.serializer.object_class_resolver')) {
+            $this->setObjectClassResolver($container, $normalizers, $container->getParameter('.serializer.object_class_resolver'));
+        }
 
         $this->configureSerializer($container, 'serializer', $normalizers, $encoders, 'default');
 
@@ -130,6 +135,23 @@ class SerializerPass implements CompilerPassInterface
         }
     }
 
+    private function setObjectClassResolver(ContainerBuilder $container, array $services, string|callable $objectClassResolver): void
+    {
+        foreach ($services as $id) {
+            $definition = $container->getDefinition((string) $id);
+
+            if (!is_a($definition->getClass(), AbstractObjectNormalizer::class, true)) {
+                continue;
+            }
+
+            if (!\is_callable($objectClassResolver)) {
+                $objectClassResolver = new Reference($objectClassResolver);
+            }
+
+            $definition->setArgument('$objectClassResolver', $objectClassResolver);
+        }
+    }
+
     private function configureSerializer(ContainerBuilder $container, string $id, array $normalizers, array $encoders, string $serializerName): void
     {
         if ($container->getParameter('kernel.debug') && $container->hasDefinition('serializer.data_collector')) {
@@ -174,6 +196,10 @@ class SerializerPass implements CompilerPassInterface
             $encoders = $this->buildChildDefinitions($container, $serializerName, $encoders, $config);
 
             $this->bindDefaultContext($container, array_merge($normalizers, $encoders), $config['default_context'], $circularReferenceHandler, $maxDepthHandler);
+
+            if ($config['object_class_resolver'] ?? false) {
+                $this->setObjectClassResolver($container, $normalizers, $config['object_class_resolver']);
+            }
 
             $container->registerChild($serializerId, 'serializer')->setArgument('$defaultContext', $config['default_context']);
             $container->registerAliasForArgument($serializerId, SerializerInterface::class, $serializerName.'.serializer');

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -1052,7 +1052,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
      */
     private function isMaxDepthReached(array $attributesMetadata, string $class, string $attribute, array &$context): bool
     {
-        if (!($enableMaxDepth = $context[self::ENABLE_MAX_DEPTH] ?? $this->defaultContext[self::ENABLE_MAX_DEPTH] ?? false)
+        if (!($context[self::ENABLE_MAX_DEPTH] ?? $this->defaultContext[self::ENABLE_MAX_DEPTH] ?? false)
             || !isset($attributesMetadata[$attribute]) || null === $maxDepth = $attributesMetadata[$attribute]?->getMaxDepth()
         ) {
             return false;

--- a/src/Symfony/Component/Serializer/Tests/DependencyInjection/SerializerPassTest.php
+++ b/src/Symfony/Component/Serializer/Tests/DependencyInjection/SerializerPassTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Serializer\Debug\TraceableEncoder;
 use Symfony\Component\Serializer\Debug\TraceableNormalizer;
 use Symfony\Component\Serializer\Debug\TraceableSerializer;
 use Symfony\Component\Serializer\DependencyInjection\SerializerPass;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
@@ -115,8 +116,7 @@ class SerializerPassTest extends TestCase
         $container->setParameter('kernel.debug', false);
         $container->register('serializer')->setArguments([null, null, []]);
         $container->getParameterBag()->add($parameters);
-        $definition = $container->register('serializer.normalizer.object')
-            ->setClass(ObjectNormalizer::class)
+        $definition = $container->register('serializer.normalizer.object', ObjectNormalizer::class)
             ->addTag('serializer.normalizer')
             ->addTag('serializer.encoder')
         ;
@@ -126,6 +126,40 @@ class SerializerPassTest extends TestCase
 
         $bindings = $definition->getBindings();
         $this->assertEquals($bindings['array $defaultContext'], new BoundArgument($context, false));
+    }
+
+    /**
+     * @dataProvider provideSetObjectClassResolverData
+     */
+    public function testSetObjectClassResolver(array $parameters, array $expectedArguments)
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.debug', false);
+        $container->register('serializer')->setArguments([null, null]);
+        $container->getParameterBag()->add($parameters);
+        $definition = $container->register('n1', AbstractObjectNormalizer::class)->addTag('serializer.normalizer')->addTag('serializer.encoder');
+
+        $serializerPass = new SerializerPass();
+        $serializerPass->process($container);
+
+        $this->assertEquals($expectedArguments, $definition->getArguments());
+    }
+
+    public static function provideSetObjectClassResolverData(): iterable
+    {
+        yield [[], []];
+        yield [
+            ['.serializer.object_class_resolver' => 'strlen'],
+            ['$objectClassResolver' => 'strlen'],
+        ];
+        yield [
+            ['.serializer.object_class_resolver' => [self::class, 'provideSetObjectClassResolverData']],
+            ['$objectClassResolver' => [self::class, 'provideSetObjectClassResolverData']],
+        ];
+        yield [
+            ['.serializer.object_class_resolver' => 'my.service'],
+            ['$objectClassResolver' => new Reference('my.service')],
+        ];
     }
 
     public function testNormalizersAndEncodersAreDecoratedAndOrderedWhenCollectingData()
@@ -622,8 +656,7 @@ class SerializerPassTest extends TestCase
 
         $container->register('serializer')->setArguments([null, null, []]);
         $container->getParameterBag()->add($parameters);
-        $container->register('serializer.normalizer.object')
-            ->setClass(ObjectNormalizer::class)
+        $container->register('serializer.normalizer.object', ObjectNormalizer::class)
             ->addTag('serializer.normalizer', ['serializer' => '*'])
             ->addTag('serializer.encoder', ['serializer' => '*'])
         ;
@@ -634,6 +667,30 @@ class SerializerPassTest extends TestCase
         $bindings = $container->getDefinition('serializer.normalizer.object.api')->getBindings();
         $this->assertArrayHasKey('array $defaultContext', $bindings);
         $this->assertEquals($bindings['array $defaultContext'], new BoundArgument($context, false));
+    }
+
+    /**
+     * @dataProvider provideSetObjectClassResolverData
+     */
+    public function testSetObjectClassResolverToNamedSerializers(array $parameters, array $expectedArguments)
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.debug', false);
+        $container->setParameter('.serializer.named_serializers', [
+            'api' => ['object_class_resolver' => $parameters['.serializer.object_class_resolver'] ?? null],
+        ]);
+
+        $container->register('serializer')->setArguments([null, null]);
+        $container->register('n1', AbstractObjectNormalizer::class)
+            ->addTag('serializer.normalizer', ['serializer' => '*'])
+            ->addTag('serializer.encoder', ['serializer' => '*'])
+        ;
+
+        $serializerPass = new SerializerPass();
+        $serializerPass->process($container);
+
+        $definition = $container->getDefinition('n1.api');
+        $this->assertEquals($expectedArguments, $definition->getArguments());
     }
 
     public function testNamedSerializersAreRegistered()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #58526
| License       | MIT

Currently, the `MaxDepth` feature doesn't work correctly with Doctrine proxies because the `isMaxDepthReached` method relies on the object's class:
https://github.com/symfony/symfony/blob/091ae5bd491f73eccc77a937c7f001ed9cbed5c4/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php#L1053-L1075

This class is determined using `get_class()`, which returns a different result for proxy and non-proxy objects:
https://github.com/symfony/symfony/blob/091ae5bd491f73eccc77a937c7f001ed9cbed5c4/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php#L149

Both the `ObjectNormalizer` and `PropertyNormalizer` have a `$objectClassResolver` property, but there is currently no way to configure it.

This PR introduces a new configuration option to set the `$objectClassResolver`. You can provide either a callable or a service:

**Using a callable:**
```yaml
framework:
    serializer:
        object_class_resolver: [ 'Doctrine\ORM\Proxy\DefaultProxyClassNameResolver', 'getClass' ]
```

**Using a service:**
```yaml
services:
    app.object_class_resolver:
        class: Closure
        from_callable: [ !service { class: 'Doctrine\ORM\Proxy\DefaultProxyClassNameResolver' }, 'getClass' ]

framework:
    serializer:
        object_class_resolver: app.object_class_resolver
```
