### PR TITLE
[HtmlSanitizer] Add support for securing target="_blank" links

### DIFF
--- a/src/Symfony/Component/HtmlSanitizer/HtmlSanitizerConfig.php
+++ b/src/Symfony/Component/HtmlSanitizer/HtmlSanitizerConfig.php
@@ -88,6 +88,12 @@ class HtmlSanitizerConfig
     private bool $allowRelativeMedias = false;
 
     /**
+     * When set to true, the sanitizer will ensure that any <a> element with target="_blank" is also accompanied
+     * by rel="noopener noreferrer" to prevent potential reverse tabnabbing vulnerabilities.
+     */
+    private bool $ensureSafeBlankTarget = true;
+
+    /**
      * Should the URL in the sanitized document be transformed to HTTPS if they are using HTTP.
      */
     private bool $forceHttpsUrls = false;
@@ -253,6 +259,17 @@ class HtmlSanitizerConfig
     {
         $clone = clone $this;
         $clone->allowRelativeMedias = $allowRelativeMedias;
+
+        return $clone;
+    }
+
+    /**
+     * Allows the use of the target="_blank" attribute without rel="noopener noreferrer".
+     */
+    public function allowUnsafeBlankTargets(): static
+    {
+        $clone = clone $this;
+        $clone->ensureSafeBlankTarget = false;
 
         return $clone;
     }
@@ -527,6 +544,11 @@ class HtmlSanitizerConfig
     public function getAllowRelativeMedias(): bool
     {
         return $this->allowRelativeMedias;
+    }
+
+    public function getEnsureSafeBlankTarget(): bool
+    {
+        return $this->ensureSafeBlankTarget;
     }
 
     public function getForceHttpsUrls(): bool

--- a/src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerAllTest.php
+++ b/src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerAllTest.php
@@ -600,4 +600,57 @@ class HtmlSanitizerAllTest extends TestCase
         $sanitizer = new HtmlSanitizer($config);
         self::assertSame('<foo><div><p><a>Hello</a></p></div></foo>', $sanitizer->sanitize('<foo data-attr="value"><div class="foo"><p><a target="_blank">Hello<span> World</span></a></p></div></foo>'));
     }
+
+    /**
+     * @dataProvider provideTargetBlank
+     */
+    public function testSafeTargetBlank(array $allowedAttributes, string $input, string $expectedSanitized)
+    {
+        $sanitizer = new HtmlSanitizer((new HtmlSanitizerConfig())
+            ->allowElement('a', $allowedAttributes)
+            ->allowLinkHosts(['trusted.com'])
+        );
+
+        $sanitized = $sanitizer->sanitize($input);
+
+        $this->assertSame($expectedSanitized, $sanitized);
+    }
+
+    public static function provideTargetBlank()
+    {
+        return [
+            // No rel attribute
+            [
+                ['href', 'target', 'rel'],
+                '<a href="https://trusted.com" target="_blank">Lorem ipsum</a>',
+                '<a href="https://trusted.com" target="_blank" rel="noopener noreferrer">Lorem ipsum</a>',
+            ],
+
+            // Normal tags
+            [
+                ['href', 'target', 'rel'],
+                '<a href="https://trusted.com" target="_blank" rel="external">Lorem ipsum</a>',
+                '<a href="https://trusted.com" target="_blank" rel="external noopener noreferrer">Lorem ipsum</a>',
+            ],
+
+            // Normal tags
+            [
+                ['href', 'target'],
+                '<a href="https://trusted.com" target="_blank" rel="external">Lorem ipsum</a>',
+                '<a href="https://trusted.com" target="_blank" rel="noopener noreferrer">Lorem ipsum</a>',
+            ],
+            // Missing noreferrer
+            [
+                ['href', 'target', 'rel'],
+                '<a href="https://trusted.com" target="_blank" rel="noopener">Lorem ipsum</a>',
+                '<a href="https://trusted.com" target="_blank" rel="noopener noreferrer">Lorem ipsum</a>',
+            ],
+            // Missing noopener
+            [
+                ['href', 'target', 'rel'],
+                '<a href="https://trusted.com" target="_blank" rel="noreferrer">Lorem ipsum</a>',
+                '<a href="https://trusted.com" target="_blank" rel="noreferrer noopener">Lorem ipsum</a>',
+            ],
+        ];
+    }
 }

--- a/src/Symfony/Component/HtmlSanitizer/Visitor/DomVisitor.php
+++ b/src/Symfony/Component/HtmlSanitizer/Visitor/DomVisitor.php
@@ -184,5 +184,15 @@ final class DomVisitor
                 $node->setAttribute($name, $value);
             }
         }
+        if ('a' === $domNodeName
+            && $this->config->getEnsureSafeBlankTarget()
+            && '_blank' === strtolower($node->getAttribute('target') ?? '')
+        ) {            $rel = $node->getAttribute('rel') ?? '';
+            $parts = explode(' ', strtolower($rel));
+            if (!in_array('noopener', $parts, true) || !in_array('noreferrer', $parts, true)) {
+                $parts = array_unique(array_merge($parts, ['noopener', 'noreferrer']));
+                $node->setAttribute('rel', trim(implode(' ', $parts)));
+            }
+        }
     }
 }

--- a/src/Symfony/Component/HtmlSanitizer/Visitor/Node/Node.php
+++ b/src/Symfony/Component/HtmlSanitizer/Visitor/Node/Node.php
@@ -58,10 +58,7 @@ final class Node implements NodeInterface
 
     public function setAttribute(string $name, ?string $value): void
     {
-        // Always use only the first declaration (ease sanitization)
-        if (!\array_key_exists($name, $this->attributes)) {
-            $this->attributes[$name] = $value;
-        }
+        $this->attributes[$name] = $value;
     }
 
     public function addChild(NodeInterface $node): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #
| License       | MIT

Introduce `ensureSafeBlankTarget` to automatically add `rel="noopener noreferrer"` to `<a>` elements with `target="_blank"`, mitigating reverse tabnabbing risks.

```html
<!-- Before -->
<a href="https://site.example" target="_blank">Outgoing link</a>


<!-- After -->
<a href="https://site.example" target="_blank" rel="noopener noreferrer">Outgoing link</a>
```

The `allowUnsafeBlankTargets` method allows opting out of this behavior if needed.

**ℹ️ Info**: Modern browsers already consider `noopener` event if missing. However the presence of the `rel` attribute is still considered as [a good practice]
(https://cheatsheetseries.owasp.org/cheatsheets/HTML5_Security_Cheat_Sheet.html#tabnabbing) by the OWASP.
**⚠ Warning**: I modified `Node::setAttribute` to allow overwriting existing attributes. I might have missed the reason for the comment `Always use only the first declaration (ease sanitization)`.
**⚠ Warning**: The logic is implemented in `DomVisitor`. It works, however I am wondering if an abstraction is needed.