### PR TITLE
[VarExporter] Fix: Use correct closure call for property-specific logic in $notByRef

### DIFF
--- a/src/Symfony/Component/VarExporter/Internal/Hydrator.php
+++ b/src/Symfony/Component/VarExporter/Internal/Hydrator.php
@@ -166,7 +166,7 @@ class Hydrator
                     $object->$name = $value;
                     $object->$name = &$value;
                 } elseif (true !== $noRef) {
-                    $notByRef($object, $value);
+                    $noRef($object, $value);
                 } else {
                     $object->$name = $value;
                 }

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyProxy/HookedWithDefaultValue.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyProxy/HookedWithDefaultValue.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy;
+
+class HookedWithDefaultValue
+{
+    public int $backedWithDefault = 321 {
+        get => $this->backedWithDefault;
+        set => $this->backedWithDefault = $value;
+    }
+}

--- a/src/Symfony/Component/VarExporter/Tests/LazyGhostTraitTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/LazyGhostTraitTest.php
@@ -27,6 +27,7 @@ use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\ReadOnlyClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\TestClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\AsymmetricVisibility;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\Hooked;
+use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\HookedWithDefaultValue;
 use Symfony\Component\VarExporter\Tests\Fixtures\SimpleObject;
 
 class LazyGhostTraitTest extends TestCase
@@ -503,6 +504,28 @@ class LazyGhostTraitTest extends TestCase
         $object->backed = 345;
         $this->assertTrue($initialized);
         $this->assertSame(345, $object->backed);
+    }
+
+    /**
+     * @requires PHP 8.4
+     */
+    public function testPropertyHooksWithDefaultValue()
+    {
+        $initialized = false;
+        $object = $this->createLazyGhost(HookedWithDefaultValue::class, function ($instance) use (&$initialized) {
+            $initialized = true;
+        });
+
+        $this->assertSame(321, $object->backedWithDefault);
+        $this->assertTrue($initialized);
+
+        $initialized = false;
+        $object = $this->createLazyGhost(HookedWithDefaultValue::class, function ($instance) use (&$initialized) {
+            $initialized = true;
+        });
+        $object->backedWithDefault = 654;
+        $this->assertTrue($initialized);
+        $this->assertSame(654, $object->backedWithDefault);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #... 
| License       | MIT

Previously, $notByRef was treated as a callable instead of an array of closures. Now, the closure is correctly invoked with $notByRef[$name]($object, $value) if it's not true.

Encountered the following error after loading an entity from the database using Doctrine, which held a reference to another entity. The error occurred when modifying this lazily-loaded reference.
```
[critical] Uncaught Error: Array callback must have exactly two elements

In Hydrator.php line 163:
                                                 
  [Error]                                        
  Array callback must have exactly two elements  
  
Exception trace:
  at C:\Users\hakayashii\repos\test\vendor\symfony\var-exporter\Internal\Hydrator.php:163
 Proxies\__CG__\App\Entity\Subscription->{closure:Symfony\Component\VarExporter\Internal\Hydrator::getSimpleHydrator():155}() at C:\Users\hakayashii\repos\test\vendor\symfony\var-exporter\Hydrator.php:72
 Symfony\Component\VarExporter\Hydrator::hydrate() at C:\Users\hakayashii\repos\test\vendor\symfony\var-exporter\Internal\LazyObjectState.php:56
 Symfony\Component\VarExporter\Internal\LazyObjectState->initialize() at C:\Users\hakayashii\repos\test\vendor\symfony\var-exporter\LazyGhostTrait.php:146
 Proxies\__CG__\App\Entity\Subscription->__get() at C:\Users\hakayashii\repos\test\src\Service\OrderBuilder.php:45
[...]
```                                                 
