### PR TITLE
[JsonPath] Add `JsonPathAssertionsTrait` and related constraints

### DIFF
--- a/src/Symfony/Component/JsonPath/Test/JsonPathAssertionsTrait.php
+++ b/src/Symfony/Component/JsonPath/Test/JsonPathAssertionsTrait.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonPath\Test;
+
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\ExpectationFailedException;
+use Symfony\Component\JsonPath\JsonPath;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ *
+ * @experimental
+ */
+trait JsonPathAssertionsTrait
+{
+    /**
+     * @throws ExpectationFailedException
+     */
+    final public static function assertJsonPathEquals(mixed $expectedValue, JsonPath|string $jsonPath, string $json, string $message = ''): void
+    {
+        Assert::assertThat($expectedValue, new JsonPathEquals($jsonPath, $json), $message);
+    }
+
+    /**
+     * @throws ExpectationFailedException
+     */
+    final public static function assertJsonPathNotEquals(mixed $expectedValue, JsonPath|string $jsonPath, string $json, string $message = ''): void
+    {
+        Assert::assertThat($expectedValue, new JsonPathNotEquals($jsonPath, $json), $message);
+    }
+
+    /**
+     * @throws ExpectationFailedException
+     */
+    final public static function assertJsonPathCount(int $expectedCount, JsonPath|string $jsonPath, string $json, string $message = ''): void
+    {
+        Assert::assertThat($expectedCount, new JsonPathCount($jsonPath, $json), $message);
+    }
+
+    /**
+     * @throws ExpectationFailedException
+     */
+    final public static function assertJsonPathSame(mixed $expectedValue, JsonPath|string $jsonPath, string $json, string $message = ''): void
+    {
+        Assert::assertThat($expectedValue, new JsonPathSame($jsonPath, $json), $message);
+    }
+
+    /**
+     * @throws ExpectationFailedException
+     */
+    final public static function assertJsonPathNotSame(mixed $expectedValue, JsonPath|string $jsonPath, string $json, string $message = ''): void
+    {
+        Assert::assertThat($expectedValue, new JsonPathNotSame($jsonPath, $json), $message);
+    }
+
+    /**
+     * @throws ExpectationFailedException
+     */
+    final public static function assertJsonPathContains(mixed $expectedValue, JsonPath|string $jsonPath, string $json, bool $strict = true, string $message = ''): void
+    {
+        Assert::assertThat($expectedValue, new JsonPathContains($jsonPath, $json, $strict), $message);
+    }
+
+    /**
+     * @throws ExpectationFailedException
+     */
+    final public static function assertJsonPathNotContains(mixed $expectedValue, JsonPath|string $jsonPath, string $json, bool $strict = true, string $message = ''): void
+    {
+        Assert::assertThat($expectedValue, new JsonPathNotContains($jsonPath, $json, $strict), $message);
+    }
+}

--- a/src/Symfony/Component/JsonPath/Test/JsonPathContains.php
+++ b/src/Symfony/Component/JsonPath/Test/JsonPathContains.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonPath\Test;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use Symfony\Component\JsonPath\JsonCrawler;
+use Symfony\Component\JsonPath\JsonPath;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ *
+ * @experimental
+ */
+class JsonPathContains extends Constraint
+{
+    public function __construct(
+        private JsonPath|string $jsonPath,
+        private string $json,
+        private bool $strict = true,
+    ) {
+    }
+
+    public function toString(): string
+    {
+        return \sprintf('is found in elements at JSON path "%s"', $this->jsonPath);
+    }
+
+    protected function matches(mixed $other): bool
+    {
+        $result = (new JsonCrawler($this->json))->find($this->jsonPath);
+
+        return \in_array($other, $result, $this->strict);
+    }
+}

--- a/src/Symfony/Component/JsonPath/Test/JsonPathCount.php
+++ b/src/Symfony/Component/JsonPath/Test/JsonPathCount.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonPath\Test;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use Symfony\Component\JsonPath\JsonCrawler;
+use Symfony\Component\JsonPath\JsonPath;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ *
+ * @experimental
+ */
+class JsonPathCount extends Constraint
+{
+    public function __construct(
+        private JsonPath|string $jsonPath,
+        private string $json,
+    ) {
+    }
+
+    public function toString(): string
+    {
+        return \sprintf('matches expected count of JSON path "%s"', $this->jsonPath);
+    }
+
+    protected function matches(mixed $other): bool
+    {
+        return $other === \count((new JsonCrawler($this->json))->find($this->jsonPath));
+    }
+}

