### PR TITLE
Release v7.2.6

### DIFF
--- a/CHANGELOG-7.2.md
+++ b/CHANGELOG-7.2.md
@@ -7,6 +7,32 @@ in 7.2 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v7.2.0...v7.2.1
 
+* 7.2.6 (2025-05-02)
+
+ * bug #60288 [VarExporter] dump default value for property hooks if present (xabbuh)
+ * bug #60267 [Contracts] Fix `ServiceMethodsSubscriberTrait` for nullable service (StevenRenaux)
+ * bug #60268 [Contracts] Fix `ServiceSubscriberTrait` for nullable service (StevenRenaux)
+ * bug #60256 [Mailer][Postmark] drop the `Date` header using the API transport (xabbuh)
+ * bug #60258 [VarExporter] Fix: Use correct closure call for property-specific logic in $notByRef (Hakayashii, denjas)
+ * bug #60269 [Notifier] [Discord] Fix value limits (norkunas)
+ * bug #60270 [Validator] [WordCount] Treat 0 as one character word and do not exclude it (sidz)
+ * bug #60248 [Messenger] Revert " Add call to `gc_collect_cycles()` after each message is handled" (jwage)
+ * bug #60236 [String] Support nexus -> nexuses pluralization (KorvinSzanto)
+ * bug #60238 [Lock] read (possible) error from Redis instance where evalSha() was called (xabbuh)
+ * bug #60194 [Workflow] Fix dispatch of entered event when the subject is already in this marking (lyrixx)
+ * bug #60174 [PhpUnitBridge] properly clean up mocked features after tests have run (xabbuh)
+ * bug #60172 [Cache] Fix invalidating on save failures with Array|ApcuAdapter (nicolas-grekas)
+ * bug #60122 [Cache] ArrayAdapter serialization exception clean $expiries (bastien-wink)
+ * bug #60167 [Cache] Fix proxying third party PSR-6 cache items (Dmitry Danilson)
+ * bug #60165 [HttpKernel] Do not ignore enum in controller arguments when it has an `#[Autowire]` attribute (ruudk)
+ * bug #60168 [Console] Correctly convert `SIGSYS` to its name (cs278)
+ * bug #60166 [Security] fix(security): fix OIDC user identifier (vincentchalamon)
+ * bug #60124 [Validator] : fix url validation when punycode is on tld but not on domain (joelwurtz)
+ * bug #60137 [Config] ResourceCheckerConfigCache metadata unserialize emits warning (Colin Michoudet)
+ * bug #60057 [Mailer] Fix `Trying to access array offset on value of type null` error by adding null checking (khushaalan)
+ * bug #60094 [DoctrineBridge] Fix support for entities that leverage native lazy objects (nicolas-grekas)
+ * bug #60094 [DoctrineBridge] Fix support for entities that leverage native lazy objects (nicolas-grekas)
+
 * 7.2.5 (2025-03-28)
 
  * bug #60054 [Form] Use duplicate_preferred_choices to set value of ChoiceType (aleho)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -73,12 +73,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     private static array $freshCache = [];
 
-    public const VERSION = '7.2.6-DEV';
+    public const VERSION = '7.2.6';
     public const VERSION_ID = 70206;
     public const MAJOR_VERSION = 7;
     public const MINOR_VERSION = 2;
     public const RELEASE_VERSION = 6;
-    public const EXTRA_VERSION = 'DEV';
+    public const EXTRA_VERSION = '';
 
     public const END_OF_MAINTENANCE = '07/2025';
     public const END_OF_LIFE = '07/2025';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v7.2.5...v7.2.6)

 * bug #60288 [VarExporter] dump default value for property hooks if present (@xabbuh)
 * bug #60267 [Contracts] Fix `ServiceMethodsSubscriberTrait` for nullable service (@StevenRenaux)
 * bug #60268 [Contracts] Fix `ServiceSubscriberTrait` for nullable service (@StevenRenaux)
 * bug #60256 [Mailer][Postmark] drop the `Date` header using the API transport (@xabbuh)
 * bug #60258 [VarExporter] Fix: Use correct closure call for property-specific logic in $notByRef (@Hakayashii, @denjas)
 * bug #60269 [Notifier] [Discord] Fix value limits (@norkunas)
 * bug #60270 [Validator] [WordCount] Treat 0 as one character word and do not exclude it (@sidz)
 * bug #60248 [Messenger] Revert " Add call to `gc_collect_cycles()` after each message is handled" (@jwage)
 * bug #60236 [String] Support nexus -> nexuses pluralization (@KorvinSzanto)
 * bug #60238 [Lock] read (possible) error from Redis instance where evalSha() was called (@xabbuh)
 * bug #60194 [Workflow] Fix dispatch of entered event when the subject is already in this marking (@lyrixx)
 * bug #60174 [PhpUnitBridge] properly clean up mocked features after tests have run (@xabbuh)
 * bug #60172 [Cache] Fix invalidating on save failures with Array|ApcuAdapter (@nicolas-grekas)
 * bug #60122 [Cache] ArrayAdapter serialization exception clean $expiries (@bastien-wink)
 * bug #60167 [Cache] Fix proxying third party PSR-6 cache items (Dmitry Danilson)
 * bug #60165 [HttpKernel] Do not ignore enum in controller arguments when it has an `#[Autowire]` attribute (@ruudk)
 * bug #60168 [Console] Correctly convert `SIGSYS` to its name (@cs278)
 * bug #60166 [Security] fix(security): fix OIDC user identifier (@vincentchalamon)
 * bug #60124 [Validator] : fix url validation when punycode is on tld but not on domain (@joelwurtz)
 * bug #60137 [Config] ResourceCheckerConfigCache metadata unserialize emits warning (Colin Michoudet)
 * bug #60057 [Mailer] Fix `Trying to access array offset on value of type null` error by adding null checking (@khushaalan)
 * bug #60094 [DoctrineBridge] Fix support for entities that leverage native lazy objects (@nicolas-grekas)
 * bug #60094 [DoctrineBridge] Fix support for entities that leverage native lazy objects (@nicolas-grekas)
