### PR TITLE
[FrameworkBundle] bump min constraint for the ObjectMapper component

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -54,7 +54,7 @@
         "symfony/messenger": "^6.4|^7.0",
         "symfony/mime": "^6.4|^7.0",
         "symfony/notifier": "^6.4|^7.0",
-        "symfony/object-mapper": "^7.3",
+        "symfony/object-mapper": "^v7.3.0-beta2",
         "symfony/process": "^6.4|^7.0",
         "symfony/rate-limiter": "^6.4|^7.0",
         "symfony/scheduler": "^6.4.4|^7.0.4",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

fixes the low deps job, we should revert this change after the next beta/rc/stable release
