### PR TITLE
[FrameworkBundle] Fix activation strategy of traceable decorators

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle;
 
+use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddDebugLogProcessorPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AssetsContextPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ContainerBuilderDebugDumpPass;
@@ -200,6 +201,14 @@ class FrameworkBundle extends Bundle
             $container->addCompilerPass(new CacheCollectorPass(), PassConfig::TYPE_BEFORE_REMOVING);
             $this->addCompilerPassIfExists($container, WorkflowDebugPass::class);
         }
+    }
+
+    /**
+     * @internal
+     */
+    public static function considerProfilerEnabled(): bool
+    {
+        return !($GLOBALS['app'] ?? null) instanceof Application || empty($_GET) && \in_array('--profile', $_SERVER['argv'] ?? [], true);
     }
 
     private function addCompilerPassIfExists(ContainerBuilder $container, string $class, string $type = PassConfig::TYPE_BEFORE_OPTIMIZATION, int $priority = 0): void

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/profiling.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/profiling.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Bundle\FrameworkBundle\EventListener\ConsoleProfilerListener;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Component\HttpKernel\Debug\VirtualRequestStack;
 use Symfony\Component\HttpKernel\EventListener\ProfilerListener;
 use Symfony\Component\HttpKernel\Profiler\FileProfilerStorage;
@@ -61,7 +62,7 @@ return static function (ContainerConfigurator $container) {
         ->set('profiler.state_checker', ProfilerStateChecker::class)
             ->args([
                 service_locator(['profiler' => service('profiler')->ignoreOnUninitialized()]),
-                param('kernel.runtime_mode.web'),
+                inline_service('bool')->factory([FrameworkBundle::class, 'considerProfilerEnabled']),
             ])
 
         ->set('profiler.is_disabled_state_checker', 'Closure')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60481
| License       | MIT

With this change, we're going to auto-enable traceable decorators in the test env, which should fix #60481
The added logic relies on the SymfonyRuntime component, which is the one exposing the currently running app under `$GLOBALS['app']`. If the global var is not found, we just fallback to auto-enabled mode.