### PR TITLE
[Validator] add missing `$extensions` and `$extensionsMessage` to the `Image` constraint

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Image.php
+++ b/src/Symfony/Component/Validator/Constraints/Image.php
@@ -64,7 +64,7 @@ class Image extends File
      */
     protected static $errorNames = self::ERROR_NAMES;
 
-    public $mimeTypes = 'image/*';
+    public $mimeTypes;
     public $minWidth;
     public $maxWidth;
     public $maxHeight;
@@ -140,7 +140,9 @@ class Image extends File
         ?string $allowPortraitMessage = null,
         ?string $corruptedMessage = null,
         ?array $groups = null,
-        mixed $payload = null
+        mixed $payload = null,
+        array|string|null $extensions = null,
+        ?string $extensionsMessage = null,
     ) {
         parent::__construct(
             $options,
@@ -163,7 +165,9 @@ class Image extends File
             $uploadExtensionErrorMessage,
             $uploadErrorMessage,
             $groups,
-            $payload
+            $payload,
+            $extensions,
+            $extensionsMessage,
         );
 
         $this->minWidth = $minWidth ?? $this->minWidth;
@@ -191,6 +195,10 @@ class Image extends File
         $this->allowLandscapeMessage = $allowLandscapeMessage ?? $this->allowLandscapeMessage;
         $this->allowPortraitMessage = $allowPortraitMessage ?? $this->allowPortraitMessage;
         $this->corruptedMessage = $corruptedMessage ?? $this->corruptedMessage;
+
+        if (null === $this->mimeTypes && [] === $this->extensions) {
+            $this->mimeTypes = 'image/*';
+        }
 
         if (!\in_array('image/*', (array) $this->mimeTypes, true) && !\array_key_exists('mimeTypesMessage', $options ?? []) && null === $mimeTypesMessage) {
             $this->mimeTypesMessage = 'The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony/commit/1613e55a598c533e3d86492087c3997dbbe23792#commitcomment-137679894
| License       | MIT