### PR TITLE
[Console] Support `BackedEnum` in invokable commands

### DIFF
--- a/src/Symfony/Component/Console/Attribute/Option.php
+++ b/src/Symfony/Component/Console/Attribute/Option.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Console\Attribute;
 
 use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Completion\Suggestion;
+use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Console\Exception\LogicException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -75,7 +76,7 @@ class Option
             $self->name = (new UnicodeString($name))->kebab();
         }
 
-        $self->default = $parameter->getDefaultValue();
+        $self->default = $parameter->getDefaultValue() instanceof \BackedEnum ? $parameter->getDefaultValue()->value : $parameter->getDefaultValue();
         $self->allowNull = $parameter->allowsNull();
 
         if ($type instanceof \ReflectionUnionType) {
@@ -87,9 +88,10 @@ class Option
         }
 
         $self->typeName = $type->getName();
+        $isBackedEnum = is_subclass_of($self->typeName, \BackedEnum::class);
 
-        if (!\in_array($self->typeName, self::ALLOWED_TYPES, true)) {
-            throw new LogicException(\sprintf('The type "%s" on parameter "$%s" of "%s()" is not supported as a command option. Only "%s" types are allowed.', $self->typeName, $name, $self->function, implode('", "', self::ALLOWED_TYPES)));
+        if (!\in_array($self->typeName, self::ALLOWED_TYPES, true) && !$isBackedEnum) {
+            throw new LogicException(\sprintf('The type "%s" on parameter "$%s" of "%s()" is not supported as a command option. Only "%s" types and BackedEnum are allowed.', $self->typeName, $name, $self->function, implode('", "', self::ALLOWED_TYPES)));
         }
 
         if ('bool' === $self->typeName && $self->allowNull && \in_array($self->default, [true, false], true)) {
@@ -115,6 +117,10 @@ class Option
             $self->suggestedValues = [$instance, $self->suggestedValues[1]];
         }
 
+        if ($isBackedEnum && !$self->suggestedValues) {
+            $self->suggestedValues = array_column(($self->typeName)::cases(), 'value');
+        }
+
         return $self;
     }
 
@@ -138,6 +144,10 @@ class Option
 
         if (null === $value && \in_array($this->typeName, self::ALLOWED_UNION_TYPES, true)) {
             return true;
+        }
+
+        if (is_subclass_of($this->typeName, \BackedEnum::class) && (is_string($value) || is_int($value))) {
+            return ($this->typeName)::tryFrom($value) ?? throw InvalidOptionException::fromEnumValue($this->name, $value, $this->suggestedValues);
         }
 
         if ('array' === $this->typeName && $this->allowNull && [] === $value) {

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Allow setting aliases and the hidden flag via the command name passed to the constructor
  * Introduce `Symfony\Component\Console\Application::addCommand()` to simplify using invokable commands when the component is used standalone
  * Deprecate `Symfony\Component\Console\Application::add()` in favor of `Symfony\Component\Console\Application::addCommand()`
+ * Add `BackedEnum` support with `#[Argument]` and `#[Option]` inputs in invokable commands
 
 7.3
 ---

--- a/src/Symfony/Component/Console/Exception/InvalidArgumentException.php
+++ b/src/Symfony/Component/Console/Exception/InvalidArgumentException.php
@@ -16,4 +16,17 @@ namespace Symfony\Component\Console\Exception;
  */
 class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
 {
+    /**
+     * @internal
+     */
+    public static function fromEnumValue(string $name, string $value, array|\Closure $suggestedValues): self
+    {
+        $error = \sprintf('The value "%s" is not valid for the "%s" argument.', $value, $name);
+
+        if (\is_array($suggestedValues)) {
+            $error .= \sprintf(' Supported values are "%s".', implode('", "', $suggestedValues));
+        }
+
+        return new self($error);
+    }
 }

--- a/src/Symfony/Component/Console/Exception/InvalidOptionException.php
+++ b/src/Symfony/Component/Console/Exception/InvalidOptionException.php
@@ -18,4 +18,17 @@ namespace Symfony\Component\Console\Exception;
  */
 class InvalidOptionException extends \InvalidArgumentException implements ExceptionInterface
 {
+    /**
+     * @internal
+     */
+    public static function fromEnumValue(string $name, string $value, array|\Closure $suggestedValues): self
+    {
+        $error = \sprintf('The value "%s" is not valid for the "%s" option.', $value, $name);
+
+        if (\is_array($suggestedValues)) {
+            $error .= \sprintf(' Supported values are "%s".', implode('", "', $suggestedValues));
+        }
+
+        return new self($error);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #60433
| License       | MIT

- Convert automatically from the string input into the backed enum value using `BackedEnum::from($value)`
- Display a nice error message when the input value is not compatible with the typed enum
- Use `BackedEnum::cases()` to provide autocompletion. Also part of the error message.

### Example

Given this 2 backed enums
```php
enum StringEnum: string
{
    case Image = 'image';
    case Video = 'video';
}

enum IntEnum: int
{
    case First = 1;
    case Second = 2;
}
```

We declare this command:
```php
#[AsCommand('enum')]
class EnumCommand
{
    public function __invoke(
        OutputInterface $output,
        #[Argument] StringEnum $string,
        #[Option] ?IntEnum $int = null,
    ): int {
        $output->writeln($string->value);
        $output->writeln($int?->value ?? 'No value');

        return Command::SUCCESS;
    }
}
```

Usage:
<img width="393" alt="image" src="https://github.com/user-attachments/assets/5eb4cfe0-fbbb-4a48-966b-ac2bfe582bbd" />


Error with invalid **argument** value:
<img width="906" alt="image" src="https://github.com/user-attachments/assets/ddc42d98-3f5e-41ee-9bd1-036ba9353a71" />


Error with invalid **option** value:
<img width="758" alt="image" src="https://github.com/user-attachments/assets/c67c5dee-248e-4c0d-aaf7-fb8a52ea12c8" />
