### PR TITLE
[Security] Allow enums in `SignatureHasher::computeSignatureHash()`

### DIFF
--- a/src/Symfony/Component/Security/Core/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Core/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Add ability for voters to explain their vote
  * Add support for voting on closures
  * Add `OAuth2User` with OAuth2 Access Token Introspection support for `OAuth2TokenHandler`
+ * Add support for backed enums in `SignatureHasher::computeSignatureHash()`
 
 7.2
 ---

--- a/src/Symfony/Component/Security/Core/Signature/HashContext.php
+++ b/src/Symfony/Component/Security/Core/Signature/HashContext.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Security\Core\Signature;
+
+final readonly class HashContext implements HashContextInterface
+{
+    public function __construct(
+        private \HashContext $hashContext,
+    ) {
+    }
+
+    public function update(string $data): void
+    {
+        hash_update($this->hashContext, ':' . base64_encode($data));
+    }
+
+    public function final(): string
+    {
+        return strtr(base64_encode(hash_final($this->hashContext, true)), '+/=', '-_~');
+    }
+}

--- a/src/Symfony/Component/Security/Core/Signature/HashContextInterface.php
+++ b/src/Symfony/Component/Security/Core/Signature/HashContextInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Security\Core\Signature;
+
+interface HashContextInterface
+{
+    public function update(string $data): void;
+
+    public function final(): string;
+}

--- a/src/Symfony/Component/Security/Core/Signature/Hasher.php
+++ b/src/Symfony/Component/Security/Core/Signature/Hasher.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Security\Core\Signature;
+
+final readonly class Hasher implements HasherInterface
+{
+    public function __construct(
+        private string $algo,
+    ) {
+    }
+
+    public function init(): HashContextInterface
+    {
+        return new HashContext(hash_init($this->algo));
+    }
+
+    public function hmac(string $data, string $key): string
+    {
+        return strtr(base64_encode(hash_hmac($this->algo, $data, $key, true)), '+/=', '-_~');
+    }
+}

--- a/src/Symfony/Component/Security/Core/Signature/HasherInterface.php
+++ b/src/Symfony/Component/Security/Core/Signature/HasherInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Security\Core\Signature;
+
+interface HasherInterface
+{
+    public function init(): HashContextInterface;
+
+    public function hmac(string $data, string $key): string;
+}

--- a/src/Symfony/Component/Security/Core/Signature/SignatureHasher.php
+++ b/src/Symfony/Component/Security/Core/Signature/SignatureHasher.php
@@ -36,6 +36,7 @@ class SignatureHasher
         #[\SensitiveParameter] private string $secret,
         private ?ExpiredSignatureStorage $expiredSignaturesStorage = null,
         private ?int $maxUses = null,
+        private readonly HasherInterface $hasher = new Hasher('sha256'),
     ) {
         if (!$secret) {
             throw new InvalidArgumentException('A non-empty secret is required.');
@@ -102,7 +103,7 @@ class SignatureHasher
     public function computeSignatureHash(UserInterface $user, int $expires): string
     {
         $userIdentifier = $user->getUserIdentifier();
-        $fieldsHash = hash_init('sha256');
+        $fieldsHashContext = $this->hasher->init();
 
         foreach ($this->signatureProperties as $property) {
             $value = $this->propertyAccessor->getValue($user, $property) ?? '';
@@ -115,16 +116,16 @@ class SignatureHasher
                 throw new \InvalidArgumentException(\sprintf('The property path "%s" on the user object "%s" must return a value that can be cast to a string, but "%s" was returned.', $property, $user::class, get_debug_type($value)));
             }
 
-            hash_update($fieldsHash, ':'.base64_encode($value));
+            $fieldsHashContext->update($value);
         }
 
-        $fieldsHash = strtr(base64_encode(hash_final($fieldsHash, true)), '+/=', '-_~');
+        $fieldsHash = $fieldsHashContext->final();
 
         return $this->generateHash($fieldsHash.':'.$expires.':'.$userIdentifier).$fieldsHash;
     }
 
     private function generateHash(string $tokenValue): string
     {
-        return strtr(base64_encode(hash_hmac('sha256', $tokenValue, $this->secret, true)), '+/=', '-_~');
+        return $this->hasher->hmac($tokenValue, $this->secret);
     }
 }

