### PR TITLE
[Console] properly skip signal test if the pcntl extension is not installed

### DIFF
--- a/src/Symfony/Component/Console/Tests/SignalRegistry/SignalMapTest.php
+++ b/src/Symfony/Component/Console/Tests/SignalRegistry/SignalMapTest.php
@@ -18,19 +18,13 @@ class SignalMapTest extends TestCase
 {
     /**
      * @requires extension pcntl
-     * @dataProvider provideSignals
      */
-    public function testSignalExists(int $signal, string $expected)
+    public function testSignalExists()
     {
-        $this->assertSame($expected, SignalMap::getSignalName($signal));
-    }
-
-    public function provideSignals()
-    {
-        yield [\SIGINT, 'SIGINT'];
-        yield [\SIGKILL, 'SIGKILL'];
-        yield [\SIGTERM, 'SIGTERM'];
-        yield [\SIGSYS, 'SIGSYS'];
+        $this->assertSame('SIGINT', SignalMap::getSignalName(\SIGINT));
+        $this->assertSame('SIGKILL', SignalMap::getSignalName(\SIGKILL));
+        $this->assertSame('SIGTERM', SignalMap::getSignalName(\SIGTERM));
+        $this->assertSame('SIGSYS', SignalMap::getSignalName(\SIGSYS));
     }
 
     public function testSignalDoesNotExist()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

In #60356 I missed that the build on Windows running tests without the pcntl extension failed.