### PR TITLE
[HttpClient] align the type to the one in the human description

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/TransportResponseTrait.php
+++ b/src/Symfony/Component/HttpClient/Response/TransportResponseTrait.php
@@ -30,6 +30,7 @@ use Symfony\Component\HttpClient\Internal\ClientState;
 trait TransportResponseTrait
 {
     private Canary $canary;
+    /** @var array<string, list<string>> */
     private array $headers = [];
     private array $info = [
         'response_headers' => [],

--- a/src/Symfony/Contracts/HttpClient/ResponseInterface.php
+++ b/src/Symfony/Contracts/HttpClient/ResponseInterface.php
@@ -36,7 +36,7 @@ interface ResponseInterface
      *
      * @param bool $throw Whether an exception should be thrown on 3/4/5xx status codes
      *
-     * @return string[][] The headers of the response keyed by header names in lowercase
+     * @return array<string, list<string>> The headers of the response keyed by header names in lowercase
      *
      * @throws TransportExceptionInterface   When a network error occurs
      * @throws RedirectionExceptionInterface On a 3xx when $throw is true and the "max_redirects" option has been reached


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

The current type is too wide and not aligned with the intent described in the comment, it's `array-key` but `string` is intended

It's fixing the type to align with what was intended judging by the implementation and the human description of the type.