### PR TITLE
[Mailer] Add MicrosoftGraph API Transport

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -141,6 +141,7 @@
         "league/html-to-markdown": "^5.0",
         "league/uri": "^6.5|^7.0",
         "masterminds/html5": "^2.7.2",
+        "microsoft/microsoft-graph": "^2",
         "monolog/monolog": "^1.25.1|^2",
         "nyholm/psr7": "^1.0",
         "pda/pheanstalk": "^4.0",

--- a/composer.json
+++ b/composer.json
@@ -141,7 +141,6 @@
         "league/html-to-markdown": "^5.0",
         "league/uri": "^6.5|^7.0",
         "masterminds/html5": "^2.7.2",
-        "microsoft/microsoft-graph": "^2",
         "monolog/monolog": "^1.25.1|^2",
         "nyholm/psr7": "^1.0",
         "pda/pheanstalk": "^4.0",

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer_transports.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer_transports.php
@@ -20,6 +20,7 @@ use Symfony\Component\Mailer\Bridge\MailerSend\Transport\MailerSendTransportFact
 use Symfony\Component\Mailer\Bridge\Mailgun\Transport\MailgunTransportFactory;
 use Symfony\Component\Mailer\Bridge\Mailjet\Transport\MailjetTransportFactory;
 use Symfony\Component\Mailer\Bridge\MailPace\Transport\MailPaceTransportFactory;
+use Symfony\Component\Mailer\Bridge\MicrosoftGraph\Transport\MicrosoftGraphTransportFactory;
 use Symfony\Component\Mailer\Bridge\OhMySmtp\Transport\OhMySmtpTransportFactory;
 use Symfony\Component\Mailer\Bridge\Postmark\Transport\PostmarkTransportFactory;
 use Symfony\Component\Mailer\Bridge\Scaleway\Transport\ScalewayTransportFactory;
