### PR TITLE
[Lock] DynamoDB store

### DIFF
--- a/.github/get-modified-packages.php
+++ b/.github/get-modified-packages.php
@@ -22,7 +22,7 @@ function getPackageType(string $packageDir): string
     return match (true) {
         str_contains($packageDir, 'Symfony/Bridge/') => 'bridge',
         str_contains($packageDir, 'Symfony/Bundle/') => 'bundle',
-        preg_match('@Symfony/Component/[^/]+/Bridge/@', $packageDir) => 'component_bridge',
+        1 === preg_match('@Symfony/Component/[^/]+/Bridge/@', $packageDir) => 'component_bridge',
         str_contains($packageDir, 'Symfony/Component/') => 'component',
         str_contains($packageDir, 'Symfony/Contracts/') => 'contract',
         str_ends_with($packageDir, 'Symfony/Contracts') => 'contracts',

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -121,7 +121,7 @@ jobs:
           - 8093:8093
           - 8094:8094
           - 11210:11210
-      sqs:
+      aws:
         image: localstack/localstack:3.0.2
         ports:
           - 4566:4566
@@ -254,6 +254,7 @@ jobs:
         run: ./phpunit --group integration -v
         env:
           INTEGRATION_FTP_URL: 'ftp://test:test@localhost'
+          LOCK_DYNAMODB_DSN: "dynamodb://localhost:4566/lock_keys?sslmode=disable"
           REDIS_HOST: 'localhost:16379'
           REDIS_AUTHENTICATED_HOST: 'localhost:16380'
           REDIS_CLUSTER_HOSTS: 'localhost:7000 localhost:7001 localhost:7002 localhost:7003 localhost:7004 localhost:7005'

--- a/.github/workflows/package-tests.yml
+++ b/.github/workflows/package-tests.yml
@@ -21,7 +21,10 @@ jobs:
 
       - name: Find packages
         id: find-packages
-        run: echo "packages=$(php .github/get-modified-packages.php $(find src/Symfony -mindepth 2 -type f -name composer.json -printf '%h\n' | grep -v src/Symfony/Component/Emoji/Resources/bin |jq -R -s -c 'split("\n")[:-1]') $(git diff --name-only origin/${{ github.base_ref }} HEAD | grep src/ | jq -R -s -c 'split("\n")[:-1]'))" >> $GITHUB_OUTPUT
+        run: |
+          all_packages=$(find src/Symfony -mindepth 2 -type f -name composer.json -printf '%h\n' | grep -v src/Symfony/Component/Emoji/Resources/bin |jq -R -s -c 'split("\n")[:-1]')
+          modified_files=$(git diff --name-only origin/${{ github.base_ref }} HEAD | grep src/ | jq -R -s -c 'split("\n")[:-1]')
+          echo "packages=$(php .github/get-modified-packages.php $all_packages $modified_files)" >> $GITHUB_OUTPUT
 
       - name: Verify meta files are correct
         run: |

--- a/composer.json
+++ b/composer.json
@@ -127,6 +127,7 @@
     "require-dev": {
         "amphp/http-client": "^4.2.1|^5.0",
         "amphp/http-tunnel": "^1.0|^2.0",
+        "async-aws/dynamo-db": "^3.0",
         "async-aws/ses": "^1.0",
         "async-aws/sqs": "^1.0|^2.0",
         "async-aws/sns": "^1.0",

--- a/src/Symfony/Component/Lock/Bridge/DynamoDb/.gitattributes
+++ b/src/Symfony/Component/Lock/Bridge/DynamoDb/.gitattributes
@@ -1,0 +1,3 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Lock/Bridge/DynamoDb/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Lock/Bridge/DynamoDb/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Lock/Bridge/DynamoDb/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Lock/Bridge/DynamoDb/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Lock/Bridge/DynamoDb/.gitignore
+++ b/src/Symfony/Component/Lock/Bridge/DynamoDb/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+composer.lock
+phpunit.xml

--- a/src/Symfony/Component/Lock/Bridge/DynamoDb/CHANGELOG.md
+++ b/src/Symfony/Component/Lock/Bridge/DynamoDb/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+7.4
+---
+
+* Add the bridge

--- a/src/Symfony/Component/Lock/Bridge/DynamoDb/LICENSE
+++ b/src/Symfony/Component/Lock/Bridge/DynamoDb/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2025-present Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/Lock/Bridge/DynamoDb/README.md
+++ b/src/Symfony/Component/Lock/Bridge/DynamoDb/README.md
@@ -1,0 +1,23 @@
+Amazon DynamoDB Lock
+====================
+
+Provides [Amazon DynamoDB](https://async-aws.com/clients/dynamodb.html) integration for Symfony Lock.
+
+DSN example
+-----------
+
+```
+dynamodb://default/lock_keys
+```
+
+where:
+- `default` means the DynamoDB client will use the default configuration
+- `lock_keys` is the name of the DynamoDB table to use
+
+Resources
+---------
+
+ * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+ * [Report issues](https://github.com/symfony/symfony/issues) and
+   [send Pull Requests](https://github.com/symfony/symfony/pulls)
+   in the [main Symfony repository](https://github.com/symfony/symfony)

--- a/src/Symfony/Component/Lock/Bridge/DynamoDb/Store/DynamoDbStore.php
+++ b/src/Symfony/Component/Lock/Bridge/DynamoDb/Store/DynamoDbStore.php
@@ -1,0 +1,284 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock\Bridge\DynamoDb\Store;
+
+use AsyncAws\DynamoDb\DynamoDbClient;
+use AsyncAws\DynamoDb\Exception\ConditionalCheckFailedException;
+use AsyncAws\DynamoDb\Exception\ResourceNotFoundException;
+use AsyncAws\DynamoDb\Input\CreateTableInput;
+use AsyncAws\DynamoDb\Input\DeleteItemInput;
+use AsyncAws\DynamoDb\Input\DescribeTableInput;
+use AsyncAws\DynamoDb\Input\GetItemInput;
+use AsyncAws\DynamoDb\Input\PutItemInput;
+use AsyncAws\DynamoDb\ValueObject\AttributeDefinition;
+use AsyncAws\DynamoDb\ValueObject\AttributeValue;
+use AsyncAws\DynamoDb\ValueObject\KeySchemaElement;
+use AsyncAws\DynamoDb\ValueObject\ProvisionedThroughput;
+use Symfony\Component\Lock\Exception\InvalidArgumentException;
+use Symfony\Component\Lock\Exception\InvalidTtlException;
+use Symfony\Component\Lock\Exception\LockAcquiringException;
+use Symfony\Component\Lock\Exception\LockConflictedException;
+use Symfony\Component\Lock\Key;
+use Symfony\Component\Lock\PersistingStoreInterface;
+use Symfony\Component\Lock\Store\ExpiringStoreTrait;
+
+class DynamoDbStore implements PersistingStoreInterface
+{
+    use ExpiringStoreTrait;
+
+    private const DEFAULT_OPTIONS = [
+        'access_key' => null,
+        'secret_key' => null,
+        'session_token' => null,
+        'endpoint' => null,
+        'region' => null,
+        'table_name' => 'lock_keys',
+        'id_attr' => 'key_id',
+        'token_attr' => 'key_token',
+        'expiration_attr' => 'key_expiration',
+        'read_capacity_units' => 10,
+        'write_capacity_units' => 20,
+        'sslmode' => null,
+        'debug' => null,
+    ];
+
+    private DynamoDbClient $client;
+    private string $tableName;
+    private string $idAttr;
+    private string $tokenAttr;
+    private string $expirationAttr;
+    private int $readCapacityUnits;
+    private int $writeCapacityUnits;
+
+    public function __construct(
+        DynamoDbClient|string $clientOrDsn,
+        array $options = [],
+        private readonly int $initialTtl = 300,
+    ) {
+        if ($clientOrDsn instanceof DynamoDbClient) {
+            $this->client = $clientOrDsn;
+        } else {
+            if (!str_starts_with($clientOrDsn, 'dynamodb:')) {
+                throw new InvalidArgumentException('Unsupported DSN for DynamoDB.');
+            }
+
+            if (false === $params = parse_url($clientOrDsn)) {
+                throw new InvalidArgumentException('The given Amazon DynamoDB DSN is invalid.');
+            }
+
+            $query = [];
+            if (isset($params['query'])) {
+                parse_str($params['query'], $query);
+            }
+
+            // check for extra keys in options
+            $optionsExtraKeys = array_diff_key($options, self::DEFAULT_OPTIONS);
+            if (0 < \count($optionsExtraKeys)) {
+                throw new InvalidArgumentException(\sprintf('Unknown option found: [%s]. Allowed options are [%s].', implode(', ', $optionsExtraKeys), implode(', ', array_keys(self::DEFAULT_OPTIONS))));
+            }
+
+            // check for extra keys in query
+            $queryExtraKeys = array_diff_key($query, self::DEFAULT_OPTIONS);
+            if (0 < \count($queryExtraKeys)) {
+                throw new InvalidArgumentException(\sprintf('Unknown option found in DSN: [%s]. Allowed options are [%s].', implode(', ', $queryExtraKeys), implode(', ', array_keys(self::DEFAULT_OPTIONS))));
+            }
+
+            $options = $query + $options + self::DEFAULT_OPTIONS;
+
+            $clientConfiguration = [
+                'region' => $options['region'],
+                'accessKeyId' => rawurldecode($params['user'] ?? '') ?: $options['access_key'] ?? self::DEFAULT_OPTIONS['access_key'],
+                'accessKeySecret' => rawurldecode($params['pass'] ?? '') ?: $options['secret_key'] ?? self::DEFAULT_OPTIONS['secret_key'],
+            ];
+            if (null !== $options['session_token']) {
+                $clientConfiguration['sessionToken'] = $options['session_token'];
+            }
+            if (isset($options['debug'])) {
+                $clientConfiguration['debug'] = $options['debug'];
+            }
+            unset($query['region']);
+
+            if ('default' !== ($params['host'] ?? 'default')) {
+                $clientConfiguration['endpoint'] = \sprintf('%s://%s%s', ($options['sslmode'] ?? null) === 'disable' ? 'http' : 'https', $params['host'], ($params['port'] ?? null) ? ':'.$params['port'] : '');
+                if (preg_match(';^dynamodb\.([^\.]++)\.amazonaws\.com$;', $params['host'], $matches)) {
+                    $clientConfiguration['region'] = $matches[1];
+                }
+            } elseif (null !== ($options['endpoint'] ?? self::DEFAULT_OPTIONS['endpoint'])) {
+                $clientConfiguration['endpoint'] = $options['endpoint'];
+            }
+
+            $parsedPath = explode('/', ltrim($params['path'] ?? '/', '/'));
+            if ($tableName = end($parsedPath)) {
+                $options['table_name'] = $tableName;
+            }
+
+            $this->client = new DynamoDbClient($clientConfiguration);
+        }
+
+        $this->tableName = $options['table_name'] ?? self::DEFAULT_OPTIONS['table_name'];
+        $this->idAttr = $options['id_attr'] ?? self::DEFAULT_OPTIONS['id_attr'];
+        $this->tokenAttr = $options['token_attr'] ?? self::DEFAULT_OPTIONS['token_attr'];
+        $this->expirationAttr = $options['expiration_attr'] ?? self::DEFAULT_OPTIONS['expiration_attr'];
+        $this->readCapacityUnits = $options['read_capacity_units'] ?? self::DEFAULT_OPTIONS['read_capacity_units'];
+        $this->writeCapacityUnits = $options['write_capacity_units'] ?? self::DEFAULT_OPTIONS['write_capacity_units'];
+    }
+
+    public function save(Key $key): void
+    {
+        $key->reduceLifetime($this->initialTtl);
+
+        $input = new PutItemInput([
+            'TableName' => $this->tableName,
+            'Item' => [
+                $this->idAttr => new AttributeValue(['S' => $this->getHashedKey($key)]),
+                $this->tokenAttr => new AttributeValue(['S' => $this->getUniqueToken($key)]),
+                $this->expirationAttr => new AttributeValue(['N' => (string) (\microtime(true) + $this->initialTtl)]),
+            ],
+            'ConditionExpression' => 'attribute_not_exists(#key) OR #expires_at < :now',
+            'ExpressionAttributeNames' => [
+                '#key' => $this->idAttr,
+                '#expires_at' => $this->expirationAttr,
+            ],
+            'ExpressionAttributeValues' => [
+                ':now' => new AttributeValue(['N' => (string) \microtime(true)]),
+            ],
+        ]);
+
+        try {
+            $this->client->putItem($input);
+        } catch (ResourceNotFoundException) {
+            $this->createTable();
+
+            try {
+                $this->client->putItem($input);
+            } catch (ConditionalCheckFailedException) {
+                $this->putOffExpiration($key, $this->initialTtl);
+            }
+        } catch (ConditionalCheckFailedException) {
+            // the lock is already acquired. It could be us. Let's try to put off.
+            $this->putOffExpiration($key, $this->initialTtl);
+        } catch (\Throwable $throwable) {
+            throw new LockAcquiringException('Failed to acquire lock.', 0, $throwable);
+        }
+
+        $this->checkNotExpired($key);
+    }
+
+    public function delete(Key $key): void
+    {
+        $this->client->deleteItem(new DeleteItemInput([
+            'TableName' => $this->tableName,
+            'Key' => [
+                $this->idAttr => new AttributeValue(['S' => $this->getHashedKey($key)]),
+            ],
+        ]));
+    }
+
+    public function exists(Key $key): bool
+    {
+        $existingLock = $this->client->getItem(new GetItemInput([
+            'TableName' => $this->tableName,
+            'ConsistentRead' => true,
+            'Key' => [
+                $this->idAttr => new AttributeValue(['S' => $this->getHashedKey($key)]),
+            ],
+        ]));
+
+        $item = $existingLock->getItem();
+
+        // Item not found at all
+        if ($item === []) {
+            return false;
+        }
+
+        // We are not the owner
+        if (!isset($item[$this->tokenAttr]) || $this->getUniqueToken($key) !== $item[$this->tokenAttr]->getS()) {
+            return false;
+        }
+
+        // If item is expired, consider it doesn't exist
+        return isset($item[$this->expirationAttr]) && ((float) $item[$this->expirationAttr]->getN()) > \microtime(true);
+    }
+
+    public function putOffExpiration(Key $key, float $ttl): void
+    {
+        if ($ttl < 1) {
+            throw new InvalidTtlException(\sprintf('"%s()" expects a TTL greater or equals to 1 second. Got "%s".', __METHOD__, $ttl));
+        }
+
+        $key->reduceLifetime($ttl);
+
+        $uniqueToken = $this->getUniqueToken($key);
+
+        try {
+            $this->client->putItem(new PutItemInput([
+                'TableName' => $this->tableName,
+                'Item' => [
+                    $this->idAttr => new AttributeValue(['S' => $this->getHashedKey($key)]),
+                    $this->tokenAttr => new AttributeValue(['S' => $uniqueToken]),
+                    $this->expirationAttr => new AttributeValue(['N' => (string) (\microtime(true) + $ttl)]),
+                ],
+                'ConditionExpression' => 'attribute_exists(#key) AND (#token = :token OR #expires_at <= :now)',
+                'ExpressionAttributeNames' => [
+                    '#key' => $this->idAttr,
+                    '#expires_at' => $this->expirationAttr,
+                    '#token' => $this->tokenAttr,
+                ],
+                'ExpressionAttributeValues' => [
+                    ':now' => new AttributeValue(['N' => (string) \microtime(true)]),
+                    ':token' => new AttributeValue(['S' => $uniqueToken]),
+                ],
+            ]));
+        } catch (ConditionalCheckFailedException) {
+            // The item doesn't exist or was acquired by someone else
+            throw new LockConflictedException();
+        } catch (\Throwable $throwable) {
+            throw new LockAcquiringException('Failed to acquire lock.', 0, $throwable);
+        }
+
+        $this->checkNotExpired($key);
+    }
+
+    public function createTable(): void
+    {
+        $this->client->createTable(new CreateTableInput([
+            'TableName' => $this->tableName,
+            'AttributeDefinitions' => [
+                new AttributeDefinition(['AttributeName' => $this->idAttr, 'AttributeType' => 'S']),
+            ],
+            'KeySchema' => [
+                new KeySchemaElement(['AttributeName' => $this->idAttr, 'KeyType' => 'HASH']),
+            ],
+            'ProvisionedThroughput' => new ProvisionedThroughput([
+                'ReadCapacityUnits' => $this->readCapacityUnits,
+                'WriteCapacityUnits' => $this->writeCapacityUnits,
+            ]),
+        ]));
+
+        $this->client->tableExists(new DescribeTableInput(['TableName' => $this->tableName]))->wait();
+    }
+
+    private function getHashedKey(Key $key): string
+    {
+        return hash('sha256', (string) $key);
+    }
+
+    private function getUniqueToken(Key $key): string
+    {
+        if (!$key->hasState(__CLASS__)) {
+            $token = base64_encode(random_bytes(32));
+            $key->setState(__CLASS__, $token);
+        }
+
+        return $key->getState(__CLASS__);
+    }
+}

--- a/src/Symfony/Component/Lock/Bridge/DynamoDb/Tests/Functional/Store/DynamoDbStoreTest.php
+++ b/src/Symfony/Component/Lock/Bridge/DynamoDb/Tests/Functional/Store/DynamoDbStoreTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock\Bridge\DynamoDb\Tests\Functional\Store;
+
+use Symfony\Component\Lock\Bridge\DynamoDb\Store\DynamoDbStore;
+use Symfony\Component\Lock\PersistingStoreInterface;
+use Symfony\Component\Lock\Test\AbstractStoreTestCase;
+
+/**
+ * @group integration
+ */
+class DynamoDbStoreTest extends AbstractStoreTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (!getenv('LOCK_DYNAMODB_DSN')) {
+            self::markTestSkipped('DynamoDB server not found.');
+        }
+
+        $store = new DynamoDbStore(getenv('LOCK_DYNAMODB_DSN'));
+        $store->createTable();
+    }
+
+    protected function getStore(): PersistingStoreInterface
+    {
+        return new DynamoDbStore(getenv('LOCK_DYNAMODB_DSN'));
+    }
+}

--- a/src/Symfony/Component/Lock/Bridge/DynamoDb/Tests/Store/DynamoDbStoreTest.php
+++ b/src/Symfony/Component/Lock/Bridge/DynamoDb/Tests/Store/DynamoDbStoreTest.php
@@ -1,0 +1,182 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock\Bridge\DynamoDb\Tests\Store;
+
+use AsyncAws\DynamoDb\DynamoDbClient;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Lock\Bridge\DynamoDb\Store\DynamoDbStore;
+
+class DynamoDbStoreTest extends TestCase
+{
+    public function testExtraOptions()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new DynamoDbStore('dynamodb://default/lock_keys', [
+            'extra_key',
+        ]);
+    }
+
+    public function testExtraParamsInQuery()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new DynamoDbStore('dynamodb://default/lock_keys?extra_param=some_value');
+    }
+
+    public function testConfigureWithCredentials()
+    {
+        $awsKey = 'some_aws_access_key_value';
+        $awsSecret = 'some_aws_secret_value';
+        $region = 'us-east-1';
+        $this->assertEquals(
+            new DynamoDbStore(new DynamoDbClient(['region' => $region, 'accessKeyId' => $awsKey, 'accessKeySecret' => $awsSecret]), ['table_name' => 'lock_keys']),
+            new DynamoDbStore('dynamodb://default/lock_keys', [
+                'access_key' => $awsKey,
+                'secret_key' => $awsSecret,
+                'region' => $region,
+            ])
+        );
+    }
+
+    public function testConfigureWithTemporaryCredentials()
+    {
+        $awsKey = 'some_aws_access_key_value';
+        $awsSecret = 'some_aws_secret_value';
+        $sessionToken = 'some_aws_sessionToken';
+        $region = 'us-east-1';
+        $this->assertEquals(
+            new DynamoDbStore(new DynamoDbClient(['region' => $region, 'accessKeyId' => $awsKey, 'accessKeySecret' => $awsSecret, 'sessionToken' => $sessionToken]), ['table_name' => 'table']),
+            new DynamoDbStore('dynamodb://default/table', [
+                'access_key' => $awsKey,
+                'secret_key' => $awsSecret,
+                'session_token' => $sessionToken,
+                'region' => $region,
+            ])
+        );
+    }
+
+    public function testFromInvalidDsn()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The given Amazon DynamoDB DSN is invalid.');
+
+        new DynamoDbStore('dynamodb://');
+    }
+
+    public function testFromUnsupportedDsn()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unsupported DSN for DynamoDB.');
+
+        new DynamoDbStore('unsupported://');
+    }
+
+    public function testFromDsn()
+    {
+        $this->assertEquals(
+            new DynamoDbStore(new DynamoDbClient(['region' => null, 'accessKeyId' => null, 'accessKeySecret' => null]), ['table_name' => 'table']),
+            new DynamoDbStore('dynamodb://default/table', [])
+        );
+    }
+
+    public function testDsnPrecedence()
+    {
+        $this->assertEquals(
+            new DynamoDbStore(new DynamoDbClient(['region' => 'us-east-2', 'accessKeyId' => 'key_dsn', 'accessKeySecret' => 'secret_dsn']), ['table_name' => 'table_dsn']),
+            new DynamoDbStore('dynamodb://key_dsn:secret_dsn@default/table_dsn?region=us-east-2', ['region' => 'eu-west-3', 'table_name' => 'table_options', 'access_key' => 'key_option', 'secret_key' => 'secret_option'])
+        );
+    }
+
+    public function testFromDsnWithRegion()
+    {
+        $this->assertEquals(
+            new DynamoDbStore(new DynamoDbClient(['region' => 'us-west-2', 'accessKeyId' => null, 'accessKeySecret' => null]), ['table_name' => 'table']),
+            new DynamoDbStore('dynamodb://default/table?region=us-west-2', [])
+        );
+    }
+
+    public function testFromDsnWithCustomEndpoint()
+    {
+        $this->assertEquals(
+            new DynamoDbStore(new DynamoDbClient(['region' => null, 'endpoint' => 'https://localhost', 'accessKeyId' => null, 'accessKeySecret' => null]), ['table_name' => 'table']),
+            new DynamoDbStore('dynamodb://localhost/table', [])
+        );
+    }
+
+    public function testFromDsnWithSslMode()
+    {
+        $this->assertEquals(
+            new DynamoDbStore(new DynamoDbClient(['region' => null, 'endpoint' => 'http://localhost', 'accessKeyId' => null, 'accessKeySecret' => null]), ['table_name' => 'table']),
+            new DynamoDbStore('dynamodb://localhost/table?sslmode=disable', [])
+        );
+    }
+
+    public function testFromDsnWithSslModeOnDefault()
+    {
+        $this->assertEquals(
+            new DynamoDbStore(new DynamoDbClient(['region' => null, 'accessKeyId' => null, 'accessKeySecret' => null]), ['table_name' => 'table']),
+            new DynamoDbStore('dynamodb://default/table?sslmode=disable', [])
+        );
+    }
+
+    public function testFromDsnWithCustomEndpointAndPort()
+    {
+        $this->assertEquals(
+            new DynamoDbStore(new DynamoDbClient(['region' => null, 'endpoint' => 'https://localhost:1234', 'accessKeyId' => null, 'accessKeySecret' => null]), ['table_name' => 'table']),
+            new DynamoDbStore('dynamodb://localhost:1234/table', [])
+        );
+    }
+
+    public function testFromDsnWithQueryOptions()
+    {
+        $this->assertEquals(
+            new DynamoDbStore(new DynamoDbClient(['region' => null, 'accessKeyId' => null, 'accessKeySecret' => null]), ['table_name' => 'table', 'id_attr' => 'id_dsn']),
+            new DynamoDbStore('dynamodb://default/table?id_attr=id_dsn', [])
+        );
+    }
+
+    public function testFromDsnWithTableNameOption()
+    {
+        $this->assertEquals(
+            new DynamoDbStore(new DynamoDbClient(['region' => null, 'accessKeyId' => null, 'accessKeySecret' => null]), ['table_name' => 'table']),
+            new DynamoDbStore('dynamodb://default', ['table_name' => 'table'])
+        );
+
+        $this->assertEquals(
+            new DynamoDbStore(new DynamoDbClient(['region' => null, 'accessKeyId' => null, 'accessKeySecret' => null]), ['table_name' => 'table']),
+            new DynamoDbStore('dynamodb://default/table', ['table_name' => 'table_ignored'])
+        );
+    }
+
+    public function testFromDsnWithInvalidQueryString()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('|Unknown option found in DSN: \[foo\]\. Allowed options are \[access_key, |');
+
+        new DynamoDbStore('dynamodb://default?foo=foo');
+    }
+
+    public function testFromDsnWithInvalidOption()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('|Unknown option found: \[bar\]\. Allowed options are \[access_key, |');
+
+        new DynamoDbStore('dynamodb://default', ['bar' => 'bar']);
+    }
+
+    public function testFromDsnWithInvalidQueryStringAndOption()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('|Unknown option found: \[bar\]\. Allowed options are \[access_key, |');
+
+        new DynamoDbStore('dynamodb://default?foo=foo', ['bar' => 'bar']);
+    }
+}

