### PR TITLE
[Uid] Add InvalidUidException Context

### DIFF
--- a/src/Symfony/Component/Uid/AbstractUid.php
+++ b/src/Symfony/Component/Uid/AbstractUid.php
@@ -53,7 +53,7 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable, HashableIn
     public static function fromBase58(string $uid): static
     {
         if (22 !== \strlen($uid)) {
-            throw new InvalidUidException($uid, 'Invalid base-58 uid provided.');
+            throw new InvalidUidException($uid, 'Invalid base-58 uid provided: {uid}');
         }
 
         return static::fromString($uid);
@@ -65,7 +65,7 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable, HashableIn
     public static function fromBase32(string $uid): static
     {
         if (26 !== \strlen($uid)) {
-            throw new InvalidUidException($uid, 'Invalid base-32 uid provided.');
+            throw new InvalidUidException($uid, 'Invalid base-32 uid provided: {uid}');
         }
 
         return static::fromString($uid);
@@ -79,7 +79,7 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable, HashableIn
     public static function fromRfc4122(string $uid): static
     {
         if (36 !== \strlen($uid)) {
-            throw new InvalidUidException($uid, 'Invalid RFC4122 uid provided.');
+            throw new InvalidUidException($uid, 'Invalid RFC4122 uid provided: {uid}');
         }
 
         return static::fromString($uid);

--- a/src/Symfony/Component/Uid/AbstractUid.php
+++ b/src/Symfony/Component/Uid/AbstractUid.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Uid;
 
-use Symfony\Component\Uid\Exception\InvalidArgumentException;
+use Symfony\Component\Uid\Exception\InvalidUidException;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
@@ -31,41 +31,41 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable, HashableIn
     /**
      * Creates an AbstractUid from an identifier represented in any of the supported formats.
      *
-     * @throws InvalidArgumentException When the passed value is not valid
+     * @throws InvalidUidException When the passed value is not valid
      */
     abstract public static function fromString(string $uid): static;
 
     /**
-     * @throws InvalidArgumentException When the passed value is not valid
+     * @throws InvalidUidException When the passed value is not valid
      */
     public static function fromBinary(string $uid): static
     {
         if (16 !== \strlen($uid)) {
-            throw new InvalidArgumentException('Invalid binary uid provided.');
+            throw new InvalidUidException($uid, 'Invalid binary uid provided.');
         }
 
         return static::fromString($uid);
     }
 
     /**
-     * @throws InvalidArgumentException When the passed value is not valid
+     * @throws InvalidUidException When the passed value is not valid
      */
     public static function fromBase58(string $uid): static
     {
         if (22 !== \strlen($uid)) {
-            throw new InvalidArgumentException('Invalid base-58 uid provided.');
+            throw new InvalidUidException($uid, 'Invalid base-58 uid provided.');
         }
 
         return static::fromString($uid);
     }
 
     /**
-     * @throws InvalidArgumentException When the passed value is not valid
+     * @throws InvalidUidException When the passed value is not valid
      */
     public static function fromBase32(string $uid): static
     {
         if (26 !== \strlen($uid)) {
-            throw new InvalidArgumentException('Invalid base-32 uid provided.');
+            throw new InvalidUidException($uid, 'Invalid base-32 uid provided.');
         }
 
         return static::fromString($uid);
@@ -74,12 +74,12 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable, HashableIn
     /**
      * @param string $uid A valid RFC 9562/4122 uid
      *
-     * @throws InvalidArgumentException When the passed value is not valid
+     * @throws InvalidUidException When the passed value is not valid
      */
     public static function fromRfc4122(string $uid): static
     {
         if (36 !== \strlen($uid)) {
-            throw new InvalidArgumentException('Invalid RFC4122 uid provided.');
+            throw new InvalidUidException($uid, 'Invalid RFC4122 uid provided.');
         }
 
         return static::fromString($uid);

--- a/src/Symfony/Component/Uid/Exception/InvalidUidException.php
+++ b/src/Symfony/Component/Uid/Exception/InvalidUidException.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Uid\Exception;
+
+final class InvalidUidException extends InvalidArgumentException
+{
+    public function __construct(
+        public readonly string $uid,
+        string $message,
+    ) {
+        parent::__construct($message);
+    }
+}

--- a/src/Symfony/Component/Uid/Tests/UlidTest.php
+++ b/src/Symfony/Component/Uid/Tests/UlidTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Uid\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Uid\Exception\InvalidArgumentException;
+use Symfony\Component\Uid\Exception\InvalidUidException;
 use Symfony\Component\Uid\MaxUlid;
 use Symfony\Component\Uid\NilUlid;
 use Symfony\Component\Uid\Tests\Fixtures\CustomUlid;
@@ -42,7 +42,7 @@ class UlidTest extends TestCase
 
     public function testWithInvalidUlid()
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidUidException::class);
         $this->expectExceptionMessage('Invalid ULID: "this is not a ulid".');
 
         new Ulid('this is not a ulid');
@@ -152,7 +152,7 @@ class UlidTest extends TestCase
      */
     public function testFromBinaryInvalidFormat(string $ulid)
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidUidException::class);
 
         Ulid::fromBinary($ulid);
     }
@@ -179,7 +179,7 @@ class UlidTest extends TestCase
      */
     public function testFromBase58InvalidFormat(string $ulid)
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidUidException::class);
 
         Ulid::fromBase58($ulid);
     }
