### PR TITLE
[Mailer][SendGrid] add support for scheduling delivery via `send_at` API parameter

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add support for scheduling delivery with the `send_at` API parameter via a `Send-At` date-header
+
 7.4
 ---
 

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/README.md
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/README.md
@@ -60,6 +60,20 @@ where:
  - `GROUP_ID` is your Sendgrid suppression group ID
  - `GROUPS_TO_DISPLAY_ID` is an array of the Sendgrid suppression group IDs presented to the user
 
+Scheduling
+----------
+
+When using the **API transport** (with a `sendgrid+api` DSN), you can schedule
+your emails by providing a `\DateTimeInterface` object in a
+`Symfony\Component\Mime\Header\DateHeader` named `Send-At`.
+
+```php
+$email = new \Symfony\Component\Mime\Email();
+$email->getHeaders()->addDateHeader('Send-At', new \DateTimeImmutable('+3 hours'));
+```
+It will be mapped to the `send_at` parameter of the `[POST] /mail/send`
+[API endpoint](https://www.twilio.com/docs/sendgrid/api-reference/mail-send/mail-send#request-body)
+
 Resources
 ---------
 

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridApiTransportTest.php
@@ -313,4 +313,18 @@ class SendgridApiTransportTest extends TestCase
 
         $this->assertSame([1, 2, 3, 4, 5], $payload['asm']['groups_to_display']);
     }
+
+    public function testSendAtHeader()
+    {
+        $email = new Email();
+        $email->getHeaders()->addDateHeader('Send-At', new \DateTime('2025-05-07 16:00:00', new \DateTimeZone('Europe/Paris')));
+        $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
+
+        $transport = new SendgridApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(SendgridApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertArrayHasKey('send_at', $payload);
+        $this->assertSame(1746626400, $payload['send_at']);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | N/A
| License       | MIT

This PR adds support for scheduling delivery when using the SendGrid **API transport** (with a `sendgrid+api` DSN), by providing a `\DateTimeInterface` object in a `Symfony\Component\Mime\Header\DateHeader` named `Send-At`.

```php
$email = new \Symfony\Component\Mime\Email();
$email->getHeaders()->addDateHeader('Send-At', (new \DateTime())->modify('+3 hours'));
```
It will be mapped to the `send_at` parameter of the `[POST] /mail/send` [API endpoint](https://www.twilio.com/docs/sendgrid/api-reference/mail-send/mail-send#request-body).
