### PR TITLE
[Config] ResourceCheckerConfigCache metadata unserialize emits warning

### DIFF
--- a/src/Symfony/Component/Config/ResourceCheckerConfigCache.php
+++ b/src/Symfony/Component/Config/ResourceCheckerConfigCache.php
@@ -127,7 +127,7 @@ class ResourceCheckerConfigCache implements ConfigCacheInterface
 
             $ser = preg_replace_callback('/;O:(\d+):"/', static fn ($m) => ';O:'.(9 + $m[1]).':"Tracking\\', $ser);
             $ser = preg_replace_callback('/s:(\d+):"\0[^\0]++\0/', static fn ($m) => 's:'.($m[1] - \strlen($m[0]) + 6).':"', $ser);
-            $ser = unserialize($ser);
+            $ser = unserialize($ser, ['allowed_classes' => false]);
             $ser = @json_encode($ser, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE) ?: [];
             $ser = str_replace('"__PHP_Incomplete_Class_Name":"Tracking\\\\', '"@type":"', $ser);
             $ser = \sprintf('{"resources":%s}', $ser);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59196
| License       | MIT

## Description

This PR fixes the warning unserialize(): Function spl_autoload_call() hasn't defined the class it was called for that occurs when unserializing metadata in the ResourceCheckerConfigCache when unserialize_callback_func is set to spl_autoload_call.

The fix adds the allowed_classes => false parameter to the unserialize() call, preventing PHP from attempting to reconstruct objects of unknown classes, which eliminates the warnings while maintaining the intended functionality.

## Test case

The issue can be reproduced by:
1. Adding `ini_set('unserialize_callback_func', 'spl_autoload_call');` at the beginning of a Symfony application (e.g., in `bin/console`)
2. Running `bin/console cache:clear`
3. Observing the warnings about classes that couldn't be found

With this change, the warnings no longer appear while the cache continues to function correctly.