@@ -206,7 +206,7 @@ class UlidTest extends TestCase
      */
     public function testFromBase32InvalidFormat(string $ulid)
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidUidException::class);
 
         Ulid::fromBase32($ulid);
     }
@@ -233,7 +233,7 @@ class UlidTest extends TestCase
      */
     public function testFromRfc4122InvalidFormat(string $ulid)
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidUidException::class);
 
         Ulid::fromRfc4122($ulid);
     }

--- a/src/Symfony/Component/Uid/Tests/UuidTest.php
+++ b/src/Symfony/Component/Uid/Tests/UuidTest.php
@@ -12,7 +12,8 @@
 namespace Symfony\Component\Uid\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Uid\Exception\InvalidArgumentException;
+use Symfony\Component\Uid\Exception\InvalidUidException;
+use Symfony\Component\Uid\Exception\LogicException;
 use Symfony\Component\Uid\MaxUuid;
 use Symfony\Component\Uid\NilUuid;
 use Symfony\Component\Uid\Tests\Fixtures\CustomUuid;
@@ -36,7 +37,7 @@ class UuidTest extends TestCase
      */
     public function testConstructorWithInvalidUuid(string $uuid)
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidUidException::class);
         $this->expectExceptionMessage('Invalid UUID: "'.$uuid.'".');
 
         Uuid::fromString($uuid);
@@ -59,7 +60,7 @@ class UuidTest extends TestCase
         $uuid = (string) $uuid;
         $class = Uuid::class.'V'.$uuid[14];
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidUidException::class);
         $this->expectExceptionMessage('Invalid UUIDv'.$uuid[14].': "'.$uuid.'".');
 
         new $class($uuid);
@@ -380,11 +381,11 @@ class UuidTest extends TestCase
     /**
      * @dataProvider provideInvalidBinaryFormat
      */
-    public function testFromBinaryInvalidFormat(string $ulid)
+    public function testFromBinaryInvalidFormat(string $uuid)
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidUidException::class);
 
-        Uuid::fromBinary($ulid);
+        Uuid::fromBinary($uuid);
     }
 
     public static function provideInvalidBinaryFormat(): array
@@ -407,11 +408,11 @@ class UuidTest extends TestCase
     /**
      * @dataProvider provideInvalidBase58Format
      */
-    public function testFromBase58InvalidFormat(string $ulid)
+    public function testFromBase58InvalidFormat(string $uuid)
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidUidException::class);
 
-        Uuid::fromBase58($ulid);
+        Uuid::fromBase58($uuid);
     }
 
     public static function provideInvalidBase58Format(): array
@@ -434,11 +435,11 @@ class UuidTest extends TestCase
     /**
      * @dataProvider provideInvalidBase32Format
      */
-    public function testFromBase32InvalidFormat(string $ulid)
+    public function testFromBase32InvalidFormat(string $uuid)
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidUidException::class);
 
-        Uuid::fromBase32($ulid);
+        Uuid::fromBase32($uuid);
     }
 
     public static function provideInvalidBase32Format(): array
@@ -461,11 +462,11 @@ class UuidTest extends TestCase
     /**
      * @dataProvider provideInvalidRfc4122Format
      */
-    public function testFromRfc4122InvalidFormat(string $ulid)
+    public function testFromRfc4122InvalidFormat(string $uuid)
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidUidException::class);
 
