### PR TITLE
[DoctrineBridge] Add new `DayPointType` and `TimePointType` Doctrine type

### DIFF
--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Deprecate `UniqueEntity::getRequiredOptions()` and `UniqueEntity::getDefaultOption()`
  * Use a single table named `_schema_subscriber_check` in schema listeners to detect same database connections
+ * Add support for `Symfony\Component\Clock\DatePoint` as `DayPointType` and `TimePointType` Doctrine type
 
 7.3
 ---

--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterDatePointTypePass.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterDatePointTypePass.php
@@ -12,6 +12,8 @@
 namespace Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass;
 
 use Symfony\Bridge\Doctrine\Types\DatePointType;
+use Symfony\Bridge\Doctrine\Types\DayPointType;
+use Symfony\Bridge\Doctrine\Types\TimePointType;
 use Symfony\Component\Clock\DatePoint;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -31,6 +33,8 @@ final class RegisterDatePointTypePass implements CompilerPassInterface
         $types = $container->getParameter('doctrine.dbal.connection_factory.types');
 
         $types['date_point'] ??= ['class' => DatePointType::class];
+        $types['day_point'] ??= ['class' => DayPointType::class];
+        $types['time_point'] ??= ['class' => TimePointType::class];
 
         $container->setParameter('doctrine.dbal.connection_factory.types', $types);
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterDatePointTypePassTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterDatePointTypePassTest.php
@@ -14,6 +14,8 @@ namespace Symfony\Bridge\Doctrine\Tests\DependencyInjection\CompilerPass;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\RegisterDatePointTypePass;
 use Symfony\Bridge\Doctrine\Types\DatePointType;
