### PR TITLE
[Messenger] fix asking users to select an option if `--force` option is used in `messenger:failed:retry` command

### DIFF
--- a/src/Symfony/Component/Messenger/Command/FailedMessagesRetryCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesRetryCommand.php
@@ -224,8 +224,8 @@ EOF
 
             $this->forceExit = true;
             try {
-                $choice = $io->choice('Please select an action', ['retry', 'delete', 'skip'], 'retry');
-                $shouldHandle = $shouldForce || 'retry' === $choice;
+                $choice = $shouldForce ? 'retry' : $io->choice('Please select an action', ['retry', 'delete', 'skip'], 'retry');
+                $shouldHandle = 'retry' === $choice;
             } finally {
                 $this->forceExit = false;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

See https://github.com/symfony/symfony/pull/57270/files#r2063631974

Since 7ec6914750667cb9b6b029067876c544a8ccd4ca users are asked to select an option when calling `messenger:failed:retry` and the `--force` option was used.
