### PR TITLE
[Console] Add helper resolution support for invokable commands

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+ * Add helper resolution support for invokable commands
+
 7.3
 ---
 

--- a/src/Symfony/Component/Console/Command/InvokableCommand.php
+++ b/src/Symfony/Component/Console/Command/InvokableCommand.php
@@ -133,11 +133,21 @@ class InvokableCommand implements SignalableCommandInterface
                 throw new LogicException(\sprintf('The parameter "$%s" must have a named type. Untyped, Union or Intersection types are not supported.', $parameter->getName()));
             }
 
+            if ($application = $this->command->getApplication()) {
+                foreach ($application->getHelperSet() as $helper) {
+                    if ($type->getName() === $helper::class) {
+                        $parameters[] = $helper;
+
+                        continue 2;
+                    }
+                }
+            }
+
             $parameters[] = match ($type->getName()) {
                 InputInterface::class => $input,
                 OutputInterface::class => $output,
                 SymfonyStyle::class => new SymfonyStyle($input, $output),
-                Application::class => $this->command->getApplication(),
+                Application::class => $application,
                 default => throw new RuntimeException(\sprintf('Unsupported type "%s" for parameter "$%s".', $type->getName(), $parameter->getName())),
             };
         }

--- a/src/Symfony/Component/Console/Tests/Command/InvokableCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/InvokableCommandTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Console\Tests\Command;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Attribute\Argument;
 use Symfony\Component\Console\Attribute\Option;
 use Symfony\Component\Console\Command\Command;
@@ -20,6 +21,7 @@ use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\Console\Completion\Suggestion;
 use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Console\Exception\LogicException;
+use Symfony\Component\Console\Helper\FormatterHelper;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\NullOutput;
@@ -370,6 +372,19 @@ class InvokableCommandTest extends TestCase
         $this->expectExceptionMessage('The "--a" option requires a value.');
 
         $command->run(new ArrayInput(['--a' => null]), new NullOutput());
+    }
+
+    public function testResolveHelper()
+    {
+        $command = new Command('foo');
+        $command->setApplication(new Application());
+        $command->setCode(function (FormatterHelper $formatter): int {
+            $this->assertSame('foo...', $formatter->truncate('foobar', 3));
+
+            return 0;
+        });
+
+        $command->run(new ArrayInput([]), new NullOutput());
     }
 
     public function getSuggestedRoles(CompletionInput $input): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        |  -
| License       | MIT

Discussion started here https://github.com/symfony/symfony-docs/pull/20932#discussion_r2074034539

This adds support for resolving all registered console helpers:
https://github.com/symfony/symfony/blob/5add177fd59074401f7a1d8d65d807779ce84b86/src/Symfony/Component/Console/Application.php#L1154-L1162

For example:
```php
use Symfony\Component\Console\Helper\ProcessHelper;
use Symfony\Component\Process\Process;

#[AsCommand('app:hello')]
class AppHelloCommand
{
    public function __invoke(OutputInterface $output, ProcessHelper $helper): int
    {
        $process = new Process(['figlet', 'Symfony']);
        $helper->run($output, $process);

        // ...

        return 0;
    }
}
```
Improving DX, as currently alternatives include:
 * extending from the `Command` class and then using `$this->getHelper('process')`
 * defining `__invoke(..., Application $application)` and then using `$application->getHelperSet()->get('process')`

Also, all of the above alternatives lack autocompletion for the concrete helper class.