### PR TITLE
[HttpFoundation] Emit PHP warning when `Response::sendHeaders()` is called while output has already been sent

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -317,6 +317,11 @@ class Response
     {
         // headers have already been sent by the developer
         if (headers_sent()) {
+            if (!\in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
+                $statusCode ??= $this->statusCode;
+                header(\sprintf('HTTP/%s %s %s', $this->version, $statusCode, $this->statusText), true, $statusCode);
+            }
+
             return $this;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Description:

When Symfony attempts to send HTTP headers via the sendHeaders() method, it silently aborts if headers have already been sent (e.g., due to whitespace before the <?php tag). I spent an entire day debugging this issue and discovered that the problem was caused by an unintended whitespace before a PHP opening tag. To avoid this kind of silent failure and make future debugging easier, I decided to add an error log.