### PR TITLE
make method signature compatible with PHP 8.5

### DIFF
--- a/src/Symfony/Component/Intl/Transliterator/EmojiTransliterator.php
+++ b/src/Symfony/Component/Intl/Transliterator/EmojiTransliterator.php
@@ -24,7 +24,7 @@ if (!class_exists(\Transliterator::class)) {
         private array $map;
         private \Transliterator $transliterator;
 
-        public static function create(string $id, int $direction = self::FORWARD): self
+        public static function create(string $id, int $direction = self::FORWARD): EmojiTransliterator
         {
             $id = strtolower($id);
 
@@ -65,7 +65,7 @@ if (!class_exists(\Transliterator::class)) {
             return $instance;
         }
 
-        public function createInverse(): self
+        public function createInverse(): EmojiTransliterator
         {
             return self::create($this->id, self::REVERSE);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

see https://3v4l.org/6J3Q9/rfc#vgit.master (PHP 8.5) vs. https://3v4l.org/6J3Q9#v8.4.5 (before)

I did not find the commit in the PHP source code causing this behaviour so I am not sure if it's intended or indicating a bug in PHP.
