### PR TITLE
don't hardcode OS-depending constant values

### DIFF
--- a/src/Symfony/Component/Console/Tests/SignalRegistry/SignalMapTest.php
+++ b/src/Symfony/Component/Console/Tests/SignalRegistry/SignalMapTest.php
@@ -18,15 +18,19 @@ class SignalMapTest extends TestCase
 {
     /**
      * @requires extension pcntl
-     *
-     * @testWith [2, "SIGINT"]
-     *           [9, "SIGKILL"]
-     *           [15, "SIGTERM"]
-     *           [31, "SIGSYS"]
+     * @dataProvider provideSignals
      */
     public function testSignalExists(int $signal, string $expected)
     {
         $this->assertSame($expected, SignalMap::getSignalName($signal));
+    }
+
+    public function provideSignals()
+    {
+        yield [\SIGINT, 'SIGINT'];
+        yield [\SIGKILL, 'SIGKILL'];
+        yield [\SIGTERM, 'SIGTERM'];
+        yield [\SIGSYS, 'SIGSYS'];
     }
 
     public function testSignalDoesNotExist()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

The values of the `SIG*` constants depend on the OS.

For example, on macOS the value of the `SIGSYS` constant is 12 and not 31 making the test added in #60168 fail.