### PR TITLE
[FrameworkBundle] Improve readability of disallow_search_engine_index condition

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -735,7 +735,7 @@ class FrameworkExtension extends Extension
             $container->getDefinition('config_cache_factory')->setArguments([]);
         }
 
-        if (!$config['disallow_search_engine_index'] ?? false) {
+        if (!$config['disallow_search_engine_index']) {
             $container->removeDefinition('disallow_search_engine_index_response_listener');
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4,
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no 
| Issues        | -
| License       | MIT


The use of the null coalescing operator (??) combined with the negation operator (!) and PHP's precedence rules makes this condition harder to read and understand—both for humans and IDEs.

Even my editor had trouble parsing it correctly.

To improve clarity, it's better to make the intention explicit by writing:

`if (!($config['disallow_search_engine_index'] ?? false))`

This makes the logic easier to follow and avoids any ambiguity.

