### PR TITLE
[Serializer] Add `CDATA_WRAPPING_NAME_PATTERN` support to `XmlEncoder`

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -568,6 +568,23 @@ XML;
         $this->assertEquals(get_object_vars($obj), $this->encoder->decode($source, 'xml'));
     }
 
+    public function testCDataNamePattern()
+    {
+        $expected = <<<'XML'
+<?xml version="1.0"?>
+<response><person><firstname><![CDATA[Benjamin]]></firstname><lastname><![CDATA[Alexandre]]></lastname><other>data</other></person><person><firstname><![CDATA[Damien]]></firstname><lastname><![CDATA[Clay]]></lastname><other>data</other></person></response>
+
+XML;
+        $source = ['person' => [
+            ['firstname' => 'Benjamin', 'lastname' => 'Alexandre', 'other' => 'data'],
+            ['firstname' => 'Damien', 'lastname' => 'Clay', 'other' => 'data'],
+        ]];
+
+        $this->assertEquals($expected, $this->encoder->encode($source, 'xml', [
+            XmlEncoder::CDATA_WRAPPING_NAME_PATTERN => '/(firstname|lastname)/',
+        ]));
+    }
+
     public function testDecodeIgnoreWhiteSpace()
     {
         $source = <<<'XML'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

### Add `CDATA_WRAPPING_NAME_PATTERN` support to XmlEncoder

This PR introduces a new option for the Symfony Serializer component's `XmlEncoder`: `CDATA_WRAPPING_NAME_PATTERN`.

While Symfony already provides `CDATA_WRAPPING_PATTERN` to wrap field *content* in CDATA based on a regex match, this new feature enables CDATA wrapping based on the **field name**—regardless of the field's content.

**Example use case:**

```php
$this->encoder->encode($data, 'xml', [
    XmlEncoder::CDATA_WRAPPING_NAME_PATTERN => '(firstname|lastname)'
]);
```

This ensures that fields named `firstname` or `lastname` are always wrapped in CDATA tags, even if their content doesn't match the typical pattern used by `CDATA_WRAPPING_PATTERN`.

### Motivation:

* **Consistent Output**: In many integration scenarios (e.g., with legacy systems, XML consumers, or strict XSD schemas), consumers expect certain fields to **always** use CDATA sections—even when their content doesn't require escaping. This option allows for deterministic XML output by name.

* **Better Control**: It separates concerns: one can now configure CDATA-wrapping for *content-based* needs and *field-based* policies independently.

* **Backward Compatible**: The feature is fully optional and does not interfere with existing behavior unless the option is explicitly set.