--- a/src/Symfony/Component/Security/Core/Signature/SignatureHasher.php
+++ b/src/Symfony/Component/Security/Core/Signature/SignatureHasher.php
@@ -106,13 +106,15 @@ class SignatureHasher
 
         foreach ($this->signatureProperties as $property) {
             $value = $this->propertyAccessor->getValue($user, $property) ?? '';
+
             if ($value instanceof \DateTimeInterface) {
                 $value = $value->format('c');
-            }
-
-            if (!\is_scalar($value) && !$value instanceof \Stringable) {
+            } elseif ($value instanceof \BackedEnum) {
+                $value = $value->value;
+            } elseif (!\is_scalar($value) && !$value instanceof \Stringable) {
                 throw new \InvalidArgumentException(\sprintf('The property path "%s" on the user object "%s" must return a value that can be cast to a string, but "%s" was returned.', $property, $user::class, get_debug_type($value)));
             }
+
             hash_update($fieldsHash, ':'.base64_encode($value));
         }
 

--- a/src/Symfony/Component/Security/Core/Tests/Fixtures/DummyHashContext.php
+++ b/src/Symfony/Component/Security/Core/Tests/Fixtures/DummyHashContext.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Security\Core\Tests\Fixtures;
+
+use Symfony\Component\Security\Core\Signature\HashContextInterface;
+
+class DummyHashContext implements HashContextInterface
+{
+    private string $data = '';
+
+    public function update(string $data): void
+    {
+        $this->data .= ':' . $data;
+    }
+
+    public function final(): string
+    {
+        return sprintf('HASH(%s)', $this->data);
+    }
+}

--- a/src/Symfony/Component/Security/Core/Tests/Fixtures/DummyHasher.php
+++ b/src/Symfony/Component/Security/Core/Tests/Fixtures/DummyHasher.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Security\Core\Tests\Fixtures;
+
+use Symfony\Component\Security\Core\Signature\HashContextInterface;
+use Symfony\Component\Security\Core\Signature\HasherInterface;
+
+class DummyHasher implements HasherInterface
+{
+    public function init(): HashContextInterface
+    {
+        return new DummyHashContext();
+    }
+
+    public function hmac(string $data, string $key): string
+    {
+        return sprintf('HMAC(%s,%s)', $data, $key);
+    }
+}

--- a/src/Symfony/Component/Security/Core/Tests/Fixtures/DummyUserWithProperties.php
+++ b/src/Symfony/Component/Security/Core/Tests/Fixtures/DummyUserWithProperties.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Security\Core\Tests\Fixtures;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+
+final class DummyUserWithProperties implements UserInterface
+{
+    public function __construct(
+        public string $identifier,
+        public mixed $arbitraryValue,
+    ) {
+    }
+
+    public function getUserIdentifier(): string
+    {
+        return $this->identifier;
+    }
+
+    public function getRoles(): array
+    {
+        return [];
+    }
+
+    public function eraseCredentials(): void
+    {
+    }
+}

--- a/src/Symfony/Component/Security/Core/Tests/Fixtures/Enum/IntBackedEnum.php
+++ b/src/Symfony/Component/Security/Core/Tests/Fixtures/Enum/IntBackedEnum.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Security\Core\Tests\Fixtures\Enum;
+
+enum IntBackedEnum: int
+{
+    case FOO = 0;
+    case BAR = 1;
+}

--- a/src/Symfony/Component/Security/Core/Tests/Fixtures/Enum/NonBackedEnum.php
+++ b/src/Symfony/Component/Security/Core/Tests/Fixtures/Enum/NonBackedEnum.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Security\Core\Tests\Fixtures\Enum;
+
+enum NonBackedEnum
+{
+    case FOO;
+    case BAR;
+}

--- a/src/Symfony/Component/Security/Core/Tests/Fixtures/Enum/StringBackedEnum.php
+++ b/src/Symfony/Component/Security/Core/Tests/Fixtures/Enum/StringBackedEnum.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Security\Core\Tests\Fixtures\Enum;
+
+enum StringBackedEnum: string
+{
+    case FOO = 'Foo';
+    case BAR = 'Bar';
+}

--- a/src/Symfony/Component/Security/Core/Tests/Signature/SignatureHasherTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Signature/SignatureHasherTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\Security\Core\Signature\SignatureHasher;
+use Symfony\Component\Security\Core\Tests\Fixtures\DummyHasher;
 use Symfony\Component\Security\Core\Tests\Fixtures\DummyUserWithProperties;
 use Symfony\Component\Security\Core\Tests\Fixtures\Enum\IntBackedEnum;
 use Symfony\Component\Security\Core\Tests\Fixtures\Enum\NonBackedEnum;
