### PR TITLE
[FrameworkBundle][HttpFoundation] Add Clock support for `UriSigner`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
@@ -158,6 +158,9 @@ return static function (ContainerConfigurator $container) {
         ->set('uri_signer', UriSigner::class)
             ->args([
                 new Parameter('kernel.secret'),
+                '_hash',
+                '_expiration',
+                service('clock')->nullOnInvalid(),
             ])
             ->lazy()
         ->alias(UriSigner::class, 'uri_signer')

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add `EventStreamResponse` and `ServerEvent` classes to streamline server event streaming
  * Add support for `valkey:` / `valkeys:` schemes for sessions
  * `Request::getPreferredLanguage()` now favors a more preferred language above exactly matching a locale
+ * Allow `UriSigner` to use a `ClockInterface`
 
 7.2
 ---

--- a/src/Symfony/Component/HttpFoundation/composer.json
+++ b/src/Symfony/Component/HttpFoundation/composer.json
@@ -25,6 +25,7 @@
         "doctrine/dbal": "^3.6|^4",
         "predis/predis": "^1.1|^2.0",
         "symfony/cache": "^6.4.12|^7.1.5",
+        "symfony/clock": "^6.4|^7.0",
         "symfony/dependency-injection": "^6.4|^7.0",
         "symfony/http-kernel": "^6.4|^7.0",
         "symfony/mime": "^6.4|^7.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | n/a
| License       | MIT

Optionally adds the ability to inject a `ClockInterface` to `UriSigner` (mostly to help with testing). The framework-bundle wires this up if possible.
