### PR TITLE
[ObjectMapper] added earlier skip to allow if=false when using source mapping

### DIFF
--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -122,12 +122,12 @@ final class ObjectMapper implements ObjectMapperInterface
                     $sourcePropertyName = $mapping->source;
                 }
 
-                $value = $this->getRawValue($source, $sourcePropertyName);
-                if (($if = $mapping->if) && ($fn = $this->getCallable($if, $this->conditionCallableLocator)) && !$this->call($fn, $value, $source, $mappedTarget)) {
+                if (false === $if = $mapping->if) {
                     continue;
                 }
 
-                if (false === $if) {
+                $value = $this->getRawValue($source, $sourcePropertyName);
+                if ($if && ($fn = $this->getCallable($if, $this->conditionCallableLocator)) && !$this->call($fn, $value, $source, $mappedTarget)) {
                     continue;
                 }
 

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/HydrateObject/SourceOnly.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/HydrateObject/SourceOnly.php
@@ -15,7 +15,9 @@ use Symfony\Component\ObjectMapper\Attribute\Map;
 
 class SourceOnly
 {
-    public function __construct(#[Map(source: 'name')] public string $mappedName)
-    {
+    public function __construct(
+        #[Map(source: 'name')] public string $mappedName,
+        #[Map(if: false)] public ?string $mappedDescription = null
+    ) {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Currently when using object mapper from source if seems to fail if the oiginal source class doesn't have this field.

Which means

```php
class A {
   public $id = 1
} 
class B {
  #[Map(source:'id')]
  public $id = null
  #[Map(if:false)]
  public $additionalInfo = null
}
$objectMapper->map(new A(), new B());
```
will fail because there's no property available in A.

Moving the if statement up in the object mapper solves the issue if #Map(if: false). It doesn't support full "IF" logic as it's dependent on value, but I think that's all right. Don't really see why someone would need that if there's no mapping value either way. 

