### PR TITLE
[GitHub] Update .github/PULL_REQUEST_TEMPLATE.md to remove SF 7.1 as it's not supported anymore

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 | Q             | A
 | ------------- | ---
-| Branch?       | 7.3 for features / 6.4, 7.1, and 7.2 for bug fixes <!-- see below -->
+| Branch?       | 7.3 for features / 6.4, and 7.2 for bug fixes <!-- see below -->
 | Bug fix?      | yes/no
 | New feature?  | yes/no <!-- please update src/**/CHANGELOG.md files -->
 | Deprecations? | yes/no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT

---

According to https://symfony.com/releases ; SF 7.1 is not supported anymore
