### PR TITLE
[Cache] ArrayAdapter serialization exception clean $expiries

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/ArrayAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ArrayAdapter.php
@@ -312,7 +312,7 @@ class ArrayAdapter implements AdapterInterface, CacheInterface, LoggerAwareInter
             try {
                 $serialized = serialize($value);
             } catch (\Exception $e) {
-                unset($this->values[$key], $this->tags[$key]);
+                unset($this->values[$key], $this->expiries[$key], $this->tags[$key]);
                 $type = get_debug_type($value);
                 $message = sprintf('Failed to save key "{key}" of type %s: %s', $type, $e->getMessage());
                 CacheItem::log($this->logger, $message, ['key' => $key, 'exception' => $e, 'cache-adapter' => get_debug_type($this)]);

--- a/src/Symfony/Component/Cache/Tests/Adapter/ArrayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ArrayAdapterTest.php
@@ -102,4 +102,17 @@ class ArrayAdapterTest extends AdapterTestCase
 
         $this->assertSame(TestEnum::Foo, $cache->getItem('foo')->get());
     }
+
+    public function testExpiryCleanupOnError()
+    {
+        $cache = new ArrayAdapter();
+
+        $item = $cache->getItem('foo');
+        $this->assertTrue($cache->save($item->set('bar')));
+        $this->assertTrue($cache->hasItem('foo'));
+
+        $item->set(static fn () => null);
+        $this->assertFalse($cache->save($item));
+        $this->assertFalse($cache->hasItem('foo'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60121
| License       | MIT

In [ArrayAdapter.php:339](https://github.com/symfony/symfony/blame/7.3/src/Symfony/Component/Cache/Adapter/ArrayAdapter.php#L339), if $value contains a Closure, an Exception is triggered and $this->values get cleaned.
```
  try {
      $serialized = serialize($value);
  } catch (\Exception $e) {
      unset($this->values[$key], $this->expiries[$key], $this->tags[$key]);
      $type = get_debug_type($value);
      $message = \sprintf('Failed to save key "{key}" of type %s: %s', $type, $e->getMessage());
      CacheItem::log($this->logger, $message, ['key' => $key, 'exception' => $e, 'cache-adapter' => get_debug_type($this)]);

      return null;
  }
```
$this->expiries is used in [ArrayAdapter.php:300](https://github.com/symfony/symfony/blame/7.3/src/Symfony/Component/Cache/Adapter/ArrayAdapter.php#L300) to determine cache hit. If hash is found in $this->expiries but missing in $this->keys it generate a NOTICE.

On serialize($value); catch Exception, clean expiries with unset.
