### PR TITLE
[Messenger] fix: Add argument as integer

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -31,6 +31,7 @@ class Connection
         'x-max-length-bytes',
         'x-max-priority',
         'x-message-ttl',
+        'x-delivery-limit',
     ];
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT

## Description

Added an argument ('x-delivery-limit') to the ARGUMENT_AS_INTEGER array. This change was made to ensure compatibility with RabbitMQ, as the argument was previously being sent as a string, which caused errors. By adding it to the ARGUMENT_AS_INTEGER array, the argument is now properly sent as an integer instead of a string, resolving the issue.