### PR TITLE
[FrameworkBundle] fix lowest allowed Workflow component version

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -108,7 +108,7 @@
         "symfony/validator": "<6.4",
         "symfony/web-profiler-bundle": "<6.4",
         "symfony/webhook": "<7.2",
-        "symfony/workflow": "<7.3"
+        "symfony/workflow": "<7.3.0-beta2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Bundle\\FrameworkBundle\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT
