### PR TITLE
[Cache] Fix proxying third party PSR-6 cache items

### DIFF
--- a/src/Symfony/Component/Cache/CacheItem.php
+++ b/src/Symfony/Component/Cache/CacheItem.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache;
 
+use Psr\Cache\CacheItemInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Cache\Exception\InvalidArgumentException;
 use Symfony\Component\Cache\Exception\LogicException;
@@ -30,7 +31,7 @@ final class CacheItem implements ItemInterface
     protected float|int|null $expiry = null;
     protected array $metadata = [];
     protected array $newMetadata = [];
-    protected ?ItemInterface $innerItem = null;
+    protected ?CacheItemInterface $innerItem = null;
     protected ?string $poolHash = null;
     protected bool $isTaggable = false;
 


### PR DESCRIPTION
...work with adapter of CacheItemPoolInterface other than \Symfony\Component\Cache\Adapter\AdapterInterface

| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60160
| License       | MIT
