### PR TITLE
[TwigBridge][Mime] Use content for images attached to emails

### DIFF
--- a/src/Symfony/Bridge/Twig/Mime/WrappedTemplatedEmail.php
+++ b/src/Symfony/Bridge/Twig/Mime/WrappedTemplatedEmail.php
@@ -47,9 +47,10 @@ final class WrappedTemplatedEmail
     {
         $file = $this->twig->getLoader()->getSourceContext($image);
         $body = $file->getPath() ? new File($file->getPath()) : $file->getCode();
-        $this->message->addPart((new DataPart($body, $image, $contentType))->asInline());
+        $part = (new DataPart($body, $image, $contentType))->asInline();
+        $this->message->addPart($part);
 
-        return 'cid:'.$image;
+        return 'cid:'.$part->getContentId();
     }
 
     /**

--- a/src/Symfony/Bridge/Twig/Mime/WrappedTemplatedEmail.php
+++ b/src/Symfony/Bridge/Twig/Mime/WrappedTemplatedEmail.php
@@ -42,12 +42,13 @@ final class WrappedTemplatedEmail
      *                                 some Twig namespace for email images (e.g. '@email/images/logo.png').
      * @param string|null $contentType The media type (i.e. MIME type) of the image file (e.g. 'image/png').
      *                                 Some email clients require this to display embedded images.
+     * @param string|null $name        A custom file name that overrides the original name (filepath) of the image
      */
-    public function image(string $image, ?string $contentType = null): string
+    public function image(string $image, ?string $contentType = null, ?string $name = null): string
     {
         $file = $this->twig->getLoader()->getSourceContext($image);
         $body = $file->getPath() ? new File($file->getPath()) : $file->getCode();
-        $part = (new DataPart($body, $image, $contentType))->asInline();
+        $part = (new DataPart($body, $name ?: $image, $contentType))->asInline();
         $this->message->addPart($part);
 
         return 'cid:'.$part->getContentId();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

I tested this change with local Maildev and a real Postmark API transport.

Instead of referencing a path like `<img src=3D"cid:@assets/img/email-bg.png"` the content ID of the attachment will be used, e.g., `<img src=3D"cid:18ca3e824a76c3d38ac2f1817ad9f6af@symfony"`.