### PR TITLE
[VarDumper] Add support for adding more default casters to `AbstractCloner::addDefaultCasters()`

### DIFF
--- a/src/Symfony/Component/VarDumper/CHANGELOG.md
+++ b/src/Symfony/Component/VarDumper/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+ * Add support for adding more default casters to `AbstractCloner::addDefaultCasters()`
+
 7.3
 ---
 

--- a/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
@@ -251,18 +251,33 @@ abstract class AbstractCloner implements ClonerInterface
     /**
      * Adds casters for resources and objects.
      *
-     * Maps resources or objects types to a callback.
-     * Types are in the key, with a callable caster for value.
-     * Resource types are to be prefixed with a `:`,
-     * see e.g. static::$defaultCasters.
+     * Maps resources or object types to a callback.
+     * Use types as keys and callable casters as values.
+     * Prefix types with `::`,
+     * see e.g. self::$defaultCasters.
      *
-     * @param callable[] $casters A map of casters
+     * @param array<string, callable> $casters A map of casters
      */
     public function addCasters(array $casters): void
     {
         foreach ($casters as $type => $callback) {
             $this->casters[$type][] = $callback;
         }
+    }
+
+    /**
+     * Adds default casters for resources and objects.
+     *
+     * Maps resources or object types to a callback.
+     * Use types as keys and callable casters as values.
+     * Prefix types with `::`,
+     * see e.g. self::$defaultCasters.
+     *
+     * @param array<string, callable> $casters A map of casters
+     */
+    public static function addDefaultCasters(array $casters): void
+    {
+        self::$defaultCasters = [...self::$defaultCasters, ...$casters];
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        |
| License       | MIT

This PR let us to write better code, and we also get a better discovery
