### PR TITLE
[ObjectMapper] add minimum stability to allow the installation of unstable dependencies

### DIFF
--- a/src/Symfony/Component/ObjectMapper/composer.json
+++ b/src/Symfony/Component/ObjectMapper/composer.json
@@ -32,5 +32,6 @@
     },
     "conflict": {
       "symfony/property-access": "<7.2"
-    }
+    },
+    "minimum-stability": "dev"
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

[fixes the high deps job](https://github.com/symfony/symfony/actions/runs/15269874524/job/42942748725#step:9:79) for the ObjectMapper component