### PR TITLE
[WebProfilerBundle] display profiler url in logs

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add dump indicator to profiler list view for profiles with dumped content
+ * Log the profiler URL of each request at debug level on the `profiler` channel
 
 8.1
 ---

--- a/src/Symfony/Bundle/WebProfilerBundle/EventListener/ProfilerLinkLogListener.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/EventListener/ProfilerLinkLogListener.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\WebProfilerBundle\EventListener;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+/**
+ * @author Jérémy Romey jeremyFreeAgent <jeremy@free-agent.fr>
+ */
+final class ProfilerLinkLogListener implements EventSubscriberInterface
+{
+    public function __construct(
+        private ?LoggerInterface $logger = null,
+        private ?UrlGeneratorInterface $urlGenerator = null,
+    ) {
+    }
+
+    public function onKernelResponse(ResponseEvent $event): void
+    {
+        if (null === $this->logger || null === $this->urlGenerator || !$event->isMainRequest()) {
+            return;
+        }
+
+        if (null === $token = $event->getResponse()->headers->get('X-Debug-Token')) {
+            return;
+        }
+
+        // the "X-Debug-Token-Link" header holds the same URL, but it is set by
+        // WebDebugToolbarListener, which is only registered when the toolbar is enabled
+        $this->logger->debug('See profiler at {profiler_url}', [
+            'profiler_url' => $this->urlGenerator->generate('_profiler', ['token' => $token], UrlGeneratorInterface::ABSOLUTE_URL),
+        ]);
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::RESPONSE => ['onKernelResponse', -2048],
+        ];
+    }
+}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/profiler.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/profiler.php
@@ -16,6 +16,7 @@ use Symfony\Bundle\WebProfilerBundle\Controller\ProfilerController;
 use Symfony\Bundle\WebProfilerBundle\Controller\RouterController;
 use Symfony\Bundle\WebProfilerBundle\Csp\ContentSecurityPolicyHandler;
 use Symfony\Bundle\WebProfilerBundle\Csp\NonceGenerator;
+use Symfony\Bundle\WebProfilerBundle\EventListener\ProfilerLinkLogListener;
 use Symfony\Bundle\WebProfilerBundle\Profiler\CodeExtension;
 use Symfony\Bundle\WebProfilerBundle\Twig\WebProfilerExtension;
 use Symfony\Component\ErrorHandler\ErrorRenderer\FileLinkFormatter;
@@ -84,5 +85,14 @@ return static function (ContainerConfigurator $container) {
         ->set('twig.extension.code', CodeExtension::class)
             ->args([service('debug.file_link_formatter'), param('kernel.project_dir'), param('kernel.charset')])
             ->tag('twig.extension')
+
+        ->set('web_profiler.profiler_link_log_listener', ProfilerLinkLogListener::class)
+            ->args([
+                service('logger')->nullOnInvalid(),
+                service('router')->ignoreOnInvalid(),
+            ])
+
+            ->tag('monolog.logger', ['channel' => 'profiler'])
+            ->tag('kernel.event_subscriber')
     ;
 };

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/EventListener/ProfilerLinkLogListenerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/EventListener/ProfilerLinkLogListenerTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\WebProfilerBundle\Tests\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\WebProfilerBundle\EventListener\ProfilerLinkLogListener;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+/**
+ * @author Jérémy Romey jeremyFreeAgent <jeremy@free-agent.fr>
+ */
+final class ProfilerLinkLogListenerTest extends TestCase
+{
+    public function testProfilerLinkLog()
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger
+            ->expects($this->once())
+            ->method('debug')
+            ->with('See profiler at {profiler_url}', ['profiler_url' => 'http://mydomain.com/_profiler/04bb3f'])
+        ;
+
+        (new ProfilerLinkLogListener($logger, $this->createUrlGenerator()))->onKernelResponse($this->createEvent(['X-Debug-Token' => '04bb3f']));
+    }
+
+    public function testProfilerLinkLogShouldNotLogWhenNoLogger()
+    {
+        (new ProfilerLinkLogListener(null, $this->createUrlGenerator(false)))->onKernelResponse($this->createEvent(['X-Debug-Token' => '04bb3f']));
+    }
+
+    public function testProfilerLinkLogShouldNotLogWhenNoUrlGenerator()
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->never())->method('debug');
+
+        (new ProfilerLinkLogListener($logger))->onKernelResponse($this->createEvent(['X-Debug-Token' => '04bb3f']));
+    }
+
+    public function testProfilerLinkLogShouldNotLogWhenNotMainRequest()
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->never())->method('debug');
+
+        (new ProfilerLinkLogListener($logger, $this->createUrlGenerator(false)))->onKernelResponse($this->createEvent(['X-Debug-Token' => '04bb3f'], HttpKernelInterface::SUB_REQUEST));
+    }
+
+    public function testProfilerLinkLogShouldNotLogWhenNoToken()
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->never())->method('debug');
+
+        (new ProfilerLinkLogListener($logger, $this->createUrlGenerator(false)))->onKernelResponse($this->createEvent([]));
+    }
+
+    private function createUrlGenerator(bool $expectCall = true): UrlGeneratorInterface
+    {
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator
+            ->expects($expectCall ? $this->once() : $this->never())
+            ->method('generate')
+            ->with('_profiler', ['token' => '04bb3f'], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('http://mydomain.com/_profiler/04bb3f')
+        ;
+
+        return $urlGenerator;
+    }
+
+    private function createEvent(array $headers, int $requestType = HttpKernelInterface::MAIN_REQUEST): ResponseEvent
+    {
+        $response = new Response('I love Symfony', 200);
+        foreach ($headers as $name => $value) {
+            $response->headers->set($name, $value);
+        }
+
+        return new ResponseEvent($this->createStub(Kernel::class), new Request(), $requestType, $response);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

This add the display of the profiler URL in the log as follows:

```
[Application] May 21 17:05:15 |DEBUG  | PROFIL See profiler at https://127.0.0.1:8000/_profiler/92ff6e
```

Thank you @nicolas-grekas for this idea.
