### PR TITLE
[DependencyInjection][FrameworkBundle] Fix precedence of `App\Kernel` alias and ignore `container.excluded` tag on synthetic services

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -791,34 +791,34 @@ class FrameworkExtension extends Extension
         }
 
         $container->registerForAutoconfiguration(CompilerPassInterface::class)
-            ->addTag('container.excluded', ['source' => 'because it\'s a compiler pass'])->setAbstract(true);
+            ->addTag('container.excluded', ['source' => 'because it\'s a compiler pass']);
         $container->registerForAutoconfiguration(Constraint::class)
-            ->addTag('container.excluded', ['source' => 'because it\'s a validation constraint'])->setAbstract(true);
+            ->addTag('container.excluded', ['source' => 'because it\'s a validation constraint']);
         $container->registerForAutoconfiguration(TestCase::class)
-            ->addTag('container.excluded', ['source' => 'because it\'s a test case'])->setAbstract(true);
+            ->addTag('container.excluded', ['source' => 'because it\'s a test case']);
         $container->registerForAutoconfiguration(\UnitEnum::class)
-            ->addTag('container.excluded', ['source' => 'because it\'s an enum'])->setAbstract(true);
+            ->addTag('container.excluded', ['source' => 'because it\'s an enum']);
         $container->registerAttributeForAutoconfiguration(AsMessage::class, static function (ChildDefinition $definition) {
-            $definition->addTag('container.excluded', ['source' => 'because it\'s a messenger message'])->setAbstract(true);
+            $definition->addTag('container.excluded', ['source' => 'because it\'s a messenger message']);
         });
         $container->registerAttributeForAutoconfiguration(\Attribute::class, static function (ChildDefinition $definition) {
-            $definition->addTag('container.excluded', ['source' => 'because it\'s an attribute'])->setAbstract(true);
+            $definition->addTag('container.excluded', ['source' => 'because it\'s a PHP attribute']);
         });
         $container->registerAttributeForAutoconfiguration(Entity::class, static function (ChildDefinition $definition) {
-            $definition->addTag('container.excluded', ['source' => 'because it\'s a doctrine entity'])->setAbstract(true);
+            $definition->addTag('container.excluded', ['source' => 'because it\'s a Doctrine entity']);
         });
         $container->registerAttributeForAutoconfiguration(Embeddable::class, static function (ChildDefinition $definition) {
-            $definition->addTag('container.excluded', ['source' => 'because it\'s a doctrine embeddable'])->setAbstract(true);
+            $definition->addTag('container.excluded', ['source' => 'because it\'s a Doctrine embeddable']);
         });
         $container->registerAttributeForAutoconfiguration(MappedSuperclass::class, static function (ChildDefinition $definition) {
-            $definition->addTag('container.excluded', ['source' => 'because it\'s a doctrine mapped superclass'])->setAbstract(true);
+            $definition->addTag('container.excluded', ['source' => 'because it\'s a Doctrine mapped superclass']);
         });
 
         $container->registerAttributeForAutoconfiguration(JsonStreamable::class, static function (ChildDefinition $definition, JsonStreamable $attribute) {
             $definition->addTag('json_streamer.streamable', [
                 'object' => $attribute->asObject,
                 'list' => $attribute->asList,
-            ])->addTag('container.excluded', ['source' => 'because it\'s a streamable JSON'])->setAbstract(true);
+            ])->addTag('container.excluded', ['source' => 'because it\'s a streamable JSON']);
         });
 
         if (!$container->getParameter('kernel.debug')) {

--- a/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
@@ -165,7 +165,6 @@ trait MicroKernelTrait
                     ->setPublic(true)
                 ;
             }
-            $container->setAlias($kernelClass, 'kernel')->setPublic(true);
 
             $kernelDefinition = $container->getDefinition('kernel');
             $kernelDefinition->addTag('routing.route_loader');
@@ -198,6 +197,8 @@ trait MicroKernelTrait
                 $kernelLoader->registerAliasesForSinglyImplementedInterfaces();
                 AbstractConfigurator::$valuePreProcessor = $valuePreProcessor;
             }
+
+            $container->setAlias($kernelClass, 'kernel')->setPublic(true);
         });
     }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
@@ -112,8 +112,8 @@ class ResolveInstanceofConditionalsPass implements CompilerPassInterface
                 $definition = substr_replace($definition, '53', 2, 2);
                 $definition = substr_replace($definition, 'Child', 44, 0);
             }
-            /** @var ChildDefinition $definition */
             $definition = unserialize($definition);
+            /** @var ChildDefinition $definition */
             $definition->setParent($parent);
 
             if (null !== $shared && !isset($definition->getChanges()['shared'])) {
@@ -147,6 +147,11 @@ class ResolveInstanceofConditionalsPass implements CompilerPassInterface
                 ->setDecoratedService(null)
                 ->setTags([])
                 ->setAbstract(true);
+        }
+
+        if ($definition->isSynthetic()) {
+            // Ignore container.excluded tag on synthetic services
+            $definition->clearTag('container.excluded');
         }
 
         return $definition;

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInstanceofConditionalsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInstanceofConditionalsPassTest.php
@@ -376,6 +376,21 @@ class ResolveInstanceofConditionalsPassTest extends TestCase
         ], $container->getDefinition('decorator')->getTags());
         $this->assertFalse($container->hasParameter('container.behavior_describing_tags'));
     }
+
+    public function testSyntheticService()
+    {
+        $container = new ContainerBuilder();
+        $container->register('kernel', \stdClass::class)
+            ->setInstanceofConditionals([
+                \stdClass::class => (new ChildDefinition(''))
+                    ->addTag('container.excluded'),
+            ])
+            ->setSynthetic(true);
+
+        (new ResolveInstanceofConditionalsPass())->process($container);
+
+        $this->assertSame([], $container->getDefinition('kernel')->getTags());
+    }
 }
 
 class DecoratorWithBehavior implements ResetInterface, ResourceCheckerInterface, ServiceSubscriberInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60191
| License       | MIT

Autoconfiguration cannot make a service abstract so I'm removing the related calls, they're confusing.

Then, I'm moving the definition of the `App\Kernel` alias after loading `services.yaml`, so that the alias overrides the discovered corresponding class.

And I make instance-of-conditionals ignore `container.excluded` tags on synthetic services. An alternative could be to check if the class implements `KernelInterface` like proposed in https://github.com/symfony/symfony/issues/60191#issuecomment-2858889476 but I think the rule I'm proposing here is more generic.