### PR TITLE
[Notifier] document the array shape of the content option

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Mercure/MercureOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mercure/MercureOptions.php
@@ -22,6 +22,21 @@ final class MercureOptions implements MessageOptionsInterface
 
     /**
      * @param string|string[]|null $topics
+     * @param array{
+     *     badge?: string,
+     *     body?: string,
+     *     data?: mixed,
+     *     dir?: 'auto'|'ltr'|'rtl',
+     *     icon?: string,
+     *     image?: string,
+     *     lang?: string,
+     *     renotify?: bool,
+     *     requireInteraction?: bool,
+     *     silent?: bool,
+     *     tag?: string,
+     *     timestamp?: int,
+     *     vibrate?: int|list<int>,
+     * }|null $content
      */
     public function __construct(
         string|array|null $topics = null,
@@ -62,6 +77,23 @@ final class MercureOptions implements MessageOptionsInterface
         return $this->retry;
     }
 
+    /**
+     * @return array{
+     *      badge?: string,
+     *      body?: string,
+     *      data?: mixed,
+     *      dir?: 'auto'|'ltr'|'rtl',
+     *      icon?: string,
+     *      image?: string,
+     *      lang?: string,
+     *      renotify?: bool,
+     *      requireInteraction?: bool,
+     *      silent?: bool,
+     *      tag?: string,
+     *      timestamp?: int,
+     *      vibrate?: int|list<int>,
+     *  }|null
+     */
     public function getContent(): ?array
     {
         return $this->content;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony/pull/60140#discussion_r2028459056
| License       | MIT

but I wonder: is it actually correct that `$content` is an array, according to https://www.w3.org/TR/activitystreams-vocabulary/#dfn-content I would have guessed that it needs to be a string or (if it was an array), we would have to call it `contentMap` in the payload instead