### PR TITLE
[String] fix EmojiTransliterator return type compatibility with PHP 8.5

### DIFF
--- a/.github/expected-missing-return-types.diff
+++ b/.github/expected-missing-return-types.diff
@@ -8923,6 +8923,23 @@ diff --git a/src/Symfony/Component/Intl/Data/Bundle/Writer/BundleWriterInterface
 -    public function write(string $path, string $locale, mixed $data);
 +    public function write(string $path, string $locale, mixed $data): void;
  }
+diff --git a/src/Symfony/Component/Intl/Transliterator/EmojiTransliterator.php b/src/Symfony/Component/Intl/Transliterator/EmojiTransliterator.php
+--- a/src/Symfony/Component/Intl/Transliterator/EmojiTransliterator.php
++++ b/src/Symfony/Component/Intl/Transliterator/EmojiTransliterator.php
+@@ -74,5 +74,5 @@ if (!class_exists(\Transliterator::class)) {
+          */
+         #[\ReturnTypeWillChange]
+-        public function getErrorCode(): int|false
++        public function getErrorCode(): int
+         {
+             return isset($this->transliterator) ? $this->transliterator->getErrorCode() : 0;
+@@ -83,5 +83,5 @@ if (!class_exists(\Transliterator::class)) {
+          */
+         #[\ReturnTypeWillChange]
+-        public function getErrorMessage(): string|false
++        public function getErrorMessage(): string
+         {
+             return isset($this->transliterator) ? $this->transliterator->getErrorMessage() : '';
 diff --git a/src/Symfony/Component/Intl/Util/IntlTestHelper.php b/src/Symfony/Component/Intl/Util/IntlTestHelper.php
 --- a/src/Symfony/Component/Intl/Util/IntlTestHelper.php
 +++ b/src/Symfony/Component/Intl/Util/IntlTestHelper.php

--- a/src/Symfony/Component/Intl/Tests/Transliterator/EmojiTransliteratorTest.php
+++ b/src/Symfony/Component/Intl/Tests/Transliterator/EmojiTransliteratorTest.php
@@ -189,6 +189,6 @@ class EmojiTransliteratorTest extends TestCase
     {
         $transliterator = EmojiTransliterator::create('emoji-en');
 
-        $this->assertFalse($transliterator->getErrorMessage());
+        $this->assertSame('', $transliterator->getErrorMessage());
     }
 }

--- a/src/Symfony/Component/Intl/Transliterator/EmojiTransliterator.php
+++ b/src/Symfony/Component/Intl/Transliterator/EmojiTransliterator.php
@@ -70,14 +70,22 @@ if (!class_exists(\Transliterator::class)) {
             return self::create($this->id, self::REVERSE);
         }
 
+        /**
+         * @return int
+         */
+        #[\ReturnTypeWillChange]
         public function getErrorCode(): int|false
         {
             return isset($this->transliterator) ? $this->transliterator->getErrorCode() : 0;
         }
 
+        /**
+         * @return string
+         */
+        #[\ReturnTypeWillChange]
         public function getErrorMessage(): string|false
         {
-            return isset($this->transliterator) ? $this->transliterator->getErrorMessage() : false;
+            return isset($this->transliterator) ? $this->transliterator->getErrorMessage() : '';
         }
 
         public static function listIDs(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

see php/php-src#18470