--- a/src/Symfony/Component/Lock/Bridge/DynamoDb/composer.json
+++ b/src/Symfony/Component/Lock/Bridge/DynamoDb/composer.json
@@ -1,0 +1,34 @@
+{
+    "name": "symfony/amazon-dynamodb-lock",
+    "type": "symfony-lock-bridge",
+    "description": "Symfony Amazon DynamoDb extension Lock Bridge",
+    "keywords": [],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Fabien Potencier",
+            "email": "fabien@symfony.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=8.2",
+        "async-aws/core": "^1.7",
+        "async-aws/dynamo-db": "^3.0",
+        "symfony/lock": "^7.4"
+    },
+    "conflict": {
+        "symfony/polyfill-uuid": "<1.15"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Component\\Lock\\Bridge\\DynamoDb\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev"
+}

--- a/src/Symfony/Component/Lock/Bridge/DynamoDb/phpunit.xml.dist
+++ b/src/Symfony/Component/Lock/Bridge/DynamoDb/phpunit.xml.dist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/9.3/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony Amazon DynamoDb Lock Component Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage>
+        <include>
+            <directory>./</directory>
+        </include>
+        <exclude>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </coverage>
+</phpunit>

--- a/src/Symfony/Component/Lock/Test/AbstractStoreTestCase.php
+++ b/src/Symfony/Component/Lock/Test/AbstractStoreTestCase.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Lock\Tests\Store;
+namespace Symfony\Component\Lock\Test;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Lock\Exception\LockConflictedException;

