### PR TITLE
[Messenger][Amqp] delayed quorum queues

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Allow setting `queues` to `false` to skip binding the default `messages` queue
+ * Add option `delay[daily_delay_queues]` in the transport definition
 
 7.3
 ---

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
@@ -606,6 +606,22 @@ class ConnectionTest extends TestCase
         $connection->publish('{}', ['x-some-headers' => 'foo'], -5000);
     }
 
+    public function testItDelaysTheMessageWithDailyDelayQueues()
+    {
+        $delayExchange = $this->createMock(\AMQPExchange::class);
+        $date = (new \DateTimeImmutable())->format('Y-m-d');
+        $delayExchange->expects($this->once())
+            ->method('publish')
+            ->with('{}', "delay_messages__5000_delay_$date", \AMQP_NOPARAM, [
+                'headers' => ['x-some-headers' => 'foo'],
+                'delivery_mode' => 2,
+                'timestamp' => time(),
+            ]);
+        $connection = $this->createDelayOrRetryConnection($delayExchange, self::DEFAULT_EXCHANGE_NAME, "delay_messages__5000_delay_$date", true);
+
+        $connection->publish('{}', ['x-some-headers' => 'foo'], 5000);
+    }
+
     public function testItRetriesTheMessage()
     {
         $delayExchange = $this->createMock(\AMQPExchange::class);
@@ -616,6 +632,19 @@ class ConnectionTest extends TestCase
 
         $amqpEnvelope = $this->createStub(\AMQPEnvelope::class);
         $amqpStamp = AmqpStamp::createFromAmqpEnvelope($amqpEnvelope, null, '');
+        $connection->publish('{}', [], 5000, $amqpStamp);
+    }
+
+    public function testItRetriesTheMessageWithDailyDelayQueues()
+    {
+        $delayExchange = $this->createMock(\AMQPExchange::class);
+        $date = (new \DateTimeImmutable())->format('Y-m-d');
+        $delayExchange->expects($this->once())
+            ->method('publish')
+            ->with('{}', "delay_messages__5000_retry_$date", \AMQP_NOPARAM);
+        $connection = $this->createDelayOrRetryConnection($delayExchange, '', "delay_messages__5000_retry_$date", true);
+
+        $amqpStamp = AmqpStamp::createFromAmqpEnvelope($this->createStub(\AMQPEnvelope::class), null, '');
         $connection->publish('{}', [], 5000, $amqpStamp);
     }
 
@@ -1010,7 +1039,7 @@ class ConnectionTest extends TestCase
         $connection->publish('body');
     }
 
-    private function createDelayOrRetryConnection(\AMQPExchange $delayExchange, string $deadLetterExchangeName, string $delayQueueName): Connection
+    private function createDelayOrRetryConnection(\AMQPExchange $delayExchange, string $deadLetterExchangeName, string $delayQueueName, bool $dailyDelayQueues = false): Connection
     {
         $amqpConnection = $this->createStub(\AMQPConnection::class);
         $amqpChannel = $this->createStub(\AMQPChannel::class);
@@ -1022,19 +1051,20 @@ class ConnectionTest extends TestCase
         $delayQueue = $this->createMock(\AMQPQueue::class);
         $factory->method('createQueue')->willReturn($this->createStub(\AMQPQueue::class), $delayQueue);
         $factory->method('createExchange')->willReturn($this->createStub(\AMQPExchange::class), $delayExchange);
-
+        $baseExpire = $dailyDelayQueues ? 86400 * 1000 : 0;
         $delayQueue->expects($this->once())->method('setName')->with($delayQueueName);
         $delayQueue->expects($this->once())->method('setArguments')->with([
             'x-message-ttl' => 5000,
-            'x-expires' => 5000 + 10000,
+            'x-expires' => 5000 + 10000 + $baseExpire,
             'x-dead-letter-exchange' => $deadLetterExchangeName,
             'x-dead-letter-routing-key' => '',
         ]);
 
         $delayQueue->expects($this->once())->method('declareQueue');
         $delayQueue->expects($this->once())->method('bind')->with('delays', $delayQueueName);
+        $options = $dailyDelayQueues ? ['delay' => ['daily_delay_queues' => true]] : [];
 
-        return Connection::fromDsn('amqp://localhost', [], $factory);
+        return Connection::fromDsn('amqp://localhost', $options, $factory);
     }
 
     public function testGettingDefaultExchange()

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -155,6 +155,11 @@ class Connection
      *     * queue_name_pattern: Pattern to use to create the queues (Default: "delay_%exchange_name%_%routing_key%_%delay%")
      *     * exchange_name: Name of the exchange to be used for the delayed/retried messages (Default: "delays")
      *     * arguments: array of extra delay queue arguments (for example:  ['x-queue-type' => 'classic', 'x-message-deduplication' => true,])
