### PR TITLE
[Console][Messenger] Fix: Allow `UnrecoverableExceptionInterface` to bypass retry in `RunCommandMessageHandler`

### DIFF
--- a/src/Symfony/Component/Console/Messenger/RunCommandMessageHandler.php
+++ b/src/Symfony/Component/Console/Messenger/RunCommandMessageHandler.php
@@ -16,6 +16,8 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\RunCommandFailedException;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Messenger\Exception\RecoverableExceptionInterface;
+use Symfony\Component\Messenger\Exception\UnrecoverableExceptionInterface;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -35,6 +37,8 @@ final class RunCommandMessageHandler
 
         try {
             $exitCode = $this->application->run($input, $output);
+        } catch (UnrecoverableExceptionInterface|RecoverableExceptionInterface $e) {
+            throw $e;
         } catch (\Throwable $e) {
             throw new RunCommandFailedException($e, new RunCommandContext($message, Command::FAILURE, $output->fetch()));
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60427 
| License       | MIT

This PR ensures that `UnrecoverableExceptionInterface` exceptions thrown during the execution of a command via `RunCommandMessage` are no longer retried.
