### PR TITLE
[Security] Add ability for authenticators to explain why they didn’t support a request

### DIFF
--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -34,3 +34,14 @@ Security
  * Deprecate callable firewall listeners, extend `AbstractListener` or implement `FirewallListenerInterface` instead
  * Deprecate `AbstractListener::__invoke`
  * Deprecate `LazyFirewallContext::__invoke()`
+ * Add argument `$requestSupport` to `AuthenticatorInterface::supports()`;
+   it should be used to report the reason a request isn't supported. E.g:
+
+   ```php
+   public function supports(Request $request, ?RequestSupport $requestSupport = null): ?bool
+   {
+       $requestSupport?->addReason('This authenticator does not support any request.');
+
+       return false;
+   }
+   ```

--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -34,13 +34,13 @@ Security
  * Deprecate callable firewall listeners, extend `AbstractListener` or implement `FirewallListenerInterface` instead
  * Deprecate `AbstractListener::__invoke`
  * Deprecate `LazyFirewallContext::__invoke()`
- * Add argument `$requestSupport` to `AuthenticatorInterface::supports()`;
+ * Add argument `$requestDecision` to `AuthenticatorInterface::supports()`;
    it should be used to report the reason a request isn't supported. E.g:
 
    ```php
-   public function supports(Request $request, ?RequestSupport $requestSupport = null): ?bool
+   public function supports(Request $request, ?RequestDecision $requestDecision = null): ?bool
    {
-       $requestSupport?->addReason('This authenticator does not support any request.');
+       $requestDecision?->addReason('This authenticator does not support any request.');
 
        return false;
    }

--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -423,7 +423,7 @@
                                         <div id="authenticator-{{ i }}" class="font-normal">
                                             {% if authenticator.supports is same as(false) %}
                                                 <div class="empty">
-                                                    {% for reason in (authenticator.supportReasons ?? []) is empty ? ['This authenticator did not support the request.'] : authenticator.supportReasons %}
+                                                    {% for reason in (authenticator.requestDecisionReasons ?? []) is empty ? ['This authenticator did not support the request.'] : authenticator.requestDecisionReasons %}
                                                         <p>{{ reason }}</p>
                                                     {% endfor %}
                                                 </div>

--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -423,7 +423,9 @@
                                         <div id="authenticator-{{ i }}" class="font-normal">
                                             {% if authenticator.supports is same as(false) %}
                                                 <div class="empty">
-                                                    <p>This authenticator did not support the request.</p>
+                                                    {% for reason in (authenticator.supportReasons ?? []) is empty ? ['This authenticator did not support the request.'] : authenticator.supportReasons %}
+                                                        <p>{{ reason }}</p>
+                                                    {% endfor %}
                                                 </div>
                                             {% elseif authenticator.authenticated is null %}
                                                 <div class="empty">

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/RegisterEntryPointsPassTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/RegisterEntryPointsPassTest.php
@@ -28,6 +28,7 @@ use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 use Symfony\Component\Security\Http\Firewall\ExceptionListener;
+use Symfony\Component\Security\Http\RequestSupport;
 
 class RegisterEntryPointsPassTest extends TestCase
 {
@@ -71,7 +72,7 @@ class RegisterEntryPointsPassTest extends TestCase
 
 class CustomAuthenticator extends AbstractAuthenticator implements AuthenticationEntryPointInterface
 {
-    public function supports(Request $request): ?bool
+    public function supports(Request $request, ?RequestSupport $requestSupport = null): ?bool
     {
         return false;
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/RegisterEntryPointsPassTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/RegisterEntryPointsPassTest.php
@@ -28,7 +28,7 @@ use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 use Symfony\Component\Security\Http\Firewall\ExceptionListener;
-use Symfony\Component\Security\Http\RequestSupport;
+use Symfony\Component\Security\Http\RequestDecision;
 
 class RegisterEntryPointsPassTest extends TestCase
 {
@@ -72,7 +72,7 @@ class RegisterEntryPointsPassTest extends TestCase
 
 class CustomAuthenticator extends AbstractAuthenticator implements AuthenticationEntryPointInterface
 {
-    public function supports(Request $request, ?RequestSupport $requestSupport = null): ?bool
+    public function supports(Request $request, ?RequestDecision $requestDecision = null): ?bool
     {
         return false;
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -39,6 +39,7 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\HttpBasicAuthenticator;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\RequestSupport;
 
 class SecurityExtensionTest extends TestCase
 {
@@ -968,7 +969,7 @@ class SecurityExtensionTest extends TestCase
 
 class TestAuthenticator implements AuthenticatorInterface
 {
-    public function supports(Request $request): ?bool
+    public function supports(Request $request, ?RequestSupport $requestSupport = null): ?bool
     {
     }
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -39,7 +39,7 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\HttpBasicAuthenticator;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
-use Symfony\Component\Security\Http\RequestSupport;
+use Symfony\Component\Security\Http\RequestDecision;
 
 class SecurityExtensionTest extends TestCase
 {
@@ -969,7 +969,7 @@ class SecurityExtensionTest extends TestCase
 
 class TestAuthenticator implements AuthenticatorInterface
 {
-    public function supports(Request $request, ?RequestSupport $requestSupport = null): ?bool
+    public function supports(Request $request, ?RequestDecision $requestDecision = null): ?bool
     {
     }
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/AuthenticatorBundle/ApiAuthenticator.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/AuthenticatorBundle/ApiAuthenticator.php
@@ -22,6 +22,7 @@ use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+use Symfony\Component\Security\Http\RequestSupport;
 
 class ApiAuthenticator extends AbstractAuthenticator
 {
@@ -32,7 +33,7 @@ class ApiAuthenticator extends AbstractAuthenticator
         $this->selfLoadingUser = $selfLoadingUser;
     }
 
-    public function supports(Request $request): ?bool
+    public function supports(Request $request, ?RequestSupport $requestSupport = null): ?bool
     {
         return $request->headers->has('X-USER-EMAIL');
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/AuthenticatorBundle/ApiAuthenticator.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/AuthenticatorBundle/ApiAuthenticator.php
@@ -22,7 +22,7 @@ use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
-use Symfony\Component\Security\Http\RequestSupport;
+use Symfony\Component\Security\Http\RequestDecision;
 
 class ApiAuthenticator extends AbstractAuthenticator
 {
@@ -33,7 +33,7 @@ class ApiAuthenticator extends AbstractAuthenticator
         $this->selfLoadingUser = $selfLoadingUser;
     }
 
-    public function supports(Request $request, ?RequestSupport $requestSupport = null): ?bool
+    public function supports(Request $request, ?RequestDecision $requestDecision = null): ?bool
     {
         return $request->headers->has('X-USER-EMAIL');
     }

--- a/src/Symfony/Component/Ldap/Security/LdapAuthenticator.php
+++ b/src/Symfony/Component/Ldap/Security/LdapAuthenticator.php
@@ -20,7 +20,7 @@ use Symfony\Component\Security\Http\Authenticator\InteractiveAuthenticatorInterf
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 use Symfony\Component\Security\Http\EntryPoint\Exception\NotAnEntryPointException;
-use Symfony\Component\Security\Http\RequestSupport;
+use Symfony\Component\Security\Http\RequestDecision;
 
 /**
  * This class decorates internal authenticators to add the LDAP integration.
@@ -45,9 +45,9 @@ class LdapAuthenticator implements AuthenticationEntryPointInterface, Interactiv
     ) {
     }
 
-    public function supports(Request $request, ?RequestSupport $requestSupport = null): ?bool
+    public function supports(Request $request, ?RequestDecision $requestDecision = null): ?bool
     {
-        return $this->authenticator->supports($request, $requestSupport);
+        return $this->authenticator->supports($request, $requestDecision);
     }
 
     public function authenticate(Request $request): Passport

--- a/src/Symfony/Component/Ldap/Security/LdapAuthenticator.php
+++ b/src/Symfony/Component/Ldap/Security/LdapAuthenticator.php
@@ -20,6 +20,7 @@ use Symfony\Component\Security\Http\Authenticator\InteractiveAuthenticatorInterf
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 use Symfony\Component\Security\Http\EntryPoint\Exception\NotAnEntryPointException;
+use Symfony\Component\Security\Http\RequestSupport;
 
 /**
  * This class decorates internal authenticators to add the LDAP integration.
@@ -44,9 +45,9 @@ class LdapAuthenticator implements AuthenticationEntryPointInterface, Interactiv
     ) {
     }
 
-    public function supports(Request $request): ?bool
+    public function supports(Request $request, ?RequestSupport $requestSupport = null): ?bool
     {
-        return $this->authenticator->supports($request);
+        return $this->authenticator->supports($request, $requestSupport);
     }
 
     public function authenticate(Request $request): Passport

--- a/src/Symfony/Component/Ldap/Tests/Security/CheckLdapCredentialsListenerTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Security/CheckLdapCredentialsListenerTest.php
@@ -33,6 +33,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordC
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\Event\CheckPassportEvent;
+use Symfony\Component\Security\Http\RequestSupport;
 use Symfony\Contracts\Service\ServiceLocatorTrait;
 
 class CheckLdapCredentialsListenerTest extends TestCase
@@ -206,7 +207,7 @@ class CheckLdapCredentialsListenerTest extends TestCase
 if (interface_exists(AuthenticatorInterface::class)) {
     class TestAuthenticator implements AuthenticatorInterface
     {
-        public function supports(Request $request): ?bool
+        public function supports(Request $request, ?RequestSupport $requestSupport = null): ?bool
         {
         }
 

--- a/src/Symfony/Component/Ldap/Tests/Security/CheckLdapCredentialsListenerTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Security/CheckLdapCredentialsListenerTest.php
@@ -33,7 +33,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordC
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\Event\CheckPassportEvent;
-use Symfony\Component\Security\Http\RequestSupport;
+use Symfony\Component\Security\Http\RequestDecision;
 use Symfony\Contracts\Service\ServiceLocatorTrait;
 
 class CheckLdapCredentialsListenerTest extends TestCase
@@ -207,7 +207,7 @@ class CheckLdapCredentialsListenerTest extends TestCase
 if (interface_exists(AuthenticatorInterface::class)) {
     class TestAuthenticator implements AuthenticatorInterface
     {
-        public function supports(Request $request, ?RequestSupport $requestSupport = null): ?bool
+        public function supports(Request $request, ?RequestDecision $requestDecision = null): ?bool
         {
         }
 

--- a/src/Symfony/Component/Security/Http/Authenticator/AbstractLoginFormAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/AbstractLoginFormAuthenticator.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
+use Symfony\Component\Security\Http\RequestSupport;
 use Symfony\Component\Security\Http\SecurityRequestAttributes;
 
 /**
@@ -36,10 +37,26 @@ abstract class AbstractLoginFormAuthenticator extends AbstractAuthenticator impl
      *
      * This default implementation handles all POST requests to the
      * login path (@see getLoginUrl()).
+     *
+     * @param RequestSupport|null $requestSupport
      */
-    public function supports(Request $request): bool
+    public function supports(Request $request, /* ?RequestSupport $requestSupport = null */): bool
     {
-        return $request->isMethod('POST') && $this->getLoginUrl($request) === $request->getBaseUrl().$request->getPathInfo();
+        $requestSupport = 2 <= \func_num_args() ? func_get_arg(1) : null;
+
+        if (!$request->isMethod('POST')) {
+            $requestSupport?->addReason('Request is not a POST.');
+
+            return false;
+        }
+
+        if ($this->getLoginUrl($request) !== $request->getBaseUrl().$request->getPathInfo()) {
+            $requestSupport?->addReason('Request does not match the login URL.');
+
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/src/Symfony/Component/Security/Http/Authenticator/AbstractLoginFormAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/AbstractLoginFormAuthenticator.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
-use Symfony\Component\Security\Http\RequestSupport;
+use Symfony\Component\Security\Http\RequestDecision;
 use Symfony\Component\Security\Http\SecurityRequestAttributes;
 
 /**
@@ -38,20 +38,20 @@ abstract class AbstractLoginFormAuthenticator extends AbstractAuthenticator impl
      * This default implementation handles all POST requests to the
      * login path (@see getLoginUrl()).
      *
-     * @param RequestSupport|null $requestSupport
+     * @param RequestDecision|null $requestDecision
      */
-    public function supports(Request $request, /* ?RequestSupport $requestSupport = null */): bool
+    public function supports(Request $request, /* ?RequestDecision $requestDecision = null */): bool
     {
-        $requestSupport = 2 <= \func_num_args() ? func_get_arg(1) : null;
+        $requestDecision = 2 <= \func_num_args() ? func_get_arg(1) : null;
 
         if (!$request->isMethod('POST')) {
-            $requestSupport?->addReason('Request is not a POST.');
+            $requestDecision?->addReason('Request is not a POST.');
 
             return false;
         }
 
         if ($this->getLoginUrl($request) !== $request->getBaseUrl().$request->getPathInfo()) {
-            $requestSupport?->addReason('Request does not match the login URL.');
+            $requestDecision?->addReason('Request does not match the login URL.');
 
             return false;
         }

--- a/src/Symfony/Component/Security/Http/Authenticator/AbstractPreAuthenticatedAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/AbstractPreAuthenticatedAuthenticator.php
@@ -24,7 +24,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\PreAuthenticate
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
-use Symfony\Component\Security\Http\RequestSupport;
+use Symfony\Component\Security\Http\RequestDecision;
 
 /**
  * The base authenticator for authenticators to use pre-authenticated
@@ -54,11 +54,11 @@ abstract class AbstractPreAuthenticatedAuthenticator implements InteractiveAuthe
     abstract protected function extractUsername(Request $request): ?string;
 
     /**
-     * @param RequestSupport|null $requestSupport
+     * @param RequestDecision|null $requestDecision
      */
-    public function supports(Request $request, /* ?RequestSupport $requestSupport = null */): ?bool
+    public function supports(Request $request, /* ?RequestDecision $requestDecision = null */): ?bool
     {
-        $requestSupport = 2 <= \func_num_args() ? func_get_arg(1) : null;
+        $requestDecision = 2 <= \func_num_args() ? func_get_arg(1) : null;
 
         try {
             $username = $this->extractUsername($request);
@@ -66,14 +66,14 @@ abstract class AbstractPreAuthenticatedAuthenticator implements InteractiveAuthe
             $this->clearToken($e);
 
             $this->logger?->debug('Skipping pre-authenticated authenticator as a BadCredentialsException is thrown.', ['exception' => $e, 'authenticator' => static::class]);
-            $requestSupport?->addReason('Could not find the username in the request.');
+            $requestDecision?->addReason('Could not find the username in the request.');
 
             return false;
         }
 
         if (null === $username) {
             $this->logger?->debug('Skipping pre-authenticated authenticator no username could be extracted.', ['authenticator' => static::class]);
-            $requestSupport?->addReason('Username found in the request was empty.');
+            $requestDecision?->addReason('Username found in the request was empty.');
 
             return false;
         }
@@ -83,7 +83,7 @@ abstract class AbstractPreAuthenticatedAuthenticator implements InteractiveAuthe
 
         if ($token instanceof PreAuthenticatedToken && $this->firewallName === $token->getFirewallName() && $token->getUserIdentifier() === $username) {
             $this->logger?->debug('Skipping pre-authenticated authenticator as the user already has an existing session.', ['authenticator' => static::class]);
-            $requestSupport?->addReason('A token already exists for the user in the session.');
+            $requestDecision?->addReason('A token already exists for the user in the session.');
 
             return false;
         }

--- a/src/Symfony/Component/Security/Http/Authenticator/AbstractPreAuthenticatedAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/AbstractPreAuthenticatedAuthenticator.php
@@ -24,6 +24,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\PreAuthenticate
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+use Symfony\Component\Security\Http\RequestSupport;
 
 /**
  * The base authenticator for authenticators to use pre-authenticated
@@ -52,20 +53,27 @@ abstract class AbstractPreAuthenticatedAuthenticator implements InteractiveAuthe
      */
     abstract protected function extractUsername(Request $request): ?string;
 
-    public function supports(Request $request): ?bool
+    /**
+     * @param RequestSupport|null $requestSupport
+     */
+    public function supports(Request $request, /* ?RequestSupport $requestSupport = null */): ?bool
     {
+        $requestSupport = 2 <= \func_num_args() ? func_get_arg(1) : null;
+
         try {
             $username = $this->extractUsername($request);
         } catch (BadCredentialsException $e) {
             $this->clearToken($e);
 
             $this->logger?->debug('Skipping pre-authenticated authenticator as a BadCredentialsException is thrown.', ['exception' => $e, 'authenticator' => static::class]);
+            $requestSupport?->addReason('Could not find the username in the request.');
 
             return false;
         }
 
         if (null === $username) {
             $this->logger?->debug('Skipping pre-authenticated authenticator no username could be extracted.', ['authenticator' => static::class]);
+            $requestSupport?->addReason('Username found in the request was empty.');
 
             return false;
         }
@@ -75,6 +83,7 @@ abstract class AbstractPreAuthenticatedAuthenticator implements InteractiveAuthe
 
         if ($token instanceof PreAuthenticatedToken && $this->firewallName === $token->getFirewallName() && $token->getUserIdentifier() === $username) {
             $this->logger?->debug('Skipping pre-authenticated authenticator as the user already has an existing session.', ['authenticator' => static::class]);
+            $requestSupport?->addReason('A token already exists for the user in the session.');
 
             return false;
         }

--- a/src/Symfony/Component/Security/Http/Authenticator/AccessTokenAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/AccessTokenAuthenticator.php
@@ -24,6 +24,7 @@ use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerI
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\Authenticator\Token\PostAuthenticationToken;
+use Symfony\Component\Security\Http\RequestSupport;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -46,9 +47,20 @@ class AccessTokenAuthenticator implements AuthenticatorInterface
     ) {
     }
 
-    public function supports(Request $request): ?bool
+    /**
+     * @param RequestSupport|null $requestSupport
+     */
+    public function supports(Request $request, /* ?RequestSupport $requestSupport = null */): ?bool
     {
-        return null === $this->accessTokenExtractor->extractAccessToken($request) ? false : null;
+        $requestSupport = 2 <= \func_num_args() ? func_get_arg(1) : null;
+
+        if (null === $this->accessTokenExtractor->extractAccessToken($request)) {
+            $requestSupport?->addReason(sprintf('No token was found in the request by the %s.', $this->accessTokenExtractor::class));
+
+            return false;
+        }
+
+        return null;
     }
 
     public function authenticate(Request $request): Passport

--- a/src/Symfony/Component/Security/Http/Authenticator/AccessTokenAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/AccessTokenAuthenticator.php
@@ -24,7 +24,7 @@ use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerI
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\Authenticator\Token\PostAuthenticationToken;
-use Symfony\Component\Security\Http\RequestSupport;
+use Symfony\Component\Security\Http\RequestDecision;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -48,14 +48,14 @@ class AccessTokenAuthenticator implements AuthenticatorInterface
     }
 
     /**
-     * @param RequestSupport|null $requestSupport
+     * @param RequestDecision|null $requestDecision
      */
-    public function supports(Request $request, /* ?RequestSupport $requestSupport = null */): ?bool
+    public function supports(Request $request, /* ?RequestDecision $requestDecision = null */): ?bool
     {
-        $requestSupport = 2 <= \func_num_args() ? func_get_arg(1) : null;
+        $requestDecision = 2 <= \func_num_args() ? func_get_arg(1) : null;
 
         if (null === $this->accessTokenExtractor->extractAccessToken($request)) {
-            $requestSupport?->addReason(sprintf('No token was found in the request by the %s.', $this->accessTokenExtractor::class));
+            $requestDecision?->addReason(sprintf('No token was found in the request by the %s.', $this->accessTokenExtractor::class));
 
             return false;
         }

--- a/src/Symfony/Component/Security/Http/Authenticator/AuthenticatorInterface.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/AuthenticatorInterface.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
-use Symfony\Component\Security\Http\RequestSupport;
+use Symfony\Component\Security\Http\RequestDecision;
 
 /**
  * The interface for all authenticators.
@@ -34,9 +34,9 @@ interface AuthenticatorInterface
      *
      * Returning null means authenticate() can be called lazily when accessing the token storage.
      *
-     * @param RequestSupport|null $requestSupport
+     * @param RequestDecision|null $requestDecision
      */
-    public function supports(Request $request, /* ?RequestSupport $requestSupport = null */): ?bool;
+    public function supports(Request $request, /* ?RequestDecision $requestDecision = null */): ?bool;
 
     /**
      * Create a passport for the current request.

--- a/src/Symfony/Component/Security/Http/Authenticator/AuthenticatorInterface.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/AuthenticatorInterface.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\RequestSupport;
 
 /**
  * The interface for all authenticators.
@@ -32,8 +33,10 @@ interface AuthenticatorInterface
      * If this returns true, authenticate() will be called. If false, the authenticator will be skipped.
      *
      * Returning null means authenticate() can be called lazily when accessing the token storage.
+     *
+     * @param RequestSupport|null $requestSupport
      */
-    public function supports(Request $request): ?bool;
+    public function supports(Request $request, /* ?RequestSupport $requestSupport = null */): ?bool;
 
     /**
      * Create a passport for the current request.

--- a/src/Symfony/Component/Security/Http/Authenticator/Debug/TraceableAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Debug/TraceableAuthenticator.php
@@ -21,7 +21,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\BadgeInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 use Symfony\Component\Security\Http\EntryPoint\Exception\NotAnEntryPointException;
-use Symfony\Component\Security\Http\RequestSupport;
+use Symfony\Component\Security\Http\RequestDecision;
 use Symfony\Component\VarDumper\Caster\ClassStub;
 
 /**
@@ -32,7 +32,7 @@ use Symfony\Component\VarDumper\Caster\ClassStub;
 final class TraceableAuthenticator implements AuthenticatorInterface, InteractiveAuthenticatorInterface, AuthenticationEntryPointInterface
 {
     private ?bool $supports = false;
-    private array $supportReasons = [];
+    private array $requestDecisionReasons = [];
     private ?Passport $passport = null;
     private ?float $duration = null;
     private ClassStub|string $stub;
@@ -47,7 +47,7 @@ final class TraceableAuthenticator implements AuthenticatorInterface, Interactiv
     {
         return [
             'supports' => $this->supports,
-            'supportReasons' => $this->supportReasons,
+            'requestDecisionReasons' => $this->requestDecisionReasons,
             'passport' => $this->passport,
             'duration' => $this->duration,
             'stub' => $this->stub ??= class_exists(ClassStub::class) ? new ClassStub($this->authenticator::class) : $this->authenticator::class,
@@ -66,20 +66,20 @@ final class TraceableAuthenticator implements AuthenticatorInterface, Interactiv
     }
 
     /**
-     * @param RequestSupport|null $requestSupport
+     * @param RequestDecision|null $requestDecision
      */
-    public function supports(Request $request, /* ?RequestSupport $requestSupport = null */): ?bool
+    public function supports(Request $request, /* ?RequestDecision $requestDecision = null */): ?bool
     {
-        $requestSupport = 2 <= \func_num_args() ? func_get_arg(1) : new RequestSupport();
+        $requestDecision = 2 <= \func_num_args() ? func_get_arg(1) : new RequestDecision();
 
-        $this->supports = $this->authenticator->supports($request, $requestSupport);
-        $this->supportReasons = $requestSupport->reasons;
+        $this->supports = $this->authenticator->supports($request, $requestDecision);
+        $this->requestDecisionReasons = $requestDecision->reasons;
 
         if ($this->supports === false) {
-            $requestSupport->result = false;
+            $requestDecision->isSupported = false;
         } else {
-            $requestSupport->result = true;
-            $requestSupport->lazy = null === $this->supports;
+            $requestDecision->isSupported = true;
+            $requestDecision->isLazy = null === $this->supports;
         }
 
         return $this->supports;

--- a/src/Symfony/Component/Security/Http/Authenticator/Debug/TraceableAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Debug/TraceableAuthenticator.php
@@ -21,6 +21,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\BadgeInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 use Symfony\Component\Security\Http\EntryPoint\Exception\NotAnEntryPointException;
+use Symfony\Component\Security\Http\RequestSupport;
 use Symfony\Component\VarDumper\Caster\ClassStub;
 
 /**
@@ -31,6 +32,7 @@ use Symfony\Component\VarDumper\Caster\ClassStub;
 final class TraceableAuthenticator implements AuthenticatorInterface, InteractiveAuthenticatorInterface, AuthenticationEntryPointInterface
 {
     private ?bool $supports = false;
+    private array $supportReasons = [];
     private ?Passport $passport = null;
     private ?float $duration = null;
     private ClassStub|string $stub;
@@ -45,6 +47,7 @@ final class TraceableAuthenticator implements AuthenticatorInterface, Interactiv
     {
         return [
             'supports' => $this->supports,
+            'supportReasons' => $this->supportReasons,
             'passport' => $this->passport,
             'duration' => $this->duration,
             'stub' => $this->stub ??= class_exists(ClassStub::class) ? new ClassStub($this->authenticator::class) : $this->authenticator::class,
@@ -62,9 +65,24 @@ final class TraceableAuthenticator implements AuthenticatorInterface, Interactiv
         ];
     }
 
-    public function supports(Request $request): ?bool
+    /**
+     * @param RequestSupport|null $requestSupport
+     */
+    public function supports(Request $request, /* ?RequestSupport $requestSupport = null */): ?bool
     {
-        return $this->supports = $this->authenticator->supports($request);
+        $requestSupport = 2 <= \func_num_args() ? func_get_arg(1) : new RequestSupport();
+
+        $this->supports = $this->authenticator->supports($request, $requestSupport);
+        $this->supportReasons = $requestSupport->reasons;
+
+        if ($this->supports === false) {
+            $requestSupport->result = false;
+        } else {
+            $requestSupport->result = true;
+            $requestSupport->lazy = null === $this->supports;
+        }
+
+        return $this->supports;
     }
 
     public function authenticate(Request $request): Passport

--- a/src/Symfony/Component/Security/Http/Authenticator/FormLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/FormLoginAuthenticator.php
@@ -31,6 +31,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordC
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\HttpUtils;
 use Symfony\Component\Security\Http\ParameterBagUtils;
+use Symfony\Component\Security\Http\RequestSupport;
 use Symfony\Component\Security\Http\SecurityRequestAttributes;
 
 /**
@@ -68,11 +69,32 @@ class FormLoginAuthenticator extends AbstractLoginFormAuthenticator
         return $this->httpUtils->generateUri($request, $this->options['login_path']);
     }
 
-    public function supports(Request $request): bool
+    /**
+     * @param RequestSupport|null $requestSupport
+     */
+    public function supports(Request $request, /* ?RequestSupport $requestSupport = null */): bool
     {
-        return ($this->options['post_only'] ? $request->isMethod('POST') : true)
-            && $this->httpUtils->checkRequestPath($request, $this->options['check_path'])
-            && ($this->options['form_only'] ? 'form' === $request->getContentTypeFormat() : true);
+        $requestSupport = 2 <= \func_num_args() ? func_get_arg(1) : null;
+
+        if ($this->options['post_only'] && !$request->isMethod('POST')) {
+            $requestSupport?->addReason('Request is not a POST while "post_only" is set.');
+
+            return false;
+        }
+
+        if (!$this->httpUtils->checkRequestPath($request, $this->options['check_path'])) {
+            $requestSupport?->addReason('Request does not match the "check_path".');
+
+            return false;
+        }
+
+        if ($this->options['form_only'] && 'form' !== $request->getContentTypeFormat()) {
+            $requestSupport?->addReason('Request is not a form submission while "form_only" is set.');
+
+            return false;
+        }
+
+        return true;
     }
 
     public function authenticate(Request $request): Passport

--- a/src/Symfony/Component/Security/Http/Authenticator/FormLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/FormLoginAuthenticator.php
@@ -31,7 +31,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordC
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\HttpUtils;
 use Symfony\Component\Security\Http\ParameterBagUtils;
-use Symfony\Component\Security\Http\RequestSupport;
+use Symfony\Component\Security\Http\RequestDecision;
 use Symfony\Component\Security\Http\SecurityRequestAttributes;
 
 /**
@@ -70,26 +70,26 @@ class FormLoginAuthenticator extends AbstractLoginFormAuthenticator
     }
 
     /**
-     * @param RequestSupport|null $requestSupport
+     * @param RequestDecision|null $requestDecision
      */
-    public function supports(Request $request, /* ?RequestSupport $requestSupport = null */): bool
+    public function supports(Request $request, /* ?RequestDecision $requestDecision = null */): bool
     {
-        $requestSupport = 2 <= \func_num_args() ? func_get_arg(1) : null;
+        $requestDecision = 2 <= \func_num_args() ? func_get_arg(1) : null;
 
         if ($this->options['post_only'] && !$request->isMethod('POST')) {
-            $requestSupport?->addReason('Request is not a POST while "post_only" is set.');
+            $requestDecision?->addReason('Request is not a POST while "post_only" is set.');
 
             return false;
         }
 
         if (!$this->httpUtils->checkRequestPath($request, $this->options['check_path'])) {
-            $requestSupport?->addReason('Request does not match the "check_path".');
+            $requestDecision?->addReason('Request does not match the "check_path".');
 
             return false;
         }
 
         if ($this->options['form_only'] && 'form' !== $request->getContentTypeFormat()) {
-            $requestSupport?->addReason('Request is not a form submission while "form_only" is set.');
+            $requestDecision?->addReason('Request is not a form submission while "form_only" is set.');
 
             return false;
         }

--- a/src/Symfony/Component/Security/Http/Authenticator/HttpBasicAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/HttpBasicAuthenticator.php
@@ -24,6 +24,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordCredentials;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
+use Symfony\Component\Security\Http\RequestSupport;
 
 /**
  * @author Wouter de Jong <wouter@wouterj.nl>
@@ -49,9 +50,20 @@ class HttpBasicAuthenticator implements AuthenticatorInterface, AuthenticationEn
         return $response;
     }
 
-    public function supports(Request $request): ?bool
+    /**
+     * @param RequestSupport|null $requestSupport
+     */
+    public function supports(Request $request, /* ?RequestSupport $requestSupport = null */): ?bool
     {
-        return $request->headers->has('PHP_AUTH_USER');
+        $requestSupport = 2 <= \func_num_args() ? func_get_arg(1) : null;
+
+        if (!$request->headers->has('PHP_AUTH_USER')) {
+            $requestSupport?->addReason('Request has no basic authentication header.');
+
+            return false;
+        }
+
+        return true;
     }
 
     public function authenticate(Request $request): Passport

--- a/src/Symfony/Component/Security/Http/Authenticator/HttpBasicAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/HttpBasicAuthenticator.php
@@ -24,7 +24,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordCredentials;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
-use Symfony\Component\Security\Http\RequestSupport;
+use Symfony\Component\Security\Http\RequestDecision;
 
 /**
  * @author Wouter de Jong <wouter@wouterj.nl>
@@ -51,14 +51,14 @@ class HttpBasicAuthenticator implements AuthenticatorInterface, AuthenticationEn
     }
 
     /**
-     * @param RequestSupport|null $requestSupport
+     * @param RequestDecision|null $requestDecision
      */
-    public function supports(Request $request, /* ?RequestSupport $requestSupport = null */): ?bool
+    public function supports(Request $request, /* ?RequestDecision $requestDecision = null */): ?bool
     {
-        $requestSupport = 2 <= \func_num_args() ? func_get_arg(1) : null;
+        $requestDecision = 2 <= \func_num_args() ? func_get_arg(1) : null;
 
         if (!$request->headers->has('PHP_AUTH_USER')) {
-            $requestSupport?->addReason('Request has no basic authentication header.');
+            $requestDecision?->addReason('Request has no basic authentication header.');
 
             return false;
         }

--- a/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
@@ -31,6 +31,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordCredentials;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\HttpUtils;
+use Symfony\Component\Security\Http\RequestSupport;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -60,16 +61,25 @@ class JsonLoginAuthenticator implements InteractiveAuthenticatorInterface
         $this->propertyAccessor = $propertyAccessor ?: PropertyAccess::createPropertyAccessor();
     }
 
-    public function supports(Request $request): ?bool
+    /**
+     * @param RequestSupport|null $requestSupport
+     */
+    public function supports(Request $request, /* ?RequestSupport $requestSupport = null */): ?bool
     {
+        $requestSupport = 2 <= \func_num_args() ? func_get_arg(1) : null;
+
         if (
             !str_contains($request->getRequestFormat() ?? '', 'json')
             && !str_contains($request->getContentTypeFormat() ?? '', 'json')
         ) {
+            $requestSupport?->addReason('Request format is not JSON.');
+
             return false;
         }
 
         if (isset($this->options['check_path']) && !$this->httpUtils->checkRequestPath($request, $this->options['check_path'])) {
+            $requestSupport?->addReason('Request does not match the "check_path".');
+
             return false;
         }
 

--- a/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
@@ -31,7 +31,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordCredentials;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\HttpUtils;
-use Symfony\Component\Security\Http\RequestSupport;
+use Symfony\Component\Security\Http\RequestDecision;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -62,23 +62,23 @@ class JsonLoginAuthenticator implements InteractiveAuthenticatorInterface
     }
 
     /**
-     * @param RequestSupport|null $requestSupport
+     * @param RequestDecision|null $requestDecision
      */
-    public function supports(Request $request, /* ?RequestSupport $requestSupport = null */): ?bool
+    public function supports(Request $request, /* ?RequestDecision $requestDecision = null */): ?bool
     {
-        $requestSupport = 2 <= \func_num_args() ? func_get_arg(1) : null;
+        $requestDecision = 2 <= \func_num_args() ? func_get_arg(1) : null;
 
         if (
             !str_contains($request->getRequestFormat() ?? '', 'json')
             && !str_contains($request->getContentTypeFormat() ?? '', 'json')
         ) {
-            $requestSupport?->addReason('Request format is not JSON.');
+            $requestDecision?->addReason('Request format is not JSON.');
 
             return false;
         }
 
         if (isset($this->options['check_path']) && !$this->httpUtils->checkRequestPath($request, $this->options['check_path'])) {
-            $requestSupport?->addReason('Request does not match the "check_path".');
+            $requestDecision?->addReason('Request does not match the "check_path".');
 
             return false;
         }

--- a/src/Symfony/Component/Security/Http/Authenticator/LoginLinkAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/LoginLinkAuthenticator.php
@@ -25,7 +25,7 @@ use Symfony\Component\Security\Http\HttpUtils;
 use Symfony\Component\Security\Http\LoginLink\Exception\InvalidLoginLinkAuthenticationException;
 use Symfony\Component\Security\Http\LoginLink\Exception\InvalidLoginLinkExceptionInterface;
 use Symfony\Component\Security\Http\LoginLink\LoginLinkHandlerInterface;
-use Symfony\Component\Security\Http\RequestSupport;
+use Symfony\Component\Security\Http\RequestDecision;
 
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
@@ -45,20 +45,20 @@ final class LoginLinkAuthenticator extends AbstractAuthenticator implements Inte
     }
 
     /**
-     * @param RequestSupport|null $requestSupport
+     * @param RequestDecision|null $requestDecision
      */
-    public function supports(Request $request, /* ?RequestSupport $requestSupport = null */): ?bool
+    public function supports(Request $request, /* ?RequestDecision $requestDecision = null */): ?bool
     {
-        $requestSupport = 2 <= \func_num_args() ? func_get_arg(1) : null;
+        $requestDecision = 2 <= \func_num_args() ? func_get_arg(1) : null;
 
         if ($this->options['check_post_only'] && !$request->isMethod('POST')) {
-            $requestSupport?->addReason('Request is not a POST while "check_post_only" is set.');
+            $requestDecision?->addReason('Request is not a POST while "check_post_only" is set.');
 
             return false;
         }
 
         if (!$this->httpUtils->checkRequestPath($request, $this->options['check_route'])) {
-            $requestSupport?->addReason('Request does not match the "check_route".');
+            $requestDecision?->addReason('Request does not match the "check_route".');
 
             return false;
         }

--- a/src/Symfony/Component/Security/Http/Authenticator/LoginLinkAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/LoginLinkAuthenticator.php
@@ -25,6 +25,7 @@ use Symfony\Component\Security\Http\HttpUtils;
 use Symfony\Component\Security\Http\LoginLink\Exception\InvalidLoginLinkAuthenticationException;
 use Symfony\Component\Security\Http\LoginLink\Exception\InvalidLoginLinkExceptionInterface;
 use Symfony\Component\Security\Http\LoginLink\LoginLinkHandlerInterface;
+use Symfony\Component\Security\Http\RequestSupport;
 
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
@@ -43,10 +44,26 @@ final class LoginLinkAuthenticator extends AbstractAuthenticator implements Inte
         $this->options = $options + ['check_post_only' => false];
     }
 
-    public function supports(Request $request): ?bool
+    /**
+     * @param RequestSupport|null $requestSupport
+     */
+    public function supports(Request $request, /* ?RequestSupport $requestSupport = null */): ?bool
     {
-        return ($this->options['check_post_only'] ? $request->isMethod('POST') : true)
-            && $this->httpUtils->checkRequestPath($request, $this->options['check_route']);
+        $requestSupport = 2 <= \func_num_args() ? func_get_arg(1) : null;
+
+        if ($this->options['check_post_only'] && !$request->isMethod('POST')) {
+            $requestSupport?->addReason('Request is not a POST while "check_post_only" is set.');
+
+            return false;
+        }
+
+        if (!$this->httpUtils->checkRequestPath($request, $this->options['check_route'])) {
+            $requestSupport?->addReason('Request does not match the "check_route".');
+
+            return false;
+        }
+
+        return true;
     }
 
     public function authenticate(Request $request): Passport

--- a/src/Symfony/Component/Security/Http/Authenticator/RememberMeAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/RememberMeAuthenticator.php
@@ -27,6 +27,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPasspor
 use Symfony\Component\Security\Http\RememberMe\RememberMeDetails;
 use Symfony\Component\Security\Http\RememberMe\RememberMeHandlerInterface;
 use Symfony\Component\Security\Http\RememberMe\ResponseListener;
+use Symfony\Component\Security\Http\RequestSupport;
 
 /**
  * The RememberMe *Authenticator* performs remember me authentication.
@@ -73,18 +74,35 @@ class RememberMeAuthenticator implements InteractiveAuthenticatorInterface
         $this->logger = $logger;
     }
 
-    public function supports(Request $request): ?bool
+    /**
+     * @param RequestSupport|null $requestSupport
+     */
+    public function supports(Request $request, /* ?RequestSupport $requestSupport = null */): ?bool
     {
+        $requestSupport = 2 <= \func_num_args() ? func_get_arg(1) : null;
+
         // do not overwrite already stored tokens (i.e. from the session)
         if (null !== $this->tokenStorage->getToken()) {
+            $requestSupport?->addReason('A token already exists in the session.');
+
             return false;
         }
 
         if (($cookie = $request->attributes->get(ResponseListener::COOKIE_ATTR_NAME)) && null === $cookie->getValue()) {
+            $requestSupport?->addReason('Cookie is cleared.');
+
             return false;
         }
 
-        if (!$request->cookies->has($this->cookieName) || !\is_scalar($request->cookies->all()[$this->cookieName] ?: null)) {
+        if (!$request->cookies->has($this->cookieName)) {
+            $requestSupport?->addReason(sprintf('Request does not have a "%s" cookie.', $this->cookieName));
+
+            return false;
+        }
+
+        if (!\is_scalar($request->cookies->all()[$this->cookieName] ?: null)) {
+            $requestSupport?->addReason(sprintf('Request does not have a "%s" cookie.', $this->cookieName));
+
             return false;
         }
 

--- a/src/Symfony/Component/Security/Http/Authenticator/RememberMeAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/RememberMeAuthenticator.php
@@ -27,7 +27,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPasspor
 use Symfony\Component\Security\Http\RememberMe\RememberMeDetails;
 use Symfony\Component\Security\Http\RememberMe\RememberMeHandlerInterface;
 use Symfony\Component\Security\Http\RememberMe\ResponseListener;
-use Symfony\Component\Security\Http\RequestSupport;
+use Symfony\Component\Security\Http\RequestDecision;
 
 /**
  * The RememberMe *Authenticator* performs remember me authentication.
@@ -75,33 +75,33 @@ class RememberMeAuthenticator implements InteractiveAuthenticatorInterface
     }
 
     /**
-     * @param RequestSupport|null $requestSupport
+     * @param RequestDecision|null $requestDecision
      */
-    public function supports(Request $request, /* ?RequestSupport $requestSupport = null */): ?bool
+    public function supports(Request $request, /* ?RequestDecision $requestDecision = null */): ?bool
     {
-        $requestSupport = 2 <= \func_num_args() ? func_get_arg(1) : null;
+        $requestDecision = 2 <= \func_num_args() ? func_get_arg(1) : null;
 
         // do not overwrite already stored tokens (i.e. from the session)
         if (null !== $this->tokenStorage->getToken()) {
-            $requestSupport?->addReason('A token already exists in the session.');
+            $requestDecision?->addReason('A token already exists in the session.');
 
             return false;
         }
 
         if (($cookie = $request->attributes->get(ResponseListener::COOKIE_ATTR_NAME)) && null === $cookie->getValue()) {
-            $requestSupport?->addReason('Cookie is cleared.');
+            $requestDecision?->addReason('Cookie is cleared.');
 
             return false;
         }
 
         if (!$request->cookies->has($this->cookieName)) {
-            $requestSupport?->addReason(sprintf('Request does not have a "%s" cookie.', $this->cookieName));
+            $requestDecision?->addReason(sprintf('Request does not have a "%s" cookie.', $this->cookieName));
 
             return false;
         }
 
         if (!\is_scalar($request->cookies->all()[$this->cookieName] ?: null)) {
-            $requestSupport?->addReason(sprintf('Request does not have a "%s" cookie.', $this->cookieName));
+            $requestDecision?->addReason(sprintf('Request does not have a "%s" cookie.', $this->cookieName));
 
             return false;
         }

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Deprecate callable firewall listeners, extend `AbstractListener` or implement `FirewallListenerInterface` instead
  * Deprecate `AbstractListener::__invoke`
+ * Add ability for authenticators to explain why they didn't support a request
 
 7.3
 ---

--- a/src/Symfony/Component/Security/Http/RequestDecision.php
+++ b/src/Symfony/Component/Security/Http/RequestDecision.php
@@ -11,10 +11,10 @@
 
 namespace Symfony\Component\Security\Http;
 
-class RequestSupport
+class RequestDecision
 {
-    public bool $result;
-    public ?bool $lazy = null;
+    public bool $isSupported;
+    public ?bool $isLazy = null;
 
     /** @var list<string> */
     public array $reasons = [];

--- a/src/Symfony/Component/Security/Http/RequestSupport.php
+++ b/src/Symfony/Component/Security/Http/RequestSupport.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http;
+
+class RequestSupport
+{
+    public bool $result;
+    public ?bool $lazy = null;
+
+    /** @var list<string> */
+    public array $reasons = [];
+
+    public function addReason(string $reason): void
+    {
+        $this->reasons[] = $reason;
+    }
+}

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/AbstractAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/AbstractAuthenticatorTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\Authenticator\Token\PostAuthenticationToken;
+use Symfony\Component\Security\Http\RequestSupport;
 
 class AbstractAuthenticatorTest extends TestCase
 {
@@ -42,7 +43,7 @@ class ConcreteAuthenticator extends AbstractAuthenticator
         return parent::createToken($passport, $firewallName);
     }
 
-    public function supports(Request $request): ?bool
+    public function supports(Request $request, ?RequestSupport $requestSupport = null): ?bool
     {
         return null;
     }

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/AbstractAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/AbstractAuthenticatorTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\Authenticator\Token\PostAuthenticationToken;
-use Symfony\Component\Security\Http\RequestSupport;
+use Symfony\Component\Security\Http\RequestDecision;
 
 class AbstractAuthenticatorTest extends TestCase
 {
@@ -43,7 +43,7 @@ class ConcreteAuthenticator extends AbstractAuthenticator
         return parent::createToken($passport, $firewallName);
     }
 
-    public function supports(Request $request, ?RequestSupport $requestSupport = null): ?bool
+    public function supports(Request $request, ?RequestDecision $requestDecision = null): ?bool
     {
         return null;
     }

--- a/src/Symfony/Component/Security/Http/Tests/Fixtures/DummyAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Tests/Fixtures/DummyAuthenticator.php
@@ -18,14 +18,14 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\PassportInterface;
-use Symfony\Component\Security\Http\RequestSupport;
+use Symfony\Component\Security\Http\RequestDecision;
 
 /**
  * @author Alexandre Daubois <alex.daubois@gmail.com>
  */
 class DummyAuthenticator implements AuthenticatorInterface
 {
-    public function supports(Request $request, ?RequestSupport $requestSupport = null): ?bool
+    public function supports(Request $request, ?RequestDecision $requestDecision = null): ?bool
     {
         return null;
     }

--- a/src/Symfony/Component/Security/Http/Tests/Fixtures/DummyAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Tests/Fixtures/DummyAuthenticator.php
@@ -18,13 +18,14 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\PassportInterface;
+use Symfony\Component\Security\Http\RequestSupport;
 
 /**
  * @author Alexandre Daubois <alex.daubois@gmail.com>
  */
 class DummyAuthenticator implements AuthenticatorInterface
 {
-    public function supports(Request $request): ?bool
+    public function supports(Request $request, ?RequestSupport $requestSupport = null): ?bool
     {
         return null;
     }

--- a/src/Symfony/Component/Security/Http/Tests/Fixtures/DummySupportsAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Tests/Fixtures/DummySupportsAuthenticator.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Http\Tests\Fixtures;
 
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Http\RequestSupport;
 
 class DummySupportsAuthenticator extends DummyAuthenticator
 {
@@ -22,7 +23,7 @@ class DummySupportsAuthenticator extends DummyAuthenticator
         $this->supports = $supports;
     }
 
-    public function supports(Request $request): ?bool
+    public function supports(Request $request, ?RequestSupport $requestSupport = null): ?bool
     {
         return $this->supports;
     }

--- a/src/Symfony/Component/Security/Http/Tests/Fixtures/DummySupportsAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Tests/Fixtures/DummySupportsAuthenticator.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Security\Http\Tests\Fixtures;
 
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Security\Http\RequestSupport;
+use Symfony\Component\Security\Http\RequestDecision;
 
 class DummySupportsAuthenticator extends DummyAuthenticator
 {
@@ -23,7 +23,7 @@ class DummySupportsAuthenticator extends DummyAuthenticator
         $this->supports = $supports;
     }
 
-    public function supports(Request $request, ?RequestSupport $requestSupport = null): ?bool
+    public function supports(Request $request, ?RequestDecision $requestDecision = null): ?bool
     {
         return $this->supports;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Inspired by #59771 this PR allows authenticators to advertise why they didn’t support a request by passing a new `RequestSupport` argument to their `supports` method. Calling its `addReason` method will cause the profiler to display them:

![](https://github.com/user-attachments/assets/7d9ce02e-8cc6-4f6b-a828-5d211972737e)

If this is accepted, this will pave the way for firewall listeners to expose informations about their calls to `supports` (this is why the `RequestSupport` class also holds `$result` and `$lazy` properties) and `authenticate`, thus closing #36668.