### PR TITLE
[Routing] [WIP] New override property in Route attribute

### DIFF
--- a/src/Symfony/Component/Routing/Attribute/Route.php
+++ b/src/Symfony/Component/Routing/Attribute/Route.php
@@ -44,6 +44,7 @@ class Route
      * @param bool|null                                         $stateless    Whether the route is defined as stateless or stateful, @see https://symfony.com/doc/current/routing.html#stateless-routes
      * @param string|null                                       $env          The env in which the route is defined (i.e. "dev", "test", "prod")
      * @param string|DeprecatedAlias|(string|DeprecatedAlias)[] $alias        The list of aliases for this route
+     * @param bool|null                                         $override     Whether the route should override existing routes with the same name
      */
     public function __construct(
         string|array|null $path = null,
@@ -62,6 +63,7 @@ class Route
         ?bool $stateless = null,
         private ?string $env = null,
         string|DeprecatedAlias|array $alias = [],
+        private ?bool $override = null,
     ) {
         if (\is_array($path)) {
             $this->localizedPaths = $path;
@@ -223,6 +225,16 @@ class Route
     public function setAliases(string|DeprecatedAlias|array $aliases): void
     {
         $this->aliases = \is_array($aliases) ? $aliases : [$aliases];
+    }
+
+    public function setOverride(?bool $override): void
+    {
+        $this->override = $override;
+    }
+
+    public function getOverride(): ?bool
+    {
+        return $this->override;
     }
 }
 

--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Allow aliases and deprecations in `#[Route]` attribute
  * Add the `Requirement::MONGODB_ID` constant to validate MongoDB ObjectIDs in hexadecimal format
+ * Add `override` parameter in `#[Route]` attribute
 
 7.2
 ---

--- a/src/Symfony/Component/Routing/Loader/AttributeClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AttributeClassLoader.php
@@ -185,6 +185,7 @@ abstract class AttributeClassLoader implements LoaderInterface
         $host = $attr->getHost() ?? $globals['host'];
         $condition = $attr->getCondition() ?? $globals['condition'];
         $priority = $attr->getPriority() ?? $globals['priority'];
+        $override = $attr->getOverride() ?? $globals['override'];
 
         $path = $attr->getLocalizedPaths() ?: $attr->getPath();
         $prefix = $globals['localized_paths'] ?: $globals['path'];
@@ -237,9 +238,9 @@ abstract class AttributeClassLoader implements LoaderInterface
                 $route->setDefault('_locale', $locale);
                 $route->setRequirement('_locale', preg_quote($locale));
                 $route->setDefault('_canonical_route', $name);
-                $collection->add($name.'.'.$locale, $route, $priority);
+                $collection->add($name.'.'.$locale, $route, $priority, $override);
             } else {
-                $collection->add($name, $route, $priority);
+                $collection->add($name, $route, $priority, $override);
             }
             foreach ($attr->getAliases() as $aliasAttribute) {
                 if ($aliasAttribute instanceof DeprecatedAlias) {

--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -82,9 +82,11 @@ class RouteCollection implements \IteratorAggregate, \Countable
         return \count($this->routes);
     }
 
-    public function add(string $name, Route $route, int $priority = 0): void
+    public function add(string $name, Route $route, int $priority = 0, bool $override = true): void
     {
-        unset($this->routes[$name], $this->priorities[$name], $this->aliases[$name]);
+        if ($override) {
+            unset($this->routes[$name], $this->priorities[$name], $this->aliases[$name]);
+        }
 
         $this->routes[$name] = $route;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

It could be useful to add 'override' property into Route attribute. In this example, I need to override 'add' function but by default, the trait's route replace the controller's route.

```php
trait CrudTrait
{
    #[Route('/add', name: 'add', methods: ['GET', 'POST'], override: false)]
    public function add(Request $request)
    {
        // ... Logic to create a new entity
    }
}
```

```php
class PostController
{
    use CrudTrait {add as crudAdd;}

    #[Route('/add', name: 'add', methods: ['GET', 'POST'])]
    public function add(Request $request, TranslatorInterface $trans)
    {
        // Custom logic for creating a new post entity
        // This will override the method from the CrudTrait
    }
}
```

Maybe `default` instead of `override` ?

