### PR TITLE
do not ignore flock() return values for PHP 8.5 compat

### DIFF
--- a/src/Symfony/Component/Cache/LockRegistry.php
+++ b/src/Symfony/Component/Cache/LockRegistry.php
@@ -74,7 +74,6 @@ final class LockRegistry
 
         foreach (self::$openedFiles as $file) {
             if ($file) {
-                flock($file, \LOCK_UN);
                 fclose($file);
             }
         }
@@ -123,9 +122,9 @@ final class LockRegistry
                 }
                 // if we failed the race, retry locking in blocking mode to wait for the winner
                 $logger?->info('Item "{key}" is locked, waiting for it to be released', ['key' => $item->getKey()]);
-                flock($lock, \LOCK_SH);
+                $locked = flock($lock, \LOCK_SH);
             } finally {
-                flock($lock, \LOCK_UN);
+                (bool) flock($lock, \LOCK_UN);
                 unset(self::$lockedFiles[$key]);
             }
 

--- a/src/Symfony/Component/HttpKernel/HttpCache/Store.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Store.php
@@ -62,7 +62,6 @@ class Store implements StoreInterface
     {
         // unlock everything
         foreach ($this->locks as $lock) {
-            flock($lock, \LOCK_UN);
             fclose($lock);
         }
 
@@ -106,7 +105,6 @@ class Store implements StoreInterface
         $key = $this->getCacheKey($request);
 
         if (isset($this->locks[$key])) {
-            flock($this->locks[$key], \LOCK_UN);
             fclose($this->locks[$key]);
             unset($this->locks[$key]);
 
@@ -129,8 +127,7 @@ class Store implements StoreInterface
         }
 
         $h = fopen($path, 'r');
-        flock($h, \LOCK_EX | \LOCK_NB, $wouldBlock);
-        flock($h, \LOCK_UN); // release the lock we just acquired
+        flock($h, \LOCK_EX | \LOCK_NB, $wouldBlock) && flock($h, \LOCK_UN); // release the lock we just acquired
         fclose($h);
 
         return (bool) $wouldBlock;
@@ -340,7 +337,6 @@ class Store implements StoreInterface
     {
         $key = $this->getCacheKey(Request::create($url));
         if (isset($this->locks[$key])) {
-            flock($this->locks[$key], \LOCK_UN);
             fclose($this->locks[$key]);
             unset($this->locks[$key]);
         }

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -435,7 +435,6 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
                 } elseif (!is_file($cachePath) || !\is_object($this->container = include $cachePath)) {
                     $this->container = null;
                 } elseif (!$oldContainer || $this->container::class !== $oldContainer->name) {
-                    flock($lock, \LOCK_UN);
                     fclose($lock);
                     $this->container->set('kernel', $this);
 
@@ -517,7 +516,6 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
         $this->dumpContainer($cache, $container, $class, $this->getContainerBaseClass());
 
         if ($lock) {
-            flock($lock, \LOCK_UN);
             fclose($lock);
         }
 

--- a/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
@@ -307,9 +307,8 @@ class FileProfilerStorage implements ProfilerStorageInterface
         }
 
         $h = fopen($file, 'r');
-        flock($h, \LOCK_SH);
+        (bool) flock($h, \LOCK_SH);
         $data = stream_get_contents($h);
-        flock($h, \LOCK_UN);
         fclose($h);
 
         if (\function_exists('gzdecode')) {

--- a/src/Symfony/Component/Lock/Store/FlockStore.php
+++ b/src/Symfony/Component/Lock/Store/FlockStore.php
@@ -152,7 +152,6 @@ class FlockStore implements BlockingStoreInterface, SharedLockStoreInterface
 
         $handle = $key->getState(__CLASS__)[1];
 
-        flock($handle, \LOCK_UN | \LOCK_NB);
         fclose($handle);
 
         $key->removeState(__CLASS__);

--- a/src/Symfony/Component/Process/Pipes/WindowsPipes.php
+++ b/src/Symfony/Component/Process/Pipes/WindowsPipes.php
@@ -66,13 +66,11 @@ class WindowsPipes extends AbstractPipes
                         continue 2;
                     }
                     if (isset($this->lockHandles[$pipe])) {
-                        flock($this->lockHandles[$pipe], \LOCK_UN);
                         fclose($this->lockHandles[$pipe]);
                     }
                     $this->lockHandles[$pipe] = $h;
 
                     if (!($h = fopen($file, 'w')) || !fclose($h) || !$h = fopen($file, 'r')) {
-                        flock($this->lockHandles[$pipe], \LOCK_UN);
                         fclose($this->lockHandles[$pipe]);
                         unset($this->lockHandles[$pipe]);
                         continue 2;
@@ -153,7 +151,6 @@ class WindowsPipes extends AbstractPipes
             if ($close) {
                 ftruncate($fileHandle, 0);
                 fclose($fileHandle);
-                flock($this->lockHandles[$type], \LOCK_UN);
                 fclose($this->lockHandles[$type]);
                 unset($this->fileHandles[$type], $this->lockHandles[$type]);
             }
@@ -178,7 +175,6 @@ class WindowsPipes extends AbstractPipes
         foreach ($this->fileHandles as $type => $handle) {
             ftruncate($handle, 0);
             fclose($handle);
-            flock($this->lockHandles[$type], \LOCK_UN);
             fclose($this->lockHandles[$type]);
         }
         $this->fileHandles = $this->lockHandles = [];

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -413,10 +413,10 @@ class ProcessTest extends TestCase
     {
         $lock = tempnam(sys_get_temp_dir(), __FUNCTION__);
 
-        $p = $this->getProcessForCode('file_put_contents($s = \''.$uri.'\', \'foo\'); flock(fopen('.var_export($lock, true).', \'r\'), LOCK_EX); file_put_contents($s, \'bar\');');
+        $p = $this->getProcessForCode('file_put_contents($s = \''.$uri.'\', \'foo\'); (bool) flock(fopen('.var_export($lock, true).', \'r\'), LOCK_EX); file_put_contents($s, \'bar\');');
 
         $h = fopen($lock, 'w');
-        flock($h, \LOCK_EX);
+        (bool) flock($h, \LOCK_EX);
 
         $p->start();
 
@@ -428,7 +428,7 @@ class ProcessTest extends TestCase
             $this->assertSame($s, $p->$getIncrementalOutput());
             $this->assertSame('', $p->$getIncrementalOutput());
 
-            flock($h, \LOCK_UN);
+            (bool) flock($h, \LOCK_UN);
         }
 
         fclose($h);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60128
| License       | MIT