### PR TITLE
[Serializer] Fix collect_denormalization_errors flag in defaultContext

### DIFF
--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -222,7 +222,7 @@ class Serializer implements SerializerInterface, ContextAwareNormalizerInterface
             throw new NotNormalizableValueException(sprintf('Could not denormalize object of type "%s", no supporting normalizer found.', $type));
         }
 
-        if (isset($context[DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS]) || isset($this->defaultContext[DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS])) {
+        if ((isset($context[DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS]) || isset($this->defaultContext[DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS])) && !isset($context['not_normalizable_value_exceptions'])) {
             unset($context[DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS]);
             $context['not_normalizable_value_exceptions'] = [];
             $errors = &$context['not_normalizable_value_exceptions'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59721 
| License       | MIT


When using the `COLLECT_DENORMALIZATION_ERRORS` flag during denormalization, Symfony should collect **all errors** and report them together in a `PartialDenormalizationException`.

Here is an example with two expected errors:

```php
final readonly class Foo
{
    public function __construct(
        public string $bar,
        public \DateTimeInterface $createdAt,
    ) {}
}

$foo = $this->denormalizer->denormalize(
    data: ['createdAt' => ''],
    type: Foo::class,
);
```

Expected errors
1. `Failed to create object because the class misses the "bar" property.`
2. `The data is either not a string, an empty string, or null; you should pass a string that can be parsed with the passed format or a valid DateTime string.`

---

When the flag is passed via the `context`

```php
$foo = $this->denormalizer->denormalize(
    data: ['createdAt' => ''],
    type: Foo::class,
    context: [
        DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS => true,
    ],
);
```

Both errors are correctly collected and returned.

When the flag is set via `default_context` in `framework.yaml`:

```yaml
serializer:
    default_context:
        collect_denormalization_errors: true
```

Only one error is returned:
`The data is either not a string, an empty string, or null; you should pass a string that can be parsed with the passed format or a valid DateTime string.`

#Root Cause
The issue originates in the` \src\Symfony\Component\Serializer\Serializer.php`,
`function normalize` :

```php
if (isset($context[DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS]) || isset($this->defaultContext[DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS])) {
    unset($context[DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS]);
    $context['not_normalizable_value_exceptions'] = [];
    $errors = &$context['not_normalizable_value_exceptions'];
    $denormalized = $normalizer->denormalize($data, $type, $format, $context);
}
```

The first time this block is hit, it checks for the flag either in $context or $defaultContext. If found, it initializes the error array with:

```php
    $context['not_normalizable_value_exceptions'] = [];
```
However, during nested denormalization (e.g., when parsing the `createdAt` field), Symfony re-enters this code path. If the flag was provided via `defaultContext`, it is still present on re-entry. Therefore, the `not_normalizable_value_exceptions` array is reset again, losing the previously collected errors.

#My Fix

The fix is to enhance the condition with an additional check to ensure the array of errors is not already initialized:
```php
if (
    (isset($context[DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS]) || isset($this->defaultContext[DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS]))
    && !isset($context['not_normalizable_value_exceptions'])
)
```

This ensures the array is only initialized once, preserving previously collected errors in recursive calls, regardless of whether the flag was passed via context or default_context.



