### PR TITLE
[Workflow] Deprecate `Event::getWorkflow()` method

### DIFF
--- a/src/Symfony/Component/Workflow/CHANGELOG.md
+++ b/src/Symfony/Component/Workflow/CHANGELOG.md
@@ -1,13 +1,18 @@
 CHANGELOG
 =========
 
+7.3
+---
+
+ * Deprecate `Event::getWorkflow()` method
+
 7.1
 ---
 
  * Add method `getEnabledTransition()` to `WorkflowInterface`
  * Automatically register places from transitions
  * Add support for workflows that need to store many tokens in the marking
- * Add method `getName()` in event classes to build event names in subscribers 
+ * Add method `getName()` in event classes to build event names in subscribers
 
 7.0
 ---

--- a/src/Symfony/Component/Workflow/Event/Event.php
+++ b/src/Symfony/Component/Workflow/Event/Event.php
@@ -46,8 +46,13 @@ class Event extends BaseEvent
         return $this->transition;
     }
 
+    /**
+     * @deprecated since Symfony 7.3, inject the workflow in the constructor where you need it
+     */
     public function getWorkflow(): WorkflowInterface
     {
+        trigger_deprecation('symfony/workflow', '7.3', 'The "%s()" method is deprecated, inject the workflow in the constructor where you need it.', __METHOD__);
+
         return $this->workflow;
     }
 

--- a/src/Symfony/Component/Workflow/composer.json
+++ b/src/Symfony/Component/Workflow/composer.json
@@ -20,15 +20,16 @@
         }
     ],
     "require": {
-        "php": ">=8.2"
+        "php": ">=8.2",
+        "symfony/deprecation-contracts": "2.5|^3"
     },
     "require-dev": {
         "psr/log": "^1|^2|^3",
         "symfony/dependency-injection": "^6.4|^7.0",
-        "symfony/event-dispatcher": "^6.4|^7.0",
         "symfony/error-handler": "^6.4|^7.0",
-        "symfony/http-kernel": "^6.4|^7.0",
+        "symfony/event-dispatcher": "^6.4|^7.0",
         "symfony/expression-language": "^6.4|^7.0",
+        "symfony/http-kernel": "^6.4|^7.0",
         "symfony/security-core": "^6.4|^7.0",
         "symfony/stopwatch": "^6.4|^7.0",
         "symfony/validator": "^6.4|^7.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | kind of
| New feature?  | no
| Deprecations? | yes
| Issues        | Fix #59748
| License       | MIT



```diff
+use Symfony\Component\DependencyInjection\Attribute\Target;
 
 class ContinueToState3 implements EventSubscriberInterface
 {
+    public function __construct(
+        #[Target('your_workflow_name')]
+        private readonly WorkflowInterface $workflow,
+    ) {
+    }
 
     public static function getSubscribedEvents(): array
     {
         return [
             'workflow.your_workflow_name.completed.to_state2' => ['terminateOrder', \PHP_INT_MIN],
         ];
     }
 
     public function terminateOrder(Event $event): void
     {
         $subject = $event->getSubject();
-        if ($event->getWorkflow()->workflow->can($subject, 'to_state3')) {
-            $event->getWorkflow()->apply($subject, 'to_state3');
+        if ($this->workflow->can($subject, 'to_state3')) {
+            $this->workflow->apply($subject, 'to_state3');
         }
     }
 }
```

If one has a listener able to run on many workflow, it need to inject a locator

```php
   use Symfony\Component\DependencyInjection\ServiceLocator;
   use Symfony\Component\DependencyInjection\Attribute\AutowireLocator;
   use Symfony\Component\Workflow\Attribute\AsTransitionListener;
   use Symfony\Component\Workflow\Event\TransitionEvent;

   class GenericListener
   {
       public function __construct(
           #[AutowireLocator('workflow', 'name')]
           private ServiceLocator $workflows
       ) {
       }

       #[AsTransitionListener()]
       public function doSomething(TransitionEvent $event): void
       {
           $workflow = $this->workflows->get($event->getWorkflowName());
       }
   }
```