### PR TITLE
[Notifier][Slack] Add SlackPlainTextInputBlock for Slack message

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Slack/Block/SlackPlainTextInputBlock.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Block/SlackPlainTextInputBlock.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Slack\Block;
+
+final class SlackPlainTextInputBlock extends AbstractSlackBlock
+{
+    private const LABEL_LIMIT = 150;
+    private const ACTION_ID_LIMIT = 255;
+    private const PLACEHOLDER_LIMIT = 150;
+
+    public function __construct(string $labelText, string $actionId, ?string $placeholderText = null)
+    {
+        if (\strlen($labelText) > self::LABEL_LIMIT) {
+            throw new \LengthException(\sprintf('Maximum length for the label text is %d characters.', self::LABEL_LIMIT));
+        }
+
+        if (\strlen($actionId) > self::ACTION_ID_LIMIT) {
+            throw new \LengthException(\sprintf('Maximum length for the action ID is %d characters.', self::ACTION_ID_LIMIT));
+        }
+
+        if ($placeholderText && \strlen($placeholderText) > self::PLACEHOLDER_LIMIT) {
+            throw new \LengthException(\sprintf('Maximum length for the placeholder text is %d characters.', self::PLACEHOLDER_LIMIT));
+        }
+        $this->options = [
+            'type' => 'input',
+            'element' => [
+                'type' => 'plain_text_input',
+                'action_id' => $actionId,
+            ],
+            'label' => [
+                'type' => 'plain_text',
+                'text' => $labelText,
+            ],
+        ];
+
+        if ($placeholderText) {
+            $this->options['element']['placeholder'] = [
+                'type' => 'plain_text',
+                'text' => $placeholderText,
+            ];
+        }
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Slack/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add `SlackPlainTextInputBlock` to add a plain-text input to a Slack message
+
 7.4
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Slack/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/README.md
@@ -250,6 +250,28 @@ $chatMessage->options($options);
 $chatter->send($chatMessage);
 ```
 
+Adding a Plain Text Input to a Message
+----------------------------
+To add a simple text input field to your Slack message, use the `SlackPlainTextInputBlock` class.
+```php
+use Symfony\Component\Notifier\Bridge\Slack\Block\SlackPlainTextInputBlock;
+use Symfony\Component\Notifier\Bridge\Slack\SlackOptions;
+use Symfony\Component\Notifier\Message\ChatMessage;
+
+$chatMessage = new ChatMessage('Enter your feedback');
+
+$options = (new SlackOptions())
+->block(
+new SlackPlainTextInputBlock('Your Feedback', 'feedback_action_id', 'Type your feedback here...')
+);
+
+// Add the custom options to the chat message and send the message
+$chatMessage->options($options);
+
+$chatter->send($chatMessage);
+```
+
+
 Sending a Message as a Reply
 ----------------------------
 

--- a/src/Symfony/Component/Notifier/Bridge/Slack/Tests/Block/SlackPlainTextInputBlockTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Tests/Block/SlackPlainTextInputBlockTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Slack\Tests\Block;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Notifier\Bridge\Slack\Block\SlackPlainTextInputBlock;
+
+final class SlackPlainTextInputBlockTest extends TestCase
+{
+    public function testCanBeInstantiatedWithPlaceholder()
+    {
+        $block = new SlackPlainTextInputBlock('Time spent', 'time_spent_input', 'Enter some text here');
+        $this->assertSame([
+            'type' => 'input',
+            'element' => [
+                'type' => 'plain_text_input',
+                'action_id' => 'time_spent_input',
+                'placeholder' => [
+                    'type' => 'plain_text',
+                    'text' => 'Enter some text here',
+                ],
+            ],
+            'label' => [
+                'type' => 'plain_text',
+                'text' => 'Time spent',
+            ],
+        ], $block->toArray());
+    }
+
+    public function testCanBeInstantiatedWithoutPlaceholder()
+    {
+        $block = new SlackPlainTextInputBlock('Time spent', 'time_spent_input');
+        $this->assertSame([
+            'type' => 'input',
+            'element' => [
+                'type' => 'plain_text_input',
+                'action_id' => 'time_spent_input',
+            ],
+            'label' => [
+                'type' => 'plain_text',
+                'text' => 'Time spent',
+            ],
+        ], $block->toArray());
+    }
+
+    public function testThrowsWhenLabelExceedsCharacterLimit()
+    {
+        $this->expectException(\LengthException::class);
+        $this->expectExceptionMessage('Maximum length for the label text is 150 characters.');
+        new SlackPlainTextInputBlock(str_repeat('a', 151), 'time_spent_input');
+    }
+
+    public function testThrowsWhenActionIdExceedsCharacterLimit()
+    {
+        $this->expectException(\LengthException::class);
+        $this->expectExceptionMessage('Maximum length for the action ID is 255 characters.');
+        new SlackPlainTextInputBlock('Time spent', str_repeat('a', 256));
+    }
+
+    public function testThrowsWhenPlaceholderExceedsCharacterLimit()
+    {
+        $this->expectException(\LengthException::class);
+        $this->expectExceptionMessage('Maximum length for the placeholder text is 150 characters.');
+        new SlackPlainTextInputBlock('Time spent', 'time_spent_input', str_repeat('a', 151));
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackTransportTest.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\Notifier\Bridge\Slack\Tests;
 use PHPUnit\Framework\Attributes\TestWith;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Notifier\Bridge\Slack\Block\SlackPlainTextInputBlock;
+use Symfony\Component\Notifier\Bridge\Slack\Block\SlackSectionBlock;
 use Symfony\Component\Notifier\Bridge\Slack\SlackOptions;
 use Symfony\Component\Notifier\Bridge\Slack\SlackSentMessage;
 use Symfony\Component\Notifier\Bridge\Slack\SlackTransport;
@@ -240,6 +242,46 @@ final class SlackTransportTest extends TransportTestCase
         $transport = $this->createTransport($client, 'another-channel');
 
         $sentMessage = $transport->send($chatMessage);
+
+        $this->assertSame('1503435956.000247', $sentMessage->getMessageId());
+    }
+
+    public function testSlackTransportSendsMessageWithInputBlock()
+    {
+        $channel = 'testChannel';
+        $message = 'testMessage';
+
+        $response = $this->createMock(ResponseInterface::class);
+
+        $response->expects($this->exactly(2))
+            ->method('getStatusCode')
+            ->willReturn(200);
+
+        $response->expects($this->once())
+            ->method('getContent')
+            ->willReturn(json_encode(['ok' => true, 'ts' => '1503435956.000247', 'channel' => 'C123456']));
+
+        $options = new SlackOptions();
+
+        $options->block((new SlackSectionBlock())->text($message));
+
+        $options->block(new SlackPlainTextInputBlock('Time spent', 'time_spent_input', 'Enter some text here'));
+
+        $expectedBody = json_encode([
+            'blocks' => $options->toArray()['blocks'],
+            'channel' => $channel,
+            'text' => $message,
+        ]);
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options = []) use ($response, $expectedBody): ResponseInterface {
+            $this->assertJsonStringEqualsJsonString($expectedBody, $options['body']);
+
+            return $response;
+        });
+
+        $transport = self::createTransport($client, $channel);
+
+        $sentMessage = $transport->send(new ChatMessage('testMessage', $options));
 
         $this->assertSame('1503435956.000247', $sentMessage->getMessageId());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| License       | MIT

Add SlackPlainTextInputBlock for Slack message 

-  Implemented SlackPlainTextInputBlock class to add a plain text input field to Slack messages.
-  Created tests for SlackPlainTextInputBlock to ensure proper functionality, including label, action ID, and placeholder validation.
-  Updated README with usage example for adding a plain text input to a Slack message.

Allow to do send message like that :

<img width="986" alt="Capture d’écran 2025-05-01 à 12 19 56" src="https://github.com/user-attachments/assets/d120027b-068e-47f3-8a1b-78df611846f5" />

