### PR TITLE
[Notifier] Fix Clicksend transport

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/ClickSend/ClickSendTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/ClickSend/ClickSendTransport.php
@@ -87,7 +87,7 @@ final class ClickSendTransport extends AbstractTransport
 
         $response = $this->client->request('POST', $endpoint, [
             'auth_basic' => [$this->apiUsername, $this->apiKey],
-            'json' => array_filter($options),
+            'json' => ['messages' => [array_filter($options)]],
         ]);
 
         try {

--- a/src/Symfony/Component/Notifier/Bridge/ClickSend/Tests/ClickSendTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/ClickSend/Tests/ClickSendTransportTest.php
@@ -63,9 +63,13 @@ final class ClickSendTransportTest extends TransportTestCase
         $response = $this->createMock(ResponseInterface::class);
         $response->expects(self::exactly(2))->method('getStatusCode')->willReturn(200);
         $response->expects(self::once())->method('getContent')->willReturn('');
-        $client = new MockHttpClient(function (string $method, string $url) use ($response): ResponseInterface {
+        $client = new MockHttpClient(function (string $method, string $url, array $options) use ($response): ResponseInterface {
             self::assertSame('POST', $method);
             self::assertSame('https://rest.clicksend.com/v3/sms/send', $url);
+
+            $body = json_decode($options['body'], true);
+            self::assertIsArray($body);
+            self::assertArrayHasKey('messages', $body);
 
             return $response;
         });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52486
| License       | MIT

Hello,

It seems to be an old issue (see https://github.com/symfony/symfony/discussions/52486) but the format sent to Clicksend is not correct. When using the library we have this error: `[Symfony\Component\Notifier\Exception\TransportException]
  Unable to send the SMS - "{"http_code":400,"response_code":"BAD_REQUEST","response_msg":"The messages array is empty.","data":null}"`. The correct structure should have a "messages" key (see documentation: https://developers-dev.clicksend.net/docs/messaging/sms/other/send-sms).