+use Symfony\Bridge\Doctrine\Types\DayPointType;
+use Symfony\Bridge\Doctrine\Types\TimePointType;
 use Symfony\Component\Clock\DatePoint;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -35,6 +37,8 @@ class RegisterDatePointTypePassTest extends TestCase
         $expected = [
             'foo' => 'bar',
             'date_point' => ['class' => DatePointType::class],
+            'day_point' => ['class' => DayPointType::class],
+            'time_point' => ['class' => TimePointType::class],
         ];
         $this->assertSame($expected, $container->getParameter('doctrine.dbal.connection_factory.types'));
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/Types/DayPointTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Types/DayPointTypeTest.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Types;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Types\Type;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Doctrine\Types\DayPointType;
+use Symfony\Component\Clock\DatePoint;
+
+final class DayPointTypeTest extends TestCase
+{
+    private DayPointType $type;
+
+    public static function setUpBeforeClass(): void
+    {
+        $name = DayPointType::NAME;
+        if (Type::hasType($name)) {
+            Type::overrideType($name, DayPointType::class);
+        } else {
+            Type::addType($name, DayPointType::class);
+        }
+    }
+
+    protected function setUp(): void
+    {
+        if (!class_exists(DatePoint::class)) {
+            self::markTestSkipped('The DatePoint class is not available.');
+        }
+        $this->type = Type::getType(DayPointType::NAME);
+    }
+
+    public function testDatePointConvertsToDatabaseValue()
+    {
+        $datePoint = DatePoint::createFromFormat('!Y-m-d', '2025-03-03');
+
+        $expected = $datePoint->format('Y-m-d');
+        $actual = $this->type->convertToDatabaseValue($datePoint, new PostgreSQLPlatform());
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testDatePointConvertsToPHPValue()
+    {
+        $datePoint = new DatePoint();
+        $actual = $this->type->convertToPHPValue($datePoint, self::getSqlitePlatform());
+
+        $this->assertSame($datePoint, $actual);
+    }
+
+    public function testNullConvertsToPHPValue()
+    {
+        $actual = $this->type->convertToPHPValue(null, self::getSqlitePlatform());
+
+        $this->assertNull($actual);
+    }
+
+    public function testDateTimeImmutableConvertsToPHPValue()
+    {
+        $format = 'Y-m-d H:i:s.u';
+        $date = '2025-03-03';
+        $dateTime = \DateTimeImmutable::createFromFormat('!Y-m-d', $date);
+        $actual = $this->type->convertToPHPValue($dateTime, self::getSqlitePlatform());
+        $expected = DatePoint::createFromFormat('!Y-m-d', $date);
+
+        $this->assertInstanceOf(DatePoint::class, $actual);
+        $this->assertSame($expected->format($format), $actual->format($format));
+    }
+
+    public function testDatabaseValueConvertsToPHPValue()
+    {
+        $format = 'Y-m-d H:i:s.u';
+        $date = '2025-03-03';
+        $actual = $this->type->convertToPHPValue($date, new PostgreSQLPlatform());
+        $expected = DatePoint::createFromFormat('!Y-m-d', $date);
+
+        $this->assertInstanceOf(DatePoint::class, $actual);
+        $this->assertSame($expected->format($format), $actual->format($format));
+    }
+
+    public function testGetName()
+    {
+        $this->assertSame('day_point', $this->type->getName());
+    }
+
+    private static function getSqlitePlatform(): AbstractPlatform
+    {
+        if (interface_exists(Exception::class)) {
+            // DBAL 4+
+            return new \Doctrine\DBAL\Platforms\SQLitePlatform();
+        }
+
+        return new \Doctrine\DBAL\Platforms\SqlitePlatform();
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Types/TimePointTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Types/TimePointTypeTest.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Types;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Types\Type;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Doctrine\Types\TimePointType;
+use Symfony\Component\Clock\DatePoint;
+
+final class TimePointTypeTest extends TestCase
+{
+    private TimePointType $type;
+
+    public static function setUpBeforeClass(): void
+    {
+        $name = TimePointType::NAME;
+        if (Type::hasType($name)) {
+            Type::overrideType($name, TimePointType::class);
+        } else {
+            Type::addType($name, TimePointType::class);
+        }
+    }
+
+    protected function setUp(): void
+    {
+        if (!class_exists(DatePoint::class)) {
+            self::markTestSkipped('The DatePoint class is not available.');
+        }
+        $this->type = Type::getType(TimePointType::NAME);
+    }
+
+    public function testDatePointConvertsToDatabaseValue()
+    {
+        $datePoint = DatePoint::createFromFormat('!H:i:s', '05:10:15');
+
+        $expected = $datePoint->format('H:i:s');
+        $actual = $this->type->convertToDatabaseValue($datePoint, new PostgreSQLPlatform());
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testDatePointConvertsToPHPValue()
+    {
+        $datePoint = new DatePoint();
+        $actual = $this->type->convertToPHPValue($datePoint, self::getSqlitePlatform());
+
+        $this->assertSame($datePoint, $actual);
+    }
+
+    public function testNullConvertsToPHPValue()
+    {
+        $actual = $this->type->convertToPHPValue(null, self::getSqlitePlatform());
+
+        $this->assertNull($actual);
+    }
+
+    public function testDateTimeImmutableConvertsToPHPValue()
+    {
+        $format = 'Y-m-d H:i:s.u';
+        $time = '05:10:15';
+        $dateTime = \DateTimeImmutable::createFromFormat('!H:i:s', $time);
+        $actual = $this->type->convertToPHPValue($dateTime, self::getSqlitePlatform());
+        $expected = DatePoint::createFromFormat('!H:i:s', $time);
+
+        $this->assertInstanceOf(DatePoint::class, $actual);
+        $this->assertSame($expected->format($format), $actual->format($format));
+    }
+
+    public function testDatabaseValueConvertsToPHPValue()
+    {
+        $format = 'Y-m-d H:i:s.u';
+        $time = '05:10:15';
+        $actual = $this->type->convertToPHPValue($time, new PostgreSQLPlatform());
+        $expected = DatePoint::createFromFormat('!H:i:s', $time);
+
+        $this->assertInstanceOf(DatePoint::class, $actual);
+        $this->assertSame($expected->format($format), $actual->format($format));
+    }
+
+    public function testGetName()
+    {
+        $this->assertSame('time_point', $this->type->getName());
+    }
+
+    private static function getSqlitePlatform(): AbstractPlatform
+    {
+        if (interface_exists(Exception::class)) {
+            // DBAL 4+
+            return new \Doctrine\DBAL\Platforms\SQLitePlatform();
+        }
+
+        return new \Doctrine\DBAL\Platforms\SqlitePlatform();
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Types/DayPointType.php
+++ b/src/Symfony/Bridge/Doctrine/Types/DayPointType.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\DateImmutableType;
+use Symfony\Component\Clock\DatePoint;
+
+final class DayPointType extends DateImmutableType
+{
+    public const NAME = 'day_point';
+
+    /**
+     * @return ($value is null ? null : DatePoint)
+     */
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?DatePoint
+    {
+        if (null === $value || $value instanceof DatePoint) {
+            return $value;
+        }
+
+        $value = parent::convertToPHPValue($value, $platform);
+
+        return DatePoint::createFromInterface($value);
+    }
+
+    public function getName(): string
+    {
+        return self::NAME;
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Types/TimePointType.php
+++ b/src/Symfony/Bridge/Doctrine/Types/TimePointType.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\TimeImmutableType;
+use Symfony\Component\Clock\DatePoint;
+
+final class TimePointType extends TimeImmutableType
+{
+    public const NAME = 'time_point';
+
+    /**
+     * @return ($value is null ? null : DatePoint)
+     */
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?DatePoint
+    {
+        if (null === $value || $value instanceof DatePoint) {
+            return $value;
+        }
+
+        $value = parent::convertToPHPValue($value, $platform);
+
+        return DatePoint::createFromInterface($value);
+    }
+
+    public function getName(): string
+    {
+        return self::NAME;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch       | 7.4
| Bug fix      | no
| New feature  | yes
| Deprecations | no
| License       | MIT

Doctrine provides both [date_immutable](https://www.doctrine-project.org/projects/doctrine-dbal/en/4.2/reference/types.html#date-immutable) and [datetime_immutable](https://www.doctrine-project.org/projects/doctrine-dbal/en/4.2/reference/types.html#datetime-immutable) types. Restricting the conversion of DatePoint only to datetime_immutable is problematic.   

New version:


Previous [pull request](https://github.com/symfony/symfony/pull/59900).

```yaml
doctrine:
    dbal:
        types:
            date_point: Symfony\Bridge\Doctrine\Types\DatePointType
            day_point: Symfony\Bridge\Doctrine\Types\DayPointType
            time_point: Symfony\Bridge\Doctrine\Types\TimePointType
```   

```php

#[ORM\Column(type: 'date_point')]
public DatePoint $createdAt; 

#[ORM\Column(type: 'day_point')]
public DatePoint $birthday;

#[ORM\Column(type: 'time_point')]
public DatePoint $openAt;
```   


Old version:

Therefore, I propose renaming the current DatePointType to DateTimePointType, and introducing a new DatePointType.

Previous [pull request](https://github.com/symfony/symfony/pull/59900).

If this pull request is to be merged, it should be included in version 7.3 to avoid any breaking changes in the future.

```yaml
doctrine:
    dbal:
        types:
            date_point: Symfony\Bridge\Doctrine\Types\DatePointType
            datetime_point: Symfony\Bridge\Doctrine\Types\DateTimePointType
```            

```php
#[ORM\Column(type: 'date_point')]
public DatePoint $birthday;

#[ORM\Column(type: 'datetime_point')]
public DatePoint $createdAt;            