### PR TITLE
[VarExporter] dump default value for property hooks if present

### DIFF
--- a/src/Symfony/Component/VarExporter/ProxyHelper.php
+++ b/src/Symfony/Component/VarExporter/ProxyHelper.php
@@ -79,7 +79,9 @@ final class ProxyHelper
             $hooks .= "\n    "
                 .($p->isProtected() ? 'protected' : 'public')
                 .($p->isProtectedSet() ? ' protected(set)' : '')
-                ." {$type} \${$name} {\n";
+                ." {$type} \${$name}"
+                .($p->hasDefaultValue() ? ' = '.$p->getDefaultValue() : '')
+                ." {\n";
 
             foreach ($p->getHooks() as $hook => $method) {
                 if ('get' === $hook) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

The test added in #60258 reveals that we have another bug in our lazy ghost generation logic which leads to an error at runtime when a hook tries to read the property's default value.