### PR TITLE
Add extension requirements

### DIFF
--- a/src/Symfony/Component/Console/composer.json
+++ b/src/Symfony/Component/Console/composer.json
@@ -17,6 +17,8 @@
     ],
     "require": {
         "php": ">=8.2",
+        "ext-intl": "*",
+        "ext-mbstring": "*",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/service-contracts": "^2.5|^3",
         "symfony/string": "^6.4|^7.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes (not sure if bug or just bad DX, but it does _crash_ unexpectedly)
| New feature?  | no
| Deprecations? | no
| Issues        | see below
| License       | MIT

Instead of warning of the missing extensions during `composer install`, it crashes in PHP code, forcing us to search online to figure out that two extensions are required.