-        Uuid::fromRfc4122($ulid);
+        Uuid::fromRfc4122($uuid);
     }
 
     public static function provideInvalidRfc4122Format(): array
@@ -510,7 +511,7 @@ class UuidTest extends TestCase
 
     public function testV1ToV7BeforeUnixEpochThrows()
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Cannot convert UUID to v7: its timestamp is before the Unix epoch.');
 
         (new UuidV1('9aba8000-ff00-11b0-b3db-3b3fc83afdfc'))->toV7(); // Timestamp is 1969-01-01 00:00:00.0000000

--- a/src/Symfony/Component/Uid/Ulid.php
+++ b/src/Symfony/Component/Uid/Ulid.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Uid;
 
 use Symfony\Component\Uid\Exception\InvalidArgumentException;
+use Symfony\Component\Uid\Exception\InvalidUidException;
 
 /**
  * A ULID is lexicographically sortable and contains a 48-bit timestamp and 80-bit of crypto-random entropy.
@@ -38,7 +39,7 @@ class Ulid extends AbstractUid implements TimeBasedUidInterface
             $this->uid = $ulid;
         } else {
             if (!self::isValid($ulid)) {
-                throw new InvalidArgumentException(\sprintf('Invalid ULID: "%s".', $ulid));
+                throw new InvalidUidException($ulid, \sprintf('Invalid ULID: "%s".', $ulid));
             }
 
             $this->uid = strtoupper($ulid);

--- a/src/Symfony/Component/Uid/Uuid.php
+++ b/src/Symfony/Component/Uid/Uuid.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Uid;
 
-use Symfony\Component\Uid\Exception\InvalidArgumentException;
+use Symfony\Component\Uid\Exception\InvalidUidException;
 
 /**
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
@@ -41,13 +41,13 @@ class Uuid extends AbstractUid
         $type = preg_match('{^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$}Di', $uuid) ? (int) $uuid[14] : false;
 
         if (false === $type || (static::TYPE ?: $type) !== $type) {
-            throw new InvalidArgumentException(\sprintf('Invalid UUID%s: "%s".', static::TYPE ? 'v'.static::TYPE : '', $uuid));
+            throw new InvalidUidException($uuid, \sprintf('Invalid UUID%s: "%s".', static::TYPE ? 'v'.static::TYPE : '', $uuid));
         }
 
         $this->uid = strtolower($uuid);
 
         if ($checkVariant && !\in_array($this->uid[19], ['8', '9', 'a', 'b'], true)) {
-            throw new InvalidArgumentException(\sprintf('Invalid UUID%s: "%s".', static::TYPE ? 'v'.static::TYPE : '', $uuid));
+            throw new InvalidUidException($uuid, \sprintf('Invalid UUID%s: "%s".', static::TYPE ? 'v'.static::TYPE : '', $uuid));
         }
     }
 

--- a/src/Symfony/Component/Uid/UuidV6.php
+++ b/src/Symfony/Component/Uid/UuidV6.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Uid;
 
-use Symfony\Component\Uid\Exception\InvalidArgumentException;
+use Symfony\Component\Uid\Exception\LogicException;
 
 /**
  * A v6 UUID is lexicographically sortable and contains a 60-bit timestamp and 62 extra unique bits.
@@ -50,7 +50,7 @@ class UuidV6 extends Uuid implements TimeBasedUidInterface
         $uuid = $this->uid;
         $time = BinaryUtil::hexToNumericString('0'.substr($uuid, 0, 8).substr($uuid, 9, 4).substr($uuid, 15, 3));
         if ('-' === $time[0]) {
-            throw new InvalidArgumentException('Cannot convert UUID to v7: its timestamp is before the Unix epoch.');
+            throw new LogicException('Cannot convert UUID to v7: its timestamp is before the Unix epoch.');
         }
 
         $ms = \strlen($time) > 4 ? substr($time, 0, -4) : '0';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes (minor)
| Deprecations? | no
| Issues        | https://github.com/symfony/symfony/pull/60328
| License       | MIT

Considering the main purpose of the exceptions - to be logged, it is best to have their context normalized, so that it can be easily processed by special tools (like Graylog, Logstash, etc).

This PR adds context to `InvalidUidException` so that its value will appear in logs, and also it adds PSR3-interpolation placeholders for uid value where such were absent.