@@ -32,7 +33,7 @@ class SignatureHasherTest extends TestCase
     /**
      * @dataProvider providerComputeSignatureHash
      */
-    public function testComputeSignatureHash(mixed $arbitraryValue, array $signatureProperties, string $expectedHash)
+    public function testComputeSignatureHash(mixed $arbitraryValue, array $signatureProperties, bool $useDummyHasher, string $expectedHash)
     {
         $user = new DummyUserWithProperties(self::USER_IDENTIFIER, $arbitraryValue);
 
@@ -40,6 +41,7 @@ class SignatureHasherTest extends TestCase
             new PropertyAccessor(),
             $signatureProperties,
             self::SECRET,
+            ...($useDummyHasher ? ['hasher' => new DummyHasher()] : []),
         );
 
         $actualHash = $signatureHasher->computeSignatureHash($user, self::EXPIRES);
@@ -49,22 +51,26 @@ class SignatureHasherTest extends TestCase
     public function providerComputeSignatureHash(): array
     {
         return [
-            ['someValue', [], 'G8FxuQ7xlU0L132MkzxZu5KRob7AQBcxzpaDAUC6b54~47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU~'],
-            ['someValue', ['identifier'], 'a5YdlgWCmg7usTIoClr2uFFOEfO_XY1f7rCAoswmstE~blXCO2vRdOtJA_aCJPBaNpRpsaS957uvosMktnrI6wY~'],
-            ['someValue', ['arbitraryValue'], 'kfMzZgYYD1oeqSSW7m0k94VuRvS7LeHcKq-PKU8WD7k~0nuV8X2IlHqxDdPRNOLP-wp_v2KdVL9dNYJ0_557fGc~'],
-            ['someValue', ['identifier', 'arbitraryValue'], 'myxvvho8WkMuOcMMeuRlZQFe58TNDQFgDrVFb8SZ50g~iJ4d_Agaa0AaCHZinVr_zZCgR2nSZgokvXIkv7ne1b4~'],
-            [null, ['arbitraryValue'], 'RMzJFvIb5BMTbyJb_VZwuKEchdxH8bA00ci1kYVJgEc~56wHhmaOD_DwK2K9BPRf9jb9gttjsRBGAcl13ABfOmc~'],
-            [false, ['arbitraryValue'], 'RMzJFvIb5BMTbyJb_VZwuKEchdxH8bA00ci1kYVJgEc~56wHhmaOD_DwK2K9BPRf9jb9gttjsRBGAcl13ABfOmc~'],
-            [true, ['arbitraryValue'], 'otQtMUGvEkdfOynddQ5WvoRldq8honHbEb1HcM8UR8I~D60nAF03Qti0aU2B2Z5nVMOl_evP1uYHUVXRtHzgea0~'],
-            [123, ['arbitraryValue'], 'FTEV8ag4ndPfukNSOgsQtT7M7V0_Ab0Q6xnpqbWNhZ0~wWwB3p8Bp_5t2VDeCwTuCFHI-3gDxIPgP-C9ZZHEzaY~'],
-            [123.456, ['arbitraryValue'], 'bmSC3nku_rZA6KjVLJgEZhfx7GOhrQDfxaAubuncdII~nriT5yCE-wjOnuk-yycrgCtch4raCAhuuVeja7X6N7k~'],
-            [['foo', 'bar', 'baz'], ['arbitraryValue[0]', 'arbitraryValue[1]'], 'RRujHUR7iidZDEMkSHXEGvyaTCA5C4m0n5H200gqLxw~Zt46jI-2GYxtNTzeTcOoq2_jxow7h7PuI2C0qp7-H28~'],
-            [['a' => 'foo', 'b' => 'bar', 'c' => 'baz'], ['arbitraryValue[b]', 'arbitraryValue[c]'], 'J6hgo51Cax5NBrtIH1JpZSuLgNXZ0G24dN1v7WGFyqg~fePV3ZmKYu5tz49IF6nlmAwhchNOkkGMCEIFapsOVYw~'],
-            [(object) ['a' => 'foo', 'b' => 'bar', 'c' => 'baz'], ['arbitraryValue.c', 'arbitraryValue.a', 'arbitraryValue.b'], 'sXS_9yKjlog_OhI6oI5I0oG-M-A8TCaHhE7yhuUfhQU~6bdXP2SGmxK_WmYcg_mBySv40I_aKpbySb78NfJLQVA~'],
-            [IntBackedEnum::FOO, ['arbitraryValue'], '3CtZMZJ-YGRX6xUInO9pn3Re0oyojM57L-7CDWzY51k~BtLamVEszxpZWe7HwvgW9MB2XJfepVW7yEWydNHdr2k~'],
-            [IntBackedEnum::BAR, ['arbitraryValue'], 'otQtMUGvEkdfOynddQ5WvoRldq8honHbEb1HcM8UR8I~D60nAF03Qti0aU2B2Z5nVMOl_evP1uYHUVXRtHzgea0~'],
-            [StringBackedEnum::FOO, ['arbitraryValue'], 'H0kSG0c8UDJswEoMdkvpPvksK5yL7XO-UOPT93H-1Xo~JFWxxE-9gSaxRbu2nBFRqYShfEIp87D6nFTv3Qcidas~'],
-            [StringBackedEnum::BAR, ['arbitraryValue'], '5UzmukUROyA6-v0VEac9Tc2Wz1HiV_nbqbWraFXbIu0~ZYCW1TBi_AyktUQPgz9tP3utfjTx-lv2Ea45T-0o4w8~'],
+            // test with dummy hasher
+            ['someValue', [], true, 'HMAC(HASH():1234567890:username,s3cr3t)HASH()'],
+            ['someValue', ['identifier'], true, 'HMAC(HASH(:username):1234567890:username,s3cr3t)HASH(:username)'],
+            ['someValue', ['arbitraryValue'], true, 'HMAC(HASH(:someValue):1234567890:username,s3cr3t)HASH(:someValue)'],
+            ['someValue', ['identifier', 'arbitraryValue'], true, 'HMAC(HASH(:username:someValue):1234567890:username,s3cr3t)HASH(:username:someValue)'],
+            [null, ['arbitraryValue'], true, 'HMAC(HASH(:):1234567890:username,s3cr3t)HASH(:)'],
+            [false, ['arbitraryValue'], true, 'HMAC(HASH(:):1234567890:username,s3cr3t)HASH(:)'],
+            [true, ['arbitraryValue'], true, 'HMAC(HASH(:1):1234567890:username,s3cr3t)HASH(:1)'],
+            [123, ['arbitraryValue'], true, 'HMAC(HASH(:123):1234567890:username,s3cr3t)HASH(:123)'],
+            [123.456, ['arbitraryValue'], true, 'HMAC(HASH(:123.456):1234567890:username,s3cr3t)HASH(:123.456)'],
+            [['foo', 'bar', 'baz'], ['arbitraryValue[0]', 'arbitraryValue[1]'], true, 'HMAC(HASH(:foo:bar):1234567890:username,s3cr3t)HASH(:foo:bar)'],
+            [['a' => 'foo', 'b' => 'bar', 'c' => 'baz'], ['arbitraryValue[b]', 'arbitraryValue[c]'], true, 'HMAC(HASH(:bar:baz):1234567890:username,s3cr3t)HASH(:bar:baz)'],
+            [(object) ['a' => 'foo', 'b' => 'bar', 'c' => 'baz'], ['arbitraryValue.c', 'arbitraryValue.a', 'arbitraryValue.b'], true, 'HMAC(HASH(:baz:foo:bar):1234567890:username,s3cr3t)HASH(:baz:foo:bar)'],
+            [IntBackedEnum::FOO, ['arbitraryValue'], true, 'HMAC(HASH(:0):1234567890:username,s3cr3t)HASH(:0)'],
+            [IntBackedEnum::BAR, ['arbitraryValue'], true, 'HMAC(HASH(:1):1234567890:username,s3cr3t)HASH(:1)'],
+            [StringBackedEnum::FOO, ['arbitraryValue'], true, 'HMAC(HASH(:Foo):1234567890:username,s3cr3t)HASH(:Foo)'],
+            [StringBackedEnum::BAR, ['arbitraryValue'], true, 'HMAC(HASH(:Bar):1234567890:username,s3cr3t)HASH(:Bar)'],
+            // test with actual hasher
+            ['someValue', ['identifier'], false, 'a5YdlgWCmg7usTIoClr2uFFOEfO_XY1f7rCAoswmstE~blXCO2vRdOtJA_aCJPBaNpRpsaS957uvosMktnrI6wY~'],
+            ['someValue', ['identifier', 'arbitraryValue'], false, 'myxvvho8WkMuOcMMeuRlZQFe58TNDQFgDrVFb8SZ50g~iJ4d_Agaa0AaCHZinVr_zZCgR2nSZgokvXIkv7ne1b4~'],
         ];
     }
 

