### PR TITLE
[HttpKernel] Do not superseed private cache-control when no-store is set

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/CacheAttributeListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/CacheAttributeListener.php
@@ -165,7 +165,6 @@ class CacheAttributeListener implements EventSubscriberInterface
             }
 
             if (true === $cache->noStore) {
-                $response->setPrivate();
                 $response->headers->addCacheControlDirective('no-store');
             }
 

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/CacheAttributeListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/CacheAttributeListenerTest.php
@@ -102,18 +102,18 @@ class CacheAttributeListenerTest extends TestCase
         $this->assertFalse($this->response->headers->hasCacheControlDirective('no-store'));
     }
 
-    public function testResponseIsPrivateIfConfigurationIsPublicTrueNoStoreTrue()
+    public function testResponseKeepPublicIfConfigurationIsPublicTrueNoStoreTrue()
     {
         $request = $this->createRequest(new Cache(public: true, noStore: true));
 
         $this->listener->onKernelResponse($this->createEventMock($request, $this->response));
 
-        $this->assertFalse($this->response->headers->hasCacheControlDirective('public'));
-        $this->assertTrue($this->response->headers->hasCacheControlDirective('private'));
+        $this->assertTrue($this->response->headers->hasCacheControlDirective('public'));
+        $this->assertFalse($this->response->headers->hasCacheControlDirective('private'));
         $this->assertTrue($this->response->headers->hasCacheControlDirective('no-store'));
     }
 
-    public function testResponseIsPrivateNoStoreIfConfigurationIsNoStoreTrue()
+    public function testResponseKeepPrivateNoStoreIfConfigurationIsNoStoreTrue()
     {
         $request = $this->createRequest(new Cache(noStore: true));
 
@@ -124,14 +124,14 @@ class CacheAttributeListenerTest extends TestCase
         $this->assertTrue($this->response->headers->hasCacheControlDirective('no-store'));
     }
 
-    public function testResponseIsPrivateIfSharedMaxAgeSetAndNoStoreIsTrue()
+    public function testResponseIsPublicIfSharedMaxAgeSetAndNoStoreIsTrue()
     {
         $request = $this->createRequest(new Cache(smaxage: 1, noStore: true));
 
         $this->listener->onKernelResponse($this->createEventMock($request, $this->response));
 
-        $this->assertFalse($this->response->headers->hasCacheControlDirective('public'));
-        $this->assertTrue($this->response->headers->hasCacheControlDirective('private'));
+        $this->assertTrue($this->response->headers->hasCacheControlDirective('public'));
+        $this->assertFalse($this->response->headers->hasCacheControlDirective('private'));
         $this->assertTrue($this->response->headers->hasCacheControlDirective('no-store'));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3 
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

I don't think its a good idea to superseed the private cache control via the new noStore option
* https://github.com/symfony/symfony/pull/59301

If somebody want to set it to `private` they should explicit do it. via `#[Cache(private: true, noStore: true)]`. I would avoid this non transparent changes in general.

I had usecases in the past where the response is still public for the symfony cache and varnish public and the no store was only for the third party caches and in browser caches. This specially come into play with usage of `ESI` where the general page is cached, but no-store set to not allow back forwards caches, because of the ESI content. 

/cc @smnandre 

