### PR TITLE
[Notifier][Firebase] Add Firebase v1 API support

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Firebase/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/CHANGELOG.md
@@ -1,6 +1,14 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Send messages through the Firebase Cloud Messaging v1 API
+ * Deprecate `AndroidNotification`, `IOSNotification` and `WebNotification`, use `FirebaseOptions` instead
+ * Deprecate the `firebase://USERNAME:PASSWORD@default` DSN, use `firebase://PROJECT_ID?client_email=...&private_key_id=...&private_key=...` instead
+ * Deprecate the `$token` argument of `FirebaseTransport::__construct()`
+
 5.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/FirebaseOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/FirebaseOptions.php
@@ -15,36 +15,35 @@ use Symfony\Component\Notifier\Message\MessageOptionsInterface;
 
 /**
  * @author Jeroen Spee <https://github.com/Jeroeny>
+ * @author Vojtech Smejkal <https://vojtechsmejkal.cz>
  *
- * @see https://firebase.google.com/docs/cloud-messaging/xmpp-server-ref.html
+ * @see https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages
  */
-abstract class FirebaseOptions implements MessageOptionsInterface
+class FirebaseOptions implements MessageOptionsInterface
 {
     /**
-     * @see https://firebase.google.com/docs/cloud-messaging/xmpp-server-ref.html#notification-payload-support
+     * @param array<string, string> $data arbitrary meta-data (both keys and values must be a string)
      */
-    protected array $options;
-
     public function __construct(
-        private string $to,
-        array $options,
-        private array $data = [],
+        private string $target,
+        protected array $options = [],
+        array $data = [],
+        protected TargetType $targetType = TargetType::Topic,
     ) {
-        $this->options = $options;
+        $this->options['data'] = $data;
     }
 
     public function toArray(): array
     {
-        return [
-            'to' => $this->to,
-            'notification' => $this->options,
-            'data' => $this->data,
-        ];
+        $options = $this->options;
+        $options[$this->targetType->value] = $this->target;
+
+        return $options;
     }
 
     public function getRecipientId(): ?string
     {
-        return $this->to;
+        return '['.$this->targetType->value.']'.$this->target;
     }
 
     /**
@@ -52,7 +51,7 @@ abstract class FirebaseOptions implements MessageOptionsInterface
      */
     public function title(string $title): static
     {
-        $this->options['title'] = $title;
+        $this->addNotificationOption('title', $title);
 
         return $this;
     }
@@ -62,7 +61,101 @@ abstract class FirebaseOptions implements MessageOptionsInterface
      */
     public function body(string $body): static
     {
-        $this->options['body'] = $body;
+        $this->addNotificationOption('body', $body);
+
+        return $this;
+    }
+
+    /**
+     * @param string $image URL of an image that is going to be downloaded on the device and displayed in a notification
+     *
+     * @return $this
+     */
+    public function image(string $image): static
+    {
+        $this->addNotificationOption('image', $image);
+
+        return $this;
+    }
+
+    /**
+     * @param array<string, string> $data
+     *
+     * @return $this
+     */
+    public function data(array $data): static
+    {
+        $this->options['data'] = $data;
+
+        return $this;
+    }
+
+    /**
+     * @param array<string, mixed> $notification
+     *
+     * @return $this
+     *
+     * @see https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#notification
+     */
+    public function notification(array $notification): static
+    {
+        $this->options['notification'] = $notification;
+
+        return $this;
+    }
+
+    /**
+     * @param array<string, mixed> $android
+     *
+     * @return $this
+     *
+     * @see https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#androidconfig
+     */
+    public function android(array $android): static
+    {
+        $this->options['android'] = $android;
+
+        return $this;
+    }
+
+    /**
+     * @param array<string, mixed> $webpush
+     *
+     * @return $this
+     *
+     * @see https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#webpushconfig
+     */
+    public function webpush(array $webpush): static
+    {
+        $this->options['webpush'] = $webpush;
+
+        return $this;
+    }
+
+    /**
+     * @param array<string, mixed> $apns
+     *
+     * @return $this
+     *
+     * @see https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#apnsconfig
+     */
+    public function apns(array $apns): static
+    {
+        $this->options['apns'] = $apns;
+
+        return $this;
+    }
+
+    /**
+     * @param array<string, mixed> $fcmOptions
+     *
+     * @return $this
+     *
+     * @see https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#fcmoptions
+     */
+    public function fcmOptions(array $fcmOptions): static
+    {
+        $this->options['fcm_options'] = $fcmOptions;
 
         return $this;
     }
@@ -70,9 +163,61 @@ abstract class FirebaseOptions implements MessageOptionsInterface
     /**
      * @return $this
      */
-    public function data(array $data): static
+    protected function addNotificationOption(string $key, mixed $value): static
     {
-        $this->data = $data;
+        $this->options['notification'] ??= [];
+        $this->options['notification'][$key] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    protected function addAndroidOption(string $key, mixed $value): static
+    {
+        $this->options['android'] ??= [];
+        $this->options['android']['notification'] ??= [];
+        $this->options['android']['notification'][$key] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    protected function addWebpushOption(string $key, mixed $value): static
+    {
+        $this->options['webpush'] ??= [];
+        $this->options['webpush']['notification'] ??= [];
+        $this->options['webpush']['notification'][$key] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    protected function addApnsOption(string $key, mixed $value): static
+    {
+        $this->options['apns'] ??= [];
+        $this->options['apns']['payload'] ??= [];
+        $this->options['apns']['payload']['aps'] ??= [];
+        $this->options['apns']['payload']['aps'][$key] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    protected function addApnsAlertOption(string $key, mixed $value): static
+    {
+        $this->options['apns'] ??= [];
+        $this->options['apns']['payload'] ??= [];
+        $this->options['apns']['payload']['aps'] ??= [];
+        $this->options['apns']['payload']['aps']['alert'] ??= [];
+        $this->options['apns']['payload']['aps']['alert'][$key] = $value;
 
         return $this;
     }

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/FirebaseTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/FirebaseTransport.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Notifier\Bridge\Firebase;
 
+use Symfony\Component\Notifier\Exception\IncompleteDsnException;
 use Symfony\Component\Notifier\Exception\InvalidArgumentException;
 use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
@@ -24,16 +25,30 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * @author Jeroen Spee <https://github.com/Jeroeny>
+ * @author Vojtech Smejkal <https://vojtechsmejkal.cz>
+ *
+ * @see https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages/send
  */
 final class FirebaseTransport extends AbstractTransport
 {
-    protected const HOST = 'fcm.googleapis.com/fcm/send';
+    protected const HOST = 'fcm.googleapis.com';
+
+    private string $jwt = '';
+    private int $jwtExpiresAt = 0;
 
     public function __construct(
         #[\SensitiveParameter] private string $token,
+        #[\SensitiveParameter] private string $projectId = '',
+        #[\SensitiveParameter] private string $clientEmail = '',
+        #[\SensitiveParameter] private string $privateKeyId = '',
+        #[\SensitiveParameter] private string $privateKey = '',
         ?HttpClientInterface $client = null,
         ?EventDispatcherInterface $dispatcher = null,
     ) {
+        if ('' !== $this->token) {
+            trigger_deprecation('symfony/firebase-notifier', '8.2', 'The $token parameter in "%s" is deprecated, use $projectId, $clientEmail, $privateKeyId and $privateKey instead.', self::class);
+        }
+
         parent::__construct($client, $dispatcher);
     }
 
@@ -53,48 +68,97 @@ final class FirebaseTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, ChatMessage::class, $message);
         }
 
-        $endpoint = \sprintf('https://%s', $this->getEndpoint());
-        $options = $message->getOptions()?->toArray() ?? [];
-        $options['to'] = $message->getRecipientId();
-
-        if (!$options['to']) {
-            throw new InvalidArgumentException(\sprintf('The "%s" transport required the "to" option to be set.', __CLASS__));
+        if (!$this->projectId || !$this->privateKeyId || !$this->privateKey) {
+            throw new IncompleteDsnException(\sprintf('The "%s" transport requires project_id, private_key_id and private_key options to be specified in DSN.', self::class));
         }
+
+        $endpoint = \sprintf('https://%s/v1/projects/%s/messages:send', $this->getEndpoint(), $this->projectId);
+
+        $options = $message->getOptions()?->toArray() ?? [];
+        $options['notification'] ??= [];
         $options['notification']['body'] = $message->getSubject();
         $options['data'] ??= [];
 
+        if (!isset($options['token']) && !isset($options['topic']) && !isset($options['condition'])) {
+            throw new InvalidArgumentException(\sprintf('The "%s" transport requires the "token", "topic" or "condition" option to be set.', self::class));
+        }
+
+        // Send
         $response = $this->client->request('POST', $endpoint, [
-            'headers' => [
-                'Authorization' => \sprintf('key=%s', $this->token),
-            ],
-            'json' => array_filter($options),
+            'headers' => ['Authorization' => \sprintf('Bearer %s', $this->getJwt())],
+            'json' => ['message' => $options],
         ]);
 
         try {
             $statusCode = $response->getStatusCode();
         } catch (TransportExceptionInterface $e) {
-            throw new TransportException('Could not reach the remote Firebase server.', $response, 0, $e);
+            throw new TransportException('Sending message to Firebase failed.', $response, 0, $e);
         }
 
         $contentType = $response->getHeaders(false)['content-type'][0] ?? '';
         $jsonContents = str_starts_with($contentType, 'application/json') ? $response->toArray(false) : null;
         $errorMessage = null;
 
-        if ($jsonContents && isset($jsonContents['results'][0]['error'])) {
-            $errorMessage = $jsonContents['results'][0]['error'];
+        if (null !== $jsonContents && isset($jsonContents['error']['message'])) {
+            $errorMessage = $jsonContents['error']['message'];
         } elseif (200 !== $statusCode) {
             $errorMessage = $response->getContent(false);
         }
 
         if (null !== $errorMessage) {
-            throw new TransportException('Unable to post the Firebase message: '.$errorMessage, $response);
+            throw new TransportException(\sprintf('Firebase server responded with error "%s"', $errorMessage), $response);
         }
 
         $success = $response->toArray(false);
 
         $sentMessage = new SentMessage($message, (string) $this);
-        $sentMessage->setMessageId($success['results'][0]['message_id'] ?? '');
+        $sentMessage->setMessageId($success['name'] ?? '');
 
         return $sentMessage;
+    }
+
+    private function getJwt(): string
+    {
+        // the assertion is valid for an hour, so it is reused until shortly before it expires
+        if ($this->jwtExpiresAt > $time = time()) {
+            return $this->jwt;
+        }
+
+        // "kid" is a JOSE header parameter: Google selects the signing key from it
+        $header = $this->base64UrlEncode([
+            'alg' => 'RS256',
+            'typ' => 'JWT',
+            'kid' => $this->privateKeyId,
+        ]);
+        $payload = $this->base64UrlEncode([
+            'iss' => $this->clientEmail,
+            'sub' => $this->clientEmail,
+            'aud' => 'https://fcm.googleapis.com/',
+            'iat' => $time,
+            'exp' => $time + 3600,
+        ]);
+        $key = openssl_pkey_get_private($this->privateKey);
+
+        if (false === $key) {
+            throw new InvalidArgumentException(\sprintf('The "%s" transport could not load private key from DSN. Is the key valid?', self::class));
+        }
+
+        openssl_sign($header.'.'.$payload, $signature, $key, \OPENSSL_ALGO_SHA256);
+
+        $this->jwtExpiresAt = $time + 3540;
+
+        return $this->jwt = $header.'.'.$payload.'.'.$this->base64UrlEncode($signature);
+    }
+
+    /**
+     * @param string|array<string, string|int|float> $data
+     */
+    private function base64UrlEncode(string|array $data): string
+    {
+        if (\is_array($data)) {
+            $data = json_encode($data, \JSON_UNESCAPED_SLASHES | \JSON_THROW_ON_ERROR);
+        }
+
+        return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/FirebaseTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/FirebaseTransportFactory.php
@@ -11,12 +11,14 @@
 
 namespace Symfony\Component\Notifier\Bridge\Firebase;
 
+use Symfony\Component\Notifier\Exception\MissingRequiredOptionException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
 use Symfony\Component\Notifier\Transport\Dsn;
 
 /**
  * @author Jeroen Spee <https://github.com/Jeroeny>
+ * @author Vojtech Smejkal <https://vojtechsmejkal.cz>
  */
 final class FirebaseTransportFactory extends AbstractTransportFactory
 {
@@ -28,11 +30,25 @@ final class FirebaseTransportFactory extends AbstractTransportFactory
             throw new UnsupportedSchemeException($dsn, 'firebase', $this->getSupportedSchemes());
         }
 
-        $token = \sprintf('%s:%s', $this->getUser($dsn), $this->getPassword($dsn));
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
+        $user = $this->getUser($dsn);
 
-        return (new FirebaseTransport($token, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        try {
+            $projectId = $dsn->getRequiredOption('project_id');
+            $privateKeyId = $dsn->getRequiredOption('private_key_id');
+            $privateKey = $dsn->getRequiredOption('private_key');
+
+            return (new FirebaseTransport('', $projectId, $user, $privateKeyId, $privateKey, $this->client, $this->dispatcher))
+                ->setHost($host)
+                ->setPort($port);
+        } catch (MissingRequiredOptionException) {
+            trigger_deprecation('symfony/firebase-notifier', '8.2', 'Using Firebase Notifier without project_id, private_key_id and private_key options is deprecated. Update your Firebase DSN.');
+
+            return (new FirebaseTransport('', '', '', '', '', $this->client, $this->dispatcher))
+                ->setHost($host)
+                ->setPort($port);
+        }
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/Notification/AndroidNotification.php
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/Notification/AndroidNotification.php
@@ -12,17 +12,23 @@
 namespace Symfony\Component\Notifier\Bridge\Firebase\Notification;
 
 use Symfony\Component\Notifier\Bridge\Firebase\FirebaseOptions;
+use Symfony\Component\Notifier\Bridge\Firebase\TargetType;
 
 final class AndroidNotification extends FirebaseOptions
 {
+    public function __construct(string $target, array $options = [], array $data = [], TargetType $targetType = TargetType::Topic)
+    {
+        trigger_deprecation('symfony/firebase-notifier', '8.2', 'Using %s class is deprecated, use %s instead.', self::class, FirebaseOptions::class);
+
+        parent::__construct($target, ['notification' => $options], $data, $targetType);
+    }
+
     /**
      * @return $this
      */
     public function channelId(string $channelId): static
     {
-        $this->options['android_channel_id'] = $channelId;
-
-        return $this;
+        return $this->addAndroidOption('channel_id', $channelId);
     }
 
     /**
@@ -30,9 +36,7 @@ final class AndroidNotification extends FirebaseOptions
      */
     public function icon(string $icon): static
     {
-        $this->options['icon'] = $icon;
-
-        return $this;
+        return $this->addAndroidOption('icon', $icon);
     }
 
     /**
@@ -40,9 +44,7 @@ final class AndroidNotification extends FirebaseOptions
      */
     public function sound(string $sound): static
     {
-        $this->options['sound'] = $sound;
-
-        return $this;
+        return $this->addAndroidOption('sound', $sound);
     }
 
     /**
@@ -50,9 +52,7 @@ final class AndroidNotification extends FirebaseOptions
      */
     public function tag(string $tag): static
     {
-        $this->options['tag'] = $tag;
-
-        return $this;
+        return $this->addAndroidOption('tag', $tag);
     }
 
     /**
@@ -60,9 +60,7 @@ final class AndroidNotification extends FirebaseOptions
      */
     public function color(string $color): static
     {
-        $this->options['color'] = $color;
-
-        return $this;
+        return $this->addAndroidOption('color', $color);
     }
 
     /**
@@ -70,9 +68,7 @@ final class AndroidNotification extends FirebaseOptions
      */
     public function clickAction(string $clickAction): static
     {
-        $this->options['click_action'] = $clickAction;
-
-        return $this;
+        return $this->addAndroidOption('click_action', $clickAction);
     }
 
     /**
@@ -80,9 +76,7 @@ final class AndroidNotification extends FirebaseOptions
      */
     public function bodyLocKey(string $bodyLocKey): static
     {
-        $this->options['body_loc_key'] = $bodyLocKey;
-
-        return $this;
+        return $this->addAndroidOption('body_loc_key', $bodyLocKey);
     }
 
     /**
@@ -92,9 +86,7 @@ final class AndroidNotification extends FirebaseOptions
      */
     public function bodyLocArgs(array $bodyLocArgs): static
     {
-        $this->options['body_loc_args'] = $bodyLocArgs;
-
-        return $this;
+        return $this->addAndroidOption('body_loc_args', $bodyLocArgs);
     }
 
     /**
@@ -102,9 +94,7 @@ final class AndroidNotification extends FirebaseOptions
      */
     public function titleLocKey(string $titleLocKey): static
     {
-        $this->options['title_loc_key'] = $titleLocKey;
-
-        return $this;
+        return $this->addAndroidOption('title_loc_key', $titleLocKey);
     }
 
     /**
@@ -114,8 +104,6 @@ final class AndroidNotification extends FirebaseOptions
      */
     public function titleLocArgs(array $titleLocArgs): static
     {
-        $this->options['title_loc_args'] = $titleLocArgs;
-
-        return $this;
+        return $this->addAndroidOption('title_loc_args', $titleLocArgs);
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/Notification/IOSNotification.php
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/Notification/IOSNotification.php
@@ -12,17 +12,23 @@
 namespace Symfony\Component\Notifier\Bridge\Firebase\Notification;
 
 use Symfony\Component\Notifier\Bridge\Firebase\FirebaseOptions;
+use Symfony\Component\Notifier\Bridge\Firebase\TargetType;
 
 final class IOSNotification extends FirebaseOptions
 {
+    public function __construct(string $target, array $options = [], array $data = [], TargetType $targetType = TargetType::Topic)
+    {
+        trigger_deprecation('symfony/firebase-notifier', '8.2', 'Using %s class is deprecated, use %s instead.', self::class, FirebaseOptions::class);
+
+        parent::__construct($target, ['notification' => $options], $data, $targetType);
+    }
+
     /**
      * @return $this
      */
     public function sound(string $sound): static
     {
-        $this->options['sound'] = $sound;
-
-        return $this;
+        return $this->addApnsOption('sound', $sound);
     }
 
     /**
@@ -30,9 +36,7 @@ final class IOSNotification extends FirebaseOptions
      */
     public function badge(string $badge): static
     {
-        $this->options['badge'] = $badge;
-
-        return $this;
+        return $this->addApnsOption('badge', $badge);
     }
 
     /**
@@ -40,9 +44,7 @@ final class IOSNotification extends FirebaseOptions
      */
     public function clickAction(string $clickAction): static
     {
-        $this->options['click_action'] = $clickAction;
-
-        return $this;
+        return $this->addApnsOption('category', $clickAction);
     }
 
     /**
@@ -50,9 +52,7 @@ final class IOSNotification extends FirebaseOptions
      */
     public function subtitle(string $subtitle): static
     {
-        $this->options['subtitle'] = $subtitle;
-
-        return $this;
+        return $this->addApnsAlertOption('subtitle', $subtitle);
     }
 
     /**
@@ -60,9 +60,7 @@ final class IOSNotification extends FirebaseOptions
      */
     public function bodyLocKey(string $bodyLocKey): static
     {
-        $this->options['body_loc_key'] = $bodyLocKey;
-
-        return $this;
+        return $this->addApnsAlertOption('body_loc_key', $bodyLocKey);
     }
 
     /**
@@ -72,9 +70,7 @@ final class IOSNotification extends FirebaseOptions
      */
     public function bodyLocArgs(array $bodyLocArgs): static
     {
-        $this->options['body_loc_args'] = $bodyLocArgs;
-
-        return $this;
+        return $this->addApnsAlertOption('body_loc_args', $bodyLocArgs);
     }
 
     /**
@@ -82,9 +78,7 @@ final class IOSNotification extends FirebaseOptions
      */
     public function titleLocKey(string $titleLocKey): static
     {
-        $this->options['title_loc_key'] = $titleLocKey;
-
-        return $this;
+        return $this->addApnsAlertOption('title_loc_key', $titleLocKey);
     }
 
     /**
@@ -94,8 +88,6 @@ final class IOSNotification extends FirebaseOptions
      */
     public function titleLocArgs(array $titleLocArgs): static
     {
-        $this->options['title_loc_args'] = $titleLocArgs;
-
-        return $this;
+        return $this->addApnsAlertOption('title_loc_args', $titleLocArgs);
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/Notification/WebNotification.php
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/Notification/WebNotification.php
@@ -12,17 +12,23 @@
 namespace Symfony\Component\Notifier\Bridge\Firebase\Notification;
 
 use Symfony\Component\Notifier\Bridge\Firebase\FirebaseOptions;
+use Symfony\Component\Notifier\Bridge\Firebase\TargetType;
 
 final class WebNotification extends FirebaseOptions
 {
+    public function __construct(string $target, array $options = [], array $data = [], TargetType $targetType = TargetType::Topic)
+    {
+        trigger_deprecation('symfony/firebase-notifier', '8.2', 'Using %s class is deprecated, use %s instead.', self::class, FirebaseOptions::class);
+
+        parent::__construct($target, ['notification' => $options], $data, $targetType);
+    }
+
     /**
      * @return $this
      */
     public function icon(string $icon): static
     {
-        $this->options['icon'] = $icon;
-
-        return $this;
+        return $this->addWebpushOption('icon', $icon);
     }
 
     /**
@@ -30,8 +36,6 @@ final class WebNotification extends FirebaseOptions
      */
     public function clickAction(string $clickAction): static
     {
-        $this->options['click_action'] = $clickAction;
-
-        return $this;
+        return $this->addWebpushOption('click_action', $clickAction);
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/README.md
@@ -7,32 +7,107 @@ DSN example
 -----------
 
 ```
-FIREBASE_DSN=firebase://USERNAME:PASSWORD@default
+FIREBASE_DSN=firebase://<CLIENT_EMAIL>@default?project_id=<PROJECT_ID>&private_key_id=<PRIVATE_KEY_ID>&private_key=<PRIVATE_KEY>
 ```
 
-where:
- - `USERNAME` is your Firebase username
- - `PASSWORD` is your Firebase password
+All 4 parameters are required. All 4 parameters are located inside your firebase json private key.
+
+IMPORTANT: Make sure that `PRIVATE_KEY` is safely url encoded. Get more information in [Notifier documentation](https://symfony.com/doc/current/notifier.html#chat-channel) or use the script below.
+
+
+Getting credentials for your DSN
+--------------------------------
+
+Steps for getting your private key:
+ 1. Log into the [firebase console](https://console.firebase.google.com/).
+ 2. Click on your project
+ 3. Click on the gear icon next to "Project Overview" and click on "Project settings"
+ 4. Click on "Service accounts" tab
+ 5. Click on "Generate new private key" button at the bottom
+ 6. A JSON file with your private key will be downloaded
+
+The downloaded private key is a JSON file which should contain the following keys:
+ * `type`
+ * `project_id`
+ * `private_key_id`
+ * `private_key`
+ * `client_email`
+ * `client_id`
+ * `auth_uri`
+ * `token_uri`
+ * `auth_provider_x509_cert_url`
+ * `client_x509_cert_url`
+ * `universe_domain`
+
+You can then use the following script to convert your JSON private key to DSN format:
+
+```php
+<?php
+
+if (!isset($argv[1])) {
+    echo 'Usage: php ' . $argv[0] . ' path_to_your_key.json'.PHP_EOL;
+    exit(1);
+}
+
+$file = file_get_contents($argv[1]);
+
+if (false === $file) {
+    echo 'Could not open file at path: '.$argv[1].PHP_EOL.PHP_EOL;
+    exit(1);
+}
+
+$key = json_decode($file, true);
+
+if (false === $key) {
+    echo 'Unable to load JSON content of the file at path: '.$argv[1].PHP_EOL;
+    exit(1);
+}
+
+foreach (['client_email', 'project_id', 'private_key_id', 'private_key'] as $param) {
+    if (!isset($key[$param])) {
+        echo 'Missing param '.$param.' inside the JSON key.'.PHP_EOL;
+        exit(1);
+    }
+}
+
+echo sprintf(
+    'FIREBASE_DSN=firebase://%s@default?project_id=%s&private_key_id=%s&private_key=%s',
+    $key['client_email'],
+    $key['project_id'],
+    $key['private_key_id'],
+    urlencode($key['private_key']),
+).PHP_EOL;
+```
+
+The script then can be used as follows:
+```bash
+php script_name.php path/to/your/firebase/key.json
+```
+
 
 Adding Interactions to a Message
 --------------------------------
 
-With a Firebase message, you can use the `AndroidNotification`, `IOSNotification` or `WebNotification` classes to add
-[message options](https://firebase.google.com/docs/cloud-messaging/xmpp-server-ref.html).
+With a Firebase message, you can use the `FirebaseOptions` class to add
+[platform specific message options](https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#resource:-message).
+
+Specifying Firebase options for a message:
 
 ```php
 use Symfony\Component\Notifier\Message\ChatMessage;
-use Symfony\Component\Notifier\Bridge\Firebase\Notification\AndroidNotification;
+use Symfony\Component\Notifier\Bridge\Firebase\FirebaseOptions;
 
-$chatMessage = new ChatMessage('');
+$chatMessage = new ChatMessage('Hello, you should contribute to Symfony.');
 
-// Create AndroidNotification options
-$androidOptions = (new AndroidNotification('/topics/news', []))
-    ->icon('myicon')
-    ->sound('default')
-    ->tag('myNotificationId')
-    ->color('#cccccc')
-    ->clickAction('OPEN_ACTIVITY_1')
+// Specify options for Firebase
+$firebaseOptions = (new FirebaseOptions('/topics/news'))
+    ->title('New message!')
+    ->body('This will overwrite the subject from ChatMessage object.')
+    ->image('https://path-to-your-image.png')
+    ->data([
+        'key1' => 'value1',
+        'key2' => 'value2',
+    ])
     // ...
     ;
 
@@ -41,6 +116,66 @@ $chatMessage->options($androidOptions);
 
 $chatter->send($chatMessage);
 ```
+
+Firebase offers 3 different types of targets to send the message to:
+ * token
+ * topic
+ * condition
+
+How to specify different targets for firebase messages:
+
+```php
+use Symfony\Component\Notifier\Bridge\Firebase\FirebaseOptions;
+use Symfony\Component\Notifier\Bridge\Firebase\TargetType;
+
+// Use a topic as a target
+$topicOptions = new FirebaseOptions('/topics/news', targetType: TargetType::Topic);
+
+// Use a token as a target
+$tokenOptions = new FirebaseOptions('dU5e3nFJf9bE:APA91bH3Kd/exampleToken', targetType: TargetType::Token);
+
+// Use a condition as a target
+$conditionOptions = new FirebaseOptions('\'news\' in topics', targetType: TargetType::Condition);
+```
+
+Firebase also allows specifying platform specific options. They can be specified as follows:
+
+```php
+use Symfony\Component\Notifier\Bridge\Firebase\FirebaseOptions;
+use Symfony\Component\Notifier\Bridge\Firebase\TargetType;
+
+$detailedOptions = (new FirebaseOptions('dU5e3nFJf9bE:APA91bH3Kd/exampleToken', targetType: TargetType::Token))
+    // Basic options
+    ->title('New message!')
+    ->data([
+        'key1' => 'value1',
+        'key2' => 'value2',
+    ])
+    // Android specific options
+    ->android([
+        'notification' => [
+            'color' => '#4538D5',
+        ],
+    ])
+    // WebPush specific options
+    ->webpush([
+        'notification' => [
+            'icon' => 'https://path-to-an-icon.png',
+        ],
+    ])
+    // APNS specific options
+    ->apns([
+        'payload' => [
+            'aps' => [
+                'sound' => 'default',
+            ],
+        ],
+    ])
+    // ...
+    ;
+```
+
+For all available options please refer to the [firebase documentation](https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages).
 
 Sponsor
 -------

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/TargetType.php
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/TargetType.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Firebase;
+
+/**
+ * @author Vojtech Smejkal <https://vojtechsmejkal.cz>
+ */
+enum TargetType: string
+{
+    case Topic = 'topic';
+    case Token = 'token';
+    case Condition = 'condition';
+}

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/Tests/FirebaseTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/Tests/FirebaseTransportFactoryTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\Notifier\Test\IncompleteDsnTestTrait;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>
+ * @author Vojtech Smejkal <https://vojtechsmejkal.cz>
  */
 final class FirebaseTransportFactoryTest extends AbstractTransportFactoryTestCase
 {
@@ -30,14 +31,15 @@ final class FirebaseTransportFactoryTest extends AbstractTransportFactoryTestCas
     public static function createProvider(): iterable
     {
         yield [
-            'firebase://host.test',
-            'firebase://username:password@host.test',
+            'firebase://fcm.googleapis.com',
+            'firebase://firebase-adminsdk@iam.gserviceaccount.com@default?project_id=PROJECT_ID&private_key_id=PRIVATE_KEY_ID&private_key=PRIVATE_KEY',
         ];
     }
 
     public static function supportsProvider(): iterable
     {
         yield [true, 'firebase://username:password@default'];
+        yield [true, 'firebase://firebase-adminsdk@iam.gserviceaccount.com@default?project_id=PROJECT_ID&private_key_id=PRIVATE_KEY_ID&private_key=PRIVATE_KEY'];
         yield [false, 'somethingElse://username:password@default'];
     }
 
@@ -49,6 +51,5 @@ final class FirebaseTransportFactoryTest extends AbstractTransportFactoryTestCas
     public static function incompleteDsnProvider(): iterable
     {
         yield ['firebase://:password@default'];
-        yield ['firebase://username@default'];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/Tests/FirebaseTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/Tests/FirebaseTransportTest.php
@@ -26,17 +26,20 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>
+ * @author Vojtech Smejkal <https://vojtechsmejkal.cz>
  */
 final class FirebaseTransportTest extends TransportTestCase
 {
+    private const PRIVATE_KEY = "-----BEGIN PRIVATE KEY-----\nMIIBVAIBADANBgkqhkiG9w0BAQEFAASCAT4wggE6AgEAAkEAmU2f/GKCLuvw8NAl\nbqJW5RxhMrUrcampGQxz2F2OT3fqoyKBhAGzNhxbgPZYDeXp7WNNLTk9WLT7sDNM\ndjVUuQIDAQABAkAtOTX52QF4YAfKskxoj6E8oxuVPtabCCanCgJekHK7xDpYpYre\ncvxoPhw0c4McZiFoBOlr0TqyY9qpDWXDHLDFAiEAy9jNU/N438WrurUPuOfyqIYx\n25NJWQ7sgjfDJBMVHO8CIQDAhmed4Uih7QKZAMPeRayFeemdjcXNmN4wp/YjiLZ4\n1wIgaTWnnBnAnDYo0T+cMsI8QvCoEP0u0TFbrkXbiOX0cq8CIQCrg9GxrG75mt1y\nk2TrkuS0cLy4GQJ8PFDNxgSY+YWeNwIgavjv+v6MgyLrMTuZsAd67+5Z5axjdJL8\nbwLzq+QOXk8=\n-----END PRIVATE KEY-----\n";
+
     public static function createTransport(?HttpClientInterface $client = null): FirebaseTransport
     {
-        return new FirebaseTransport('username:password', $client ?? new MockHttpClient());
+        return new FirebaseTransport('', 'test_project_id', 'firebase-adminsdk-test@test-project.iam.gserviceaccount.com', 'private_key_id', self::PRIVATE_KEY, $client ?? new MockHttpClient());
     }
 
     public static function toStringProvider(): iterable
     {
-        yield ['firebase://fcm.googleapis.com/fcm/send', self::createTransport()];
+        yield ['firebase://fcm.googleapis.com', self::createTransport()];
     }
 
     public static function supportedMessagesProvider(): iterable
@@ -66,12 +69,12 @@ final class FirebaseTransportTest extends TransportTestCase
     public static function sendWithErrorThrowsExceptionProvider(): iterable
     {
         yield [new MockResponse(
-            json_encode(['results' => [['error' => 'testErrorCode']]]),
+            json_encode(['error' => ['message' => 'testErrorCode']]),
             ['response_headers' => ['content-type' => ['application/json']], 'http_code' => 200]
         )];
 
         yield [new MockResponse(
-            json_encode(['results' => [['error' => 'testErrorCode']]]),
+            json_encode(['error' => ['message' => 'testErrorCode']]),
             ['response_headers' => ['content-type' => ['application/json']], 'http_code' => 400]
         )];
     }

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/Tests/Notification/AndroidNotificationTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/Tests/Notification/AndroidNotificationTest.php
@@ -11,11 +11,15 @@
 
 namespace Symfony\Component\Notifier\Bridge\Firebase\Tests\Notification;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Notifier\Bridge\Firebase\Notification\AndroidNotification;
 
 final class AndroidNotificationTest extends TestCase
 {
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
     public function testAndroidNotificationOptions()
     {
         $notification = new AndroidNotification('device_token', [
@@ -24,17 +28,19 @@ final class AndroidNotificationTest extends TestCase
         ], ['key' => 'value']);
 
         $this->assertSame([
-            'to' => 'device_token',
             'notification' => [
                 'title' => 'Test Title',
                 'body' => 'Test Body',
             ],
             'data' => ['key' => 'value'],
+            'topic' => 'device_token',
         ], $notification->toArray());
 
-        $this->assertSame('device_token', $notification->getRecipientId());
+        $this->assertSame('[topic]device_token', $notification->getRecipientId());
     }
 
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
     public function testAndroidNotificationWithAllOptions()
     {
         $notification = (new AndroidNotification('device_token', []))
@@ -53,27 +59,35 @@ final class AndroidNotificationTest extends TestCase
             ->titleLocArgs(['title_arg1', 'title_arg2']);
 
         $expected = [
-            'to' => 'device_token',
             'notification' => [
                 'title' => 'New Title',
                 'body' => 'New Body',
-                'android_channel_id' => 'channel_123',
-                'icon' => 'notification_icon',
-                'sound' => 'notification_sound',
-                'tag' => 'tag_123',
-                'color' => '#FF0000',
-                'click_action' => 'OPEN_ACTIVITY',
-                'body_loc_key' => 'body_key',
-                'body_loc_args' => ['arg1', 'arg2'],
-                'title_loc_key' => 'title_key',
-                'title_loc_args' => ['title_arg1', 'title_arg2'],
             ],
-            'data' => ['custom' => 'data'],
+            'data' => [
+                'custom' => 'data',
+            ],
+            'android' => [
+                'notification' => [
+                    'channel_id' => 'channel_123',
+                    'icon' => 'notification_icon',
+                    'sound' => 'notification_sound',
+                    'tag' => 'tag_123',
+                    'color' => '#FF0000',
+                    'click_action' => 'OPEN_ACTIVITY',
+                    'body_loc_key' => 'body_key',
+                    'body_loc_args' => ['arg1', 'arg2'],
+                    'title_loc_key' => 'title_key',
+                    'title_loc_args' => ['title_arg1', 'title_arg2'],
+                ],
+            ],
+            'topic' => 'device_token',
         ];
 
         $this->assertSame($expected, $notification->toArray());
     }
 
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
     public function testAndroidNotificationChaining()
     {
         $notification = new AndroidNotification('device_token', []);
@@ -84,12 +98,15 @@ final class AndroidNotificationTest extends TestCase
 
         $this->assertSame($notification, $result);
         $this->assertSame([
-            'to' => 'device_token',
-            'notification' => [
-                'android_channel_id' => 'test_channel',
-                'icon' => 'test_icon',
-            ],
+            'notification' => [],
             'data' => [],
+            'android' => [
+                'notification' => [
+                    'channel_id' => 'test_channel',
+                    'icon' => 'test_icon',
+                ],
+            ],
+            'topic' => 'device_token',
         ], $notification->toArray());
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/Tests/Notification/IOSNotificationTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/Tests/Notification/IOSNotificationTest.php
@@ -11,11 +11,15 @@
 
 namespace Symfony\Component\Notifier\Bridge\Firebase\Tests\Notification;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Notifier\Bridge\Firebase\Notification\IOSNotification;
 
 final class IOSNotificationTest extends TestCase
 {
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
     public function testIOSNotificationOptions()
     {
         $notification = new IOSNotification('device_token', [
@@ -24,17 +28,19 @@ final class IOSNotificationTest extends TestCase
         ], ['key' => 'value']);
 
         $this->assertSame([
-            'to' => 'device_token',
             'notification' => [
                 'title' => 'Test Title',
                 'body' => 'Test Body',
             ],
             'data' => ['key' => 'value'],
+            'topic' => 'device_token',
         ], $notification->toArray());
 
-        $this->assertSame('device_token', $notification->getRecipientId());
+        $this->assertSame('[topic]device_token', $notification->getRecipientId());
     }
 
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
     public function testIOSNotificationWithAllOptions()
     {
         $notification = (new IOSNotification('device_token', []))
@@ -51,25 +57,37 @@ final class IOSNotificationTest extends TestCase
             ->titleLocArgs(['title_arg1', 'title_arg2']);
 
         $expected = [
-            'to' => 'device_token',
             'notification' => [
                 'title' => 'New Title',
                 'body' => 'New Body',
-                'sound' => 'default',
-                'badge' => '5',
-                'click_action' => 'OPEN_ACTIVITY',
-                'subtitle' => 'Test Subtitle',
-                'body_loc_key' => 'body_key',
-                'body_loc_args' => ['arg1', 'arg2'],
-                'title_loc_key' => 'title_key',
-                'title_loc_args' => ['title_arg1', 'title_arg2'],
             ],
-            'data' => ['custom' => 'data'],
+            'data' => [
+                'custom' => 'data',
+            ],
+            'apns' => [
+                'payload' => [
+                    'aps' => [
+                        'sound' => 'default',
+                        'badge' => '5',
+                        'category' => 'OPEN_ACTIVITY',
+                        'alert' => [
+                            'subtitle' => 'Test Subtitle',
+                            'body_loc_key' => 'body_key',
+                            'body_loc_args' => ['arg1', 'arg2'],
+                            'title_loc_key' => 'title_key',
+                            'title_loc_args' => ['title_arg1', 'title_arg2'],
+                        ],
+                    ],
+                ],
+            ],
+            'topic' => 'device_token',
         ];
 
         $this->assertSame($expected, $notification->toArray());
     }
 
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
     public function testIOSNotificationChaining()
     {
         $notification = new IOSNotification('device_token', []);
@@ -81,13 +99,20 @@ final class IOSNotificationTest extends TestCase
 
         $this->assertSame($notification, $result);
         $this->assertSame([
-            'to' => 'device_token',
-            'notification' => [
-                'sound' => 'ping.aiff',
-                'badge' => '10',
-                'subtitle' => 'Important',
-            ],
+            'notification' => [],
             'data' => [],
+            'apns' => [
+                'payload' => [
+                    'aps' => [
+                        'sound' => 'ping.aiff',
+                        'badge' => '10',
+                        'alert' => [
+                            'subtitle' => 'Important',
+                        ],
+                    ],
+                ],
+            ],
+            'topic' => 'device_token',
         ], $notification->toArray());
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/Tests/Notification/WebNotificationTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/Tests/Notification/WebNotificationTest.php
@@ -11,11 +11,15 @@
 
 namespace Symfony\Component\Notifier\Bridge\Firebase\Tests\Notification;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Notifier\Bridge\Firebase\Notification\WebNotification;
 
 final class WebNotificationTest extends TestCase
 {
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
     public function testWebNotificationOptions()
     {
         $notification = new WebNotification('device_token', [
@@ -24,17 +28,19 @@ final class WebNotificationTest extends TestCase
         ], ['key' => 'value']);
 
         $this->assertSame([
-            'to' => 'device_token',
             'notification' => [
                 'title' => 'Test Title',
                 'body' => 'Test Body',
             ],
             'data' => ['key' => 'value'],
+            'topic' => 'device_token',
         ], $notification->toArray());
 
-        $this->assertSame('device_token', $notification->getRecipientId());
+        $this->assertSame('[topic]device_token', $notification->getRecipientId());
     }
 
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
     public function testWebNotificationWithAllOptions()
     {
         $notification = (new WebNotification('device_token', []))
@@ -45,19 +51,27 @@ final class WebNotificationTest extends TestCase
             ->clickAction('https://example.com');
 
         $expected = [
-            'to' => 'device_token',
             'notification' => [
                 'title' => 'New Title',
                 'body' => 'New Body',
-                'icon' => '/images/icon.png',
-                'click_action' => 'https://example.com',
             ],
-            'data' => ['custom' => 'data'],
+            'data' => [
+                'custom' => 'data',
+            ],
+            'webpush' => [
+                'notification' => [
+                    'icon' => '/images/icon.png',
+                    'click_action' => 'https://example.com',
+                ],
+            ],
+            'topic' => 'device_token',
         ];
 
         $this->assertSame($expected, $notification->toArray());
     }
 
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
     public function testWebNotificationChaining()
     {
         $notification = new WebNotification('device_token', []);
@@ -68,12 +82,15 @@ final class WebNotificationTest extends TestCase
 
         $this->assertSame($notification, $result);
         $this->assertSame([
-            'to' => 'device_token',
-            'notification' => [
-                'icon' => '/favicon.ico',
-                'click_action' => 'https://myapp.com/action',
-            ],
+            'notification' => [],
             'data' => [],
+            'webpush' => [
+                'notification' => [
+                    'icon' => '/favicon.ico',
+                    'click_action' => 'https://myapp.com/action',
+                ],
+            ],
+            'topic' => 'device_token',
         ], $notification->toArray());
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/composer.json
@@ -17,6 +17,8 @@
     ],
     "require": {
         "php": ">=8.4.1",
+        "ext-openssl": "*",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/http-client": "^7.4|^8.0",
         "symfony/notifier": "^7.4|^8.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | Fix #51147
| License       | MIT

This PR adds support for the new [v1 API](https://firebase.google.com/docs/reference/fcm/rest).

The main changes were:
- Changed authorization process to use short lived JWT
- Changed DSN shape to provide all information required by new API
- New API endpoint was used
- `FirebaseOptions` were extended to hold params supported by new API

This PR does not break backwards compatibility meaning that new Firebase bridge should behave the same way inside the Symfony app as the old one does right now.

Support for the old API was completely removed as the API has been shut down in 2024 already and attempting to use it throws exceptions.

### Deprecations
- `$token` param in `FirebaseTransport::__construct()` was deprecated - the param no longer exists for the new API
- `AndroidNotification`, `IOSNotification` and `WebNotification` classes were deprecated - new Firebase API allows for all platform specific options to be specified for the message and having options separated by platform limits usability
- If you attempt to use the `FirebaseTransport` with the old DSN format a deprecation notice is triggered to inform the user to upgrade (this has been done mainly to not break apps which have the `FirebaseTransport` configured with the old credentials format)