### PR TITLE
[Console] Correctly convert `SIGSYS` to its name

### DIFF
--- a/src/Symfony/Component/Console/SignalRegistry/SignalMap.php
+++ b/src/Symfony/Component/Console/SignalRegistry/SignalMap.php
@@ -27,7 +27,7 @@ class SignalMap
         if (!isset(self::$map)) {
             $r = new \ReflectionExtension('pcntl');
             $c = $r->getConstants();
-            $map = array_filter($c, fn ($k) => str_starts_with($k, 'SIG') && !str_starts_with($k, 'SIG_'), \ARRAY_FILTER_USE_KEY);
+            $map = array_filter($c, fn ($k) => str_starts_with($k, 'SIG') && !str_starts_with($k, 'SIG_') && 'SIGBABY' !== $k, \ARRAY_FILTER_USE_KEY);
             self::$map = array_flip($map);
         }
 

--- a/src/Symfony/Component/Console/Tests/SignalRegistry/SignalMapTest.php
+++ b/src/Symfony/Component/Console/Tests/SignalRegistry/SignalMapTest.php
@@ -22,6 +22,7 @@ class SignalMapTest extends TestCase
      * @testWith [2, "SIGINT"]
      *           [9, "SIGKILL"]
      *           [15, "SIGTERM"]
+     *           [31, "SIGSYS"]
      */
     public function testSignalExists(int $signal, string $expected)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | N/A
| License       | MIT


Because of a [PHP easter egg](https://stackoverflow.com/a/48485134) using the `SignalMap::getSignalName()` method with `SIGSYS` results in `'SIGBABY'` instead of the expected `'SIGSYS'` being returned.

https://github.com/php/php-src/blob/213949dc340e17b7234c8a753703b1ab455c8585/ext/pcntl/pcntl_arginfo.h#L398-L400

```php
require 'vendor/autoload.php';
var_dump(Symfony\Component\Console\SignalRegistry\SignalMap::getSignalName(SIGSYS));
// string(7) "SIGBABY"
```