### PR TITLE
[Console][FrameworkBundle] Simplify using invokable commands when the component is used standalone

### DIFF
--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -8,6 +8,16 @@ Read more about this in the [Symfony documentation](https://symfony.com/doc/7.4/
 
 If you're upgrading from a version below 7.3, follow the [7.3 upgrade guide](UPGRADE-7.3.md) first.
 
+Console
+-------
+
+ * Deprecate `Symfony\Component\Console\Application::add()` in favor of `Symfony\Component\Console\Application::addCommand()`
+
+FrameworkBundle
+---------------
+
+ * Deprecate `Symfony\Bundle\FrameworkBundle\Console\Application::add()` in favor of `Symfony\Bundle\FrameworkBundle\Console\Application::addCommand()`
+
 HttpClient
 ----------
 

--- a/src/Symfony/Bridge/Twig/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Command/DebugCommandTest.php
@@ -304,7 +304,12 @@ TXT
         $environment = new Environment($loader);
 
         $application = new Application();
-        $application->add(new DebugCommand($environment, $projectDir, [], null, null));
+        $command = new DebugCommand($environment, $projectDir, [], null, null);
+        if (method_exists($application, 'addCommand')) {
+            $application->addCommand($command);
+        } else {
+            $application->add($command);
+        }
 
         $tester = new CommandCompletionTester($application->find('debug:twig'));
         $suggestions = $tester->complete($input, 2);
@@ -339,7 +344,12 @@ TXT
         }
 
         $application = new Application();
-        $application->add(new DebugCommand($environment, $projectDir, $bundleMetadata, $defaultPath, null));
+        $command = new DebugCommand($environment, $projectDir, $bundleMetadata, $defaultPath, null);
+        if (method_exists($application, 'addCommand')) {
+            $application->addCommand($command);
+        } else {
+            $application->add($command);
+        }
         $command = $application->find('debug:twig');
 
         return new CommandTester($command);

--- a/src/Symfony/Bridge/Twig/Tests/Command/LintCommandTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Command/LintCommandTest.php
@@ -179,7 +179,11 @@ class LintCommandTest extends TestCase
         $command = new LintCommand($environment);
 
         $application = new Application();
