### PR TITLE
[FrameworkBundle][RateLimiter] default `lock_factory` to `auto`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -22,6 +22,7 @@ CHANGELOG
  * Enable service argument resolution on classes that use the `#[Route]` attribute,
    the `#[AsController]` attribute is no longer required
  * Deprecate setting the `framework.profiler.collect_serializer_data` config option to `false`
+ * Set `framework.rate_limiter.limiters.*.lock_factory` to `auto` by default
 
 7.2
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -2504,7 +2504,7 @@ class Configuration implements ConfigurationInterface
                                 ->children()
                                     ->scalarNode('lock_factory')
                                         ->info('The service ID of the lock factory used by this limiter (or null to disable locking).')
-                                        ->defaultValue('lock.factory')
+                                        ->defaultValue('auto')
                                     ->end()
                                     ->scalarNode('cache_pool')
                                         ->info('The cache pool to use for storing the current limiter state.')

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -3239,6 +3239,10 @@ class FrameworkExtension extends Extension
             $limiter = $container->setDefinition($limiterId = 'limiter.'.$name, new ChildDefinition('limiter'))
                 ->addTag('rate_limiter', ['name' => $name]);
 
+            if ('auto' === $limiterConfig['lock_factory']) {
+                $limiterConfig['lock_factory'] = $this->isInitializedConfigEnabled('lock') ? 'lock.factory' : null;
+            }
+
             if (null !== $limiterConfig['lock_factory']) {
                 if (!interface_exists(LockInterface::class)) {
                     throw new LogicException(\sprintf('Rate limiter "%s" requires the Lock component to be installed. Try running "composer require symfony/lock".', $name));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | n/a
| License       | MIT

Currently, when configuring a rate limiter and using the default configured lock factory (`lock.factory`), it fails if `symfony/lock` isn't installed. You have to explicitly set it to `null` if you want to configure rate limiters without the lock component.

This changes the default `lock_factory` to `auto` then, at compile time, sets it to `lock.factory` if `symfony/lock` is installed and `null` if not.
