### PR TITLE
[SecurityBundle] Deprecate XML-configured custom authenticators and providers under security namespace

### DIFF
--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -1,0 +1,41 @@
+UPGRADE FROM 7.3 to 7.4
+=======================
+
+Symfony 7.4 is a minor release. According to the Symfony release process, there should be no significant
+backward compatibility breaks. Minor backward compatibility breaks are prefixed in this document with
+`[BC BREAK]`, make sure your code is compatible with these entries before upgrading.
+Read more about this in the [Symfony documentation](https://symfony.com/doc/7.4/setup/upgrade_minor.html).
+
+If you're upgrading from a version below 7.3, follow the [7.3 upgrade guide](UPGRADE-7.3.md) first.
+string in `UserInterface::getUserIdentifier()`
+
+SecurityBundle
+--------------
+
+ * Deprecate XML-configured custom authenticators and providers under security namespace; they must now have their own:
+
+   ```diff
+   <srv:container xmlns="http://symfony.com/schema/dic/security"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns:srv="http://symfony.com/schema/dic/services"
+   +           xmlns:custom="http://example.com/schema"
+               xsi:schemaLocation="http://symfony.com/schema/dic/services
+        https://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/security
+   -    https://symfony.com/schema/dic/security/security-1.0.xsd">
+   +    https://symfony.com/schema/dic/security/security-1.0.xsd
+   +    http://example.com/schema http://example.com/schema.xsd">
+   +    <!-- the line above can be omitted if the schema does not have a definition -->
+
+        <config>
+           <provider name="custom_provider">
+   -           <provider-name>
+   -               <config key="value"/>
+   -           </provider-name>
+   +           <custom:provider-name>
+   +               <custom:config key="value"/>
+   +           </custom:provider-name>
+           </provider>
+        </config>
+   </srv:container>
+   ```

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -1,6 +1,37 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+* Deprecate XML-configured custom authenticators and providers under security namespace; they must now have their own:
+
+  ```diff
+  <srv:container xmlns="http://symfony.com/schema/dic/security"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xmlns:srv="http://symfony.com/schema/dic/services"
+  +           xmlns:custom="http://example.com/schema"
+              xsi:schemaLocation="http://symfony.com/schema/dic/services
+       https://symfony.com/schema/dic/services/services-1.0.xsd
+       http://symfony.com/schema/dic/security
+  -    https://symfony.com/schema/dic/security/security-1.0.xsd">
+  +    https://symfony.com/schema/dic/security/security-1.0.xsd
+  +    http://example.com/schema http://example.com/schema.xsd">
+  +    <!-- the line above can be omitted if the schema does not have a definition -->
+
+       <config>
+          <provider name="custom_provider">
+  -           <provider-name>
+  -               <config key="value"/>
+  -           </provider-name>
+  +           <custom:provider-name>
+  +               <custom:config key="value"/>
+  +           </custom:provider-name>
+          </provider>
+       </config>
+  </srv:container>
+  ```
+
 7.3
 ---
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/XmlCustomAuthenticatorTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/XmlCustomAuthenticatorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\SecurityBundle\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
 use Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Fixtures\Authenticator\CustomAuthenticator;
 use Symfony\Component\Config\FileLocator;
@@ -20,10 +21,12 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
 class XmlCustomAuthenticatorTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     /**
-     * @dataProvider provideXmlConfigurationFile
+     * @group legacy
      */
-    public function testCustomProviderElement(string $configurationFile)
+    public function testCustomAuthenticatorElementUnderSecurityNamespace()
     {
         $container = new ContainerBuilder();
         $container->setParameter('kernel.debug', false);
@@ -33,18 +36,30 @@ class XmlCustomAuthenticatorTest extends TestCase
         $security->addAuthenticatorFactory(new CustomAuthenticator());
         $container->registerExtension($security);
 
-        (new XmlFileLoader($container, new FileLocator(__DIR__.'/Fixtures/xml')))->load($configurationFile);
+        $this->expectDeprecation('Since symfony/security-bundle 7.4: Custom authenticators must now be namespaced; please update your security configuration "custom" tag.');
+        (new XmlFileLoader($container, new FileLocator(__DIR__.'/Fixtures/xml')))->load('custom_authenticator_under_security_namespace.xml');
+
+        $container->getCompilerPassConfig()->setRemovingPasses([]);
+        $container->getCompilerPassConfig()->setAfterRemovingPasses([]);
+        $container->compile();
+    }
+
+    public function testCustomAuthenticatorElementUnderOwnNamespace()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.debug', false);
+        $container->register('cache.system', \stdClass::class);
+
+        $security = new SecurityExtension();
+        $security->addAuthenticatorFactory(new CustomAuthenticator());
+        $container->registerExtension($security);
+
+        (new XmlFileLoader($container, new FileLocator(__DIR__.'/Fixtures/xml')))->load('custom_authenticator_under_own_namespace.xml');
 
         $container->getCompilerPassConfig()->setRemovingPasses([]);
         $container->getCompilerPassConfig()->setAfterRemovingPasses([]);
         $container->compile();
 
         $this->addToAssertionCount(1);
-    }
-
-    public static function provideXmlConfigurationFile(): iterable
-    {
-        yield 'Custom authenticator element under SecurityBundle’s namespace' => ['custom_authenticator_under_security_namespace.xml'];
-        yield 'Custom authenticator element under its own namespace' => ['custom_authenticator_under_own_namespace.xml'];
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/XmlCustomProviderTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/XmlCustomProviderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\SecurityBundle\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
 use Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Fixtures\UserProvider\CustomProvider;
 use Symfony\Component\Config\FileLocator;
@@ -20,10 +21,12 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
 class XmlCustomProviderTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     /**
-     * @dataProvider provideXmlConfigurationFile
+     * @group legacy
      */
-    public function testCustomProviderElement(string $configurationFile)
+    public function testCustomProviderElementUnderSecurityNamespace()
     {
         $container = new ContainerBuilder();
         $container->setParameter('kernel.debug', false);
@@ -33,18 +36,30 @@ class XmlCustomProviderTest extends TestCase
         $security->addUserProviderFactory(new CustomProvider());
         $container->registerExtension($security);
 
-        (new XmlFileLoader($container, new FileLocator(__DIR__.'/Fixtures/xml')))->load($configurationFile);
+        $this->expectDeprecation('Since symfony/security-bundle 7.4: Custom providers must now be namespaced; please update your security configuration "custom" tag.');
+        (new XmlFileLoader($container, new FileLocator(__DIR__.'/Fixtures/xml')))->load('custom_provider_under_security_namespace.xml');
+
+        $container->getCompilerPassConfig()->setRemovingPasses([]);
+        $container->getCompilerPassConfig()->setAfterRemovingPasses([]);
+        $container->compile();
+    }
+
+    public function testCustomProviderElementUnderOwnNamespace()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.debug', false);
+        $container->register('cache.system', \stdClass::class);
+
+        $security = new SecurityExtension();
+        $security->addUserProviderFactory(new CustomProvider());
+        $container->registerExtension($security);
+
+        (new XmlFileLoader($container, new FileLocator(__DIR__.'/Fixtures/xml')))->load('custom_provider_under_own_namespace.xml');
 
         $container->getCompilerPassConfig()->setRemovingPasses([]);
         $container->getCompilerPassConfig()->setAfterRemovingPasses([]);
         $container->compile();
 
         $this->addToAssertionCount(1);
-    }
-
-    public static function provideXmlConfigurationFile(): iterable
-    {
-        yield 'Custom provider element under SecurityBundle’s namespace' => ['custom_provider_under_security_namespace.xml'];
-        yield 'Custom provider element under its own namespace' => ['custom_provider_under_own_namespace.xml'];
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -21,7 +21,7 @@
         "ext-xml": "*",
         "symfony/clock": "^6.4|^7.0",
         "symfony/config": "^7.3",
-        "symfony/dependency-injection": "^6.4.11|^7.1.4",
+        "symfony/dependency-injection": "^7.2",
         "symfony/event-dispatcher": "^6.4|^7.0",
         "symfony/http-kernel": "^6.4|^7.0",
         "symfony/http-foundation": "^6.4|^7.0",

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -458,6 +458,8 @@ class XmlFileLoader extends FileLoader
         try {
             $dom = XmlUtils::loadFile($file, $this->validateSchema(...));
         } catch (\InvalidArgumentException $e) {
+            // When starting the 8.0 branch, this whole catch block should be replaced by the line below:
+            // throw new InvalidArgumentException(\sprintf('Unable to parse file "%s": ', $file).$e->getMessage(), $e->getCode(), $e);
             $invalidSecurityElements = [];
             $errors = explode("\n", $e->getMessage());
             foreach ($errors as $i => $error) {
@@ -477,6 +479,8 @@ class XmlFileLoader extends FileLoader
                             continue;
                         }
                         if ('provider' === $parent->localName || 'firewall' === $parent->localName) {
+                            trigger_deprecation('symfony/security-bundle', '7.4', 'Custom %s must now be namespaced; please update your security configuration "%s" tag.', 'provider' === $parent->localName ? 'providers' : 'authenticators', $tagName);
+
                             unset($errors[$errorIndex]);
                         }
                     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | N/A
| License       | MIT

#57493 allowed XML-configured custom authenticators and providers to stay under the security namespace to avoid a BC break. Since it got merged this can now be deprecated.