### PR TITLE
[Serializer] Prevent `Cannot traverse an already closed generator` error by materializing Traversable input

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
@@ -65,6 +65,10 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
         } elseif (empty($data)) {
             $data = [[]];
         } else {
+            if ($data instanceof \Traversable) {
+                // Generators can only be iterated once — convert to array to allow multiple traversals
+                $data = iterator_to_array($data);
+            }
             // Sequential arrays of arrays are considered as collections
             $i = 0;
             foreach ($data as $key => $value) {

--- a/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
@@ -710,4 +710,28 @@ CSV;
         $encoder = new CsvEncoder([CsvEncoder::END_OF_LINE => "\r\n"]);
         $this->assertSame("foo,bar\r\nhello,test\r\n", $encoder->encode($value, 'csv'));
     }
+
+    /** @dataProvider provideIterable */
+    public function testIterable(mixed $data)
+    {
+        $this->assertEquals(<<<'CSV'
+            foo,bar
+            hello,"hey ho"
+            hi,"let's go"
+
+            CSV, $this->encoder->encode($data, 'csv'));
+    }
+
+    public static function provideIterable()
+    {
+        $data = [
+            ['foo' => 'hello', 'bar' => 'hey ho'],
+            ['foo' => 'hi', 'bar' => 'let\'s go'],
+        ];
+
+        yield 'array' => [$data];
+        yield 'array iterator' => [new \ArrayIterator($data)];
+        yield 'iterator aggregate' => [new \IteratorIterator(new \ArrayIterator($data))];
+        yield 'generator' => [(fn (): \Generator => yield from $data)()];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60141 
| License       | MIT

### ✅ Pull Request description:
This PR addresses the issue reported in the linked ticket, specifically the error:
`Cannot traverse an already closed generator`

The fix involves converting `Traversable` input into an array using `iterator_to_array($data)`, in order to allow multiple traversals of generator-based inputs.

At first glance, it might seem that this approach significantly increases memory usage, since all generator values are stored in memory. However, this is not the case. In the current logic, the following [loop](https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php#L82-L86) already forces all values from the generator into memory:
```php
foreach ($data as &$value) {
    $flattened = [];
    $this->flatten($value, $flattened, $keySeparator, '', $escapeFormulas);
    $value = $flattened;
}
```
Therefore, materializing the generator with `iterator_to_array() `does not increase peak memory usage in any meaningful way.
As an example, here's the comparison of peak memory usage (measured with [memory_get_peak_usage](https://www.php.net/manual/en/function.memory-get-peak-usage.php)) when processing an array of 1 million integers:
* **With the fix**: 90,044,272 bytes
* **Without the fix**: 89,936,680 bytes

The difference is negligible, confirming that the fix does not introduce a meaningful performance cost in terms of memory.