### PR TITLE
Unnecessary cast, return, semicolon and comma

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/ArgumentResolver/EntityValueResolverTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ArgumentResolver/EntityValueResolverTest.php
@@ -153,7 +153,7 @@ class EntityValueResolverTest extends TestCase
         $request = new Request();
         $request->attributes->set('nullValue', null);
 
-        $argument = $this->createArgument(entity: new MapEntity(id: ['nullValue']), isNullable: true,);
+        $argument = $this->createArgument(entity: new MapEntity(id: ['nullValue']), isNullable: true);
 
         $this->assertSame([null], $resolver->resolve($request, $argument));
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
@@ -239,7 +239,7 @@ class DateTimeToLocalizedStringTransformerTest extends BaseDateTimeTransformerTe
     {
         if (version_compare(Intl::getIcuVersion(), '71.1', '>')) {
             $this->markTestSkipped('ICU version 71.1 or lower is required.');
-        };
+        }
 
         \Locale::setDefault('en_US');
 

--- a/src/Symfony/Component/Notifier/Tests/Channel/AbstractChannelTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Channel/AbstractChannelTest.php
@@ -34,7 +34,6 @@ class DummyChannel extends AbstractChannel
 {
     public function notify(Notification $notification, RecipientInterface $recipient, ?string $transportName = null): void
     {
-        return;
     }
 
     public function supports(Notification $notification, RecipientInterface $recipient): bool

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -290,7 +290,7 @@ class ContextListener extends AbstractListener
         $refreshedUser = $refreshedToken->getUser();
 
         if ($originalUser instanceof EquatableInterface) {
-            return !(bool) $originalUser->isEqualTo($refreshedUser);
+            return !$originalUser->isEqualTo($refreshedUser);
         }
 
         if ($originalUser instanceof PasswordAuthenticatedUserInterface || $refreshedUser instanceof PasswordAuthenticatedUserInterface) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

isEqualTo always return null.