--- a/src/Symfony/Component/Lock/Tests/Store/AbstractRedisStoreTestCase.php
+++ b/src/Symfony/Component/Lock/Tests/Store/AbstractRedisStoreTestCase.php
@@ -18,6 +18,7 @@ use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\PersistingStoreInterface;
 use Symfony\Component\Lock\Store\RedisStore;
+use Symfony\Component\Lock\Test\AbstractStoreTestCase;
 
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>

--- a/src/Symfony/Component/Lock/Tests/Store/BlockingStoreTestTrait.php
+++ b/src/Symfony/Component/Lock/Tests/Store/BlockingStoreTestTrait.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Lock\Tests\Store;
 use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\PersistingStoreInterface;
+use Symfony\Component\Lock\Test\AbstractStoreTestCase;
 
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>

--- a/src/Symfony/Component/Lock/Tests/Store/CombinedStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/CombinedStoreTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\Lock\Store\CombinedStore;
 use Symfony\Component\Lock\Store\RedisStore;
 use Symfony\Component\Lock\Strategy\StrategyInterface;
 use Symfony\Component\Lock\Strategy\UnanimousStrategy;
+use Symfony\Component\Lock\Test\AbstractStoreTestCase;
 
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>

--- a/src/Symfony/Component/Lock/Tests/Store/DoctrineDbalPostgreSqlStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/DoctrineDbalPostgreSqlStoreTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\PersistingStoreInterface;
 use Symfony\Component\Lock\Store\DoctrineDbalPostgreSqlStore;
