### PR TITLE
[Validator] Fix - Missing translations for Turkish (tr)

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.tr.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.tr.xlf
@@ -468,7 +468,7 @@
             </trans-unit>
             <trans-unit id="121">
                 <source>This value is not a valid Twig template.</source>
-                <target state="needs-review-translation">Bu değer geçerli bir Twig şablonu değil.</target>
+                <target>Bu değer geçerli bir Twig şablonu olarak kabul edilmiyor.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60473
| License       | MIT

This PR improves the Turkish translation for the validation message:

**"This value is not a valid Twig template."**

The previous translation was:

> Bu değer geçerli bir Twig şablonu değil.

It has been updated for clarity and consistency with other translations:

> Bu değer geçerli bir Twig şablonu olarak kabul edilmiyor.

This aligns better with the tone used in other Turkish validation messages across the Symfony project.
