### PR TITLE
[DoctrineBridge] Improve exception message when `EntityValueResolver` gets no mapping information

### DIFF
--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Reset the manager registry using native lazy objects when applicable
  * Deprecate the `DoctrineExtractor::getTypes()` method, use `DoctrineExtractor::getType()` instead
  * Add support for `Symfony\Component\Clock\DatePoint` as `DatePointType` Doctrine type
+ * Improve exception message when `EntityValueResolver` gets no mapping information
 
 7.2
 ---

--- a/src/Symfony/Bridge/Doctrine/Tests/ArgumentResolver/EntityValueResolverTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ArgumentResolver/EntityValueResolverTest.php
@@ -24,6 +24,7 @@ use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\ExpressionLanguage\SyntaxError;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\HttpKernel\Exception\NearMissValueResolverException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class EntityValueResolverTest extends TestCase
@@ -75,6 +76,11 @@ class EntityValueResolverTest extends TestCase
         $request = new Request();
         $argument = $this->createArgument(null, new MapEntity(), 'arg', true);
 
+        if (class_exists(NearMissValueResolverException::class)) {
+            $this->expectException(NearMissValueResolverException::class);
+            $this->expectExceptionMessage('Cannot find mapping for "stdClass": declare one using either the #[MapEntity] attribute or mapped route parameters.');
+        }
+
         $this->assertSame([], $resolver->resolve($request, $argument));
     }
 
@@ -93,6 +99,11 @@ class EntityValueResolverTest extends TestCase
 
         $manager->expects($this->never())
             ->method('getRepository');
+
+        if (class_exists(NearMissValueResolverException::class)) {
+            $this->expectException(NearMissValueResolverException::class);
+            $this->expectExceptionMessage('Cannot find mapping for "stdClass": declare one using either the #[MapEntity] attribute or mapped route parameters.');
+        }
 
         $this->assertSame([], $resolver->resolve($request, $argument));
     }
@@ -261,6 +272,11 @@ class EntityValueResolverTest extends TestCase
             ->willReturn($metadata);
 
         $manager->expects($this->never())->method('getRepository');
+
+        if (class_exists(NearMissValueResolverException::class)) {
+            $this->expectException(NearMissValueResolverException::class);
+            $this->expectExceptionMessage('Cannot find mapping for "stdClass": declare one using either the #[MapEntity] attribute or mapped route parameters.');
+        }
 
         $this->assertSame([], $resolver->resolve($request, $argument));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #60111
| License       | MIT

Message based on https://github.com/symfony/symfony/blob/1a8b82e5dfd43f18b6f9e280a9468296d1f5bffe/src/Symfony/Bridge/Doctrine/ArgumentResolver/EntityValueResolver.php#L188