### PR TITLE
[DependencyInjection] Add "when" argument to #[AsAlias]

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/AsAlias.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/AsAlias.php
@@ -20,12 +20,20 @@ namespace Symfony\Component\DependencyInjection\Attribute;
 final class AsAlias
 {
     /**
-     * @param string|null $id     The id of the alias
-     * @param bool        $public Whether to declare the alias public
+     * @var list<string>
+     */
+    public array $when = [];
+
+    /**
+     * @param string|null         $id     The id of the alias
+     * @param bool                $public Whether to declare the alias public
+     * @param string|list<string> $when   The environments under which the class will be registered as a service (i.e. "dev", "test", "prod")
      */
     public function __construct(
         public ?string $id = null,
         public bool $public = false,
+        string|array $when = [],
     ) {
+        $this->when = (array) $when;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
    for auto-configuration of classes excluded from the service container
  * Accept multiple auto-configuration callbacks for the same attribute class
  * Leverage native lazy objects when possible for lazy services
+ * Add `when` argument to `#[AsAlias]`
 
 7.2
 ---

--- a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
@@ -224,10 +224,14 @@ abstract class FileLoader extends BaseFileLoader
                 if (null === $alias) {
                     throw new LogicException(\sprintf('Alias cannot be automatically determined for class "%s". If you have used the #[AsAlias] attribute with a class implementing multiple interfaces, add the interface you want to alias to the first parameter of #[AsAlias].', $class));
                 }
-                if (isset($this->aliases[$alias])) {
-                    throw new LogicException(\sprintf('The "%s" alias has already been defined with the #[AsAlias] attribute in "%s".', $alias, $this->aliases[$alias]));
+
+                if (!$attribute->when || \in_array($this->env, $attribute->when, true)) {
+                    if (isset($this->aliases[$alias])) {
+                        throw new LogicException(\sprintf('The "%s" alias has already been defined with the #[AsAlias] attribute in "%s".', $alias, $this->aliases[$alias]));
+                    }
+
+                    $this->aliases[$alias] = new Alias($class, $public);
                 }
-                $this->aliases[$alias] = new Alias($class, $public);
             }
         }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeAsAlias/WithAsAliasBothEnv.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeAsAlias/WithAsAliasBothEnv.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias;
+
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
+
+#[AsAlias(id: AliasBarInterface::class, when: ['dev', 'prod'])]
+class WithAsAliasBothEnv
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeAsAlias/WithAsAliasDevEnv.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeAsAlias/WithAsAliasDevEnv.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias;
+
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
+
+#[AsAlias(id: AliasFooInterface::class, when: 'dev')]
+class WithAsAliasDevEnv
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeAsAlias/WithAsAliasProdEnv.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeAsAlias/WithAsAliasProdEnv.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias;
+
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
+
+#[AsAlias(id: AliasFooInterface::class, when: 'prod')]
+class WithAsAliasProdEnv
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
@@ -26,6 +26,7 @@ use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\WithAsAliasBothEnv;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\BadClasses\MissingParent;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\FooInterface;
@@ -39,9 +40,11 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\BarInterf
 use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\AliasBarInterface;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\AliasFooInterface;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\WithAsAlias;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\WithAsAliasDevEnv;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\WithAsAliasIdMultipleInterface;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\WithAsAliasInterface;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\WithAsAliasMultiple;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\WithAsAliasProdEnv;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Utils\NotAService;
 
 class FileLoaderTest extends TestCase
@@ -349,10 +352,10 @@ class FileLoaderTest extends TestCase
     /**
      * @dataProvider provideResourcesWithAsAliasAttributes
      */
-    public function testRegisterClassesWithAsAlias(string $resource, array $expectedAliases)
+    public function testRegisterClassesWithAsAlias(string $resource, array $expectedAliases, ?string $env = null)
     {
         $container = new ContainerBuilder();
-        $loader = new TestFileLoader($container, new FileLocator(self::$fixturesPath.'/Fixtures'));
+        $loader = new TestFileLoader($container, new FileLocator(self::$fixturesPath.'/Fixtures'), $env);
         $loader->registerClasses(
             (new Definition())->setAutoconfigured(true),
             'Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\\',
@@ -374,6 +377,15 @@ class FileLoaderTest extends TestCase
             AliasBarInterface::class => new Alias(WithAsAliasIdMultipleInterface::class),
             AliasFooInterface::class => new Alias(WithAsAliasIdMultipleInterface::class),
         ]];
+        yield 'Dev-env specific' => ['PrototypeAsAlias/WithAsAlias*Env.php', [
+            AliasFooInterface::class => new Alias(WithAsAliasDevEnv::class),
+            AliasBarInterface::class => new Alias(WithAsAliasBothEnv::class),
+        ], 'dev'];
+        yield 'Prod-env specific' => ['PrototypeAsAlias/WithAsAlias*Env.php', [
+            AliasFooInterface::class => new Alias(WithAsAliasProdEnv::class),
+            AliasBarInterface::class => new Alias(WithAsAliasBothEnv::class),
+        ], 'prod'];
+        yield 'Test-env specific' => ['PrototypeAsAlias/WithAsAlias*Env.php', [], 'test'];
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #60118
| License       | MIT

Also I wonder if it would make sense to accept an array of environments in `#[AsAlias]`, since in practice if I want to use the same service in two envs I'd have to duplicate the whole declaration now
```php
#[AsAlias(MyInterface::class, when: 'dev']
#[AsAlias(MyInterface::class, when: 'test']
class MyClass {}
```

Thoughts ?