### PR TITLE
[HttpFoundation] Fix flush after echo in `StreamedResponse`

### DIFF
--- a/src/Symfony/Component/HttpFoundation/StreamedResponse.php
+++ b/src/Symfony/Component/HttpFoundation/StreamedResponse.php
@@ -56,6 +56,8 @@ class StreamedResponse extends Response
         $this->callback = static function () use ($chunks): void {
             foreach ($chunks as $chunk) {
                 echo $chunk;
+                @ob_flush();
+                flush();
             }
         };
 

--- a/src/Symfony/Component/HttpFoundation/Tests/StreamedResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/StreamedResponseTest.php
@@ -30,10 +30,14 @@ class StreamedResponseTest extends TestCase
         $chunks = ['foo', 'bar', 'baz'];
         $callback = (new StreamedResponse($chunks))->getCallback();
 
-        ob_start();
+        $buffer = '';
+        ob_start(function (string $chunk) use (&$buffer) {
+            $buffer .= $chunk;
+        });
         $callback();
 
-        $this->assertSame('foobarbaz', ob_get_clean());
+        ob_get_clean();
+        $this->assertSame('foobarbaz', $buffer);
     }
 
     public function testPrepareWith11Protocol()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

The StreamedResponse doesn't flush after echoing. Therefore, all the chunks are kept in output buffer, which prevents proper streaming.

This PR triggers flushes after each `echo`.