### PR TITLE
[Form][HttpFoundation] Fix overwriting an array element

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/WeekType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/WeekType.php
@@ -42,7 +42,6 @@ class WeekType extends AbstractType
         } else {
             $yearOptions = $weekOptions = [
                 'error_bubbling' => true,
-                'empty_data' => '',
             ];
             // when the form is compound the entries of the array are ignored in favor of children data
             // so we need to handle the cascade setting here

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -604,7 +604,6 @@ class RequestTest extends TestCase
 
         $server['REDIRECT_QUERY_STRING'] = 'query=string';
         $server['REDIRECT_URL'] = '/path/info';
-        $server['SCRIPT_NAME'] = '/index.php';
         $server['QUERY_STRING'] = 'query=string';
         $server['REQUEST_URI'] = '/path/info?toto=test&1=1';
         $server['SCRIPT_NAME'] = '/index.php';
@@ -731,7 +730,6 @@ class RequestTest extends TestCase
 
         $server['REDIRECT_QUERY_STRING'] = 'query=string';
         $server['REDIRECT_URL'] = '/path/info';
-        $server['SCRIPT_NAME'] = '/index.php';
         $server['QUERY_STRING'] = 'query=string';
         $server['REQUEST_URI'] = '/path/info?toto=test&1=1';
         $server['SCRIPT_NAME'] = '/index.php';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  6.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Issues        | 
| License       | MIT

`empty_data` is overwritten in the line 51-52

`$server['SCRIPT_NAME']` is assigned twice with the same value:
line 609 and 610
line 734 and 737
