### PR TITLE
[Notifier] [Discord] Fix value limits

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Discord/Embeds/DiscordAuthorEmbedObject.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/Embeds/DiscordAuthorEmbedObject.php
@@ -25,7 +25,7 @@ final class DiscordAuthorEmbedObject extends AbstractDiscordEmbedObject
      */
     public function name(string $name): static
     {
-        if (\strlen($name) > self::NAME_LIMIT) {
+        if (mb_strlen($name, 'UTF-8') > self::NAME_LIMIT) {
             throw new LengthException(sprintf('Maximum length for the name is %d characters.', self::NAME_LIMIT));
         }
 

--- a/src/Symfony/Component/Notifier/Bridge/Discord/Embeds/DiscordEmbed.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/Embeds/DiscordEmbed.php
@@ -27,7 +27,7 @@ final class DiscordEmbed extends AbstractDiscordEmbed
      */
     public function title(string $title): static
     {
-        if (\strlen($title) > self::TITLE_LIMIT) {
+        if (mb_strlen($title, 'UTF-8') > self::TITLE_LIMIT) {
             throw new LengthException(sprintf('Maximum length for the title is %d characters.', self::TITLE_LIMIT));
         }
 
@@ -41,7 +41,7 @@ final class DiscordEmbed extends AbstractDiscordEmbed
      */
     public function description(string $description): static
     {
-        if (\strlen($description) > self::DESCRIPTION_LIMIT) {
+        if (mb_strlen($description, 'UTF-8') > self::DESCRIPTION_LIMIT) {
             throw new LengthException(sprintf('Maximum length for the description is %d characters.', self::DESCRIPTION_LIMIT));
         }
 

--- a/src/Symfony/Component/Notifier/Bridge/Discord/Embeds/DiscordFieldEmbedObject.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/Embeds/DiscordFieldEmbedObject.php
@@ -26,7 +26,7 @@ final class DiscordFieldEmbedObject extends AbstractDiscordEmbedObject
      */
     public function name(string $name): static
     {
-        if (\strlen($name) > self::NAME_LIMIT) {
+        if (mb_strlen($name, 'UTF-8') > self::NAME_LIMIT) {
             throw new LengthException(sprintf('Maximum length for the name is %d characters.', self::NAME_LIMIT));
         }
 
@@ -40,7 +40,7 @@ final class DiscordFieldEmbedObject extends AbstractDiscordEmbedObject
      */
     public function value(string $value): static
     {
-        if (\strlen($value) > self::VALUE_LIMIT) {
+        if (mb_strlen($value, 'UTF-8') > self::VALUE_LIMIT) {
             throw new LengthException(sprintf('Maximum length for the value is %d characters.', self::VALUE_LIMIT));
         }
 

--- a/src/Symfony/Component/Notifier/Bridge/Discord/Embeds/DiscordFooterEmbedObject.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/Embeds/DiscordFooterEmbedObject.php
@@ -25,7 +25,7 @@ final class DiscordFooterEmbedObject extends AbstractDiscordEmbedObject
      */
     public function text(string $text): static
     {
-        if (\strlen($text) > self::TEXT_LIMIT) {
+        if (mb_strlen($text, 'UTF-8') > self::TEXT_LIMIT) {
             throw new LengthException(sprintf('Maximum length for the text is %d characters.', self::TEXT_LIMIT));
         }
 

--- a/src/Symfony/Component/Notifier/Bridge/Discord/Tests/Embeds/DiscordAuthorEmbedObjectTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/Tests/Embeds/DiscordAuthorEmbedObjectTest.php
@@ -38,6 +38,6 @@ final class DiscordAuthorEmbedObjectTest extends TestCase
         $this->expectException(LengthException::class);
         $this->expectExceptionMessage('Maximum length for the name is 256 characters.');
 
-        (new DiscordAuthorEmbedObject())->name(str_repeat('h', 257));
+        (new DiscordAuthorEmbedObject())->name(str_repeat('š', 257));
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Discord/Tests/Embeds/DiscordEmbedTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/Tests/Embeds/DiscordEmbedTest.php
@@ -45,7 +45,7 @@ final class DiscordEmbedTest extends TestCase
         $this->expectException(LengthException::class);
         $this->expectExceptionMessage('Maximum length for the title is 256 characters.');
 
-        (new DiscordEmbed())->title(str_repeat('h', 257));
+        (new DiscordEmbed())->title(str_repeat('š', 257));
     }
 
     public function testThrowsWhenDescriptionExceedsCharacterLimit()
@@ -53,7 +53,7 @@ final class DiscordEmbedTest extends TestCase
         $this->expectException(LengthException::class);
         $this->expectExceptionMessage('Maximum length for the description is 4096 characters.');
 
-        (new DiscordEmbed())->description(str_repeat('h', 4097));
+        (new DiscordEmbed())->description(str_repeat('š', 4097));
     }
 
     public function testThrowsWhenFieldsLimitReached()

--- a/src/Symfony/Component/Notifier/Bridge/Discord/Tests/Embeds/DiscordFieldEmbedObjectTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/Tests/Embeds/DiscordFieldEmbedObjectTest.php
@@ -36,7 +36,7 @@ final class DiscordFieldEmbedObjectTest extends TestCase
         $this->expectException(LengthException::class);
         $this->expectExceptionMessage('Maximum length for the name is 256 characters.');
 
-        (new DiscordFieldEmbedObject())->name(str_repeat('h', 257));
+        (new DiscordFieldEmbedObject())->name(str_repeat('š', 257));
     }
 
     public function testThrowsWhenValueExceedsCharacterLimit()
@@ -44,6 +44,6 @@ final class DiscordFieldEmbedObjectTest extends TestCase
         $this->expectException(LengthException::class);
         $this->expectExceptionMessage('Maximum length for the value is 1024 characters.');
 
-        (new DiscordFieldEmbedObject())->value(str_repeat('h', 1025));
+        (new DiscordFieldEmbedObject())->value(str_repeat('š', 1025));
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Discord/Tests/Embeds/DiscordFooterEmbedObjectTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/Tests/Embeds/DiscordFooterEmbedObjectTest.php
@@ -36,6 +36,6 @@ final class DiscordFooterEmbedObjectTest extends TestCase
         $this->expectException(LengthException::class);
         $this->expectExceptionMessage('Maximum length for the text is 2048 characters.');
 
-        (new DiscordFooterEmbedObject())->text(str_repeat('h', 2049));
+        (new DiscordFooterEmbedObject())->text(str_repeat('š', 2049));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

It was not properly calculating values length with non latin characters for embed data. This makes it consistent with calculating chat message length in `DiscordTransport`.