### PR TITLE
[Security] Avoid failing when PersistentRememberMeHandler handles a malformed cookie

### DIFF
--- a/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php
@@ -160,7 +160,12 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
             return;
         }
 
-        $rememberMeDetails = RememberMeDetails::fromRawCookie($cookie);
+        try {
+            $rememberMeDetails = RememberMeDetails::fromRawCookie($cookie);
+        } catch (AuthenticationException) {
+            // malformed cookie should not fail the response and can be simply ignored
+            return;
+        }
         [$series] = explode(':', $rememberMeDetails->getValue());
         $this->tokenProvider->deleteTokenBySeries($series);
     }

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentRememberMeHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentRememberMeHandlerTest.php
@@ -74,6 +74,22 @@ class PersistentRememberMeHandlerTest extends TestCase
         $this->assertNull($cookie->getValue());
     }
 
+    public function testClearRememberMeCookieMalformedCookie()
+    {
+        $this->tokenProvider->expects($this->exactly(0))
+            ->method('deleteTokenBySeries');
+
+        $this->request->cookies->set('REMEMBERME', 'malformed');
+
+        $this->handler->clearRememberMeCookie();
+
+        $this->assertTrue($this->request->attributes->has(ResponseListener::COOKIE_ATTR_NAME));
+
+        /** @var Cookie $cookie */
+        $cookie = $this->request->attributes->get(ResponseListener::COOKIE_ATTR_NAME);
+        $this->assertNull($cookie->getValue());
+    }
+
     public function testConsumeRememberMeCookieValid()
     {
         $this->tokenProvider->expects($this->any())


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

If the remember me cookie is malformed like `"foo"` then the page crashes due to https://github.com/symfony/symfony/blob/7.3/src/Symfony/Component/Security/Http/RememberMe/RememberMeDetails.php#L39

Not a huge deal but not very elegant