### PR TITLE
[Validator] Add option to allow `ANY` protocol in `Assert\Url` constraint

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Url.php
+++ b/src/Symfony/Component/Validator/Constraints/Url.php
@@ -40,7 +40,7 @@ class Url extends Constraint
     public $normalizer;
 
     /**
-     * @param string[]|null $protocols        The protocols considered to be valid for the URL (e.g. http, https, ftp, etc.) (defaults to ['http', 'https']
+     * @param string[]|null $protocols        The protocols considered to be valid for the URL (e.g. http, https, ftp, etc.) (defaults to ['http', 'https']; use ['*'] to allow any protocol or regex patterns like ['.*'] for custom matching)
      * @param bool|null     $relativeProtocol Whether to accept URL without the protocol (i.e. //example.com) (defaults to false)
      * @param string[]|null $groups
      * @param bool|null     $requireTld       Whether to require the URL to include a top-level domain (defaults to false)

--- a/src/Symfony/Component/Validator/Constraints/UrlValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UrlValidator.php
@@ -73,8 +73,15 @@ class UrlValidator extends ConstraintValidator
             $value = ($constraint->normalizer)($value);
         }
 
+        if (['*'] === $constraint->protocols) {
+            // Use RFC 3986 compliant scheme pattern: scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
+            $protocols = '[a-zA-Z][a-zA-Z0-9+.-]*';
+        } else {
+            $protocols = implode('|', $constraint->protocols);
+        }
+
         $pattern = $constraint->relativeProtocol ? str_replace('(%s):', '(?:(%s):)?', static::PATTERN) : static::PATTERN;
-        $pattern = \sprintf($pattern, implode('|', $constraint->protocols));
+        $pattern = sprintf($pattern, $protocols);
 
         if (!preg_match($pattern, $value)) {
             $this->context->buildViolation($constraint->message)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      |  no
| New feature?  | yes
| Deprecations? | no
| Issues        |  [Validator] Add option to allow ANY protocol in Assert\Url constraint
| License       | MIT

<!--
Adding any protocol for Url Constraint for more flexibility
https://github.com/symfony/symfony/issues/60525
-->
