### PR TITLE
[Uid] Use more concrete exception classes

### DIFF
--- a/src/Symfony/Component/Uid/CHANGELOG.md
+++ b/src/Symfony/Component/Uid/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+7.3
+---
+
+ * Make `Uuid` throw more concrete `InvalidUuidException`
+ * Make `Ulid` throw more concrete `InvalidUlidException`
+
 7.2
 ---
 

--- a/src/Symfony/Component/Uid/CHANGELOG.md
+++ b/src/Symfony/Component/Uid/CHANGELOG.md
@@ -4,8 +4,8 @@ CHANGELOG
 7.3
 ---
 
- * Make `Uuid` throw more concrete `InvalidUuidException`
- * Make `Ulid` throw more concrete `InvalidUlidException`
+ * Add `Symfony\Component\Uid\InvalidUuidException`
+ * Add `Symfony\Component\Uid\InvalidUlidException`
 
 7.2
 ---

--- a/src/Symfony/Component/Uid/InvalidUidException.php
+++ b/src/Symfony/Component/Uid/InvalidUidException.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Uid;
+
+abstract class InvalidUidException extends \InvalidArgumentException
+{
+    public function __construct(
+        private readonly string $value,
+        string $message,
+    ) {
+        parent::__construct($message);
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Symfony/Component/Uid/InvalidUlidException.php
+++ b/src/Symfony/Component/Uid/InvalidUlidException.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Uid;
+
+final class InvalidUlidException extends \InvalidArgumentException
+{
+    public function __construct(
+        private readonly string $value,
+    ) {
+        parent::__construct(\sprintf('Invalid ULID: "%s".', $this->value));
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Symfony/Component/Uid/InvalidUlidException.php
+++ b/src/Symfony/Component/Uid/InvalidUlidException.php
@@ -11,16 +11,10 @@
 
 namespace Symfony\Component\Uid;
 
-final class InvalidUlidException extends \InvalidArgumentException
+final class InvalidUlidException extends InvalidUidException
 {
-    public function __construct(
-        private readonly string $value,
-    ) {
-        parent::__construct(\sprintf('Invalid ULID: "%s".', $this->value));
-    }
-
-    public function getValue(): string
+    public function __construct(string $value)
     {
-        return $this->value;
+        parent::__construct($value, \sprintf('Invalid ULID: "%s".', $value));
     }
 }

--- a/src/Symfony/Component/Uid/InvalidUuidException.php
+++ b/src/Symfony/Component/Uid/InvalidUuidException.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Uid;
+
+final class InvalidUuidException extends \InvalidArgumentException
+{
+    public function __construct(
+        private readonly int $type,
+        private readonly string $value,
+    ) {
+        parent::__construct(\sprintf('Invalid UUID%s: "%s".', $this->type ? 'v'.$this->type : '', $this->value));
+    }
+
+    public function getType(): int
+    {
+        return $this->type;
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Symfony/Component/Uid/InvalidUuidException.php
+++ b/src/Symfony/Component/Uid/InvalidUuidException.php
@@ -11,22 +11,10 @@
 
 namespace Symfony\Component\Uid;
 
-final class InvalidUuidException extends \InvalidArgumentException
+final class InvalidUuidException extends InvalidUidException
 {
-    public function __construct(
-        private readonly int $type,
-        private readonly string $value,
-    ) {
-        parent::__construct(\sprintf('Invalid UUID%s: "%s".', $this->type ? 'v'.$this->type : '', $this->value));
-    }
-
-    public function getType(): int
+    public function __construct(int $type, string $value)
     {
-        return $this->type;
-    }
-
-    public function getValue(): string
-    {
-        return $this->value;
+        parent::__construct($value, \sprintf('Invalid UUID%s: "%s".', $type ? 'v'.$type : '', $value));
     }
 }

--- a/src/Symfony/Component/Uid/Tests/UlidTest.php
+++ b/src/Symfony/Component/Uid/Tests/UlidTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Uid\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\InvalidUlidException;
 use Symfony\Component\Uid\MaxUlid;
 use Symfony\Component\Uid\NilUlid;
 use Symfony\Component\Uid\Tests\Fixtures\CustomUlid;
@@ -41,7 +42,7 @@ class UlidTest extends TestCase
 
     public function testWithInvalidUlid()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidUlidException::class);
         $this->expectExceptionMessage('Invalid ULID: "this is not a ulid".');
 
         new Ulid('this is not a ulid');

--- a/src/Symfony/Component/Uid/Ulid.php
+++ b/src/Symfony/Component/Uid/Ulid.php
@@ -36,7 +36,7 @@ class Ulid extends AbstractUid implements TimeBasedUidInterface
             $this->uid = $ulid;
         } else {
             if (!self::isValid($ulid)) {
-                throw new \InvalidArgumentException(\sprintf('Invalid ULID: "%s".', $ulid));
+                throw new InvalidUlidException($ulid);
             }
 
             $this->uid = strtoupper($ulid);

--- a/src/Symfony/Component/Uid/Uuid.php
+++ b/src/Symfony/Component/Uid/Uuid.php
@@ -39,13 +39,13 @@ class Uuid extends AbstractUid
         $type = preg_match('{^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$}Di', $uuid) ? (int) $uuid[14] : false;
 
         if (false === $type || (static::TYPE ?: $type) !== $type) {
-            throw new \InvalidArgumentException(\sprintf('Invalid UUID%s: "%s".', static::TYPE ? 'v'.static::TYPE : '', $uuid));
+            throw new InvalidUuidException(static::TYPE, $uuid);
         }
 
         $this->uid = strtolower($uuid);
 
         if ($checkVariant && !\in_array($this->uid[19], ['8', '9', 'a', 'b'], true)) {
-            throw new \InvalidArgumentException(\sprintf('Invalid UUID%s: "%s".', static::TYPE ? 'v'.static::TYPE : '', $uuid));
+            throw new InvalidUuidException(static::TYPE, $uuid);
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

Hello

This PR introduces two exception classes: `InvalidUuidException` and `InvalidUlidException` that replace `\InvalidArgumentException` thrown  from the constructor.

In particular, this is useful if we rely on exceptions as a primary source of validation. 