### PR TITLE
[Cache] Fix invalidating on save failures with Array|ApcuAdapter

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/ApcuAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ApcuAdapter.php
@@ -101,19 +101,10 @@ class ApcuAdapter extends AbstractAdapter
             return $failed;
         }
 
-        try {
-            if (false === $failures = apcu_store($values, null, $lifetime)) {
-                $failures = $values;
-            }
-
-            return array_keys($failures);
-        } catch (\Throwable $e) {
-            if (1 === \count($values)) {
-                // Workaround https://github.com/krakjoe/apcu/issues/170
-                apcu_delete(array_key_first($values));
-            }
-
-            throw $e;
+        if (false === $failures = apcu_store($values, null, $lifetime)) {
+            $failures = $values;
         }
+
+        return array_keys($failures);
     }
 }

--- a/src/Symfony/Component/Cache/Adapter/ArrayAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ArrayAdapter.php
@@ -312,7 +312,9 @@ class ArrayAdapter implements AdapterInterface, CacheInterface, LoggerAwareInter
             try {
                 $serialized = serialize($value);
             } catch (\Exception $e) {
-                unset($this->values[$key], $this->expiries[$key], $this->tags[$key]);
+                if (!isset($this->expiries[$key])) {
+                    unset($this->values[$key]);
+                }
                 $type = get_debug_type($value);
                 $message = sprintf('Failed to save key "{key}" of type %s: %s', $type, $e->getMessage());
                 CacheItem::log($this->logger, $message, ['key' => $key, 'exception' => $e, 'cache-adapter' => get_debug_type($this)]);

--- a/src/Symfony/Component/Cache/Tests/Adapter/AdapterTestCase.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/AdapterTestCase.php
@@ -352,6 +352,23 @@ abstract class AdapterTestCase extends CachePoolTest
 
         $this->assertEquals('value-50', $cache->getItem((string) 50)->get());
     }
+
+    public function testErrorsDontInvalidate()
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $cache = $this->createCachePool(0, __FUNCTION__);
+
+        $item = $cache->getItem('foo');
+        $this->assertTrue($cache->save($item->set('bar')));
+        $this->assertTrue($cache->hasItem('foo'));
+
+        $item->set(static fn () => null);
+        $this->assertFalse($cache->save($item));
+        $this->assertSame('bar', $cache->getItem('foo')->get());
+    }
 }
 
 class NotUnserializable

--- a/src/Symfony/Component/Cache/Tests/Adapter/ArrayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ArrayAdapterTest.php
@@ -102,17 +102,4 @@ class ArrayAdapterTest extends AdapterTestCase
 
         $this->assertSame(TestEnum::Foo, $cache->getItem('foo')->get());
     }
-
-    public function testExpiryCleanupOnError()
-    {
-        $cache = new ArrayAdapter();
-
-        $item = $cache->getItem('foo');
-        $this->assertTrue($cache->save($item->set('bar')));
-        $this->assertTrue($cache->hasItem('foo'));
-
-        $item->set(static fn () => null);
-        $this->assertFalse($cache->save($item));
-        $this->assertFalse($cache->hasItem('foo'));
-    }
 }

--- a/src/Symfony/Component/Cache/Tests/Adapter/PhpArrayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PhpArrayAdapterTest.php
@@ -42,6 +42,7 @@ class PhpArrayAdapterTest extends AdapterTestCase
         'testSaveDeferredWhenChangingValues' => 'PhpArrayAdapter is read-only.',
         'testSaveDeferredOverwrite' => 'PhpArrayAdapter is read-only.',
         'testIsHitDeferred' => 'PhpArrayAdapter is read-only.',
+        'testErrorsDontInvalidate' => 'PhpArrayAdapter is read-only.',
 
         'testExpiresAt' => 'PhpArrayAdapter does not support expiration.',
         'testExpiresAtWithNull' => 'PhpArrayAdapter does not support expiration.',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

I merged #60122 and then realized it was fixing a bad behavior. Saving an invalid key should not remove the previous one, if any.