### PR TITLE
[HttpFoundation] Add `#[IsSignatureValid]` attribute

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Add `assertEmailAddressNotContains()` to the `MailerAssertionsTrait`
  * Add `framework.type_info.aliases` option
  * Add `KernelBrowser::getSession()`
+ * Add autoconfiguration tag `kernel.uri_signer` to `Symfony\Component\HttpFoundation\UriSigner`
 
 7.3
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
@@ -61,6 +61,7 @@ class UnusedTagsPass implements CompilerPassInterface
         'kernel.fragment_renderer',
         'kernel.locale_aware',
         'kernel.reset',
+        'kernel.uri_signer',
         'ldap',
         'mailer.transport_factory',
         'messenger.bus',

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -101,6 +101,7 @@ use Symfony\Component\HttpClient\ScopingHttpClient;
 use Symfony\Component\HttpClient\ThrottlingHttpClient;
 use Symfony\Component\HttpClient\UriTemplateHttpClient;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\UriSigner;
 use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\HttpKernel\Attribute\AsTargetedValueResolver;
 use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
@@ -108,6 +109,7 @@ use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
 use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\HttpKernel\EventListener\IsSignatureValidAttributeListener;
 use Symfony\Component\HttpKernel\Log\DebugLoggerConfigurator;
 use Symfony\Component\HttpKernel\Profiler\ProfilerStateChecker;
 use Symfony\Component\JsonStreamer\Attribute\JsonStreamable;