--- a/src/Symfony/Component/JsonPath/Test/JsonPathEquals.php
+++ b/src/Symfony/Component/JsonPath/Test/JsonPathEquals.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonPath\Test;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use Symfony\Component\JsonPath\JsonCrawler;
+use Symfony\Component\JsonPath\JsonPath;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ *
+ * @experimental
+ */
+class JsonPathEquals extends Constraint
+{
+    public function __construct(
+        private JsonPath|string $jsonPath,
+        private string $json,
+    ) {
+    }
+
+    public function toString(): string
+    {
+        return \sprintf('equals JSON path "%s" result', $this->jsonPath);
+    }
+
+    protected function matches(mixed $other): bool
+    {
+        return (new JsonCrawler($this->json))->find($this->jsonPath) == $other;
+    }
+}

--- a/src/Symfony/Component/JsonPath/Test/JsonPathNotContains.php
+++ b/src/Symfony/Component/JsonPath/Test/JsonPathNotContains.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonPath\Test;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use Symfony\Component\JsonPath\JsonCrawler;
+use Symfony\Component\JsonPath\JsonPath;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ *
+ * @experimental
+ */
+class JsonPathNotContains extends Constraint
+{
+    public function __construct(
+        private JsonPath|string $jsonPath,
+        private string $json,
+        private bool $strict = true,
+    ) {
+    }
+
+    public function toString(): string
+    {
+        return \sprintf('is not found in elements at JSON path "%s"', $this->jsonPath);
+    }
+
+    protected function matches(mixed $other): bool
+    {
+        $result = (new JsonCrawler($this->json))->find($this->jsonPath);
+
+        return !\in_array($other, $result, $this->strict);
+    }
+}

--- a/src/Symfony/Component/JsonPath/Test/JsonPathNotEquals.php
+++ b/src/Symfony/Component/JsonPath/Test/JsonPathNotEquals.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonPath\Test;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use Symfony\Component\JsonPath\JsonCrawler;
+use Symfony\Component\JsonPath\JsonPath;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ *
+ * @experimental
+ */
+class JsonPathNotEquals extends Constraint
+{
+    public function __construct(
+        private JsonPath|string $jsonPath,
+        private string $json,
+    ) {
+    }
+
+    public function toString(): string
+    {
+        return \sprintf('does not equal JSON path "%s" result', $this->jsonPath);
+    }
+
+    protected function matches(mixed $other): bool
+    {
+        return (new JsonCrawler($this->json))->find($this->jsonPath) != $other;
+    }
+}

--- a/src/Symfony/Component/JsonPath/Test/JsonPathNotSame.php
+++ b/src/Symfony/Component/JsonPath/Test/JsonPathNotSame.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonPath\Test;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use Symfony\Component\JsonPath\JsonCrawler;
+use Symfony\Component\JsonPath\JsonPath;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ *
+ * @experimental
+ */
+class JsonPathNotSame extends Constraint
+{
+    public function __construct(
+        private JsonPath|string $jsonPath,
+        private string $json,
+    ) {
+    }
+
+    public function toString(): string
+    {
+        return \sprintf('is not identical to JSON path "%s" result', $this->jsonPath);
+    }
+
+    protected function matches(mixed $other): bool
+    {
+        return (new JsonCrawler($this->json))->find($this->jsonPath) !== $other;
+    }
+}

--- a/src/Symfony/Component/JsonPath/Test/JsonPathSame.php
+++ b/src/Symfony/Component/JsonPath/Test/JsonPathSame.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonPath\Test;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use Symfony\Component\JsonPath\JsonCrawler;
+use Symfony\Component\JsonPath\JsonPath;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ *
+ * @experimental
+ */
+class JsonPathSame extends Constraint
+{
+    public function __construct(
+        private JsonPath|string $jsonPath,
+        private string $json,
+    ) {
+    }
+
+    public function toString(): string
+    {
+        return \sprintf('is identical to JSON path "%s" result', $this->jsonPath);
+    }
+
+    protected function matches(mixed $other): bool
+    {
+        return (new JsonCrawler($this->json))->find($this->jsonPath) === $other;
+    }
+}

