### PR TITLE
[Config] Fix generated comment for multiline "info"

### DIFF
--- a/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
+++ b/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
@@ -413,39 +413,39 @@ public function NAME($value): static
     {
         $comment = '';
         if ('' !== $info = (string) $node->getInfo()) {
-            $comment .= ' * '.$info."\n";
+            $comment .= $info."\n";
         }
 
         if (!$node instanceof ArrayNode) {
             foreach ((array) ($node->getExample() ?? []) as $example) {
-                $comment .= ' * @example '.$example."\n";
+                $comment .= '@example '.$example."\n";
             }
 
             if ('' !== $default = $node->getDefaultValue()) {
-                $comment .= ' * @default '.(null === $default ? 'null' : var_export($default, true))."\n";
+                $comment .= '@default '.(null === $default ? 'null' : var_export($default, true))."\n";
             }
 
             if ($node instanceof EnumNode) {
-                $comment .= sprintf(' * @param ParamConfigurator|%s $value', implode('|', array_unique(array_map(fn ($a) => !$a instanceof \UnitEnum ? var_export($a, true) : '\\'.ltrim(var_export($a, true), '\\'), $node->getValues()))))."\n";
+                $comment .= sprintf('@param ParamConfigurator|%s $value', implode('|', array_unique(array_map(fn ($a) => !$a instanceof \UnitEnum ? var_export($a, true) : '\\'.ltrim(var_export($a, true), '\\'), $node->getValues()))))."\n";
             } else {
                 $parameterTypes = $this->getParameterTypes($node);
-                $comment .= ' * @param ParamConfigurator|'.implode('|', $parameterTypes).' $value'."\n";
+                $comment .= '@param ParamConfigurator|'.implode('|', $parameterTypes).' $value'."\n";
             }
         } else {
             foreach ((array) ($node->getExample() ?? []) as $example) {
-                $comment .= ' * @example '.json_encode($example)."\n";
+                $comment .= '@example '.json_encode($example)."\n";
             }
 
             if ($node->hasDefaultValue() && [] != $default = $node->getDefaultValue()) {
-                $comment .= ' * @default '.json_encode($default)."\n";
+                $comment .= '@default '.json_encode($default)."\n";
             }
         }
 
         if ($node->isDeprecated()) {
-            $comment .= ' * @deprecated '.$node->getDeprecation($node->getName(), $node->getParent()->getName())['message']."\n";
+            $comment .= '@deprecated '.$node->getDeprecation($node->getName(), $node->getParent()->getName())['message']."\n";
         }
 
-        return $comment;
+        return $comment ? ' * '.str_replace("\n", "\n * ", rtrim($comment, "\n"))."\n" : '';
     }
 
     /**

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues.php
@@ -38,7 +38,13 @@ class NodeInitialValues implements ConfigurationInterface
                             ->arrayPrototype()
                                 ->fixXmlConfig('option')
                                 ->children()
-                                    ->scalarNode('dsn')->end()
+                                    ->scalarNode('dsn')
+                                        ->info(<<<'INFO'
+                                            The DSN to use. This is a required option.
+                                            The info is used to describe the DSN,
+                                            it can be multi-line.
+                                            INFO)
+                                        ->end()
                                     ->scalarNode('serializer')->defaultNull()->end()
                                     ->arrayNode('options')
                                         ->normalizeKeys(false)

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValues/Messenger/TransportsConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValues/Messenger/TransportsConfig.php
@@ -16,6 +16,9 @@ class TransportsConfig
     private $_usedProperties = [];
 
     /**
+     * The DSN to use. This is a required option.
+     * The info is used to describe the DSN,
+     * it can be multi-line.
      * @default null
      * @param ParamConfigurator|mixed $value
      * @return $this


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60317
| License       | MIT

Instead of fixing the multiline comment formatting only for the "info" part, the `* ` is now prepended to every line of the generated comment block.
`nette/code-generator` uses almost the same transformation: https://github.com/nette/php-generator/blob/42806049a7774a2bd316c958f5dcf01c6b5c56fa/src/PhpGenerator/Helpers.php#L60