### PR TITLE
[Mailer][Mime] Update SMIME repository node description in configuration

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -2350,7 +2350,7 @@ class Configuration implements ConfigurationInterface
                             ->info('S/MIME encrypter configuration')
                             ->children()
                                 ->scalarNode('repository')
-                                    ->info('Path to the S/MIME certificate repository. Shall implement the `Symfony\Component\Mailer\EventListener\SmimeCertificateRepositoryInterface`.')
+                                    ->info('S/MIME certificate repository service. This service shall implement the `Symfony\Component\Mailer\EventListener\SmimeCertificateRepositoryInterface`.')
                                     ->defaultValue('')
                                     ->cannotBeEmpty()
                                 ->end()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Nothing
| License       | MIT

Clarified the documentation for the S/MIME certificate repository configuration. It now specifies that the repository should be a service implementing `SmimeCertificateRepositoryInterface`.