+     *     * daily_delay_queues: When true, delay queues will be created with names including the current date
+     *       (e.g., '%queue_name_pattern%_%current_date%'). These queues are automatically deleted by RabbitMQ after they
+     *       expire (x-expires argument), the x-expires argument is set to 24 hours (24 * 60 * 60 * 1000) plus delay. This is useful for quorum queues.
+     *       because quorum queues do not redeclare expire time.
+     *       (Default: false)
      *   * auto_setup: Enable or not the auto-setup of queues and exchanges (Default: true)
      *
      *   * Connection tuning options (see http://www.rabbitmq.com/amqp-0-9-1-reference.html#connection.tune for details):
@@ -402,11 +407,14 @@ class Connection
         $queue = $this->amqpFactory->createQueue($this->channel());
         $queue->setName($this->getRoutingKeyForDelay($delay, $routingKey, $isRetryAttempt));
         $queue->setFlags(\AMQP_DURABLE);
+        $queueExpirationBase = ($this->connectionOptions['delay']['daily_delay_queues'] ?? false) ? 24 * 60 * 60 * 1000 : 0;
         $queue->setArguments(array_merge([
             'x-message-ttl' => $delay,
             // delete the delay queue 10 seconds after the message expires
             // publishing another message redeclares the queue which renews the lease
-            'x-expires' => $delay + 10000,
+            // For quorum queues, redeclaration is not allowed, so using daily_delay_queues=true is recommended to manage cleanup.
+            // It will create a new queue for each day, with x-expires set to 24 hours (24 * 60 * 60 * 1000) plus delay.
+            'x-expires' => $queueExpirationBase + $delay + 10000,
             // message should be broadcast to all consumers during delay, but to only one queue during retry
             // empty name is default direct exchange
             'x-dead-letter-exchange' => $isRetryAttempt ? '' : $this->exchangeOptions['name'],
@@ -421,12 +429,13 @@ class Connection
     private function getRoutingKeyForDelay(int $delay, ?string $finalRoutingKey, bool $isRetryAttempt): string
     {
         $action = $isRetryAttempt ? '_retry' : '_delay';
+        $date = ($this->connectionOptions['delay']['daily_delay_queues'] ?? false) ? '_'.(new \DateTimeImmutable())->format('Y-m-d') : '';
 
         return str_replace(
             ['%delay%', '%exchange_name%', '%routing_key%'],
             [$delay, $this->exchangeOptions['name'], $finalRoutingKey ?? ''],
             $this->connectionOptions['delay']['queue_name_pattern']
-        ).$action;
+        ).$action.$date;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #57867 
| License       | MIT
| Docs PR       | https://github.com/symfony/symfony-docs/pull/20925

As described in the issue: https://github.com/symfony/symfony/issues/57867 when we create delayed quorum queues this doesn't update the expire time.
I've first tried what is suggested by rabbit maintainers here: https://github.com/rabbitmq/rabbitmq-server/issues/5894#issuecomment-2801069106 but it doesn't supported either.
So the final solution is create a delayed quorum queue per day, with expire of one day + ttl + 10 seconds, with this approach, when you enqueue a message to a delayed queue, you'll be sure that all the delayed message of the same day will be in the same queue and this queue won't die before the last message is processed.
For example you delay a message with 10s delay at 10:00 of 2025-04-29, this will create a delayed queue named:
delay_test_test_delay_2025-04-29 with expire on 2025-04-30 at 10:10:10.
If another message comes at 23:59:59, it will go to the same queue, that is already created.
And in the next day will create a new queue for the 30th.