### PR TITLE
[Serializer] Support preserving array keys with `XmlEncoder`

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add `CDATA_WRAPPING_NAME_PATTERN` support to `XmlEncoder`
  * Add support for `can*()` methods to `AttributeLoader`
  * Make `AttributeMetadata` and `ClassMetadata` final
+ * Add `XmlEncoder::PRESERVE_NUMERIC_KEYS` context option
  * Deprecate class aliases in the `Annotation` namespace, use attributes instead
  * Deprecate getters in attribute classes in favor of public properties
  * Deprecate `ClassMetadataFactoryCompiler`

--- a/src/Symfony/Component/Serializer/Context/Encoder/XmlEncoderContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Encoder/XmlEncoderContextBuilder.php
@@ -168,4 +168,12 @@ final class XmlEncoderContextBuilder implements ContextBuilderInterface
     {
         return $this->with(XmlEncoder::IGNORE_EMPTY_ATTRIBUTES, $ignoreEmptyAttributes);
     }
+
+    /**
+     * Configures whether to preserve numeric keys in array.
+     */
+    public function withPreserveNumericKeys(?bool $preserveNumericKeys): static
+    {
+        return $this->with(XmlEncoder::PRESERVE_NUMERIC_KEYS, $preserveNumericKeys);
+    }
 }

--- a/src/Symfony/Component/Serializer/Mapping/Loader/schema/serialization.schema.json
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/schema/serialization.schema.json
@@ -326,6 +326,10 @@
           "type": "boolean",
           "description": "Whether to ignore empty attributes (XmlEncoder)"
         },
+        "preserve_numeric_keys": {
+          "type": "boolean",
+          "description": "Whether to preserve numeric keys in array (XmlEncoder)"
+        },
         "inline_threshold": {
           "type": "integer",
           "description": "Threshold to switch to inline YAML (YamlEncoder)"

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -1033,4 +1033,48 @@ class XmlEncoderTest extends TestCase
 
         $this->assertEquals($expected, $this->encoder->encode($data, 'xml', ['ignore_empty_attributes' => true]));
     }
+
+    public function testEncodeArrayAsItem()
+    {
+        $expected = <<<'XML'
+            <?xml version="1.0"?>
+            <response><person><item key="0"><firstname>Benjamin</firstname><lastname>Alexandre</lastname></item><item key="1"><firstname>Damien</firstname><lastname>Clay</lastname></item></person></response>
+
+            XML;
+        $source = ['person' => [
+            ['@key' => 0, 'firstname' => 'Benjamin', 'lastname' => 'Alexandre'],
+            ['@key' => 1, 'firstname' => 'Damien', 'lastname' => 'Clay'],
+        ]];
+
+        $this->assertSame($expected, $this->encoder->encode($source, 'xml', [
+            XmlEncoder::PRESERVE_NUMERIC_KEYS => true,
+        ]));
+    }
+
+    public function testDecodeArrayAsItem()
+    {
+        $source = <<<'XML'
+            <?xml version="1.0"?>
+            <response>
+                <person>
+                    <item key="0">
+                        <firstname>Benjamin</firstname>
+                        <lastname>Alexandre</lastname>
+                    </item>
+                    <item key="1">
+                        <firstname>Damien</firstname>
+                        <lastname>Clay</lastname>
+                    </item>
+                </person>
+            </response>
+            XML;
+        $expected = ['person' => [
+            ['@key' => 0, 'firstname' => 'Benjamin', 'lastname' => 'Alexandre', ],
+            ['@key' => 1, 'firstname' => 'Damien', 'lastname' => 'Clay', ],
+        ]];
+
+        $this->assertSame($expected, $this->encoder->decode($source, 'xml', [
+            XmlEncoder::PRESERVE_NUMERIC_KEYS => true,
+        ]));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

### Feature: Add Support for preserving array keys as Child `<item>` Elements in XML Encoder

This PR introduces a new option to the Symfony Serializer's `XmlEncoder` that allows indexed arrays to be encoded as `<item>` elements under a single parent element, rather than repeating the parent element for each array item.

#### Motivation

Currently, encoding an array like:

```php
['person' => [
    ['firstname' => 'Benjamin', 'lastname' => 'Alexandre'],
    ['firstname' => 'Damien', 'lastname' => 'Clay'],
]]
```

produces the following XML:

```xml
<response>
    <person>
        <firstname>Benjamin</firstname>
        <lastname>Alexandre</lastname>
    </person>
    <person>
        <firstname>Damien</firstname>
        <lastname>Clay</lastname>
    </person>
</response>
```

This structure is not ideal when a clear container-child relationship is required, such as when interoperating with systems that expect such XML structures.

#### New Behavior

With the new `XmlEncoder::PRESERVE_NUMERIC_KEYS` option enabled, the same data now encodes to:

```xml
<response>
    <person>
        <item key="0">
            <firstname>Benjamin</firstname>
            <lastname>Alexandre</lastname>
        </item>
        <item key="1">
            <firstname>Damien</firstname>
            <lastname>Clay</lastname>
        </item>
    </person>
</response>
```

#### Usage

```php
$xml = $encoder->encode($data, 'xml', [
    XmlEncoder::PRESERVE_NUMERIC_KEYS => true,
]);
```
