### PR TITLE
[Messenger] Revert " Add call to `gc_collect_cycles()` after each message is handled"

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/WorkerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/WorkerTest.php
@@ -584,25 +584,6 @@ class WorkerTest extends TestCase
 
         $this->assertSame($expectedMessages, $handler->processedMessages);
     }
-
-    public function testGcCollectCyclesIsCalledOnMessageHandle()
-    {
-        $apiMessage = new DummyMessage('API');
-
-        $receiver = new DummyReceiver([[new Envelope($apiMessage)]]);
-
-        $bus = $this->createMock(MessageBusInterface::class);
-
-        $dispatcher = new EventDispatcher();
-        $dispatcher->addSubscriber(new StopWorkerOnMessageLimitListener(1));
-
-        $worker = new Worker(['transport' => $receiver], $bus, $dispatcher);
-        $worker->run();
-
-        $gcStatus = gc_status();
-
-        $this->assertGreaterThan(0, $gcStatus['runs']);
-    }
 }
 
 class DummyQueueReceiver extends DummyReceiver implements QueueReceiverInterface

--- a/src/Symfony/Component/Messenger/Worker.php
+++ b/src/Symfony/Component/Messenger/Worker.php
@@ -117,8 +117,6 @@ class Worker
                 // this should prevent multiple lower priority receivers from
                 // blocking too long before the higher priority are checked
                 if ($envelopeHandled) {
-                    gc_collect_cycles();
-
                     break;
                 }
             }


### PR DESCRIPTION
This reverts commit b0df65ae9aeb86a650abe9cd4d627c3bade66000.

Reverting changes introduced in #52253 because of the issue reported here #59788