+use Symfony\Component\Lock\Test\AbstractStoreTestCase;
 
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>

--- a/src/Symfony/Component/Lock/Tests/Store/DoctrineDbalStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/DoctrineDbalStoreTest.php
@@ -21,6 +21,7 @@ use Doctrine\DBAL\Schema\Schema;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\PersistingStoreInterface;
 use Symfony\Component\Lock\Store\DoctrineDbalStore;
+use Symfony\Component\Lock\Test\AbstractStoreTestCase;
 
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>

--- a/src/Symfony/Component/Lock/Tests/Store/ExpiringStoreTestTrait.php
+++ b/src/Symfony/Component/Lock/Tests/Store/ExpiringStoreTestTrait.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Lock\Tests\Store;
 use Symfony\Component\Lock\Exception\LockExpiredException;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\PersistingStoreInterface;
+use Symfony\Component\Lock\Test\AbstractStoreTestCase;
 
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>

--- a/src/Symfony/Component/Lock/Tests/Store/FlockStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/FlockStoreTest.php
@@ -15,6 +15,7 @@ use Symfony\Component\Lock\Exception\InvalidArgumentException;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\PersistingStoreInterface;
 use Symfony\Component\Lock\Store\FlockStore;
+use Symfony\Component\Lock\Test\AbstractStoreTestCase;
 
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>

