### PR TITLE
Add PHP config support for routing

### DIFF
--- a/UPGRADE-7.3.md
+++ b/UPGRADE-7.3.md
@@ -76,6 +76,33 @@ FrameworkBundle
    public function __construct(#[Autowire('@serializer.normalizer.object')] NormalizerInterface $normalizer) {}
    ```
 
+ * The XML routing configuration files (`errors.xml` and `webhook.xml`) are
+   deprecated, use their PHP equivalent ones:
+
+  *Before*
+  ```yaml
+    when@dev:
+        _errors:
+            resource: '@FrameworkBundle/Resources/config/routing/errors.xml'
+            prefix: /_error
+
+    webhook:
+        resource: '@FrameworkBundle/Resources/config/routing/webhook.xml'
+        prefix: /webhook
+    ```
+
+  *After*
+  ```yaml
+    when@dev:
+        _errors:
+            resource: '@FrameworkBundle/Resources/config/routing/errors.php'
+            prefix: /_error
+
+    webhook:
+        resource: '@FrameworkBundle/Resources/config/routing/webhook.php'
+        prefix: /webhook
+    ```
+
 HttpFoundation
 --------------
 
@@ -111,6 +138,36 @@ PropertyInfo
  * Deprecate the `Type` class, use `Symfony\Component\TypeInfo\Type` class from `symfony/type-info` instead
  * Deprecate the `PropertyTypeExtractorInterface::getTypes()` method, use `PropertyTypeExtractorInterface::getType()` instead
  * Deprecate the `ConstructorArgumentTypeExtractorInterface::getTypesFromConstructor()` method, use `ConstructorArgumentTypeExtractorInterface::getTypeFromConstructor()` instead
+
+Routing
+-------
+
+ * The XML routing configuration files (`profiler.xml` and `wdt.xml`) are
+   deprecated, use their PHP equivalent ones:
+
+  *Before*
+  ```yaml
+    when@dev:
+        web_profiler_wdt:
+            resource: '@WebProfilerBundle/Resources/config/routing/wdt.xml'
+            prefix: /_wdt
+
+        web_profiler_profiler:
+            resource: '@WebProfilerBundle/Resources/config/routing/profiler.xml'
+            prefix: /_profiler
+    ```
+
+  *After*
+  ```yaml
+    when@dev:
+        web_profiler_wdt:
+            resource: '@WebProfilerBundle/Resources/config/routing/wdt.php'
+            prefix: /_wdt
+
+        web_profiler_profiler:
+            resource: '@WebProfilerBundle/Resources/config/routing/profiler.php
+            prefix: /_profiler
+    ```
 
 Security
 --------

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 7.3
 ---
 
+ * Add `errors.php` and `webhook.php` routing configuration files (use them instead of their XML equivalent)
  * Add support for the ObjectMapper component
  * Add support for assets pre-compression
  * Rename `TranslationUpdateCommand` to `TranslationExtractCommand`

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing/errors.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing/errors.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+return function (RoutingConfigurator $routes): void {
+    $routes->add('_preview_error', '/{code}.{_format}')
+        ->controller('error_controller::preview')
+        ->defaults(['_format' => 'html'])
+        ->requirements(['code' => '\d+'])
+    ;
+};

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing/errors.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing/errors.xml
@@ -4,9 +4,5 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing https://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="_preview_error" path="/{code}.{_format}">
-        <default key="_controller">error_controller::preview</default>
-        <default key="_format">html</default>
-        <requirement key="code">\d+</requirement>
-    </route>
+    <import resource="errors.php" type="php" />
 </routes>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing/webhook.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing/webhook.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+return function (RoutingConfigurator $routes): void {
+    $routes->add('_webhook_controller', '/{type}')
+        ->controller('webhook_controller::handle')
+        ->requirements(['type' => '.+'])
+    ;
+};

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing/webhook.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing/webhook.xml
@@ -4,8 +4,5 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing https://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="_webhook_controller" path="/{type}">
-        <default key="_controller">webhook.controller::handle</default>
-        <requirement key="type">.+</requirement>
-    </route>
+    <import resource="webhook.php" type="php" />
 </routes>

--- a/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 7.3
 ---
 
+ * Add `profiler.php` and `wdt.php` routing configuration files (use them instead of their XML equivalent)
  * Add `ajax_replace` option for replacing toolbar on AJAX requests
 
 7.2

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/profiler.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/profiler.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+return function (RoutingConfigurator $routes): void {
+    $routes->add('_profiler_home', '/')
+        ->controller('web_profiler.controller.profiler::homeAction')
+    ;
+    $routes->add('_profiler_search', '/search')
+        ->controller('web_profiler.controller.profiler::searchAction')
+    ;
+    $routes->add('_profiler_search_bar', '/search_bar')
+        ->controller('web_profiler.controller.profiler::searchBarAction')
+    ;
+    $routes->add('_profiler_phpinfo', '/phpinfo')
+        ->controller('web_profiler.controller.profiler::phpinfoAction')
+    ;
+    $routes->add('_profiler_xdebug', '/xdebug')
+        ->controller('web_profiler.controller.profiler::xdebugAction')
+    ;
+    $routes->add('_profiler_font', '/font/{fontName}.woff2')
+        ->controller('web_profiler.controller.profiler::fontAction')
+    ;
+    $routes->add('_profiler_search_results', '/{token}/search/results')
+        ->controller('web_profiler.controller.profiler::searchResultsAction')
+    ;
+    $routes->add('_profiler_open_file', '/open')
+        ->controller('web_profiler.controller.profiler::openAction')
+    ;
+    $routes->add('_profiler', '/{token}')
+        ->controller('web_profiler.controller.profiler::panelAction')
+    ;
+    $routes->add('_profiler_router', '/{token}/router')
+        ->controller('web_profiler.controller.router::panelAction')
+    ;
+    $routes->add('_profiler_exception', '/{token}/exception')
+        ->controller('web_profiler.controller.exception_panel::body')
+    ;
+    $routes->add('_profiler_exception_css', '/{token}/exception.css')
+        ->controller('web_profiler.controller.exception_panel::stylesheet')
+    ;
+};

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/profiler.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/profiler.php
@@ -10,8 +10,19 @@
  */
 
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+use Symfony\Component\Routing\Loader\XmlFileLoader;
 
 return function (RoutingConfigurator $routes): void {
+    foreach (debug_backtrace(\DEBUG_BACKTRACE_PROVIDE_OBJECT) as $trace) {
+        if (isset($trace['object']) && $trace['object'] instanceof XmlFileLoader && 'doImport' === $trace['function']) {
+            if (__DIR__ === dirname(realpath($trace['args'][3]))) {
+                trigger_deprecation('symfony/routing', '7.3', 'The "profiler.xml" routing configuration file is deprecated, import "profile.php" instead.');
+
+                break;
+            }
+        }
+    }
+
     $routes->add('_profiler_home', '/')
         ->controller('web_profiler.controller.profiler::homeAction')
     ;

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/profiler.xml
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/profiler.xml
@@ -4,52 +4,5 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing https://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="_profiler_home" path="/">
-        <default key="_controller">web_profiler.controller.profiler::homeAction</default>
-    </route>
-
-    <route id="_profiler_search" path="/search">
-        <default key="_controller">web_profiler.controller.profiler::searchAction</default>
-    </route>
-
-    <route id="_profiler_search_bar" path="/search_bar">
-        <default key="_controller">web_profiler.controller.profiler::searchBarAction</default>
-    </route>
-
-    <route id="_profiler_phpinfo" path="/phpinfo">
-        <default key="_controller">web_profiler.controller.profiler::phpinfoAction</default>
-    </route>
-
-    <route id="_profiler_xdebug" path="/xdebug">
-        <default key="_controller">web_profiler.controller.profiler::xdebugAction</default>
-    </route>
-
-    <route id="_profiler_font" path="/font/{fontName}.woff2">
-        <default key="_controller">web_profiler.controller.profiler::fontAction</default>
-    </route>
-
-    <route id="_profiler_search_results" path="/{token}/search/results">
-        <default key="_controller">web_profiler.controller.profiler::searchResultsAction</default>
-    </route>
-
-    <route id="_profiler_open_file" path="/open">
-        <default key="_controller">web_profiler.controller.profiler::openAction</default>
-    </route>
-
-    <route id="_profiler" path="/{token}">
-        <default key="_controller">web_profiler.controller.profiler::panelAction</default>
-    </route>
-
-    <route id="_profiler_router" path="/{token}/router">
-        <default key="_controller">web_profiler.controller.router::panelAction</default>
-    </route>
-
-    <route id="_profiler_exception" path="/{token}/exception">
-        <default key="_controller">web_profiler.controller.exception_panel::body</default>
-    </route>
-
-    <route id="_profiler_exception_css" path="/{token}/exception.css">
-        <default key="_controller">web_profiler.controller.exception_panel::stylesheet</default>
-    </route>
-
+    <import resource="profiler.php" type="php" />
 </routes>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/wdt.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/wdt.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+return function (RoutingConfigurator $routes): void {
+    $routes->add('_wdt_stylesheet', '/styles')
+        ->controller('web_profiler.controller.profiler::toolbarStylesheetAction')
+    ;
+    $routes->add('_wdt', '/{token}')
+        ->controller('web_profiler.controller.profiler::toolbarAction')
+    ;
+};

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/wdt.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/wdt.php
@@ -10,8 +10,19 @@
  */
 
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+use Symfony\Component\Routing\Loader\XmlFileLoader;
 
 return function (RoutingConfigurator $routes): void {
+    foreach (debug_backtrace(\DEBUG_BACKTRACE_PROVIDE_OBJECT) as $trace) {
+        if (isset($trace['object']) && $trace['object'] instanceof XmlFileLoader && 'doImport' === $trace['function']) {
+            if (__DIR__ === dirname(realpath($trace['args'][3]))) {
+                trigger_deprecation('symfony/routing', '7.3', 'The "xdt.xml" routing configuration file is deprecated, import "xdt.php" instead.');
+
+                break;
+            }
+        }
+    }
+
     $routes->add('_wdt_stylesheet', '/styles')
         ->controller('web_profiler.controller.profiler::toolbarStylesheetAction')
     ;

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/wdt.xml
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/wdt.xml
@@ -4,11 +4,5 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing https://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="_wdt_stylesheet" path="/styles">
-        <default key="_controller">web_profiler.controller.profiler::toolbarStylesheetAction</default>
-    </route>
-
-    <route id="_wdt" path="/{token}">
-        <default key="_controller">web_profiler.controller.profiler::toolbarAction</default>
-    </route>
+    <import resource="wdt.php" type="php" />
 </routes>

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Functional/WebProfilerBundleKernel.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Functional/WebProfilerBundleKernel.php
@@ -43,8 +43,8 @@ class WebProfilerBundleKernel extends Kernel
 
     protected function configureRoutes(RoutingConfigurator $routes): void
     {
-        $routes->import(__DIR__.'/../../Resources/config/routing/profiler.xml')->prefix('/_profiler');
-        $routes->import(__DIR__.'/../../Resources/config/routing/wdt.xml')->prefix('/_wdt');
+        $routes->import(__DIR__.'/../../Resources/config/routing/profiler.php')->prefix('/_profiler');
+        $routes->import(__DIR__.'/../../Resources/config/routing/wdt.php')->prefix('/_wdt');
         $routes->add('_', '/')->controller('kernel::homepageController');
     }
 

--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -19,6 +19,7 @@
         "php": ">=8.2",
         "composer-runtime-api": ">=2.1",
         "symfony/config": "^7.3",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/framework-bundle": "^6.4|^7.0",
         "symfony/http-kernel": "^6.4|^7.0",
         "symfony/routing": "^6.4|^7.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | n/a
| License       | MIT

This is the first to stop using XML for the routing configuration provided by core bundles. We did the same for all other configuration files a while ago, so this is really the last step.
