### PR TITLE
[WebLink] Hint that prerender is deprecated

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/WebLinkExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/WebLinkExtension.php
@@ -46,7 +46,7 @@ final class WebLinkExtension extends AbstractExtension
     /**
      * Adds a "Link" HTTP header.
      *
-     * @param string $rel        The relation type (e.g. "preload", "prefetch", "prerender" or "dns-prefetch")
+     * @param string $rel        The relation type (e.g. "preload", "prefetch", or "dns-prefetch")
      * @param array  $attributes The attributes of this link (e.g. "['as' => true]", "['pr' => 0.5]")
      *
      * @return string The relation URI
@@ -117,7 +117,11 @@ final class WebLinkExtension extends AbstractExtension
     }
 
     /**
-     * Indicates to the client that it should prerender this resource .
+     * Indicates to the client that it should prerender this resource.
+     *
+     * This feature is deprecated and superseded by the Speculation Rules API.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel/prerender
      *
      * @param array $attributes The attributes of this link (e.g. "['as' => true]", "['pr' => 0.5]")
      *

--- a/src/Symfony/Component/WebLink/Link.php
+++ b/src/Symfony/Component/WebLink/Link.php
@@ -98,6 +98,12 @@ class Link implements EvolvableLinkInterface
     public const REL_PREDECESSOR_VERSION = 'predecessor-version';
     public const REL_PREFETCH = 'prefetch';
     public const REL_PRELOAD = 'preload';
+
+    /**
+     * This feature is deprecated and superseded by the Speculation Rules API.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel/prerender
+     */
     public const REL_PRERENDER = 'prerender';
     public const REL_PREV = 'prev';
     public const REL_PREVIEW = 'preview';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | n/a
| License       | MIT

[`prerender` ](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel/prerender) has been deprecated. Add a hint in the PHPDoc not to use it.

I decided not to deprecate the constant and the function itself because even if the keyword is deprecated in the web platform, it can be useful.