### PR TITLE
[SecurityBundle] normalize string values to a single ExposeSecurityLevel instance

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -76,7 +76,7 @@ class MainConfiguration implements ConfigurationInterface
                     ->setDeprecated('symfony/security-bundle', '7.3', 'The "%node%" option is deprecated and will be removed in 8.0. Use the "expose_security_errors" option instead.')
                 ->end()
                 ->enumNode('expose_security_errors')
-                    ->beforeNormalization()->ifString()->then(fn ($v) => ['value' => ExposeSecurityLevel::tryFrom($v)])->end()
+                    ->beforeNormalization()->ifString()->then(fn ($v) => ExposeSecurityLevel::tryFrom($v))->end()
                     ->values(ExposeSecurityLevel::cases())
                     ->defaultValue(ExposeSecurityLevel::None)
                 ->end()

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/MainConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/MainConfigurationTest.php
@@ -254,6 +254,9 @@ class MainConfigurationTest extends TestCase
         yield [['expose_security_errors' => ExposeSecurityLevel::None], ExposeSecurityLevel::None];
         yield [['expose_security_errors' => ExposeSecurityLevel::AccountStatus], ExposeSecurityLevel::AccountStatus];
         yield [['expose_security_errors' => ExposeSecurityLevel::All], ExposeSecurityLevel::All];
+        yield [['expose_security_errors' => 'none'], ExposeSecurityLevel::None];
+        yield [['expose_security_errors' => 'account_status'], ExposeSecurityLevel::AccountStatus];
+        yield [['expose_security_errors' => 'all'], ExposeSecurityLevel::All];
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT