### PR TITLE
[Security] do not construct Vote instances inside vote()

### DIFF
--- a/UPGRADE-7.3.md
+++ b/UPGRADE-7.3.md
@@ -179,9 +179,7 @@ Security
    ```php
    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?Vote $vote = null): bool
    {
-       $vote ??= new Vote();
-
-       $vote->reasons[] = 'A brief explanation of why access is granted or denied, as appropriate.';
+       $vote?->addReason('A brief explanation of why access is granted or denied, as appropriate.');
    }
    ```
 

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/AuthenticatedVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/AuthenticatedVoter.php
@@ -45,11 +45,10 @@ class AuthenticatedVoter implements CacheableVoterInterface
      */
     public function vote(TokenInterface $token, mixed $subject, array $attributes/* , ?Vote $vote = null */): int
     {
-        $vote = 3 < \func_num_args() ? func_get_arg(3) : new Vote();
-        $vote ??= new Vote();
+        $vote = 3 < \func_num_args() ? func_get_arg(3) : null;
 
         if ($attributes === [self::PUBLIC_ACCESS]) {
-            $vote->reasons[] = 'Access is public.';
+            $vote?->addReason('Access is public.');
 
             return VoterInterface::ACCESS_GRANTED;
         }
@@ -73,7 +72,7 @@ class AuthenticatedVoter implements CacheableVoterInterface
             if ((self::IS_AUTHENTICATED_FULLY === $attribute || self::IS_AUTHENTICATED_REMEMBERED === $attribute)
                 && $this->authenticationTrustResolver->isFullFledged($token)
             ) {
-                $vote->reasons[] = 'The user is fully authenticated.';
+                $vote?->addReason('The user is fully authenticated.');
 
                 return VoterInterface::ACCESS_GRANTED;
             }
@@ -81,32 +80,32 @@ class AuthenticatedVoter implements CacheableVoterInterface
             if (self::IS_AUTHENTICATED_REMEMBERED === $attribute
                 && $this->authenticationTrustResolver->isRememberMe($token)
             ) {
-                $vote->reasons[] = 'The user is remembered.';
+                $vote?->addReason('The user is remembered.');
 
                 return VoterInterface::ACCESS_GRANTED;
             }
 
             if (self::IS_AUTHENTICATED === $attribute && $this->authenticationTrustResolver->isAuthenticated($token)) {
-                $vote->reasons[] = 'The user is authenticated.';
+                $vote?->addReason('The user is authenticated.');
 
                 return VoterInterface::ACCESS_GRANTED;
             }
 
             if (self::IS_REMEMBERED === $attribute && $this->authenticationTrustResolver->isRememberMe($token)) {
-                $vote->reasons[] = 'The user is remembered.';
+                $vote?->addReason('The user is remembered.');
 
                 return VoterInterface::ACCESS_GRANTED;
             }
 
             if (self::IS_IMPERSONATOR === $attribute && $token instanceof SwitchUserToken) {
-                $vote->reasons[] = 'The user is impersonating another user.';
+                $vote?->addReason('The user is impersonating another user.');
 
                 return VoterInterface::ACCESS_GRANTED;
             }
         }
 
         if (VoterInterface::ACCESS_DENIED === $result) {
-            $vote->reasons[] = 'The user is not appropriately authenticated.';
+            $vote?->addReason('The user is not appropriately authenticated.');
         }
 
         return $result;

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/ClosureVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/ClosureVoter.php
@@ -42,7 +42,6 @@ final class ClosureVoter implements CacheableVoterInterface
 
     public function vote(TokenInterface $token, mixed $subject, array $attributes, ?Vote $vote = null): int
     {
-        $vote ??= new Vote();
         $context = new IsGrantedContext($token, $token->getUser(), $this->authorizationChecker);
         $failingClosures = [];
         $result = VoterInterface::ACCESS_ABSTAIN;
@@ -54,7 +53,7 @@ final class ClosureVoter implements CacheableVoterInterface
             $name = (new \ReflectionFunction($attribute))->name;
             $result = VoterInterface::ACCESS_DENIED;
             if ($attribute($context, $subject)) {
-                $vote->reasons[] = \sprintf('Closure %s returned true.', $name);
+                $vote?->addReason(\sprintf('Closure %s returned true.', $name));
 
                 return VoterInterface::ACCESS_GRANTED;
             }
@@ -63,7 +62,7 @@ final class ClosureVoter implements CacheableVoterInterface
         }
 
         if ($failingClosures) {
-            $vote->reasons[] = \sprintf('Closure%s %s returned false.', 1 < \count($failingClosures) ? 's' : '', implode(', ', $failingClosures));
+            $vote?->addReason(\sprintf('Closure%s %s returned false.', 1 < \count($failingClosures) ? 's' : '', implode(', ', $failingClosures)));
         }
 
         return $result;

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/ExpressionVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/ExpressionVoter.php
@@ -49,8 +49,7 @@ class ExpressionVoter implements CacheableVoterInterface
      */
     public function vote(TokenInterface $token, mixed $subject, array $attributes/* , ?Vote $vote = null */): int
     {
-        $vote = 3 < \func_num_args() ? func_get_arg(3) : new Vote();
-        $vote ??= new Vote();
+        $vote = 3 < \func_num_args() ? func_get_arg(3) : null;
         $result = VoterInterface::ACCESS_ABSTAIN;
         $variables = null;
         $failingExpressions = [];
@@ -64,7 +63,7 @@ class ExpressionVoter implements CacheableVoterInterface
             $result = VoterInterface::ACCESS_DENIED;
 
             if ($this->expressionLanguage->evaluate($attribute, $variables)) {
-                $vote->reasons[] = \sprintf('Expression (%s) is true.', $attribute);
+                $vote?->addReason(\sprintf('Expression (%s) is true.', $attribute));
 
                 return VoterInterface::ACCESS_GRANTED;
             }
@@ -73,7 +72,7 @@ class ExpressionVoter implements CacheableVoterInterface
         }
 
         if ($failingExpressions) {
-            $vote->reasons[] = \sprintf('Expression (%s) is false.', implode(') || (', $failingExpressions));
+            $vote?->addReason(\sprintf('Expression (%s) is false.', implode(') || (', $failingExpressions)));
         }
 
         return $result;

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/RoleVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/RoleVoter.php
@@ -30,8 +30,7 @@ class RoleVoter implements CacheableVoterInterface
      */
     public function vote(TokenInterface $token, mixed $subject, array $attributes/* , ?Vote $vote = null */): int
     {
-        $vote = 3 < \func_num_args() ? func_get_arg(3) : new Vote();
-        $vote ??= new Vote();
+        $vote = 3 < \func_num_args() ? func_get_arg(3) : null;
         $result = VoterInterface::ACCESS_ABSTAIN;
         $roles = $this->extractRoles($token);
         $missingRoles = [];
@@ -44,7 +43,7 @@ class RoleVoter implements CacheableVoterInterface
             $result = VoterInterface::ACCESS_DENIED;
 
             if (\in_array($attribute, $roles, true)) {
-                $vote->reasons[] = \sprintf('The user has %s.', $attribute);
+                $vote?->addReason(\sprintf('The user has %s.', $attribute));
 
                 return VoterInterface::ACCESS_GRANTED;
             }
@@ -53,7 +52,7 @@ class RoleVoter implements CacheableVoterInterface
         }
 
         if (VoterInterface::ACCESS_DENIED === $result) {
-            $vote->reasons[] = \sprintf('The user doesn\'t have%s %s.', 1 < \count($missingRoles) ? ' any of' : '', implode(', ', $missingRoles));
+            $vote?->addReason(\sprintf('The user doesn\'t have%s %s.', 1 < \count($missingRoles) ? ' any of' : '', implode(', ', $missingRoles)));
         }
 
         return $result;

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/TraceableVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/TraceableVoter.php
@@ -32,9 +32,9 @@ class TraceableVoter implements CacheableVoterInterface
 
     public function vote(TokenInterface $token, mixed $subject, array $attributes, ?Vote $vote = null): int
     {
-        $result = $this->voter->vote($token, $subject, $attributes, $vote ??= new Vote());
+        $result = $this->voter->vote($token, $subject, $attributes, $vote);
 
-        $this->eventDispatcher->dispatch(new VoteEvent($this->voter, $subject, $attributes, $result, $vote->reasons), 'debug.security.authorization.vote');
+        $this->eventDispatcher->dispatch(new VoteEvent($this->voter, $subject, $attributes, $result, $vote->reasons ?? []), 'debug.security.authorization.vote');
 
         return $result;
     }

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/VoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/VoterTest.php
@@ -33,35 +33,51 @@ class VoterTest extends TestCase
 
         return [
             [$voter, ['EDIT'], VoterInterface::ACCESS_GRANTED, new \stdClass(), 'ACCESS_GRANTED if attribute and class are supported and attribute grants access'],
+            [$voter, ['EDIT'], VoterInterface::ACCESS_GRANTED, new \stdClass(), 'ACCESS_GRANTED if attribute and class are supported and attribute grants access', new Vote()],
             [$voter, ['CREATE'], VoterInterface::ACCESS_DENIED, new \stdClass(), 'ACCESS_DENIED if attribute and class are supported and attribute does not grant access'],
+            [$voter, ['CREATE'], VoterInterface::ACCESS_DENIED, new \stdClass(), 'ACCESS_DENIED if attribute and class are supported and attribute does not grant access', new Vote()],
 
             [$voter, ['DELETE', 'EDIT'], VoterInterface::ACCESS_GRANTED, new \stdClass(), 'ACCESS_GRANTED if one attribute is supported and grants access'],
+            [$voter, ['DELETE', 'EDIT'], VoterInterface::ACCESS_GRANTED, new \stdClass(), 'ACCESS_GRANTED if one attribute is supported and grants access', new Vote()],
             [$voter, ['DELETE', 'CREATE'], VoterInterface::ACCESS_DENIED, new \stdClass(), 'ACCESS_DENIED if one attribute is supported and denies access'],
+            [$voter, ['DELETE', 'CREATE'], VoterInterface::ACCESS_DENIED, new \stdClass(), 'ACCESS_DENIED if one attribute is supported and denies access', new Vote()],
 
             [$voter, ['CREATE', 'EDIT'], VoterInterface::ACCESS_GRANTED, new \stdClass(), 'ACCESS_GRANTED if one attribute grants access'],
+            [$voter, ['CREATE', 'EDIT'], VoterInterface::ACCESS_GRANTED, new \stdClass(), 'ACCESS_GRANTED if one attribute grants access', new Vote()],
 
             [$voter, ['DELETE'], VoterInterface::ACCESS_ABSTAIN, new \stdClass(), 'ACCESS_ABSTAIN if no attribute is supported'],
+            [$voter, ['DELETE'], VoterInterface::ACCESS_ABSTAIN, new \stdClass(), 'ACCESS_ABSTAIN if no attribute is supported', new Vote()],
 
             [$voter, ['EDIT'], VoterInterface::ACCESS_ABSTAIN, new class {}, 'ACCESS_ABSTAIN if class is not supported'],
+            [$voter, ['EDIT'], VoterInterface::ACCESS_ABSTAIN, new class {}, 'ACCESS_ABSTAIN if class is not supported', new Vote()],
 
             [$voter, ['EDIT'], VoterInterface::ACCESS_ABSTAIN, null, 'ACCESS_ABSTAIN if object is null'],
+            [$voter, ['EDIT'], VoterInterface::ACCESS_ABSTAIN, null, 'ACCESS_ABSTAIN if object is null', new Vote()],
 
             [$voter, [], VoterInterface::ACCESS_ABSTAIN, new \stdClass(), 'ACCESS_ABSTAIN if no attributes were provided'],
+            [$voter, [], VoterInterface::ACCESS_ABSTAIN, new \stdClass(), 'ACCESS_ABSTAIN if no attributes were provided', new Vote()],
 
             [$voter, [new StringableAttribute()], VoterInterface::ACCESS_GRANTED, new \stdClass(), 'ACCESS_GRANTED if attribute and class are supported and attribute grants access'],
+            [$voter, [new StringableAttribute()], VoterInterface::ACCESS_GRANTED, new \stdClass(), 'ACCESS_GRANTED if attribute and class are supported and attribute grants access', new Vote()],
 
             [$voter, [new \stdClass()], VoterInterface::ACCESS_ABSTAIN, new \stdClass(), 'ACCESS_ABSTAIN if attributes were not strings'],
+            [$voter, [new \stdClass()], VoterInterface::ACCESS_ABSTAIN, new \stdClass(), 'ACCESS_ABSTAIN if attributes were not strings', new Vote()],
 
             [$integerVoter, [42], VoterInterface::ACCESS_GRANTED, new \stdClass(), 'ACCESS_GRANTED if attribute is an integer'],
+            [$integerVoter, [42], VoterInterface::ACCESS_GRANTED, new \stdClass(), 'ACCESS_GRANTED if attribute is an integer', new Vote()],
         ];
     }
 
     /**
      * @dataProvider getTests
      */
-    public function testVote(VoterInterface $voter, array $attributes, $expectedVote, $object, $message)
+    public function testVote(VoterInterface $voter, array $attributes, $expectedVote, $object, $message, ?Vote $vote = null)
     {
-        $this->assertEquals($expectedVote, $voter->vote($this->token, $object, $attributes), $message);
+        $this->assertSame($expectedVote, $voter->vote($this->token, $object, $attributes, $vote), $message);
+
+        if (null !== $vote) {
+            self::assertSame($expectedVote, $vote->result);
+        }
     }
 
     public function testVoteWithTypeError()

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/IsGrantedAttributeListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/IsGrantedAttributeListenerTest.php
@@ -232,7 +232,7 @@ class IsGrantedAttributeListenerTest extends TestCase
 
                 protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?Vote $vote = null): bool
                 {
-                    $vote->reasons[] = 'Because I can 😈.';
+                    $vote?->addReason('Because I can 😈.');
 
                     return false;
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

The so constructed objects will never be seen from the outside. Thus, adding reasons to them doesn't have an effect.