@@ -287,6 +289,9 @@ class FrameworkExtension extends Extension
 
         if (!class_exists(RunProcessMessageHandler::class)) {
             $container->removeDefinition('process.messenger.process_message_handler');
+        }
+        if (!class_exists(IsSignatureValidAttributeListener::class)) {
+            $container->removeDefinition('controller.is_signature_valid_attribute_listener');
         }
 
         if ($this->hasConsole()) {
@@ -762,6 +767,8 @@ class FrameworkExtension extends Extension
             ->addTag('mime.mime_type_guesser');
         $container->registerForAutoconfiguration(LoggerAwareInterface::class)
             ->addMethodCall('setLogger', [new Reference('logger')]);
+        $container->registerForAutoconfiguration(UriSigner::class)
+            ->addTag('kernel.uri_signer');
 
         $container->registerAttributeForAutoconfiguration(AsEventListener::class, static function (ChildDefinition $definition, AsEventListener $attribute, \ReflectionClass|\ReflectionMethod $reflector) {
             $tagAttributes = get_object_vars($attribute);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
@@ -32,6 +32,7 @@ use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadataFactory;
 use Symfony\Component\HttpKernel\EventListener\CacheAttributeListener;
 use Symfony\Component\HttpKernel\EventListener\DisallowRobotsIndexingListener;
 use Symfony\Component\HttpKernel\EventListener\ErrorListener;
+use Symfony\Component\HttpKernel\EventListener\IsSignatureValidAttributeListener;
 use Symfony\Component\HttpKernel\EventListener\LocaleListener;
 use Symfony\Component\HttpKernel\EventListener\ResponseListener;
 use Symfony\Component\HttpKernel\EventListener\ValidateRequestListener;
@@ -147,6 +148,13 @@ return static function (ContainerConfigurator $container) {
         ->set('controller.cache_attribute_listener', CacheAttributeListener::class)
             ->tag('kernel.event_subscriber')
             ->tag('kernel.reset', ['method' => '?reset'])
+
+        ->set('controller.is_signature_valid_attribute_listener', IsSignatureValidAttributeListener::class)
+            ->args([
+                service('uri_signer'),
+                tagged_locator('kernel.uri_signer'),
+            ])
+            ->tag('kernel.event_subscriber')
 
         ->set('controller.helper', ControllerHelper::class)
             ->tag('container.service_subscriber')

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Deprecate using `Request::sendHeaders()` after headers have already been sent; use a `StreamedResponse` instead
+ * Add `#[WithHttpStatus]` to define status codes: 404 for `SignedUriException` and 403 for `ExpiredSignedUriException`
  * Add support for the `QUERY` HTTP method
  * Add support for structured MIME suffix
 

--- a/src/Symfony/Component/HttpFoundation/Exception/ExpiredSignedUriException.php
+++ b/src/Symfony/Component/HttpFoundation/Exception/ExpiredSignedUriException.php
@@ -11,9 +11,13 @@
 
 namespace Symfony\Component\HttpFoundation\Exception;
 
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\WithHttpStatus;
+
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
+#[WithHttpStatus(Response::HTTP_FORBIDDEN)]
 final class ExpiredSignedUriException extends SignedUriException
 {
     /**

--- a/src/Symfony/Component/HttpFoundation/Exception/SignedUriException.php
+++ b/src/Symfony/Component/HttpFoundation/Exception/SignedUriException.php
@@ -11,9 +11,13 @@
 
 namespace Symfony\Component\HttpFoundation\Exception;
 
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\WithHttpStatus;
+
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
+#[WithHttpStatus(Response::HTTP_NOT_FOUND)]
 abstract class SignedUriException extends \RuntimeException implements ExceptionInterface
 {
 }

--- a/src/Symfony/Component/HttpKernel/Attribute/IsSignatureValid.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/IsSignatureValid.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Attribute;
+
+/**
+ * Validates the request signature for specific HTTP methods.
+ *
+ * This class determines whether a request's signature should be validated
+ * based on the configured HTTP methods. If the request method matches one
+ * of the specified methods (or if no methods are specified), the signature
+ * is checked.
+ *
+ * If the signature is invalid, a {@see \Symfony\Component\HttpFoundation\Exception\SignedUriException}
+ * is thrown during validation.
+ *
+ * @author Santiago San Martin <sanmartindev@gmail.com>
+ */
+#[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_FUNCTION)]
+final class IsSignatureValid
+{
+    /** @var string[] */
+    public readonly array $methods;
+    public readonly ?string $signer;
+
+    /**
+     * @param string[]|string $methods HTTP methods that require signature validation. An empty array means that no method filtering is done
+     * @param string          $signer  The ID of the UriSigner service to use for signature validation. Defaults to 'uri_signer'
+     */
+    public function __construct(
+        array|string $methods = [],
+        ?string $signer = null,
+    ) {
+        $this->methods = (array) $methods;
+        $this->signer = $signer;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add support for the `QUERY` HTTP method
  * Deprecate implementing `__sleep/wakeup()` on kernels; use `__(un)serialize()` instead
  * Deprecate implementing `__sleep/wakeup()` on data collectors; use `__(un)serialize()` instead
+ * Add `#[IsSignatureValid]` attribute to validate URI signatures
  * Make `Profile` final and `Profiler::__sleep()` internal
 
 7.3

--- a/src/Symfony/Component/HttpKernel/EventListener/IsSignatureValidAttributeListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/IsSignatureValidAttributeListener.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\EventListener;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\UriSigner;
+use Symfony\Component\HttpKernel\Attribute\IsSignatureValid;
+use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Handles the IsSignatureValid attribute.
+ *
+ * @author Santiago San Martin <sanmartindev@gmail.com>
+ */
+class IsSignatureValidAttributeListener implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly UriSigner $uriSigner,
+        private readonly ContainerInterface $container,
+    ) {
+    }
+
+    public function onKernelControllerArguments(ControllerArgumentsEvent $event): void
+    {
+        if (!$attributes = $event->getAttributes(IsSignatureValid::class)) {
+            return;
+        }
+
+        $request = $event->getRequest();
+        foreach ($attributes as $attribute) {
+            $methods = array_map('strtoupper', $attribute->methods);
+            if ($methods && !\in_array($request->getMethod(), $methods, true)) {
+                continue;
+            }
+
+            if (null === $attribute->signer) {
+                $this->uriSigner->verify($request);
+                continue;
+            }
+
+            $signer = $this->container->get($attribute->signer);
+            if (!$signer instanceof UriSigner) {
+                throw new \LogicException(\sprintf('The service "%s" is not an instance of "%s".', $attribute->signer, UriSigner::class));
+            }
+
+            $signer->verify($request);
+        }
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [KernelEvents::CONTROLLER_ARGUMENTS => ['onKernelControllerArguments', 30]];
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/IsSignatureValidAttributeListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/IsSignatureValidAttributeListenerTest.php
@@ -1,0 +1,245 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\EventListener;
+
+use PHPUnit\Framework\Attributes\RequiresMethod;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\HttpFoundation\Exception\UnsignedUriException;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\UriSigner;
+use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
+use Symfony\Component\HttpKernel\EventListener\IsSignatureValidAttributeListener;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\Tests\Fixtures\ExtendedSigner;
+use Symfony\Component\HttpKernel\Tests\Fixtures\IsSignatureValidAttributeController;
+use Symfony\Component\HttpKernel\Tests\Fixtures\IsSignatureValidAttributeMethodsController;
+
+#[RequiresMethod(UriSigner::class, 'verify')]
+class IsSignatureValidAttributeListenerTest extends TestCase
+{
+    public function testInvokableControllerWithValidSignature()
+    {
+        $request = new Request();
+
+        $signer = $this->createMock(UriSigner::class);
+        $signer->expects($this->once())->method('verify')->with($request);
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->never())->method('get');
+
+        $event = new ControllerArgumentsEvent(
+            $kernel,
+            new IsSignatureValidAttributeController(),
+            [],
+            $request,
+            null
+        );
+
+        $listener = new IsSignatureValidAttributeListener($signer, $container);
+        $listener->onKernelControllerArguments($event);
+    }
+
+    public function testNoAttributeSkipsValidation()
+    {
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $signer = $this->createMock(UriSigner::class);
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->never())->method('get');
+
+        $event = new ControllerArgumentsEvent(
+            $kernel,
+            [new IsSignatureValidAttributeMethodsController(), 'noAttribute'],
+            [],
+            new Request(),
+            null
+        );
+
+        $listener = new IsSignatureValidAttributeListener($signer, $container);
+        $listener->onKernelControllerArguments($event);
+    }
+
+    public function testDefaultCheckRequestSucceeds()
+    {
+        $request = new Request();
+        $signer = $this->createMock(UriSigner::class);
+        $signer->expects($this->once())->method('verify')->with($request);
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->never())->method('get');
+
+        $event = new ControllerArgumentsEvent(
+            $kernel,
+            [new IsSignatureValidAttributeMethodsController(), 'withDefaultBehavior'],
+            [],
+            $request,
+            null
+        );
+
+        $listener = new IsSignatureValidAttributeListener($signer, $container);
+        $listener->onKernelControllerArguments($event);
+    }
+
+    public function testCheckRequestFailsThrowsHttpException()
+    {
+        $request = new Request();
+        $signer = $this->createMock(UriSigner::class);
+        $signer->expects($this->once())->method('verify')->willThrowException(new UnsignedUriException());
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->never())->method('get');
+
+        $event = new ControllerArgumentsEvent(
+            $kernel,
+            [new IsSignatureValidAttributeMethodsController(), 'withDefaultBehavior'],
+            [],
+            $request,
+            null
+        );
+
+        $listener = new IsSignatureValidAttributeListener($signer, $container);
+
+        $this->expectException(UnsignedUriException::class);
+        $listener->onKernelControllerArguments($event);
+    }
+
+    public function testMultipleAttributesAllValid()
+    {
+        $request = new Request();
+
+        $signer = $this->createMock(UriSigner::class);
+        $signer->expects($this->exactly(2))->method('verify')->with($request);
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->never())->method('get');
+
+        $event = new ControllerArgumentsEvent(
+            $kernel,
+            [new IsSignatureValidAttributeMethodsController(), 'withMultiple'],
+            [],
+            $request,
+            null
+        );
+
+        $listener = new IsSignatureValidAttributeListener($signer, $container);
+        $listener->onKernelControllerArguments($event);
+    }
+
+    public function testValidationWithStringMethod()
+    {
+        $request = new Request([], [], [], [], [], ['REQUEST_METHOD' => 'POST']);
+
+        $signer = $this->createMock(UriSigner::class);
+        $signer->expects($this->once())->method('verify')->with($request);
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->never())->method('get');
+
+        $event = new ControllerArgumentsEvent(
+            $kernel,
+            [new IsSignatureValidAttributeMethodsController(), 'withPostOnly'],
+            [],
+            $request,
+            null
+        );
+
+        $listener = new IsSignatureValidAttributeListener($signer, $container);
+        $listener->onKernelControllerArguments($event);
+    }
+
+    public function testValidationWithArrayMethods()
+    {
+        $request = new Request([], [], [], [], [], ['REQUEST_METHOD' => 'POST']);
+
+        $signer = $this->createMock(UriSigner::class);
+        $signer->expects($this->once())->method('verify')->with($request);
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->never())->method('get');
+
+        $event = new ControllerArgumentsEvent(
+            $kernel,
+            [new IsSignatureValidAttributeMethodsController(), 'withGetAndPost'],
+            [],
+            $request,
+            null
+        );
+
+        $listener = new IsSignatureValidAttributeListener($signer, $container);
+        $listener->onKernelControllerArguments($event);
+    }
+
+    public function testValidationSkippedForNonMatchingMethod()
+    {
+        $request = new Request([], [], [], [], [], ['REQUEST_METHOD' => 'GET']);
+
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $signer = $this->createMock(UriSigner::class);
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->never())->method('get');
+
+        $event = new ControllerArgumentsEvent(
+            $kernel,
+            [new IsSignatureValidAttributeMethodsController(), 'withPostOnly'],
+            [],
+            $request,
+            null
+        );
+
+        $listener = new IsSignatureValidAttributeListener($signer, $container);
+        $listener->onKernelControllerArguments($event);
+    }
+
+    public function testValidationWithSigner()
+    {
+        $request = new Request();
+        $signer = $this->createMock(UriSigner::class);
+        $customSigner = $this->createMock(UriSigner::class);
+        $customSigner->expects($this->once())->method('verify')->with($request);
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->once())->method('get')->with('app.test.signer')->willReturn($customSigner);
+
+        $event = new ControllerArgumentsEvent(
+            $kernel,
+            [new IsSignatureValidAttributeMethodsController(), 'withCustomSigner'],
+            [],
+            $request,
+            null
+        );
+
+        $listener = new IsSignatureValidAttributeListener($signer, $container);
+        $listener->onKernelControllerArguments($event);
+    }
+
+    public function testValidationWithExtendedSigner()
+    {
+        $request = new Request();
+        $signer = $this->createMock(UriSigner::class);
+        $extendedSigner = $this->createMock(ExtendedSigner::class);
+        $extendedSigner->expects($this->once())->method('verify')->with($request);
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->once())->method('get')->with('app.test.extended_signer')->willReturn($extendedSigner);
+
+        $event = new ControllerArgumentsEvent(
+            $kernel,
+            [new IsSignatureValidAttributeMethodsController(), 'withCustomExtendedSigner'],
+            [],
+            $request,
+            null
+        );
+
+        $listener = new IsSignatureValidAttributeListener($signer, $container);
+        $listener->onKernelControllerArguments($event);
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/ExtendedSigner.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/ExtendedSigner.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures;
+
+use Symfony\Component\HttpFoundation\UriSigner;
+
+class ExtendedSigner extends UriSigner
+{
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/IsSignatureValidAttributeController.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/IsSignatureValidAttributeController.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures;
+
+use Symfony\Component\HttpKernel\Attribute\IsSignatureValid;
+
+#[IsSignatureValid]
+class IsSignatureValidAttributeController
+{
+    public function __invoke()
+    {
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/IsSignatureValidAttributeMethodsController.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/IsSignatureValidAttributeMethodsController.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures;
+
+use Symfony\Component\HttpKernel\Attribute\IsSignatureValid;
+
+class IsSignatureValidAttributeMethodsController
+{
+    public function noAttribute()
+    {
+    }
+
+    #[IsSignatureValid]
+    public function withDefaultBehavior()
+    {
+    }
+
+    #[IsSignatureValid]
+    #[IsSignatureValid]
+    public function withMultiple()
+    {
+    }
+
+    #[IsSignatureValid(methods: 'POST')]
+    public function withPostOnly()
+    {
+    }
+
+    #[IsSignatureValid(methods: ['GET', 'POST'])]
+    public function withGetAndPost()
+    {
+    }
+
+    #[IsSignatureValid(signer: 'app.test.signer')]
+    public function withCustomSigner()
+    {
+    }
+
+    #[IsSignatureValid(signer: 'app.test.extended_signer')]
+    public function withCustomExtendedSigner()
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Feature #60189 
| License       | MIT

## ✨ New Feature: `#[IsSignatureValid]` Attribute
This attribute enables declarative signature validation on controller actions. It ensures that requests using specific HTTP methods are validated using `UriSigner`. If the signature is invalid, a `SignedUriException` is thrown.

## ✅ Usage Examples
```php
#[IsSignatureValid] // Applies to all HTTP methods by default
public function someAction(): Response
```
```php
#[IsSignatureValid(methods: ['POST', 'PUT'])] // Only validates POST and PUT requests
public function updateAction(): Response
```
```php
#[IsSignatureValid(signer: 'my_custom_signer_service')] // Uses a custom UriSigner service
public function customSignedAction(): Response
```
