### PR TITLE
[Validator] fix php doc

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Type.php
+++ b/src/Symfony/Component/Validator/Constraints/Type.php
@@ -31,9 +31,9 @@ class Type extends Constraint
     public string|array|null $type = null;
 
     /**
-     * @param string|string[]|array<string,mixed>|null $type    The type(s) to enforce on the value
-     * @param string[]|null                            $groups
-     * @param array<string,mixed>                      $options
+     * @param string|list<string>|array<string,mixed>|null $type    The type(s) to enforce on the value
+     * @param string[]|null                                $groups
+     * @param array<string,mixed>                          $options
      */
     public function __construct(string|array|null $type, ?string $message = null, ?array $groups = null, mixed $payload = null, array $options = [])
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

From actual 7.2 doc of https://symfony.com/doc/current/reference/constraints/Type.html#basic-usage

```php
$metadata->addPropertyConstraint('accessCode', new Assert\Type([
    'type' => ['alpha', 'digit'],
]));
```

We can add an array of `type` to validates against
But the array shape is not recognized as "valid" regarding the actual php doc
I am quite new on phpstan, perhaps it's on their side with the `mixed` usage? 
nonetheless, with this PR [it seems to "work"](https://phpstan.org/r/615100b1-300f-45c5-8ac0-557a8b764739)

## before

```php
new Type(['type' => 'float']),
// static analysis OK
```

## after without this PR

```php
new Type(['type' => ['float', 'int',]]),
// static analysis KO
```

## after with this PR

```php
new Type(['type' => ['float', 'int',]]),
// static analysis OK
```