### PR TITLE
[Cache][EventDispatcher][HttpClient][HttpKernel][Messenger][Validator][Workflow] Don't enable tracing unless the profiler is enabled

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -106,6 +106,7 @@ use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
 use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\HttpKernel\Log\DebugLoggerConfigurator;
+use Symfony\Component\HttpKernel\Profiler\ProfilerStateChecker;
 use Symfony\Component\JsonStreamer\Attribute\JsonStreamable;
 use Symfony\Component\JsonStreamer\JsonStreamWriter;
 use Symfony\Component\JsonStreamer\StreamReaderInterface;
@@ -962,6 +963,11 @@ class FrameworkExtension extends Extension
         $loader->load('profiling.php');
         $loader->load('collectors.php');
         $loader->load('cache_debug.php');
+
+        if (!class_exists(ProfilerStateChecker::class)) {
+            $container->removeDefinition('profiler.state_checker');
+            $container->removeDefinition('profiler.is_disabled_state_checker');
+        }
 
         if ($this->isInitializedConfigEnabled('form')) {
             $loader->load('form_debug.php');

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug.php
@@ -25,6 +25,7 @@ return static function (ContainerConfigurator $container) {
                 service('debug.stopwatch'),
                 service('logger')->nullOnInvalid(),
                 service('.virtual_request_stack')->nullOnInvalid(),
+                service('profiler.is_disabled_state_checker')->nullOnInvalid(),
             ])
             ->tag('monolog.logger', ['channel' => 'event'])
             ->tag('kernel.reset', ['method' => 'reset'])

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/profiling.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/profiling.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpKernel\Debug\VirtualRequestStack;
 use Symfony\Component\HttpKernel\EventListener\ProfilerListener;
 use Symfony\Component\HttpKernel\Profiler\FileProfilerStorage;
 use Symfony\Component\HttpKernel\Profiler\Profiler;
