### PR TITLE
Fix detection of `component_bridge` in `.github/get-modified-packages.php`

### DIFF
--- a/.github/get-modified-packages.php
+++ b/.github/get-modified-packages.php
@@ -22,7 +22,7 @@ function getPackageType(string $packageDir): string
     return match (true) {
         str_contains($packageDir, 'Symfony/Bridge/') => 'bridge',
         str_contains($packageDir, 'Symfony/Bundle/') => 'bundle',
-        preg_match('@Symfony/Component/[^/]+/Bridge/@', $packageDir) => 'component_bridge',
+        1 === preg_match('@Symfony/Component/[^/]+/Bridge/@', $packageDir) => 'component_bridge',
         str_contains($packageDir, 'Symfony/Component/') => 'component',
         str_contains($packageDir, 'Symfony/Contracts/') => 'contract',
         str_ends_with($packageDir, 'Symfony/Contracts') => 'contracts',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

> `preg_match()` returns `1` if the pattern matches given subject, `0` if it does not, or `false` on failure.

And 

> A `match` arm compares values strictly (`===`)

This change was introduced into 7.1 by https://github.com/symfony/symfony/commit/e29033486d39e5f0c7778d3ee0e56ceda2074743.