### PR TITLE
[Routing] Add possibility to create a request context with parameters directly

### DIFF
--- a/src/Symfony/Component/Routing/RequestContext.php
+++ b/src/Symfony/Component/Routing/RequestContext.php
@@ -33,7 +33,7 @@ class RequestContext
     private string $queryString;
     private array $parameters = [];
 
-    public function __construct(string $baseUrl = '', string $method = 'GET', string $host = 'localhost', string $scheme = 'http', int $httpPort = 80, int $httpsPort = 443, string $path = '/', string $queryString = '')
+    public function __construct(string $baseUrl = '', string $method = 'GET', string $host = 'localhost', string $scheme = 'http', int $httpPort = 80, int $httpsPort = 443, string $path = '/', string $queryString = '', ?array $parameters = null)
     {
         $this->setBaseUrl($baseUrl);
         $this->setMethod($method);
@@ -43,6 +43,7 @@ class RequestContext
         $this->setHttpsPort($httpsPort);
         $this->setPathInfo($path);
         $this->setQueryString($queryString);
+        $this->parameters = $parameters ?? $this->parameters;
     }
 
     public static function fromUri(string $uri, string $host = 'localhost', string $scheme = 'http', int $httpPort = 80, int $httpsPort = 443): self

--- a/src/Symfony/Component/Routing/Tests/RequestContextTest.php
+++ b/src/Symfony/Component/Routing/Tests/RequestContextTest.php
@@ -27,7 +27,10 @@ class RequestContextTest extends TestCase
             8080,
             444,
             '/baz',
-            'bar=foobar'
+            'bar=foobar',
+            [
+                'foo' => 'bar',
+            ]
         );
 
         $this->assertEquals('foo', $requestContext->getBaseUrl());
@@ -38,6 +41,20 @@ class RequestContextTest extends TestCase
         $this->assertSame(444, $requestContext->getHttpsPort());
         $this->assertEquals('/baz', $requestContext->getPathInfo());
         $this->assertEquals('bar=foobar', $requestContext->getQueryString());
+        $this->assertSame(['foo' => 'bar'], $requestContext->getParameters());
+    }
+
+    public function testConstructParametersBcLayer()
+    {
+        $requestContext = new class() extends RequestContext {
+            public function __construct()
+            {
+                $this->setParameters(['foo' => 'bar']);
+                parent::__construct();
+            }
+        };
+
+        $this->assertSame(['foo' => 'bar'], $requestContext->getParameters());
     }
 
     public function testFromUriWithBaseUrl()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes<!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

While I worked on the route integration into Sulu. I had to write a few tests for depending on the RequestContext. To improve the DX I think the parameters should be possible also inside the construct directly so instead of:

```php
$requestContext = new RequestContext();
$requestContext->setParameters(['foo' => 'bar']);
$service->myMethod($requestContext);
```

I can do:

```php
$service->myMethod(new RequestContext(parameters: ['foo' => 'bar']));
```
