### PR TITLE
[Validator] Add ConstraintViolationBuilder methods: fromViolation(), setPath(), getViolation()

### DIFF
--- a/src/Symfony/Component/Console/Debug/CliRequest.php
+++ b/src/Symfony/Component/Console/Debug/CliRequest.php
@@ -24,7 +24,7 @@ final class CliRequest extends Request
         public readonly TraceableCommand $command,
     ) {
         parent::__construct(
-            attributes: ['_controller' => \get_class($command->command), '_virtual_type' => 'command'],
+            attributes: ['_controller' => $command->command::class, '_virtual_type' => 'command'],
             server: $_SERVER,
         );
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ServiceLocatorTagPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ServiceLocatorTagPassTest.php
@@ -83,7 +83,7 @@ class ServiceLocatorTagPassTest extends TestCase
         $this->assertSame(CustomDefinition::class, $locator('bar')::class);
         $this->assertSame(CustomDefinition::class, $locator('baz')::class);
         $this->assertSame(CustomDefinition::class, $locator('some.service')::class);
-        $this->assertSame(CustomDefinition::class, \get_class($locator('inlines.service')));
+        $this->assertSame(CustomDefinition::class, $locator('inlines.service')::class);
     }
 
     public function testServiceWithKeyOverwritesPreviousInheritedKey()

--- a/src/Symfony/Component/Dotenv/README.md
+++ b/src/Symfony/Component/Dotenv/README.md
@@ -11,6 +11,15 @@ Getting Started
 composer require symfony/dotenv
 ```
 
+Usage
+-----
+
+> For an .env file with this format:
+
+```env
+YOUR_VARIABLE_NAME=my-string
+```
+
 ```php
 use Symfony\Component\Dotenv\Dotenv;
 
@@ -25,6 +34,12 @@ $dotenv->overload(__DIR__.'/.env');
 
 // loads .env, .env.local, and .env.$APP_ENV.local or .env.$APP_ENV
 $dotenv->loadEnv(__DIR__.'/.env');
