### PR TITLE
[FrameworkBundle] remove no longer used service definition

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer.php
@@ -45,7 +45,6 @@ return static function (ContainerConfigurator $container) {
                 tagged_iterator('mailer.transport_factory'),
             ])
 
-        ->set('mailer.default_transport', TransportInterface::class)
         ->alias('mailer.default_transport', 'mailer.transports')
         ->alias(TransportInterface::class, 'mailer.default_transport')
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

In #59781 it was forgotten to remove the definition when an alias with the same name was introduced.