### PR TITLE
[Process] Narrow `PhpExecutableFinder` return types

### DIFF
--- a/src/Symfony/Component/Process/PhpExecutableFinder.php
+++ b/src/Symfony/Component/Process/PhpExecutableFinder.php
@@ -83,6 +83,8 @@ class PhpExecutableFinder
 
     /**
      * Finds the PHP executable arguments.
+     *
+     * @return list<non-empty-string>
      */
     public function findArguments(): array
     {


### PR DESCRIPTION
Narrow `PhpExecutableFinder` return types to the actual ones.