### PR TITLE
[Runtime] Support extra dot-env files

### DIFF
--- a/src/Symfony/Component/Runtime/Tests/phpt/.env.extra
+++ b/src/Symfony/Component/Runtime/Tests/phpt/.env.extra
@@ -1,0 +1,1 @@
+SOME_VAR=foo_bar_extra

--- a/src/Symfony/Component/Runtime/Tests/phpt/dotenv_extra_load.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/dotenv_extra_load.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+$_SERVER['SOME_VAR'] = 'ccc';
+$_SERVER['APP_RUNTIME_OPTIONS'] = [
+    'dotenv_extra_paths' => [
+        '.env.extra',
+    ],
+    'dotenv_overload' => false,
+];
+
+require __DIR__.'/autoload.php';
+
+return fn (Request $request, array $context) => new Response('OK Request '.$context['SOME_VAR']);

--- a/src/Symfony/Component/Runtime/Tests/phpt/dotenv_extra_load.phpt
+++ b/src/Symfony/Component/Runtime/Tests/phpt/dotenv_extra_load.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test Dotenv extra paths load
+--INI--
+display_errors=1
+--FILE--
+<?php
+
+require $_SERVER['SCRIPT_FILENAME'] = __DIR__.'/dotenv_extra_load.php';
+
+?>
+--EXPECTF--
+OK Request ccc

--- a/src/Symfony/Component/Runtime/Tests/phpt/dotenv_extra_overload.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/dotenv_extra_overload.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+$_SERVER['SOME_VAR'] = 'ccc';
+$_SERVER['APP_RUNTIME_OPTIONS'] = [
+    'dotenv_extra_paths' => [
+        '.env.extra',
+    ],
+    'dotenv_overload' => true,
+];
+
+require __DIR__.'/autoload.php';
+
+return fn (Request $request, array $context) => new Response('OK Request '.$context['SOME_VAR']);

--- a/src/Symfony/Component/Runtime/Tests/phpt/dotenv_extra_overload.phpt
+++ b/src/Symfony/Component/Runtime/Tests/phpt/dotenv_extra_overload.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test Dotenv extra paths overload
+--INI--
+display_errors=1
+--FILE--
+<?php
+
+require $_SERVER['SCRIPT_FILENAME'] = __DIR__.'/dotenv_extra_overload.php';
+
+?>
+--EXPECTF--
+OK Request foo_bar_extra


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #60116  <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

This change allows applications to load/overload more than one dot-env files using the `SymfonyRuntime`
