### PR TITLE
[Routing] ignore `#[Route]` attribute on non-public methods

### DIFF
--- a/src/Symfony/Component/Routing/Loader/AttributeClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AttributeClassLoader.php
@@ -119,6 +119,10 @@ abstract class AttributeClassLoader implements LoaderInterface
         }
 
         foreach ($class->getMethods() as $method) {
+            if (!$method->isPublic()) {
+                continue;
+            }
+
             $this->defaultRouteIndex = 0;
             $routeNamesBefore = array_keys($collection->all());
             foreach ($this->getAttributes($method) as $attr) {

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/PrivateProtectedMethodsController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/PrivateProtectedMethodsController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures;
+
+use Symfony\Component\Routing\Attribute\Route;
+
+class PrivateProtectedMethodsController
+{
+    #[Route(name: 'foo')]
+    private function privateFoo()
+    {
+    }
+
+    #[Route(name: 'foo')]
+    protected function protectedFoo()
+    {
+    }
+
+    #[Route(name: 'foo')]
+    public function publicFoo()
+    {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Loader/AttributeClassLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AttributeClassLoaderTest.php
@@ -44,6 +44,7 @@ use Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures\MultipleDeprecate
 use Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures\NothingButNameController;
 use Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures\PrefixedActionLocalizedRouteController;
 use Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures\PrefixedActionPathController;
+use Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures\PrivateProtectedMethodsController;
 use Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures\RequirementsWithoutPlaceholderNameController;
 use Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures\RouteWithEnv;
 use Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures\RouteWithPrefixController;
@@ -307,6 +308,13 @@ class AttributeClassLoaderTest extends TestCase
     {
         $this->expectException(\LogicException::class);
         $this->loader->load(AbstractClassController::class);
+    }
+
+    public function testLoadingClassWithRouteAttributeOnNonPublicMethod()
+    {
+        $routes = $this->loader->load(PrivateProtectedMethodsController::class);
+        $this->assertCount(1, $routes);
+        $routes->get('foo');
     }
 
     public function testLocalizedPrefixWithoutRouteLocale()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | maybe <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | maybe <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #60197
| License       | MIT

I don't know if there is an actual use-case for using a non-public controller in a route, as the `ControllerResolver` will throw an exception. But we could deprecate the current behavior and ignore the `#[Route]` attribute on private and protected methods in the next major version.