### PR TITLE
[TwigBundle] Skip build dir warmup when auto-reload is enabled

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/CacheWarmer/TemplateCacheWarmer.php
+++ b/src/Symfony/Bundle/TwigBundle/CacheWarmer/TemplateCacheWarmer.php
@@ -41,6 +41,17 @@ class TemplateCacheWarmer implements CacheWarmerInterface, ServiceSubscriberInte
     {
         $this->twig ??= $this->container->get('twig');
 
+        // No cache, nothing to warmup
+        if (!$this->twig->getCache()) {
+            return [];
+        }
+
+        // When auto-reload is enabled, cache don't need to be warmed up during the initial build.
+        // This speedups dev env when the build dir is configured.
+        if ($buildDir && $this->twig->isAutoReload()) {
+            return [];
+        }
+
         foreach ($this->iterator as $template) {
             try {
                 $this->twig->load($template);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When the build dir is different from the cache dir, the twig cache warmer is called 2 times, once during build, and the second during cache warmup. In development, when auto-reload is enabled, warming the cache during the build of the container is not necessary. Skipping will save time in dev.

If https://github.com/symfony/symfony/pull/54384 is merged before 7.3, this PR is not necessary.