### PR TITLE
Add intl-icu fallback for MessageCatalogue metadata

### DIFF
--- a/src/Symfony/Component/Translation/MessageCatalogue.php
+++ b/src/Symfony/Component/Translation/MessageCatalogue.php
@@ -217,6 +217,16 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
             return $this->metadata;
         }
 
+        if (isset($this->metadata[$domain.self::INTL_DOMAIN_SUFFIX])) {
+            if ('' == $key) {
+                return $this->metadata[$domain.self::INTL_DOMAIN_SUFFIX];
+            }
+
+            if (isset($this->metadata[$domain.self::INTL_DOMAIN_SUFFIX][$key])) {
+                return $this->metadata[$domain.self::INTL_DOMAIN_SUFFIX][$key];
+            }
+        }
+
         if (isset($this->metadata[$domain])) {
             if ('' == $key) {
                 return $this->metadata[$domain];

--- a/src/Symfony/Component/Translation/Tests/Catalogue/MetadataTest.php
+++ b/src/Symfony/Component/Translation/Tests/Catalogue/MetadataTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Symfony\Component\Translation\Tests\Catalogue;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Translation\MessageCatalogue;
+
+class MetadataTest extends TestCase
+{
+    public function testIcuMetadataKept()
+    {
+        $mc = new MessageCatalogue('en', ['messages' => ['a' => 'new_a']]);
+        $metadata = ['metadata' => 'value'];
+        $mc->setMetadata('a', $metadata, 'messages+intl-icu');
+        $this->assertEquals($metadata, $mc->getMetadata('a', 'messages'));
+        $this->assertEquals($metadata, $mc->getMetadata('a', 'messages+intl-icu'));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60523 
| License       | MIT

Added domain fallback for metadata, which should match the behavior used for fetching messages.