### PR TITLE
[HttpCache] Add a `waiting` trace when finding the cache locked

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -4,11 +4,12 @@ CHANGELOG
 7.3
 ---
 
+ * Record a `waiting` trace in the `HttpCache` when the cache had to wait for another request to finish
  * Add `$key` argument to `#[MapQueryString]` that allows using a specific key for argument resolving
  * Support `Uid` in `#[MapQueryParameter]`
  * Add `ServicesResetterInterface`, implemented by `ServicesResetter`
  * Allow configuring the logging channel per type of exceptions in ErrorListener
- 
+
 7.2
 ---
 

--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -558,6 +558,8 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
             return true;
         }
 
+        $this->record($request, 'waiting');
+
         // wait for the lock to be released
         if ($this->waitForLock($request)) {
             // replace the current entry with the fresh one

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTestCase.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTestCase.php
@@ -30,7 +30,7 @@ abstract class HttpCacheTestCase extends TestCase
     protected $responses;
     protected $catch;
     protected $esi;
-    protected Store $store;
+    protected ?Store $store = null;
 
     protected function setUp(): void
     {
@@ -115,7 +115,9 @@ abstract class HttpCacheTestCase extends TestCase
 
         $this->kernel->reset();
 
-        $this->store = new Store(sys_get_temp_dir().'/http_cache');
+        if (!$this->store) {
+            $this->store = $this->createStore();
+        }
 
         if (!isset($this->cacheConfig['debug'])) {
             $this->cacheConfig['debug'] = true;
@@ -182,5 +184,10 @@ abstract class HttpCacheTestCase extends TestCase
         }
 
         closedir($fp);
+    }
+
+    protected function createStore(): Store
+    {
+        return new Store(sys_get_temp_dir().'/http_cache');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

This adds a new `waiting` trace that will be recorded by the `HttpCache` when the cache had to wait for another, concurrent request to the same resource to finish first.

The information can be used for profiling - a high rate of `waiting` requests means there is a lot of concurrency, so that it might be beneficial to either speed up request processing or consider using `stale-while-revalidate`.