### PR TITLE
[Mailer] Update Mailer Azure bridge API docs link

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Azure/README.md
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/README.md
@@ -21,7 +21,7 @@ where:
 Resources
 ---------
 
- * [Microsoft Azure (ACS) Email API Docs](https://learn.microsoft.com/en-us/rest/api/communication/dataplane/email/send)
+ * [Microsoft Azure (ACS) Email API Docs](https://learn.microsoft.com/en-us/rest/api/communication/email/email/send)
  * [Contributing](https://symfony.com/doc/current/contributing/index.html)
  * [Report issues](https://github.com/symfony/symfony/issues) and
    [send Pull Requests](https://github.com/symfony/symfony/pulls)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes(?)
| License       | MIT

The current link to Azure API docs leads to a 404 error.
