### PR TITLE
[Validator] : fix url validation when punycode is on tld but not on domain

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/UrlValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UrlValidator.php
@@ -26,9 +26,14 @@ class UrlValidator extends ConstraintValidator
             (((?:[\_\.\pL\pN-]|%%[0-9A-Fa-f]{2})+:)?((?:[\_\.\pL\pN-]|%%[0-9A-Fa-f]{2})+)@)?  # basic auth
             (
                 (?:
-                    (?:xn--[a-z0-9-]++\.)*+xn--[a-z0-9-]++            # a domain name using punycode
-                        |
-                    (?:[\pL\pN\pS\pM\-\_]++\.)+[\pL\pN\pM]++          # a multi-level domain name
+                    (?:
+                        (?:[\pL\pN\pS\pM\-\_]++\.)+
+                        (?:
+                            (?:xn--[a-z0-9-]++)                       # punycode in tld
+                            |
+                            (?:[\pL\pN\pM]++)                         # no punycode in tld
+                        )
+                    )                                                 # a multi-level domain name
                         |
                     [a-z0-9\-\_]++                                    # a single-level domain name
                 )\.?

--- a/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
@@ -186,6 +186,8 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
             ['http://xn--e1afmkfd.xn--80akhbyknj4f.xn--e1afmkfd/'],
             ['http://xn--espaa-rta.xn--ca-ol-fsay5a/'],
             ['http://xn--d1abbgf6aiiy.xn--p1ai/'],
+            ['http://example.xn--p1ai/'],
+            ['http://xn--d1abbgf6aiiy.example.xn--p1ai/'],
             ['http://☎.com/'],
             ['http://username:password@symfony.com'],
             ['http://user.name:password@symfony.com'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Issues        | 
| License       | MIT

When there is punycode in the tld current validator will force all others parts of domain to use punycode, however this should not be required i updated the regex to match only punycode in tld (as the other regex allow all valid characters needed for punycode)
