### PR TITLE
[PropertyAccess] Improve PropertyAccessor::setValue param docs

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -109,6 +109,11 @@ class PropertyAccessor implements PropertyAccessorInterface
         return $propertyValues[\count($propertyValues) - 1][self::VALUE];
     }
 
+    /**
+     * @template T of object|array
+     * @param T $objectOrArray
+     * @param-out ($objectOrArray is array ? array : T) $objectOrArray
+     */
     public function setValue(object|array &$objectOrArray, string|PropertyPathInterface $propertyPath, mixed $value): void
     {
         if (\is_object($objectOrArray) && (false === strpbrk((string) $propertyPath, '.[') || $objectOrArray instanceof \stdClass && property_exists($objectOrArray, $propertyPath))) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This pull request was made to help static code analyzers understand that when calling `PropertyAccessor::setValue`, this will not change the type of the passed `$objectOrArray`. 
At the moment static analysis will point out that the value of `$objectOrArray` can be any object or an array after calling the `setValue` method, which is of course not the case.

The solution comes directly from this closed PHPStan issue: https://github.com/phpstan/phpstan/issues/12399 
(Other tools like Psalm also support `@param-out`)