--- a/src/Symfony/Component/Lock/Tests/Store/InMemoryStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/InMemoryStoreTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Lock\Tests\Store;
 
 use Symfony\Component\Lock\PersistingStoreInterface;
 use Symfony\Component\Lock\Store\InMemoryStore;
+use Symfony\Component\Lock\Test\AbstractStoreTestCase;
 
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>

--- a/src/Symfony/Component/Lock/Tests/Store/MemcachedStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/MemcachedStoreTest.php
@@ -15,6 +15,7 @@ use Symfony\Component\Lock\Exception\InvalidTtlException;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\PersistingStoreInterface;
 use Symfony\Component\Lock\Store\MemcachedStore;
+use Symfony\Component\Lock\Test\AbstractStoreTestCase;
 
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>

--- a/src/Symfony/Component/Lock/Tests/Store/MongoDbStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/MongoDbStoreTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\Lock\Exception\InvalidArgumentException;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\PersistingStoreInterface;
 use Symfony\Component\Lock\Store\MongoDbStore;
+use Symfony\Component\Lock\Test\AbstractStoreTestCase;
 
 require_once __DIR__.'/stubs/mongodb.php';
 

--- a/src/Symfony/Component/Lock/Tests/Store/PdoStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/PdoStoreTest.php
@@ -15,6 +15,7 @@ use Symfony\Component\Lock\Exception\InvalidTtlException;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\PersistingStoreInterface;
 use Symfony\Component\Lock\Store\PdoStore;
