### PR TITLE
[Validator] Review "twig template" translation

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.fr.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.fr.xlf
@@ -472,7 +472,7 @@
             </trans-unit>
             <trans-unit id="121">
                 <source>This value is not a valid Twig template.</source>
-                <target state="needs-review-translation">Cette valeur n'est pas un modèle Twig valide.</target>
+                <target>Cette valeur n'est pas un modèle Twig valide.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60461
| License       | MIT

I think I would I said:
> Cette valeur n'est pas une template Twig valide.

But
* template may be a bit too technical
* people will debate on "une template" / "un template"

So the current translation seems better
