### PR TITLE
[Validator] Add tests for `MacAddress`

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Constraints/MacAddressValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/MacAddressValidatorTest.php
@@ -63,6 +63,19 @@ class MacAddressValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
+    /**
+     * @dataProvider getNotValidMacs
+     */
+    public function testNotValidMac($mac)
+    {
+        $this->validator->validate($mac, new MacAddress());
+
+        $this->buildViolation('This value is not a valid MAC address.')
+            ->setParameter('{{ value }}', '"'.$mac.'"')
+            ->setCode(MacAddress::INVALID_MAC_ERROR)
+            ->assertRaised();
+    }
+
     public static function getValidMacs(): array
     {
         return [
@@ -73,6 +86,17 @@ class MacAddressValidatorTest extends ConstraintValidatorTestCase
             ['FF:FF:FF:FF:FF:FF'],
             ['FF-FF-FF-FF-FF-FF'],
             ['FFFF.FFFF.FFFF'],
+        ];
+    }
+
+    public static function getNotValidMacs(): array
+    {
+        return [
+            ['00:00:00:00:00'],
+            ['00:00:00:00:00:0G'],
+            ['GG:GG:GG:GG:GG:GG'],
+            ['GG-GG-GG-GG-GG-GG'],
+            ['GGGG.GGGG.GGGG'],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR aims to add some tests to the MacAddress Validator.

~[x] Add testing for empty string and null values~ Already handled with `testNullIsValid` and `testEmptyStringIsValid` methods
[x] Add testing of unvalid mac addresses
~[x] Create generic method `assertViolation()` in `ConstraintValidatorTestCase.php` to test that unvalid values do throw a violation.~ See conversation below

If this PR is accepted, I'll try to continue this work on other validators. I believe testing empty string and null values is important to ensure no BC occurs, for example.
