### PR TITLE
[Scheduler] Throw error on duplicate schedule provider service registration on the schedule name

### DIFF
--- a/src/Symfony/Component/Scheduler/CHANGELOG.md
+++ b/src/Symfony/Component/Scheduler/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `TriggerNormalizer`
+ * Throw exception when multiple schedule provider services are registered under the same scheduler name
 
 7.2
 ---

--- a/src/Symfony/Component/Scheduler/DependencyInjection/AddScheduleMessengerPass.php
+++ b/src/Symfony/Component/Scheduler/DependencyInjection/AddScheduleMessengerPass.php
@@ -46,6 +46,11 @@ class AddScheduleMessengerPass implements CompilerPassInterface
         $scheduleProviderIds = [];
         foreach ($container->findTaggedServiceIds('scheduler.schedule_provider') as $serviceId => $tags) {
             $name = $tags[0]['name'];
+
+            if (isset($scheduleProviderIds[$name])) {
+                throw new InvalidArgumentException(\sprintf('Schedule provider service "%s" can not replace already registered service "%s" for schedule "%s". Make sure to register only one provider per schedule name.', $serviceId, $scheduleProviderIds[$name], $name), 1);
+            }
+
             $scheduleProviderIds[$name] = $serviceId;
         }
 

--- a/src/Symfony/Component/Scheduler/Tests/DependencyInjection/RegisterProviderTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/DependencyInjection/RegisterProviderTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Scheduler\Tests\DependencyInjection;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\Scheduler\DependencyInjection\AddScheduleMessengerPass;
+use Symfony\Component\Scheduler\Tests\Fixtures\SomeScheduleProvider;
+
+class RegisterProviderTest extends TestCase
+{
+    public function testErrorOnMultipleProvidersForTheSameSchedule()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1);
+
+        $container = new ContainerBuilder();
+
+        $container->register('provider_a', SomeScheduleProvider::class)->addTag('scheduler.schedule_provider', ['name' => 'default']);
+        $container->register('provider_b', SomeScheduleProvider::class)->addTag('scheduler.schedule_provider', ['name' => 'default']);
+
+        (new AddScheduleMessengerPass())->process($container);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | See below
| License       | MIT

The way the schedule providers work, either by tagging a service or using the [AsSchedule](https://github.com/symfony/symfony/blob/7.3/src/Symfony/Component/Scheduler/Attribute/AsSchedule.php) attribute, can lead to a scenario where multiple [ScheduleProviders](https://github.com/symfony/symfony/blob/7.3/src/Symfony/Component/Scheduler/ScheduleProviderInterface.php) register for the same schedule name (e.g. `default`).

The problem arises when the [CompilerPass](https://github.com/symfony/symfony/blob/29da4f53d4a5b6a48ae8b43330e764a86ad7a85b/src/Symfony/Component/Scheduler/DependencyInjection/AddScheduleMessengerPass.php#L49) simply overwrites the previously registered one without throwing a warning, a notice or anything else. The problem would be that a full ScheduleProvider would simply not register and therefore not run.

I decided to use the InvalidArgumentException from DI, as I could not get a trigger_error on E_USER_WARNING to show anything in a `dev` environment, in case I miss a scenario where this would actually be a desirable use case.

Not sure if the test is complete enough for this scenario. I tried to base it on others found in HttpKernel.

Also not sure if this falls under "feature" or "bug fix", so I marked it as a feature above.