### PR TITLE
[EventDispatcher] Validate existence of event listener classes

### DIFF
--- a/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php
+++ b/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php
@@ -172,10 +172,13 @@ class RegisterListenersPass implements CompilerPassInterface
 
     private function getEventFromTypeDeclaration(ContainerBuilder $container, string $id, string $method): string
     {
+        $class = $container->getDefinition($id)->getClass();
+        if (!$r = $container->getReflectionClass($class)) {
+            throw new InvalidArgumentException(sprintf('Class "%s" used for service "%s" cannot be found.', $class, $id));
+        }
+
         if (
-            null === ($class = $container->getDefinition($id)->getClass())
-            || !($r = $container->getReflectionClass($class, false))
-            || !$r->hasMethod($method)
+            !$r->hasMethod($method)
             || 1 > ($m = $r->getMethod($method))->getNumberOfParameters()
             || !($type = $m->getParameters()[0]->getType()) instanceof \ReflectionNamedType
             || $type->isBuiltin()

--- a/src/Symfony/Component/EventDispatcher/Tests/DependencyInjection/RegisterListenersPassTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/DependencyInjection/RegisterListenersPassTest.php
@@ -503,6 +503,19 @@ class RegisterListenersPassTest extends TestCase
         ];
         $this->assertEquals($expectedCalls, $definition->getMethodCalls());
     }
+    public function testMissingListenerClassThrowsClearError()
+    {
+        $container = new ContainerBuilder();
+        $container->register('broken_listener', 'App\EventListener\BrokenListener')
+            ->addTag('kernel.event_listener');
+        $container->register('event_dispatcher');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Class "App\EventListener\BrokenListener" used for service "broken_listener" cannot be found.');
+
+        $compilerPass = new RegisterListenersPass();
+        $compilerPass->process($container);
+    }
 }
 
 class SubscriberService implements EventSubscriberInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54095
| License       | MIT

This PR improves the developer experience for event listener services.

- During container compilation, it validates that the service class defined for a `kernel.event_listener` tag actually exists.
- If the class does not exist, it throws an early `InvalidArgumentException` instead of failing later at runtime.