### PR TITLE
[DependencyInjection] Make `DefinitionErrorExceptionPass` consider `IGNORE_ON_UNINITIALIZED_REFERENCE` and `RUNTIME_EXCEPTION_ON_INVALID_REFERENCE` the same

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/DefinitionErrorExceptionPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/DefinitionErrorExceptionPass.php
@@ -65,7 +65,10 @@ class DefinitionErrorExceptionPass extends AbstractRecursivePass
         }
 
         if ($value instanceof Reference && $this->currentId !== $targetId = (string) $value) {
-            if (ContainerInterface::RUNTIME_EXCEPTION_ON_INVALID_REFERENCE === $value->getInvalidBehavior()) {
+            if (
+                ContainerInterface::RUNTIME_EXCEPTION_ON_INVALID_REFERENCE === $value->getInvalidBehavior()
+                || ContainerInterface::IGNORE_ON_UNINITIALIZED_REFERENCE === $value->getInvalidBehavior()
+            ) {
                 $this->sourceReferences[$targetId][$this->currentId] ??= true;
             } else {
                 $this->sourceReferences[$targetId][$this->currentId] = false;

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/DefinitionErrorExceptionPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/DefinitionErrorExceptionPassTest.php
@@ -64,6 +64,9 @@ class DefinitionErrorExceptionPassTest extends TestCase
         $container->register('foo', 'stdClass')
             ->addArgument(new Reference('bar', ContainerBuilder::RUNTIME_EXCEPTION_ON_INVALID_REFERENCE));
 
+        $container->register('baz', 'stdClass')
+            ->addArgument(new Reference('bar', ContainerBuilder::IGNORE_ON_UNINITIALIZED_REFERENCE));
+
         $pass = new DefinitionErrorExceptionPass();
         $pass->process($container);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54570 
| License       | MIT

The test container can make runtime errors appear at compile-time: say you have a private definition referenced by a controller. Such a reference would be configured with `RUNTIME_EXCEPTION_ON_INVALID_REFERENCE`, so if the private definition references an errored one, you’d get no exception at compile-time.

Now, if this private definition is also referenced by the test container, it would be as `IGNORE_ON_UNINITIALIZED_REFERENCE`. This would change `DefinitionErrorExceptionPass::isErrorForRuntime()` result and trigger a compile-time exception.

Following https://github.com/symfony/symfony/pull/60423#issuecomment-2886348826, this PR makes the `DefinitionErrorExceptionPass` consider `IGNORE_ON_UNINITIALIZED_REFERENCE` the same way than `RUNTIME_EXCEPTION_ON_INVALID_REFERENCE` to fix this issue.