### PR TITLE
[FrameworkBundle] ensure that all supported e-mail validation modes can be configured

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -45,6 +45,7 @@ use Symfony\Component\Serializer\Encoder\JsonDecode;
 use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Translation\Translator;
 use Symfony\Component\Uid\Factory\UuidFactory;
+use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Validation;
 use Symfony\Component\Webhook\Controller\WebhookController;
 use Symfony\Component\WebLink\HttpHeaderSerializer;
@@ -1066,7 +1067,7 @@ class Configuration implements ConfigurationInterface
                             ->validate()->castToArray()->end()
                         ->end()
                         ->scalarNode('translation_domain')->defaultValue('validators')->end()
-                        ->enumNode('email_validation_mode')->values(['html5', 'loose', 'strict'])->end()
+                        ->enumNode('email_validation_mode')->values(Email::VALIDATION_MODES + ['loose'])->end()
                         ->arrayNode('mapping')
                             ->addDefaultsIfNotSet()
                             ->fixXmlConfig('path')

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/PhpFrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/PhpFrameworkExtensionTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Exception\OutOfBoundsException;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Workflow\Exception\InvalidDefinitionException;
 
 class PhpFrameworkExtensionTest extends FrameworkExtensionTestCase
@@ -244,5 +245,32 @@ class PhpFrameworkExtensionTest extends FrameworkExtensionTestCase
         $this->expectExceptionMessageMatches('/^The argument "2" doesn\'t exist.*\.$/');
 
         $container->getDefinition('limiter.without_lock')->getArgument(2);
+    }
+
+    /**
+     * @dataProvider emailValidationModeProvider
+     */
+    public function testValidatorEmailValidationMode(string $mode)
+    {
+        $this->expectNotToPerformAssertions();
+
+        $this->createContainerFromClosure(function (ContainerBuilder $container) use ($mode) {
+            $container->loadFromExtension('framework', [
+                'annotations' => false,
+                'http_method_override' => false,
+                'handle_all_throwables' => true,
+                'php_errors' => ['log' => true],
+                'validation' => [
+                    'email_validation_mode' => $mode,
+                ],
+            ]);
+        });
+    }
+
+    public function emailValidationModeProvider()
+    {
+        foreach (Email::VALIDATION_MODES as $mode) {
+            yield [$mode];
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60352
| License       | MIT

this update was forgotten when adding the `html5-allow-no-tld` e-mail validation mode in #47872