### PR TITLE
[Translation] drop support for nikic/php-parser 4

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -139,10 +139,6 @@ jobs:
           echo SYMFONY_REQUIRE=">=$([ '${{ matrix.mode }}' = low-deps ] && echo 5.4 || echo $SYMFONY_VERSION)" >> $GITHUB_ENV
           [[ "${{ matrix.mode }}" = *-deps ]] && mv composer.json.phpunit composer.json || true
 
-          if [[ "${{ matrix.mode }}" = low-deps ]]; then
-            echo SYMFONY_PHPUNIT_REQUIRE="nikic/php-parser:^4.18" >> $GITHUB_ENV
-          fi
-
       - name: Install dependencies
         run: |
           echo "::group::composer update"

--- a/composer.json
+++ b/composer.json
@@ -143,7 +143,7 @@
         "league/uri": "^6.5|^7.0",
         "masterminds/html5": "^2.7.2",
         "monolog/monolog": "^3.0",
-        "nikic/php-parser": "^4.18|^5.0",
+        "nikic/php-parser": "^5.0",
         "nyholm/psr7": "^1.0",
         "pda/pheanstalk": "^5.1|^7.0",
         "php-http/discovery": "^1.15",

--- a/src/Symfony/Component/Translation/composer.json
+++ b/src/Symfony/Component/Translation/composer.json
@@ -22,7 +22,7 @@
         "symfony/deprecation-contracts": "^2.5|^3"
     },
     "require-dev": {
-        "nikic/php-parser": "^4.18|^5.0",
+        "nikic/php-parser": "^5.0",
         "symfony/config": "^6.4|^7.0",
         "symfony/console": "^6.4|^7.0",
         "symfony/dependency-injection": "^6.4|^7.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Extracted from #58370, background: PHPUnit 11 is no longer compatible with `nikic/php-parser` 4 (see https://github.com/symfony/symfony/pull/58370#discussion_r1835337410).