### PR TITLE
[Serializer] Allow forcing timezone in `DateTimeNormalizer` during denormalization

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
  * Deprecate class aliases in the `Annotation` namespace, use attributes instead
  * Deprecate getters in attribute classes in favor of public properties
  * Deprecate `ClassMetadataFactoryCompiler`
+ * Add `FORCE_TIMEZONE_KEY` to `DateTimeNormalizer` to force the timezone during denormalization
 
 7.3
 ---

--- a/src/Symfony/Component/Serializer/Context/Normalizer/DateTimeNormalizerContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Normalizer/DateTimeNormalizerContextBuilder.php
@@ -43,12 +43,14 @@ final class DateTimeNormalizerContextBuilder implements ContextBuilderInterface
      *
      * @see https://secure.php.net/manual/en/class.datetimezone.php
      *
+     * @param ?bool $force Whether to enforce the timezone during denormalization
+     *
      * @throws InvalidArgumentException
      */
-    public function withTimezone(\DateTimeZone|string|null $timezone): static
+    public function withTimezone(\DateTimeZone|string|null $timezone, ?bool $force = null): static
     {
         if (null === $timezone) {
-            return $this->with(DateTimeNormalizer::TIMEZONE_KEY, null);
+            return $this->with(DateTimeNormalizer::TIMEZONE_KEY, null)->with(DateTimeNormalizer::FORCE_TIMEZONE_KEY, $force);
         }
 
         if (\is_string($timezone)) {
@@ -59,7 +61,7 @@ final class DateTimeNormalizerContextBuilder implements ContextBuilderInterface
             }
         }
 
-        return $this->with(DateTimeNormalizer::TIMEZONE_KEY, $timezone);
+        return $this->with(DateTimeNormalizer::TIMEZONE_KEY, $timezone)->with(DateTimeNormalizer::FORCE_TIMEZONE_KEY, $force);
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Mapping/Loader/schema/serialization.schema.json
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/schema/serialization.schema.json
@@ -235,6 +235,10 @@
           ],
           "description": "Timezone of the date (DateTimeNormalizer)"
         },
+        "forceTimezone": {
+          "type": "boolean",
+          "description": "Whether to enforce the timezone during denormalization (DateTimeNormalizer)"
+        },
         "cast": {
           "enum": ["int", "float"],
           "description": "Cast type for DateTime (DateTimeNormalizer)"

--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
@@ -25,11 +25,13 @@ final class DateTimeNormalizer implements NormalizerInterface, DenormalizerInter
     public const FORMAT_KEY = 'datetime_format';
     public const TIMEZONE_KEY = 'datetime_timezone';
     public const CAST_KEY = 'datetime_cast';
+    public const FORCE_TIMEZONE_KEY = 'datetime_force_timezone';
 
     private array $defaultContext = [
         self::FORMAT_KEY => \DateTimeInterface::RFC3339,
         self::TIMEZONE_KEY => null,
         self::CAST_KEY => null,
+        self::FORCE_TIMEZONE_KEY => false,
     ];
 
     private const SUPPORTED_TYPES = [
@@ -112,7 +114,7 @@ final class DateTimeNormalizer implements NormalizerInterface, DenormalizerInter
 
             if (null !== $dateTimeFormat) {
                 if (false !== $object = $type::createFromFormat($dateTimeFormat, $data, $timezone)) {
-                    return $object;
+                    return $this->enforceTimezone($object, $context);
                 }
 
                 $dateTimeErrors = $type::getLastErrors();
@@ -124,11 +126,11 @@ final class DateTimeNormalizer implements NormalizerInterface, DenormalizerInter
 
             if (null !== $defaultDateTimeFormat) {
                 if (false !== $object = $type::createFromFormat($defaultDateTimeFormat, $data, $timezone)) {
-                    return $object;
+                    return $this->enforceTimezone($object, $context);
                 }
             }
 
-            return new $type($data, $timezone);
+            return $this->enforceTimezone(new $type($data, $timezone), $context);
         } catch (NotNormalizableValueException $e) {
             throw $e;
         } catch (\Exception $e) {
@@ -166,5 +168,17 @@ final class DateTimeNormalizer implements NormalizerInterface, DenormalizerInter
         }
 
         return $dateTimeZone instanceof \DateTimeZone ? $dateTimeZone : new \DateTimeZone($dateTimeZone);
+    }
+
+    private function enforceTimezone(\DateTime|\DateTimeImmutable $object, array $context): \DateTimeInterface
+    {
+        $timezone = $this->getTimezone($context);
+        $forceTimezone = $context[self::FORCE_TIMEZONE_KEY] ?? $this->defaultContext[self::FORCE_TIMEZONE_KEY];
+
+        if (null === $timezone || !$forceTimezone) {
+            return $object;
+        }
+
+        return $object->setTimezone($timezone);
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Context/Normalizer/DateTimeNormalizerContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/Normalizer/DateTimeNormalizerContextBuilderTest.php
@@ -37,7 +37,7 @@ class DateTimeNormalizerContextBuilderTest extends TestCase
     {
         $context = $this->contextBuilder
             ->withFormat($values[DateTimeNormalizer::FORMAT_KEY])
-            ->withTimezone($values[DateTimeNormalizer::TIMEZONE_KEY])
+            ->withTimezone($values[DateTimeNormalizer::TIMEZONE_KEY], $values[DateTimeNormalizer::FORCE_TIMEZONE_KEY])
             ->withCast($values[DateTimeNormalizer::CAST_KEY])
             ->toArray();
 
@@ -53,18 +53,23 @@ class DateTimeNormalizerContextBuilderTest extends TestCase
             DateTimeNormalizer::FORMAT_KEY => 'format',
             DateTimeNormalizer::TIMEZONE_KEY => new \DateTimeZone('GMT'),
             DateTimeNormalizer::CAST_KEY => 'int',
+            DateTimeNormalizer::FORCE_TIMEZONE_KEY => true,
         ]];
 
         yield 'With null values' => [[
             DateTimeNormalizer::FORMAT_KEY => null,
             DateTimeNormalizer::TIMEZONE_KEY => null,
             DateTimeNormalizer::CAST_KEY => null,
+            DateTimeNormalizer::FORCE_TIMEZONE_KEY => null,
         ]];
     }
 
     public function testCastTimezoneStringToTimezone()
     {
-        $this->assertEquals([DateTimeNormalizer::TIMEZONE_KEY => new \DateTimeZone('GMT')], $this->contextBuilder->withTimezone('GMT')->toArray());
+        $this->assertEquals(
+            [DateTimeNormalizer::TIMEZONE_KEY => new \DateTimeZone('GMT'), DateTimeNormalizer::FORCE_TIMEZONE_KEY => null],
+            $this->contextBuilder->withTimezone('GMT')->toArray()
+        );
     }
 
     public function testCannotSetInvalidTimezone()

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
@@ -299,6 +299,59 @@ class DateTimeNormalizerTest extends TestCase
         ];
     }
 
