### PR TITLE
[PhpUnitBridge] Clean up mocked features only when `@group` is present

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/SymfonyExtension.php
+++ b/src/Symfony/Bridge/PhpUnit/SymfonyExtension.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Bridge\PhpUnit;
 
+use PHPUnit\Event\Code\Test;
+use PHPUnit\Event\Code\TestMethod;
 use PHPUnit\Event\Test\BeforeTestMethodErrored;
 use PHPUnit\Event\Test\BeforeTestMethodErroredSubscriber;
 use PHPUnit\Event\Test\Errored;
@@ -19,6 +21,7 @@ use PHPUnit\Event\Test\Finished;
 use PHPUnit\Event\Test\FinishedSubscriber;
 use PHPUnit\Event\Test\Skipped;
 use PHPUnit\Event\Test\SkippedSubscriber;
+use PHPUnit\Metadata\Group;
 use PHPUnit\Runner\Extension\Extension;
 use PHPUnit\Runner\Extension\Facade;
 use PHPUnit\Runner\Extension\ParameterCollection;
@@ -47,22 +50,22 @@ class SymfonyExtension implements Extension
         $facade->registerSubscriber(new class implements ErroredSubscriber {
             public function notify(Errored $event): void
             {
-                SymfonyExtension::disableClockMock();
-                SymfonyExtension::disableDnsMock();
+                SymfonyExtension::disableClockMock($event->test());
+                SymfonyExtension::disableDnsMock($event->test());
             }
         });
         $facade->registerSubscriber(new class implements FinishedSubscriber {
             public function notify(Finished $event): void
             {
-                SymfonyExtension::disableClockMock();
-                SymfonyExtension::disableDnsMock();
+                SymfonyExtension::disableClockMock($event->test());
+                SymfonyExtension::disableDnsMock($event->test());
             }
         });
         $facade->registerSubscriber(new class implements SkippedSubscriber {
             public function notify(Skipped $event): void
             {
-                SymfonyExtension::disableClockMock();
-                SymfonyExtension::disableDnsMock();
+                SymfonyExtension::disableClockMock($event->test());
+                SymfonyExtension::disableDnsMock($event->test());
             }
         });
 
@@ -70,8 +73,13 @@ class SymfonyExtension implements Extension
             $facade->registerSubscriber(new class implements BeforeTestMethodErroredSubscriber {
                 public function notify(BeforeTestMethodErrored $event): void
                 {
-                    SymfonyExtension::disableClockMock();
-                    SymfonyExtension::disableDnsMock();
+                    if (method_exists($event, 'test')) {
+                        SymfonyExtension::disableClockMock($event->test());
+                        SymfonyExtension::disableDnsMock($event->test());
+                    } else {
+                        ClockMock::withClockMock(false);
+                        DnsMock::withMockedHosts([]);
+                    }
                 }
             });
         }
@@ -88,16 +96,38 @@ class SymfonyExtension implements Extension
     /**
      * @internal
      */
-    public static function disableClockMock(): void
+    public static function disableClockMock(Test $test): void
     {
-        ClockMock::withClockMock(false);
+        if (self::hasGroup($test, 'time-sensitive')) {
+            ClockMock::withClockMock(false);
+        }
     }
 
     /**
      * @internal
      */
-    public static function disableDnsMock(): void
+    public static function disableDnsMock(Test $test): void
     {
-        DnsMock::withMockedHosts([]);
+        if (self::hasGroup($test, 'dns-sensitive')) {
+            DnsMock::withMockedHosts([]);
+        }
+    }
+
+    /**
+     * @internal
+     */
+    public static function hasGroup(Test $test, string $groupName): bool
+    {
+        if (!$test instanceof TestMethod) {
+            return false;
+        }
+
+        foreach ($test->metadata() as $metadata) {
+            if ($metadata instanceof Group && $groupName === $metadata->groupName()) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtensionWithManualRegister.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/SymfonyExtensionWithManualRegister.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ClockMock;
+use Symfony\Bridge\PhpUnit\DnsMock;
+
+class SymfonyExtensionWithManualRegister extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        ClockMock::register(self::class);
+        ClockMock::withClockMock(strtotime('2024-05-20 15:30:00'));
+
+        DnsMock::register(self::class);
+        DnsMock::withMockedHosts([
+            'example.com' => [
+                ['type' => 'A', 'ip' => '1.2.3.4'],
+            ],
+        ]);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        ClockMock::withClockMock(false);
+        DnsMock::withMockedHosts([]);
+    }
+
+    public function testDate()
+    {
+        self::assertSame('2024-05-20 15:30:00', date('Y-m-d H:i:s'));
+    }
+
+    public function testGetHostByName()
+    {
+        self::assertSame('1.2.3.4', gethostbyname('example.com'));
+    }
+
+    public function testTime()
+    {
+        self::assertSame(1716219000, time());
+    }
+
+    public function testDnsGetRecord()
+    {
+        self::assertSame([[
+            'host' => 'example.com',
+            'class' => 'IN',
+            'ttl' => 1,
+            'type' => 'A',
+            'ip' => '1.2.3.4',
+        ]], dns_get_record('example.com'));
+    }
+}

--- a/src/Symfony/Bridge/PhpUnit/Tests/symfonyextension.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/symfonyextension.phpt
@@ -5,6 +5,8 @@ if (!getenv('SYMFONY_PHPUNIT_VERSION') || version_compare(getenv('SYMFONY_PHPUNI
 --FILE--
 <?php
 passthru(\sprintf('NO_COLOR=1 php %s/simple-phpunit.php -c %s/Fixtures/symfonyextension/phpunit-with-extension.xml.dist %s/SymfonyExtension.php', getenv('SYMFONY_SIMPLE_PHPUNIT_BIN_DIR'), __DIR__, __DIR__));
+echo PHP_EOL;
+passthru(\sprintf('NO_COLOR=1 php %s/simple-phpunit.php -c %s/Fixtures/symfonyextension/phpunit-with-extension.xml.dist %s/SymfonyExtensionWithManualRegister.php', getenv('SYMFONY_SIMPLE_PHPUNIT_BIN_DIR'), __DIR__, __DIR__));
 --EXPECTF--
 PHPUnit %s
 
@@ -17,3 +19,14 @@ Time: %s, Memory: %s
 
 OK, but there were issues!
 Tests: 46, Assertions: 46, Deprecations: 1.
+
+PHPUnit %s
+
+Runtime:       PHP %s
+Configuration: %s/src/Symfony/Bridge/PhpUnit/Tests/Fixtures/symfonyextension/phpunit-with-extension.xml.dist
+
+....                                                                4 / 4 (100%)
+
+Time: %s, Memory: %s
+
+OK (4 tests, 4 assertions)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT


PR #60174 introduced a bug for tests that don't use the `@group` annotation but register mocks manually, e.g. in `setUpBeforeClass`:

```php
class ExampleTest extends TestCase
{
    public static function setUpBeforeClass(): void
    {
        ClockMock::register(self::class);
        ClockMock::withClockMock(strtotime('2024-05-20 15:30:00'));
    }

    public static function tearDownAfterClass(): void
    {
        ClockMock::withClockMock(false);
    }

    public function testDate()
    {
        self::assertSame('2024-05-20 15:30:00', date('Y-m-d H:i:s'));
    }

    public function testTime()
    {
        self::assertSame(1716219000, time());
    }
}
```

`testDate` passes, but after that `FinishedSubscriber` is triggered which cleans up the mock and causes `testTime` to fail.

I am not sure what to do about `BeforeTestMethodErroredSubscriber` since the test object is not available in that event. I think it's fine to leave it as is.

cc @xabbuh 