### PR TITLE
[HttpKernel] Do not ignore enum in controller arguments when it has an `#[Autowire]` attribute

### DIFF
--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
@@ -159,7 +159,7 @@ class RegisterControllerArgumentLocatorsPass implements CompilerPassInterface
                         continue;
                     } elseif (!$autowire || (!($autowireAttributes ??= $p->getAttributes(Autowire::class, \ReflectionAttribute::IS_INSTANCEOF)) && (!$type || '\\' !== $target[0]))) {
                         continue;
-                    } elseif (is_subclass_of($type, \UnitEnum::class)) {
+                    } elseif (!$autowireAttributes && is_subclass_of($type, \UnitEnum::class)) {
                         // do not attempt to register enum typed arguments if not already present in bindings
                         continue;
                     } elseif (!$p->allowsNull()) {

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
@@ -498,13 +498,14 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
 
         $locator = $container->get($locatorId)->get('foo::fooAction');
 
-        $this->assertCount(9, $locator->getProvidedServices());
+        $this->assertCount(10, $locator->getProvidedServices());
         $this->assertInstanceOf(\stdClass::class, $locator->get('service1'));
         $this->assertSame('foo/bar', $locator->get('value'));
         $this->assertSame('foo', $locator->get('expression'));
         $this->assertInstanceOf(\stdClass::class, $locator->get('serviceAsValue'));
         $this->assertInstanceOf(\stdClass::class, $locator->get('expressionAsValue'));
         $this->assertSame('bar', $locator->get('rawValue'));
+        $this->stringContains('Symfony_Component_HttpKernel_Tests_Fixtures_Suit_APP_SUIT', $locator->get('suit'));
         $this->assertSame('@bar', $locator->get('escapedRawValue'));
         $this->assertSame('foo', $locator->get('customAutowire'));
         $this->assertInstanceOf(FooInterface::class, $autowireCallable = $locator->get('autowireCallable'));
@@ -719,6 +720,8 @@ class WithAutowireAttribute
         \stdClass $expressionAsValue,
         #[Autowire('bar')]
         string $rawValue,
+        #[Autowire(env: 'enum:\Symfony\Component\HttpKernel\Tests\Fixtures\Suit:APP_SUIT')]
+        Suit $suit,
         #[Autowire('@@bar')]
         string $escapedRawValue,
         #[CustomAutowire('some.parameter')]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Issues        | 
| License       | MIT

When moving services injected from the constructor to the controller arguments, I noticed a bug.

We were auto wiring an env var to a backed enum like this:

```php
class Foo
{
    public function __construct(
        #[Autowire(env: 'enum:App\Enum:SOME_ENV_KEY')]
        private \App\Enum $someEnum,
    ) {}

    public function __invoke() {}
}
```

This works fine with normal Symfony Dependency Injection.

But when we switch to controller arguments like this:
```php
class Foo
{
    public function __invoke(
        #[Autowire(env: 'enum:App\Enum:SOME_ENV_KEY')]
        \App\Enum $someEnum,
    ) {}
}
```

This stops working.

The issue is that BackedEnum's are excluded. But this should only be excluded when there is no Autowire attribute.