### PR TITLE
[FrameworkBundle] Ensure `Email` class exists before using it

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1067,7 +1067,7 @@ class Configuration implements ConfigurationInterface
                             ->validate()->castToArray()->end()
                         ->end()
                         ->scalarNode('translation_domain')->defaultValue('validators')->end()
-                        ->enumNode('email_validation_mode')->values(Email::VALIDATION_MODES + ['loose'])->end()
+                        ->enumNode('email_validation_mode')->values((class_exists(Email::class) ? Email::VALIDATION_MODES : ['html5-allow-no-tld', 'html5', 'strict']) + ['loose'])->end()
                         ->arrayNode('mapping')
                             ->addDefaultsIfNotSet()
                             ->fixXmlConfig('path')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

I think the [dev-tests suite from Symfony UX](https://github.com/symfony/ux/actions/runs/14886649078/job/41808040295?pr=2711) broke after https://github.com/symfony/symfony/pull/60365, see: 
```
1) Symfony\UX\Icons\Tests\Integration\Command\ImportIconCommandTest::testCanImportIcon
Error: Class "Symfony\Component\Validator\Constraints\Email" not found

/home/runner/work/ux/ux/src/Icons/vendor/symfony/framework-bundle/DependencyInjection/Configuration.php:10[79](https://github.com/symfony/ux/actions/runs/14886649078/job/41808040295?pr=2711#step:8:80)
/home/runner/work/ux/ux/src/Icons/vendor/symfony/framework-bundle/DependencyInjection/Configuration.php:163
/home/runner/work/ux/ux/src/Icons/vendor/symfony/config/Definition/Processor.php:46
/home/runner/work/ux/ux/src/Icons/vendor/symfony/dependency-injection/Extension/Extension.php:109
/home/runner/work/ux/ux/src/Icons/vendor/symfony/framework-bundle/DependencyInjection/FrameworkExtension.php:306
/home/runner/work/ux/ux/src/Icons/vendor/symfony/dependency-injection/Compiler/MergeExtensionConfigurationPass.php:[81](https://github.com/symfony/ux/actions/runs/14886649078/job/41808040295?pr=2711#step:8:82)
/home/runner/work/ux/ux/src/Icons/vendor/symfony/http-kernel/DependencyInjection/MergeExtensionConfigurationPass.php:40
/home/runner/work/ux/ux/src/Icons/vendor/symfony/dependency-injection/Compiler/Compiler.php:73
/home/runner/work/ux/ux/src/Icons/vendor/symfony/dependency-injection/ContainerBuilder.php:813
/home/runner/work/ux/ux/src/Icons/vendor/symfony/http-kernel/Kernel.php:499
/home/runner/work/ux/ux/src/Icons/vendor/symfony/http-kernel/Kernel.php:744
/home/runner/work/ux/ux/src/Icons/vendor/symfony/http-kernel/Kernel.php:120
/home/runner/work/ux/ux/src/Icons/vendor/symfony/framework-bundle/Test/KernelTestCase.php:67
/home/runner/work/ux/ux/src/Icons/vendor/zenstruck/console-test/src/InteractsWithConsole.php:40
/home/runner/work/ux/ux/src/Icons/vendor/zenstruck/console-test/src/InteractsWithConsole.php:27
/home/runner/work/ux/ux/src/Icons/tests/Integration/Command/ImportIconCommandTest.php:46
```