### PR TITLE
[Security] [LoginLink] Throw `InvalidLoginLinkException` on invalid parameters

### DIFF
--- a/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandler.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandler.php
@@ -86,8 +86,15 @@ final class LoginLinkHandler implements LoginLinkHandlerInterface
         if (!$hash = $request->get('hash')) {
             throw new InvalidLoginLinkException('Missing "hash" parameter.');
         }
+        if (!is_string($hash)) {
+            throw new InvalidLoginLinkException('Invalid "hash" parameter.');
+        }
+
         if (!$expires = $request->get('expires')) {
             throw new InvalidLoginLinkException('Missing "expires" parameter.');
+        }
+        if (preg_match('/^\d+$/', $expires) !== 1) {
+            throw new InvalidLoginLinkException('Invalid "expires" parameter.');
         }
 
         try {

--- a/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
@@ -240,6 +240,30 @@ class LoginLinkHandlerTest extends TestCase
         $linker->consumeLoginLink($request);
     }
 
+    public function testConsumeLoginLinkWithInvalidExpiration()
+    {
+        $user = new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash');
+        $this->userProvider->createUser($user);
+
+        $this->expectException(InvalidLoginLinkException::class);
+        $request = Request::create('/login/verify?user=weaverryan&hash=thehash&expires=%E2%80%AA1000000000%E2%80%AC');
+
+        $linker = $this->createLinker();
+        $linker->consumeLoginLink($request);
+    }
+
+    public function testConsumeLoginLinkWithInvalidHash()
+    {
+        $user = new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash');
+        $this->userProvider->createUser($user);
+
+        $this->expectException(InvalidLoginLinkException::class);
+        $request = Request::create('/login/verify?user=weaverryan&hash[]=an&hash[]=array&expires=1000000000');
+
+        $linker = $this->createLinker();
+        $linker->consumeLoginLink($request);
+    }
+
     private function createSignatureHash(string $username, int $expires, array $extraFields = ['emailProperty' => 'ryan@symfonycasts.com', 'passwordProperty' => 'pwhash']): string
     {
         $hasher = new SignatureHasher($this->propertyAccessor, array_keys($extraFields), 's3cret');


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60347
| License       | MIT

With this change, in addition to checking the presence of the required request parameters, also the type is checked.