@@ -75,6 +76,10 @@ return static function (ContainerConfigurator $container) {
             ->tag('mailer.transport_factory')
 
         ->set('mailer.transport_factory.mailpace', MailPaceTransportFactory::class)
+            ->parent('mailer.transport_factory.abstract')
+            ->tag('mailer.transport_factory')
+
+        ->set('mailer.transport_factory.microsoftgraph', MicrosoftGraphTransportFactory::class)
             ->parent('mailer.transport_factory.abstract')
             ->tag('mailer.transport_factory')
 

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/.gitattributes
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/.gitattributes
@@ -1,0 +1,4 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/.gitignore
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+composer.lock
+phpunit.xml

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+6.4.0
+-----
+
+ * Added the bridge

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/CHANGELOG.md
@@ -1,7 +1,7 @@
 CHANGELOG
 =========
 
-6.4.0
+7.3.0
 -----
 
  * Added the bridge

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Exception/SendMailException.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Exception/SendMailException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\MicrosoftGraph\Exception;
+
+class SendMailException extends \RuntimeException
+{
+}

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Exception/SenderNotFoundException.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Exception/SenderNotFoundException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\MicrosoftGraph\Exception;
+
+class SenderNotFoundException extends SendMailException
+{
+}

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Exception/UnAuthorizedException.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Exception/UnAuthorizedException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\MicrosoftGraph\Exception;
+
+class UnAuthorizedException extends SendMailException
+{
+}

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/LICENSE
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2023-present Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/README.md
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/README.md
@@ -1,0 +1,54 @@
+Microsoft Graph API Mailer
+=============
+
+Provides Microsoft Graph API integration for Symfony Mailer.
+
+
+Prerequisites
+---------
+You will need to:
+ * Register an application in your Microsoft Azure portal,
+ * Grant this application the Microsoft Graph `Mail.Send` permission,
+ * Create a secret for that app.
+
+
+Configuration example
+---------
+
+```env
+# MAILER
+MAILER_DSN=microsoft+graph://CLIENT_APP_ID:SECRET@default?tenant=TENANT_ID
+```
+
+If you need to use third parties operated or specific regions Microsoft services (China, US Government, etc.), you can specify Auth Endpoint and Graph Endpoint.
+
+```env
+# MAILER e.g. for China
+MAILER_DSN=microsoft+graph://CLIENT_APP_ID:SECRET@login.partner.microsoftonline.cn?tenant=TENANT_ID&graphEndpoint=https://microsoftgraph.chinacloudapi.cn
+```
+
+|                        | Authentication endpoint                  | Graph Endpoint                          |
+|------------------------|------------------------------------------|-----------------------------------------|
+| Global (default)       | https://login.microsoftonline.com        | https://graph.microsoft.com             |
+| US Government L4       | https://login.microsoftonline.us         | https://graph.microsoft.us              |
+| US Government L5 (DOD) | https://login.microsoftonline.us         | https://dod-graph.microsoft.us          |
+| China                  | https://login.partner.microsoftonline.cn | https://microsoftgraph.chinacloudapi.cn |
+
+More details can be found in the Microsoft documentation :
+ * [Auth Endpoints](https://learn.microsoft.com/en-us/entra/identity-platform/authentication-national-cloud#microsoft-entra-authentication-endpoints)
+ * [Grpah Endpoints](https://learn.microsoft.com/en-us/graph/deployments#microsoft-graph-and-graph-explorer-service-root-endpoints)
+
+
+Troubleshooting
+--------
+//TODO : erreur stack trace
+Beware that the sender email address needs to be an address of an account inside your tenant.
+
+
+Resources
+---------
+
+ * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+ * [Report issues](https://github.com/symfony/symfony/issues) and
+   [send Pull Requests](https://github.com/symfony/symfony/pulls)
+   in the [main Symfony repository](https://github.com/symfony/symfony)

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/README.md
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/README.md
@@ -1,11 +1,12 @@
 Microsoft Graph API Mailer
-=============
+==========================
 
 Provides Microsoft Graph API integration for Symfony Mailer.
 
 
 Prerequisites
----------
+-------------
+
 You will need to:
  * Register an application in your Microsoft Azure portal,
  * Grant this application the Microsoft Graph `Mail.Send` permission,
@@ -13,7 +14,7 @@ You will need to:
 
 
 Configuration example
----------
+---------------------
 
 ```env
 # MAILER
@@ -40,9 +41,9 @@ More details can be found in the Microsoft documentation :
 
 
 Troubleshooting
---------
-Beware that the sender email address needs to be an address of an account inside your tenant.
+---------------
 
+Beware that the sender email address needs to be an address of an account inside your tenant.
 
 Resources
 ---------

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/README.md
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/README.md
@@ -36,12 +36,11 @@ MAILER_DSN=microsoft+graph://CLIENT_APP_ID:SECRET@login.partner.microsoftonline.
 
 More details can be found in the Microsoft documentation :
  * [Auth Endpoints](https://learn.microsoft.com/en-us/entra/identity-platform/authentication-national-cloud#microsoft-entra-authentication-endpoints)
- * [Grpah Endpoints](https://learn.microsoft.com/en-us/graph/deployments#microsoft-graph-and-graph-explorer-service-root-endpoints)
+ * [Graph Endpoints](https://learn.microsoft.com/en-us/graph/deployments#microsoft-graph-and-graph-explorer-service-root-endpoints)
 
 
 Troubleshooting
 --------
-//TODO : erreur stack trace
 Beware that the sender email address needs to be an address of an account inside your tenant.
 
 

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Tests/Transport/MicrosoftGraphTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Tests/Transport/MicrosoftGraphTransportFactoryTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 declare(strict_types=1);
 
 /*

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Tests/Transport/MicrosoftGraphTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Tests/Transport/MicrosoftGraphTransportFactoryTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Tests/Transport/MicrosoftGraphTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Tests/Transport/MicrosoftGraphTransportFactoryTest.php
@@ -89,12 +89,11 @@ class MicrosoftGraphTransportFactoryTest extends TransportFactoryTestCase
         yield [new Dsn('microsoft+graph', 'default', null, null)];
     }
 
-    public function testInvalidDsnHost(): void
+    public function testInvalidDsnHost()
     {
         $factory = $this->getFactory();
 
         $this->expectException(InvalidArgumentException::class);
         $factory->create(new Dsn('microsoft+graph', 'some-wrong-national-cloud', self::USER, self::PASSWORD, null, ['tenant' => self::TENANT]));
     }
-
 }

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Tests/Transport/MicrosoftGraphTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Tests/Transport/MicrosoftGraphTransportFactoryTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\MicrosoftGraph\Tests\Transport;
+
+use Microsoft\Graph\Core\NationalCloud;
+use Symfony\Component\Cache\Adapter\NullAdapter;
+use Symfony\Component\Mailer\Bridge\MicrosoftGraph\Transport\MicrosoftGraphTransport;
+use Symfony\Component\Mailer\Bridge\MicrosoftGraph\Transport\MicrosoftGraphTransportFactory;
+use Symfony\Component\Mailer\Exception\InvalidArgumentException;
+use Symfony\Component\Mailer\Test\TransportFactoryTestCase;
+use Symfony\Component\Mailer\Transport\Dsn;
+use Symfony\Component\Mailer\Transport\TransportFactoryInterface;
+
+class MicrosoftGraphTransportFactoryTest extends TransportFactoryTestCase
+{
+    protected const TENANT = 'tenantId';
+
+    public function getFactory(): TransportFactoryInterface
+    {
+        return new MicrosoftGraphTransportFactory(new NullAdapter());
+    }
+
+    public static function supportsProvider(): iterable
+    {
+        yield [
+            new Dsn('microsoft+graph', 'default'),
+            true,
+        ];
+
+        yield [
+            new Dsn('microsoft+graph', 'example.com'),
+            true,
+        ];
+    }
+
+    public static function createProvider(): iterable
+    {
+        yield [
+            new Dsn('microsoft+graph', 'default', self::USER, self::PASSWORD, null, ['tenant' => self::TENANT]),
+            new MicrosoftGraphTransport(NationalCloud::GLOBAL, self::TENANT, self::USER, self::PASSWORD, new NullAdapter()),
+        ];
+
+        yield [
+            new Dsn('microsoft+graph', 'germany', self::USER, self::PASSWORD, null, ['tenant' => self::TENANT]),
+            new MicrosoftGraphTransport(NationalCloud::GERMANY, self::TENANT, self::USER, self::PASSWORD, new NullAdapter()),
+        ];
+
+        yield [
+            new Dsn('microsoft+graph', 'china', self::USER, self::PASSWORD, null, ['tenant' => self::TENANT]),
+            new MicrosoftGraphTransport(NationalCloud::CHINA, self::TENANT, self::USER, self::PASSWORD, new NullAdapter()),
+        ];
+
+        yield [
+            new Dsn('microsoft+graph', 'us-gov', self::USER, self::PASSWORD, null, ['tenant' => self::TENANT]),
+            new MicrosoftGraphTransport(NationalCloud::US_GOV, self::TENANT, self::USER, self::PASSWORD, new NullAdapter()),
+        ];
+
+        yield [
+            new Dsn('microsoft+graph', 'us-dod', self::USER, self::PASSWORD, null, ['tenant' => self::TENANT]),
+            new MicrosoftGraphTransport(NationalCloud::US_DOD, self::TENANT, self::USER, self::PASSWORD, new NullAdapter()),
+        ];
+    }
+
+    public static function unsupportedSchemeProvider(): iterable
+    {
+        yield [
+            new Dsn('microsoft+smtp', 'default', self::USER, self::PASSWORD),
+            'The "microsoft+smtp" scheme is not supported; supported schemes for mailer "microsoft graph" are: "microsoft+graph".',
+        ];
+    }
+
+    public static function incompleteDsnProvider(): iterable
+    {
+        yield [new Dsn('microsoft+graph', 'default', self::USER)];
+
+        yield [new Dsn('microsoft+graph', 'default', self::USER, self::PASSWORD)];
+
+        yield [new Dsn('microsoft+graph', 'default', null, self::PASSWORD)];
+
+        yield [new Dsn('microsoft+graph', 'default', null, null)];
+    }
+
+    public function testInvalidDsnHost(): void
+    {
+        $factory = $this->getFactory();
+
+        $this->expectException(InvalidArgumentException::class);
+        $factory->create(new Dsn('microsoft+graph', 'some-wrong-national-cloud', self::USER, self::PASSWORD, null, ['tenant' => self::TENANT]));
+    }
+
+}

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Tests/Transport/MicrosoftGraphTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Tests/Transport/MicrosoftGraphTransportFactoryTest.php
@@ -1,5 +1,8 @@
 <?php
 
+
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -8,8 +11,6 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
-declare(strict_types=1);
 
 namespace Symfony\Component\Mailer\Bridge\MicrosoftGraph\Tests\Transport;
 

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Tests/Transport/MicrosoftGraphTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Tests/Transport/MicrosoftGraphTransportFactoryTest.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Symfony\Component\Mailer\Bridge\MicrosoftGraph\Tests\Transport;
 
 use Microsoft\Graph\Core\NationalCloud;

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Tests/Transport/MicrosoftGraphTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Tests/Transport/MicrosoftGraphTransportFactoryTest.php
@@ -12,7 +12,9 @@
 namespace Symfony\Component\Mailer\Bridge\MicrosoftGraph\Tests\Transport;
 
 use Microsoft\Graph\Core\NationalCloud;
-use Symfony\Component\Cache\Adapter\NullAdapter;
+use Microsoft\Kiota\Authentication\Oauth\ClientCredentialContext;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Mailer\Bridge\MicrosoftGraph\Transport\MicrosoftGraphTransport;
 use Symfony\Component\Mailer\Bridge\MicrosoftGraph\Transport\MicrosoftGraphTransportFactory;
 use Symfony\Component\Mailer\Exception\InvalidArgumentException;
@@ -26,7 +28,7 @@ class MicrosoftGraphTransportFactoryTest extends TransportFactoryTestCase
 
     public function getFactory(): TransportFactoryInterface
     {
-        return new MicrosoftGraphTransportFactory(new NullAdapter());
+        return new MicrosoftGraphTransportFactory(null, new MockHttpClient(), new NullLogger());
     }
 
     public static function supportsProvider(): iterable
@@ -46,27 +48,27 @@ class MicrosoftGraphTransportFactoryTest extends TransportFactoryTestCase
     {
         yield [
             new Dsn('microsoft+graph', 'default', self::USER, self::PASSWORD, null, ['tenant' => self::TENANT]),
-            new MicrosoftGraphTransport(NationalCloud::GLOBAL, self::TENANT, self::USER, self::PASSWORD, new NullAdapter()),
+            new MicrosoftGraphTransport(NationalCloud::GLOBAL, new ClientCredentialContext(self::TENANT, self::USER, self::PASSWORD)),
         ];
 
         yield [
             new Dsn('microsoft+graph', 'germany', self::USER, self::PASSWORD, null, ['tenant' => self::TENANT]),
-            new MicrosoftGraphTransport(NationalCloud::GERMANY, self::TENANT, self::USER, self::PASSWORD, new NullAdapter()),
+            new MicrosoftGraphTransport(NationalCloud::GERMANY, new ClientCredentialContext(self::TENANT, self::USER, self::PASSWORD)),
         ];
 
         yield [
             new Dsn('microsoft+graph', 'china', self::USER, self::PASSWORD, null, ['tenant' => self::TENANT]),
-            new MicrosoftGraphTransport(NationalCloud::CHINA, self::TENANT, self::USER, self::PASSWORD, new NullAdapter()),
+            new MicrosoftGraphTransport(NationalCloud::CHINA, new ClientCredentialContext(self::TENANT, self::USER, self::PASSWORD)),
         ];
 
         yield [
             new Dsn('microsoft+graph', 'us-gov', self::USER, self::PASSWORD, null, ['tenant' => self::TENANT]),
-            new MicrosoftGraphTransport(NationalCloud::US_GOV, self::TENANT, self::USER, self::PASSWORD, new NullAdapter()),
+            new MicrosoftGraphTransport(NationalCloud::US_GOV, new ClientCredentialContext(self::TENANT, self::USER, self::PASSWORD)),
         ];
 
         yield [
             new Dsn('microsoft+graph', 'us-dod', self::USER, self::PASSWORD, null, ['tenant' => self::TENANT]),
-            new MicrosoftGraphTransport(NationalCloud::US_DOD, self::TENANT, self::USER, self::PASSWORD, new NullAdapter()),
+            new MicrosoftGraphTransport(NationalCloud::US_DOD, new ClientCredentialContext(self::TENANT, self::USER, self::PASSWORD)),
         ];
     }
 

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransport.php
@@ -1,6 +1,5 @@
 <?php
 
-
 declare(strict_types=1);
 
 /*

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransport.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransport.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\MicrosoftGraph\Transport;
+
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Psr7\Stream;
+use GuzzleHttp\Psr7\Utils;
+use Microsoft\Graph\Generated\Models\BodyType;
+use Microsoft\Graph\Generated\Models\EmailAddress;
+use Microsoft\Graph\Generated\Models\FileAttachment;
+use Microsoft\Graph\Generated\Models\ItemBody;
+use Microsoft\Graph\Generated\Models\Message;
+use Microsoft\Graph\Generated\Models\ODataErrors\ODataError;
+use Microsoft\Graph\Generated\Models\Recipient;
+use Microsoft\Graph\Generated\Users\Item\SendMail\SendMailPostRequestBody;
+use Microsoft\Graph\GraphServiceClient;
+use Microsoft\Kiota\Authentication\Oauth\ClientCredentialContext;
+use Safe\Exceptions\JsonException;
+use Symfony\Component\Mailer\Bridge\MicrosoftGraph\Exception\SenderNotFoundException;
+use Symfony\Component\Mailer\Bridge\MicrosoftGraph\Exception\SendMailException;
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\SentMessage;
+use Symfony\Component\Mailer\Transport\TransportInterface;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Header\ParameterizedHeader;
+use Symfony\Component\Mime\Part\DataPart;
+use Symfony\Component\Mime\RawMessage;
+use Symfony\Contracts\Cache\CacheInterface;
+
+use function Safe\json_decode;
+
+class MicrosoftGraphTransport implements TransportInterface
+{
+    private GraphServiceClient $graphServiceClient;
+
+    public function __construct(
+        private readonly string $nationalCloud,
+        private readonly string $tenantId,
+        private readonly string $clientId,
+        private readonly string $clientSecret,
+        private readonly CacheInterface $cache,
+    ) {
+        $tokenRequestContext = new ClientCredentialContext(
+            $this->tenantId,
+            $this->clientId,
+            $this->clientSecret
+        );
+        $this->graphServiceClient = new GraphServiceClient($tokenRequestContext, [], $this->nationalCloud);
+    }
+
+    public function send(RawMessage $message, Envelope $envelope = null): ?SentMessage
+    {
+        $envelope = null !== $envelope ? clone $envelope : Envelope::create($message);
+
+        if (!$message instanceof Email) {
+            throw new SendEmailError(sprintf("This mailer can only handle mails of class '%s' or it's subclasses, instance of %s passed", Email::class, $message::class));
+        }
+
+
+        $this->sendMail($message);
+
+        return new SentMessage($message, $envelope);
+    }
+
+    private function sendMail(Email $message): void
+    {
+        $message = $this->convertEmailToGraphMessage($message);
+        $body = new SendMailPostRequestBody();
+        $body->setMessage($message);
+        // Make sure $senderAddress is the email of an account in the tenant
+        $senderAddress = $message->getFrom()->getEmailAddress()->getAddress();
+
+        try {
+            $this->graphServiceClient->users()->byUserId($senderAddress)->sendMail()->post($body)->wait();
+        } catch (ODataError $error) {
+            if ('ErrorInvalidUser' === $error->getError()->getCode()){
+                throw new SenderNotFoundException("Sender email address '".$senderAddress."' could not be found when calling the Graph API. This is usually because the email address doesn't exist in the tenant.", 404, $error);
+            }
+            throw new SendMailException('Something went wrong while sending email', $error->getCode(), $error);
+        }
+    }
+
+    private function convertEmailToGraphMessage(Email $source): Message
+    {
+        $message = new Message();
+
+        // From
+        if (0 === \count($source->getFrom())) {
+            throw new SendEmailError("Cannot send mail without 'From'");
+        }
+
+        $message->setFrom(self::convertAddressToGraphRecipient($source->getFrom()[0]));
+
+        // to
+        $message->setToRecipients(\array_map(
+            static fn (Address $address) => self::convertAddressToGraphRecipient($address),
+            $source->getTo()
+        ));
+
+        // CC
+        $message->setCcRecipients(\array_map(
+            static fn (Address $address) => self::convertAddressToGraphRecipient($address),
+            $source->getCc()
+        ));
+
+        // BCC
+        $message->setBccRecipients(\array_map(
+            static fn (Address $address) => self::convertAddressToGraphRecipient($address),
+            $source->getBcc()
+        ));
+
+        // Subject & body
+        $message->setSubject($source->getSubject() ?? 'No subject');
+        $itemBody = new ItemBody();
+        $itemBody->setContent((string) $source->getHtmlBody());
+        $itemBody->setContentType(new BodyType(BodyType::HTML));
+        $message->setBody($itemBody);
+
+        $message->setAttachments(\array_map(
+            static fn (DataPart $attachment) => self::convertAttachmentGraphAttachment($attachment),
+            $source->getAttachments()
+        ));
+
+        return $message;
+    }
+
+    private static function convertAddressToGraphRecipient(Address $source): Recipient
+    {
+        $recipient = new Recipient();
+        $emailAddress = new EmailAddress();
+        $emailAddress->setAddress($source->getAddress());
+        $emailAddress->setName($source->getName());
+        $recipient->setEmailAddress($emailAddress);
+        return $recipient;
+    }
+
+    private static function convertAttachmentGraphAttachment(DataPart $source): FileAttachment
+    {
+        $attachment = new FileAttachment();
+
+        $contentDisposition = $source->getPreparedHeaders()->get('content-disposition');
+        \assert($contentDisposition instanceof ParameterizedHeader);
+        $filename = $contentDisposition->getParameter('filename');
+
+        $fileStream = Utils::streamFor($source->bodyToString());
+        \assert($fileStream instanceof Stream);
+
+        $attachment->setContentBytes($fileStream)
+            ->setContentType($source->getMediaType().'/'.$source->getMediaSubtype())
+            ->setName($filename)
+            ->setODataType('#microsoft.graph.fileAttachment');
+
+        return $attachment;
+    }
+
+    public function __toString(): string
+    {
+        return 'microsoft_graph://oauth_mail';
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransport.php
@@ -35,25 +35,16 @@ use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Header\ParameterizedHeader;
 use Symfony\Component\Mime\Part\DataPart;
 use Symfony\Component\Mime\RawMessage;
-use Symfony\Contracts\Cache\CacheInterface;
 
 class MicrosoftGraphTransport implements TransportInterface
 {
     private GraphServiceClient $graphServiceClient;
 
     public function __construct(
-        private readonly string $nationalCloud,
-        private readonly string $tenantId,
-        private readonly string $clientId,
-        private readonly string $clientSecret,
-        private readonly CacheInterface $cache,
+        readonly string $nationalCloud,
+        readonly ClientCredentialContext $clientCredentialContext,
     ) {
-        $tokenRequestContext = new ClientCredentialContext(
-            $this->tenantId,
-            $this->clientId,
-            $this->clientSecret
-        );
-        $this->graphServiceClient = new GraphServiceClient($tokenRequestContext, [], $this->nationalCloud);
+        $this->graphServiceClient = new GraphServiceClient($clientCredentialContext, [], $this->nationalCloud);
     }
 
     public function send(RawMessage $message, Envelope $envelope = null): ?SentMessage
@@ -61,7 +52,7 @@ class MicrosoftGraphTransport implements TransportInterface
         $envelope = null !== $envelope ? clone $envelope : Envelope::create($message);
 
         if (!$message instanceof Email) {
-            throw new SendEmailError(sprintf("This mailer can only handle mails of class '%s' or it's subclasses, instance of %s passed", Email::class, $message::class));
+            throw new SendMailException(sprintf("This mailer can only handle mails of class '%s' or it's subclasses, instance of %s passed", Email::class, $message::class));
         }
 
         $this->sendMail($message);
@@ -93,12 +84,12 @@ class MicrosoftGraphTransport implements TransportInterface
 
         // From
         if (0 === \count($source->getFrom())) {
-            throw new SendEmailError("Cannot send mail without 'From'");
+            throw new SendMailException("Cannot send mail without 'From'");
         }
 
         $message->setFrom(self::convertAddressToGraphRecipient($source->getFrom()[0]));
 
-        // to
+        // To
         $message->setToRecipients(array_map(
             static fn (Address $address) => self::convertAddressToGraphRecipient($address),
             $source->getTo()
@@ -117,12 +108,18 @@ class MicrosoftGraphTransport implements TransportInterface
         ));
 
         // Subject & body
-        $message->setSubject($source->getSubject() ?? 'No subject');
-        $itemBody = new ItemBody();
-        $itemBody->setContent((string) $source->getHtmlBody());
-        $itemBody->setContentType(new BodyType(BodyType::HTML));
-        $message->setBody($itemBody);
+        $message->setSubject($source->getSubject() ?? '');
 
+        $itemBody = new ItemBody();
+        if ($source->getHtmlBody()) {
+            $itemBody->setContent((string) $source->getHtmlBody());
+            $itemBody->setContentType(new BodyType(BodyType::HTML));
+        } else {
+            $itemBody->setContent((string) $source->getTextBody());
+            $itemBody->setContentType(new BodyType(BodyType::TEXT));
+        }
+
+        $message->setBody($itemBody);
         $message->setAttachments(array_map(
             static fn (DataPart $attachment) => self::convertAttachmentGraphAttachment($attachment),
             $source->getAttachments()
@@ -153,10 +150,10 @@ class MicrosoftGraphTransport implements TransportInterface
         $fileStream = Utils::streamFor($source->bodyToString());
         \assert($fileStream instanceof Stream);
 
-        $attachment->setContentBytes($fileStream)
-            ->setContentType($source->getMediaType().'/'.$source->getMediaSubtype())
-            ->setName($filename)
-            ->setODataType('#microsoft.graph.fileAttachment');
+        $attachment->setContentBytes($fileStream);
+        $attachment->setContentType($source->getMediaType().'/'.$source->getMediaSubtype());
+        $attachment->setName($filename);
+        $attachment->setODataType('#microsoft.graph.fileAttachment');
 
         return $attachment;
     }

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransport.php
@@ -39,10 +39,10 @@ class MicrosoftGraphTransport implements TransportInterface
     private GraphServiceClient $graphServiceClient;
 
     public function __construct(
-        readonly string $nationalCloud,
-        readonly ClientCredentialContext $clientCredentialContext,
+        string $nationalCloud,
+        ClientCredentialContext $clientCredentialContext,
     ) {
-        $this->graphServiceClient = new GraphServiceClient($clientCredentialContext, [], $this->nationalCloud);
+        $this->graphServiceClient = new GraphServiceClient($clientCredentialContext, [], $nationalCloud);
     }
 
     public function send(RawMessage $message, ?Envelope $envelope = null): ?SentMessage

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransport.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+declare(strict_types=1);
 
 namespace Symfony\Component\Mailer\Bridge\MicrosoftGraph\Transport;
 
@@ -47,12 +47,12 @@ class MicrosoftGraphTransport implements TransportInterface
         $this->graphServiceClient = new GraphServiceClient($clientCredentialContext, [], $this->nationalCloud);
     }
 
-    public function send(RawMessage $message, Envelope $envelope = null): ?SentMessage
+    public function send(RawMessage $message, ?Envelope $envelope = null): ?SentMessage
     {
         $envelope = null !== $envelope ? clone $envelope : Envelope::create($message);
 
         if (!$message instanceof Email) {
-            throw new SendMailException(sprintf("This mailer can only handle mails of class '%s' or it's subclasses, instance of %s passed", Email::class, $message::class));
+            throw new SendMailException(\sprintf("This mailer can only handle mails of class '%s' or it's subclasses, instance of %s passed", Email::class, $message::class));
         }
 
         $this->sendMail($message);
@@ -72,9 +72,9 @@ class MicrosoftGraphTransport implements TransportInterface
             $this->graphServiceClient->users()->byUserId($senderAddress)->sendMail()->post($body)->wait();
         } catch (ODataError $error) {
             if ('ErrorInvalidUser' === $error->getError()->getCode()) {
-                throw new SenderNotFoundException("Sender email address '".$senderAddress."' could not be found when calling the Graph API. This is usually because the email address doesn't exist in the tenant.", 404, $error);
+                throw new SenderNotFoundException("Sender email address '.".$senderAddress."' could not be found when calling the Graph API. This is usually because the email address doesn't exist in the tenant.", 404, $error);
             }
-            throw new SendMailException('Something went wrong while sending email', $error->getCode(), $error);
+            throw new SendMailException('Something went wrong while sending email.', $error->getCode(), $error);
         }
     }
 
@@ -84,7 +84,7 @@ class MicrosoftGraphTransport implements TransportInterface
 
         // From
         if (0 === \count($source->getFrom())) {
-            throw new SendMailException("Cannot send mail without 'From'");
+            throw new SendMailException("Cannot send mail without 'From'.");
         }
 
         $message->setFrom(self::convertAddressToGraphRecipient($source->getFrom()[0]));

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransport.php
@@ -1,5 +1,8 @@
 <?php
 
+
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -8,8 +11,6 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
-declare(strict_types=1);
 
 namespace Symfony\Component\Mailer\Bridge\MicrosoftGraph\Transport;
 
@@ -52,7 +53,7 @@ class MicrosoftGraphTransport implements TransportInterface
         $envelope = null !== $envelope ? clone $envelope : Envelope::create($message);
 
         if (!$message instanceof Email) {
-            throw new SendMailException(\sprintf("This mailer can only handle mails of class '%s' or it's subclasses, instance of %s passed", Email::class, $message::class));
+            throw new SendMailException(\sprintf("This mailer can only handle mails of class '%s' or it's subclasses, instance of '%s' passed", Email::class, $message::class));
         }
 
         $this->sendMail($message);

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransport.php
@@ -25,6 +25,7 @@ use Microsoft\Graph\GraphServiceClient;
 use Microsoft\Kiota\Authentication\Oauth\ClientCredentialContext;
 use Symfony\Component\Mailer\Bridge\MicrosoftGraph\Exception\SenderNotFoundException;
 use Symfony\Component\Mailer\Bridge\MicrosoftGraph\Exception\SendMailException;
+use Symfony\Component\Mailer\Bridge\MicrosoftGraph\Exception\UnAuthorizedException;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\TransportInterface;
@@ -73,6 +74,11 @@ class MicrosoftGraphTransport implements TransportInterface
                 throw new SenderNotFoundException("Sender email address '.".$senderAddress."' could not be found when calling the Graph API. This is usually because the email address doesn't exist in the tenant.", 404, $error);
             }
             throw new SendMailException('Something went wrong while sending email.', $error->getCode(), $error);
+        } catch (\Exception $exception) {
+            if ('unauthorized_client' === $exception->getMessage()) {
+                throw new UnAuthorizedException('Unauthorized to send email. Check your credentials.', 401, $exception);
+            }
+            throw new SendMailException('Something went wrong while sending email.', 0, $exception);
         }
     }
 

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransportFactory.php
@@ -1,6 +1,5 @@
 <?php
 
-
 declare(strict_types=1);
 
 /*

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransportFactory.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransportFactory.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Symfony\Component\Mailer\Bridge\MicrosoftGraph\Transport;
 
 use Microsoft\Graph\Core\NationalCloud;
-use phpDocumentor\Reflection\Exception\PcreException;
 use Symfony\Component\Mailer\Exception\IncompleteDsnException;
 use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Mailer\Exception\UnsupportedSchemeException;
@@ -28,9 +27,9 @@ final class MicrosoftGraphTransportFactory extends AbstractTransportFactory
     private const CLOUD_MAP = [
         'default' => NationalCloud::GLOBAL,
         'germany' => NationalCloud::GERMANY,
-        'china'   => NationalCloud::CHINA,
-        'us-dod'  => NationalCloud::US_DOD,
-        'us-gov'  => NationalCloud::US_GOV,
+        'china' => NationalCloud::CHINA,
+        'us-dod' => NationalCloud::US_DOD,
+        'us-gov' => NationalCloud::US_GOV,
     ];
 
     public function __construct(
@@ -56,8 +55,8 @@ final class MicrosoftGraphTransportFactory extends AbstractTransportFactory
         if (null === $tenantId) {
             throw new IncompleteDsnException("Transport 'microsoft+graph' requires the 'tenant' option");
         }
-        if (!isset(self::CLOUD_MAP[$dsn->getHost()])){
-            throw new InvalidArgumentException(sprintf("Transport 'microsoft+graph' one of these hosts : '%s'", implode(", ", self::CLOUD_MAP)));
+        if (!isset(self::CLOUD_MAP[$dsn->getHost()])) {
+            throw new InvalidArgumentException(sprintf("Transport 'microsoft+graph' one of these hosts : '%s'", implode(', ', self::CLOUD_MAP)));
         }
 
         // This parses the MAILER_DSN containing Microsoft Graph API credentials

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransportFactory.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\MicrosoftGraph\Transport;
+
+use Microsoft\Graph\Core\NationalCloud;
+use phpDocumentor\Reflection\Exception\PcreException;
+use Symfony\Component\Mailer\Exception\IncompleteDsnException;
+use Symfony\Component\Mailer\Exception\InvalidArgumentException;
+use Symfony\Component\Mailer\Exception\UnsupportedSchemeException;
+use Symfony\Component\Mailer\Transport\AbstractTransportFactory;
+use Symfony\Component\Mailer\Transport\Dsn;
+use Symfony\Component\Mailer\Transport\TransportInterface;
+use Symfony\Contracts\Cache\CacheInterface;
+
+final class MicrosoftGraphTransportFactory extends AbstractTransportFactory
+{
+    private const CLOUD_MAP = [
+        'default' => NationalCloud::GLOBAL,
+        'germany' => NationalCloud::GERMANY,
+        'china'   => NationalCloud::CHINA,
+        'us-dod'  => NationalCloud::US_DOD,
+        'us-gov'  => NationalCloud::US_GOV,
+    ];
+
+    public function __construct(
+        private readonly CacheInterface $cache,
+    ) {
+        parent::__construct();
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getSupportedSchemes(): array
+    {
+        return ['microsoft+graph'];
+    }
+
+    public function create(Dsn $dsn): TransportInterface
+    {
+        if ('microsoft+graph' !== $dsn->getScheme()) {
+            throw new UnsupportedSchemeException($dsn, 'microsoft graph', $this->getSupportedSchemes());
+        }
+        $tenantId = $dsn->getOption('tenant');
+        if (null === $tenantId) {
+            throw new IncompleteDsnException("Transport 'microsoft+graph' requires the 'tenant' option");
+        }
+        if (!isset(self::CLOUD_MAP[$dsn->getHost()])){
+            throw new InvalidArgumentException(sprintf("Transport 'microsoft+graph' one of these hosts : '%s'", implode(", ", self::CLOUD_MAP)));
+        }
+
+        // This parses the MAILER_DSN containing Microsoft Graph API credentials
+        return new MicrosoftGraphTransport(
+            self::CLOUD_MAP[$dsn->getHost()],
+            $tenantId,
+            $this->getUser($dsn),
+            $this->getPassword($dsn),
+            $this->cache
+        );
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransportFactory.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+declare(strict_types=1);
 
 namespace Symfony\Component\Mailer\Bridge\MicrosoftGraph\Transport;
 
@@ -50,7 +50,7 @@ final class MicrosoftGraphTransportFactory extends AbstractTransportFactory
             throw new IncompleteDsnException("Transport 'microsoft+graph' requires the 'tenant' option");
         }
         if (!isset(self::CLOUD_MAP[$dsn->getHost()])) {
-            throw new InvalidArgumentException(sprintf("Transport 'microsoft+graph' one of these hosts : '%s'", implode(', ', self::CLOUD_MAP)));
+            throw new InvalidArgumentException(\sprintf("Transport 'microsoft+graph' one of these hosts : '%s'", implode(', ', self::CLOUD_MAP)));
         }
 
         return new MicrosoftGraphTransport(

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransportFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -8,8 +11,6 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
-declare(strict_types=1);
 
 namespace Symfony\Component\Mailer\Bridge\MicrosoftGraph\Transport;
 
@@ -47,7 +48,7 @@ final class MicrosoftGraphTransportFactory extends AbstractTransportFactory
         }
         $tenantId = $dsn->getOption('tenant');
         if (null === $tenantId) {
-            throw new IncompleteDsnException("Transport 'microsoft+graph' requires the 'tenant' option");
+            throw new IncompleteDsnException("Transport 'microsoft+graph' requires the 'tenant' option.");
         }
         if (!isset(self::CLOUD_MAP[$dsn->getHost()])) {
             throw new InvalidArgumentException(\sprintf("Transport 'microsoft+graph' one of these hosts : '%s'", implode(', ', self::CLOUD_MAP)));

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransportFactory.php
@@ -14,13 +14,13 @@ declare(strict_types=1);
 namespace Symfony\Component\Mailer\Bridge\MicrosoftGraph\Transport;
 
 use Microsoft\Graph\Core\NationalCloud;
+use Microsoft\Kiota\Authentication\Oauth\ClientCredentialContext;
 use Symfony\Component\Mailer\Exception\IncompleteDsnException;
 use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Mailer\Exception\UnsupportedSchemeException;
 use Symfony\Component\Mailer\Transport\AbstractTransportFactory;
 use Symfony\Component\Mailer\Transport\Dsn;
 use Symfony\Component\Mailer\Transport\TransportInterface;
-use Symfony\Contracts\Cache\CacheInterface;
 
 final class MicrosoftGraphTransportFactory extends AbstractTransportFactory
 {
@@ -31,12 +31,6 @@ final class MicrosoftGraphTransportFactory extends AbstractTransportFactory
         'us-dod' => NationalCloud::US_DOD,
         'us-gov' => NationalCloud::US_GOV,
     ];
-
-    public function __construct(
-        private readonly CacheInterface $cache,
-    ) {
-        parent::__construct();
-    }
 
     /**
      * @return string[]
@@ -59,13 +53,13 @@ final class MicrosoftGraphTransportFactory extends AbstractTransportFactory
             throw new InvalidArgumentException(sprintf("Transport 'microsoft+graph' one of these hosts : '%s'", implode(', ', self::CLOUD_MAP)));
         }
 
-        // This parses the MAILER_DSN containing Microsoft Graph API credentials
         return new MicrosoftGraphTransport(
             self::CLOUD_MAP[$dsn->getHost()],
-            $tenantId,
-            $this->getUser($dsn),
-            $this->getPassword($dsn),
-            $this->cache
+            new ClientCredentialContext(
+                $tenantId,
+                $this->getUser($dsn),
+                $this->getPassword($dsn)
+            )
         );
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/composer.json
@@ -1,0 +1,44 @@
+{
+    "name": "symfony/microsoft-graph-mailer",
+    "type": "symfony-mailer-bridge",
+    "description": "Symfony Microsoft Graph Mailer Bridge",
+    "keywords": [],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Kevin Nguyen",
+            "homepage": "https://github.com/nguyenk"
+        },
+        {
+            "name": "The Coding Machine",
+            "homepage": "https://github.com/thecodingmachine"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=8.1",
+        "symfony/mailer": "^5.4|^6.4|^7.0",
+        "thecodingmachine/safe": "^2.5.0",
+        "microsoft/microsoft-graph": "^2.0.0",
+        "symfony/cache": "6.4.x-dev"
+    },
+    "require-dev": {
+        "symfony/http-client": "^5.4|^6.4|^7.0"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Component\\Mailer\\Bridge\\MicrosoftGraph\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev",
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": true
+        }
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/composer.json
@@ -22,9 +22,8 @@
     "require": {
         "php": ">=8.1",
         "symfony/mailer": "^5.4|^6.4|^7.0",
-        "thecodingmachine/safe": "^2.5.0",
         "microsoft/microsoft-graph": "^2.0.0",
-        "symfony/cache": "6.4.x-dev"
+        "guzzlehttp/psr7": "^2.0"
     },
     "require-dev": {
         "symfony/http-client": "^5.4|^6.4|^7.0"

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/phpunit.xml.dist
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/phpunit.xml.dist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.4/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+  <php>
+    <ini name="error_reporting" value="-1"/>
+  </php>
+  <testsuites>
+    <testsuite name="Symfony Microsoft Graph API Bridge Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
+  <coverage/>
+  <source>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </source>
+</phpunit>

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/phpunit.xml.dist
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.4/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/9.3/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"

--- a/src/Symfony/Component/Mailer/Transport.php
+++ b/src/Symfony/Component/Mailer/Transport.php
@@ -21,6 +21,7 @@ use Symfony\Component\Mailer\Bridge\Mailchimp\Transport\MandrillTransportFactory
 use Symfony\Component\Mailer\Bridge\MailerSend\Transport\MailerSendTransportFactory;
 use Symfony\Component\Mailer\Bridge\Mailgun\Transport\MailgunTransportFactory;
 use Symfony\Component\Mailer\Bridge\Mailjet\Transport\MailjetTransportFactory;
+use Symfony\Component\Mailer\Bridge\MicrosoftGraph\Transport\MicrosoftGraphTransportFactory;
 use Symfony\Component\Mailer\Bridge\OhMySmtp\Transport\OhMySmtpTransportFactory;
 use Symfony\Component\Mailer\Bridge\Postmark\Transport\PostmarkTransportFactory;
 use Symfony\Component\Mailer\Bridge\Scaleway\Transport\ScalewayTransportFactory;
@@ -54,6 +55,7 @@ final class Transport
         MailgunTransportFactory::class,
         MailjetTransportFactory::class,
         MandrillTransportFactory::class,
+        MicrosoftGraphTransportFactory::class,
         OhMySmtpTransportFactory::class,
         PostmarkTransportFactory::class,
         ScalewayTransportFactory::class,

--- a/src/Symfony/Component/Mailer/Transport.php
+++ b/src/Symfony/Component/Mailer/Transport.php
@@ -66,14 +66,14 @@ final class Transport
 
     private iterable $factories;
 
-    public static function fromDsn(#[\SensitiveParameter] string $dsn, EventDispatcherInterface $dispatcher = null, HttpClientInterface $client = null, LoggerInterface $logger = null): TransportInterface
+    public static function fromDsn(#[\SensitiveParameter] string $dsn, ?EventDispatcherInterface $dispatcher = null, ?HttpClientInterface $client = null, ?LoggerInterface $logger = null): TransportInterface
     {
         $factory = new self(iterator_to_array(self::getDefaultFactories($dispatcher, $client, $logger)));
 
         return $factory->fromString($dsn);
     }
 
-    public static function fromDsns(#[\SensitiveParameter] array $dsns, EventDispatcherInterface $dispatcher = null, HttpClientInterface $client = null, LoggerInterface $logger = null): TransportInterface
+    public static function fromDsns(#[\SensitiveParameter] array $dsns, ?EventDispatcherInterface $dispatcher = null, ?HttpClientInterface $client = null, ?LoggerInterface $logger = null): TransportInterface
     {
         $factory = new self(iterator_to_array(self::getDefaultFactories($dispatcher, $client, $logger)));
 
@@ -144,7 +144,7 @@ final class Transport
             }
 
             if (preg_match('{(\w+)\(}A', $dsn, $matches, 0, $offset)) {
-                throw new InvalidArgumentException(sprintf('The "%s" keyword is not valid (valid ones are "%s"), ', $matches[1], implode('", "', array_keys($keywords))));
+                throw new InvalidArgumentException(\sprintf('The "%s" keyword is not valid (valid ones are "%s"), ', $matches[1], implode('", "', array_keys($keywords))));
             }
 
             if ($pos = strcspn($dsn, ' )', $offset)) {
@@ -169,7 +169,7 @@ final class Transport
     /**
      * @return \Traversable<int, TransportFactoryInterface>
      */
-    public static function getDefaultFactories(EventDispatcherInterface $dispatcher = null, HttpClientInterface $client = null, LoggerInterface $logger = null): \Traversable
+    public static function getDefaultFactories(?EventDispatcherInterface $dispatcher = null, ?HttpClientInterface $client = null, ?LoggerInterface $logger = null): \Traversable
     {
         foreach (self::FACTORY_CLASSES as $factoryClass) {
             if (class_exists($factoryClass)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Issues        | Old PR #52546
| License       | MIT


This PR has it beggining in #52546 and I implemented the changes from the comments by stof.

There is one thing I'm unsure with:
https://github.com/symfony/symfony/pull/52546#discussion_r1389779322
The microsoft.kiota dependency is added and managed via the microsoft-graph -> microsoft-graph-core -> microsoft/kiota-authentication-phpleague-php package. 
I'm unsure about pinning one of the transitive dependencies to a fixed version? 
I think then we should also add the other microsoft/kiota-* packages there. 


