### PR TITLE
[FrameworkBundle] drop the limiters option for non-compound rater limiters

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -3255,6 +3255,8 @@ class FrameworkExtension extends Extension
                 continue;
             }
 
+            unset($limiterConfig['limiters']);
+
             $limiters[] = $name;
 
             // default configuration (when used by other DI extensions)

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/PhpFrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/PhpFrameworkExtensionTest.php
@@ -314,6 +314,19 @@ class PhpFrameworkExtensionTest extends FrameworkExtensionTestCase
             ]);
         });
 
+        $this->assertSame([
+            'policy' => 'fixed_window',
+            'limit' => 10,
+            'interval' => '1 hour',
+            'id' => 'first',
+        ], $container->getDefinition('limiter.first')->getArgument(0));
+        $this->assertSame([
+            'policy' => 'sliding_window',
+            'limit' => 10,
+            'interval' => '1 hour',
+            'id' => 'second',
+        ], $container->getDefinition('limiter.second')->getArgument(0));
+
         $definition = $container->getDefinition('limiter.compound');
         $this->assertSame(CompoundRateLimiterFactory::class, $definition->getClass());
         $this->assertEquals(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60306
| License       | MIT