### PR TITLE
[Console] Run `InvokableCommand` via `execute()` method.

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -214,12 +214,16 @@ class Command
      *
      * @return int 0 if everything went fine, or an exit code
      *
-     * @throws LogicException When this abstract method is not implemented
+     * @throws LogicException When this abstract method is not implemented or doesn't implement InvokableCommand
      *
      * @see setCode()
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        if ($this->code) {
+            return ($this->code)($input, $output);
+        }
+
         throw new LogicException('You must override the execute() method in the concrete command class.');
     }
 
@@ -310,10 +314,6 @@ class Command
         }
 
         $input->validate();
-
-        if ($this->code) {
-            return ($this->code)($input, $output);
-        }
 
         return $this->execute($input, $output);
     }


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | n/a
| License       | MIT

Laravel Framework always allows handling a command either via `handle()` method or `__invoke()` method. The changes made for Symfony 7.3 will create an issue on existing Laravel applications on Laravel 11 and 12 when version 7.3.0 becomes available. 

Having the changes in this PR will allow Laravel to override `configureAsInvokableCommand()` to keep the current behavior.


---------

Given the following class on a basic Laravel installation:

```php
<?php

namespace App\Console\Commands;

use Illuminate\Console\Command;
use Illuminate\Contracts\Config\Repository as ConfigRepository;

class HelloWorldCommand extends Command
{
    /**
     * The name of the console command.
     *
     * @var string
     */
    protected $name = 'app:hello-world';

    /**
     * The console command description.
     *
     * @var string
     */
    protected $description = 'Command description';

    /**
     * Execute the console command.
     */
    public function __invoke(ConfigRepository $config)
    {
        $this->components->info($config->get('app.name'));

        return self::SUCCESS;
    }
}
```

#### Result on Symfony 7.2

![CleanShot 2025-05-06 at 15 02 44](https://github.com/user-attachments/assets/3b6e0069-af32-44ae-868c-d77b1f7f077d)

#### Result on Symfony 7.3

![CleanShot 2025-05-06 at 15 03 26](https://github.com/user-attachments/assets/6177e92b-5854-4a06-976e-148295cca0dd)