+use Symfony\Component\HttpKernel\Profiler\ProfilerStateChecker;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
@@ -56,5 +57,15 @@ return static function (ContainerConfigurator $container) {
         ->set('.virtual_request_stack', VirtualRequestStack::class)
             ->args([service('request_stack')])
             ->public()
+
+        ->set('profiler.state_checker', ProfilerStateChecker::class)
+            ->args([
+                service_locator(['profiler' => service('profiler')->ignoreOnUninitialized()]),
+                param('kernel.runtime_mode.web'),
+            ])
+
+        ->set('profiler.is_disabled_state_checker', 'Closure')
+            ->factory(['Closure', 'fromCallable'])
+            ->args([[service('profiler.state_checker'), 'isProfilerDisabled']])
     ;
 };

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator_debug.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator_debug.php
@@ -20,6 +20,7 @@ return static function (ContainerConfigurator $container) {
             ->decorate('validator', null, 255)
             ->args([
                 service('debug.validator.inner'),
+                service('profiler.is_disabled_state_checker')->nullOnInvalid(),
             ])
             ->tag('kernel.reset', [
                 'method' => 'reset',

--- a/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php
@@ -34,6 +34,7 @@ class TraceableAdapter implements AdapterInterface, CacheInterface, NamespacedPo
 
     public function __construct(
         protected AdapterInterface $pool,
+        protected readonly ?\Closure $disabled = null,
     ) {
     }
 
@@ -44,6 +45,9 @@ class TraceableAdapter implements AdapterInterface, CacheInterface, NamespacedPo
     {
         if (!$this->pool instanceof CacheInterface) {
             throw new BadMethodCallException(\sprintf('Cannot call "%s::get()": this class doesn\'t implement "%s".', get_debug_type($this->pool), CacheInterface::class));
+        }
+        if ($this->disabled?->__invoke()) {
+            return $this->pool->get($key, $callback, $beta, $metadata);
         }
 
         $isHit = true;
@@ -71,6 +75,9 @@ class TraceableAdapter implements AdapterInterface, CacheInterface, NamespacedPo
 
     public function getItem(mixed $key): CacheItem
     {
+        if ($this->disabled?->__invoke()) {
+            return $this->pool->getItem($key);
+        }
         $event = $this->start(__FUNCTION__);
         try {
             $item = $this->pool->getItem($key);
@@ -88,6 +95,9 @@ class TraceableAdapter implements AdapterInterface, CacheInterface, NamespacedPo
 
     public function hasItem(mixed $key): bool
     {
+        if ($this->disabled?->__invoke()) {
+            return $this->pool->hasItem($key);
+        }
         $event = $this->start(__FUNCTION__);
         try {
             return $event->result[$key] = $this->pool->hasItem($key);
@@ -98,6 +108,9 @@ class TraceableAdapter implements AdapterInterface, CacheInterface, NamespacedPo
 
     public function deleteItem(mixed $key): bool
     {
+        if ($this->disabled?->__invoke()) {
+            return $this->pool->deleteItem($key);
+        }
         $event = $this->start(__FUNCTION__);
         try {
             return $event->result[$key] = $this->pool->deleteItem($key);
@@ -108,6 +121,9 @@ class TraceableAdapter implements AdapterInterface, CacheInterface, NamespacedPo
 
     public function save(CacheItemInterface $item): bool
     {
+        if ($this->disabled?->__invoke()) {
+            return $this->pool->save($item);
+        }
         $event = $this->start(__FUNCTION__);
         try {
             return $event->result[$item->getKey()] = $this->pool->save($item);
@@ -118,6 +134,9 @@ class TraceableAdapter implements AdapterInterface, CacheInterface, NamespacedPo
 
     public function saveDeferred(CacheItemInterface $item): bool
     {
+        if ($this->disabled?->__invoke()) {
+            return $this->pool->saveDeferred($item);
+        }
         $event = $this->start(__FUNCTION__);
         try {
             return $event->result[$item->getKey()] = $this->pool->saveDeferred($item);
@@ -128,6 +147,9 @@ class TraceableAdapter implements AdapterInterface, CacheInterface, NamespacedPo
 
     public function getItems(array $keys = []): iterable
     {
+        if ($this->disabled?->__invoke()) {
+            return $this->pool->getItems($keys);
+        }
         $event = $this->start(__FUNCTION__);
         try {
             $result = $this->pool->getItems($keys);
@@ -151,6 +173,9 @@ class TraceableAdapter implements AdapterInterface, CacheInterface, NamespacedPo
 
     public function clear(string $prefix = ''): bool
     {
+        if ($this->disabled?->__invoke()) {
+            return $this->pool->clear($prefix);
+        }
         $event = $this->start(__FUNCTION__);
         try {
             if ($this->pool instanceof AdapterInterface) {
@@ -165,6 +190,9 @@ class TraceableAdapter implements AdapterInterface, CacheInterface, NamespacedPo
 
     public function deleteItems(array $keys): bool
     {
+        if ($this->disabled?->__invoke()) {
+            return $this->pool->deleteItems($keys);
+        }
         $event = $this->start(__FUNCTION__);
         $event->result['keys'] = $keys;
         try {
@@ -176,6 +204,9 @@ class TraceableAdapter implements AdapterInterface, CacheInterface, NamespacedPo
 
     public function commit(): bool
     {
+        if ($this->disabled?->__invoke()) {
+            return $this->pool->commit();
+        }
         $event = $this->start(__FUNCTION__);
         try {
             return $event->result = $this->pool->commit();
@@ -188,6 +219,9 @@ class TraceableAdapter implements AdapterInterface, CacheInterface, NamespacedPo
     {
         if (!$this->pool instanceof PruneableInterface) {
             return false;
+        }
+        if ($this->disabled?->__invoke()) {
+            return $this->pool->prune();
         }
         $event = $this->start(__FUNCTION__);
         try {
@@ -208,6 +242,9 @@ class TraceableAdapter implements AdapterInterface, CacheInterface, NamespacedPo
 
     public function delete(string $key): bool
     {
+        if ($this->disabled?->__invoke()) {
+            return $this->pool->deleteItem($key);
+        }
         $event = $this->start(__FUNCTION__);
         try {
             return $event->result[$key] = $this->pool->deleteItem($key);

--- a/src/Symfony/Component/Cache/Adapter/TraceableTagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TraceableTagAwareAdapter.php
@@ -18,13 +18,16 @@ use Symfony\Contracts\Cache\TagAwareCacheInterface;
  */
 class TraceableTagAwareAdapter extends TraceableAdapter implements TagAwareAdapterInterface, TagAwareCacheInterface
 {
-    public function __construct(TagAwareAdapterInterface $pool)
+    public function __construct(TagAwareAdapterInterface $pool, ?\Closure $disabled = null)
     {
-        parent::__construct($pool);
+        parent::__construct($pool, $disabled);
     }
 
     public function invalidateTags(array $tags): bool
     {
+        if ($this->disabled?->__invoke()) {
+            return $this->pool->invalidateTags($tags);
+        }
         $event = $this->start(__FUNCTION__);
         try {
             return $event->result = $this->pool->invalidateTags($tags);

--- a/src/Symfony/Component/Cache/DependencyInjection/CacheCollectorPass.php
+++ b/src/Symfony/Component/Cache/DependencyInjection/CacheCollectorPass.php
@@ -52,7 +52,7 @@ class CacheCollectorPass implements CompilerPassInterface
         if (!$definition->isPublic() || !$definition->isPrivate()) {
             $recorder->setPublic($definition->isPublic());
         }
-        $recorder->setArguments([new Reference($innerId = $id.'.recorder_inner')]);
+        $recorder->setArguments([new Reference($innerId = $id.'.recorder_inner'), new Reference('profiler.is_disabled_state_checker', ContainerBuilder::IGNORE_ON_INVALID_REFERENCE)]);
 
         foreach ($definition->getMethodCalls() as [$method, $args]) {
             if ('setCallbackWrapper' !== $method || !$args[0] instanceof Definition || !($args[0]->getArguments()[2] ?? null) instanceof Definition) {

--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
@@ -43,6 +43,7 @@ class TraceableEventDispatcher implements EventDispatcherInterface, ResetInterfa
         protected Stopwatch $stopwatch,
         protected ?LoggerInterface $logger = null,
         private ?RequestStack $requestStack = null,
+        protected readonly ?\Closure $disabled = null,
     ) {
     }
 
@@ -103,6 +104,9 @@ class TraceableEventDispatcher implements EventDispatcherInterface, ResetInterfa
 
     public function dispatch(object $event, ?string $eventName = null): object
     {
+        if ($this->disabled?->__invoke()) {
+            return $this->dispatcher->dispatch($event, $eventName);
+        }
         $eventName ??= $event::class;
 
         $this->callStack ??= new \SplObjectStorage();

--- a/src/Symfony/Component/HttpClient/DependencyInjection/HttpClientPass.php
+++ b/src/Symfony/Component/HttpClient/DependencyInjection/HttpClientPass.php
@@ -27,7 +27,7 @@ final class HttpClientPass implements CompilerPassInterface
 
         foreach ($container->findTaggedServiceIds('http_client.client') as $id => $tags) {
             $container->register('.debug.'.$id, TraceableHttpClient::class)
-                ->setArguments([new Reference('.debug.'.$id.'.inner'), new Reference('debug.stopwatch', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)])
+                ->setArguments([new Reference('.debug.'.$id.'.inner'), new Reference('debug.stopwatch', ContainerInterface::IGNORE_ON_INVALID_REFERENCE), new Reference('profiler.is_disabled_state_checker', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)])
                 ->addTag('kernel.reset', ['method' => 'reset'])
                 ->setDecoratedService($id, null, 5);
             $container->getDefinition('data_collector.http_client')

--- a/src/Symfony/Component/HttpClient/Response/TraceableResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/TraceableResponse.php
@@ -34,7 +34,7 @@ class TraceableResponse implements ResponseInterface, StreamableInterface
     public function __construct(
         private HttpClientInterface $client,
         private ResponseInterface $response,
-        private mixed &$content,
+        private mixed &$content = false,
         private ?StopwatchEvent $event = null,
     ) {
     }

--- a/src/Symfony/Component/HttpClient/TraceableHttpClient.php
+++ b/src/Symfony/Component/HttpClient/TraceableHttpClient.php
@@ -31,12 +31,17 @@ final class TraceableHttpClient implements HttpClientInterface, ResetInterface, 
     public function __construct(
         private HttpClientInterface $client,
         private ?Stopwatch $stopwatch = null,
+        private ?\Closure $disabled = null,
     ) {
         $this->tracedRequests = new \ArrayObject();
     }
 
     public function request(string $method, string $url, array $options = []): ResponseInterface
     {
+        if ($this->disabled?->__invoke()) {
+            return new TraceableResponse($this->client, $this->client->request($method, $url, $options));
+        }
+
         $content = null;
         $traceInfo = [];
         $this->tracedRequests[] = [

--- a/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
@@ -25,6 +25,9 @@ class TraceableEventDispatcher extends BaseTraceableEventDispatcher
 {
     protected function beforeDispatch(string $eventName, object $event): void
     {
+        if ($this->disabled?->__invoke()) {
+            return;
+        }
         switch ($eventName) {
             case KernelEvents::REQUEST:
                 $event->getRequest()->attributes->set('_stopwatch_token', bin2hex(random_bytes(3)));
@@ -57,6 +60,9 @@ class TraceableEventDispatcher extends BaseTraceableEventDispatcher
 
     protected function afterDispatch(string $eventName, object $event): void
     {
+        if ($this->disabled?->__invoke()) {
+            return;
+        }
         switch ($eventName) {
             case KernelEvents::CONTROLLER_ARGUMENTS:
                 $this->stopwatch->start('controller', 'section');

--- a/src/Symfony/Component/HttpKernel/Profiler/ProfilerStateChecker.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/ProfilerStateChecker.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Profiler;
+
+use Psr\Container\ContainerInterface;
+
+class ProfilerStateChecker
+{
+    public function __construct(
+        private ContainerInterface $container,
+        private bool $defaultEnabled,
+    ) {
+    }
+
+    public function isProfilerEnabled(): bool
+    {
+        return $this->container->get('profiler')?->isEnabled() ?? $this->defaultEnabled;
+    }
+
+    public function isProfilerDisabled(): bool
+    {
+        return !$this->isProfilerEnabled();
+    }
+}

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -19,7 +19,7 @@
         "php": ">=8.2",
         "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/error-handler": "^6.4|^7.0",
-        "symfony/event-dispatcher": "^6.4|^7.0",
+        "symfony/event-dispatcher": "^7.3",
         "symfony/http-foundation": "^7.3",
         "symfony/polyfill-ctype": "^1.8",
         "psr/log": "^1|^2|^3"

--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -337,7 +337,7 @@ class MessengerPass implements CompilerPassInterface
     {
         $container->setDefinition(
             $tracedBusId = 'debug.traced.'.$busId,
-            (new Definition(TraceableMessageBus::class, [new Reference($tracedBusId.'.inner')]))->setDecoratedService($busId)
+            (new Definition(TraceableMessageBus::class, [new Reference($tracedBusId.'.inner'), new Reference('profiler.is_disabled_state_checker', ContainerBuilder::IGNORE_ON_INVALID_REFERENCE)]))->setDecoratedService($busId)
         );
 
         $container->getDefinition('data_collector.messenger')->addMethodCall('registerBus', [$busId, new Reference($tracedBusId)]);

--- a/src/Symfony/Component/Messenger/TraceableMessageBus.php
+++ b/src/Symfony/Component/Messenger/TraceableMessageBus.php
@@ -20,11 +20,16 @@ class TraceableMessageBus implements MessageBusInterface
 
     public function __construct(
         private MessageBusInterface $decoratedBus,
+        protected readonly ?\Closure $disabled = null,
     ) {
     }
 
     public function dispatch(object $message, array $stamps = []): Envelope
     {
+        if ($this->disabled?->__invoke()) {
+            return $this->decoratedBus->dispatch($message, $stamps);
+        }
+
         $envelope = Envelope::wrap($message, $stamps);
         $context = [
             'stamps' => array_merge([], ...array_values($envelope->all())),

--- a/src/Symfony/Component/Validator/Validator/TraceableValidator.php
+++ b/src/Symfony/Component/Validator/Validator/TraceableValidator.php
@@ -29,6 +29,7 @@ class TraceableValidator implements ValidatorInterface, ResetInterface
 
     public function __construct(
         private ValidatorInterface $validator,
+        protected readonly ?\Closure $disabled = null,
     ) {
     }
 
@@ -55,6 +56,10 @@ class TraceableValidator implements ValidatorInterface, ResetInterface
     public function validate(mixed $value, Constraint|array|null $constraints = null, string|GroupSequence|array|null $groups = null): ConstraintViolationListInterface
     {
         $violations = $this->validator->validate($value, $constraints, $groups);
+
+        if ($this->disabled?->__invoke()) {
+            return $violations;
+        }
 
         $trace = debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS, 7);
 

--- a/src/Symfony/Component/Workflow/Debug/TraceableWorkflow.php
+++ b/src/Symfony/Component/Workflow/Debug/TraceableWorkflow.php
@@ -30,6 +30,7 @@ class TraceableWorkflow implements WorkflowInterface
     public function __construct(
         private readonly WorkflowInterface $workflow,
         private readonly Stopwatch $stopwatch,
+        protected readonly ?\Closure $disabled = null,
     ) {
     }
 
@@ -90,6 +91,9 @@ class TraceableWorkflow implements WorkflowInterface
 
     private function callInner(string $method, array $args): mixed
     {
+        if ($this->disabled?->__invoke()) {
+            return $this->workflow->{$method}(...$args);
+        }
         $sMethod = $this->workflow::class.'::'.$method;
         $this->stopwatch->start($sMethod, 'workflow');
 

--- a/src/Symfony/Component/Workflow/DependencyInjection/WorkflowDebugPass.php
+++ b/src/Symfony/Component/Workflow/DependencyInjection/WorkflowDebugPass.php
@@ -31,6 +31,7 @@ class WorkflowDebugPass implements CompilerPassInterface
                 ->setArguments([
                     new Reference("debug.{$id}.inner"),
                     new Reference('debug.stopwatch'),
+                    new Reference('profiler.is_disabled_state_checker', ContainerBuilder::IGNORE_ON_INVALID_REFERENCE),
                 ]);
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | https://github.com/symfony/symfony/issues/60037
| License       | MIT

This PR ensures traceable decorators are enabled only if the profiler is also enabled.

The way it works is by adding a new argument to all traceable decorators: `?\Closure $disabled`. When a closure is given and when the closure returns true, tracing should be skipped. Calling the closure should be done before every decorated method to cope for dynamically enabled/disabled states.

Then, this argument is wired using dependency injection so that a closure is passed that returns the current state of the profiler. If the profiler is not instantiated yet (eg because we're on the CLI, or because we're before ProfilerListener enabled it), then a default state is used (disabled on the CLI, enabled on the web). This allows collecting data on the web even if the profiler didn't start yet (as happens when a request comes in, before ProfilerListener is triggered).

Note that I didn't change all `Traceable*` decorators: the remaining ones look inoffensive to me. Of course, this could be wrong and fixed in follow up PRs.

