### PR TITLE
docs: Update @param for $match to reflect the correct default value.

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Regex.php
+++ b/src/Symfony/Component/Validator/Constraints/Regex.php
@@ -38,7 +38,7 @@ class Regex extends Constraint
     /**
      * @param string|array<string,mixed>|null $pattern     The regular expression to match
      * @param string|null                     $htmlPattern The pattern to use in the HTML5 pattern attribute
-     * @param bool|null                       $match       Whether to validate the value matches the configured pattern or not (defaults to false)
+     * @param bool|null                       $match       Whether to validate the value matches the configured pattern or not (defaults to true)
      * @param string[]|null                   $groups
      * @param array<string,mixed>             $options
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no 
| Deprecations? | no
| Issues        | Fix 
| License       | MIT

The docblock description for the $match parameter on the Regex constraint contains the wrong default value - `false` - and this PR changes it to `true`

![image](https://github.com/user-attachments/assets/c725e0f5-525d-4fda-85f3-279ce395a1cb)
