### PR TITLE
[PhpUnitBridge] Mark as dev package

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/composer.json
+++ b/src/Symfony/Bridge/PhpUnit/composer.json
@@ -2,7 +2,9 @@
     "name": "symfony/phpunit-bridge",
     "type": "symfony-bridge",
     "description": "Provides utilities for PHPUnit, especially user deprecation notices management",
-    "keywords": [],
+    "keywords": [
+        "testing"
+    ],
     "homepage": "https://symfony.com",
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Composer has a feature where it [automatically suggests adding a package to `require-dev`](https://github.com/composer/composer/blob/8d239c7d3d6b7cff416f4ce3546a0b2b7633cb30/src/Composer/Command/RequireCommand.php#L236) when certain keywords are used in `composer.json`:

![image](https://github.com/user-attachments/assets/815b9450-9f72-44f5-ae92-a8e95e890fe7)

This might be useful now that the bridge [no longer comes installed out of the box](https://github.com/symfony/test-pack/pull/24).

I don't think this qualifies as a feature (I think), so I targeted the 6.4 branch.