### PR TITLE
[Workflow] Add support for weighted transitions

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
  * Add `KernelBrowser::getSession()`
  * Add support for configuring workflow places with glob patterns matching consts/backed enums
  * Add support for configuring the `CachingHttpClient`
+ * Add support for weighted transitions in workflows
 
 7.3
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -518,13 +518,21 @@
 
     <xsd:complexType name="transition">
         <xsd:sequence>
-            <xsd:element name="from" type="xsd:string" minOccurs="1" maxOccurs="unbounded" />
-            <xsd:element name="to" type="xsd:string" minOccurs="1" maxOccurs="unbounded" />
+            <xsd:element name="from" type="arc" minOccurs="1" maxOccurs="unbounded" />
+            <xsd:element name="to" type="arc" minOccurs="1" maxOccurs="unbounded" />
             <xsd:element name="metadata" type="metadata" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="guard" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
         </xsd:sequence>
         <xsd:attribute name="name" type="xsd:string" />
         <xsd:attribute name="key" type="xsd:string" />
+    </xsd:complexType>
+
+    <xsd:complexType name="arc">
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+                <xsd:attribute name="weight" type="xsd:integer" />
+            </xsd:extension>
+        </xsd:simpleContent>
     </xsd:complexType>
 
     <xsd:complexType name="place" mixed="true">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_multiple_transitions_with_same_name.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_multiple_transitions_with_same_name.php
