### PR TITLE
[FrameworkBundle] ensureKernelShutdown in tearDownAfterClass

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Test;
 
+use PHPUnit\Framework\Attributes\AfterClass;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -120,8 +121,11 @@ abstract class KernelTestCase extends TestCase
 
     /**
      * Shuts the kernel down if it was used in the test - called by the tearDown method by default.
+     *
+     * @afterClass
      */
-    protected static function ensureKernelShutdown()
+    #[AfterClass]
+    public static function ensureKernelShutdown()
     {
         if (null !== static::$kernel) {
             static::$kernel->boot();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | None
| License       | MIT

This PR performs the following change: In `KernelTestCase`, the kernel is shut down after every test, as per the `static::ensureKernelShutdown()` call in the `tearDown` function. However, if one was to perform any extra code in their `tearDownAfterClass` and call `getContainer`, it would boot up a new kernel, which would then be left dangling. The main issue with that is that when the next Test class is executed, there would already be a booted kernel, so it could happen that it was pointing to dangling resources.

By adding this call to `static::ensureKernelShutdown` in the `tearDownAfterClass`, we can ensure that no dangling kernels are left even after the test class has finished.