### PR TITLE
[Lock] Use plain text (vs. hash) for short key names with database stores

### DIFF
--- a/src/Symfony/Component/Lock/Store/DatabaseTableTrait.php
+++ b/src/Symfony/Component/Lock/Store/DatabaseTableTrait.php
@@ -46,11 +46,15 @@ trait DatabaseTableTrait
     }
 
     /**
-     * Returns a hashed version of the key.
+     * Returns the key name in the database.
+     *
+     * It returns a sha256 hash, if the original key name is longer than 64 chars.
      */
-    private function getHashedKey(Key $key): string
+    private function getKeyName(Key $key): string
     {
-        return hash('sha256', (string) $key);
+        $key = (string) $key;
+
+        return strlen($key) <= 64 ? $key : hash('sha256', $key);
     }
 
     private function getUniqueToken(Key $key): string

--- a/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php
+++ b/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php
@@ -106,7 +106,7 @@ class DoctrineDbalStore implements PersistingStoreInterface
 
         try {
             $this->conn->executeStatement($sql, [
-                $this->getHashedKey($key),
+                $this->getKeyName($key),
                 $this->getUniqueToken($key),
             ], [
                 ParameterType::STRING,
@@ -119,7 +119,7 @@ class DoctrineDbalStore implements PersistingStoreInterface
 
             try {
                 $this->conn->executeStatement($sql, [
-                    $this->getHashedKey($key),
+                    $this->getKeyName($key),
                     $this->getUniqueToken($key),
                 ], [
                     ParameterType::STRING,
@@ -151,7 +151,7 @@ class DoctrineDbalStore implements PersistingStoreInterface
         $result = $this->conn->executeQuery($sql, [
             $ttl,
             $uniqueToken,
-            $this->getHashedKey($key),
+            $this->getKeyName($key),
             $uniqueToken,
         ], [
             ParameterType::INTEGER,
@@ -171,7 +171,7 @@ class DoctrineDbalStore implements PersistingStoreInterface
     public function delete(Key $key): void
     {
         $this->conn->delete($this->table, [
-            $this->idCol => $this->getHashedKey($key),
+            $this->idCol => $this->getKeyName($key),
             $this->tokenCol => $this->getUniqueToken($key),
         ]);
     }
@@ -180,7 +180,7 @@ class DoctrineDbalStore implements PersistingStoreInterface
     {
         $sql = "SELECT 1 FROM $this->table WHERE $this->idCol = ? AND $this->tokenCol = ? AND $this->expirationCol > {$this->getCurrentTimestampStatement()}";
         $result = $this->conn->fetchOne($sql, [
-            $this->getHashedKey($key),
+            $this->getKeyName($key),
             $this->getUniqueToken($key),
         ], [
             ParameterType::STRING,

--- a/src/Symfony/Component/Lock/Store/PdoStore.php
+++ b/src/Symfony/Component/Lock/Store/PdoStore.php
@@ -98,7 +98,7 @@ class PdoStore implements PersistingStoreInterface
             $stmt = $conn->prepare($sql);
         }
 
-        $stmt->bindValue(':id', $this->getHashedKey($key));
+        $stmt->bindValue(':id', $this->getKeyName($key));
         $stmt->bindValue(':token', $this->getUniqueToken($key));
 
         try {
@@ -134,7 +134,7 @@ class PdoStore implements PersistingStoreInterface
         $stmt = $this->getConnection()->prepare($sql);
 
         $uniqueToken = $this->getUniqueToken($key);
-        $stmt->bindValue(':id', $this->getHashedKey($key));
+        $stmt->bindValue(':id', $this->getKeyName($key));
         $stmt->bindValue(':token1', $uniqueToken);
         $stmt->bindValue(':token2', $uniqueToken);
         $result = $stmt->execute();
@@ -152,7 +152,7 @@ class PdoStore implements PersistingStoreInterface
         $sql = "DELETE FROM $this->table WHERE $this->idCol = :id AND $this->tokenCol = :token";
         $stmt = $this->getConnection()->prepare($sql);
 
-        $stmt->bindValue(':id', $this->getHashedKey($key));
+        $stmt->bindValue(':id', $this->getKeyName($key));
         $stmt->bindValue(':token', $this->getUniqueToken($key));
         $stmt->execute();
     }
@@ -162,7 +162,7 @@ class PdoStore implements PersistingStoreInterface
         $sql = "SELECT 1 FROM $this->table WHERE $this->idCol = :id AND $this->tokenCol = :token AND $this->expirationCol > {$this->getCurrentTimestampStatement()}";
         $stmt = $this->getConnection()->prepare($sql);
 
-        $stmt->bindValue(':id', $this->getHashedKey($key));
+        $stmt->bindValue(':id', $this->getKeyName($key));
         $stmt->bindValue(':token', $this->getUniqueToken($key));
         $result = $stmt->execute();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #57906
| License       | MIT

Use plain text for key names when they are short enough.

It helps to understand where inserted locks come from when looking at the database.

See https://github.com/symfony/symfony/issues/57906 for examples of how the locks look like in the database.
