### PR TITLE
[String] Support nexus -> nexuses pluralization

### DIFF
--- a/src/Symfony/Component/String/Inflector/EnglishInflector.php
+++ b/src/Symfony/Component/String/Inflector/EnglishInflector.php
@@ -333,6 +333,9 @@ final class EnglishInflector implements InflectorInterface
         // conspectuses (conspectus), prospectuses (prospectus)
         ['sutcep', 6, true, true, 'pectuses'],
 
+        // nexuses (nexus)
+        ['suxen', 5, false, false, 'nexuses'],
+
         // fungi (fungus), alumni (alumnus), syllabi (syllabus), radii (radius)
         ['su', 2, true, true, 'i'],
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60235 
| License       | MIT

Handle pluralizing `nexus` to `nexuses` instead of `nexi`. See linked issue for dictionary references.