+use Symfony\Component\Lock\Test\AbstractStoreTestCase;
 
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>

--- a/src/Symfony/Component/Lock/Tests/Store/PostgreSqlStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/PostgreSqlStoreTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\PersistingStoreInterface;
 use Symfony\Component\Lock\Store\PostgreSqlStore;
+use Symfony\Component\Lock\Test\AbstractStoreTestCase;
 
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>

--- a/src/Symfony/Component/Lock/Tests/Store/SemaphoreStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/SemaphoreStoreTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Lock\Tests\Store;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\PersistingStoreInterface;
 use Symfony\Component\Lock\Store\SemaphoreStore;
+use Symfony\Component\Lock\Test\AbstractStoreTestCase;
 
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>

--- a/src/Symfony/Component/Lock/Tests/Store/SharedLockStoreTestTrait.php
+++ b/src/Symfony/Component/Lock/Tests/Store/SharedLockStoreTestTrait.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Lock\Tests\Store;
 use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\PersistingStoreInterface;
+use Symfony\Component\Lock\Test\AbstractStoreTestCase;
 
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>

--- a/src/Symfony/Component/Lock/Tests/Store/StoreFactoryTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/StoreFactoryTest.php
@@ -11,10 +11,12 @@
 
 namespace Symfony\Component\Lock\Tests\Store;
 
