### PR TITLE
[JsonPath] Add utils methods `first` and `last` to `JsonPath` builder

### DIFF
--- a/src/Symfony/Component/JsonPath/JsonPath.php
+++ b/src/Symfony/Component/JsonPath/JsonPath.php
@@ -43,9 +43,19 @@ final class JsonPath
         return new self($this->path.'..');
     }
 
-    public function anyIndex(): static
+    public function all(): static
     {
         return new self($this->path.'[*]');
+    }
+
+    public function first(): static
+    {
+        return new self($this->path.'[0]');
+    }
+
+    public function last(): static
+    {
+        return new self($this->path.'[-1]');
     }
 
     public function slice(int $start, ?int $end = null, ?int $step = null): static

--- a/src/Symfony/Component/JsonPath/Tests/JsonPathTest.php
+++ b/src/Symfony/Component/JsonPath/Tests/JsonPathTest.php
@@ -35,4 +35,31 @@ class JsonPathTest extends TestCase
 
         $this->assertSame('$.users[?(@.age > 18)]', (string) $path);
     }
+
+    public function testAll()
+    {
+        $path = new JsonPath();
+        $path = $path->key('users')
+            ->all();
+
+        $this->assertSame('$.users[*]', (string) $path);
+    }
+
+    public function testFirst()
+    {
+        $path = new JsonPath();
+        $path = $path->key('users')
+            ->first();
+
+        $this->assertSame('$.users[0]', (string) $path);
+    }
+
+    public function testLast()
+    {
+        $path = new JsonPath();
+        $path = $path->key('users')
+            ->last();
+
+        $this->assertSame('$.users[-1]', (string) $path);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Small DX improvements that goes with #60105 and #60083.

This PR adds two new methods, `first()` and `last()`, added to JsonPath builder. This voluntary reminds methods from the DomCrawler component. The goal is not to add every possible method, but I think `first()` and `last()` are common enough to be added.

I also propose to rename `anyIndex()` to `all()`.

```php
$path = new JsonPath();

// Get the first user of the collection
$path = $path->key('users')->first();
```

```php
$path = new JsonPath();

// Get the last user of the collection
$path = $path->key('users')->last();
```

```php
$path = new JsonPath();

// Get all users of the collection
$path = $path->key('users')->all();
```