### PR TITLE
[HttpFoundation] Add `UriSigner::verify()` that throws named exceptions

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add support for `valkey:` / `valkeys:` schemes for sessions
  * `Request::getPreferredLanguage()` now favors a more preferred language above exactly matching a locale
  * Allow `UriSigner` to use a `ClockInterface`
+ * Add `UriSigner::verify()`
 
 7.2
 ---

--- a/src/Symfony/Component/HttpFoundation/Exception/ExpiredSignedUriException.php
+++ b/src/Symfony/Component/HttpFoundation/Exception/ExpiredSignedUriException.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Exception;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class ExpiredSignedUriException extends SignedUriException
+{
+    /**
+     * @internal
+     */
+    public function __construct()
+    {
+        parent::__construct('The URI has expired.');
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Exception/SignedUriException.php
+++ b/src/Symfony/Component/HttpFoundation/Exception/SignedUriException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Exception;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+abstract class SignedUriException extends \RuntimeException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/HttpFoundation/Exception/UnsignedUriException.php
+++ b/src/Symfony/Component/HttpFoundation/Exception/UnsignedUriException.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Exception;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class UnsignedUriException extends SignedUriException
+{
+    /**
+     * @internal
+     */
+    public function __construct()
+    {
+        parent::__construct('The URI is not signed.');
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Exception/UnverifiedSignedUriException.php
+++ b/src/Symfony/Component/HttpFoundation/Exception/UnverifiedSignedUriException.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Exception;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class UnverifiedSignedUriException extends SignedUriException
+{
+    /**
+     * @internal
+     */
+    public function __construct()
+    {
+        parent::__construct('The URI signature is invalid.');
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/UriSignerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/UriSignerTest.php
@@ -13,7 +13,10 @@ namespace Symfony\Component\HttpFoundation\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Clock\MockClock;
+use Symfony\Component\HttpFoundation\Exception\ExpiredSignedUriException;
 use Symfony\Component\HttpFoundation\Exception\LogicException;
+use Symfony\Component\HttpFoundation\Exception\UnsignedUriException;
+use Symfony\Component\HttpFoundation\Exception\UnverifiedSignedUriException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\UriSigner;
 
@@ -227,5 +230,35 @@ class UriSignerTest extends TestCase
     {
         $signer = new UriSigner('foobar');
         $this->assertTrue($signer->check('http://example.com/foo?_hash=rIOcC%2FF3DoEGo%2FvnESjSp7uU9zA9S%2F%2BOLhxgMexoPUM%3D&baz=bay&foo=bar'));
+    }
+
+    public function testVerifyUnSignedUri()
+    {
+        $signer = new UriSigner('foobar');
+        $uri = 'http://example.com/foo';
+
+        $this->expectException(UnsignedUriException::class);
+
+        $signer->verify($uri);
+    }
+
+    public function testVerifyUnverifiedUri()
+    {
+        $signer = new UriSigner('foobar');
+        $uri = 'http://example.com/foo?_hash=invalid';
+
+        $this->expectException(UnverifiedSignedUriException::class);
+
+        $signer->verify($uri);
+    }
+
+    public function testVerifyExpiredUri()
+    {
+        $signer = new UriSigner('foobar');
+        $uri = $signer->sign('http://example.com/foo', 123456);
+
+        $this->expectException(ExpiredSignedUriException::class);
+
+        $signer->verify($uri);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | n/a
| License       | MIT

This adds `UriSigner::verify()`: Similar to `check()` but throws `UnSignedUriException`, `UnverifiedSignedUriException` or `ExpiredSignedUriException` if invalid (no return if valid).

Usage example:

```php
// Verifying a Signed Uri
try {
    $uriSigner->verify($uri);
} catch (UnSignedUriException $e) {
    // the uri either not signed
    $e->uri; // the uri value
} catch (UnverifiedSignedUriException $e) {
    // the the signature is invalid
    $e->uri; // the uri value
} catch (ExpiredSignedUriException $e) {
    // the signature is valid but it's expired
    $e->uri; // the uri value
    $e->expiredAt; // \DateTimeImmutable
}
```

**TODO**
- [x] Changelog
- [x] Tests