### PR TITLE
[ObjectMapper] attribute extends metadata to avoid duplication

### DIFF
--- a/src/Symfony/Component/ObjectMapper/Attribute/Map.php
+++ b/src/Symfony/Component/ObjectMapper/Attribute/Map.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\ObjectMapper\Attribute;
 
+use Symfony\Component\ObjectMapper\Metadata\Mapping;
+
+
 /**
  * Configures a class or a property to map to.
  *
@@ -19,19 +22,6 @@ namespace Symfony\Component\ObjectMapper\Attribute;
  * @author Antoine Bluchet <soyuka@gmail.com>
  */
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_PROPERTY | \Attribute::IS_REPEATABLE)]
-readonly class Map
+readonly class Map extends Mapping
 {
-    /**
-     * @param string|class-string|null                                                                              $source    The property or the class to map from
-     * @param string|class-string|null                                                                              $target    The property or the class to map to
-     * @param string|bool|callable(mixed, object): bool|null                                         $if        A boolean, a service id or a callable that instructs whether to map
-     * @param (string|callable(mixed, object): mixed)|(string|callable(mixed, object): mixed)[]|null $transform A service id or a callable that transforms the value during mapping
-     */
-    public function __construct(
-        public ?string $target = null,
-        public ?string $source = null,
-        public mixed $if = null,
-        public mixed $transform = null,
-    ) {
-    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | none
| License       | MIT

`Symfony\Component\ObjectMapper\Attribute\Map` and `Symfony\Component\ObjectMapper\Metadata\Mapping` are the same, `Mapping` is the metadata class and is `@internal` whether `Map` is the attribute. To ease the maintenance we can just make `Map extends Mapping`. 