### PR TITLE
Create an `AsArgumentValueResolver` to allow setting priority to a value resolver

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -100,6 +100,7 @@ use Symfony\Component\HttpClient\UriTemplateHttpClient;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\HttpKernel\Attribute\AsTargetedValueResolver;
+use Symfony\Component\HttpKernel\Attribute\AsArgumentValueResolver;
 use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
@@ -765,6 +766,14 @@ class FrameworkExtension extends Extension
         $container->registerAttributeForAutoconfiguration(AsTargetedValueResolver::class, static function (ChildDefinition $definition, AsTargetedValueResolver $attribute): void {
             $definition->addTag('controller.targeted_value_resolver', $attribute->name ? ['name' => $attribute->name] : []);
         });
+
+        $container->registerAttributeForAutoconfiguration(AsArgumentValueResolver::class, static function (ChildDefinition $definition, AsArgumentValueResolver $attribute): void {
+            $definition->addTag('controller.argument_value_resolver', [
+                'name' => $attribute->name,
+                'priority' => $attribute->priority,
+            ]);
+        });
+
         $container->registerAttributeForAutoconfiguration(AsSchedule::class, static function (ChildDefinition $definition, AsSchedule $attribute): void {
             $definition->addTag('scheduler.schedule_provider', ['name' => $attribute->name]);
         });

--- a/src/Symfony/Component/HttpKernel/Attribute/AsArgumentValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/AsArgumentValueResolver.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class AsArgumentValueResolver
+{
+    public function __construct(
+        public readonly ?string $name = null,
+        public readonly ?int $priority = null,
+    ) {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | N/A
| License       | MIT

When creating a value resolver, there is a decent change you need to set the priority. Especially if you need to resolve a request attribute, as the priority needs to be higher than the `RequestAttributeValueResolver`.

Currently, the only way to do this is by setting the priority in the `services.yaml`. This PR introduces the `AsArgumentValueResolver` attribute, which allows setting the `name` and `priority` directly on the class with an attribute, rather than in the config.

I'm unsure how to properly add a test for this, so i'd like some pointers on that.