--- a/src/Symfony/Component/Security/Core/Tests/Signature/SignatureHasherTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Signature/SignatureHasherTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Security\Core\Tests\Signature;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
+use Symfony\Component\Security\Core\Signature\SignatureHasher;
+use Symfony\Component\Security\Core\Tests\Fixtures\DummyUserWithProperties;
+use Symfony\Component\Security\Core\Tests\Fixtures\Enum\IntBackedEnum;
+use Symfony\Component\Security\Core\Tests\Fixtures\Enum\NonBackedEnum;
+use Symfony\Component\Security\Core\Tests\Fixtures\Enum\StringBackedEnum;
+
+class SignatureHasherTest extends TestCase
+{
+    private const SECRET = 's3cr3t';
+    private const EXPIRES = 1234567890;
+    private const USER_IDENTIFIER = 'username';
+
+    /**
+     * @dataProvider providerComputeSignatureHash
+     */
+    public function testComputeSignatureHash(mixed $arbitraryValue, array $signatureProperties, string $expectedHash)
+    {
+        $user = new DummyUserWithProperties(self::USER_IDENTIFIER, $arbitraryValue);
+
+        $signatureHasher = new SignatureHasher(
+            new PropertyAccessor(),
+            $signatureProperties,
+            self::SECRET,
+        );
+
+        $actualHash = $signatureHasher->computeSignatureHash($user, self::EXPIRES);
+        $this->assertSame($expectedHash, $actualHash);
+    }
+
+    public function providerComputeSignatureHash(): array
+    {
+        return [
+            ['someValue', [], 'G8FxuQ7xlU0L132MkzxZu5KRob7AQBcxzpaDAUC6b54~47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU~'],
+            ['someValue', ['identifier'], 'a5YdlgWCmg7usTIoClr2uFFOEfO_XY1f7rCAoswmstE~blXCO2vRdOtJA_aCJPBaNpRpsaS957uvosMktnrI6wY~'],
+            ['someValue', ['arbitraryValue'], 'kfMzZgYYD1oeqSSW7m0k94VuRvS7LeHcKq-PKU8WD7k~0nuV8X2IlHqxDdPRNOLP-wp_v2KdVL9dNYJ0_557fGc~'],
+            ['someValue', ['identifier', 'arbitraryValue'], 'myxvvho8WkMuOcMMeuRlZQFe58TNDQFgDrVFb8SZ50g~iJ4d_Agaa0AaCHZinVr_zZCgR2nSZgokvXIkv7ne1b4~'],
+            [null, ['arbitraryValue'], 'RMzJFvIb5BMTbyJb_VZwuKEchdxH8bA00ci1kYVJgEc~56wHhmaOD_DwK2K9BPRf9jb9gttjsRBGAcl13ABfOmc~'],
+            [false, ['arbitraryValue'], 'RMzJFvIb5BMTbyJb_VZwuKEchdxH8bA00ci1kYVJgEc~56wHhmaOD_DwK2K9BPRf9jb9gttjsRBGAcl13ABfOmc~'],
+            [true, ['arbitraryValue'], 'otQtMUGvEkdfOynddQ5WvoRldq8honHbEb1HcM8UR8I~D60nAF03Qti0aU2B2Z5nVMOl_evP1uYHUVXRtHzgea0~'],
+            [123, ['arbitraryValue'], 'FTEV8ag4ndPfukNSOgsQtT7M7V0_Ab0Q6xnpqbWNhZ0~wWwB3p8Bp_5t2VDeCwTuCFHI-3gDxIPgP-C9ZZHEzaY~'],
+            [123.456, ['arbitraryValue'], 'bmSC3nku_rZA6KjVLJgEZhfx7GOhrQDfxaAubuncdII~nriT5yCE-wjOnuk-yycrgCtch4raCAhuuVeja7X6N7k~'],
+            [['foo', 'bar', 'baz'], ['arbitraryValue[0]', 'arbitraryValue[1]'], 'RRujHUR7iidZDEMkSHXEGvyaTCA5C4m0n5H200gqLxw~Zt46jI-2GYxtNTzeTcOoq2_jxow7h7PuI2C0qp7-H28~'],
+            [['a' => 'foo', 'b' => 'bar', 'c' => 'baz'], ['arbitraryValue[b]', 'arbitraryValue[c]'], 'J6hgo51Cax5NBrtIH1JpZSuLgNXZ0G24dN1v7WGFyqg~fePV3ZmKYu5tz49IF6nlmAwhchNOkkGMCEIFapsOVYw~'],
+            [(object) ['a' => 'foo', 'b' => 'bar', 'c' => 'baz'], ['arbitraryValue.c', 'arbitraryValue.a', 'arbitraryValue.b'], 'sXS_9yKjlog_OhI6oI5I0oG-M-A8TCaHhE7yhuUfhQU~6bdXP2SGmxK_WmYcg_mBySv40I_aKpbySb78NfJLQVA~'],
+            [IntBackedEnum::FOO, ['arbitraryValue'], '3CtZMZJ-YGRX6xUInO9pn3Re0oyojM57L-7CDWzY51k~BtLamVEszxpZWe7HwvgW9MB2XJfepVW7yEWydNHdr2k~'],
+            [IntBackedEnum::BAR, ['arbitraryValue'], 'otQtMUGvEkdfOynddQ5WvoRldq8honHbEb1HcM8UR8I~D60nAF03Qti0aU2B2Z5nVMOl_evP1uYHUVXRtHzgea0~'],
+            [StringBackedEnum::FOO, ['arbitraryValue'], 'H0kSG0c8UDJswEoMdkvpPvksK5yL7XO-UOPT93H-1Xo~JFWxxE-9gSaxRbu2nBFRqYShfEIp87D6nFTv3Qcidas~'],
+            [StringBackedEnum::BAR, ['arbitraryValue'], '5UzmukUROyA6-v0VEac9Tc2Wz1HiV_nbqbWraFXbIu0~ZYCW1TBi_AyktUQPgz9tP3utfjTx-lv2Ea45T-0o4w8~'],
+        ];
+    }
+
+    /**
+     * @dataProvider providerComputeSignatureHashFailure
+     */
+    public function testComputeSignatureHashFailure(mixed $arbitraryValue, array $signatureProperties, string $expectedException, string $expectedExceptionMessage)
+    {
+        $user = new DummyUserWithProperties(self::USER_IDENTIFIER, $arbitraryValue);
+
+        $signatureHasher = new SignatureHasher(
+            new PropertyAccessor(),
+            $signatureProperties,
+            self::SECRET,
+        );
+
+        $this->expectException($expectedException);
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
+        $signatureHasher->computeSignatureHash($user, self::EXPIRES);
+    }
+
+    public function providerComputeSignatureHashFailure(): array
+    {
+        return [
+            [
+                NonBackedEnum::FOO,
+                ['arbitraryValue'],
+                InvalidArgumentException::class,
+                'The property path "arbitraryValue" on the user object "'.DummyUserWithProperties::class.'" ' .
+                'must return a value that can be cast to a string, but "'.NonBackedEnum::class.'" was returned.',
+            ], [
+                (object) ['foo' => 'bar'],
+                ['arbitraryValue.bar'],
+                NoSuchPropertyException::class,
+                'Can\'t get a way to read the property "bar" in class "stdClass"',
+            ],
+        ];
+    }
+}

--- a/src/Symfony/Component/Security/Core/composer.json
+++ b/src/Symfony/Component/Security/Core/composer.json
@@ -20,7 +20,8 @@
         "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/event-dispatcher-contracts": "^2.5|^3",
         "symfony/service-contracts": "^2.5|^3",
-        "symfony/password-hasher": "^6.4|^7.0|^8.0"
+        "symfony/password-hasher": "^6.4|^7.0|^8.0",
+        "symfony/property-access": "^6.4|^7.0|^8.0"
     },
     "require-dev": {
         "psr/container": "^1.1|^2.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

Currently, using `remember_me.signature_properties` on a property holding an enum fails with:

> The property path "status" on the user object "App\Security\SecurityUser" must return a value that can be cast to a string, but "App\(...)\UserStatus" was returned.

We can add support for enums in one of three ways:

1. support all enums, and use the enum case name
2. support only backed enums, and use the enum case backing value (`int|string`)
3. support all enums, and use enum case name + backing value if available (most sensitive to changes)

In the current PR I went with option 2, but I'm thinking that option 3 could be better:

Pros:

- it would support all enums
- it would detect changes such as exchanging values of 2 enum cases

Cons:

- it would invalidate the token if an enum case is renamed

I would welcome feedback here.