### PR TITLE
[JsonStreamer] Fix reading/writing objects with generics

### DIFF
--- a/src/Symfony/Component/JsonStreamer/Mapping/GenericTypePropertyMetadataLoader.php
+++ b/src/Symfony/Component/JsonStreamer/Mapping/GenericTypePropertyMetadataLoader.php
@@ -43,10 +43,7 @@ final class GenericTypePropertyMetadataLoader implements PropertyMetadataLoaderI
 
         foreach ($result as &$metadata) {
             $type = $metadata->getType();
-
-            if (isset($variableTypes[(string) $type])) {
-                $metadata = $metadata->withType($this->replaceVariableTypes($type, $variableTypes));
-            }
+            $metadata = $metadata->withType($this->replaceVariableTypes($type, $variableTypes));
         }
 
         return $result;
@@ -122,11 +119,11 @@ final class GenericTypePropertyMetadataLoader implements PropertyMetadataLoaderI
         }
 
         if ($type instanceof UnionType) {
-            return new UnionType(...array_map(fn (Type $t): Type => $this->replaceVariableTypes($t, $variableTypes), $type->getTypes()));
+            return Type::union(...array_map(fn (Type $t): Type => $this->replaceVariableTypes($t, $variableTypes), $type->getTypes()));
         }
 
         if ($type instanceof IntersectionType) {
-            return new IntersectionType(...array_map(fn (Type $t): Type => $this->replaceVariableTypes($t, $variableTypes), $type->getTypes()));
+            return Type::intersection(...array_map(fn (Type $t): Type => $this->replaceVariableTypes($t, $variableTypes), $type->getTypes()));
         }
 
         if ($type instanceof CollectionType) {
@@ -134,7 +131,7 @@ final class GenericTypePropertyMetadataLoader implements PropertyMetadataLoaderI
         }
 
         if ($type instanceof GenericType) {
-            return new GenericType(
+            return Type::generic(
                 $this->replaceVariableTypes($type->getWrappedType(), $variableTypes),
                 ...array_map(fn (Type $t): Type => $this->replaceVariableTypes($t, $variableTypes), $type->getVariableTypes()),
             );

--- a/src/Symfony/Component/JsonStreamer/Read/StreamReaderGenerator.php
+++ b/src/Symfony/Component/JsonStreamer/Read/StreamReaderGenerator.php
@@ -34,6 +34,7 @@ use Symfony\Component\TypeInfo\Type\BackedEnumType;
 use Symfony\Component\TypeInfo\Type\BuiltinType;
 use Symfony\Component\TypeInfo\Type\CollectionType;
 use Symfony\Component\TypeInfo\Type\EnumType;
+use Symfony\Component\TypeInfo\Type\GenericType;
 use Symfony\Component\TypeInfo\Type\ObjectType;
 use Symfony\Component\TypeInfo\Type\UnionType;
 
@@ -116,6 +117,10 @@ final class StreamReaderGenerator
 
         if ($type instanceof BackedEnumType) {
             return new BackedEnumNode($type);
+        }
+
+        if ($type instanceof GenericType) {
+            $type = $type->getWrappedType();
         }
 
         if ($type instanceof ObjectType && !$type instanceof EnumType) {

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Model/DummyWithGenerics.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Model/DummyWithGenerics.php
@@ -8,7 +8,7 @@ namespace Symfony\Component\JsonStreamer\Tests\Fixtures\Model;
 class DummyWithGenerics
 {
     /**
-     * @var array<int, T>
+     * @var list<T>
      */
     public array $dummies = [];
 }

--- a/src/Symfony/Component/JsonStreamer/Tests/JsonStreamReaderTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/JsonStreamReaderTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\JsonStreamer\JsonStreamReader;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDateTimes;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithGenerics;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNullableProperties;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithPhpDoc;
@@ -98,6 +99,17 @@ class JsonStreamReaderTest extends TestCase
             $this->assertSame(10, $read->id);
             $this->assertSame('dummy name', $read->name);
         }, '{"id": 10, "name": "dummy name"}', Type::object(ClassicDummy::class));
+    }
+
+    public function testReadObjectWithGenerics()
+    {
+        $reader = JsonStreamReader::create(streamReadersDir: $this->streamReadersDir, lazyGhostsDir: $this->lazyGhostsDir);
+
+        $this->assertRead($reader, function (mixed $read) {
+            $this->assertInstanceOf(DummyWithGenerics::class, $read);
+            $this->assertSame(10, $read->dummies[0]->id);
+            $this->assertSame('dummy name', $read->dummies[0]->name);
+        }, '{"dummies":[{"id":10,"name":"dummy name"}]}', Type::generic(Type::object(DummyWithGenerics::class), Type::object(ClassicDummy::class)));
     }
 
     public function testReadObjectWithStreamedName()

--- a/src/Symfony/Component/JsonStreamer/Tests/JsonStreamWriterTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/JsonStreamWriterTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\JsonStreamer\JsonStreamWriter;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDateTimes;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithGenerics;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNullableProperties;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithPhpDoc;
@@ -115,6 +116,18 @@ class JsonStreamWriterTest extends TestCase
         $dummy->name = 'dummy name';
 
         $this->assertWritten('{"id":10,"name":"dummy name"}', $dummy, Type::object(ClassicDummy::class));
+    }
+
+    public function testWriteObjectWithGenerics()
+    {
+        $nestedDummy = new DummyWithNameAttributes();
+        $nestedDummy->id = 10;
+        $nestedDummy->name = 'dummy name';
+
+        $dummy = new DummyWithGenerics();
+        $dummy->dummies = [$nestedDummy];
+
+        $this->assertWritten('{"dummies":[{"id":10,"name":"dummy name"}]}', $dummy, Type::generic(Type::object(DummyWithGenerics::class), Type::object(ClassicDummy::class)));
     }
 
     public function testWriteObjectWithStreamedName()

--- a/src/Symfony/Component/JsonStreamer/Write/StreamWriterGenerator.php
+++ b/src/Symfony/Component/JsonStreamer/Write/StreamWriterGenerator.php
@@ -35,6 +35,7 @@ use Symfony\Component\TypeInfo\Type\BackedEnumType;
 use Symfony\Component\TypeInfo\Type\BuiltinType;
 use Symfony\Component\TypeInfo\Type\CollectionType;
 use Symfony\Component\TypeInfo\Type\EnumType;
+use Symfony\Component\TypeInfo\Type\GenericType;
 use Symfony\Component\TypeInfo\Type\ObjectType;
 use Symfony\Component\TypeInfo\Type\UnionType;
 
@@ -124,6 +125,10 @@ final class StreamWriterGenerator
             return new BackedEnumNode($accessor, $type);
         }
 
+        if ($type instanceof GenericType) {
+            $type = $type->getWrappedType();
+        }
+
         if ($type instanceof ObjectType && !$type instanceof EnumType) {
             $typeString = (string) $type;
             $className = $type->getClassName();
@@ -133,7 +138,7 @@ final class StreamWriterGenerator
             }
 
             $context['generated_classes'][$typeString] = true;
-            $propertiesMetadata = $this->propertyMetadataLoader->load($className, $options, ['original_type' => $type] + $context);
+            $propertiesMetadata = $this->propertyMetadataLoader->load($className, $options, $context);
 
             try {
                 $classReflection = new \ReflectionClass($className);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

While integrating the JsonStreamer with API Platform, I found out that the component was not able to read/write objects with generics. This PR fixes it.
