### PR TITLE
[Console] Set description as first parameter to `Argument` and `Option` attributes

### DIFF
--- a/src/Symfony/Component/Console/Attribute/Argument.php
+++ b/src/Symfony/Component/Console/Attribute/Argument.php
@@ -35,8 +35,8 @@ class Argument
      * @param array<string|Suggestion>|callable(CompletionInput):list<string|Suggestion> $suggestedValues The values used for input completion
      */
     public function __construct(
-        public string $name = '',
         public string $description = '',
+        public string $name = '',
         array|callable $suggestedValues = [],
     ) {
         $this->suggestedValues = \is_callable($suggestedValues) ? $suggestedValues(...) : $suggestedValues;

--- a/src/Symfony/Component/Console/Attribute/Option.php
+++ b/src/Symfony/Component/Console/Attribute/Option.php
@@ -38,9 +38,9 @@ class Option
      * @param array<string|Suggestion>|callable(CompletionInput):list<string|Suggestion> $suggestedValues The values used for input completion
      */
     public function __construct(
+        public string $description = '',
         public string $name = '',
         public array|string|null $shortcut = null,
-        public string $description = '',
         array|callable $suggestedValues = [],
     ) {
         $this->suggestedValues = \is_callable($suggestedValues) ? $suggestedValues(...) : $suggestedValues;


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #60359 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

`Argument` and `Option` arguments were introduced in 7.3