@@ -22,13 +22,14 @@ $container->loadFromExtension('framework', [
                 'approved_by_spellchecker',
                 'published',
             ],
+            // We also test different configuration formats here
             'transitions' => [
                 'request_review' => [
                     'from' => 'draft',
                     'to' => ['wait_for_journalist', 'wait_for_spellchecker'],
                 ],
                 'journalist_approval' => [
-                    'from' => 'wait_for_journalist',
+                    'from' => ['wait_for_journalist'],
                     'to' => 'approved_by_journalist',
                 ],
                 'spellchecker_approval' => [
@@ -36,13 +37,13 @@ $container->loadFromExtension('framework', [
                     'to' => 'approved_by_spellchecker',
                 ],
                 'publish' => [
-                    'from' => ['approved_by_journalist', 'approved_by_spellchecker'],
+                    'from' => [['place' => 'approved_by_journalist', 'weight' => 1], 'approved_by_spellchecker'],
                     'to' => 'published',
                 ],
                 'publish_editor_in_chief' => [
                     'name' => 'publish',
                     'from' => 'draft',
-                    'to' => 'published',
+                    'to' => [['place' => 'published', 'weight' => 2]],
                 ],
             ],
         ],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_multiple_transitions_with_same_name.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_multiple_transitions_with_same_name.xml
@@ -18,6 +18,7 @@
             <framework:place name="wait_for_spellchecker" />
             <framework:place name="approved_by_spellchecker" />
             <framework:place name="published" />
+            <!-- We also test different configuration formats here -->
             <framework:transition name="request_review">
                 <framework:from>draft</framework:from>
                 <framework:to>wait_for_journalist</framework:to>
@@ -32,13 +33,13 @@
                 <framework:to>approved_by_spellchecker</framework:to>
             </framework:transition>
             <framework:transition name="publish">
-                <framework:from>approved_by_journalist</framework:from>
-                <framework:from>approved_by_spellchecker</framework:from>
+                <framework:from weight="1">approved_by_journalist</framework:from>
+                <framework:from weight="1">approved_by_spellchecker</framework:from>
                 <framework:to>published</framework:to>
             </framework:transition>
             <framework:transition name="publish">
                 <framework:from>draft</framework:from>
-                <framework:to>published</framework:to>
+                <framework:to weight="2">published</framework:to>
             </framework:transition>
         </framework:workflow>
     </framework:config>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_multiple_transitions_with_same_name.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_multiple_transitions_with_same_name.yml
@@ -17,20 +17,21 @@ framework:
                 - wait_for_spellchecker
                 - approved_by_spellchecker
                 - published
+            # We also test different configuration formats here
             transitions:
                 request_review:
-                    from: [draft]
+                    from: draft
                     to: [wait_for_journalist, wait_for_spellchecker]
                 journalist_approval:
                     from: [wait_for_journalist]
-                    to: [approved_by_journalist]
+                    to: approved_by_journalist
                 spellchecker_approval:
-                    from: [wait_for_spellchecker]
-                    to: [approved_by_spellchecker]
+                    from: wait_for_spellchecker
+                    to: approved_by_spellchecker
                 publish:
-                    from: [approved_by_journalist, approved_by_spellchecker]
-                    to: [published]
+                    from: [{place: approved_by_journalist, weight: 1}, approved_by_spellchecker]
+                    to: published
                 publish_editor_in_chief:
                     name: publish
-                    from: [draft]
-                    to: [published]
+                    from: draft
+                    to: [{place: published, weight: 2}]

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -100,6 +100,7 @@ use Symfony\Component\Validator\Validation;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\Webhook\Client\RequestParser;
 use Symfony\Component\Webhook\Controller\WebhookController;
+use Symfony\Component\Workflow\Arc;
 use Symfony\Component\Workflow\DependencyInjection\WorkflowValidatorPass;
 use Symfony\Component\Workflow\Exception\InvalidDefinitionException;
 use Symfony\Component\Workflow\Metadata\InMemoryMetadataStore;
@@ -464,61 +465,104 @@ abstract class FrameworkExtensionTestCase extends TestCase
 
         $this->assertCount(5, $transitions);
 
-        $this->assertSame('.workflow.article.transition.0', (string) $transitions[0]);
-        $this->assertSame([
+        $this->assertTransitionReference(
+            $container,
+            '.workflow.article.transition.0',
             'request_review',
             [
-                'draft',
+                ['place' => 'draft', 'weight' => 1],
             ],
             [
-                'wait_for_journalist', 'wait_for_spellchecker',
+                ['place' => 'wait_for_journalist', 'weight' => 1],
+                ['place' => 'wait_for_spellchecker', 'weight' => 1],
             ],
-        ], $container->getDefinition($transitions[0])->getArguments());
+            $transitions[0]
+        );
 
-        $this->assertSame('.workflow.article.transition.1', (string) $transitions[1]);
-        $this->assertSame([
+        $this->assertTransitionReference(
+            $container,
+            '.workflow.article.transition.1',
             'journalist_approval',
             [
-                'wait_for_journalist',
+                ['place' => 'wait_for_journalist', 'weight' => 1],
             ],
             [
-                'approved_by_journalist',
+                ['place' => 'approved_by_journalist', 'weight' => 1],
             ],
-        ], $container->getDefinition($transitions[1])->getArguments());
+            $transitions[1]
+        );
 
-        $this->assertSame('.workflow.article.transition.2', (string) $transitions[2]);
-        $this->assertSame([
+        $this->assertTransitionReference(
+            $container,
+            '.workflow.article.transition.2',
             'spellchecker_approval',
             [
-                'wait_for_spellchecker',
+                ['place' => 'wait_for_spellchecker', 'weight' => 1],
             ],
             [
-                'approved_by_spellchecker',
+                ['place' => 'approved_by_spellchecker', 'weight' => 1],
             ],
-        ], $container->getDefinition($transitions[2])->getArguments());
+            $transitions[2]
+        );
 
-        $this->assertSame('.workflow.article.transition.3', (string) $transitions[3]);
-        $this->assertSame([
+        $this->assertTransitionReference(
+            $container,
+            '.workflow.article.transition.3',
             'publish',
             [
-                'approved_by_journalist',
-                'approved_by_spellchecker',
+                ['place' => 'approved_by_journalist', 'weight' => 1],
+                ['place' => 'approved_by_spellchecker', 'weight' => 1],
             ],
             [
-                'published',
+                ['place' => 'published', 'weight' => 1],
             ],
-        ], $container->getDefinition($transitions[3])->getArguments());
+            $transitions[3]
+        );
 
-        $this->assertSame('.workflow.article.transition.4', (string) $transitions[4]);
-        $this->assertSame([
+        $this->assertTransitionReference(
+            $container,
+            '.workflow.article.transition.4',
             'publish',
             [
-                'draft',
+                ['place' => 'draft', 'weight' => 1],
             ],
             [
-                'published',
+                ['place' => 'published', 'weight' => 2],
             ],
-        ], $container->getDefinition($transitions[4])->getArguments());
+            $transitions[4]
+        );
+    }
+
+    private function assertTransitionReference(ContainerBuilder $container, string $expectedServiceId, string $expectedName, array $expectedFroms, array $expectedTos, Reference $transition): void
+    {
+        $this->assertSame($expectedServiceId, (string) $transition);
+
+        $args = $container->getDefinition($transition)->getArguments();
+        $this->assertTransition($expectedName, $expectedFroms, $expectedTos, $args);
+    }
+
+    private function assertTransition(string $expectedName, array $expectedFroms, array $expectedTos, array $args): void
+    {
+        $this->assertCount(3, $args);
+        $this->assertSame($expectedName, $args[0]);
+
+        $this->assertCount(\count($expectedFroms), $args[1]);
+        foreach ($expectedFroms as $i => ['place' => $place, 'weight' => $weight]) {
+            $this->assertInstanceOf(Definition::class, $args[1][$i]);
+            $this->assertSame(Arc::class, $args[1][$i]->getClass());
+            $arcArgs = array_values($args[1][$i]->getArguments());
+            $this->assertSame($place, $arcArgs[0]);
+            $this->assertSame($weight, $arcArgs[1]);
+        }
+
+        $this->assertCount(\count($expectedTos), $args[2]);
+        foreach ($expectedTos as $i => ['place' => $place, 'weight' => $weight]) {
+            $this->assertInstanceOf(Definition::class, $args[2][$i]);
+            $this->assertSame(Arc::class, $args[2][$i]->getClass());
+            $arcArgs = array_values($args[2][$i]->getArguments());
+            $this->assertSame($place, $arcArgs[0]);
+            $this->assertSame($weight, $arcArgs[1]);
+        }
     }
 
     public function testWorkflowEnumPlaces()
@@ -527,10 +571,23 @@ abstract class FrameworkExtensionTestCase extends TestCase
 
         $workflowDefinition = $container->getDefinition('state_machine.enum.definition');
         $this->assertSame(['a', 'b', 'c'], $workflowDefinition->getArgument(0));
-        $transitionOne = $container->getDefinition('.state_machine.enum.transition.0');
-        $this->assertSame(['one', 'a', 'b'], $transitionOne->getArguments());
-        $transitionTwo = $container->getDefinition('.state_machine.enum.transition.1');
-        $this->assertSame(['two', 'b', 'c'], $transitionTwo->getArguments());
+        $this->assertTransitionReference(
+            $container,
+            '.state_machine.enum.transition.0',
+            'one',
+            [['place' => 'a', 'weight' => 1]],
+            [['place' => 'b', 'weight' => 1]],
+            $workflowDefinition->getArgument(1)[0],
+        );
+
+        $this->assertTransitionReference(
+            $container,
+            '.state_machine.enum.transition.1',
+            'two',
+            [['place' => 'b', 'weight' => 1]],
+            [['place' => 'c', 'weight' => 1]],
+            $workflowDefinition->getArgument(1)[1],
+        );
     }
 
     public function testWorkflowGlobPlaces()
