### PR TITLE
[ObjectMapper] embed collection transformer

### DIFF
--- a/src/Symfony/Component/ObjectMapper/CHANGELOG.md
+++ b/src/Symfony/Component/ObjectMapper/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `ObjectMapperAwareInterface` to set the owning object mapper instance
+ * Add a `MapCollection` transform that calls the Mapper over iterable properties
 
 7.3
 ---

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/TransformCollection/TransformCollectionA.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/TransformCollection/TransformCollectionA.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+use Symfony\Component\ObjectMapper\Transform\MapCollection;
+
+class TransformCollectionA
+{
+    #[Map(transform: new MapCollection())]
+    /** @var TransformCollectionC[] */
+    public array $foo;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/TransformCollection/TransformCollectionB.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/TransformCollection/TransformCollectionB.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection;
+
+class TransformCollectionB
+{
+    /** @var TransformCollectionD[] */
+    public array $foo;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/TransformCollection/TransformCollectionC.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/TransformCollection/TransformCollectionC.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: TransformCollectionD::class)]
+class TransformCollectionC
+{
+    public function __construct(
+        #[Map(target: 'baz')]
+        public string $bar,
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/TransformCollection/TransformCollectionD.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/TransformCollection/TransformCollectionD.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection;
+
+class TransformCollectionD
+{
+    public function __construct(
+        public string $baz,
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -72,6 +72,10 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\ServiceLocator\ConditionCallab
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ServiceLocator\TransformCallable;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\TargetTransform\SourceEntity;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\TargetTransform\TargetDto as TargetTransformTargetDto;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformCollectionA;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformCollectionB;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformCollectionC;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformCollectionD;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
 final class ObjectMapperTest extends TestCase
@@ -515,5 +519,16 @@ final class ObjectMapperTest extends TestCase
         $this->assertInstanceOf(TargetTransformTargetDto::class, $target);
         $this->assertTrue($target->transformed);
         $this->assertSame('test', $target->name);
+    }
+
+    public function testTransformCollection()
+    {
+        $u = new TransformCollectionA();
+        $u->foo = [new TransformCollectionC('a'), new TransformCollectionC('b')];
+        $mapper = new ObjectMapper();
+
+        $transformed = $mapper->map($u, TransformCollectionB::class);
+
+        $this->assertEquals([new TransformCollectionD('a'), new TransformCollectionD('b')], $transformed->foo);
     }
 }

--- a/src/Symfony/Component/ObjectMapper/Transform/MapCollection.php
+++ b/src/Symfony/Component/ObjectMapper/Transform/MapCollection.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Transform;
+
+use Symfony\Component\ObjectMapper\Exception\MappingException;
+use Symfony\Component\ObjectMapper\ObjectMapper;
+use Symfony\Component\ObjectMapper\ObjectMapperInterface;
+use Symfony\Component\ObjectMapper\TransformCallableInterface;
+
+/**
+ * @template T of object
+ *
+ * @implements TransformCallableInterface<object, T>
+ */
+class MapCollection implements TransformCallableInterface
+{
+    public function __construct(
+        private ObjectMapperInterface $objectMapper = new ObjectMapper(),
+    ) {
+    }
+
+    public function __invoke(mixed $value, object $source, ?object $target): mixed
+    {
+        if (!is_iterable($value)) {
+            throw new MappingException(\sprintf('The MapCollection transform expects an iterable, "%s" given.', get_debug_type($value)));
+        }
+
+        $values = [];
+        foreach ($value as $k => $v) {
+            $values[$k] = $this->objectMapper->map($v);
+        }
+
+        return $values;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Related to #60432 also fixes https://github.com/symfony/symfony/issues/61116
| License       | MIT

This is another approach to embeded collection mapping that avoids changing the ObjectMapper. Even if this doesn't land in the component it'd be a good thing to document. Let me know your thoughts. 