### PR TITLE
[FrameworkBundle][RateLimiter] deprecate `RateLimiterFactory` alias

### DIFF
--- a/UPGRADE-7.3.md
+++ b/UPGRADE-7.3.md
@@ -59,6 +59,7 @@ FrameworkBundle
    because its default value will change in version 8.0
  * Deprecate the `--show-arguments` option of the `container:debug` command, as arguments are now always shown
  * Deprecate the `framework.validation.cache` config option
+ * Deprecate the `RateLimiterFactory` autowiring aliases, use `RateLimiterFactoryInterface` instead
  * Deprecate setting the `framework.profiler.collect_serializer_data` config option to `false`
 
    When set to `true`, normalizers must be injected using the `NormalizerInterface`, and not using any concrete implementation.

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -23,6 +23,7 @@ CHANGELOG
    the `#[AsController]` attribute is no longer required
  * Deprecate setting the `framework.profiler.collect_serializer_data` config option to `false`
  * Set `framework.rate_limiter.limiters.*.lock_factory` to `auto` by default
+ * Deprecate `RateLimiterFactory` autowiring aliases, use `RateLimiterFactoryInterface` instead
 
 7.2
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -3266,10 +3266,11 @@ class FrameworkExtension extends Extension
             $limiterConfig['id'] = $name;
             $limiter->replaceArgument(0, $limiterConfig);
 
-            $container->registerAliasForArgument($limiterId, RateLimiterFactory::class, $name.'.limiter');
+            $factoryAlias = $container->registerAliasForArgument($limiterId, RateLimiterFactory::class, $name.'.limiter');
 
             if (interface_exists(RateLimiterFactoryInterface::class)) {
                 $container->registerAliasForArgument($limiterId, RateLimiterFactoryInterface::class, $name.'.limiter');
+                $factoryAlias->setDeprecated('symfony/dependency-injection', '7.3', 'The "%alias_id%" autowiring alias is deprecated and will be removed in 8.0, use "RateLimiterFactoryInterface" instead.');
             }
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | Fix https://github.com/symfony/symfony/pull/60155#discussion_r2031883806
| License       | MIT