### PR TITLE
[Notifier] Allow to set block_id/value for SlackActionsBlock and SlackButtonBlockElement

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Slack/Block/SlackActionsBlock.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Block/SlackActionsBlock.php
@@ -24,15 +24,25 @@ final class SlackActionsBlock extends AbstractSlackBlock
     /**
      * @return $this
      */
-    public function button(string $text, string $url, ?string $style = null): static
+    public function button(string $text, ?string $url = null, ?string $style = null, ?string $value = null): static
     {
         if (25 === \count($this->options['elements'] ?? [])) {
             throw new \LogicException('Maximum number of buttons should not exceed 25.');
         }
 
-        $element = new SlackButtonBlockElement($text, $url, $style);
+        $element = new SlackButtonBlockElement($text, $url, $style, $value);
 
         $this->options['elements'][] = $element->toArray();
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function id(string $id): static
+    {
+        $this->options['block_id'] = $id;
 
         return $this;
     }

--- a/src/Symfony/Component/Notifier/Bridge/Slack/Block/SlackButtonBlockElement.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Block/SlackButtonBlockElement.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\Notifier\Bridge\Slack\Block;
  */
 final class SlackButtonBlockElement extends AbstractSlackBlockElement
 {
-    public function __construct(string $text, string $url, ?string $style = null)
+    public function __construct(string $text, ?string $url = null, ?string $style = null, ?string $value = null)
     {
         $this->options = [
             'type' => 'button',
@@ -24,12 +24,19 @@ final class SlackButtonBlockElement extends AbstractSlackBlockElement
                 'type' => 'plain_text',
                 'text' => $text,
             ],
-            'url' => $url,
         ];
+
+        if ($url) {
+            $this->options['url'] = $url;
+        }
 
         if ($style) {
             // primary or danger
             $this->options['style'] = $style;
+        }
+
+        if ($value) {
+            $this->options['value'] = $value;
         }
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Slack/Tests/Block/SlackActionsBlockTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Tests/Block/SlackActionsBlockTest.php
@@ -19,8 +19,9 @@ final class SlackActionsBlockTest extends TestCase
     public function testCanBeInstantiated()
     {
         $actions = new SlackActionsBlock();
-        $actions->button('first button text', 'https://example.org')
+        $actions->button('first button text', 'https://example.org', null, 'test-value')
             ->button('second button text', 'https://example.org/slack', 'danger')
+            ->button('third button text', null, null, 'test-value-3')
         ;
 
         $this->assertSame([
@@ -33,6 +34,7 @@ final class SlackActionsBlockTest extends TestCase
                         'text' => 'first button text',
                     ],
                     'url' => 'https://example.org',
+                    'value' => 'test-value'
                 ],
                 [
                     'type' => 'button',
@@ -43,6 +45,14 @@ final class SlackActionsBlockTest extends TestCase
                     'url' => 'https://example.org/slack',
                     'style' => 'danger',
                 ],
+                [
+                    'type' => 'button',
+                    'text' => [
+                        'type' => 'plain_text',
+                        'text' => 'third button text',
+                    ],
+                    'value' => 'test-value-3',
+                ]
             ],
         ], $actions->toArray());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| License       | MIT

Allow to pass `null` as `$url` for `SlackActionsBlock` as [it is not required](https://api.slack.com/reference/block-kit/composition-objects#option)

Allow to set`$value` [as it is required](https://api.slack.com/reference/block-kit/composition-objects#option)

Allow to set `block_id` to `SlackActionsBlock` as [it is required](https://api.slack.com/reference/interaction-payloads/block-actions#fields)