@@ -622,7 +679,12 @@ abstract class FrameworkExtensionTestCase extends TestCase
         }
 
         $this->assertCount(1, $transitions);
-        $this->assertSame(['base_transition', ['middle'], ['alternative']], $transitions[0]);
+        $this->assertTransition(
+            'base_transition',
+            [['place' => 'middle', 'weight' => 1]],
+            [['place' => 'alternative', 'weight' => 1]],
+            $transitions[0],
+        );
     }
 
     public function testEnabledPhpErrorsConfig()

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -69,7 +69,7 @@
         "symfony/twig-bundle": "^6.4|^7.0|^8.0",
         "symfony/type-info": "^7.1.8|^8.0",
         "symfony/validator": "^7.4|^8.0",
-        "symfony/workflow": "^7.3|^8.0",
+        "symfony/workflow": "^7.4|^8.0",
         "symfony/yaml": "^7.3|^8.0",
         "symfony/property-info": "^6.4|^7.0|^8.0",
         "symfony/json-streamer": "^7.3|^8.0",
@@ -109,7 +109,7 @@
         "symfony/validator": "<6.4",
         "symfony/web-profiler-bundle": "<6.4",
         "symfony/webhook": "<7.2",
-        "symfony/workflow": "<7.3"
+        "symfony/workflow": "<7.4"
     },
     "autoload": {
         "psr-4": { "Symfony\\Bundle\\FrameworkBundle\\": "" },

--- a/src/Symfony/Component/Workflow/Arc.php
+++ b/src/Symfony/Component/Workflow/Arc.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Workflow;
+
+/**
+ * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ */
+final readonly class Arc
+{
+    public function __construct(
+        public string $place,
+        public int $weight,
+    ) {
+        if ($weight < 1) {
+            throw new \InvalidArgumentException(\sprintf('The weight must be greater than 0, %d given.', $weight));
+        }
+        if (!$place) {
+            throw new \InvalidArgumentException('The place name cannot be empty.');
+        }
+    }
+}

--- a/src/Symfony/Component/Workflow/CHANGELOG.md
+++ b/src/Symfony/Component/Workflow/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add support for `BackedEnum` in `MethodMarkingStore`
+ * Add support for weighted transitions
 
 7.3
 ---

--- a/src/Symfony/Component/Workflow/Definition.php
+++ b/src/Symfony/Component/Workflow/Definition.php
@@ -104,15 +104,15 @@ final class Definition
 
     private function addTransition(Transition $transition): void
     {
-        foreach ($transition->getFroms() as $from) {
-            if (!\array_key_exists($from, $this->places)) {
-                $this->addPlace($from);
+        foreach ($transition->getFroms(true) as $arc) {
+            if (!\array_key_exists($arc->place, $this->places)) {
+                $this->addPlace($arc->place);
             }
         }
 
-        foreach ($transition->getTos() as $to) {
-            if (!\array_key_exists($to, $this->places)) {
-                $this->addPlace($to);
+        foreach ($transition->getTos(true) as $arc) {
+            if (!\array_key_exists($arc->place, $this->places)) {
+                $this->addPlace($arc->place);
             }
         }
 

--- a/src/Symfony/Component/Workflow/Dumper/GraphvizDumper.php
+++ b/src/Symfony/Component/Workflow/Dumper/GraphvizDumper.php
@@ -199,20 +199,22 @@ class GraphvizDumper implements DumperInterface
         foreach ($definition->getTransitions() as $i => $transition) {
             $transitionName = $workflowMetadata->getMetadata('label', $transition) ?? $transition->getName();
 
-            foreach ($transition->getFroms() as $from) {
+            foreach ($transition->getFroms(true) as $arc) {
                 $dotEdges[] = [
-                    'from' => $from,
+                    'from' => $arc->place,
                     'to' => $transitionName,
                     'direction' => 'from',
                     'transition_number' => $i,
+                    'weight' => $arc->weight,
                 ];
             }
-            foreach ($transition->getTos() as $to) {
+            foreach ($transition->getTos(true) as $arc) {
                 $dotEdges[] = [
                     'from' => $transitionName,
-                    'to' => $to,
+                    'to' => $arc->place,
                     'direction' => 'to',
                     'transition_number' => $i,
+                    'weight' => $arc->weight,
                 ];
             }
         }
@@ -229,14 +231,16 @@ class GraphvizDumper implements DumperInterface
 
         foreach ($edges as $edge) {
             if ('from' === $edge['direction']) {
-                $code .= \sprintf("  place_%s -> transition_%s [style=\"solid\"];\n",
+                $code .= \sprintf("  place_%s -> transition_%s [style=\"solid\"%s];\n",
                     $this->dotize($edge['from']),
-                    $this->dotize($edge['transition_number'])
+                    $this->dotize($edge['transition_number']),
+                    $edge['weight'] > 1 ? \sprintf(',label="%s"', $this->escape($edge['weight'])) : '',
                 );
             } else {
-                $code .= \sprintf("  transition_%s -> place_%s [style=\"solid\"];\n",
+                $code .= \sprintf("  transition_%s -> place_%s [style=\"solid\"%s];\n",
                     $this->dotize($edge['transition_number']),
-                    $this->dotize($edge['to'])
+                    $this->dotize($edge['to']),
+                    $edge['weight'] > 1 ? \sprintf(',label="%s"', $this->escape($edge['weight'])) : '',
                 );
             }
         }

--- a/src/Symfony/Component/Workflow/Dumper/PlantUmlDumper.php
+++ b/src/Symfony/Component/Workflow/Dumper/PlantUmlDumper.php
@@ -78,10 +78,10 @@ class PlantUmlDumper implements DumperInterface
         }
         foreach ($definition->getTransitions() as $transition) {
             $transitionEscaped = $this->escape($transition->getName());
-            foreach ($transition->getFroms() as $from) {
-                $fromEscaped = $this->escape($from);
-                foreach ($transition->getTos() as $to) {
-                    $toEscaped = $this->escape($to);
+            foreach ($transition->getFroms(true) as $fromArc) {
+                $fromEscaped = $this->escape($fromArc->place);
+                foreach ($transition->getTos(true) as $toArc) {
+                    $toEscaped = $this->escape($toArc->place);
 
                     $transitionEscapedWithStyle = $this->getTransitionEscapedWithStyle($workflowMetadata, $transition, $transitionEscaped);
 

--- a/src/Symfony/Component/Workflow/Dumper/StateMachineGraphvizDumper.php
+++ b/src/Symfony/Component/Workflow/Dumper/StateMachineGraphvizDumper.php
@@ -65,14 +65,14 @@ class StateMachineGraphvizDumper extends GraphvizDumper
                 $attributes['color'] = $arrowColor;
             }
 
-            foreach ($transition->getFroms() as $from) {
-                foreach ($transition->getTos() as $to) {
+            foreach ($transition->getFroms(true) as $fromArc) {
+                foreach ($transition->getTos(true) as $toArc) {
                     $edge = [
                         'name' => $transitionName,
-                        'to' => $to,
+                        'to' => $toArc->place,
                         'attributes' => $attributes,
                     ];
-                    $edges[$from][] = $edge;
+                    $edges[$fromArc->place][] = $edge;
                 }
             }
         }

--- a/src/Symfony/Component/Workflow/EventListener/AuditTrailListener.php
+++ b/src/Symfony/Component/Workflow/EventListener/AuditTrailListener.php
@@ -27,8 +27,8 @@ class AuditTrailListener implements EventSubscriberInterface
 
     public function onLeave(Event $event): void
     {
-        foreach ($event->getTransition()->getFroms() as $place) {
-            $this->logger->info(\sprintf('Leaving "%s" for subject of class "%s" in workflow "%s".', $place, $event->getSubject()::class, $event->getWorkflowName()));
+        foreach ($event->getTransition()->getFroms(true) as $arc) {
+            $this->logger->info(\sprintf('Leaving "%s" for subject of class "%s" in workflow "%s".', $arc->place, $event->getSubject()::class, $event->getWorkflowName()));
         }
     }
 
@@ -39,8 +39,8 @@ class AuditTrailListener implements EventSubscriberInterface
 
     public function onEnter(Event $event): void
     {
-        foreach ($event->getTransition()->getTos() as $place) {
-            $this->logger->info(\sprintf('Entering "%s" for subject of class "%s" in workflow "%s".', $place, $event->getSubject()::class, $event->getWorkflowName()));
+        foreach ($event->getTransition()->getTos(true) as $arc) {
+            $this->logger->info(\sprintf('Entering "%s" for subject of class "%s" in workflow "%s".', $arc->place, $event->getSubject()::class, $event->getWorkflowName()));
         }
     }
 

--- a/src/Symfony/Component/Workflow/Marking.php
+++ b/src/Symfony/Component/Workflow/Marking.php
@@ -18,7 +18,11 @@ namespace Symfony\Component\Workflow;
  */
 class Marking
 {
+    /**
+     * @var array<string, int<0,max>> Keys are the place names and values are the number of tokens in that place
+     */
     private array $places = [];
+
     private ?array $context = null;
 
     /**
@@ -81,6 +85,11 @@ class Marking
     public function has(string $place): bool
     {
         return isset($this->places[$place]);
+    }
+
+    public function getTokenCount(string $place): int
+    {
+        return $this->places[$place] ?? 0;
     }
 
     public function getPlaces(): array

--- a/src/Symfony/Component/Workflow/Tests/ArcTest.php
+++ b/src/Symfony/Component/Workflow/Tests/ArcTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Workflow\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Workflow\Arc;
+
+class ArcTest extends TestCase
+{
+    public function testConstructorWithInvalidPlaceName()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The place name cannot be empty.');
+
+        new Arc('', 1);
+    }
+
+    public function testConstructorWithInvalidWeight()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The weight must be greater than 0, 0 given.');
+
+        new Arc('not empty', 0);
+    }
+}

--- a/src/Symfony/Component/Workflow/Tests/StateMachineTest.php
+++ b/src/Symfony/Component/Workflow/Tests/StateMachineTest.php
@@ -88,7 +88,7 @@ class StateMachineTest extends TestCase
         $net = new StateMachine($definition, null, $dispatcher);
 
         $dispatcher->addListener('workflow.guard', function (GuardEvent $event) {
-            $event->addTransitionBlocker(new TransitionBlocker(\sprintf('Transition blocker of place %s', $event->getTransition()->getFroms()[0]), 'blocker'));
+            $event->addTransitionBlocker(new TransitionBlocker(\sprintf('Transition blocker of place %s', $event->getTransition()->getFroms(true)[0]->place), 'blocker'));
         });
 
         $subject = new Subject();
@@ -124,7 +124,7 @@ class StateMachineTest extends TestCase
         $net = new StateMachine($definition, null, $dispatcher);
 
         $dispatcher->addListener('workflow.guard', function (GuardEvent $event) {
-            $event->addTransitionBlocker(new TransitionBlocker(\sprintf('Transition blocker of place %s', $event->getTransition()->getFroms()[0]), 'blocker'));
+            $event->addTransitionBlocker(new TransitionBlocker(\sprintf('Transition blocker of place %s', $event->getTransition()->getFroms(true)[0]->place), 'blocker'));
         });
 
         $subject = new Subject();

--- a/src/Symfony/Component/Workflow/Tests/TransitionTest.php
+++ b/src/Symfony/Component/Workflow/Tests/TransitionTest.php
@@ -11,16 +11,46 @@
 
 namespace Symfony\Component\Workflow\Tests;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Workflow\Arc;
 use Symfony\Component\Workflow\Transition;
 
 class TransitionTest extends TestCase
 {
-    public function testConstructor()
+    public static function provideConstructorTests(): iterable
+    {
+        yield 'plain strings' => ['a', 'b'];
+        yield 'array of strings' => [['a'], ['b']];
+        yield 'array of arcs' => [[new Arc('a', 1)], [new Arc('b', 1)]];
+    }
+
+    #[DataProvider('provideConstructorTests')]
+    public function testConstructor(mixed $froms, mixed $tos)
+    {
+        $transition = new Transition('name', $froms, $tos);
+
+        $this->assertSame('name', $transition->getName());
+        $this->assertCount(1, $transition->getFroms(true));
+        $this->assertSame('a', $transition->getFroms(true)[0]->place);
+        $this->assertSame(1, $transition->getFroms(true)[0]->weight);
+        $this->assertCount(1, $transition->getTos(true));
+        $this->assertSame('b', $transition->getTos(true)[0]->place);
+        $this->assertSame(1, $transition->getTos(true)[0]->weight);
+    }
+
+    public function testConstructorWithInvalidData()
+    {
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('The type of arc is invalid. Expected string or Arc, got "bool".');
+
+        new Transition('name', [true], ['a']);
+    }
+
+    public function testLegacyGetter()
     {
         $transition = new Transition('name', 'a', 'b');
 
-        $this->assertSame('name', $transition->getName());
         $this->assertSame(['a'], $transition->getFroms());
         $this->assertSame(['b'], $transition->getTos());
     }

--- a/src/Symfony/Component/Workflow/Tests/Validator/StateMachineValidatorTest.php
+++ b/src/Symfony/Component/Workflow/Tests/Validator/StateMachineValidatorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Workflow\Tests\Validator;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Workflow\Arc;
 use Symfony\Component\Workflow\Definition;
 use Symfony\Component\Workflow\Exception\InvalidDefinitionException;
 use Symfony\Component\Workflow\Transition;
@@ -122,6 +123,34 @@ class StateMachineValidatorTest extends TestCase
 
         $this->expectException(InvalidDefinitionException::class);
         $this->expectExceptionMessage('The state machine "foo" cannot store many places. But the definition has 2 initial places. Only one is supported.');
+
+        (new StateMachineValidator())->validate($definition, 'foo');
+    }
+
+    public function testWithArcInFromTooHeavy()
+    {
+        $places = ['a', 'b'];
+        $transitions = [
+            new Transition('t1', [new Arc('a', 2)], [new Arc('b', 1)]),
+        ];
+        $definition = new Definition($places, $transitions);
+
+        $this->expectException(InvalidDefinitionException::class);
+        $this->expectExceptionMessage('A transition in StateMachine can only have arc with weight equals to one. But the transition "t1" in StateMachine "foo" has an arc from "a" to the transition with a weight equals to 2.');
+
+        (new StateMachineValidator())->validate($definition, 'foo');
+    }
+
+    public function testWithArcInToTooHeavy()
+    {
+        $places = ['a', 'b'];
+        $transitions = [
+            new Transition('t1', [new Arc('a', 1)], [new Arc('b', 2)]),
+        ];
+        $definition = new Definition($places, $transitions);
+
+        $this->expectException(InvalidDefinitionException::class);
+        $this->expectExceptionMessage('A transition in StateMachine can only have arc with weight equals to one. But the transition "t1" in StateMachine "foo" has an arc from the transition to "b" with a weight equals to 2.');
 
         (new StateMachineValidator())->validate($definition, 'foo');
     }

--- a/src/Symfony/Component/Workflow/Tests/Validator/WorkflowValidatorTest.php
+++ b/src/Symfony/Component/Workflow/Tests/Validator/WorkflowValidatorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Workflow\Tests\Validator;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Workflow\Arc;
 use Symfony\Component\Workflow\Definition;
 use Symfony\Component\Workflow\Exception\InvalidDefinitionException;
 use Symfony\Component\Workflow\Tests\WorkflowBuilderTrait;
@@ -80,6 +81,34 @@ class WorkflowValidatorTest extends TestCase
 
         $this->expectException(InvalidDefinitionException::class);
         $this->expectExceptionMessage('The marking store of workflow "foo" cannot store many places. But the definition has 2 initial places. Only one is supported.');
+
+        (new WorkflowValidator(true))->validate($definition, 'foo');
+    }
+
+    public function testWithArcInFromTooHeavy()
+    {
+        $places = ['a', 'b'];
+        $transitions = [
+            new Transition('t1', [new Arc('a', 2)], [new Arc('b', 1)]),
+        ];
+        $definition = new Definition($places, $transitions);
+
+        $this->expectException(InvalidDefinitionException::class);
+        $this->expectExceptionMessage('The marking store of workflow "t1" cannot store many places. But the transition "foo" has an arc from the transition to "a" with a weight equals to 2.');
+
+        (new WorkflowValidator(true))->validate($definition, 'foo');
+    }
+
+    public function testWithArcInToTooHeavy()
+    {
+        $places = ['a', 'b'];
+        $transitions = [
+            new Transition('t1', [new Arc('a', 1)], [new Arc('b', 2)]),
+        ];
+        $definition = new Definition($places, $transitions);
+
+        $this->expectException(InvalidDefinitionException::class);
+        $this->expectExceptionMessage('The marking store of workflow "t1" cannot store many places. But the transition "foo" has an arc from "b" to the transition with a weight equals to 2.');
 
         (new WorkflowValidator(true))->validate($definition, 'foo');
     }

--- a/src/Symfony/Component/Workflow/Transition.php
+++ b/src/Symfony/Component/Workflow/Transition.php
@@ -17,20 +17,27 @@ namespace Symfony\Component\Workflow;
  */
 class Transition
 {
-    private array $froms;
-    private array $tos;
+    /**
+     * @var Arc[]
+     */
+    private array $fromArcs;
 
     /**
-     * @param string|string[] $froms
-     * @param string|string[] $tos
+     * @var Arc[]
+     */
+    private array $toArcs;
+
+    /**
+     * @param string|string[]|Arc[] $froms
+     * @param string|string[]|Arc[] $tos
      */
     public function __construct(
         private string $name,
         string|array $froms,
         string|array $tos,
     ) {
-        $this->froms = (array) $froms;
-        $this->tos = (array) $tos;
+        $this->fromArcs = array_map($this->normalize(...), (array) $froms);
+        $this->toArcs = array_map($this->normalize(...), (array) $tos);
     }
 
     public function getName(): string
@@ -39,18 +46,40 @@ class Transition
     }
 
     /**
-     * @return string[]
+     * @return $asArc is true ? array<Arc> : array<string>
      */
-    public function getFroms(): array
+    public function getFroms(/* bool $asArc = false */): array
     {
-        return $this->froms;
+        if (1 <= \func_num_args() && func_get_arg(0)) {
+            return $this->fromArcs;
+        }
+
+        return array_column($this->fromArcs, 'place');
     }
 
     /**
-     * @return string[]
+     * @return $asArc is true ? array<Arc> : array<string>
      */
-    public function getTos(): array
+    public function getTos(/* bool $asArc = false */): array
     {
-        return $this->tos;
+        if (1 <= \func_num_args() && func_get_arg(0)) {
+            return $this->toArcs;
+        }
+
+        return array_column($this->toArcs, 'place');
+    }
+
+    // No type hint for $arc to avoid implicit cast
+    private function normalize(mixed $arc): Arc
+    {
+        if ($arc instanceof Arc) {
+            return $arc;
+        }
+
+        if (\is_string($arc)) {
+            return new Arc($arc, 1);
+        }
+
+        throw new \TypeError(\sprintf('The type of arc is invalid. Expected string or Arc, got "%s".', get_debug_type($arc)));
     }
 }

--- a/src/Symfony/Component/Workflow/Validator/StateMachineValidator.php
+++ b/src/Symfony/Component/Workflow/Validator/StateMachineValidator.php
@@ -24,18 +24,29 @@ class StateMachineValidator implements DefinitionValidatorInterface
         $transitionFromNames = [];
         foreach ($definition->getTransitions() as $transition) {
             // Make sure that each transition has exactly one TO
-            if (1 !== \count($transition->getTos())) {
-                throw new InvalidDefinitionException(\sprintf('A transition in StateMachine can only have one output. But the transition "%s" in StateMachine "%s" has %d outputs.', $transition->getName(), $name, \count($transition->getTos())));
+            if (1 !== \count($transition->getTos(true))) {
+                throw new InvalidDefinitionException(\sprintf('A transition in StateMachine can only have one output. But the transition "%s" in StateMachine "%s" has %d outputs.', $transition->getName(), $name, \count($transition->getTos(true))));
+            }
+            foreach ($transition->getFroms(true) as $arc) {
+                if (1 < $arc->weight) {
+                    throw new InvalidDefinitionException(\sprintf('A transition in StateMachine can only have arc with weight equals to one. But the transition "%s" in StateMachine "%s" has an arc from "%s" to the transition with a weight equals to %d.', $transition->getName(), $name, $arc->place, $arc->weight));
+                }
             }
 
             // Make sure that each transition has exactly one FROM
-            $froms = $transition->getFroms();
-            if (1 !== \count($froms)) {
-                throw new InvalidDefinitionException(\sprintf('A transition in StateMachine can only have one input. But the transition "%s" in StateMachine "%s" has %d inputs.', $transition->getName(), $name, \count($froms)));
+            $fromArcs = $transition->getFroms(true);
+            if (1 !== \count($fromArcs)) {
+                throw new InvalidDefinitionException(\sprintf('A transition in StateMachine can only have one input. But the transition "%s" in StateMachine "%s" has %d inputs.', $transition->getName(), $name, \count($fromArcs)));
+            }
+            foreach ($transition->getTos(true) as $arc) {
+                if (1 !== $arc->weight) {
+                    throw new InvalidDefinitionException(\sprintf('A transition in StateMachine can only have arc with weight equals to one. But the transition "%s" in StateMachine "%s" has an arc from the transition to "%s" with a weight equals to %d.', $transition->getName(), $name, $arc->place, $arc->weight));
+                }
             }
 
             // Enforcing uniqueness of the names of transitions starting at each node
-            $from = reset($froms);
+            $fromArc = reset($fromArcs);
+            $from = $fromArc->place;
             if (isset($transitionFromNames[$from][$transition->getName()])) {
                 throw new InvalidDefinitionException(\sprintf('A transition from a place/state must have an unique name. Multiple transitions named "%s" from place/state "%s" were found on StateMachine "%s".', $transition->getName(), $from, $name));
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | Fix #60107
| License       | MIT

Allow to handle complex workflow like:

```yaml
make_table:
    transitions:
        start:
            from: init
            to:
                -   place: prepare_leg
                    weight: 4
                -   place: prepare_top
                    weight: 1
                -   place: stopwatch_running
                    weight: 1
        build_leg:
            from: prepare_leg
            to: leg_created
        build_top:
            from: prepare_top
            to: top_created
        join:
            from:
                - place: leg_created
                  weight: 4
                - top_created
                - stopwatch_running
            to: finished
```

```php
$definition = new Definition(
    [],
    [
        new Transition('start', 'init', [new Arc('prepare_leg', 4), 'prepare_top', 'stopwatch_running']),
        new Transition('build_leg', 'prepare_leg', 'leg_created'),
        new Transition('build_top', 'prepare_top', 'top_created'),
        new Transition('join', [new Arc('leg_created', 4), 'top_created', 'stopwatch_running'], 'finished'),
    ]
);

$subject = new Subject();
$workflow = new Workflow($definition);

$workflow->apply($subject, 'start');

$workflow->apply($subject, 'build_leg');
$workflow->apply($subject, 'build_top');
$workflow->apply($subject, 'build_leg');
$workflow->apply($subject, 'build_leg');
$workflow->apply($subject, 'build_leg');
$workflow->apply($subject, 'join');
```

---

Another example, based on https://demo-symfony-workflow.cleverapps.io/articles/show/1
[workflow.webm](https://github.com/user-attachments/assets/fe5a2fca-cfef-4621-94f9-98b7d9bb9a01)