+    public function testDenormalizeUsingPreserveContextTimezoneAndFormatPassedInConstructor()
+    {
+        $normalizer = new DateTimeNormalizer(
+            [
+                DateTimeNormalizer::TIMEZONE_KEY => new \DateTimeZone('Japan'),
+                DateTimeNormalizer::FORMAT_KEY => 'Y-m-d\\TH:i:sO',
+                DateTimeNormalizer::FORCE_TIMEZONE_KEY => true,
+            ]
+        );
+        $actual = $normalizer->denormalize('2016-12-01T12:34:56+0000', \DateTimeInterface::class);
+        $this->assertEquals(new \DateTimeZone('Japan'), $actual->getTimezone());
+    }
+
+    public function testDenormalizeUsingPreserveContextTimezoneAndFormatPassedInContext()
+    {
+        $actual = $this->normalizer->denormalize(
+            '2016-12-01T12:34:56+0000',
+            \DateTimeInterface::class,
+            null,
+            [
+                DateTimeNormalizer::TIMEZONE_KEY => new \DateTimeZone('Japan'),
+                DateTimeNormalizer::FORMAT_KEY => 'Y-m-d\\TH:i:sO',
+                DateTimeNormalizer::FORCE_TIMEZONE_KEY => true,
+            ]
+        );
+        $this->assertEquals(new \DateTimeZone('Japan'), $actual->getTimezone());
+    }
+
+    public function testDenormalizeUsingPreserveContextTimezoneWithoutFormat()
+    {
+        $actual = $this->normalizer->denormalize(
+            '2016-12-01T12:34:56+0000',
+            \DateTimeInterface::class,
+            null,
+            [
+                DateTimeNormalizer::TIMEZONE_KEY => new \DateTimeZone('Japan'),
+                DateTimeNormalizer::FORCE_TIMEZONE_KEY => true,
+            ]
+        );
+        $this->assertEquals(new \DateTimeZone('Japan'), $actual->getTimezone());
+    }
+
+    public function testDenormalizeUsingPreserveContextShouldBeIgnoredWithoutTimezoneInContext()
+    {
+        $actual = $this->normalizer->denormalize(
+            '2016-12-01T12:34:56+0000',
+            \DateTimeInterface::class,
+            null,
+            [DateTimeNormalizer::FORCE_TIMEZONE_KEY => true]
+        );
+        $this->assertEquals(new \DateTimeZone('+00:00'), $actual->getTimezone());
+    }
+
     public function testDenormalizeInvalidDataThrowsException()
     {
         $this->expectException(UnexpectedValueException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Issues        | Fix #59807
| License       | MIT

By default the `DateTimeNormalizer` will denormalize timestamps and date strings that include a timezone to `DateTime` objects with respective timezone UTC or the timezone from the date string. Even with the context key `TIMEZONE_KEY` set, the timezone from the input superceeds the context timezone. 

This PR allows to set `PRESERVE_CONTEXT_TIMEZONE_KEY` context to `true` (default: `false`), which in combination with `TIMEZONE_KEY` will set the Timezone of the denormalized DateTimes to the given timezone. The timezone from the input will be overwritten.

### Documentation
https://github.com/symfony/symfony-docs/pull/20860
