### PR TITLE
[Uid] Add value to `InvalidArgumentException`

### DIFF
--- a/src/Symfony/Component/Uid/AbstractUid.php
+++ b/src/Symfony/Component/Uid/AbstractUid.php
@@ -41,7 +41,7 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable, HashableIn
     public static function fromBinary(string $uid): static
     {
         if (16 !== \strlen($uid)) {
-            throw new InvalidArgumentException('Invalid binary uid provided.');
+            throw new InvalidArgumentException($uid, 'Invalid binary uid provided.');
         }
 
         return static::fromString($uid);
@@ -53,7 +53,7 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable, HashableIn
     public static function fromBase58(string $uid): static
     {
         if (22 !== \strlen($uid)) {
-            throw new InvalidArgumentException('Invalid base-58 uid provided.');
+            throw new InvalidArgumentException($uid, 'Invalid base-58 uid provided.');
         }
 
         return static::fromString($uid);
@@ -65,7 +65,7 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable, HashableIn
     public static function fromBase32(string $uid): static
     {
         if (26 !== \strlen($uid)) {
-            throw new InvalidArgumentException('Invalid base-32 uid provided.');
+            throw new InvalidArgumentException($uid, 'Invalid base-32 uid provided.');
         }
 
         return static::fromString($uid);
@@ -79,7 +79,7 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable, HashableIn
     public static function fromRfc4122(string $uid): static
     {
         if (36 !== \strlen($uid)) {
-            throw new InvalidArgumentException('Invalid RFC4122 uid provided.');
+            throw new InvalidArgumentException($uid, 'Invalid RFC4122 uid provided.');
         }
 
         return static::fromString($uid);

--- a/src/Symfony/Component/Uid/BinaryUtil.php
+++ b/src/Symfony/Component/Uid/BinaryUtil.php
@@ -164,7 +164,7 @@ class BinaryUtil
     {
         if (\PHP_INT_SIZE >= 8) {
             if (-self::TIME_OFFSET_INT > $time = (int) $time->format('Uu0')) {
-                throw new InvalidArgumentException('The given UUID date cannot be earlier than 1582-10-15.');
+                throw new InvalidArgumentException($time, 'The given UUID date cannot be earlier than 1582-10-15.');
             }
 
             return str_pad(dechex(self::TIME_OFFSET_INT + $time), 16, '0', \STR_PAD_LEFT);
@@ -173,7 +173,7 @@ class BinaryUtil
         $time = $time->format('Uu0');
         $negative = '-' === $time[0];
         if ($negative && self::TIME_OFFSET_INT < $time = substr($time, 1)) {
-            throw new InvalidArgumentException('The given UUID date cannot be earlier than 1582-10-15.');
+            throw new InvalidArgumentException($time, 'The given UUID date cannot be earlier than 1582-10-15.');
         }
         $time = self::fromBase($time, self::BASE10);
         $time = str_pad($time, 8, "\0", \STR_PAD_LEFT);

--- a/src/Symfony/Component/Uid/CHANGELOG.md
+++ b/src/Symfony/Component/Uid/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add component-specific exception hierarchy
+ * Add `InvalidArgumentException::$value`
 
 7.2
 ---

--- a/src/Symfony/Component/Uid/Exception/InvalidArgumentException.php
+++ b/src/Symfony/Component/Uid/Exception/InvalidArgumentException.php
@@ -13,4 +13,10 @@ namespace Symfony\Component\Uid\Exception;
 
 class InvalidArgumentException extends \InvalidArgumentException
 {
+    public function __construct(
+        public readonly mixed $value,
+        string $message,
+    ) {
+        parent::__construct($message);
+    }
 }

--- a/src/Symfony/Component/Uid/Exception/InvalidUlidException.php
+++ b/src/Symfony/Component/Uid/Exception/InvalidUlidException.php
@@ -15,6 +15,6 @@ class InvalidUlidException extends InvalidArgumentException
 {
     public function __construct(string $value)
     {
-        parent::__construct(\sprintf('Invalid ULID: "%s".', $value));
+        parent::__construct($value, \sprintf('Invalid ULID: "%s".', $value));
     }
 }

--- a/src/Symfony/Component/Uid/Exception/InvalidUuidException.php
+++ b/src/Symfony/Component/Uid/Exception/InvalidUuidException.php
@@ -17,6 +17,6 @@ class InvalidUuidException extends InvalidArgumentException
         public readonly int $type,
         string $value,
     ) {
-        parent::__construct(\sprintf('Invalid UUID%s: "%s".', $type ? 'v'.$type : '', $value));
+        parent::__construct($value, \sprintf('Invalid UUID%s: "%s".', $type ? 'v'.$type : '', $value));
     }
 }

--- a/src/Symfony/Component/Uid/Ulid.php
+++ b/src/Symfony/Component/Uid/Ulid.php
@@ -157,7 +157,7 @@ class Ulid extends AbstractUid implements TimeBasedUidInterface
             $time = microtime(false);
             $time = substr($time, 11).substr($time, 2, 3);
         } elseif (0 > $time = $time->format('Uv')) {
-            throw new InvalidArgumentException('The timestamp must be positive.');
+            throw new InvalidArgumentException($time, 'The timestamp must be positive.');
         }
 
         if ($time > self::$time || (null !== $mtime && $time !== self::$time)) {

--- a/src/Symfony/Component/Uid/UuidV6.php
+++ b/src/Symfony/Component/Uid/UuidV6.php
@@ -50,7 +50,7 @@ class UuidV6 extends Uuid implements TimeBasedUidInterface
         $uuid = $this->uid;
         $time = BinaryUtil::hexToNumericString('0'.substr($uuid, 0, 8).substr($uuid, 9, 4).substr($uuid, 15, 3));
         if ('-' === $time[0]) {
-            throw new InvalidArgumentException('Cannot convert UUID to v7: its timestamp is before the Unix epoch.');
+            throw new InvalidArgumentException($uuid, 'Cannot convert UUID to v7: its timestamp is before the Unix epoch.');
         }
 
         $ms = \strlen($time) > 4 ? substr($time, 0, -4) : '0';

--- a/src/Symfony/Component/Uid/UuidV7.php
+++ b/src/Symfony/Component/Uid/UuidV7.php
@@ -57,7 +57,7 @@ class UuidV7 extends Uuid implements TimeBasedUidInterface
             $time = microtime(false);
             $time = substr($time, 11).substr($time, 2, 3);
         } elseif (0 > $time = $time->format('Uv')) {
-            throw new InvalidArgumentException('The timestamp must be positive.');
+            throw new InvalidArgumentException($time, 'The timestamp must be positive.');
         }
 
         if ($time > self::$time || (null !== $mtime && $time !== self::$time)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Follows    | https://github.com/symfony/symfony-docs/issues/20900 , <br/>  [[Uid] Add component-specific exception classes](https://github.com/symfony/symfony/pull/60226) , <br/>  [[HttpFoundation] Add UriSigner::verify() that throws named exceptions](https://github.com/symfony/symfony/pull/60102#discussion_r2050813956)
| License       | MIT

This PR adds value to Uid-specific InvalidArgumentException.

Thus, anybody who wants to catch the exception, being outside of the scope of the client code, will be able to do so, having the knowledge of what particularly has gone wrong.
