### PR TITLE
[JsonStreamer] also reject `\DateTime` subclasses

### DIFF
--- a/src/Symfony/Component/JsonStreamer/Mapping/Read/DateTimeTypePropertyMetadataLoader.php
+++ b/src/Symfony/Component/JsonStreamer/Mapping/Read/DateTimeTypePropertyMetadataLoader.php
@@ -38,7 +38,7 @@ final class DateTimeTypePropertyMetadataLoader implements PropertyMetadataLoader
             $type = $metadata->getType();
 
             if ($type instanceof ObjectType && is_a($type->getClassName(), \DateTimeInterface::class, true)) {
-                if (\DateTime::class === $type->getClassName()) {
+                if (is_a($type->getClassName(), \DateTime::class, true)) {
                     throw new InvalidArgumentException('The "DateTime" class is not supported. Use "DateTimeImmutable" instead.');
                 }
 

--- a/src/Symfony/Component/JsonStreamer/Tests/Mapping/Read/DateTimeTypePropertyMetadataLoaderTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Mapping/Read/DateTimeTypePropertyMetadataLoaderTest.php
@@ -47,6 +47,18 @@ class DateTimeTypePropertyMetadataLoaderTest extends TestCase
         $loader->load(self::class);
     }
 
+    public function testThrowWhenDateTimeSubclassType()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "DateTime" class is not supported. Use "DateTimeImmutable" instead.');
+
+        $loader = new DateTimeTypePropertyMetadataLoader(self::propertyMetadataLoader([
+            'mutable' => new PropertyMetadata('mutable', Type::object(DateTimeChild::class)),
+        ]));
+
+        $loader->load(self::class);
+    }
+
     /**
      * @param array<string, PropertyMetadata> $propertiesMetadata
      */
@@ -63,4 +75,8 @@ class DateTimeTypePropertyMetadataLoaderTest extends TestCase
             }
         };
     }
+}
+
+class DateTimeChild extends \DateTime
+{
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | following https://github.com/symfony/symfony/pull/59290#discussion_r1903933985
| License       | MIT