### PR TITLE
Release v7.3.0

### DIFF
--- a/CHANGELOG-7.3.md
+++ b/CHANGELOG-7.3.md
@@ -7,6 +7,12 @@ in 7.3 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v7.3.0...v7.3.1
 
+* 7.3.0 (2025-05-29)
+
+ * bug #60549 [Translation] Add intl-icu fallback for MessageCatalogue metadata (pontus-mp)
+ * bug #60571 [ErrorHandler] Do not transform file to link if it does not exist (lyrixx)
+ * bug #60542 [Webhook] Fix controller service name (HypeMC)
+
 * 7.3.0-RC1 (2025-05-25)
 
  * bug #60529 [AssetMapper] Fix SequenceParser possible infinite loop (smnandre)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -73,12 +73,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     private static array $freshCache = [];
 
-    public const VERSION = '7.3.0-DEV';
+    public const VERSION = '7.3.0';
     public const VERSION_ID = 70300;
     public const MAJOR_VERSION = 7;
     public const MINOR_VERSION = 3;
     public const RELEASE_VERSION = 0;
-    public const EXTRA_VERSION = 'DEV';
+    public const EXTRA_VERSION = '';
 
     public const END_OF_MAINTENANCE = '05/2025';
     public const END_OF_LIFE = '01/2026';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v7.3.0-RC1...v7.3.0)

 * bug #60549 [Translation] Add intl-icu fallback for MessageCatalogue metadata (@pontus-mp)
 * bug #60571 [ErrorHandler] Do not transform file to link if it does not exist (@lyrixx)
 * bug #60542 [Webhook] Fix controller service name (@HypeMC)
