### PR TITLE
[Messenger] Messenger: add `--duration` option to `messenger:stop-workers` command

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -5,7 +5,7 @@ CHANGELOG
 ---
 
  * Allow any `ServiceResetterInterface` implementation in `ResetServicesListener`
- * Add `--duration` option to `messenger:stop-workers` command to keep workers in paused state.
+ * Add `--duration` option to `messenger:stop-workers` command to keep workers in paused state
 
 7.3
 ---

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Allow any `ServiceResetterInterface` implementation in `ResetServicesListener`
+ * Add `--duration` option to `messenger:stop-workers` command to keep workers in paused state.
 
 7.3
 ---

--- a/src/Symfony/Component/Messenger/Command/StopWorkersCommand.php
+++ b/src/Symfony/Component/Messenger/Command/StopWorkersCommand.php
@@ -14,7 +14,9 @@ namespace Symfony\Component\Messenger\Command;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -35,7 +37,9 @@ class StopWorkersCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setDefinition([])
+            ->setDefinition([
+                new InputOption('duration', 'd', InputOption::VALUE_REQUIRED, 'Duration in seconds to keep the workers stopped'),
+            ])
             ->setHelp(<<<'EOF'
                 The <info>%command.name%</info> command sends a signal to stop any <info>messenger:consume</info> processes that are running.
 
@@ -44,6 +48,11 @@ class StopWorkersCommand extends Command
                 Each worker command will finish the message they are currently processing
                 and then exit. Worker commands are *not* automatically restarted: that
                 should be handled by a process control system.
+
+                Use the --duration option to keep the workers in a paused state (not processing messages) for the given duration (in seconds).
+                During this time, no messages will be handled, and the workers will not resume until the pause period has passed:
+
+                    <info>php %command.full_name% --duration=60</info>
                 EOF
             )
         ;
@@ -53,11 +62,20 @@ class StopWorkersCommand extends Command
     {
         $io = new SymfonyStyle($input, $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output);
 
+        if (null !== $duration = $input->getOption('duration')) {
+            if (!is_numeric($duration) || 0 >= $duration) {
+                throw new InvalidOptionException(\sprintf('Option "duration" must be a positive integer, "%s" passed.', $duration));
+            }
+        }
+
         $cacheItem = $this->restartSignalCachePool->getItem(StopWorkerOnRestartSignalListener::RESTART_REQUESTED_TIMESTAMP_KEY);
-        $cacheItem->set(microtime(true));
+        $cacheItem->set(microtime(true) + $duration);
         $this->restartSignalCachePool->save($cacheItem);
 
         $io->success('Signal successfully sent to stop any running workers.');
+        if ($duration > 0) {
+            $io->info(sprintf('Workers will be stopped for next %s seconds.', $duration));
+        }
 
         return 0;
     }

--- a/src/Symfony/Component/Messenger/Command/StopWorkersCommand.php
+++ b/src/Symfony/Component/Messenger/Command/StopWorkersCommand.php
@@ -49,7 +49,7 @@ class StopWorkersCommand extends Command
                 and then exit. Worker commands are *not* automatically restarted: that
                 should be handled by a process control system.
 
-                Use the <comment>--duration</comment> option to keep the workers in a paused state (not processing messages) for the given duration (in seconds).
+                Use the <info>--duration</info> option to keep the workers in a paused state (not processing messages) for the given duration (in seconds).
                 During this time, no messages will be handled, and the workers will not resume until the pause period has passed:
 
                     <info>php %command.full_name% --duration=60</info>
