### PR TITLE
[VarDumper] Remove unused code

### DIFF
--- a/src/Symfony/Component/VarDumper/Cloner/VarCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/VarCloner.php
@@ -28,14 +28,12 @@ class VarCloner extends AbstractCloner
         $objRefs = [];                  // Map of original object handles to their stub object counterpart
         $objects = [];                  // Keep a ref to objects to ensure their handle cannot be reused while cloning
         $resRefs = [];                  // Map of original resource handles to their stub object counterpart
-        $values = [];                   // Map of stub objects' ids to original values
         $maxItems = $this->maxItems;
         $maxString = $this->maxString;
         $minDepth = $this->minDepth;
         $currentDepth = 0;              // Current tree depth
         $currentDepthFinalIndex = 0;    // Final $queue index for current tree depth
         $minimumDepthReached = 0 === $minDepth; // Becomes true when minimum tree depth has been reached
-        $cookie = (object) [];          // Unique object used to detect hard references
         $a = null;                      // Array cast for nested structures
         $stub = null;                   // Stub capturing the main properties of an original item value
                                         // or null if the original value is used directly
@@ -53,7 +51,7 @@ class VarCloner extends AbstractCloner
                 }
             }
 
-            $refs = $vals = $queue[$i];
+            $vals = $queue[$i];
             foreach ($vals as $k => $v) {
                 // $v is the original value or a stub object in case of hard references
 
@@ -213,10 +211,6 @@ class VarCloner extends AbstractCloner
             }
 
             $queue[$i] = $vals;
-        }
-
-        foreach ($values as $h => $v) {
-            $hardRefs[$h] = $v;
         }
 
         return $queue;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3 
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no 
| Issues        | 
| License       | MIT

Not all was removed in the [PR](https://github.com/symfony/symfony/pull/52619).

I did not remove [objects](https://github.com/symfony/symfony/pull/30350). It did look like unused code. Maybe some comment in code needed?

Last uses of `Cookie` and `refs` were deleted [here](https://github.com/symfony/symfony/pull/41295/files#diff-27fadd95a89adb229b33890577a4495e15bdbc1b25f12c44f7afa8a12a00d37b).

Last use of $[values](https://github.com/symfony/symfony/commit/ff00f8f33fcac466c8171eb59fb7cdd1e46d3fbc#diff-27fadd95a89adb229b33890577a4495e15bdbc1b25f12c44f7afa8a12a00d37bR100).
