### PR TITLE
[Workflow] Add support for `BackedEnum` in `MethodMarkingStore`

### DIFF
--- a/src/Symfony/Component/Workflow/CHANGELOG.md
+++ b/src/Symfony/Component/Workflow/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+ * Add support for `BackedEnum` in `MethodMarkingStore`
+
 7.3
 ---
 

--- a/src/Symfony/Component/Workflow/Tests/MarkingStore/MethodMarkingStoreTest.php
+++ b/src/Symfony/Component/Workflow/Tests/MarkingStore/MethodMarkingStoreTest.php
@@ -84,6 +84,24 @@ class MethodMarkingStoreTest extends TestCase
         $this->assertSame('first_place', (string) $subject->getMarking());
     }
 
+    public function testGetMarkingWithBackedEnum()
+    {
+        $subject = new SubjectWithEnum(TestEnum::Foo);
+
+        $markingStore = new MethodMarkingStore(true);
+
+        $marking = $markingStore->getMarking($subject);
+
+        $this->assertCount(1, $marking->getPlaces());
+        $this->assertSame(['foo' => 1], $marking->getPlaces());
+
+        $marking->mark('bar');
+        $marking->unmark('foo');
+        $markingStore->setMarking($subject, $marking);
+
+        $this->assertSame(TestEnum::Bar, $subject->getMarking());
+    }
+
     public function testGetMarkingWithUninitializedProperty()
     {
         $subject = new SubjectWithType();

--- a/src/Symfony/Component/Workflow/Tests/MarkingStore/SubjectWithEnum.php
+++ b/src/Symfony/Component/Workflow/Tests/MarkingStore/SubjectWithEnum.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Workflow\Tests\MarkingStore;
+
+class SubjectWithEnum
+{
+    public function __construct(
+        private ?TestEnum $marking = null,
+        private array $context = [],
+    ) {
+    }
+
+    public function getMarking(): ?TestEnum
+    {
+        return $this->marking;
+    }
+
+    public function setMarking(TestEnum $marking, array $context = []): void
+    {
+        $this->marking = $marking;
+        $this->context = $context;
+    }
+
+    public function getContext(): array
+    {
+        return $this->context;
+    }
+}

--- a/src/Symfony/Component/Workflow/Tests/MarkingStore/TestEnum.php
+++ b/src/Symfony/Component/Workflow/Tests/MarkingStore/TestEnum.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Workflow\Tests\MarkingStore;
+
+enum TestEnum: string
+{
+    case Foo = 'foo';
+    case Bar = 'bar';
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Kind of relates to #44211
| License       | MIT

<details>
<summary>Why supporting Backed Enums in Workflow can be useful</summary>

Supporting Enums in Workflow (and overall in Symfony) is a highly debated topic. While using Enums is not always a good choice, I personally found that Backed Enums are really suited for status and places because they ensure type safety in your model and naturally validate the set of allowed values. This is why I think supporting them in Workflow could be nice if not too complicated.
</details>

<details>
<summary>Reducing the supported scope to `MethodMarkingStore`</summary>

While trying to implementing BackedEnum support in my current project using custom code, I figured we could go with a really narrow scope to support them out-of-the-box (but only for Single State Machine): in such case only `MethodMarkingStore` has to support Enums. In my mind, the way the workflow uses strings internally in the `Marking` is an implementation detail and what really matters to users is being able to control the values stored in their objects. Also, I don’t believe supporting enums for transitions is necessary as they are mostly configuration and validating transitions is already part of the component’s job (and in such case I would recommend using constants anyway). </details>

Supporting BackedEnum currently requires some boilerplate in the user project (with dedicated getter and setter  for instance) or a complete implementation of a marking store. Therefore, I’m sharing what is in my mind a small patch that can greatly improve the situation for users, as it allows them to use Backed Enums in their model right away with their method or properties:
```php
class MyObject {
    // ...
    private ObjectStatus $status = ObjectStatus::Draft;

    public function getStatus(): ObjectStatus
    {
        return $this->status;
    }

    public function setStatus(ObjectStatus $status): static
    {
        $this->status = $status;

        return $this;
    }
}
```