### PR TITLE
[VarExporter] Fixed lazy-loading ghost objects generation with property hooks

### DIFF
--- a/src/Symfony/Component/VarExporter/ProxyHelper.php
+++ b/src/Symfony/Component/VarExporter/ProxyHelper.php
@@ -80,7 +80,7 @@ final class ProxyHelper
                 .($p->isProtected() ? 'protected' : 'public')
                 .($p->isProtectedSet() ? ' protected(set)' : '')
                 ." {$type} \${$name}"
-                .($p->hasDefaultValue() ? ' = '.$p->getDefaultValue() : '')
+                .($p->hasDefaultValue() ? ' = '.VarExporter::export($p->getDefaultValue()) : '')
                 ." {\n";
 
             foreach ($p->getHooks() as $hook => $method) {

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyProxy/HookedWithDefaultValue.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyProxy/HookedWithDefaultValue.php
@@ -4,8 +4,18 @@ namespace Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy;
 
 class HookedWithDefaultValue
 {
-    public int $backedWithDefault = 321 {
-        get => $this->backedWithDefault;
-        set => $this->backedWithDefault = $value;
+    public int $backedIntWithDefault = 321 {
+        get => $this->backedIntWithDefault;
+        set => $this->backedIntWithDefault = $value;
+    }
+
+    public string $backedStringWithDefault = '321' {
+        get => $this->backedStringWithDefault;
+        set => $this->backedStringWithDefault = $value;
+    }
+
+    public bool $backedBoolWithDefault = false {
+        get => $this->backedBoolWithDefault;
+        set => $this->backedBoolWithDefault = $value;
     }
 }

--- a/src/Symfony/Component/VarExporter/Tests/LazyGhostTraitTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/LazyGhostTraitTest.php
@@ -516,16 +516,22 @@ class LazyGhostTraitTest extends TestCase
             $initialized = true;
         });
 
-        $this->assertSame(321, $object->backedWithDefault);
+        $this->assertSame(321, $object->backedIntWithDefault);
+        $this->assertSame('321', $object->backedStringWithDefault);
+        $this->assertSame(false, $object->backedBoolWithDefault);
         $this->assertTrue($initialized);
 
         $initialized = false;
         $object = $this->createLazyGhost(HookedWithDefaultValue::class, function ($instance) use (&$initialized) {
             $initialized = true;
         });
-        $object->backedWithDefault = 654;
+        $object->backedIntWithDefault = 654;
+        $object->backedStringWithDefault = '654';
+        $object->backedBoolWithDefault = true;
         $this->assertTrue($initialized);
-        $this->assertSame(654, $object->backedWithDefault);
+        $this->assertSame(654, $object->backedIntWithDefault);
+        $this->assertSame('654', $object->backedStringWithDefault);
+        $this->assertSame(true, $object->backedBoolWithDefault);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| License       | MIT

Fixed the bug introduced in https://github.com/symfony/symfony/pull/60288.

If the type is boolean:

```php
public bool $property = false {
    set {
       ...
    }
}
```
an empty string is exported:
```php
public bool $property =  {
    ...
}
```

which leads to `ParseError: syntax error, unexpected token "{"` error.