### PR TITLE
[Messenger] fix RedisCluster seed if REDIS_CLUSTER_HOST env var is not set

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisExtIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisExtIntegrationTest.php
@@ -450,7 +450,7 @@ class RedisExtIntegrationTest extends TestCase
     private function skipIfRedisClusterUnavailable()
     {
         try {
-            new \RedisCluster(null, explode(' ', getenv('REDIS_CLUSTER_HOSTS')));
+            new \RedisCluster(null, getenv('REDIS_CLUSTER_HOST') ? explode(' ', getenv('REDIS_CLUSTER_HOST')) : []);
         } catch (\Exception $e) {
             self::markTestSkipped($e->getMessage());
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT
