### PR TITLE
[FrameworkBundle] use use statements instead of FQCNs

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -92,6 +92,7 @@ use Symfony\Component\Validator\Validation;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\Webhook\Client\RequestParser;
 use Symfony\Component\Webhook\Controller\WebhookController;
+use Symfony\Component\Workflow\DependencyInjection\WorkflowValidatorPass;
 use Symfony\Component\Workflow\Exception\InvalidDefinitionException;
 use Symfony\Component\Workflow\Metadata\InMemoryMetadataStore;
 use Symfony\Component\Workflow\WorkflowEvents;
@@ -291,7 +292,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
         DefinitionValidator::$called = false;
 
         $container = $this->createContainerFromFile('workflows', compile: false);
-        $container->addCompilerPass(new \Symfony\Component\Workflow\DependencyInjection\WorkflowValidatorPass());
+        $container->addCompilerPass(new WorkflowValidatorPass());
         $container->compile();
 
         $this->assertTrue($container->hasDefinition('workflow.article'), 'Workflow is registered as a service');
@@ -410,7 +411,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->expectException(InvalidDefinitionException::class);
         $this->expectExceptionMessage('A transition from a place/state must have an unique name. Multiple transitions named "go" from place/state "first" were found on StateMachine "my_workflow".');
         $container = $this->createContainerFromFile('workflow_not_valid', compile: false);
-        $container->addCompilerPass(new \Symfony\Component\Workflow\DependencyInjection\WorkflowValidatorPass());
+        $container->addCompilerPass(new WorkflowValidatorPass());
         $container->compile();
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/PhpFrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/PhpFrameworkExtensionTest.php
@@ -20,7 +20,10 @@ use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\RateLimiter\CompoundRateLimiterFactory;
 use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
 use Symfony\Component\Validator\Constraints\Email;
+use Symfony\Component\Workflow\Definition;
+use Symfony\Component\Workflow\DependencyInjection\WorkflowValidatorPass;
 use Symfony\Component\Workflow\Exception\InvalidDefinitionException;
+use Symfony\Component\Workflow\Validator\DefinitionValidatorInterface;
 
 class PhpFrameworkExtensionTest extends FrameworkExtensionTestCase
 {
@@ -128,7 +131,7 @@ class PhpFrameworkExtensionTest extends FrameworkExtensionTestCase
                     ],
                 ],
             ]);
-            $container->addCompilerPass(new \Symfony\Component\Workflow\DependencyInjection\WorkflowValidatorPass());
+            $container->addCompilerPass(new WorkflowValidatorPass());
         });
     }
 
@@ -456,13 +459,13 @@ class PhpFrameworkExtensionTest extends FrameworkExtensionTestCase
     }
 }
 
-class WorkflowValidatorWithConstructor implements \Symfony\Component\Workflow\Validator\DefinitionValidatorInterface
+class WorkflowValidatorWithConstructor implements DefinitionValidatorInterface
 {
     public function __construct(bool $enabled)
     {
     }
 
-    public function validate(\Symfony\Component\Workflow\Definition $definition, string $name): void
+    public function validate(Definition $definition, string $name): void
     {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

some code style fixes after #54276