### PR TITLE
[DoctrineBridge] add test for `DatePointType` converting database string to PHP value

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Types/DatePointTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Types/DatePointTypeTest.php
@@ -76,6 +76,14 @@ final class DatePointTypeTest extends TestCase
         $this->assertSame($expected->format($format), $actual->format($format));
     }
 
+    public function testDatabaseValueConvertsToPHPValue()
+    {
+        $actual = $this->type->convertToPHPValue('2025-03-03 12:13:14', new PostgreSQLPlatform());
+
+        $this->assertInstanceOf(DatePoint::class, $actual);
+        $this->assertSame('2025-03-03 12:13:14', $actual->format('Y-m-d H:i:s'));
+    }
+
     public function testGetName()
     {
         $this->assertSame('date_point', $this->type->getName());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

the present tests were not covering the case were a value was being read from the database and converted to a `DatePoint` instance