--- a/src/Symfony/Component/JsonPath/Tests/Test/JsonPathAssertionsTraitTest.php
+++ b/src/Symfony/Component/JsonPath/Tests/Test/JsonPathAssertionsTraitTest.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace Symfony\Component\JsonPath\Tests\Test;
+
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\JsonPath\Test\JsonPathAssertionsTrait;
+
+class JsonPathAssertionsTraitTest extends TestCase
+{
+    use JsonPathAssertionsTrait;
+
+    public function testAssertJsonPathEqualsOk()
+    {
+        self::assertJsonPathEquals([1], '$.a[2]', self::getSimpleCollectionCrawlerData());
+    }
+
+    public function testAssertJsonPathEqualsOkWithTypeCoercion()
+    {
+        self::assertJsonPathEquals(['1'], '$.a[2]', self::getSimpleCollectionCrawlerData());
+    }
+
+    public function testAssertJsonPathEqualsKo()
+    {
+        $thrown = false;
+        try {
+            self::assertJsonPathEquals([2], '$.a[2]', self::getSimpleCollectionCrawlerData());
+        } catch (AssertionFailedError $exception) {
+            self::assertMatchesRegularExpression('/Failed asserting that .+ equals JSON path "\$\.a\[2]" result./s', $exception->getMessage());
+
+            $thrown = true;
+        }
+
+        self::assertTrue($thrown);
+    }
+
+    public function testAssertJsonPathNotEqualsOk()
+    {
+        self::assertJsonPathNotEquals([2], '$.a[2]', self::getSimpleCollectionCrawlerData());
+    }
+
+    public function testAssertJsonPathNotEqualsKo()
+    {
+        $thrown = false;
+        try {
+            self::assertJsonPathNotEquals([1], '$.a[2]', self::getSimpleCollectionCrawlerData());
+        } catch (AssertionFailedError $exception) {
+            self::assertMatchesRegularExpression('/Failed asserting that .+ does not equal JSON path "\$\.a\[2]" result./s', $exception->getMessage());
+
+            $thrown = true;
+        }
+
+        self::assertTrue($thrown);
+    }
+
+    public function testAssertJsonPathCountOk()
+    {
+        self::assertJsonPathCount(6, '$.a[*]', self::getSimpleCollectionCrawlerData());
+    }
+
+    public function testAssertJsonPathCountOkWithFilter()
+    {
+        self::assertJsonPathCount(2, '$.book[?(@.price > 25)]', <<<JSON
+            {
+                "book": [
+                    { "price":  10 },
+                    { "price":  20 },
+                    { "price":  30 },
+                    { "price":  40 }
+                ]
+            }
+            JSON
+        );
+    }
+
+    public function testAssertJsonPathCountKo()
+    {
+        $thrown = false;
+        try {
+            self::assertJsonPathCount(5, '$.a[*]', self::getSimpleCollectionCrawlerData());
+        } catch (AssertionFailedError $exception) {
+            self::assertSame('Failed asserting that 5 matches expected count of JSON path "$.a[*]".', $exception->getMessage());
+
+            $thrown = true;
+        }
+
+        self::assertTrue($thrown);
+    }
+
+    public function testAssertJsonPathSameOk()
+    {
+        self::assertJsonPathSame([1], '$.a[2]', self::getSimpleCollectionCrawlerData());
+    }
+
+    public function testAssertJsonPathSameKo()
+    {
+        $thrown = false;
+        try {
+            self::assertJsonPathSame([2], '$.a[2]', self::getSimpleCollectionCrawlerData());
+        } catch (AssertionFailedError $exception) {
+            self::assertMatchesRegularExpression('/Failed asserting that .+ is identical to JSON path "\$\.a\[2]" result\./s', $exception->getMessage());
+
+            $thrown = true;
+        }
+
+        self::assertTrue($thrown);
+    }
+
+    public function testAssertJsonPathHasNoTypeCoercion()
+    {
+        $thrown = false;
+        try {
+            self::assertJsonPathSame(['1'], '$.a[2]', self::getSimpleCollectionCrawlerData());
+        } catch (AssertionFailedError $exception) {
+            self::assertMatchesRegularExpression('/Failed asserting that .+ is identical to JSON path "\$\.a\[2]" result\./s', $exception->getMessage());
+
+            $thrown = true;
+        }
+
+        self::assertTrue($thrown);
+    }
+
+    public function testAssertJsonPathNotSameOk()
+    {
+        self::assertJsonPathNotSame([2], '$.a[2]', self::getSimpleCollectionCrawlerData());
+    }
+
+    public function testAssertJsonPathNotSameKo()
+    {
+        $thrown = false;
+        try {
+            self::assertJsonPathNotSame([1], '$.a[2]', self::getSimpleCollectionCrawlerData());
+        } catch (AssertionFailedError $exception) {
+            self::assertMatchesRegularExpression('/Failed asserting that .+ is not identical to JSON path "\$\.a\[2]" result\./s', $exception->getMessage());
+
+            $thrown = true;
+        }
+
+        self::assertTrue($thrown);
+    }
+
+    public function testAssertJsonPathNotSameHasNoTypeCoercion()
+    {
+        self::assertJsonPathNotSame(['1'], '$.a[2]', self::getSimpleCollectionCrawlerData());
+    }
+
+    public function testAssertJsonPathContainsOk()
+    {
+        self::assertJsonPathContains(1, '$.a[*]', self::getSimpleCollectionCrawlerData());
+    }
+
+    public function testAssertJsonPathContainsKo()
+    {
+        $thrown = false;
+        try {
+            self::assertJsonPathContains(0, '$.a[*]', self::getSimpleCollectionCrawlerData());
+        } catch (AssertionFailedError $exception) {
+            self::assertSame('Failed asserting that 0 is found in elements at JSON path "$.a[*]".', $exception->getMessage());
+
+            $thrown = true;
+        }
+
+        self::assertTrue($thrown);
+    }
+
+    public function testAssertJsonPathNotContainsOk()
+    {
+        self::assertJsonPathNotContains(0, '$.a[*]', self::getSimpleCollectionCrawlerData());
+    }
+
+    public function testAssertJsonPathNotContainsKo()
+    {
+        $thrown = false;
+        try {
+            self::assertJsonPathNotContains(1, '$.a[*]', self::getSimpleCollectionCrawlerData());
+        } catch (AssertionFailedError $exception) {
+            self::assertSame('Failed asserting that 1 is not found in elements at JSON path "$.a[*]".', $exception->getMessage());
+
+            $thrown = true;
+        }
+
+        self::assertTrue($thrown);
+    }
+
+    private static function getSimpleCollectionCrawlerData(): string
+    {
+        return <<<JSON
+            {"a": [3, 5, 1, 2, 4, 6]}
+            JSON;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Let's leverage JsonPath in test cases. I propose to add a new trait to ease testing JSON strings against JsonPath:

```php
use PHPUnit\Framework\TestCase;
use Symfony\Component\JsonPath\Test\JsonPathAssertionsTrait;

class MyApiTest extends TestCase
{
    use JsonPathAssertionsTrait;

    public function testItFetchesAllUsers(): void
    {
        $json = self::fetchUserCollection();

        $this->assertJsonPathCount(3, '$.users[*]', $json);
        $this->assertJsonPathSame(['Melchior'], '$.users[0].username', $json);
        $this->assertJsonPathEquals(['30'], '$.users[0].age', $json, 'should return the age as string or int');
    }

    public function testItFetchesOneUser(): void
    {
        $json = self::fetchOneUser();

        $this->assertJsonPathSame(['Melchior'], '$.user.username', $json);
        $this->assertJsonPathEquals(['30'], '$.user.age', $json, 'should return the age as string or int');
    }

    /**
     * Hard-coded for the example, but in a real integration test, you would actually make the API call!
     */
    private static function fetchUserCollection(): string
    {
        // Simulate fetching JSON data from an API
        return <<<JSON
        {
            "users": [
                {
                    "username": "Melchior",
                    "age": 30
                },
                {
                    "username": "Gaspard",
                    "age": 50
                },
                {
                    "username": "Balthazar",
                    "age": 55
                }
            ]
        }
        JSON;
    }

    private static function fetchOneUser(): string
    {
        // Simulate fetching JSON data from an API
        return <<<JSON
        {
            "user": {
                "username": "Melchior",
                "age": 30
            }
        }
        JSON;
    }
}
```