### PR TITLE
[Validator] let the `SlugValidator` accept `AsciiSlugger` results

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Slug.php
+++ b/src/Symfony/Component/Validator/Constraints/Slug.php
@@ -25,7 +25,7 @@ class Slug extends Constraint
     public const NOT_SLUG_ERROR = '14e6df1e-c8ab-4395-b6ce-04b132a3765e';
 
     public string $message = 'This value is not a valid slug.';
-    public string $regex = '/^[a-z0-9]+(?:-[a-z0-9]+)*$/';
+    public string $regex = '/^[a-z0-9]+(?:-[a-z0-9]+)*$/i';
 
     #[HasNamedArguments]
     public function __construct(

--- a/src/Symfony/Component/Validator/Tests/Constraints/SlugValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/SlugValidatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Component\String\Slugger\AsciiSlugger;
 use Symfony\Component\Validator\Constraints\Slug;
 use Symfony\Component\Validator\Constraints\SlugValidator;
 use Symfony\Component\Validator\Exception\UnexpectedValueException;
@@ -47,6 +48,7 @@ class SlugValidatorTest extends ConstraintValidatorTestCase
      * @testWith ["test-slug"]
      *           ["slug-123-test"]
      *           ["slug"]
+     *           ["TestSlug"]
      */
     public function testValidSlugs($slug)
     {
@@ -56,8 +58,7 @@ class SlugValidatorTest extends ConstraintValidatorTestCase
     }
 
     /**
-     * @testWith ["NotASlug"]
-     *           ["Not a slug"]
+     * @testWith ["Not a slug"]
      *           ["not-á-slug"]
      *           ["not-@-slug"]
      */
@@ -91,13 +92,25 @@ class SlugValidatorTest extends ConstraintValidatorTestCase
 
     /**
      * @testWith ["slug"]
-     * @testWith ["test1234"]
+     *           ["test1234"]
      */
     public function testCustomRegexValidSlugs($slug)
     {
         $constraint = new Slug(regex: '/^[a-z0-9]+$/i');
 
         $this->validator->validate($slug, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    /**
+     * @testWith ["PHP"]
+     *           ["Symfony is cool"]
+     *           ["Lorem ipsum dolor sit amet"]
+     */
+    public function testAcceptAsciiSluggerResults(string $text)
+    {
+        $this->validator->validate((new AsciiSlugger())->slug($text), new Slug());
 
         $this->assertNoViolation();
     }

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -38,6 +38,7 @@
         "symfony/mime": "^6.4|^7.0",
         "symfony/property-access": "^6.4|^7.0",
         "symfony/property-info": "^6.4|^7.0",
+        "symfony/string": "^6.4|^7.0",
         "symfony/translation": "^6.4.3|^7.0.3",
         "symfony/type-info": "^7.1",
         "egulias/email-validator": "^2.1.10|^3|^4"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony/pull/58542#issuecomment-2837797401
| License       | MIT