+use AsyncAws\DynamoDb\DynamoDbClient;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\MemcachedAdapter;
+use Symfony\Component\Lock\Bridge\DynamoDb\Store\DynamoDbStore;
 use Symfony\Component\Lock\Store\DoctrineDbalPostgreSqlStore;
 use Symfony\Component\Lock\Store\DoctrineDbalStore;
 use Symfony\Component\Lock\Store\FlockStore;
@@ -87,6 +89,9 @@ class StoreFactoryTest extends TestCase
             yield ['pgsql+advisory://server.com/test', DoctrineDbalPostgreSqlStore::class];
             yield ['postgres+advisory://server.com/test', DoctrineDbalPostgreSqlStore::class];
             yield ['postgresql+advisory://server.com/test', DoctrineDbalPostgreSqlStore::class];
+        }
+        if (class_exists(DynamoDbClient::class)) {
+            yield ['dynamodb://default', DynamoDbStore::class];
         }
 
         yield ['in-memory', InMemoryStore::class];

--- a/src/Symfony/Component/Lock/Tests/Store/UnserializableTestTrait.php
+++ b/src/Symfony/Component/Lock/Tests/Store/UnserializableTestTrait.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Lock\Tests\Store;
 use Symfony\Component\Lock\Exception\UnserializableKeyException;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\PersistingStoreInterface;
+use Symfony\Component\Lock\Test\AbstractStoreTestCase;
 
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>

--- a/src/Symfony/Component/Lock/Tests/Store/ZookeeperStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/ZookeeperStoreTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Lock\Tests\Store;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\Store\StoreFactory;
 use Symfony\Component\Lock\Store\ZookeeperStore;
+use Symfony\Component\Lock\Test\AbstractStoreTestCase;
 
 /**
  * @author Ganesh Chandrasekaran <gchandrasekaran@wayfair.com>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #59996  <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

This PR introduces a new Lock store using AWS DynamoDb. The idea is coming from this [article](https://aws.amazon.com/blogs/database/building-distributed-locks-with-the-dynamodb-lock-client/).

The implementation is heavily based on:

- [DoctrineDbalStore](https://github.com/symfony/symfony/blob/7.3/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php) for the overall logic
- [AmazonSqsMessenger Connection](https://github.com/symfony/amazon-sqs-messenger/blob/7.3/Transport/Connection.php) for the DSN/options handling
