### PR TITLE
update the Scorecards branch

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -6,7 +6,7 @@ on:
   schedule:
     - cron: '34 4 * * 6'
   push:
-    branches: [ "7.3" ]
+    branches: [ "7.4" ]
 
 # Declare default permissions as read only.
 permissions: read-all


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

The job for Scorecards needs to be run on the default branch.