-        $application->add($command);
+        if (method_exists($application, 'addCommand')) {
+            $application->addCommand($command);
+        } else {
+            $application->add($command);
+        }
 
         return $application->find('lint:twig');
     }

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+ * Deprecate `Symfony\Bundle\FrameworkBundle\Console\Application::add()` in favor of `Symfony\Bundle\FrameworkBundle\Console\Application::addCommand()`
+
 7.3
 ---
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/AboutCommand/AboutCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/AboutCommand/AboutCommandTest.php
@@ -82,7 +82,7 @@ class AboutCommandTest extends TestCase
     private function createCommandTester(TestAppKernel $kernel): CommandTester
     {
         $application = new Application($kernel);
-        $application->add(new AboutCommand());
+        $application->addCommand(new AboutCommand());
 
         return new CommandTester($application->find('about'));
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CachePoolClearCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CachePoolClearCommandTest.php
@@ -36,7 +36,7 @@ class CachePoolClearCommandTest extends TestCase
     public function testComplete(array $input, array $expectedSuggestions)
     {
         $application = new Application($this->getKernel());
-        $application->add(new CachePoolClearCommand(new Psr6CacheClearer(['foo' => $this->cachePool]), ['foo']));
+        $application->addCommand(new CachePoolClearCommand(new Psr6CacheClearer(['foo' => $this->cachePool]), ['foo']));
         $tester = new CommandCompletionTester($application->get('cache:pool:clear'));
 
         $suggestions = $tester->complete($input);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CachePoolDeleteCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CachePoolDeleteCommandTest.php
@@ -90,7 +90,7 @@ class CachePoolDeleteCommandTest extends TestCase
     public function testComplete(array $input, array $expectedSuggestions)
     {
         $application = new Application($this->getKernel());
-        $application->add(new CachePoolDeleteCommand(new Psr6CacheClearer(['foo' => $this->cachePool]), ['foo']));
+        $application->addCommand(new CachePoolDeleteCommand(new Psr6CacheClearer(['foo' => $this->cachePool]), ['foo']));
         $tester = new CommandCompletionTester($application->get('cache:pool:delete'));
 
         $suggestions = $tester->complete($input);
@@ -125,7 +125,7 @@ class CachePoolDeleteCommandTest extends TestCase
     private function getCommandTester(KernelInterface $kernel): CommandTester
     {
         $application = new Application($kernel);
-        $application->add(new CachePoolDeleteCommand(new Psr6CacheClearer(['foo' => $this->cachePool])));
+        $application->addCommand(new CachePoolDeleteCommand(new Psr6CacheClearer(['foo' => $this->cachePool])));
 
         return new CommandTester($application->find('cache:pool:delete'));
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CachePruneCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CachePruneCommandTest.php
@@ -77,7 +77,7 @@ class CachePruneCommandTest extends TestCase
     private function getCommandTester(KernelInterface $kernel, RewindableGenerator $generator): CommandTester
     {
         $application = new Application($kernel);
-        $application->add(new CachePoolPruneCommand($generator));
+        $application->addCommand(new CachePoolPruneCommand($generator));
 
         return new CommandTester($application->find('cache:pool:prune'));
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterMatchCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterMatchCommandTest.php
@@ -46,8 +46,8 @@ class RouterMatchCommandTest extends TestCase
     private function createCommandTester(): CommandTester
     {
         $application = new Application($this->getKernel());
-        $application->add(new RouterMatchCommand($this->getRouter()));
-        $application->add(new RouterDebugCommand($this->getRouter()));
+        $application->addCommand(new RouterMatchCommand($this->getRouter()));
+        $application->addCommand(new RouterDebugCommand($this->getRouter()));
 
         return new CommandTester($application->find('router:match'));
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationDebugCommandTest.php
@@ -223,7 +223,7 @@ class TranslationDebugCommandTest extends TestCase
         $command = new TranslationDebugCommand($translator, $loader, $extractor, $this->translationDir.'/translations', $this->translationDir.'/templates', $transPaths, $codePaths, $enabledLocales);
 
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommand($command);
 
         return $application->find('debug:translation');
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationExtractCommandCompletionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationExtractCommandCompletionTest.php
@@ -132,7 +132,7 @@ class TranslationExtractCommandCompletionTest extends TestCase
         $command = new TranslationExtractCommand($writer, $loader, $extractor, 'en', $this->translationDir.'/translations', $this->translationDir.'/templates', $transPaths, $codePaths, ['en', 'fr']);
 
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommand($command);
 
         return new CommandCompletionTester($application->find('translation:extract'));
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationExtractCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationExtractCommandTest.php
@@ -304,7 +304,7 @@ class TranslationExtractCommandTest extends TestCase
         $command = new TranslationExtractCommand($writer, $loader, $extractor, 'en', $this->translationDir.'/translations', $this->translationDir.'/templates', $transPaths, $codePaths);
 
         $application = new Application($kernel);
-        $application->add($command);
+        $application->addCommand($command);
 
         return new CommandTester($application->find('translation:extract'));
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/WorkflowDumpCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/WorkflowDumpCommandTest.php
@@ -25,7 +25,12 @@ class WorkflowDumpCommandTest extends TestCase
     public function testComplete(array $input, array $expectedSuggestions)
     {
         $application = new Application();
-        $application->add(new WorkflowDumpCommand(new ServiceLocator([])));
+        $command = new WorkflowDumpCommand(new ServiceLocator([]));
+        if (method_exists($application, 'addCommand')) {
+            $application->addCommand($command);
+        } else {
+            $application->add($command);
+        }
 
         $tester = new CommandCompletionTester($application->find('workflow:dump'));
         $suggestions = $tester->complete($input, 2);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/XliffLintCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/XliffLintCommandTest.php
@@ -59,7 +59,12 @@ EOF;
     {
         if (!$application) {
             $application = new BaseApplication();
-            $application->add(new XliffLintCommand());
+            $command = new XliffLintCommand();
+            if (method_exists($application, 'addCommand')) {
+                $application->addCommand($command);
+            } else {
+                $application->add($command);
+            }
         }
 
         $command = $application->find('lint:xliff');

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/YamlLintCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/YamlLintCommandTest.php
@@ -107,7 +107,12 @@ EOF;
     {
         if (!$application) {
             $application = new BaseApplication();
-            $application->add(new YamlLintCommand());
+            $command = new YamlLintCommand();
+            if (method_exists($application, 'addCommand')) {
+                $application->addCommand($command);
+            } else {
+                $application->add($command);
+            }
         }
 
         $command = $application->find('lint:yaml');

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
@@ -119,7 +119,7 @@ class ApplicationTest extends TestCase
 
         $application = new Application($kernel);
         $newCommand = new Command('example');
-        $application->add($newCommand);
+        $application->addCommand($newCommand);
 
         $this->assertSame($newCommand, $application->get('example'));
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/BundlePathsTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/BundlePathsTest.php
@@ -28,7 +28,7 @@ class BundlePathsTest extends AbstractWebTestCase
         $fs = new Filesystem();
         $fs->remove($projectDir);
         $fs->mkdir($projectDir.'/public');
-        $command = (new Application($kernel))->add(new AssetsInstallCommand($fs, $projectDir));
+        $command = (new Application($kernel))->addCommand(new AssetsInstallCommand($fs, $projectDir));
         $exitCode = (new CommandTester($command))->execute(['target' => $projectDir.'/public']);
 
         $this->assertSame(0, $exitCode);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolClearCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolClearCommandTest.php
@@ -146,7 +146,7 @@ class CachePoolClearCommandTest extends AbstractWebTestCase
     private function createCommandTester(?array $poolNames = null)
     {
         $application = new Application(static::$kernel);
-        $application->add(new CachePoolClearCommand(static::getContainer()->get('cache.global_clearer'), $poolNames));
+        $application->addCommand(new CachePoolClearCommand(static::getContainer()->get('cache.global_clearer'), $poolNames));
 
         return new CommandTester($application->find('cache:pool:clear'));
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolListCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolListCommandTest.php
@@ -46,7 +46,7 @@ class CachePoolListCommandTest extends AbstractWebTestCase
     private function createCommandTester(array $poolNames)
     {
         $application = new Application(static::$kernel);
-        $application->add(new CachePoolListCommand($poolNames));
+        $application->addCommand(new CachePoolListCommand($poolNames));
 
         return new CommandTester($application->find('cache:pool:list'));
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDebugCommandTest.php
@@ -241,7 +241,7 @@ class ConfigDebugCommandTest extends AbstractWebTestCase
     {
         $application = $this->createApplication($debug);
 
-        $application->add(new ConfigDebugCommand());
+        $application->addCommand(new ConfigDebugCommand());
         $tester = new CommandCompletionTester($application->get('debug:config'));
         $suggestions = $tester->complete($input);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDumpReferenceCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDumpReferenceCommandTest.php
@@ -132,7 +132,7 @@ EOL
     {
         $application = $this->createApplication($debug);
 
-        $application->add(new ConfigDumpReferenceCommand());
+        $application->addCommand(new ConfigDumpReferenceCommand());
         $tester = new CommandCompletionTester($application->get('config:dump-reference'));
         $suggestions = $tester->complete($input);
         $this->assertSame($expectedSuggestions, $suggestions);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/DebugAutowiringCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/DebugAutowiringCommandTest.php
@@ -122,7 +122,7 @@ class DebugAutowiringCommandTest extends AbstractWebTestCase
     public function testComplete(array $input, array $expectedSuggestions)
     {
         $kernel = static::bootKernel(['test_case' => 'ContainerDebug', 'root_config' => 'config.yml']);
-        $command = (new Application($kernel))->add(new DebugAutowiringCommand());
+        $command = (new Application($kernel))->addCommand(new DebugAutowiringCommand());
 
         $tester = new CommandCompletionTester($command);
 

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -5,6 +5,8 @@ CHANGELOG
 ---
 
  * Allow setting aliases and the hidden flag via the command name passed to the constructor
+ * Introduce `Symfony\Component\Console\Application::addCommand()` to simplify using invokable commands when the component is used standalone
+ * Deprecate `Symfony\Component\Console\Application::add()` in favor of `Symfony\Component\Console\Application::addCommand()`
 
 7.3
 ---

--- a/src/Symfony/Component/Console/SingleCommandApplication.php
+++ b/src/Symfony/Component/Console/SingleCommandApplication.php
@@ -57,7 +57,7 @@ class SingleCommandApplication extends Command
         $application->setAutoExit($this->autoExit);
         // Fix the usage of the command displayed with "--help"
         $this->setName($_SERVER['argv'][0]);
-        $application->add($this);
+        $application->addCommand($this);
         $application->setDefaultCommand($this->getName(), true);
 
         $this->running = true;

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -50,7 +50,7 @@ class CommandTest extends TestCase
     {
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('The command defined in "Symfony\Component\Console\Command\Command" cannot have an empty name.');
-        (new Application())->add(new Command());
+        (new Application())->addCommand(new Command());
     }
 
     public function testSetApplication()
@@ -190,7 +190,7 @@ class CommandTest extends TestCase
         $command = new \TestCommand();
         $command->setHelp('The %command.name% command does... Example: %command.full_name%.');
         $application = new Application();
-        $application->add($command);
+        $application->addCommand($command);
         $application->setDefaultCommand('namespace:name', true);
         $this->assertStringContainsString('The namespace:name command does...', $command->getProcessedHelp(), '->getProcessedHelp() replaces %command.name% correctly in single command applications');
         $this->assertStringNotContainsString('%command.full_name%', $command->getProcessedHelp(), '->getProcessedHelp() replaces %command.full_name% in single command applications');

--- a/src/Symfony/Component/Console/Tests/Command/CompleteCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CompleteCommandTest.php
@@ -33,7 +33,7 @@ class CompleteCommandTest extends TestCase
         $this->command = new CompleteCommand();
 
         $this->application = new Application();
-        $this->application->add(new CompleteCommandTest_HelloCommand());
+        $this->application->addCommand(new CompleteCommandTest_HelloCommand());
 
         $this->command->setApplication($this->application);
         $this->tester = new CommandTester($this->command);

--- a/src/Symfony/Component/Console/Tests/Command/HelpCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/HelpCommandTest.php
@@ -77,7 +77,7 @@ class HelpCommandTest extends TestCase
     {
         require_once realpath(__DIR__.'/../Fixtures/FooCommand.php');
         $application = new Application();
-        $application->add(new \FooCommand());
+        $application->addCommand(new \FooCommand());
         $tester = new CommandCompletionTester($application->get('help'));
         $suggestions = $tester->complete($input, 2);
         $this->assertSame($expectedSuggestions, $suggestions);

--- a/src/Symfony/Component/Console/Tests/Command/ListCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/ListCommandTest.php
@@ -54,7 +54,7 @@ EOF;
     {
         require_once realpath(__DIR__.'/../Fixtures/FooCommand.php');
         $application = new Application();
-        $application->add(new \FooCommand());
+        $application->addCommand(new \FooCommand());
         $commandTester = new CommandTester($command = $application->get('list'));
         $commandTester->execute(['command' => $command->getName(), 'namespace' => 'foo', '--raw' => true]);
         $output = <<<'EOF'
@@ -69,7 +69,7 @@ EOF;
     {
         require_once realpath(__DIR__.'/../Fixtures/Foo6Command.php');
         $application = new Application();
-        $application->add(new \Foo6Command());
+        $application->addCommand(new \Foo6Command());
         $commandTester = new CommandTester($command = $application->get('list'));
         $commandTester->execute(['command' => $command->getName()], ['decorated' => false]);
         $output = <<<'EOF'
@@ -102,7 +102,7 @@ EOF;
     {
         require_once realpath(__DIR__.'/../Fixtures/Foo6Command.php');
         $application = new Application();
-        $application->add(new \Foo6Command());
+        $application->addCommand(new \Foo6Command());
         $commandTester = new CommandTester($command = $application->get('list'));
         $commandTester->execute(['command' => $command->getName(), '--raw' => true]);
         $output = <<<'EOF'
@@ -122,7 +122,7 @@ EOF;
     {
         require_once realpath(__DIR__.'/../Fixtures/FooCommand.php');
         $application = new Application();
-        $application->add(new \FooCommand());
+        $application->addCommand(new \FooCommand());
         $tester = new CommandCompletionTester($application->get('list'));
         $suggestions = $tester->complete($input, 2);
         $this->assertSame($expectedSuggestions, $suggestions);

--- a/src/Symfony/Component/Console/Tests/ConsoleEventsTest.php
+++ b/src/Symfony/Component/Console/Tests/ConsoleEventsTest.php
@@ -58,7 +58,7 @@ class ConsoleEventsTest extends TestCase
             ->setPublic(true)
             ->addMethodCall('setAutoExit', [false])
             ->addMethodCall('setDispatcher', [new Reference('event_dispatcher')])
-            ->addMethodCall('add', [new Reference('failing_command')])
+            ->addMethodCall('addCommand', [new Reference('failing_command')])
         ;
 
         $container->compile();

--- a/src/Symfony/Component/Console/Tests/Descriptor/ApplicationDescriptionTest.php
+++ b/src/Symfony/Component/Console/Tests/Descriptor/ApplicationDescriptionTest.php
@@ -25,7 +25,7 @@ final class ApplicationDescriptionTest extends TestCase
     {
         $application = new TestApplication();
         foreach ($names as $name) {
-            $application->add(new Command($name));
+            $application->addCommand(new Command($name));
         }
 
         $this->assertSame($expected, array_keys((new ApplicationDescription($application))->getNamespaces()));

--- a/src/Symfony/Component/Console/Tests/Fixtures/DescriptorApplication2.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/DescriptorApplication2.php
@@ -18,9 +18,9 @@ class DescriptorApplication2 extends Application
     public function __construct()
     {
         parent::__construct('My Symfony application', 'v1.0');
-        $this->add(new DescriptorCommand1());
-        $this->add(new DescriptorCommand2());
-        $this->add(new DescriptorCommand3());
-        $this->add(new DescriptorCommand4());
+        $this->addCommand(new DescriptorCommand1());
+        $this->addCommand(new DescriptorCommand2());
+        $this->addCommand(new DescriptorCommand3());
+        $this->addCommand(new DescriptorCommand4());
     }
 }

--- a/src/Symfony/Component/Console/Tests/Fixtures/DescriptorApplicationMbString.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/DescriptorApplicationMbString.php
@@ -19,6 +19,6 @@ class DescriptorApplicationMbString extends Application
     {
         parent::__construct('MbString åpplicätion');
 
-        $this->add(new DescriptorCommandMbString());
+        $this->addCommand(new DescriptorCommandMbString());
     }
 }

--- a/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
@@ -104,7 +104,7 @@ class CommandTesterTest extends TestCase
             return 0;
         });
 
-        $application->add($command);
+        $application->addCommand($command);
 
         $tester = new CommandTester($application->find('foo'));
 

--- a/src/Symfony/Component/Console/Tests/phpt/alarm/command_exit.phpt
+++ b/src/Symfony/Component/Console/Tests/phpt/alarm/command_exit.phpt
@@ -53,7 +53,7 @@ class MyCommand extends Command
 
 $app = new Application();
 $app->setDispatcher(new \Symfony\Component\EventDispatcher\EventDispatcher());
-$app->add(new MyCommand('foo'));
+$app->addCommand(new MyCommand('foo'));
 
 $app
     ->setDefaultCommand('foo', true)

--- a/src/Symfony/Component/Console/Tests/phpt/signal/command_exit.phpt
+++ b/src/Symfony/Component/Console/Tests/phpt/signal/command_exit.phpt
@@ -45,7 +45,7 @@ class MyCommand extends Command
 
 $app = new Application();
 $app->setDispatcher(new \Symfony\Component\EventDispatcher\EventDispatcher());
-$app->add(new MyCommand('foo'));
+$app->addCommand(new MyCommand('foo'));
 
 $app
     ->setDefaultCommand('foo', true)

--- a/src/Symfony/Component/Dotenv/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/Command/DebugCommandTest.php
@@ -288,7 +288,11 @@ OUTPUT;
 
         $command = new DebugCommand($env, $projectDirectory);
         $application = new Application();
-        $application->add($command);
+        if (method_exists($application, 'addCommand')) {
+            $application->addCommand($command);
+        } else {
+            $application->add($command);
+        }
         $tester = new CommandCompletionTester($application->get('debug:dotenv'));
         $this->assertSame(['FOO', 'TEST'], $tester->complete(['']));
     }

--- a/src/Symfony/Component/Dotenv/Tests/Command/DotenvDumpCommandTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/Command/DotenvDumpCommandTest.php
@@ -95,7 +95,12 @@ EOF
     private function createCommand(): CommandTester
     {
         $application = new Application();
-        $application->add(new DotenvDumpCommand(__DIR__));
+        $command = new DotenvDumpCommand(__DIR__);
+        if (method_exists($application, 'addCommand')) {
+            $application->addCommand($command);
+        } else {
+            $application->add($command);
+        }
 
         return new CommandTester($application->find('dotenv:dump'));
     }

--- a/src/Symfony/Component/ErrorHandler/Tests/Command/ErrorDumpCommandTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Command/ErrorDumpCommandTest.php
@@ -102,11 +102,16 @@ class ErrorDumpCommandTest extends TestCase
         $entrypointLookup = $this->createMock(EntrypointLookupInterface::class);
 
         $application = new Application($kernel);
-        $application->add(new ErrorDumpCommand(
+        $command = new ErrorDumpCommand(
             new Filesystem(),
             $errorRenderer,
             $entrypointLookup,
-        ));
+        );
+        if (method_exists($application, 'addCommand')) {
+            $application->addCommand($command);
+        } else {
+            $application->add($command);
+        }
 
         return new CommandTester($application->find('error:dump'));
     }

--- a/src/Symfony/Component/Form/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Form/Tests/Command/DebugCommandTest.php
@@ -194,7 +194,11 @@ TXT
         $formRegistry = new FormRegistry([], new ResolvedFormTypeFactory());
         $command = new DebugCommand($formRegistry);
         $application = new Application();
-        $application->add($command);
+        if (method_exists($application, 'addCommand')) {
+            $application->addCommand($command);
+        } else {
+            $application->add($command);
+        }
         $tester = new CommandCompletionTester($application->get('debug:form'));
         $this->assertSame($expectedSuggestions, $tester->complete($input));
     }
@@ -278,7 +282,11 @@ TXT
         $formRegistry = new FormRegistry([], new ResolvedFormTypeFactory());
         $command = new DebugCommand($formRegistry, $namespaces, $types);
         $application = new Application();
-        $application->add($command);
+        if (method_exists($application, 'addCommand')) {
+            $application->addCommand($command);
+        } else {
+            $application->add($command);
+        }
 
         return new CommandTester($application->find('debug:form'));
     }

--- a/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
@@ -59,7 +59,11 @@ class ConsumeMessagesCommandTest extends TestCase
         $command = new ConsumeMessagesCommand(new RoutableMessageBus($busLocator), $receiverLocator, new EventDispatcher());
 
         $application = new Application();
-        $application->add($command);
+        if (method_exists($application, 'addCommand')) {
+            $application->addCommand($command);
+        } else {
+            $application->add($command);
+        }
         $tester = new CommandTester($application->get('messenger:consume'));
         $tester->execute([
             'receivers' => ['dummy-receiver'],
@@ -89,7 +93,11 @@ class ConsumeMessagesCommandTest extends TestCase
         $command = new ConsumeMessagesCommand(new RoutableMessageBus($busLocator), $receiverLocator, new EventDispatcher());
 
         $application = new Application();
-        $application->add($command);
+        if (method_exists($application, 'addCommand')) {
+            $application->addCommand($command);
+        } else {
+            $application->add($command);
+        }
         $tester = new CommandTester($application->get('messenger:consume'));
         $tester->execute([
             'receivers' => ['dummy-receiver'],
@@ -132,7 +140,11 @@ class ConsumeMessagesCommandTest extends TestCase
         $command = new ConsumeMessagesCommand($bus, $receiverLocator, new EventDispatcher(), null, [], new ResetServicesListener($servicesResetter));
 
         $application = new Application();
-        $application->add($command);
+        if (method_exists($application, 'addCommand')) {
+            $application->addCommand($command);
+        } else {
+            $application->add($command);
+        }
         $tester = new CommandTester($application->get('messenger:consume'));
         $tester->execute(array_merge([
             'receivers' => ['dummy-receiver'],
@@ -156,7 +168,11 @@ class ConsumeMessagesCommandTest extends TestCase
         $command = new ConsumeMessagesCommand(new RoutableMessageBus(new Container()), $receiverLocator, new EventDispatcher());
 
         $application = new Application();
-        $application->add($command);
+        if (method_exists($application, 'addCommand')) {
+            $application->addCommand($command);
+        } else {
+            $application->add($command);
+        }
         $tester = new CommandTester($application->get('messenger:consume'));
 
         $this->expectException(InvalidOptionException::class);
@@ -194,7 +210,11 @@ class ConsumeMessagesCommandTest extends TestCase
         $command = new ConsumeMessagesCommand(new RoutableMessageBus($busLocator), $receiverLocator, new EventDispatcher());
 
         $application = new Application();
-        $application->add($command);
+        if (method_exists($application, 'addCommand')) {
+            $application->addCommand($command);
+        } else {
+            $application->add($command);
+        }
         $tester = new CommandTester($application->get('messenger:consume'));
         $tester->execute([
             'receivers' => ['dummy-receiver'],
@@ -232,7 +252,11 @@ class ConsumeMessagesCommandTest extends TestCase
         );
 
         $application = new Application();
-        $application->add($command);
+        if (method_exists($application, 'addCommand')) {
+            $application->addCommand($command);
+        } else {
+            $application->add($command);
+        }
         $tester = new CommandTester($application->get('messenger:consume'));
         $tester->execute([
             '--all' => true,

--- a/src/Symfony/Component/Messenger/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/DebugCommandTest.php
@@ -176,7 +176,11 @@ TXT
     {
         $command = new DebugCommand(['command_bus' => [], 'query_bus' => []]);
         $application = new Application();
-        $application->add($command);
+        if (method_exists($application, 'addCommand')) {
+            $application->addCommand($command);
+        } else {
+            $application->add($command);
+        }
         $tester = new CommandCompletionTester($application->get('debug:messenger'));
         $this->assertSame($expectedSuggestions, $tester->complete($input));
     }

--- a/src/Symfony/Component/Runtime/SymfonyRuntime.php
+++ b/src/Symfony/Component/Runtime/SymfonyRuntime.php
@@ -162,7 +162,11 @@ class SymfonyRuntime extends GenericRuntime
 
             if (!$application->getName() || !$console->has($application->getName())) {
                 $application->setName($_SERVER['argv'][0]);
-                $console->add($application);
+                if (method_exists($console, 'addCommand')) {
+                    $console->addCommand($application);
+                } else {
+                    $console->add($application);
+                }
             }
 
             $console->setDefaultCommand($application->getName(), true);

--- a/src/Symfony/Component/Runtime/Tests/phpt/application.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/application.php
@@ -25,7 +25,11 @@ return function (array $context) {
     });
 
     $app = new Application();
-    $app->add($command);
+    if (method_exists($app, 'addCommand')) {
+        $app->addCommand($command);
+    } else {
+        $app->add($command);
+    }
     $app->setDefaultCommand('go', true);
 
     return $app;

--- a/src/Symfony/Component/Runtime/Tests/phpt/command_list.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/command_list.php
@@ -23,7 +23,11 @@ return function (Application $app, Command $command, RuntimeInterface $runtime) 
     $command->setName('my_command');
 
     [$cmd, $args] = $runtime->getResolver(require __DIR__.'/command.php')->resolve();
-    $app->add($cmd(...$args));
+    if (method_exists($app, 'addCommand')) {
+        $app->addCommand($cmd(...$args));
+    } else {
+        $app->add($cmd(...$args));
+    }
 
     return $app;
 };

--- a/src/Symfony/Component/Translation/Tests/Command/TranslationLintCommandTest.php
+++ b/src/Symfony/Component/Translation/Tests/Command/TranslationLintCommandTest.php
@@ -138,7 +138,11 @@ EOF, $display);
         $command = new TranslationLintCommand($translator, $enabledLocales);
 
         $application = new Application();
-        $application->add($command);
+        if (method_exists($application, 'addCommand')) {
+            $application->addCommand($command);
+        } else {
+            $application->add($command);
+        }
 
         return $command;
     }

--- a/src/Symfony/Component/Translation/Tests/Command/TranslationPullCommandTest.php
+++ b/src/Symfony/Component/Translation/Tests/Command/TranslationPullCommandTest.php
@@ -695,7 +695,12 @@ XLIFF
     public function testComplete(array $input, array $expectedSuggestions)
     {
         $application = new Application();
-        $application->add($this->createCommand($this->createMock(ProviderInterface::class), ['en', 'fr', 'it'], ['messages', 'validators'], 'en', ['loco', 'crowdin', 'lokalise']));
+        $command = $this->createCommand($this->createMock(ProviderInterface::class), ['en', 'fr', 'it'], ['messages', 'validators'], 'en', ['loco', 'crowdin', 'lokalise']);
+        if (method_exists($application, 'addCommand')) {
+            $application->addCommand($command);
+        } else {
+            $application->add($command);
+        }
 
         $tester = new CommandCompletionTester($application->get('translation:pull'));
         $suggestions = $tester->complete($input);
@@ -724,7 +729,11 @@ XLIFF
     {
         $command = $this->createCommand($provider, $locales, $domains, $defaultLocale);
         $application = new Application();
-        $application->add($command);
+        if (method_exists($application, 'addCommand')) {
+            $application->addCommand($command);
+        } else {
+            $application->add($command);
+        }
 
         return new CommandTester($application->find('translation:pull'));
     }

--- a/src/Symfony/Component/Translation/Tests/Command/TranslationPushCommandTest.php
+++ b/src/Symfony/Component/Translation/Tests/Command/TranslationPushCommandTest.php
@@ -361,7 +361,11 @@ class TranslationPushCommandTest extends TranslationProviderTestCase
         );
 
         $application = new Application();
-        $application->add($command);
+        if (method_exists($application, 'addCommand')) {
+            $application->addCommand($command);
+        } else {
+            $application->add($command);
+        }
         $tester = new CommandTester($application->find('translation:push'));
 
         $tester->execute(['--locales' => ['en', 'fr']]);
@@ -375,7 +379,12 @@ class TranslationPushCommandTest extends TranslationProviderTestCase
     public function testComplete(array $input, array $expectedSuggestions)
     {
         $application = new Application();
-        $application->add($this->createCommand($this->createMock(ProviderInterface::class), ['en', 'fr', 'it'], ['messages', 'validators'], ['loco', 'crowdin', 'lokalise']));
+        $command = $this->createCommand($this->createMock(ProviderInterface::class), ['en', 'fr', 'it'], ['messages', 'validators'], ['loco', 'crowdin', 'lokalise']);
+        if (method_exists($application, 'addCommand')) {
+            $application->addCommand($command);
+        } else {
+            $application->add($command);
+        }
 
         $tester = new CommandCompletionTester($application->get('translation:push'));
         $suggestions = $tester->complete($input);
@@ -404,7 +413,11 @@ class TranslationPushCommandTest extends TranslationProviderTestCase
     {
         $command = $this->createCommand($provider, $locales, $domains);
         $application = new Application();
-        $application->add($command);
+        if (method_exists($application, 'addCommand')) {
+            $application->addCommand($command);
+        } else {
+            $application->add($command);
+        }
 
         return new CommandTester($application->find('translation:push'));
     }

--- a/src/Symfony/Component/Translation/Tests/Command/XliffLintCommandTest.php
+++ b/src/Symfony/Component/Translation/Tests/Command/XliffLintCommandTest.php
@@ -210,7 +210,12 @@ XLIFF;
     {
         if (!$application) {
             $application = new Application();
-            $application->add(new XliffLintCommand(null, null, null, $requireStrictFileNames));
+            $command = new XliffLintCommand(null, null, null, $requireStrictFileNames);
+            if (method_exists($application, 'addCommand')) {
+                $application->addCommand($command);
+            } else {
+                $application->add($command);
+            }
         }
 
         $command = $application->find('lint:xliff');

--- a/src/Symfony/Component/Uid/Tests/Command/GenerateUlidCommandTest.php
+++ b/src/Symfony/Component/Uid/Tests/Command/GenerateUlidCommandTest.php
@@ -109,7 +109,12 @@ final class GenerateUlidCommandTest extends TestCase
     public function testComplete(array $input, array $expectedSuggestions)
     {
         $application = new Application();
-        $application->add(new GenerateUlidCommand());
+        $command = new GenerateUlidCommand();
+        if (method_exists($application, 'addCommand')) {
+            $application->addCommand($command);
+        } else {
+            $application->add($command);
+        }
         $tester = new CommandCompletionTester($application->get('ulid:generate'));
         $suggestions = $tester->complete($input, 2);
         $this->assertSame($expectedSuggestions, $suggestions);

--- a/src/Symfony/Component/Uid/Tests/Command/GenerateUuidCommandTest.php
+++ b/src/Symfony/Component/Uid/Tests/Command/GenerateUuidCommandTest.php
@@ -238,7 +238,12 @@ final class GenerateUuidCommandTest extends TestCase
     public function testComplete(array $input, array $expectedSuggestions)
     {
         $application = new Application();
-        $application->add(new GenerateUuidCommand());
+        $command = new GenerateUuidCommand();
+        if (method_exists($application, 'addCommand')) {
+            $application->addCommand($command);
+        } else {
+            $application->add($command);
+        }
         $tester = new CommandCompletionTester($application->get('uuid:generate'));
         $suggestions = $tester->complete($input, 2);
         $this->assertSame($expectedSuggestions, $suggestions);

--- a/src/Symfony/Component/VarDumper/Resources/bin/var-dump-server
+++ b/src/Symfony/Component/VarDumper/Resources/bin/var-dump-server
@@ -60,8 +60,13 @@ $app->getDefinition()->addOption(
     new InputOption('--host', null, InputOption::VALUE_REQUIRED, 'The address the server should listen to', $defaultHost)
 );
 
-$app->add($command = new ServerDumpCommand(new DumpServer($host, $logger)))
-    ->getApplication()
+$command = new ServerDumpCommand(new DumpServer($host, $logger));
+if (method_exists($app, 'addCommand')) {
+    $app->addCommand($command);
+} else {
+    $app->add($command);
+}
+$app
     ->setDefaultCommand($command->getName(), true)
     ->run($input, $output)
 ;

--- a/src/Symfony/Component/Yaml/Resources/bin/yaml-lint
+++ b/src/Symfony/Component/Yaml/Resources/bin/yaml-lint
@@ -42,8 +42,13 @@ if (!class_exists(Application::class)) {
     exit(1);
 }
 
-(new Application())->add($command = new LintCommand())
-    ->getApplication()
+$command = new LintCommand();
+if (method_exists($app = new Application(), 'addCommand')) {
+    $app->addCommand($command);
+} else {
+    $app->add($command);
+}
+$app
     ->setDefaultCommand($command->getName(), true)
     ->run()
 ;

--- a/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
+++ b/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
@@ -180,7 +180,12 @@ YAML;
     protected function createCommand(): Command
     {
         $application = new Application();
-        $application->add(new LintCommand());
+        $command = new LintCommand();
+        if (method_exists($application, 'addCommand')) {
+            $application->addCommand($command);
+        } else {
+            $application->add($command);
+        }
 
         return $application->find('lint:yaml');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | -
| License       | MIT

Inspired by https://github.com/symfony/symfony/pull/60389#issuecomment-2866530275 .

This PR enables using invokable command when the component is used standalone:

```php
#[AsCommand(name: 'app:example')]
class ExampleCommand implements SignalableCommandInterface
{
    public function __invoke(InputInterface $input, OutputInterface $output): int
    {
        // ...

        return Command::SUCCESS;
    }

    public function getSubscribedSignals(): array
    {
        return [\SIGINT, \SIGTERM];
    }

    public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false
    {
        // handle signal

        return 0;
    }
}

$application = new Application();
$application->addCommand(new ExampleCommand());
$application->run();
```