### PR TITLE
[Mailer] Fix memory leak with `mailer.message_logger_listener`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer.php
@@ -15,7 +15,6 @@ use Symfony\Component\Mailer\Command\MailerTestCommand;
 use Symfony\Component\Mailer\EventListener\DkimSignedMessageListener;
 use Symfony\Component\Mailer\EventListener\EnvelopeListener;
 use Symfony\Component\Mailer\EventListener\MessageListener;
-use Symfony\Component\Mailer\EventListener\MessageLoggerListener;
 use Symfony\Component\Mailer\EventListener\MessengerTransportListener;
 use Symfony\Component\Mailer\EventListener\SmimeEncryptedMessageListener;
 use Symfony\Component\Mailer\EventListener\SmimeSignedMessageListener;
@@ -71,10 +70,6 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('headers'),
             ])
             ->tag('kernel.event_subscriber')
-
-        ->set('mailer.message_logger_listener', MessageLoggerListener::class)
-            ->tag('kernel.event_subscriber')
-            ->tag('kernel.reset', ['method' => 'reset'])
 
         ->set('mailer.messenger_transport_listener', MessengerTransportListener::class)
             ->tag('kernel.event_subscriber')

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer_debug.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer_debug.php
@@ -12,9 +12,17 @@
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Component\Mailer\DataCollector\MessageDataCollector;
+use Symfony\Component\Mailer\EventListener\MessageLoggerListener;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
+        ->set('mailer.message_logger_listener', MessageLoggerListener::class)
+            ->args([
+                service('profiler.is_disabled_state_checker')->nullOnInvalid(),
+            ])
+            ->tag('kernel.event_subscriber')
+            ->tag('kernel.reset', ['method' => 'reset'])
+
         ->set('mailer.data_collector', MessageDataCollector::class)
             ->args([
                 service('mailer.message_logger_listener'),

--- a/src/Symfony/Component/Mailer/EventListener/MessageLoggerListener.php
+++ b/src/Symfony/Component/Mailer/EventListener/MessageLoggerListener.php
@@ -25,8 +25,9 @@ class MessageLoggerListener implements EventSubscriberInterface, ResetInterface
 {
     private MessageEvents $events;
 
-    public function __construct()
-    {
+    public function __construct(
+        protected ?\Closure $disabled = null,
+    ) {
         $this->events = new MessageEvents();
     }
 
@@ -37,6 +38,10 @@ class MessageLoggerListener implements EventSubscriberInterface, ResetInterface
 
     public function onMessage(MessageEvent $event): void
     {
+        if ($this->disabled?->__invoke()) {
+            return;
+        }
+
         $this->events->add($event);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #50580
| License       | MIT

Register `mailer.message_logger_listener` only when profiler enabled to prevent memory leaks as suggested in:
- https://github.com/symfony/symfony/issues/50580#issuecomment-2901453945
- https://github.com/symfony/symfony/issues/50580#issuecomment-2244558218

~~@stof can you guide me about the way how to implement your second suggestion too? https://github.com/symfony/symfony/issues/50580#issuecomment-2901464612~~ UPD: resolved

_This change may be considered as a minor BC break - DI service won't be available anymore with disabled profiler._