### PR TITLE
[FrameworkBundle] Add support for configuring workflow places with glob patterns matching consts/backed enums

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
  * Add `framework.type_info.aliases` option
  * Add `KernelBrowser::getSession()`
  * Add autoconfiguration tag `kernel.uri_signer` to `Symfony\Component\HttpFoundation\UriSigner`
+ * Add support for configuring workflow places with glob patterns matching consts/backed enums
 
 7.3
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -475,6 +475,7 @@
         <xsd:attribute name="initial-marking" type="xsd:string" />
         <xsd:attribute name="support-strategy" type="xsd:string" />
         <xsd:attribute name="enabled" type="xsd:boolean" />
+        <xsd:attribute name="places" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:complexType name="php-errors">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/Workflow/Places.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/Workflow/Places.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Fixtures\Workflow;
+
+enum Places: string
+{
+    case A = 'a';
+    case B = 'b';
+    case C = 'c';
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_enum.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_enum.php
@@ -1,0 +1,25 @@
+<?php
+
+use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Fixtures\Workflow\Places;
+use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase;
+
+$container->loadFromExtension('framework', [
+    'workflows' => [
+        'enum' => [
+            'supports' => [
+                FrameworkExtensionTestCase::class,
+            ],
+            'places' => Places::cases(),
+            'transitions' => [
+                'one' => [
+                    'from' => Places::A->value,
+                    'to' => Places::B->value,
+                ],
+                'two' => [
+                    'from' => Places::B->value,
+                    'to' => Places::C->value,
+                ],
+            ],
+        ]
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflows.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflows.php
@@ -1,5 +1,6 @@
 <?php
 
+use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Fixtures\Workflow\Places;
 use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase;
 
 $container->loadFromExtension('framework', [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_enum.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_enum.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:framework="http://symfony.com/schema/dic/symfony"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config http-method-override="false" handle-all-throwables="true">
+        <framework:workflow name="enum" type="state_machine" places="Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Fixtures\Workflow\Places::*">
+            <framework:marking-store service="workflow_service"/>
+            <framework:support>Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase</framework:support>
+            <framework:transition name="one">
+                <framework:from>a</framework:from>
+                <framework:to>b</framework:to>
+            </framework:transition>
+            <framework:transition name="two">
+                <framework:from>b</framework:from>
+                <framework:to>c</framework:to>
+            </framework:transition>
+        </framework:workflow>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_enum.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_enum.yml
@@ -1,0 +1,13 @@
+framework:
+    workflows:
+        enum:
+            supports:
+                - Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase
+            places: !php/enum Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Fixtures\Workflow\Places
+            transitions:
+                one:
+                    from: !php/enum Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Fixtures\Workflow\Places::A
+                    to: !php/enum Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Fixtures\Workflow\Places::B
+                two:
+                    from: !php/enum Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Fixtures\Workflow\Places::B
+                    to: !php/enum Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Fixtures\Workflow\Places::C

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -519,6 +519,14 @@ abstract class FrameworkExtensionTestCase extends TestCase
         ], $container->getDefinition($transitions[4])->getArguments());
     }
 
+    public function testWorkflowEnum()
+    {
+        $container = $this->createContainerFromFile('workflow_enum');
+
+        $workflowDefinition = $container->getDefinition('state_machine.enum.definition');
+        $this->assertSame(['a', 'b', 'c'], $workflowDefinition->getArgument(0));
+    }
+
     public function testWorkflowGuardExpressions()
     {
         $container = $this->createContainerFromFile('workflow_with_guard_expression');

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/PhpFrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/PhpFrameworkExtensionTest.php
@@ -75,7 +75,7 @@ class PhpFrameworkExtensionTest extends FrameworkExtensionTestCase
     public function testWorkflowValidationPlacesIsArray()
     {
         $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessage('The "places" option must be an array in workflow configuration.');
+        $this->expectExceptionMessage('The "places" option must be an array or a "FQCN::glob" pattern in workflow configuration.');
         $this->createContainerFromClosure(function ($container) {
             $container->loadFromExtension('framework', [
                 'workflows' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        |
| License       | MIT

This PR improves the DX on two aspects:
- allowing to use FQCN::glob patterns to list places - works with enums and consts
- allowing to use backed enums to list places and reference them in transitions

---

#### Example with consts:

```yaml
framework:
    workflows:
        my_workflow_name:
            places: 'App\Workflow\MyWorkflow::PLACE_*'
            transitions:
                one:
                    from: !php/const App\Workflow\MyWorkflow::PLACE_A
                    to: !php/const App\Workflow\MyWorkflow::PLACE_B
```

and

```php
<?php

namespace App\Workflow;

class MyWorkflow
{
    const PLACE_A = 'a';
    const PLACE_B = 'b';
    const PLACE_C = 'c';
// [...]
}
```

---

#### Example with enums:

```yaml
framework:
    workflows:
        my_workflow_name:
            places: !php/enum App\Workflow\Places
            transitions:
                one:
                    from: !php/enum App\Workflow\Places::A
                    to: !php/enum App\Workflow\Places::B
```

and

```php
<?php

namespace App\Workflow;

enum Places: string
{
    case A = 'a';
    case B = 'b';
    case C = 'c';
}
```
