### PR TITLE
[Messenger] meaningfully error in `DeduplicateStamp` if the Lock component is missing

### DIFF
--- a/src/Symfony/Component/Messenger/Stamp/DeduplicateStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/DeduplicateStamp.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Messenger\Stamp;
 
 use Symfony\Component\Lock\Key;
+use Symfony\Component\Messenger\Exception\LogicException;
 
 final class DeduplicateStamp implements StampInterface
 {
@@ -22,6 +23,10 @@ final class DeduplicateStamp implements StampInterface
         private ?float $ttl = 300.0,
         private bool $onlyDeduplicateInQueue = false,
     ) {
+        if (!class_exists(Key::class)) {
+            throw new LogicException(\sprintf('You cannot use the "%s" as the Lock component is not installed. Try running "composer require symfony/lock".', self::class));
+        }
+
         $this->key = new Key($key);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60510
| License       | MIT

This way we don't hide the fact that the `DeduplicateStamp` requires the Lock component to be installed.