### PR TITLE
[Console] Mark `AsCommand` attribute as `@final`

### DIFF
--- a/UPGRADE-7.3.md
+++ b/UPGRADE-7.3.md
@@ -40,6 +40,7 @@ Console
    ```
 
  * Deprecate methods `Command::getDefaultName()` and `Command::getDefaultDescription()` in favor of the `#[AsCommand]` attribute
+ * `#[AsCommand]` attribute is now marked as `@final`; you should use separate attributes to add more logic to commands
 
 DependencyInjection
 -------------------

--- a/src/Symfony/Component/Console/Attribute/AsCommand.php
+++ b/src/Symfony/Component/Console/Attribute/AsCommand.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\Console\Attribute;
 
 /**
  * Service tag to autoconfigure commands.
+ *
+ * @final since Symfony 7.3
  */
 #[\Attribute(\Attribute::TARGET_CLASS)]
 class AsCommand

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
  * Add support for Markdown format in `Table`
  * Add support for `LockableTrait` in invokable commands
  * Deprecate returning a non-integer value from a `\Closure` function set via `Command::setCode()`
+ * Mark `#[AsCommand]` attribute as `@final`
 
 7.2
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | yes
| License       | MIT

`AsCommand` attribute doesn't work as expected when extended and probably should be declared as final.

In order to not break BC and trigger a deprecation warning, I marked the attribute as `@final` as per suggestions in previous PR.

Superseeds https://github.com/symfony/symfony/pull/60066 as I closed it accidentally, sorry for confusion 😕