### PR TITLE
[TypeInfo] Fix composite type unexpected sorting

### DIFF
--- a/src/Symfony/Component/TypeInfo/Tests/Type/IntersectionTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/IntersectionTypeTest.php
@@ -57,12 +57,6 @@ class IntersectionTypeTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
-    public function testSortTypesOnCreation()
-    {
-        $type = new IntersectionType(Type::object(\DateTime::class), Type::object(\Iterator::class), Type::object(\Stringable::class));
-        $this->assertEquals([Type::object(\DateTime::class), Type::object(\Iterator::class), Type::object(\Stringable::class)], $type->getTypes());
-    }
-
     public function testComposedTypesAreSatisfiedBy()
     {
         $type = new IntersectionType(Type::object(\Iterator::class), Type::object(\Stringable::class));

--- a/src/Symfony/Component/TypeInfo/Tests/Type/NullableTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/NullableTypeTest.php
@@ -27,10 +27,10 @@ class NullableTypeTest extends TestCase
     public function testNullPartIsAdded()
     {
         $type = new NullableType(Type::int());
-        $this->assertEquals([Type::int(), Type::null()], $type->getTypes());
+        $this->assertEquals([Type::null(), Type::int()], $type->getTypes());
 
         $type = new NullableType(Type::union(Type::int(), Type::string()));
-        $this->assertEquals([Type::int(), Type::null(), Type::string()], $type->getTypes());
+        $this->assertEquals([Type::null(), Type::int(), Type::string()], $type->getTypes());
     }
 
     public function testWrappedTypeIsSatisfiedBy()

--- a/src/Symfony/Component/TypeInfo/Tests/Type/UnionTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/UnionTypeTest.php
@@ -62,12 +62,6 @@ class UnionTypeTest extends TestCase
         new UnionType(Type::object(), Type::object(\DateTime::class));
     }
 
-    public function testSortTypesOnCreation()
-    {
-        $type = new UnionType(Type::int(), Type::string(), Type::bool());
-        $this->assertEquals([Type::bool(), Type::int(), Type::string()], $type->getTypes());
-    }
-
     public function testComposedTypesAreSatisfiedBy()
     {
         $type = new UnionType(Type::object(\Iterator::class), Type::int());
@@ -80,9 +74,9 @@ class UnionTypeTest extends TestCase
     public function testToString()
     {
         $type = new UnionType(Type::int(), Type::string(), Type::float());
-        $this->assertSame('float|int|string', (string) $type);
+        $this->assertSame('int|string|float', (string) $type);
 
         $type = new UnionType(Type::int(), Type::string(), Type::intersection(Type::object(\DateTime::class), Type::object(\Iterator::class)));
-        $this->assertSame(\sprintf('(%s&%s)|int|string', \DateTime::class, \Iterator::class), (string) $type);
+        $this->assertSame(\sprintf('int|string|(%s&%s)', \DateTime::class, \Iterator::class), (string) $type);
     }
 }

--- a/src/Symfony/Component/TypeInfo/Tests/TypeResolver/ReflectionTypeResolverTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeResolver/ReflectionTypeResolverTest.php
@@ -67,7 +67,7 @@ class ReflectionTypeResolverTest extends TestCase
         yield [Type::nullable(Type::enum(DummyEnum::class)), $reflection->getProperty('nullableEnum')->getType()];
         yield [Type::enum(DummyBackedEnum::class), $reflection->getProperty('backedEnum')->getType()];
         yield [Type::nullable(Type::enum(DummyBackedEnum::class)), $reflection->getProperty('nullableBackedEnum')->getType()];
-        yield [Type::union(Type::int(), Type::string()), $reflection->getProperty('union')->getType()];
+        yield [Type::union(Type::string(), Type::int()), $reflection->getProperty('union')->getType()];
         yield [Type::intersection(Type::object(\Traversable::class), Type::object(\Stringable::class)), $reflection->getProperty('intersection')->getType()];
     }
 

--- a/src/Symfony/Component/TypeInfo/Type/IntersectionType.php
+++ b/src/Symfony/Component/TypeInfo/Type/IntersectionType.php
@@ -52,7 +52,6 @@ final class IntersectionType extends Type implements CompositeTypeInterface
             }
         }
 
-        usort($types, fn (Type $a, Type $b): int => (string) $a <=> (string) $b);
         $this->types = array_values(array_unique($types));
     }
 

--- a/src/Symfony/Component/TypeInfo/Type/UnionType.php
+++ b/src/Symfony/Component/TypeInfo/Type/UnionType.php
@@ -55,7 +55,6 @@ class UnionType extends Type implements CompositeTypeInterface
             }
         }
 
-        usort($types, fn (Type $a, Type $b): int => (string) $a <=> (string) $b);
         $this->types = array_values(array_unique($types));
 
         $builtinTypesIdentifiers = array_map(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60100
| License       | MIT

From the PHP point of view, `int|string` is the very same as `string|int` (https://3v4l.org/HjX3F).
That's why types of composite types (such as `UnionType` and `IntersectionType`) were sorted during the construction.

But even if the order doesn't make any sense from the PHP point of view, some users are relying on it (see the related issue).

This PR only sorts types when a composite type is cast to string. In that way, the comparison will still work, and `getTypes` still returns the initial type order.