### PR TITLE
[Console] Use kebab-case for auto-guessed input arguments/options names

### DIFF
--- a/src/Symfony/Component/Console/Attribute/Argument.php
+++ b/src/Symfony/Component/Console/Attribute/Argument.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Completion\Suggestion;
 use Symfony\Component\Console\Exception\LogicException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\String\UnicodeString;
 
 #[\Attribute(\Attribute::TARGET_PARAMETER)]
 class Argument
@@ -65,7 +66,7 @@ class Argument
         }
 
         if (!$self->name) {
-            $self->name = $name;
+            $self->name = (new UnicodeString($name))->kebab();
         }
 
         $self->default = $parameter->isDefaultValueAvailable() ? $parameter->getDefaultValue() : null;

--- a/src/Symfony/Component/Console/Attribute/Option.php
+++ b/src/Symfony/Component/Console/Attribute/Option.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Completion\Suggestion;
 use Symfony\Component\Console\Exception\LogicException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\String\UnicodeString;
 
 #[\Attribute(\Attribute::TARGET_PARAMETER)]
 class Option
@@ -73,7 +74,7 @@ class Option
         }
 
         if (!$self->name) {
-            $self->name = $name;
+            $self->name = (new UnicodeString($name))->kebab();
         }
 
         $self->default = $parameter->getDefaultValue();

--- a/src/Symfony/Component/Console/Tests/Command/InvokableCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/InvokableCommandTest.php
@@ -29,7 +29,7 @@ class InvokableCommandTest extends TestCase
     {
         $command = new Command('foo');
         $command->setCode(function (
-            #[Argument(name: 'first-name')] string $name,
+            #[Argument(name: 'very-first-name')] string $name,
             #[Argument] ?string $firstName,
             #[Argument] string $lastName = '',
             #[Argument(description: 'Short argument description')] string $bio = '',
@@ -38,17 +38,17 @@ class InvokableCommandTest extends TestCase
             return 0;
         });
 
-        $nameInputArgument = $command->getDefinition()->getArgument('first-name');
-        self::assertSame('first-name', $nameInputArgument->getName());
+        $nameInputArgument = $command->getDefinition()->getArgument('very-first-name');
+        self::assertSame('very-first-name', $nameInputArgument->getName());
         self::assertTrue($nameInputArgument->isRequired());
 
-        $lastNameInputArgument = $command->getDefinition()->getArgument('firstName');
-        self::assertSame('firstName', $lastNameInputArgument->getName());
+        $lastNameInputArgument = $command->getDefinition()->getArgument('first-name');
+        self::assertSame('first-name', $lastNameInputArgument->getName());
         self::assertFalse($lastNameInputArgument->isRequired());
         self::assertNull($lastNameInputArgument->getDefault());
 
-        $lastNameInputArgument = $command->getDefinition()->getArgument('lastName');
-        self::assertSame('lastName', $lastNameInputArgument->getName());
+        $lastNameInputArgument = $command->getDefinition()->getArgument('last-name');
+        self::assertSame('last-name', $lastNameInputArgument->getName());
         self::assertFalse($lastNameInputArgument->isRequired());
         self::assertSame('', $lastNameInputArgument->getDefault());
 

--- a/src/Symfony/Component/Console/composer.json
+++ b/src/Symfony/Component/Console/composer.json
@@ -20,7 +20,7 @@
         "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/service-contracts": "^2.5|^3",
-        "symfony/string": "^6.4|^7.0"
+        "symfony/string": "^7.2"
     },
     "require-dev": {
         "symfony/config": "^6.4|^7.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

As it is standard for console options/arguments to be named using kebab-case, I propose to map the invoke parameter names using their kebab-case form in the input definition when they are initially camelCased or snake_cased.