### PR TITLE
[HttpFoundation] Encode path in `X-Accel-Redirect` header

### DIFF
--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -229,7 +229,7 @@ class BinaryFileResponse extends Response
                         $path = $location.substr($path, \strlen($pathPrefix));
                         // Only set X-Accel-Redirect header if a valid URI can be produced
                         // as nginx does not serve arbitrary file paths.
-                        $this->headers->set($type, $path);
+                        $this->headers->set($type, rawurlencode($path));
                         $this->maxlen = 0;
                         break;
                     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

The path in `X-Accel-Redirect` header needs to be encoded otherwise nginx fail when certain characters are present in it (like % or ?)

* https://github.com/rack/rack/issues/1306

