### PR TITLE
[DoctrineBridge] Fix resetting the manager when using native lazy objects

### DIFF
--- a/src/Symfony/Bridge/Doctrine/ManagerRegistry.php
+++ b/src/Symfony/Bridge/Doctrine/ManagerRegistry.php
@@ -80,21 +80,35 @@ abstract class ManagerRegistry extends AbstractManagerRegistry
             return;
         }
 
-        try {
-            $r->resetAsLazyProxy($manager, \Closure::bind(
-                function () use ($name) {
-                    $name = $this->aliases[$name] ?? $name;
+        $asProxy = $r->initializeLazyObject($manager) !== $manager;
+        $initializer = \Closure::bind(
+            function ($manager) use ($name, $asProxy) {
+                $name = $this->aliases[$name] ?? $name;
+                if ($asProxy) {
+                    $manager = false;
+                }
 
-                    return match (true) {
-                        isset($this->fileMap[$name]) => $this->load($this->fileMap[$name], false),
-                        !$method = $this->methodMap[$name] ?? null => throw new \LogicException(\sprintf('The "%s" service is synthetic and cannot be reset.', $name)),
-                        (new \ReflectionMethod($this, $method))->isStatic() => $this->{$method}($this, false),
-                        default => $this->{$method}(false),
-                    };
-                },
-                $this->container,
-                Container::class
-            ));
+                $manager = match (true) {
+                    isset($this->fileMap[$name]) => $this->load($this->fileMap[$name], $manager),
+                    !$method = $this->methodMap[$name] ?? null => throw new \LogicException(\sprintf('The "%s" service is synthetic and cannot be reset.', $name)),
+                    (new \ReflectionMethod($this, $method))->isStatic() => $this->{$method}($this, $manager),
+                    default => $this->{$method}($manager),
+                };
+
+                if ($asProxy) {
+                    return $manager;
+                }
+            },
+            $this->container,
+            Container::class
+        );
+
+        try {
+            if ($asProxy) {
+                $r->resetAsLazyProxy($manager, $initializer);
+            } else {
+                $r->resetAsLazyGhost($manager, $initializer);
+            }
         } catch (\Error $e) {
             if (__FILE__ !== $e->getFile()) {
                 throw $e;

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/DummyManager.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/DummyManager.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
 
 use Doctrine\Persistence\Mapping\ClassMetadata;
@@ -10,6 +19,10 @@ use Doctrine\Persistence\ObjectRepository;
 class DummyManager implements ObjectManager
 {
     public $bar;
+
+    public function __construct()
+    {
+    }
 
     public function find($className, $id): ?object
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

PR #59913 doesn't seem to work as expected. For example, a simple test like this:

```php
class DoctrineTest extends KernelTestCase
{
    public function testManagerRegistryReset(): void
    {
        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
        $entityManager->close();

        self::assertFalse($entityManager->isOpen());

        $managerRegistry = self::getContainer()->get(ManagerRegistry::class);
        $managerRegistry->resetManager();

        self::assertTrue($entityManager->isOpen());
    }
}
```

fails with:

> There was 1 error:
> 
> 1) App\Tests\DoctrineTest::testManagerRegistryReset
> Error: Call to a member function __construct() on false
> 
> /project/var/cache/test/ContainerTVZSKa5/App_KernelTestDebugContainer.php:709
> /project/vendor/symfony/doctrine-bridge/ManagerRegistry.php:91
> /project/vendor/doctrine/orm/src/EntityManager.php:534
> /project/tests/DoctrineTest.php:21

Here's the dumped container for reference:

```php
protected static function getDoctrine_Orm_DefaultEntityManagerService($container, $lazyLoad = true)
{
    if (true === $lazyLoad) {
        return $container->services['doctrine.orm.default_entity_manager'] = new \ReflectionClass('Doctrine\ORM\EntityManager')->newLazyGhost(static function ($proxy) use ($container) { self::getDoctrine_Orm_DefaultEntityManagerService($container, $proxy); });
    }

    include_once \dirname(__DIR__, 4).'/vendor/doctrine/orm/src/Proxy/Autoloader.php';
    include_once \dirname(__DIR__, 4).'/vendor/doctrine/persistence/src/Persistence/ObjectManager.php';
    include_once \dirname(__DIR__, 4).'/vendor/doctrine/orm/src/EntityManagerInterface.php';
    include_once \dirname(__DIR__, 4).'/vendor/doctrine/orm/src/EntityManager.php';

    $instance = ($lazyLoad->__construct(($container->services['doctrine.dbal.default_connection'] ?? self::getDoctrine_Dbal_DefaultConnectionService($container)), ($container->privates['doctrine.orm.default_configuration'] ?? self::getDoctrine_Orm_DefaultConfigurationService($container)), ($container->privates['doctrine.dbal.default_connection.event_manager'] ?? self::getDoctrine_Dbal_DefaultConnection_EventManagerService($container))) && false ?: $lazyLoad);

    ($container->privates['doctrine.orm.default_manager_configurator'] ??= new \Doctrine\Bundle\DoctrineBundle\ManagerConfigurator([], []))->configure($instance);

    return $instance;
}
```

cc @nicolas-grekas 