### PR TITLE
[Form][Routing] Fix return type is non-nullable

### DIFF
--- a/src/Symfony/Component/Form/Tests/Fixtures/TestExtension.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/TestExtension.php
@@ -34,7 +34,7 @@ class TestExtension implements FormExtensionInterface
 
     public function getType($name): FormTypeInterface
     {
-        return $this->types[$name] ?? null;
+        return $this->types[$name];
     }
 
     public function hasType($name): bool

--- a/src/Symfony/Component/Routing/Tests/Loader/ObjectLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/ObjectLoaderTest.php
@@ -104,7 +104,7 @@ class TestObjectLoader extends ObjectLoader
 
     protected function getObject(string $id): object
     {
-        return $this->loaderMap[$id] ?? null;
+        return $this->loaderMap[$id];
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Issues        | 
| License       | MIT

Those are test objects so we don't need to throw any `Symfony\Component\Form\Exception\InvalidArgumentException` like in the `Symfony/Component/Form/AbstractExtension.php`