### PR TITLE
[HttpKernel] Fix `#[MapUploadedFile]` handling for optional file uploads

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
@@ -232,6 +232,10 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
 
     private function mapUploadedFile(Request $request, ArgumentMetadata $argument, MapUploadedFile $attribute): UploadedFile|array|null
     {
-        return $request->files->get($attribute->name ?? $argument->getName(), []);
+        if (!($files = $request->files->get($attribute->name ?? $argument->getName(), [])) && ($argument->isNullable() || $argument->hasDefaultValue())) {
+            return null;
+        }
+
+        return $files;
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/UploadedFileValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/UploadedFileValueResolverTest.php
@@ -307,6 +307,66 @@ class UploadedFileValueResolverTest extends TestCase
         $resolver->onKernelControllerArguments($event);
     }
 
+    /**
+     * @dataProvider provideContext
+     */
+    public function testShouldAllowEmptyWhenNullable(RequestPayloadValueResolver $resolver, Request $request)
+    {
+        $attribute = new MapUploadedFile();
+        $argument = new ArgumentMetadata(
+            'qux',
+            UploadedFile::class,
+            false,
+            false,
+            null,
+            true,
+            [$attribute::class => $attribute]
+        );
+        /** @var HttpKernelInterface&MockObject $httpKernel */
+        $httpKernel = $this->createMock(HttpKernelInterface::class);
+        $event = new ControllerArgumentsEvent(
+            $httpKernel,
+            static function () {},
+            $resolver->resolve($request, $argument),
+            $request,
+            HttpKernelInterface::MAIN_REQUEST
+        );
+        $resolver->onKernelControllerArguments($event);
+        $data = $event->getArguments()[0];
+
+        $this->assertNull($data);
+    }
+
+    /**
+     * @dataProvider provideContext
+     */
+    public function testShouldAllowEmptyWhenHasDefaultValue(RequestPayloadValueResolver $resolver, Request $request)
+    {
+        $attribute = new MapUploadedFile();
+        $argument = new ArgumentMetadata(
+            'qux',
+            UploadedFile::class,
+            false,
+            true,
+            'default-value',
+            false,
+            [$attribute::class => $attribute]
+        );
+        /** @var HttpKernelInterface&MockObject $httpKernel */
+        $httpKernel = $this->createMock(HttpKernelInterface::class);
+        $event = new ControllerArgumentsEvent(
+            $httpKernel,
+            static function () {},
+            $resolver->resolve($request, $argument),
+            $request,
+            HttpKernelInterface::MAIN_REQUEST
+        );
+        $resolver->onKernelControllerArguments($event);
+        $data = $event->getArguments()[0];
+
+        $this->assertSame('default-value', $data);
+    }
+
     public static function provideContext(): iterable
     {
         $resolver = new RequestPayloadValueResolver(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58590 
| License       | MIT

This PR fixes a bug with the `#[MapUploadedFile]` attribute in routes, where an optional ?UploadedFile parameter does not behave as expected when no file is provided.

