### PR TITLE
[Routing] Allow query-specific parameters in `UrlGenerator` using `_query`

### DIFF
--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+ * Allow query-specific parameters in `UrlGenerator` using `_query`
+
 7.3
 ---
 

--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -142,6 +142,18 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
      */
     protected function doGenerate(array $variables, array $defaults, array $requirements, array $tokens, array $parameters, string $name, int $referenceType, array $hostTokens, array $requiredSchemes = []): string
     {
+        $queryParameters = [];
+
+        if (isset($parameters['_query'])) {
+            if (\is_array($parameters['_query'])) {
+                $queryParameters = $parameters['_query'];
+                unset($parameters['_query']);
+            } else {
+                trigger_deprecation('symfony/routing', '7.4', 'Parameter "_query" is reserved for passing an array of query parameters. Passing a scalar value is deprecated and will throw an exception in Symfony 8.0.');
+                // throw new InvalidParameterException('Parameter "_query" must be an array of query parameters.');
+            }
+        }
+
         $variables = array_flip($variables);
         $mergedParams = array_replace($defaults, $this->context->getParameters(), $parameters);
 
@@ -260,6 +272,7 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
 
         // add a query string if needed
         $extra = array_udiff_assoc(array_diff_key($parameters, $variables), $defaults, fn ($a, $b) => $a == $b ? 0 : 1);
+        $extra = array_merge($extra, $queryParameters);
 
         array_walk_recursive($extra, $caster = static function (&$v) use (&$caster) {
             if (\is_object($v)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR adds support for a special `_query` key in `$parameters` of `UrlGenerator::generate()`, that is used exclusively to generate query parameters. This is useful when query parameters may conflict with route parameters of the same name.

Concrete use case:

My application has a route that looks like:

    https://{siteCode}.{domain}/admin/stats

And I want to generate this URL:

    https://fr.example.com/admin/stats?siteCode=us

With this PR, I can now call:

```php
$urlGenerator->generate('admin_stats', [
    'siteCode' => 'fr',
    'domain' => 'example.com',
    '_query' => [
        'siteCode' => 'us',
    ]
]);
```