### PR TITLE
[HttpFoundation] Fixed 'Via' header regex

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1466,7 +1466,7 @@ class Request
     public function getProtocolVersion(): ?string
     {
         if ($this->isFromTrustedProxy()) {
-            preg_match('~^(HTTP/)?([1-9]\.[0-9]) ~', $this->headers->get('Via') ?? '', $matches);
+            preg_match('~^(HTTP/)?([1-9]\.[0-9])\b~', $this->headers->get('Via') ?? '', $matches);
 
             if ($matches) {
                 return 'HTTP/'.$matches[2];

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -2402,6 +2402,8 @@ class RequestTest extends TestCase
             'trusted with via and protocol name' => ['HTTP/2.0', true, 'HTTP/1.0 fred, HTTP/1.1 nowhere.com (Apache/1.1)', 'HTTP/1.0'],
             'trusted with broken via' => ['HTTP/2.0', true, 'HTTP/1^0 foo', 'HTTP/2.0'],
             'trusted with partially-broken via' => ['HTTP/2.0', true, '1.0 fred, foo', 'HTTP/1.0'],
+            'trusted with simple via' => ['HTTP/2.0', true, 'HTTP/1.0', 'HTTP/1.0'],
+            'trusted with only version via' => ['HTTP/2.0', true, '1.0', 'HTTP/1.0'],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

#### 📝 Purpose
This MR updates the regular expression used to extract the HTTP protocol version from the `Via` header in the `Request::getProtocolVersion()` method.

#### 🎯 Summary of Changes
**Old regex:**
```php
~^(HTTP/)?([1-9]\.[0-9]) ~
```

This pattern failed to match valid values like HTTP/1.1 or 2.0 when there was no trailing space. As a result, values passed from proxies (e.g., via proxy_set_header Via $server_protocol;) were not detected correctly.

New regex:
```php
~^(HTTP/)?([1-9]\.[0-9])\b~
```
#### ✅ Benefits

- Replaces dependency on a trailing space with `\b` (word boundary), allowing the regex to match both space-terminated and non-space-terminated inputs.
- Correctly handles common `Via` header formats such as:
  - `HTTP/1.1`
  - `2.0`
  - `HTTP/2.0 nginx-proxy`
  - `1.1 custom-hop`
- Ensures compatibility with reverse proxy configurations (e.g., Nginx, Traefik) where the `Via` header may vary in format.
- Improves robustness and reliability of HTTP version detection in proxied environments.