@@ -62,11 +62,7 @@ class StopWorkersCommand extends Command
     {
         $io = new SymfonyStyle($input, $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output);
 
-        if (null !== $duration = $input->getOption('duration')) {
-            if (!is_numeric($duration) || 0 >= $duration) {
-                throw new InvalidOptionException(\sprintf('Option "duration" must be a positive integer, "%s" passed.', $duration));
-            }
-        }
+        $duration = (int) $input->getOption('duration');
 
         $cacheItem = $this->restartSignalCachePool->getItem(StopWorkerOnRestartSignalListener::RESTART_REQUESTED_TIMESTAMP_KEY);
         $cacheItem->set(microtime(true) + $duration);
@@ -74,7 +70,7 @@ class StopWorkersCommand extends Command
 
         $io->success('Signal successfully sent to stop any running workers.');
         if ($duration > 0) {
-            $io->info(sprintf('Workers will be paused for %s seconds.', $duration));
+            $io->info(\sprintf('Workers will be paused for %s seconds.', $duration));
         }
 
         return 0;

--- a/src/Symfony/Component/Messenger/Command/StopWorkersCommand.php
+++ b/src/Symfony/Component/Messenger/Command/StopWorkersCommand.php
@@ -38,7 +38,7 @@ class StopWorkersCommand extends Command
     {
         $this
             ->setDefinition([
-                new InputOption('duration', 'd', InputOption::VALUE_REQUIRED, 'Duration in seconds to keep the workers stopped'),
+                new InputOption('duration', 'd', InputOption::VALUE_REQUIRED, 'Duration in seconds during which workers are paused (not processing messages)'),
             ])
             ->setHelp(<<<'EOF'
                 The <info>%command.name%</info> command sends a signal to stop any <info>messenger:consume</info> processes that are running.
@@ -49,7 +49,7 @@ class StopWorkersCommand extends Command
                 and then exit. Worker commands are *not* automatically restarted: that
                 should be handled by a process control system.
 
-                Use the --duration option to keep the workers in a paused state (not processing messages) for the given duration (in seconds).
+                Use the <comment>--duration</comment> option to keep the workers in a paused state (not processing messages) for the given duration (in seconds).
                 During this time, no messages will be handled, and the workers will not resume until the pause period has passed:
 
                     <info>php %command.full_name% --duration=60</info>
@@ -74,7 +74,7 @@ class StopWorkersCommand extends Command
 
         $io->success('Signal successfully sent to stop any running workers.');
         if ($duration > 0) {
-            $io->info(sprintf('Workers will be stopped for next %s seconds.', $duration));
+            $io->info(sprintf('Workers will be paused for %s seconds.', $duration));
         }
 
         return 0;

--- a/src/Symfony/Component/Messenger/Command/StopWorkersCommand.php
+++ b/src/Symfony/Component/Messenger/Command/StopWorkersCommand.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\Messenger\Command;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;

--- a/src/Symfony/Component/Messenger/EventListener/StopWorkerOnRestartSignalListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/StopWorkerOnRestartSignalListener.php
@@ -64,13 +64,13 @@ class StopWorkerOnRestartSignalListener implements EventSubscriberInterface
         return $this->workerStartedAt < $this->getEndOfStopTime();
     }
 
-    private function getEndOfStopTime(): float
+    private function getEndOfStopTime(): ?float
     {
         $cacheItem = $this->cachePool->getItem(self::RESTART_REQUESTED_TIMESTAMP_KEY);
 
         if (!$cacheItem->isHit()) {
             // no restart has ever been scheduled
-            return false;
+            return null;
         }
 
         return (float) $cacheItem->get();

--- a/src/Symfony/Component/Messenger/EventListener/StopWorkerOnRestartSignalListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/StopWorkerOnRestartSignalListener.php
@@ -39,7 +39,7 @@ class StopWorkerOnRestartSignalListener implements EventSubscriberInterface
         if ($this->shouldRestart()) {
             $event->getWorker()->stop();
             $remainingStopSeconds = ceil($this->getEndOfStopTime()) - time();
-            $this->logger?->info(sprintf('Worker is stopped and message processing is paused for the next %d seconds.', $remainingStopSeconds));
+            $this->logger?->info(sprintf('The worker is paused and message processing will resume in %d seconds.', $remainingStopSeconds));
         }
     }
 

--- a/src/Symfony/Component/Messenger/EventListener/StopWorkerOnRestartSignalListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/StopWorkerOnRestartSignalListener.php
@@ -39,7 +39,7 @@ class StopWorkerOnRestartSignalListener implements EventSubscriberInterface
         if ($this->shouldRestart()) {
             $event->getWorker()->stop();
             $remainingStopSeconds = ceil($this->getEndOfStopTime()) - time();
-            $this->logger?->info(sprintf('The worker is paused and message processing will resume in %d seconds.', $remainingStopSeconds));
+            $this->logger?->info(\sprintf('The worker is paused and message processing will resume in %d seconds.', $remainingStopSeconds));
         }
     }
 

--- a/src/Symfony/Component/Messenger/EventListener/StopWorkerOnRestartSignalListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/StopWorkerOnRestartSignalListener.php
@@ -32,9 +32,15 @@ class StopWorkerOnRestartSignalListener implements EventSubscriberInterface
     ) {
     }
 
