### PR TITLE
[Console] Add support for `SignalableCommandInterface` with invokable commands

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -17,7 +17,6 @@ use Symfony\Component\Console\Command\DumpCompletionCommand;
 use Symfony\Component\Console\Command\HelpCommand;
 use Symfony\Component\Console\Command\LazyCommand;
 use Symfony\Component\Console\Command\ListCommand;
-use Symfony\Component\Console\Command\SignalableCommandInterface;
 use Symfony\Component\Console\CommandLoader\CommandLoaderInterface;
 use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Completion\CompletionSuggestions;
@@ -1005,8 +1004,7 @@ class Application implements ResetInterface
             }
         }
 
-        $commandSignals = $command instanceof SignalableCommandInterface ? $command->getSubscribedSignals() : [];
-        if ($commandSignals || $this->dispatcher && $this->signalsToDispatchEvent) {
+        if (($commandSignals = $command->getSubscribedSignals()) || $this->dispatcher && $this->signalsToDispatchEvent) {
             $signalRegistry = $this->getSignalRegistry();
 
             if (Terminal::hasSttyAvailable()) {

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG
  * Add support for `LockableTrait` in invokable commands
  * Deprecate returning a non-integer value from a `\Closure` function set via `Command::setCode()`
  * Mark `#[AsCommand]` attribute as `@final`
+ * Add support for `SignalableCommandInterface` with invokable commands
 
 7.2
 ---

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -32,7 +32,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class Command
+class Command implements SignalableCommandInterface
 {
     // see https://tldp.org/LDP/abs/html/exitcodes.html
     public const SUCCESS = 0;
@@ -672,6 +672,16 @@ class Command
         }
 
         return $this->helperSet->get($name);
+    }
+
+    public function getSubscribedSignals(): array
+    {
+        return $this->code?->getSubscribedSignals() ?? [];
+    }
+
+    public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false
+    {
+        return $this->code?->handleSignal($signal, $previousExitCode) ?? false;
     }
 
     /**

--- a/src/Symfony/Component/Console/Command/TraceableCommand.php
+++ b/src/Symfony/Component/Console/Command/TraceableCommand.php
@@ -27,7 +27,7 @@ use Symfony\Component\Stopwatch\Stopwatch;
  *
  * @author Jules Pietri <jules@heahprod.com>
  */
-final class TraceableCommand extends Command implements SignalableCommandInterface
+final class TraceableCommand extends Command
 {
     public readonly Command $command;
     public int $exitCode;
@@ -89,15 +89,11 @@ final class TraceableCommand extends Command implements SignalableCommandInterfa
 
     public function getSubscribedSignals(): array
     {
-        return $this->command instanceof SignalableCommandInterface ? $this->command->getSubscribedSignals() : [];
+        return $this->command->getSubscribedSignals();
     }
 
     public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false
     {
-        if (!$this->command instanceof SignalableCommandInterface) {
-            return false;
-        }
-
         $event = $this->stopwatch->start($this->getName().'.handle_signal');
 
         $exit = $this->command->handleSignal($signal, $previousExitCode);

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_signalable.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_signalable.php
@@ -1,6 +1,5 @@
 <?php
 
-use Symfony\Component\Console\Command\SignalableCommandInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
@@ -12,7 +11,7 @@ while (!file_exists($vendor.'/vendor')) {
 }
 require $vendor.'/vendor/autoload.php';
 
-(new class extends SingleCommandApplication implements SignalableCommandInterface {
+(new class extends SingleCommandApplication {
     public function getSubscribedSignals(): array
     {
         return [SIGINT];

--- a/src/Symfony/Component/Console/Tests/phpt/alarm/command_exit.phpt
+++ b/src/Symfony/Component/Console/Tests/phpt/alarm/command_exit.phpt
@@ -7,7 +7,6 @@ Test command that exits
 
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Command\SignalableCommandInterface;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -19,7 +18,7 @@ while (!file_exists($vendor.'/vendor')) {
 }
 require $vendor.'/vendor/autoload.php';
 
-class MyCommand extends Command implements SignalableCommandInterface
+class MyCommand extends Command
 {
     protected function initialize(InputInterface $input, OutputInterface $output): void
     {

--- a/src/Symfony/Component/Console/Tests/phpt/signal/command_exit.phpt
+++ b/src/Symfony/Component/Console/Tests/phpt/signal/command_exit.phpt
@@ -7,7 +7,6 @@ Test command that exits
 
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Command\SignalableCommandInterface;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -19,7 +18,7 @@ while (!file_exists($vendor.'/vendor')) {
 }
 require $vendor.'/vendor/autoload.php';
 
-class MyCommand extends Command implements SignalableCommandInterface
+class MyCommand extends Command
 {
     protected function execute(InputInterface $input, OutputInterface $output): int
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Currently, it's not possible to use the `SignalableCommandInterface` with invokable commands.
This PR adds support for that.

```php
#[AsCommand(name: 'app:example')]
class ExampleCommand implements SignalableCommandInterface
{
    public function __invoke(InputInterface $input, OutputInterface $output): int
    {
        // ...

        return Command::SUCCESS;
    }

    public function getSubscribedSignals(): array
    {
        return [\SIGINT, \SIGTERM];
    }

    public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false
    {
        // handle signal

        return 0;
    }
}
```