### PR TITLE
[Contracts] Fix `ServiceSubscriberTrait` for nullable service

### DIFF
--- a/src/Symfony/Contracts/Service/ServiceSubscriberTrait.php
+++ b/src/Symfony/Contracts/Service/ServiceSubscriberTrait.php
@@ -51,7 +51,7 @@ trait ServiceSubscriberTrait
             $attribute = $attribute->newInstance();
             $attribute->key ??= self::class.'::'.$method->name;
             $attribute->type ??= $returnType instanceof \ReflectionNamedType ? $returnType->getName() : (string) $returnType;
-            $attribute->nullable = $returnType->allowsNull();
+            $attribute->nullable = $attribute->nullable ?: $returnType->allowsNull();
 
             if ($attribute->attributes) {
                 $services[] = $attribute;

--- a/src/Symfony/Contracts/Tests/Service/ServiceSubscriberTraitTest.php
+++ b/src/Symfony/Contracts/Tests/Service/ServiceSubscriberTraitTest.php
@@ -27,7 +27,8 @@ class ServiceSubscriberTraitTest extends TestCase
     {
         $expected = [
             TestService::class.'::aService' => Service2::class,
-            TestService::class.'::nullableService' => '?'.Service2::class,
+            TestService::class.'::nullableInAttribute' => '?'.Service2::class,
+            TestService::class.'::nullableReturnType' => '?'.Service2::class,
             new SubscribedService(TestService::class.'::withAttribute', Service2::class, true, new Required()),
         ];
 
@@ -103,8 +104,18 @@ class TestService extends ParentTestService implements ServiceSubscriberInterfac
     {
     }
 
+    #[SubscribedService(nullable: true)]
+    public function nullableInAttribute(): Service2
+    {
+        if (!$this->container->has(__METHOD__)) {
+            throw new \LogicException();
+        }
+
+        return $this->container->get(__METHOD__);
+    }
+
     #[SubscribedService]
-    public function nullableService(): ?Service2
+    public function nullableReturnType(): ?Service2
     {
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Used in a bundle context.

If you use the following example, you will get an exception:
 `ServiceNotFoundException: The service "twig" in the container provided to "App\Service\Dependency" has a dependency on a non-existent service "Twig\Environment".`

The `nullable` argument of the `SubscribedService` attribute is ignored.

```php
// src/Service/TwigAware.php
namespace App\Service;

use Twig\Environment;
use Symfony\Contracts\Service\Attribute\SubscribedService;

trait TwigAware
{
   #[SubscribedService('twig', nullable: true)]
    private function twig(): Environment
    {
         if (!$this->container->has('twig') ) {
            throw new \LogicException(\sprintf('Twig is required to use "%s" method. Try to run "composer require symfony/twig-bundle".', __METHOD__));
        }

        return $environment;
    }
}

// src/Service/MyService.php
namespace App\Service;

use Symfony\Contracts\Service\ServiceSubscriberInterface;
use Symfony\Contracts\Service\ServiceSubscriberTrait;

class MyService implements ServiceSubscriberInterface
{
    use ServiceSubscriberTrait, TwigAware;

    public function doWithTwig(): void
    {
        // $this->twig() ...
    }
}
```

Related to https://github.com/symfony/symfony/pull/60265


