### PR TITLE
[Messenger] Reduce lock time when using MySQL for transport

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/ConnectionTest.php
@@ -668,46 +668,41 @@ class ConnectionTest extends TestCase
         $connection->get();
     }
 
+    /**
+     * @dataProvider providePlatformMySQLSql
+     */
+    public function testGeneratedMySQLSqlOnGet(AbstractPlatform $platform, string $expectedSql, string $expectedUpdateSql)
+    {
+        $driverConnection = $this->createMock(DBALConnection::class);
+        $driverConnection->method('getDatabasePlatform')->willReturn($platform);
+        $driverConnection->method('createQueryBuilder')->willReturnCallback(fn () => new QueryBuilder($driverConnection));
+
+        $result = $this->createMock(Result::class);
+        $result->method('fetchFirstColumn')->willReturn(['id' => 3]);
+
+        $driverConnection
+            ->expects($this->once())
+            ->method('executeQuery')
+            ->with($this->callback(function ($sql) use ($expectedSql) {
+                return trim($expectedSql) === trim($sql);
+            }))
+            ->willReturn($result)
+        ;
+        $driverConnection
+            ->expects($this->once())
+            ->method('executeStatement')
+            ->with($this->callback(function ($sql) use ($expectedUpdateSql) {
+                return trim($expectedUpdateSql) === trim($sql);
+            }))
+            ->willReturn(0)
+        ;
+
+        $connection = new Connection([], $driverConnection);
+        $connection->get();
+    }
+
     public static function providePlatformSql(): iterable
     {
-        yield 'MySQL' => [
-            class_exists(MySQLPlatform::class) ? new MySQLPlatform() : new MySQL57Platform(),
-            'SELECT m.* FROM messenger_messages m WHERE (m.queue_name = ?) AND (m.delivered_at is null OR m.delivered_at < ?) AND (m.available_at <= ?) ORDER BY available_at ASC LIMIT 1 FOR UPDATE',
-        ];
-
-        if (class_exists(MySQL80Platform::class) && !method_exists(QueryBuilder::class, 'forUpdate')) {
-            yield 'MySQL8 & DBAL<3.8' => [
-                new MySQL80Platform(),
-                'SELECT m.* FROM messenger_messages m WHERE (m.queue_name = ?) AND (m.delivered_at is null OR m.delivered_at < ?) AND (m.available_at <= ?) ORDER BY available_at ASC LIMIT 1 FOR UPDATE',
-            ];
-        }
-
-        if (class_exists(MySQL80Platform::class) && method_exists(QueryBuilder::class, 'forUpdate')) {
-            yield 'MySQL8 & DBAL>=3.8' => [
-                new MySQL80Platform(),
-                'SELECT m.* FROM messenger_messages m WHERE (m.queue_name = ?) AND (m.delivered_at is null OR m.delivered_at < ?) AND (m.available_at <= ?) ORDER BY available_at ASC LIMIT 1 FOR UPDATE SKIP LOCKED',
-            ];
-        }
-
-        yield 'MariaDB' => [
-            new MariaDBPlatform(),
-            'SELECT m.* FROM messenger_messages m WHERE (m.queue_name = ?) AND (m.delivered_at is null OR m.delivered_at < ?) AND (m.available_at <= ?) ORDER BY available_at ASC LIMIT 1 FOR UPDATE',
-        ];
-
-        if (interface_exists(DBALException::class)) {
-            // DBAL 4+
-            $mariaDbPlatformClass = 'Doctrine\DBAL\Platforms\MariaDB1060Platform';
-        } else {
-            $mariaDbPlatformClass = 'Doctrine\DBAL\Platforms\MariaDb1060Platform';
-        }
-
-        if (class_exists($mariaDbPlatformClass)) {
-            yield 'MariaDB106' => [
-                new $mariaDbPlatformClass(),
-                'SELECT m.* FROM messenger_messages m WHERE (m.queue_name = ?) AND (m.delivered_at is null OR m.delivered_at < ?) AND (m.available_at <= ?) ORDER BY available_at ASC LIMIT 1 FOR UPDATE SKIP LOCKED',
-            ];
-        }
-
         if (class_exists(MySQL57Platform::class)) {
             yield 'Postgres & DBAL<4' => [
                 new PostgreSQLPlatform(),
@@ -769,6 +764,51 @@ class ConnectionTest extends TestCase
             yield 'Oracle & DBAL>=4' => [
                 new OraclePlatform(),
                 'SELECT w.id AS "id", w.body AS "body", w.headers AS "headers", w.queue_name AS "queue_name", w.created_at AS "created_at", w.available_at AS "available_at", w.delivered_at AS "delivered_at" FROM messenger_messages w WHERE w.id IN (SELECT m.id FROM messenger_messages m WHERE (m.queue_name = ?) AND (m.delivered_at is null OR m.delivered_at < ?) AND (m.available_at <= ?) ORDER BY available_at ASC FETCH NEXT 1 ROWS ONLY) FOR UPDATE SKIP LOCKED',
+            ];
+        }
+    }
+
+    public static function providePlatformMySQLSql(): iterable
+    {
+        yield 'MySQL' => [
+            class_exists(MySQLPlatform::class) ? new MySQLPlatform() : new MySQL57Platform(),
+            'SELECT id FROM messenger_messages m WHERE (m.queue_name = ?) AND (m.delivered_at is null OR m.delivered_at < ?) AND (m.available_at <= ?) ORDER BY available_at ASC LIMIT 100',
+            'UPDATE messenger_messages SET delivered_at = :now WHERE (id = :id) AND (queue_name = :queue_name) AND (delivered_at is null OR delivered_at < :redeliver_imit)',
+        ];
+
+        if (class_exists(MySQL80Platform::class) && !method_exists(QueryBuilder::class, 'forUpdate')) {
+            yield 'MySQL8 & DBAL<3.8' => [
+                new MySQL80Platform(),
+                'SELECT id FROM messenger_messages m WHERE (m.queue_name = ?) AND (m.delivered_at is null OR m.delivered_at < ?) AND (m.available_at <= ?) ORDER BY available_at ASC LIMIT 100',
+                'UPDATE messenger_messages SET delivered_at = :now WHERE (id = :id) AND (queue_name = :queue_name) AND (delivered_at is null OR delivered_at < :redeliver_imit)',
+            ];
+        }
+
+        if (class_exists(MySQL80Platform::class) && method_exists(QueryBuilder::class, 'forUpdate')) {
+            yield 'MySQL8 & DBAL>=3.8' => [
+                new MySQL80Platform(),
+                'SELECT id FROM messenger_messages m WHERE (m.queue_name = ?) AND (m.delivered_at is null OR m.delivered_at < ?) AND (m.available_at <= ?) ORDER BY available_at ASC LIMIT 100',
+                'UPDATE messenger_messages SET delivered_at = :now WHERE (id = :id) AND (queue_name = :queue_name) AND (delivered_at is null OR delivered_at < :redeliver_imit)',
+            ];
+        }
+        yield 'MariaDB' => [
+            new MariaDBPlatform(),
+            'SELECT id FROM messenger_messages m WHERE (m.queue_name = ?) AND (m.delivered_at is null OR m.delivered_at < ?) AND (m.available_at <= ?) ORDER BY available_at ASC LIMIT 100',
+            'UPDATE messenger_messages SET delivered_at = :now WHERE (id = :id) AND (queue_name = :queue_name) AND (delivered_at is null OR delivered_at < :redeliver_imit)',
+        ];
+
+        if (interface_exists(DBALException::class)) {
+            // DBAL 4+
+            $mariaDbPlatformClass = 'Doctrine\DBAL\Platforms\MariaDB1060Platform';
+        } else {
+            $mariaDbPlatformClass = 'Doctrine\DBAL\Platforms\MariaDb1060Platform';
+        }
+
+        if (class_exists($mariaDbPlatformClass)) {
+            yield 'MariaDB106' => [
+                new $mariaDbPlatformClass(),
+                'SELECT id FROM messenger_messages m WHERE (m.queue_name = ?) AND (m.delivered_at is null OR m.delivered_at < ?) AND (m.available_at <= ?) ORDER BY available_at ASC LIMIT 100',
+                'UPDATE messenger_messages SET delivered_at = :now WHERE (id = :id) AND (queue_name = :queue_name) AND (delivered_at is null OR delivered_at < :redeliver_imit)',
             ];
         }
     }

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
@@ -638,7 +638,7 @@ class Connection implements ResetInterface
             ->orderBy('available_at', 'ASC')
             ->setMaxResults(100)->fetchFirstColumn();
 
-        if (0 === \count($possibleIdsToClaim)) {
+        if (!$possibleIdsToClaim) {
             $this->queueEmptiedAt = microtime(true) * 1000;
 
             return null;

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
@@ -645,13 +645,14 @@ class Connection implements ResetInterface
         }
         $this->queueEmptiedAt = null;
 
+        $claimedId = null;
         foreach ($possibleIdsToClaim as $id) {
             if (null === $claimedId = $this->claimMessage($id)) {
                 break;
             }
         }
 
-        if (!isset($claimedId)) {
+        if (!null === $claimedId) {
             // all open messages already have been claimed by other workers.
             return null;
         }
@@ -732,7 +733,7 @@ class Connection implements ResetInterface
                     'queue_name' => Types::STRING,
                     'redeliver_imit' => Types::DATETIME_IMMUTABLE,
                 ])
-                ->executeStatement() > 0;
+                ->executeStatement();
 
         return $claimed ? $id : null;
     }

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
@@ -646,8 +646,7 @@ class Connection implements ResetInterface
         $this->queueEmptiedAt = null;
 
         foreach ($possibleIdsToClaim as $id) {
-            $claimedId = $this->claimMessage($id);
-            if (null !== $claimedId) {
+            if (null === $claimedId = $this->claimMessage($id)) {
                 break;
             }
         }

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
@@ -715,7 +715,7 @@ class Connection implements ResetInterface
         $now = new \DateTimeImmutable('UTC');
         $redeliverLimit = $now->modify(\sprintf('-%d seconds', $this->configuration['redeliver_timeout']));
 
-        $claimed = $this->driverConnection->createQueryBuilder()
+        $claimed = 0 < $this->driverConnection->createQueryBuilder()
                 ->update($this->configuration['table_name'])
                 ->set('delivered_at', ':now')
                 ->andWhere('id = :id')

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Messenger\Bridge\Doctrine\Transport;
 
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection as DBALConnection;
 use Doctrine\DBAL\Driver\Exception as DriverException;
 use Doctrine\DBAL\Exception as DBALException;
@@ -158,15 +159,17 @@ class Connection implements ResetInterface
 
     public function get(): ?array
     {
-        if ($this->doMysqlCleanup && $this->driverConnection->getDatabasePlatform() instanceof AbstractMySQLPlatform) {
+        if ($this->driverConnection->getDatabasePlatform() instanceof AbstractMySQLPlatform) {
+            if ($this->doMysqlCleanup) {
+                $this->deleteDeliveredMessageForMySQLPlatform();
+            }
             try {
-                $this->driverConnection->delete($this->configuration['table_name'], ['delivered_at' => '9999-12-31 23:59:59']);
-                $this->doMysqlCleanup = false;
-            } catch (DriverException $e) {
-                // Ignore the exception
-            } catch (TableNotFoundException $e) {
+                return $this->getMessageForMySQLPlatform();
+            } catch (TableNotFoundException) {
                 if ($this->autoSetup) {
                     $this->setup();
+
+                    return $this->getMessageForMySQLPlatform();
                 }
             }
         }
@@ -626,5 +629,112 @@ class Connection implements ResetInterface
         } catch (DBALException) {
             return $sql;
         }
+    }
+
+    private function getMessageForMySQLPlatform(): ?array
+    {
+        $possibleIdsToClaim = $this->createAvailableMessagesQueryBuilder()
+            ->select('id')
+            ->orderBy('available_at', 'ASC')
+            ->setMaxResults(100)->fetchFirstColumn();
+
+        if (0 === \count($possibleIdsToClaim)) {
+            $this->queueEmptiedAt = microtime(true) * 1000;
+
+            return null;
+        }
+        $this->queueEmptiedAt = null;
+
+        foreach ($possibleIdsToClaim as $id) {
+            $claimedId = $this->claimMessage($id);
+            if (null !== $claimedId) {
+                break;
+            }
+        }
+
+        if (!isset($claimedId)) {
+            // all open messages already have been claimed by other workers.
+            return null;
+        }
+
+        $messageData = $this->createQueryBuilder()
+            ->andWhere('m.id = :id')
+            ->setParameter(':id', $claimedId)
+            ->fetchAssociative();
+
+        return $this->decodeEnvelopeHeaders($messageData);
+    }
+
+    /**
+     * @throws DBALException
+     */
+    private function deleteDeliveredMessageForMySQLPlatform(): void
+    {
+        try {
+            $ids = $this->selectMessageIdsToDelete();
+            $this->driverConnection->createQueryBuilder()
+                ->delete($this->configuration['table_name'])
+                ->where('id IN (:ids)')
+                ->setParameter('ids', $ids, ArrayParameterType::INTEGER)
+                ->executeQuery()
+            ;
+            $this->doMysqlCleanup = false;
+        } catch (DriverException $e) {
+            // Ignore the exception
+        } catch (TableNotFoundException $e) {
+            if ($this->autoSetup) {
+                $this->setup();
+            }
+        }
+    }
+
+    /**
+     * @return array<int, mixed>
+     *
+     * @throws DBALException
+     */
+    private function selectMessageIdsToDelete(): array
+    {
+        return $this->driverConnection->createQueryBuilder()
+            ->select('m.id')
+            ->from($this->configuration['table_name'], 'm')
+            ->where('m.queue_name = ?')
+            ->andWhere('m.delivered_at = ?')
+            ->setParameters([
+                $this->configuration['queue_name'],
+                '9999-12-31 23:59:59',
+            ], [
+                Types::STRING,
+                Types::STRING,
+            ])
+            ->setMaxResults(5_000)
+            ->fetchFirstColumn();
+    }
+
+    private function claimMessage(mixed $id): mixed
+    {
+        $now = new \DateTimeImmutable('UTC');
+        $redeliverLimit = $now->modify(\sprintf('-%d seconds', $this->configuration['redeliver_timeout']));
+
+        $claimed = $this->driverConnection->createQueryBuilder()
+                ->update($this->configuration['table_name'])
+                ->set('delivered_at', ':now')
+                ->andWhere('id = :id')
+                ->andWhere('queue_name = :queue_name')
+                ->andWhere('delivered_at is null OR delivered_at < :redeliver_imit')
+                ->setParameters([
+                    'now' => $now,
+                    'id' => $id,
+                    'queue_name' => $this->configuration['queue_name'],
+                    'redeliver_imit' => $redeliverLimit,
+                ], [
+                    'now' => Types::DATETIME_IMMUTABLE,
+                    'id' => Types::INTEGER,
+                    'queue_name' => Types::STRING,
+                    'redeliver_imit' => Types::DATETIME_IMMUTABLE,
+                ])
+                ->executeStatement() > 0;
+
+        return $claimed ? $id : null;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes 
| Deprecations? | no 
| Issues        | no
| License       | MIT

i experienced alot of lock wait time and some deadlocks on my database when working with multiple workers handling the same queue. so i fixed it in my application with a decorater. i want to contribute back to symfony.

introduce a algorithm in `Connection` for mysql platforms to minimize exclusive locking

[TODO list]
- [ ] update pr description
- [ ] let tests pass
- [ ] discuss