### PR TITLE
[Security] Exclude remember_me from default login authenticators

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security.php
@@ -188,8 +188,7 @@ class Security extends InternalSecurity implements AuthorizationCheckerInterface
         $firewallAuthenticatorLocator = $this->authenticators[$firewallName];
 
         if (!$authenticatorName) {
-            $authenticatorIds = array_keys($firewallAuthenticatorLocator->getProvidedServices());
-
+            $authenticatorIds = array_filter(array_keys($firewallAuthenticatorLocator->getProvidedServices()), fn (string $authenticatorId) => $authenticatorId !== \sprintf('security.authenticator.remember_me.%s', $firewallName));
             if (!$authenticatorIds) {
                 throw new LogicException(sprintf('No authenticator was found for the firewall "%s".', $firewallName));
             }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/SecurityTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/SecurityTest.php
@@ -155,7 +155,10 @@ class SecurityTest extends TestCase
         $firewallAuthenticatorLocator
             ->expects($this->once())
             ->method('getProvidedServices')
-            ->willReturn(['security.authenticator.custom.dev' => $authenticator])
+            ->willReturn([
+                'security.authenticator.custom.dev' => $authenticator,
+                'security.authenticator.remember_me.main' => $authenticator
+            ])
         ;
         $firewallAuthenticatorLocator
             ->expects($this->once())
@@ -271,6 +274,49 @@ class SecurityTest extends TestCase
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Unable to login without a request context.');
 
+        $security->login($user);
+    }
+
+    public function testLoginFailsWhenTooManyAuthenticatorsFound()
+    {
+        $request = new Request();
+        $authenticator = $this->createMock(AuthenticatorInterface::class);
+        $requestStack = $this->createMock(RequestStack::class);
+        $firewallMap = $this->createMock(FirewallMap::class);
+        $firewall = new FirewallConfig('main', 'main');
+        $userAuthenticator = $this->createMock(UserAuthenticatorInterface::class);
+        $user = $this->createMock(UserInterface::class);
+        $userChecker = $this->createMock(UserCheckerInterface::class);
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->expects($this->atLeastOnce())
+            ->method('get')
+            ->willReturnMap([
+                ['request_stack', $requestStack],
+                ['security.firewall.map', $firewallMap],
+                ['security.authenticator.managers_locator', $this->createContainer('main', $userAuthenticator)],
+                ['security.user_checker_locator', $this->createContainer('main', $userChecker)],
+            ])
+        ;
+
+        $requestStack->expects($this->once())->method('getCurrentRequest')->willReturn($request);
+        $firewallMap->expects($this->once())->method('getFirewallConfig')->willReturn($firewall);
+
+        $firewallAuthenticatorLocator = $this->createMock(ServiceProviderInterface::class);
+        $firewallAuthenticatorLocator
+            ->expects($this->once())
+            ->method('getProvidedServices')
+            ->willReturn([
+                'security.authenticator.custom.main' => $authenticator,
+                'security.authenticator.other.main' => $authenticator
+            ])
+        ;
+
+        $security = new Security($container, ['main' => $firewallAuthenticatorLocator]);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Too many authenticators were found for the current firewall "main". You must provide an instance of "Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface" to login programmatically. The available authenticators for the firewall "main" are "security.authenticator.custom.main" ,"security.authenticator.other.main');
         $security->login($user);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60221 
| License       | MIT


🐛 Bugfix Description:
This fix addresses an issue where the remember_me authenticator was incorrectly included in the list of authenticators used during the security login process. When only one authenticator was configured and it was remember_me, the login flow could break or behave unexpectedly, as remember_me is not intended to be used as a primary authenticator. The login() method has been updated to exclude remember_me from the list, ensuring proper handling of login attempts and avoiding unintended authentication behavior.