### PR TITLE
[Security] CleanUp UserInterface PHPDoc

### DIFF
--- a/src/Symfony/Component/Security/Core/User/UserInterface.php
+++ b/src/Symfony/Component/Security/Core/User/UserInterface.php
@@ -15,9 +15,7 @@ namespace Symfony\Component\Security\Core\User;
  * Represents the interface that all user classes must implement.
  *
  * This interface is useful because the authentication layer can deal with
- * the object through its lifecycle, using the object to get the hashed
- * password (for checking against a submitted password), assigning roles
- * and so on.
+ * the object through its lifecycle, assigning roles and so on.
  *
  * Regardless of how your users are loaded or where they come from (a database,
  * configuration, web service, etc.), you will have a class that implements


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 
| Bug fix?      | no
| New feature?  | no 
| Deprecations? | no 
| Issues        | --
| License       | MIT

This PR removes outdated or potentially misleading references to passwords from the PHPDoc comments in the UserInterface. Since the interface does not directly handle password logic, these mentions are unnecessary and could cause confusion for implementers.

**Changes**:

- Removed password-related text from PHPDoc comments in UserInterface.

**Reasoning**:

- Clarifies the responsibilities of UserInterface.
- Ensures documentation is aligned with actual interface behavior.

No functional code changes have been made—this is purely a documentation cleanup.
