### PR TITLE
[HttpClient] Improve memory consumption

### DIFF
--- a/src/Symfony/Component/HttpClient/TraceableHttpClient.php
+++ b/src/Symfony/Component/HttpClient/TraceableHttpClient.php
@@ -39,7 +39,7 @@ final class TraceableHttpClient implements HttpClientInterface, ResetInterface, 
     {
         $content = null;
         $traceInfo = [];
-        $this->tracedRequests[] = [
+        $tracedRequest = [
             'method' => $method,
             'url' => $url,
             'options' => $options,
@@ -51,7 +51,9 @@ final class TraceableHttpClient implements HttpClientInterface, ResetInterface, 
         if (false === ($options['extra']['trace_content'] ?? true)) {
             unset($content);
             $content = false;
+            unset($tracedRequest['options']['body'], $tracedRequest['options']['json']);
         }
+        $this->tracedRequests[] = $tracedRequest;
 
         $options['on_progress'] = function (int $dlNow, int $dlSize, array $info) use (&$traceInfo, $onProgress) {
             $traceInfo = $info;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Partially #60037
| License       | MIT

On the CLI, even if the profiler is not enabled by default, the underlying infrastructure is still in place.
In this PR, I'm targeting TraceableHttpClient, which collects requests and responses for nothing.
To fix this, I'm adding an "enabled" flag on TraceableHttpClient, so that we can enable the tracing only when the profiler is enabled.

In addition, I'm augmenting option `extra.trace_content` so that when disabled, we don't collect request's bodies, which can be huge when uploading.

And last but not least, I'm fixing the implementation of curl's debug info collection, which currently relies on allocating new strings all the time instead of reusing the already created zval when debug info didn't change.