### PR TITLE
[DependencyInjection] Fix missing binding for ServiceCollectionInterface when declaring a service subscriber

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/RegisterServiceSubscribersPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RegisterServiceSubscribersPass.php
@@ -20,6 +20,7 @@ use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\TypedReference;
 use Symfony\Contracts\Service\Attribute\SubscribedService;
+use Symfony\Contracts\Service\ServiceCollectionInterface;
 use Symfony\Contracts\Service\ServiceProviderInterface;
 use Symfony\Contracts\Service\ServiceSubscriberInterface;
 
@@ -134,6 +135,7 @@ class RegisterServiceSubscribersPass extends AbstractRecursivePass
         $value->setBindings([
             PsrContainerInterface::class => new BoundArgument($locatorRef, false),
             ServiceProviderInterface::class => new BoundArgument($locatorRef, false),
+            ServiceCollectionInterface::class => new BoundArgument($locatorRef, false),
         ] + $value->getBindings());
 
         return parent::processValue($value);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Looks like we forgot this in https://github.com/symfony/symfony/pull/53163
I figured it out when reviewing https://github.com/symfony/symfony-docs/pull/20961