### PR TITLE
[SecurityBundle] forbid to use `hide_user_not_found` and `expose_security_errors` at the same time

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -59,6 +59,10 @@ class MainConfiguration implements ConfigurationInterface
             ->beforeNormalization()
                 ->always()
                 ->then(function ($v) {
+                    if (isset($v['hide_user_not_found']) && isset($v['expose_security_errors'])) {
+                        throw new InvalidConfigurationException('You cannot use both "hide_user_not_found" and "expose_security_errors" at the same time.');
+                    }
+
                     if (isset($v['hide_user_not_found']) && !isset($v['expose_security_errors'])) {
                         $v['expose_security_errors'] = $v['hide_user_not_found'] ? ExposeSecurityLevel::None : ExposeSecurityLevel::All;
                     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/MainConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/MainConfigurationTest.php
@@ -283,4 +283,18 @@ class MainConfigurationTest extends TestCase
         yield [['hide_user_not_found' => true], ExposeSecurityLevel::None, true];
         yield [['hide_user_not_found' => false], ExposeSecurityLevel::All, false];
     }
+
+    public function testCannotUseHideUserNotFoundAndExposeSecurityErrorsAtTheSameTime()
+    {
+        $processor = new Processor();
+        $configuration = new MainConfiguration([], []);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('You cannot use both "hide_user_not_found" and "expose_security_errors" at the same time.');
+
+        $processor->processConfiguration($configuration, [static::$minimalConfig + [
+            'hide_user_not_found' => true,
+            'expose_security_errors' => ExposeSecurityLevel::None,
+        ]]);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

`hide_user_not_found` will not have any effect if `expose_security_errors` is set. Throwing an exception early will improve DX and avoid WTF moments where one might be wondering why the "hide_user_not_found" option doesn't change anything.
