### PR TITLE
[Validator] [WordCount] Treat 0 as one character word and do not exclude it

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/WordCountValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/WordCountValidator.php
@@ -44,7 +44,7 @@ final class WordCountValidator extends ConstraintValidator
         $words = iterator_to_array($iterator->getPartsIterator());
 
         // erase "blank words" and don't count them as words
-        $wordsCount = \count(array_filter(array_map(trim(...), $words)));
+        $wordsCount = \count(array_filter(array_map(trim(...), $words), fn ($word) => '' !== $word));
 
         if (null !== $constraint->min && $wordsCount < $constraint->min) {
             $this->context->buildViolation($constraint->minMessage)

--- a/src/Symfony/Component/Validator/Tests/Constraints/WordCountValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/WordCountValidatorTest.php
@@ -83,6 +83,7 @@ class WordCountValidatorTest extends ConstraintValidatorTestCase
         yield [new StringableValue('my ûtf 8'), 3];
         yield [null, 1]; // null should always pass and eventually be handled by NotNullValidator
         yield ['', 1]; // empty string should always pass and eventually be handled by NotBlankValidator
+        yield ['My String 0', 3];
     }
 
     public static function provideInvalidTypes()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | no
| License       | MIT

New **WordCount** validator has been introduced in the Symfony 7.2 but it has an issue and treats sentence ended on zero (0) as contains an empty string.

This PR adds a callback function into `array_filter` to fix the issue.