### PR TITLE
[Notifier][Clicksend] Fix lack of recipient in case DSN does not have optional LIST_ID param

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/ClickSend/ClickSendTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/ClickSend/ClickSendTransport.php
@@ -75,13 +75,13 @@ final class ClickSendTransport extends AbstractTransport
         $options['from'] = $message->getFrom() ?: $this->from;
         $options['source'] ??= $this->source;
         $options['list_id'] ??= $this->listId;
-        $options['from_email'] ?? $this->fromEmail;
+        $options['from_email'] ??= $this->fromEmail;
 
         if (isset($options['from']) && !preg_match('/^[a-zA-Z0-9\s]{3,11}$/', $options['from']) && !preg_match('/^\+[1-9]\d{1,14}$/', $options['from'])) {
             throw new InvalidArgumentException(sprintf('The "From" number "%s" is not a valid phone number, shortcode, or alphanumeric sender ID.', $options['from']));
         }
 
-        if ($options['list_id'] ?? false) {
+        if (!$options['list_id']) {
             $options['to'] = $message->getPhone();
         }
 


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       |6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR fixes an issue in the ClickSend Notifier bridge where a message would fail to send if the DSN does not include the optional `LIST_ID` parameter.

According to the [ClickSend API documentation] (https://developers.clicksend.com/docs/messaging/sms/other/send-sms/#request&path=messages/list_id), either the `to` field or a `list_id` must be present. In some cases, the `list_id` may be omitted, and the transport must fall back to the `to` recipient value instead.

Also added forwarding the `FROM_EMAIL` value to the request. Because following code in line 78 looks like typo:
`$options['from_email'] ?? $this->fromEmail;`
