### PR TITLE
[Console] Ensure overriding `Command::execute()` keeps priority over `__invoke()`

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -134,7 +134,7 @@ class Command
             $this->setHelp($attribute?->help ?? '');
         }
 
-        if (\is_callable($this)) {
+        if (\is_callable($this) && (new \ReflectionMethod($this, 'execute'))->getDeclaringClass()->name === self::class) {
             $this->code = new InvokableCommand($this, $this(...));
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Replace #60353
| License       | MIT

Implements https://github.com/symfony/symfony/pull/60353#discussion_r2074900654
