### PR TITLE
[Lock] Add namespace support to Redis & Memcache lock stores

### DIFF
--- a/src/Symfony/Component/Lock/CHANGELOG.md
+++ b/src/Symfony/Component/Lock/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add support for `valkey:` / `valkeys:` schemes
+ * RedisStore and MemcacheStore namespace support
 
 7.2
 ---

--- a/src/Symfony/Component/Lock/CHANGELOG.md
+++ b/src/Symfony/Component/Lock/CHANGELOG.md
@@ -5,7 +5,7 @@ CHANGELOG
 ---
 
  * Add support for `valkey:` / `valkeys:` schemes
- * RedisStore and MemcacheStore namespace support
+ * Add namespace support for `RedisStore` and `MemcacheStore`
 
 7.2
 ---

--- a/src/Symfony/Component/Lock/Store/MemcachedStore.php
+++ b/src/Symfony/Component/Lock/Store/MemcachedStore.php
@@ -26,15 +26,9 @@ class MemcachedStore implements PersistingStoreInterface
 {
     use ExpiringStoreTrait;
 
-    /**
-     * @internal
-     */
     private const NS_SEPARATOR = ':';
-
     private bool $useExtendedReturn;
-
     private string $namespace = '';
-
 
     public static function isSupported(): bool
     {
@@ -64,7 +58,7 @@ class MemcachedStore implements PersistingStoreInterface
     {
         $token = $this->getUniqueToken($key);
         $key->reduceLifetime($this->initialTtl);
-        if (!$this->memcached->add($this->namespace . $key, $token, (int) ceil($this->initialTtl))) {
+        if (!$this->memcached->add($this->namespace.$key, $token, (int) ceil($this->initialTtl))) {
             // the lock is already acquired. It could be us. Let's try to put off.
             $this->putOffExpiration($key, $this->initialTtl);
         }
@@ -88,7 +82,7 @@ class MemcachedStore implements PersistingStoreInterface
         $key->reduceLifetime($ttl);
         // Could happens when we ask a putOff after a timeout but in luck nobody steal the lock
         if (\Memcached::RES_NOTFOUND === $this->memcached->getResultCode()) {
-            if ($this->memcached->add($this->namespace . $key, $token, $ttl)) {
+            if ($this->memcached->add($this->namespace.$key, $token, $ttl)) {
                 return;
             }
 
@@ -101,7 +95,7 @@ class MemcachedStore implements PersistingStoreInterface
             throw new LockConflictedException();
         }
 
-        if (!$this->memcached->cas($cas, $this->namespace . $key, $token, $ttl)) {
+        if (!$this->memcached->cas($cas, $this->namespace.$key, $token, $ttl)) {
             throw new LockConflictedException();
         }
 
@@ -120,18 +114,18 @@ class MemcachedStore implements PersistingStoreInterface
         }
 
         // To avoid concurrency in deletion, the trick is to extends the TTL then deleting the key
-        if (!$this->memcached->cas($cas, $this->namespace . $key, $token, 2)) {
+        if (!$this->memcached->cas($cas, $this->namespace.$key, $token, 2)) {
             // Someone steal our lock. It does not belongs to us anymore. Nothing to do.
             return;
         }
 
         // Now, we are the owner of the lock for 2 more seconds, we can delete it.
-        $this->memcached->delete($this->namespace . $key);
+        $this->memcached->delete($this->namespace.$key);
     }
 
     public function exists(Key $key): bool
     {
-        return $this->memcached->get($this->namespace . $key) === $this->getUniqueToken($key);
+        return $this->memcached->get($this->namespace.$key) === $this->getUniqueToken($key);
     }
 
     private function getUniqueToken(Key $key): string
@@ -147,7 +141,7 @@ class MemcachedStore implements PersistingStoreInterface
     private function getValueAndCas(Key $key): array
     {
         if ($this->useExtendedReturn ??= version_compare(phpversion('memcached'), '2.9.9', '>')) {
-            $extendedReturn = $this->memcached->get($this->namespace . $key, null, \Memcached::GET_EXTENDED);
+            $extendedReturn = $this->memcached->get($this->namespace.$key, null, \Memcached::GET_EXTENDED);
             if (\Memcached::GET_ERROR_RETURN_VALUE === $extendedReturn) {
                 return [$extendedReturn, 0.0];
             }
@@ -156,7 +150,7 @@ class MemcachedStore implements PersistingStoreInterface
         }
 
         $cas = 0.0;
-        $value = $this->memcached->get($this->namespace . $key, null, $cas);
+        $value = $this->memcached->get($this->namespace.$key, null, $cas);
 
         return [$value, $cas];
     }

--- a/src/Symfony/Component/Lock/Store/MemcachedStore.php
+++ b/src/Symfony/Component/Lock/Store/MemcachedStore.php
@@ -75,7 +75,7 @@ class MemcachedStore implements PersistingStoreInterface
     public function putOffExpiration(Key $key, float $ttl): void
     {
         if ($ttl < 1) {
-            throw new InvalidTtlException(\sprintf('"%s()" expects a TTL greater or equals to 1 second. Got %s.', __METHOD__, $ttl));
+            throw new InvalidTtlException(\sprintf('"%s()" expects a TTL greater or equals to 1 second. Got "%s".', __METHOD__, $ttl));
         }
 
         // Interface defines a float value but Store required an integer.

--- a/src/Symfony/Component/Lock/Store/MemcachedStore.php
+++ b/src/Symfony/Component/Lock/Store/MemcachedStore.php
@@ -26,7 +26,15 @@ class MemcachedStore implements PersistingStoreInterface
 {
     use ExpiringStoreTrait;
 
+    /**
+     * @internal
+     */
+    private const NS_SEPARATOR = ':';
+
     private bool $useExtendedReturn;
+
+    private string $namespace = '';
+
 
     public static function isSupported(): bool
     {
@@ -39,6 +47,7 @@ class MemcachedStore implements PersistingStoreInterface
     public function __construct(
         private \Memcached $memcached,
         private int $initialTtl = 300,
+        private array $options = [],
     ) {
         if (!static::isSupported()) {
             throw new InvalidArgumentException('Memcached extension is required.');
@@ -47,13 +56,15 @@ class MemcachedStore implements PersistingStoreInterface
         if ($initialTtl < 1) {
             throw new InvalidArgumentException(\sprintf('"%s()" expects a strictly positive TTL. Got %d.', __METHOD__, $initialTtl));
         }
+
+        $this->namespace = isset($this->options['namespace']) ? $this->options['namespace'] . static::NS_SEPARATOR : '';
     }
 
     public function save(Key $key): void
     {
         $token = $this->getUniqueToken($key);
         $key->reduceLifetime($this->initialTtl);
-        if (!$this->memcached->add((string) $key, $token, (int) ceil($this->initialTtl))) {
+        if (!$this->memcached->add($this->namespace . $key, $token, (int) ceil($this->initialTtl))) {
             // the lock is already acquired. It could be us. Let's try to put off.
             $this->putOffExpiration($key, $this->initialTtl);
         }
@@ -77,7 +88,7 @@ class MemcachedStore implements PersistingStoreInterface
         $key->reduceLifetime($ttl);
         // Could happens when we ask a putOff after a timeout but in luck nobody steal the lock
         if (\Memcached::RES_NOTFOUND === $this->memcached->getResultCode()) {
-            if ($this->memcached->add((string) $key, $token, $ttl)) {
+            if ($this->memcached->add($this->namespace . $key, $token, $ttl)) {
                 return;
             }
 
@@ -90,7 +101,7 @@ class MemcachedStore implements PersistingStoreInterface
             throw new LockConflictedException();
         }
 
-        if (!$this->memcached->cas($cas, (string) $key, $token, $ttl)) {
+        if (!$this->memcached->cas($cas, $this->namespace . $key, $token, $ttl)) {
             throw new LockConflictedException();
         }
 
@@ -109,18 +120,18 @@ class MemcachedStore implements PersistingStoreInterface
         }
 
         // To avoid concurrency in deletion, the trick is to extends the TTL then deleting the key
-        if (!$this->memcached->cas($cas, (string) $key, $token, 2)) {
+        if (!$this->memcached->cas($cas, $this->namespace . $key, $token, 2)) {
             // Someone steal our lock. It does not belongs to us anymore. Nothing to do.
             return;
         }
 
         // Now, we are the owner of the lock for 2 more seconds, we can delete it.
-        $this->memcached->delete((string) $key);
+        $this->memcached->delete($this->namespace . $key);
     }
 
     public function exists(Key $key): bool
     {
-        return $this->memcached->get((string) $key) === $this->getUniqueToken($key);
+        return $this->memcached->get($this->namespace . $key) === $this->getUniqueToken($key);
     }
 
     private function getUniqueToken(Key $key): string
@@ -136,7 +147,7 @@ class MemcachedStore implements PersistingStoreInterface
     private function getValueAndCas(Key $key): array
     {
         if ($this->useExtendedReturn ??= version_compare(phpversion('memcached'), '2.9.9', '>')) {
-            $extendedReturn = $this->memcached->get((string) $key, null, \Memcached::GET_EXTENDED);
+            $extendedReturn = $this->memcached->get($this->namespace . $key, null, \Memcached::GET_EXTENDED);
             if (\Memcached::GET_ERROR_RETURN_VALUE === $extendedReturn) {
                 return [$extendedReturn, 0.0];
             }
@@ -145,7 +156,7 @@ class MemcachedStore implements PersistingStoreInterface
         }
 
         $cas = 0.0;
-        $value = $this->memcached->get((string) $key, null, $cas);
+        $value = $this->memcached->get($this->namespace . $key, null, $cas);
 
         return [$value, $cas];
     }

--- a/src/Symfony/Component/Lock/Store/RedisStore.php
+++ b/src/Symfony/Component/Lock/Store/RedisStore.php
@@ -32,13 +32,8 @@ class RedisStore implements SharedLockStoreInterface
     use ExpiringStoreTrait;
 
     private const NO_SCRIPT_ERROR_MESSAGE_PREFIX = 'NOSCRIPT';
-    /**
-     * @internal
-     */
     private const NS_SEPARATOR = ':';
-
     private bool $supportTime;
-
     private string $namespace = '';
 
     /**
@@ -98,7 +93,7 @@ class RedisStore implements SharedLockStoreInterface
         ';
 
         $key->reduceLifetime($this->initialTtl);
-        if (!$this->evaluate($script, $this->namespace . $key, [microtime(true), $this->getUniqueToken($key), (int) ceil($this->initialTtl * 1000)])) {
+        if (!$this->evaluate($script, $this->namespace.$key, [microtime(true), $this->getUniqueToken($key), (int) ceil($this->initialTtl * 1000)])) {
             throw new LockConflictedException();
         }
 
@@ -138,7 +133,7 @@ class RedisStore implements SharedLockStoreInterface
         ';
 
         $key->reduceLifetime($this->initialTtl);
-        if (!$this->evaluate($script, $this->namespace . $key, [microtime(true), $this->getUniqueToken($key), (int) ceil($this->initialTtl * 1000)])) {
+        if (!$this->evaluate($script, $this->namespace.$key, [microtime(true), $this->getUniqueToken($key), (int) ceil($this->initialTtl * 1000)])) {
             throw new LockConflictedException();
         }
 
@@ -178,7 +173,7 @@ class RedisStore implements SharedLockStoreInterface
         ';
 
         $key->reduceLifetime($ttl);
-        if (!$this->evaluate($script, $this->namespace . $key, [microtime(true), $this->getUniqueToken($key), (int) ceil($ttl * 1000)])) {
+        if (!$this->evaluate($script, $this->namespace.$key, [microtime(true), $this->getUniqueToken($key), (int) ceil($ttl * 1000)])) {
             throw new LockConflictedException();
         }
 
@@ -212,7 +207,7 @@ class RedisStore implements SharedLockStoreInterface
             return true
         ';
 
-        $this->evaluate($script, $this->namespace . $key, [$this->getUniqueToken($key)]);
+        $this->evaluate($script, $this->namespace.$key, [$this->getUniqueToken($key)]);
     }
 
     public function exists(Key $key): bool
@@ -238,7 +233,7 @@ class RedisStore implements SharedLockStoreInterface
             return false
         ';
 
-        return (bool) $this->evaluate($script, $this->namespace . $key, [microtime(true), $this->getUniqueToken($key)]);
+        return (bool) $this->evaluate($script, $this->namespace.$key, [microtime(true), $this->getUniqueToken($key)]);
     }
 
     private function evaluate(string $script, string $resource, array $args): mixed
@@ -336,7 +331,7 @@ class RedisStore implements SharedLockStoreInterface
 	            return 1
             ';
             try {
-                $this->supportTime = 1 === $this->evaluate($script, $this->namespace . 'symfony_check_support_time', []);
+                $this->supportTime = 1 === $this->evaluate($script, $this->namespace.'symfony_check_support_time', []);
             } catch (LockStorageException $e) {
                 if (!str_contains($e->getMessage(), 'commands not allowed after non deterministic')
                     && !str_contains($e->getMessage(), 'is not allowed from script script')

--- a/src/Symfony/Component/Lock/Store/RedisStore.php
+++ b/src/Symfony/Component/Lock/Store/RedisStore.php
@@ -336,7 +336,7 @@ class RedisStore implements SharedLockStoreInterface
 	            return 1
             ';
             try {
-                $this->supportTime = 1 === $this->evaluate($script, 'symfony_check_support_time', []);
+                $this->supportTime = 1 === $this->evaluate($script, $this->namespace . 'symfony_check_support_time', []);
             } catch (LockStorageException $e) {
                 if (!str_contains($e->getMessage(), 'commands not allowed after non deterministic')
                     && !str_contains($e->getMessage(), 'is not allowed from script script')

--- a/src/Symfony/Component/Lock/Store/RedisStore.php
+++ b/src/Symfony/Component/Lock/Store/RedisStore.php
@@ -32,19 +32,32 @@ class RedisStore implements SharedLockStoreInterface
     use ExpiringStoreTrait;
 
     private const NO_SCRIPT_ERROR_MESSAGE_PREFIX = 'NOSCRIPT';
+    /**
+     * @internal
+     */
+    private const NS_SEPARATOR = ':';
 
     private bool $supportTime;
 
+    private string $namespace = '';
+
     /**
      * @param float $initialTtl The expiration delay of locks in seconds
+     * @param array $options See below
+     *
+     *  Options:
+     *       namespace: Prefix used for keys
      */
     public function __construct(
         private \Redis|Relay|RelayCluster|\RedisArray|\RedisCluster|\Predis\ClientInterface $redis,
         private float $initialTtl = 300.0,
+        private array $options = [],
     ) {
         if ($initialTtl <= 0) {
             throw new InvalidTtlException(\sprintf('"%s()" expects a strictly positive TTL. Got %d.', __METHOD__, $initialTtl));
         }
+
+        $this->namespace = isset($this->options['namespace']) ? $this->options['namespace'] . static::NS_SEPARATOR : '';
     }
 
     public function save(Key $key): void
@@ -85,7 +98,7 @@ class RedisStore implements SharedLockStoreInterface
         ';
 
         $key->reduceLifetime($this->initialTtl);
-        if (!$this->evaluate($script, (string) $key, [microtime(true), $this->getUniqueToken($key), (int) ceil($this->initialTtl * 1000)])) {
+        if (!$this->evaluate($script, $this->namespace . $key, [microtime(true), $this->getUniqueToken($key), (int) ceil($this->initialTtl * 1000)])) {
             throw new LockConflictedException();
         }
 
@@ -125,7 +138,7 @@ class RedisStore implements SharedLockStoreInterface
         ';
 
         $key->reduceLifetime($this->initialTtl);
-        if (!$this->evaluate($script, (string) $key, [microtime(true), $this->getUniqueToken($key), (int) ceil($this->initialTtl * 1000)])) {
+        if (!$this->evaluate($script, $this->namespace . $key, [microtime(true), $this->getUniqueToken($key), (int) ceil($this->initialTtl * 1000)])) {
             throw new LockConflictedException();
         }
 
@@ -165,7 +178,7 @@ class RedisStore implements SharedLockStoreInterface
         ';
 
         $key->reduceLifetime($ttl);
-        if (!$this->evaluate($script, (string) $key, [microtime(true), $this->getUniqueToken($key), (int) ceil($ttl * 1000)])) {
+        if (!$this->evaluate($script, $this->namespace . $key, [microtime(true), $this->getUniqueToken($key), (int) ceil($ttl * 1000)])) {
             throw new LockConflictedException();
         }
 
@@ -199,7 +212,7 @@ class RedisStore implements SharedLockStoreInterface
             return true
         ';
 
-        $this->evaluate($script, (string) $key, [$this->getUniqueToken($key)]);
+        $this->evaluate($script, $this->namespace . $key, [$this->getUniqueToken($key)]);
     }
 
     public function exists(Key $key): bool
@@ -225,7 +238,7 @@ class RedisStore implements SharedLockStoreInterface
             return false
         ';
 
-        return (bool) $this->evaluate($script, (string) $key, [microtime(true), $this->getUniqueToken($key)]);
+        return (bool) $this->evaluate($script, $this->namespace . $key, [microtime(true), $this->getUniqueToken($key)]);
     }
 
     private function evaluate(string $script, string $resource, array $args): mixed

--- a/src/Symfony/Component/Lock/Store/StoreFactory.php
+++ b/src/Symfony/Component/Lock/Store/StoreFactory.php
@@ -83,7 +83,7 @@ class StoreFactory
 
                 $connection = AbstractAdapter::createConnection($connection, ['lazy' => true]);
 
-                return new $storeClass($connection, ['namespace' => $namespace]);
+                return new $storeClass($connection, options: ['namespace' => $namespace]);
 
             case str_starts_with($connection, 'mongodb'):
                 return new MongoDbStore($connection);

--- a/src/Symfony/Component/Lock/Store/StoreFactory.php
+++ b/src/Symfony/Component/Lock/Store/StoreFactory.php
@@ -69,9 +69,21 @@ class StoreFactory
                     throw new InvalidArgumentException('Unsupported Redis or Memcached DSN. Try running "composer require symfony/cache".');
                 }
                 $storeClass = str_starts_with($connection, 'memcached:') ? MemcachedStore::class : RedisStore::class;
+
+                $matches = [];
+                $namespace = '';
+                if (preg_match('/^(.*[\?&])namespace=([^&#]*)&?(([^#]*).*)$/', $connection, $matches)) {
+                    $prefix = $matches[1];
+                    $namespace = $matches[2];
+                    if (empty($matches[4])) {
+                        $prefix = substr($prefix, 0, -1);
+                    }
+                    $connection = $prefix.$matches[3];
+                }
+
                 $connection = AbstractAdapter::createConnection($connection, ['lazy' => true]);
 
-                return new $storeClass($connection);
+                return new $storeClass($connection, ['namespace' => $namespace]);
 
             case str_starts_with($connection, 'mongodb'):
                 return new MongoDbStore($connection);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| License       | MIT

Sometimes we need use shared redis cluster between applications. By security reasons we allow each application to access only own keys. Cache component can deal with it, lock - is not.