-    public function onWorkerStarted(): void
+    public function onWorkerStarted(WorkerStartedEvent $event): void
     {
         $this->workerStartedAt = microtime(true);
+
+        if ($this->shouldRestart()) {
+            $event->getWorker()->stop();
+            $remainingStopSeconds = ceil($this->getEndOfStopTime()) - time();
+            $this->logger?->info(sprintf('Worker is stopped and message processing is paused for the next %d seconds.', $remainingStopSeconds));
+        }
     }
 
     public function onWorkerRunning(WorkerRunningEvent $event): void
@@ -55,6 +61,11 @@ class StopWorkerOnRestartSignalListener implements EventSubscriberInterface
 
     private function shouldRestart(): bool
     {
+        return $this->workerStartedAt < $this->getEndOfStopTime();
+    }
+
+    private function getEndOfStopTime(): float
+    {
         $cacheItem = $this->cachePool->getItem(self::RESTART_REQUESTED_TIMESTAMP_KEY);
 
         if (!$cacheItem->isHit()) {
@@ -62,6 +73,6 @@ class StopWorkerOnRestartSignalListener implements EventSubscriberInterface
             return false;
         }
 
-        return $this->workerStartedAt < $cacheItem->get();
+        return (float) $cacheItem->get();
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Command/StopWorkersCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/StopWorkersCommandTest.php
@@ -23,7 +23,7 @@ class StopWorkersCommandTest extends TestCase
     {
         $cachePool = $this->createMock(CacheItemPoolInterface::class);
         $cacheItem = $this->createMock(CacheItemInterface::class);
-        $cacheItem->expects($this->once())->method('set');
+        $cacheItem->expects($this->once())->method('set')->with();
         $cachePool->expects($this->once())->method('getItem')->willReturn($cacheItem);
         $cachePool->expects($this->once())->method('save')->with($cacheItem);
 

--- a/src/Symfony/Component/Messenger/Tests/Command/StopWorkersCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/StopWorkersCommandTest.php
@@ -23,7 +23,7 @@ class StopWorkersCommandTest extends TestCase
     {
         $cachePool = $this->createMock(CacheItemPoolInterface::class);
         $cacheItem = $this->createMock(CacheItemInterface::class);
-        $cacheItem->expects($this->once())->method('set');
+        $cacheItem->expects($this->once())->method('set')->with();
         $cachePool->expects($this->once())->method('getItem')->willReturn($cacheItem);
         $cachePool->expects($this->once())->method('save')->with($cacheItem);
 
@@ -31,5 +31,22 @@ class StopWorkersCommandTest extends TestCase
 
         $tester = new CommandTester($command);
         $tester->execute([]);
+    }
+
+    /**
+     * @group time-sensitive
+     */
+    public function testItSetsCacheItemWithDurationAdded()
+    {
+        $cachePool = $this->createMock(CacheItemPoolInterface::class);
+        $cacheItem = $this->createMock(CacheItemInterface::class);
+        $cacheItem->expects($this->once())->method('set')->with($this->equalToWithDelta(microtime(true), 62)); // "extra" 2 seconds
+        $cachePool->expects($this->once())->method('getItem')->willReturn($cacheItem);
+        $cachePool->expects($this->once())->method('save')->with($cacheItem);
+
+        $command = new StopWorkersCommand($cachePool);
+
+        $tester = new CommandTester($command);
+        $tester->execute(['--duration' => 60]);
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Command/StopWorkersCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/StopWorkersCommandTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Messenger\Tests\Command;
 
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
@@ -33,9 +34,7 @@ class StopWorkersCommandTest extends TestCase
         $tester->execute([]);
     }
 
-    /**
-     * @group time-sensitive
-     */
+    #[Group('time-sensitive')]
     public function testItSetsCacheItemWithDurationAdded()
     {
         $cachePool = $this->createMock(CacheItemPoolInterface::class);

--- a/src/Symfony/Component/Messenger/Tests/Command/StopWorkersCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/StopWorkersCommandTest.php
@@ -23,7 +23,7 @@ class StopWorkersCommandTest extends TestCase
     {
         $cachePool = $this->createMock(CacheItemPoolInterface::class);
         $cacheItem = $this->createMock(CacheItemInterface::class);
-        $cacheItem->expects($this->once())->method('set')->with();
+        $cacheItem->expects($this->once())->method('set');
         $cachePool->expects($this->once())->method('getItem')->willReturn($cacheItem);
         $cachePool->expects($this->once())->method('save')->with($cacheItem);
 

--- a/src/Symfony/Component/Messenger/Tests/EventListener/StopWorkerOnRestartSignalListenerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EventListener/StopWorkerOnRestartSignalListenerTest.php
@@ -16,7 +16,9 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\DependencyInjection\CachePoolPass;
 use Symfony\Component\Messenger\Event\WorkerRunningEvent;
+use Symfony\Component\Messenger\Event\WorkerStartedEvent;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnRestartSignalListener;
 use Symfony\Component\Messenger\Worker;
 
@@ -24,44 +26,87 @@ use Symfony\Component\Messenger\Worker;
 class StopWorkerOnRestartSignalListenerTest extends TestCase
 {
     #[DataProvider('restartTimeProvider')]
-    public function testWorkerStopsWhenMemoryLimitExceeded(?int $lastRestartTimeOffset, bool $shouldStop)
+    public function testWorkerStopsOnStartIfRestartInCache(?int $lastRestartTimeOffset, bool $shouldStop)
     {
-        $cachePool = $this->createMock(CacheItemPoolInterface::class);
-        $cacheItem = $this->createMock(CacheItemInterface::class);
-        $cacheItem->expects($this->once())->method('isHit')->willReturn(true);
-        $cacheItem->expects($this->once())->method('get')->willReturn(null === $lastRestartTimeOffset ? null : time() + $lastRestartTimeOffset);
-        $cachePool->expects($this->once())->method('getItem')->willReturn($cacheItem);
+        $cachePool = $this->createRestartInCachePool($lastRestartTimeOffset);
 
         $worker = $this->createMock(Worker::class);
         $worker->expects($shouldStop ? $this->once() : $this->never())->method('stop');
-        $event = new WorkerRunningEvent($worker, false);
+        $workerStartedEvent = new WorkerStartedEvent($worker);
 
         $stopOnSignalListener = new StopWorkerOnRestartSignalListener($cachePool);
-        $stopOnSignalListener->onWorkerStarted();
-        $stopOnSignalListener->onWorkerRunning($event);
+        $stopOnSignalListener->onWorkerStarted($workerStartedEvent);
     }
 
-    public static function restartTimeProvider()
+    /**
+     * @dataProvider restartTimeProvider
+     */
+    public function testWorkerStopsIfRestartInCache(?int $lastRestartTimeOffset, bool $shouldStop)
+    {
+        $cachePool = $this->createRestartInCachePool($lastRestartTimeOffset);
+
+        $worker = $this->createMock(Worker::class);
+        $worker->expects($shouldStop ? $this->atLeast(1) : $this->never())->method('stop');
+        $workerStartedEvent = new WorkerStartedEvent($worker);
+        $workerRunningEvent = new WorkerRunningEvent($worker, false);
+
+        $stopOnSignalListener = new StopWorkerOnRestartSignalListener($cachePool);
+        $stopOnSignalListener->onWorkerStarted($workerStartedEvent);
+        $stopOnSignalListener->onWorkerRunning($workerRunningEvent);
+    }
+
+    public static function restartTimeProvider(): iterable
     {
         yield [null, false]; // no cached restart time, do not restart
         yield [+10, true]; // 10 seconds after starting, a restart was requested
         yield [-10, false]; // a restart was requested, but 10 seconds before we started
     }
 
-    public function testWorkerDoesNotStopIfRestartNotInCache()
+    public function testWorkerDoesNotStopOnStartIfRestartNotInCache()
     {
-        $cachePool = $this->createMock(CacheItemPoolInterface::class);
-        $cacheItem = $this->createMock(CacheItemInterface::class);
-        $cacheItem->expects($this->once())->method('isHit')->willReturn(false);
-        $cacheItem->expects($this->never())->method('get');
-        $cachePool->expects($this->once())->method('getItem')->willReturn($cacheItem);
+        $cachePool = $this->createRestartNotInCachePool();
 
         $worker = $this->createMock(Worker::class);
         $worker->expects($this->never())->method('stop');
-        $event = new WorkerRunningEvent($worker, false);
+        $workerStartedEvent = new WorkerStartedEvent($worker);
 
         $stopOnSignalListener = new StopWorkerOnRestartSignalListener($cachePool);
-        $stopOnSignalListener->onWorkerStarted();
-        $stopOnSignalListener->onWorkerRunning($event);
+        $stopOnSignalListener->onWorkerStarted($workerStartedEvent);
+    }
+
+    public function testWorkerDoesNotStopIfRestartNotInCache()
+    {
+        $cachePool = $this->createRestartNotInCachePool();
+
+        $worker = $this->createMock(Worker::class);
+        $worker->expects($this->never())->method('stop');
+        $workerStartedEvent = new WorkerStartedEvent($worker);
+        $workerRunningEvent = new WorkerRunningEvent($worker, false);
+
+        $stopOnSignalListener = new StopWorkerOnRestartSignalListener($cachePool);
+        $stopOnSignalListener->onWorkerStarted($workerStartedEvent);
+        $stopOnSignalListener->onWorkerRunning($workerRunningEvent);
+    }
+
+    private function createRestartInCachePool(?int $value): CacheItemPoolInterface
+    {
+        $cachePool = $this->createMock(CacheItemPoolInterface::class);
+        $cacheItem = $this->createMock(CacheItemInterface::class);
+        $cacheItem->method('isHit')->willReturn(true);
+        $cacheItem->method('get')->willReturn(null === $value ? null : time() + $value);
+        $cachePool->method('getItem')->willReturn($cacheItem);
+
+        return $cachePool;
+    }
+
+    private function createRestartNotInCachePool(): CacheItemPoolInterface
+    {
+        $cachePool = $this->createMock(CacheItemPoolInterface::class);
+        $cacheItem = $this->createMock(CacheItemInterface::class);
+        $cacheItem->method('isHit')->willReturn(false);
+        $cacheItem->method('get');
+        $cachePool->method('getItem')->willReturn($cacheItem);
+
+        return $cachePool;
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/EventListener/StopWorkerOnRestartSignalListenerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EventListener/StopWorkerOnRestartSignalListenerTest.php
@@ -16,7 +16,6 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
-use Symfony\Component\Cache\DependencyInjection\CachePoolPass;
 use Symfony\Component\Messenger\Event\WorkerRunningEvent;
 use Symfony\Component\Messenger\Event\WorkerStartedEvent;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnRestartSignalListener;

--- a/src/Symfony/Component/Messenger/Tests/EventListener/StopWorkerOnRestartSignalListenerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EventListener/StopWorkerOnRestartSignalListenerTest.php
@@ -38,9 +38,7 @@ class StopWorkerOnRestartSignalListenerTest extends TestCase
         $stopOnSignalListener->onWorkerStarted($workerStartedEvent);
     }
 
-    /**
-     * @dataProvider restartTimeProvider
-     */
+    #[DataProvider('restartTimeProvider')]
     public function testWorkerStopsIfRestartInCache(?int $lastRestartTimeOffset, bool $shouldStop)
     {
         $cachePool = $this->createRestartInCachePool($lastRestartTimeOffset);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

Hi!

My proposal is to add a `--duration` option to the `messenger:stop-workers` command, which would allow to "pause" the workers for the amount of time specified in this option.

For example, if we pass `--duration=10`, then for the next 10 seconds, running `messenger:consume` will return a message indicating how many seconds are left until the "pause" ends.

I think this option would be helpful during deployments (we're using it this way in my company).

![image](https://github.com/user-attachments/assets/e35112da-fe10-412f-8297-2b65c09629ff)


![image](https://github.com/user-attachments/assets/25fa21a3-4aa3-4fa6-9a2f-065adb44f96d)

