### PR TITLE
[Console] `#[Option] ?string $opt = null` as `VALUE_REQUIRED`

### DIFF
--- a/src/Symfony/Component/Console/Attribute/Option.php
+++ b/src/Symfony/Component/Console/Attribute/Option.php
@@ -84,10 +84,6 @@ class Option
             throw new LogicException(\sprintf('The option parameter "$%s" must not be nullable when it has a default boolean value.', $name));
         }
 
-        if ('string' === $self->typeName && null === $self->default) {
-            throw new LogicException(\sprintf('The option parameter "$%s" must not have a default of null.', $name));
-        }
-
         if ('array' === $self->typeName && $self->allowNull) {
             throw new LogicException(\sprintf('The option parameter "$%s" must not be nullable.', $name));
         }
@@ -97,11 +93,10 @@ class Option
             if (false !== $self->default) {
                 $self->mode |= InputOption::VALUE_NEGATABLE;
             }
+        } elseif ('array' === $self->typeName) {
+            $self->mode = InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY;
         } else {
-            $self->mode = $self->allowNull ? InputOption::VALUE_OPTIONAL : InputOption::VALUE_REQUIRED;
-            if ('array' === $self->typeName) {
-                $self->mode |= InputOption::VALUE_IS_ARRAY;
-            }
+            $self->mode = $self->allowNull && null !== $self->default ? InputOption::VALUE_OPTIONAL : InputOption::VALUE_REQUIRED;
         }
 
         if (\is_array($self->suggestedValues) && !\is_callable($self->suggestedValues) && 2 === \count($self->suggestedValues) && ($instance = $parameter->getDeclaringFunction()->getClosureThis()) && $instance::class === $self->suggestedValues[0] && \is_callable([$instance, $self->suggestedValues[1]])) {

--- a/src/Symfony/Component/Console/Tests/Command/InvokableCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/InvokableCommandTest.php
@@ -86,7 +86,8 @@ class InvokableCommandTest extends TestCase
         $timeoutInputOption = $command->getDefinition()->getOption('idle');
         self::assertSame('idle', $timeoutInputOption->getName());
         self::assertNull($timeoutInputOption->getShortcut());
-        self::assertTrue($timeoutInputOption->isValueOptional());
+        self::assertTrue($timeoutInputOption->isValueRequired());
+        self::assertFalse($timeoutInputOption->isValueOptional());
         self::assertFalse($timeoutInputOption->isNegatable());
         self::assertNull($timeoutInputOption->getDefault());
 
@@ -265,11 +266,13 @@ class InvokableCommandTest extends TestCase
             #[Option] ?string $b = '',
             #[Option] array $c = [],
             #[Option] array $d = ['a', 'b'],
+            #[Option] ?string $e = null,
         ) use ($expected): int {
             $this->assertSame($expected[0], $a);
             $this->assertSame($expected[1], $b);
             $this->assertSame($expected[2], $c);
             $this->assertSame($expected[3], $d);
+            $this->assertSame($expected[4], $e);
 
             return 0;
         });
@@ -279,9 +282,9 @@ class InvokableCommandTest extends TestCase
 
     public static function provideNonBinaryInputOptions(): \Generator
     {
-        yield 'defaults' => [[], ['', '', [], ['a', 'b']]];
-        yield 'with-value' => [['--a' => 'x', '--b' => 'y', '--c' => ['z'], '--d' => ['c', 'd']], ['x', 'y', ['z'], ['c', 'd']]];
-        yield 'without-value' => [['--b' => null], ['', null, [], ['a', 'b']]];
+        yield 'defaults' => [[], ['', '', [], ['a', 'b'], null]];
+        yield 'with-value' => [['--a' => 'x', '--b' => 'y', '--c' => ['z'], '--d' => ['c', 'd'], '--e' => 'a'], ['x', 'y', ['z'], ['c', 'd'], 'a']];
+        yield 'without-value' => [['--b' => null], ['', null, [], ['a', 'b'], null]];
     }
 
     /**
@@ -311,10 +314,6 @@ class InvokableCommandTest extends TestCase
         yield 'nullable-bool-default-false' => [
             function (#[Option] ?bool $a = false) {},
             'The option parameter "$a" must not be nullable when it has a default boolean value.',
-        ];
-        yield 'nullable-string' => [
-            function (#[Option] ?string $a = null) {},
-            'The option parameter "$a" must not have a default of null.',
         ];
         yield 'nullable-array' => [
             function (#[Option] ?array $a = null) {},


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony/pull/59602#issuecomment-2869873668
| License       | MIT

Adds the following rule for invokable command options:

| Signature | Definition | Usage | Value |
|--|--|--|--|
| `?string $opt = null` | `VALUE_REQUIRED` | `<omitted>` <br> `--opt=val` | `null` (default)<br>`"val"` |
