### PR TITLE
[Routing] Fix inline default `null`

### DIFF
--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -420,7 +420,7 @@ class Route implements \Serializable
 
         $pattern = preg_replace_callback('#\{(!?)([\w\x80-\xFF]++)(:([\w\x80-\xFF]++)(\.[\w\x80-\xFF]++)?)?(<.*?>)?(\?[^\}]*+)?\}#', function ($m) use (&$mapping) {
             if (isset($m[7][0])) {
-                $this->setDefault($m[2], '?' !== $m[6] ? substr($m[7], 1) : null);
+                $this->setDefault($m[2], '?' !== $m[7] ? substr($m[7], 1) : null);
             }
             if (isset($m[6][0])) {
                 $this->setRequirement($m[2], substr($m[6], 1, -1));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

PR #59904 broke setting `null` as the default route param value using inline syntax. Instead of `null`, an empty string is set as the default. The tests didn't catch it because `$this->assertEquals(null, '')` is true.