+
+// Usage with $_ENV
+$envVariable = $_ENV['YOUR_VARIABLE_NAME'];
+
+// Usage with $_SERVER
+$envVariable = $_SERVER['YOUR_VARIABLE_NAME'];
 ```
 
 Resources

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+ * Add `input=date_point` to `DateTimeType`, `DateType` and `TimeType`
+
 7.3
 ---
 

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DatePointToDateTimeTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DatePointToDateTimeTransformer.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Extension\Core\DataTransformer;
+
+use Symfony\Component\Clock\DatePoint;
+use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+
+/**
+ * Transforms between a DatePoint object and a DateTime object.
+ *
+ * @implements DataTransformerInterface<DatePoint, \DateTime>
+ */
+final class DatePointToDateTimeTransformer implements DataTransformerInterface
+{
+    /**
+     * Transforms a DatePoint into a DateTime object.
+     *
+     * @param DatePoint|null $value A DatePoint object
+     *
+     * @throws TransformationFailedException If the given value is not a DatePoint
+     */
+    public function transform(mixed $value): ?\DateTime
+    {
+        if (null === $value) {
+            return null;
+        }
+
+        if (!$value instanceof DatePoint) {
+            throw new TransformationFailedException(\sprintf('Expected a "%s".', DatePoint::class));
+        }
+
+        return \DateTime::createFromImmutable($value);
+    }
+
+    /**
+     * Transforms a DateTime object into a DatePoint object.
+     *
+     * @param \DateTime|null $value A DateTime object
+     *
+     * @throws TransformationFailedException If the given value is not a \DateTime
+     */
+    public function reverseTransform(mixed $value): ?DatePoint
+    {
+        if (null === $value) {
+            return null;
+        }
+
+        if (!$value instanceof \DateTime) {
+            throw new TransformationFailedException('Expected a \DateTime.');
+        }
+
+        return DatePoint::createFromMutable($value);
+    }
+}

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -11,10 +11,12 @@
 
 namespace Symfony\Component\Form\Extension\Core\Type;
 
+use Symfony\Component\Clock\DatePoint;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Exception\LogicException;
 use Symfony\Component\Form\Extension\Core\DataTransformer\ArrayToPartsTransformer;
 use Symfony\Component\Form\Extension\Core\DataTransformer\DataTransformerChain;
+use Symfony\Component\Form\Extension\Core\DataTransformer\DatePointToDateTimeTransformer;
 use Symfony\Component\Form\Extension\Core\DataTransformer\DateTimeImmutableToDateTimeTransformer;
 use Symfony\Component\Form\Extension\Core\DataTransformer\DateTimeToArrayTransformer;
 use Symfony\Component\Form\Extension\Core\DataTransformer\DateTimeToHtml5LocalDateTimeTransformer;
@@ -178,7 +180,12 @@ class DateTimeType extends AbstractType
             ;
         }
 
-        if ('datetime_immutable' === $options['input']) {
+        if ('date_point' === $options['input']) {
+            if (!class_exists(DatePoint::class)) {
+                throw new LogicException(\sprintf('The "symfony/clock" component is required to use "%s" with option "input=date_point". Try running "composer require symfony/clock".', self::class));
+            }
+            $builder->addModelTransformer(new DatePointToDateTimeTransformer());
+        } elseif ('datetime_immutable' === $options['input']) {
             $builder->addModelTransformer(new DateTimeImmutableToDateTimeTransformer());
         } elseif ('string' === $options['input']) {
             $builder->addModelTransformer(new ReversedTransformer(
@@ -194,7 +201,7 @@ class DateTimeType extends AbstractType
             ));
         }
 
-        if (\in_array($options['input'], ['datetime', 'datetime_immutable'], true) && null !== $options['model_timezone']) {
+        if (\in_array($options['input'], ['datetime', 'datetime_immutable', 'date_point'], true) && null !== $options['model_timezone']) {
             $builder->addEventListener(FormEvents::POST_SET_DATA, static function (FormEvent $event) use ($options): void {
                 $date = $event->getData();
 
@@ -283,6 +290,7 @@ class DateTimeType extends AbstractType
         $resolver->setAllowedValues('input', [
             'datetime',
             'datetime_immutable',
+            'date_point',
             'string',
             'timestamp',
             'array',

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -11,8 +11,10 @@
 
 namespace Symfony\Component\Form\Extension\Core\Type;
 
+use Symfony\Component\Clock\DatePoint;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Exception\LogicException;
+use Symfony\Component\Form\Extension\Core\DataTransformer\DatePointToDateTimeTransformer;
 use Symfony\Component\Form\Extension\Core\DataTransformer\DateTimeImmutableToDateTimeTransformer;
 use Symfony\Component\Form\Extension\Core\DataTransformer\DateTimeToArrayTransformer;
 use Symfony\Component\Form\Extension\Core\DataTransformer\DateTimeToLocalizedStringTransformer;
@@ -156,7 +158,12 @@ class DateType extends AbstractType
             ;
         }
 
-        if ('datetime_immutable' === $options['input']) {
+        if ('date_point' === $options['input']) {
+            if (!class_exists(DatePoint::class)) {
+                throw new LogicException(\sprintf('The "symfony/clock" component is required to use "%s" with option "input=date_point". Try running "composer require symfony/clock".', self::class));
+            }
+            $builder->addModelTransformer(new DatePointToDateTimeTransformer());
+        } elseif ('datetime_immutable' === $options['input']) {
             $builder->addModelTransformer(new DateTimeImmutableToDateTimeTransformer());
         } elseif ('string' === $options['input']) {
             $builder->addModelTransformer(new ReversedTransformer(
@@ -172,7 +179,7 @@ class DateType extends AbstractType
             ));
         }
 
-        if (\in_array($options['input'], ['datetime', 'datetime_immutable'], true) && null !== $options['model_timezone']) {
+        if (\in_array($options['input'], ['datetime', 'datetime_immutable', 'date_point'], true) && null !== $options['model_timezone']) {
             $builder->addEventListener(FormEvents::POST_SET_DATA, static function (FormEvent $event) use ($options): void {
                 $date = $event->getData();
 
@@ -298,6 +305,7 @@ class DateType extends AbstractType
         $resolver->setAllowedValues('input', [
             'datetime',
             'datetime_immutable',
+            'date_point',
             'string',
             'timestamp',
             'array',

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
+use Symfony\Component\Clock\DatePoint;
 use Symfony\Component\Form\Exception\LogicException;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\FormError;
@@ -60,6 +61,37 @@ class DateTimeTypeTest extends BaseTypeTestCase
         $dateTime = new \DateTime('2010-06-02 03:04:00 UTC');
 
         $this->assertEquals($dateTime, $form->getData());
+    }
+
+    public function testSubmitDatePoint()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
+            'date_widget' => 'choice',
+            'years' => [2010],
+            'time_widget' => 'choice',
+            'input' => 'date_point',
+        ]);
+
+        $input = [
+            'date' => [
+                'day' => '2',
+                'month' => '6',
+                'year' => '2010',
+            ],
+            'time' => [
+                'hour' => '3',
+                'minute' => '4',
+            ],
+        ];
+
+        $form->submit($input);
+
+        $this->assertInstanceOf(DatePoint::class, $form->getData());
+        $datePoint = DatePoint::createFromMutable(new \DateTime('2010-06-02 03:04:00 UTC'));
+        $this->assertEquals($datePoint, $form->getData());
+        $this->assertEquals($input, $form->getViewData());
     }
 
     public function testSubmitDateTimeImmutable()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
+use Symfony\Component\Clock\DatePoint;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 use Symfony\Component\Form\Exception\LogicException;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
@@ -113,6 +114,27 @@ class DateTypeTest extends BaseTypeTestCase
 
         $this->assertEquals(new \DateTime('2010-06-02 UTC'), $form->getData());
         $this->assertEquals('02.06.2010', $form->getViewData());
+    }
+
+    public function testSubmitFromSingleTextDatePoint()
+    {
+        if (!class_exists(DatePoint::class)) {
+            self::markTestSkipped('The DatePoint class is not available.');
+        }
+
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'html5' => false,
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
+            'widget' => 'single_text',
+            'input' => 'date_point',
+        ]);
+
+        $form->submit('2010-06-02');
+
+        $this->assertInstanceOf(DatePoint::class, $form->getData());
+        $this->assertEquals(DatePoint::createFromMutable(new \DateTime('2010-06-02 UTC')), $form->getData());
+        $this->assertEquals('2010-06-02', $form->getViewData());
     }
 
     public function testSubmitFromSingleTextDateTimeImmutable()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
+use Symfony\Component\Clock\DatePoint;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 use Symfony\Component\Form\Exception\InvalidConfigurationException;
 use Symfony\Component\Form\Exception\LogicException;
@@ -42,6 +43,32 @@ class TimeTypeTest extends BaseTypeTestCase
         $dateTime = new \DateTime('1970-01-01 03:04:00 UTC');
 
         $this->assertEquals($dateTime, $form->getData());
+        $this->assertEquals($input, $form->getViewData());
+    }
+
+    public function testSubmitDatePoint()
+    {
+        if (!class_exists(DatePoint::class)) {
+            self::markTestSkipped('The DatePoint class is not available.');
+        }
+
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
+            'widget' => 'choice',
+            'input' => 'date_point',
+        ]);
+
+        $input = [
+            'hour' => '3',
+            'minute' => '4',
+        ];
+
+        $form->submit($input);
+
+        $this->assertInstanceOf(DatePoint::class, $form->getData());
+        $datePoint = DatePoint::createFromMutable(new \DateTime('1970-01-01 03:04:00 UTC'));
+        $this->assertEquals($datePoint, $form->getData());
         $this->assertEquals($input, $form->getViewData());
     }
 

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -31,6 +31,7 @@
         "symfony/validator": "^6.4|^7.0",
         "symfony/dependency-injection": "^6.4|^7.0",
         "symfony/expression-language": "^6.4|^7.0",
+        "symfony/clock": "^6.4|^7.0",
         "symfony/config": "^6.4|^7.0",
         "symfony/console": "^6.4|^7.0",
         "symfony/html-sanitizer": "^6.4|^7.0",

--- a/src/Symfony/Component/Scheduler/CHANGELOG.md
+++ b/src/Symfony/Component/Scheduler/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `TriggerNormalizer`
+ * Throw exception when multiple schedule provider services are registered under the same scheduler name
 
 7.2
 ---

--- a/src/Symfony/Component/Scheduler/DependencyInjection/AddScheduleMessengerPass.php
+++ b/src/Symfony/Component/Scheduler/DependencyInjection/AddScheduleMessengerPass.php
@@ -46,6 +46,11 @@ class AddScheduleMessengerPass implements CompilerPassInterface
         $scheduleProviderIds = [];
         foreach ($container->findTaggedServiceIds('scheduler.schedule_provider') as $serviceId => $tags) {
             $name = $tags[0]['name'];
+
+            if (isset($scheduleProviderIds[$name])) {
+                throw new InvalidArgumentException(\sprintf('Schedule provider service "%s" can not replace already registered service "%s" for schedule "%s". Make sure to register only one provider per schedule name.', $serviceId, $scheduleProviderIds[$name], $name), 1);
+            }
+
             $scheduleProviderIds[$name] = $serviceId;
         }
 

--- a/src/Symfony/Component/Scheduler/Tests/DependencyInjection/RegisterProviderTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/DependencyInjection/RegisterProviderTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Scheduler\Tests\DependencyInjection;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\Scheduler\DependencyInjection\AddScheduleMessengerPass;
+use Symfony\Component\Scheduler\Tests\Fixtures\SomeScheduleProvider;
+
+class RegisterProviderTest extends TestCase
+{
+    public function testErrorOnMultipleProvidersForTheSameSchedule()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1);
+
+        $container = new ContainerBuilder();
+
+        $container->register('provider_a', SomeScheduleProvider::class)->addTag('scheduler.schedule_provider', ['name' => 'default']);
+        $container->register('provider_b', SomeScheduleProvider::class)->addTag('scheduler.schedule_provider', ['name' => 'default']);
+
+        (new AddScheduleMessengerPass())->process($container);
+    }
+}

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+* Add `ConstraintViolationBuilder` methods: `fromViolation()`, `setPath()`, `getViolation()`
+
 7.3
 ---
 

--- a/src/Symfony/Component/Validator/Tests/Violation/ConstraintViolationBuilderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Violation/ConstraintViolationBuilderTest.php
@@ -15,7 +15,9 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Translation\IdentityTranslator;
 use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationInterface;
 use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\Util\PropertyPath;
 use Symfony\Component\Validator\Violation\ConstraintViolationBuilder;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -42,7 +44,7 @@ class ConstraintViolationBuilderTest extends TestCase
     {
         $this->builder->addViolation();
 
-        $this->assertViolationEquals(new ConstraintViolation($this->messageTemplate, $this->messageTemplate, [], $this->root, 'data', 'foo', null, null, new Valid()));
+        $this->assertBuiltViolationEquals(new ConstraintViolation($this->messageTemplate, $this->messageTemplate, [], $this->root, 'data', 'foo', null, null, new Valid()));
     }
 
     public function testAppendPropertyPath()
@@ -51,7 +53,7 @@ class ConstraintViolationBuilderTest extends TestCase
             ->atPath('foo')
             ->addViolation();
 
-        $this->assertViolationEquals(new ConstraintViolation($this->messageTemplate, $this->messageTemplate, [], $this->root, 'data.foo', 'foo', null, null, new Valid()));
+        $this->assertBuiltViolationEquals(new ConstraintViolation($this->messageTemplate, $this->messageTemplate, [], $this->root, 'data.foo', 'foo', null, null, new Valid()));
     }
 
     public function testAppendMultiplePropertyPaths()
@@ -61,7 +63,7 @@ class ConstraintViolationBuilderTest extends TestCase
             ->atPath('bar')
             ->addViolation();
 
-        $this->assertViolationEquals(new ConstraintViolation($this->messageTemplate, $this->messageTemplate, [], $this->root, 'data.foo.bar', 'foo', null, null, new Valid()));
+        $this->assertBuiltViolationEquals(new ConstraintViolation($this->messageTemplate, $this->messageTemplate, [], $this->root, 'data.foo.bar', 'foo', null, null, new Valid()));
     }
 
     public function testCodeCanBeSet()
@@ -70,7 +72,7 @@ class ConstraintViolationBuilderTest extends TestCase
             ->setCode('5')
             ->addViolation();
 
-        $this->assertViolationEquals(new ConstraintViolation($this->messageTemplate, $this->messageTemplate, [], $this->root, 'data', 'foo', null, '5', new Valid()));
+        $this->assertBuiltViolationEquals(new ConstraintViolation($this->messageTemplate, $this->messageTemplate, [], $this->root, 'data', 'foo', null, '5', new Valid()));
     }
 
     public function testCauseCanBeSet()
@@ -81,7 +83,7 @@ class ConstraintViolationBuilderTest extends TestCase
             ->setCause($cause)
             ->addViolation();
 
-        $this->assertViolationEquals(new ConstraintViolation($this->messageTemplate, $this->messageTemplate, [], $this->root, 'data', 'foo', null, null, new Valid(), $cause));
+        $this->assertBuiltViolationEquals(new ConstraintViolation($this->messageTemplate, $this->messageTemplate, [], $this->root, 'data', 'foo', null, null, new Valid(), $cause));
     }
 
     public function testTranslationDomainFalse()
@@ -96,12 +98,31 @@ class ConstraintViolationBuilderTest extends TestCase
         $builder->addViolation();
     }
 
-    private function assertViolationEquals(ConstraintViolation $expectedViolation)
+    public function testBuildViolationFromExistingViolation()
+    {
+        $originalViolation = $this->builder->getViolation();
+
+        $violation = ConstraintViolationBuilder::fromViolation($originalViolation)
+            ->setPath(PropertyPath::append('top', $originalViolation->getPropertyPath()))
+            ->setCause($cause = new \LogicException())
+            ->getViolation();
+
+        $this->assertCount(0, $this->violations);
+
+        $this->assertViolationEquals(new ConstraintViolation($this->messageTemplate, $this->messageTemplate, [], $this->root, 'top.data', 'foo', null, null, new Valid(), $cause), $violation);
+    }
+
+    private function assertBuiltViolationEquals(ConstraintViolation $expectedViolation): void
     {
         $this->assertCount(1, $this->violations);
 
         $violation = $this->violations->get(0);
 
+        $this->assertViolationEquals($expectedViolation, $violation);
+    }
+
+    private function assertViolationEquals(ConstraintViolation $expectedViolation, ConstraintViolationInterface $violation): void
+    {
         $this->assertSame($expectedViolation->getMessage(), $violation->getMessage());
         $this->assertSame($expectedViolation->getMessageTemplate(), $violation->getMessageTemplate());
         $this->assertSame($expectedViolation->getParameters(), $violation->getParameters());

--- a/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilder.php
+++ b/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilder.php
@@ -13,7 +13,8 @@ namespace Symfony\Component\Validator\Violation;
 
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintViolation;
-use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\ConstraintViolationInterface;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
 use Symfony\Component\Validator\Util\PropertyPath;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -27,22 +28,50 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class ConstraintViolationBuilder implements ConstraintViolationBuilderInterface
 {
     private string $propertyPath;
+    private ?string $message = null;
     private ?int $plural = null;
     private ?string $code = null;
     private mixed $cause = null;
 
     public function __construct(
-        private ConstraintViolationList $violations,
+        private ?ConstraintViolationListInterface $violations,
         private ?Constraint $constraint,
-        private string|\Stringable $message,
+        private string|\Stringable $messageTemplate,
         private array $parameters,
         private mixed $root,
         ?string $propertyPath,
         private mixed $invalidValue,
-        private TranslatorInterface $translator,
+        private TranslatorInterface|null $translator = null,
         private string|false|null $translationDomain = null,
     ) {
         $this->propertyPath = $propertyPath ?? '';
+    }
+
+    public static function fromViolation(ConstraintViolationInterface $violation): static
+    {
+        $builder = new self(
+            null,
+            $violation->getConstraint(),
+            $violation->getMessageTemplate(),
+            $violation->getParameters(),
+            $violation->getRoot(),
+            $violation->getPropertyPath(),
+            $violation->getInvalidValue(),
+        );
+
+        $builder->message = $violation->getMessage();
+
+        return $builder
+            ->setPlural($violation->getPlural())
+            ->setCode($violation->getCode())
+            ->setCause($violation->getCause());
+    }
+
+    public function setPath(string $path): static
+    {
+        $this->propertyPath = $path;
+
+        return $this;
     }
 
     public function atPath(string $path): static
@@ -79,6 +108,7 @@ class ConstraintViolationBuilder implements ConstraintViolationBuilderInterface
     public function disableTranslation(): static
     {
         $this->translationDomain = false;
+        $this->translator = null;
 
         return $this;
     }
@@ -90,7 +120,7 @@ class ConstraintViolationBuilder implements ConstraintViolationBuilderInterface
         return $this;
     }
 
-    public function setPlural(int $number): static
+    public function setPlural(?int $number): static
     {
         $this->plural = $number;
 
@@ -113,20 +143,18 @@ class ConstraintViolationBuilder implements ConstraintViolationBuilderInterface
 
     public function addViolation(): void
     {
-        $parameters = null === $this->plural ? $this->parameters : (['%count%' => $this->plural] + $this->parameters);
-        if (false === $this->translationDomain) {
-            $translatedMessage = strtr($this->message, $parameters);
-        } else {
-            $translatedMessage = $this->translator->trans(
-                $this->message,
-                $parameters,
-                $this->translationDomain
-            );
+        if (null === $this->violations) {
+            throw new \LogicException('Cannot add a violation without an execution context.');
         }
 
-        $this->violations->add(new ConstraintViolation(
-            $translatedMessage,
-            $this->message,
+        $this->violations->add($this->getViolation());
+    }
+
+    public function getViolation(): ConstraintViolationInterface
+    {
+        return new ConstraintViolation(
+            $this->message ??= $this->translateMessage(),
+            $this->messageTemplate,
             $this->parameters,
             $this->root,
             $this->propertyPath,
@@ -135,6 +163,21 @@ class ConstraintViolationBuilder implements ConstraintViolationBuilderInterface
             $this->code,
             $this->constraint,
             $this->cause
-        ));
+        );
+    }
+
+    private function translateMessage(): string
+    {
+        $parameters = null === $this->plural ? $this->parameters : (['%count%' => $this->plural] + $this->parameters);
+
+        if (null === $this->translator || false === $this->translationDomain) {
+            return strtr($this->messageTemplate, $parameters);
+        }
+
+        return $this->translator->trans(
+            $this->messageTemplate,
+            $parameters,
+            $this->translationDomain
+        );
     }
 }

--- a/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilderInterface.php
+++ b/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilderInterface.php
@@ -89,13 +89,13 @@ interface ConstraintViolationBuilderInterface
      * Sets the number which determines how the plural form of the violation
      * message is chosen when it is translated.
      *
-     * @param int|null $number The number for determining the plural form
+     * @param int $number The number for determining the plural form
      *
      * @return $this
      *
      * @see \Symfony\Contracts\Translation\TranslatorInterface::trans()
      */
-    public function setPlural(?int $number): static;
+    public function setPlural(int $number): static;
 
     /**
      * Sets the violation code.

--- a/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilderInterface.php
+++ b/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilderInterface.php
@@ -11,8 +11,10 @@
 
 namespace Symfony\Component\Validator\Violation;
 
+use Symfony\Component\Validator\ConstraintViolationInterface;
+
 /**
- * Builds {@link \Symfony\Component\Validator\ConstraintViolationInterface}
+ * Builds {@link ConstraintViolationInterface}
  * objects.
  *
  * Use the various methods on this interface to configure the built violation.
@@ -20,6 +22,9 @@ namespace Symfony\Component\Validator\Violation;
  * execution context.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @method ConstraintViolationInterface getViolation()
+ * @method $this setPath(string $path)
  */
 interface ConstraintViolationBuilderInterface
 {
@@ -84,13 +89,13 @@ interface ConstraintViolationBuilderInterface
      * Sets the number which determines how the plural form of the violation
      * message is chosen when it is translated.
      *
-     * @param int $number The number for determining the plural form
+     * @param int|null $number The number for determining the plural form
      *
      * @return $this
      *
      * @see \Symfony\Contracts\Translation\TranslatorInterface::trans()
      */
-    public function setPlural(int $number): static;
+    public function setPlural(?int $number): static;
 
     /**
      * Sets the violation code.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | https://github.com/symfony/symfony/issues/58029#issuecomment-2722367527
| License       | MIT

This PR: (1) adds the ability to create constraint violation builder from an existing violation (static factory method: `ConstraintViolationBuilder::fromViolation($violation)`) so that it can be adjusted in the builder, in particular (2) `setPath()` method, and finally retrieve new violation with (3) `getViolation()` method.

