### PR TITLE
[DebugBundle] require the 7.3+ of the Config component

### DIFF
--- a/src/Symfony/Bundle/DebugBundle/composer.json
+++ b/src/Symfony/Bundle/DebugBundle/composer.json
@@ -19,18 +19,14 @@
         "php": ">=8.2",
         "ext-xml": "*",
         "composer-runtime-api": ">=2.1",
+        "symfony/config": "^7.3",
         "symfony/dependency-injection": "^6.4|^7.0",
         "symfony/http-kernel": "^6.4|^7.0",
         "symfony/twig-bridge": "^6.4|^7.0",
         "symfony/var-dumper": "^6.4|^7.0"
     },
     "require-dev": {
-        "symfony/config": "^7.3",
         "symfony/web-profiler-bundle": "^6.4|^7.0"
-    },
-    "conflict": {
-        "symfony/config": "<6.4",
-        "symfony/dependency-injection": "<6.4"
     },
     "autoload": {
         "psr-4": { "Symfony\\Bundle\\DebugBundle\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

related to #59762, we could bump the conflict rule instead, but I don't see a use case where using the bundle without the Config component actually makes sense
