### PR TITLE
[Runtime] fix tests

### DIFF
--- a/src/Symfony/Component/Runtime/Tests/phpt/application.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/application.php
@@ -18,8 +18,10 @@ require __DIR__.'/autoload.php';
 
 return function (array $context) {
     $command = new Command('go');
-    $command->setCode(function (InputInterface $input, OutputInterface $output) use ($context) {
+    $command->setCode(function (InputInterface $input, OutputInterface $output) use ($context): int {
         $output->write('OK Application '.$context['SOME_VAR']);
+
+        return 0;
     });
 
     $app = new Application();

--- a/src/Symfony/Component/Runtime/Tests/phpt/command.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/command.php
@@ -19,7 +19,9 @@ require __DIR__.'/autoload.php';
 return function (Command $command, InputInterface $input, OutputInterface $output, array $context) {
     $command->addOption('hello', 'e', InputOption::VALUE_REQUIRED, 'How should I greet?', 'OK');
 
-    return $command->setCode(function () use ($input, $output, $context) {
+    return $command->setCode(function () use ($input, $output, $context): int {
         $output->write($input->getOption('hello').' Command '.$context['SOME_VAR']);
+
+        return 0;
     });
 };

--- a/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload_command_debug_exists_0_to_1.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload_command_debug_exists_0_to_1.php
@@ -20,6 +20,8 @@ $_SERVER['APP_RUNTIME_OPTIONS'] = [
 
 require __DIR__.'/autoload.php';
 
-return static fn (Command $command, OutputInterface $output, array $context): Command => $command->setCode(static function () use ($output, $context): void {
+return static fn (Command $command, OutputInterface $output, array $context): Command => $command->setCode(static function () use ($output, $context): int {
     $output->writeln($context['DEBUG_ENABLED']);
+
+    return 0;
 });

--- a/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload_command_debug_exists_1_to_0.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload_command_debug_exists_1_to_0.php
@@ -20,6 +20,8 @@ $_SERVER['APP_RUNTIME_OPTIONS'] = [
 
 require __DIR__.'/autoload.php';
 
-return static fn (Command $command, OutputInterface $output, array $context): Command => $command->setCode(static function () use ($output, $context): void {
+return static fn (Command $command, OutputInterface $output, array $context): Command => $command->setCode(static function () use ($output, $context): int {
     $output->writeln($context['DEBUG_MODE']);
+
+    return 0;
 });

--- a/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload_command_env_exists.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload_command_env_exists.php
@@ -20,6 +20,8 @@ $_SERVER['APP_RUNTIME_OPTIONS'] = [
 
 require __DIR__.'/autoload.php';
 
-return static fn (Command $command, OutputInterface $output, array $context): Command => $command->setCode(static function () use ($output, $context): void {
+return static fn (Command $command, OutputInterface $output, array $context): Command => $command->setCode(static function () use ($output, $context): int {
     $output->writeln($context['ENV_MODE']);
+
+    return 0;
 });

--- a/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload_command_no_debug.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload_command_no_debug.php
@@ -19,6 +19,8 @@ $_SERVER['APP_RUNTIME_OPTIONS'] = [
 
 require __DIR__.'/autoload.php';
 
-return static fn (Command $command, OutputInterface $output, array $context): Command => $command->setCode(static function () use ($output, $context): void {
+return static fn (Command $command, OutputInterface $output, array $context): Command => $command->setCode(static function () use ($output, $context): int {
     $output->writeln($context['DEBUG_ENABLED']);
+
+    return 0;
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Since #60076 using a closure as the command code that does not return an integer is deprecated. This means that our tests can trigger deprecations on older branches when the high deps job is run. This usually is not an issue as we silence them with the `SYMFONY_DEPRECATIONS_HELPER` env var. However, phpt tests are run in a child process where the deprecation error handler of the PHPUnit bridge doesn't step in. Thus, for them deprecations are not silenced leading to failures.