### PR TITLE
[WebProfilerBundle] fix compatibility between WebProfilerBundle and the Workflow component

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -36,7 +36,8 @@
         "symfony/form": "<6.4",
         "symfony/mailer": "<6.4",
         "symfony/messenger": "<6.4",
-        "symfony/serializer": "<7.2"
+        "symfony/serializer": "<7.2",
+        "symfony/workflow": "<7.3"
     },
     "autoload": {
         "psr-4": { "Symfony\\Bundle\\WebProfilerBundle\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

related to #60193, the `buildMermaidLiveLink()` method used in the `workflow.html.twig` template requires 7.3+ of the Workflow component
