### PR TITLE
[DependencyInjection] add `factory` argument in the `#[Autoconfigure]` attribute and also enabled the use of `factory` within `instanceof` conditionals

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/Autoconfigure.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/Autoconfigure.php
@@ -20,17 +20,18 @@ namespace Symfony\Component\DependencyInjection\Attribute;
 class Autoconfigure
 {
     /**
-     * @param array<array<mixed>>|string[]|null $tags         The tags to add to the service; a tag's attributes may be a \Closure or a [class-string, method] callable that computes them from each tagged service's class-string
-     * @param array<array<mixed>>|null          $calls        The calls to be made when instantiating the service
-     * @param array<string, mixed>|null         $bind         The bindings to declare for the service
-     * @param bool|string|null                  $lazy         Whether the service is lazy-loaded
-     * @param bool|null                         $public       Whether to declare the service as public
-     * @param bool|null                         $shared       Whether to declare the service as shared
-     * @param bool|null                         $autowire     Whether to declare the service as autowired
-     * @param array<string, mixed>|null         $properties   The properties to define when creating the service
-     * @param array{string, string}|string|null $configurator A PHP function, reference or an array containing a class/reference and a method to call after the service is fully initialized
-     * @param string|null                       $constructor  The public static method to use to instantiate the service
-     * @param array<array<mixed>>|string[]|null $resourceTags The resource tags to add to the service
+     * @param array<array<mixed>>|string[]|null      $tags         The tags to add to the service; a tag's attributes may be a \Closure or a [class-string, method] callable that computes them from each tagged service's class-string
+     * @param array<array<mixed>>|null               $calls        The calls to be made when instantiating the service
+     * @param array<string, mixed>|null              $bind         The bindings to declare for the service
+     * @param bool|string|null                       $lazy         Whether the service is lazy-loaded
+     * @param bool|null                              $public       Whether to declare the service as public
+     * @param bool|null                              $shared       Whether to declare the service as shared
+     * @param bool|null                              $autowire     Whether to declare the service as autowired
+     * @param array<string, mixed>|null              $properties   The properties to define when creating the service
+     * @param array{string, string}|string|null      $configurator A PHP function, reference or an array containing a class/reference and a method to call after the service is fully initialized
+     * @param string|null                            $constructor  The public static method to use to instantiate the service
+     * @param array<array<mixed>>|string[]|null      $resourceTags The resource tags to add to the service
+     * @param array{string|null, string}|string|null $factory      A reference, an expression, or an array containing a class/reference and a method to call to create the service
      */
     public function __construct(
         public ?array $tags = null,
@@ -44,6 +45,7 @@ class Autoconfigure
         public array|string|null $configurator = null,
         public ?string $constructor = null,
         public ?array $resourceTags = null,
+        public array|string|null $factory = null,
     ) {
     }
 }

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Call `#[Required]` methods in the order defined by the attribute's `$priority` argument
  * Add support for injecting a service as a lazy proxy on a per-argument basis, using the `!lazy_proxy` YAML tag, the `@~` reference prefix or the `lazy_proxy()` function in the PHP-DSL
  * Write a `CACHEDIR.TAG` file in the cache and build directories so backup tools can skip them
+ * Add a `factory` argument to the `#[Autoconfigure]` attribute, and support the `factory` key under `_instanceof`
 
 8.1
 ---

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/AppReference.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/AppReference.php
@@ -60,6 +60,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
  *     shared?: bool,
  *     lazy?: bool|string,
  *     public?: bool,
+ *     factory?: CallbackType,
  *     properties?: array<string, mixed>,
  *     configurator?: CallbackType,
  *     calls?: list<CallType>,

--- a/src/Symfony/Component/DependencyInjection/Loader/ContentLoaderTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/ContentLoaderTrait.php
@@ -93,6 +93,7 @@ trait ContentLoaderTrait
         'shared' => 'shared',
         'lazy' => 'lazy',
         'public' => 'public',
+        'factory' => 'factory',
         'properties' => 'properties',
         'configurator' => 'configurator',
         'calls' => 'calls',

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/services.schema.json
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/services.schema.json
@@ -352,6 +352,7 @@
         "shared": { "type": "boolean" },
         "lazy": { "oneOf": [ { "type": "boolean" }, { "$ref": "#/$defs/fqcn" } ] },
         "public": { "type": "boolean" },
+        "factory": { "$ref": "#/$defs/factoryCallable" },
         "properties": { "type": "object", "additionalProperties": { "$ref": "#/$defs/parameterValue" } },
         "configurator": { "$ref": "#/$defs/callable" },
         "calls": { "$ref": "#/$defs/calls" },

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterAutoconfigureAttributesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterAutoconfigureAttributesPassTest.php
@@ -27,6 +27,12 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\AutoconfigureRepeatedOv
 use Symfony\Component\DependencyInjection\Tests\Fixtures\AutoconfigureRepeatedProperties;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\AutoconfigureRepeatedTag;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\AutoconfigureResourceTagsAttributed;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\AutoconfigureWithExpressionFactory;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\AutoconfigureWithInstanceExternalFactory;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\AutoconfigureWithInvokableFactory;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\AutoconfigureWithStaticExternalFactory;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\AutoconfigureWithStaticSelfFactory;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\FactoryDummy;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\LazyAutoconfigured;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\LazyLoaded;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\MultipleAutoconfigureAttributed;
@@ -207,6 +213,88 @@ class RegisterAutoconfigureAttributesPassTest extends TestCase
             ->setBindings(['$foo' => $argument])
         ;
         $this->assertEquals([StaticConstructorAutoconfigure::class => $expected], $container->getAutoconfiguredInstanceof());
+    }
+
+    public function testAutoconfigureWithStaticSelfFactory()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', AutoconfigureWithStaticSelfFactory::class)
+            ->setAutoconfigured(true);
+
+        $argument = new BoundArgument('foo', false, BoundArgument::INSTANCEOF_BINDING, realpath(__DIR__.'/../Fixtures/AutoconfigureWithStaticSelfFactory.php'));
+
+        (new RegisterAutoconfigureAttributesPass())->process($container);
+
+        $expected = (new ChildDefinition(''))
+            ->setFactory([null, 'create'])
+            ->setBindings(['$foo' => $argument])
+        ;
+        $this->assertEquals([AutoconfigureWithStaticSelfFactory::class => $expected], $container->getAutoconfiguredInstanceof());
+    }
+
+    public function testAutoconfigureWithStaticExternalFactory()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', AutoconfigureWithStaticExternalFactory::class)
+            ->setAutoconfigured(true);
+
+        $argument = new BoundArgument('foo', false, BoundArgument::INSTANCEOF_BINDING, realpath(__DIR__.'/../Fixtures/AutoconfigureWithStaticExternalFactory.php'));
+
+        (new RegisterAutoconfigureAttributesPass())->process($container);
+
+        $expected = (new ChildDefinition(''))
+            ->setFactory([FactoryDummy::class, 'create'])
+            ->setBindings(['$foo' => $argument])
+        ;
+        $this->assertEquals([AutoconfigureWithStaticExternalFactory::class => $expected], $container->getAutoconfiguredInstanceof());
+    }
+
+    public function testAutoconfigureWithInstanceExternalFactory()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', AutoconfigureWithInstanceExternalFactory::class)
+            ->setAutoconfigured(true);
+
+        $argument = new BoundArgument('foo', false, BoundArgument::INSTANCEOF_BINDING, realpath(__DIR__.'/../Fixtures/AutoconfigureWithInstanceExternalFactory.php'));
+
+        (new RegisterAutoconfigureAttributesPass())->process($container);
+
+        $expected = (new ChildDefinition(''))
+            ->setFactory([new Reference('factory_for_autoconfigure'), 'createStatic'])
+            ->setBindings(['$foo' => $argument])
+        ;
+        $this->assertEquals([AutoconfigureWithInstanceExternalFactory::class => $expected], $container->getAutoconfiguredInstanceof());
+    }
+
+    public function testAutoconfigureWithInvokableFactory()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', AutoconfigureWithInvokableFactory::class)
+            ->setAutoconfigured(true);
+
+        $argument = new BoundArgument('foo', false, BoundArgument::INSTANCEOF_BINDING, realpath(__DIR__.'/../Fixtures/AutoconfigureWithInvokableFactory.php'));
+
+        (new RegisterAutoconfigureAttributesPass())->process($container);
+
+        $expected = (new ChildDefinition(''))
+            ->setFactory([new Reference('factory_for_autoconfigure'), '__invoke'])
+            ->setBindings(['$foo' => $argument])
+        ;
+        $this->assertEquals([AutoconfigureWithInvokableFactory::class => $expected], $container->getAutoconfiguredInstanceof());
+    }
+
+    public function testAutoconfigureWithExpressionFactory()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', AutoconfigureWithExpressionFactory::class)
+            ->setAutoconfigured(true);
+
+        (new RegisterAutoconfigureAttributesPass())->process($container);
+
+        $expected = (new ChildDefinition(''))
+            ->setFactory('@=service("factory_for_autoconfigure").create()')
+        ;
+        $this->assertEquals([AutoconfigureWithExpressionFactory::class => $expected], $container->getAutoconfiguredInstanceof());
     }
 
     public function testLazyServiceAttribute()

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AutoconfigureWithExpressionFactory.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AutoconfigureWithExpressionFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+
+#[Autoconfigure(factory: '@=service("factory_for_autoconfigure").create()')]
+class AutoconfigureWithExpressionFactory
+{
+    public function __construct(public readonly string $foo)
+    {
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AutoconfigureWithInstanceExternalFactory.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AutoconfigureWithInstanceExternalFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+
+#[Autoconfigure(bind: ['$foo' => 'foo'], factory: ['@factory_for_autoconfigure', 'createStatic'])]
+class AutoconfigureWithInstanceExternalFactory
+{
+    public function __construct(public readonly string $foo)
+    {
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AutoconfigureWithInvokableFactory.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AutoconfigureWithInvokableFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+
+#[Autoconfigure(bind: ['$foo' => 'foo'], factory: '@factory_for_autoconfigure')]
+class AutoconfigureWithInvokableFactory
+{
+    public function __construct(public readonly string $foo)
+    {
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AutoconfigureWithStaticExternalFactory.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AutoconfigureWithStaticExternalFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+
+#[Autoconfigure(bind: ['$foo' => 'foo'], factory: [FactoryDummy::class, 'create'])]
+class AutoconfigureWithStaticExternalFactory
+{
+    public function __construct(public readonly string $foo)
+    {
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AutoconfigureWithStaticSelfFactory.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AutoconfigureWithStaticSelfFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+
+#[Autoconfigure(bind: ['$foo' => 'foo'], factory: [null, 'create'])]
+class AutoconfigureWithStaticSelfFactory
+{
+    public function __construct(public readonly string $foo)
+    {
+    }
+
+    public static function create(string $foo): static
+    {
+        return new static($foo);
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/instanceof_factory.expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/instanceof_factory.expected.yml
@@ -1,0 +1,16 @@
+
+services:
+    service_container:
+        class: Symfony\Component\DependencyInjection\ContainerInterface
+        public: true
+        synthetic: true
+    Symfony\Component\DependencyInjection\Tests\Fixtures\Bar:
+        class: Symfony\Component\DependencyInjection\Tests\Fixtures\Bar
+        public: true
+        tags:
+            - bar
+        factory: ['@Symfony\Component\DependencyInjection\Tests\Fixtures\BarFactory', getDefaultBar]
+    Symfony\Component\DependencyInjection\Tests\Fixtures\BarFactory:
+        class: Symfony\Component\DependencyInjection\Tests\Fixtures\BarFactory
+        public: true
+        arguments: [!tagged_iterator bar]

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/instanceof_factory.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/instanceof_factory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Component\DependencyInjection\Tests\Fixtures\Bar;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\BarFactory;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\BarInterface;
+
+return [
+    'services' => [
+        '_defaults' => [
+            'public' => true,
+        ],
+        '_instanceof' => [
+            BarInterface::class => [
+                'factory' => [service(BarFactory::class), 'getDefaultBar'],
+                'tags' => ['bar'],
+            ],
+        ],
+        Bar::class => null,
+        BarFactory::class => [
+            'arguments' => [tagged_iterator('bar')],
+        ],
+    ],
+];

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/service_instanceof_factory2.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/service_instanceof_factory2.yml
@@ -1,0 +1,12 @@
+services:
+    _instanceof:
+        Symfony\Component\DependencyInjection\Tests\Fixtures\BarInterface:
+            factory: ['@Symfony\Component\DependencyInjection\Tests\Fixtures\BarFactory', 'getDefaultBar']
+            tags:
+                - { name: bar }
+
+    Symfony\Component\DependencyInjection\Tests\Fixtures\Bar:
+        public: true
+
+    Symfony\Component\DependencyInjection\Tests\Fixtures\BarFactory:
+        arguments: [!tagged_iterator 'bar']

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
@@ -144,6 +144,7 @@ class PhpFileLoaderTest extends TestCase
         yield ['static_constructor'];
         yield ['inline_static_constructor'];
         yield ['instanceof_static_constructor'];
+        yield ['instanceof_factory'];
         yield ['closure'];
         yield ['from_callable'];
         yield ['env_param'];

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -1100,15 +1100,24 @@ class YamlFileLoaderTest extends TestCase
 
     #[IgnoreDeprecations]
     #[Group('legacy')]
-    public function testServiceWithSameNameAsInterfaceAndFactoryIsNotTagged()
+    #[DataProvider('provideServiceInstanceOfFactoryFiles')]
+    public function testServiceWithSameNameAsInterfaceAndFactoryIsNotTagged(string $fileName)
     {
         $container = new ContainerBuilder();
         $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
-        $loader->load('service_instanceof_factory.yml');
+        $loader->load($fileName);
         $container->compile();
 
         $tagged = $container->findTaggedServiceIds('bar');
         $this->assertCount(1, $tagged);
+    }
+
+    public static function provideServiceInstanceOfFactoryFiles(): iterable
+    {
+        return [
+            ['service_instanceof_factory.yml'],
+            ['service_instanceof_factory2.yml'],
+        ];
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | no
| License       | MIT

This PR adds support for a new `factory` argument in the `#[Autoconfigure]` attribute.  **It also enables the use of `factory` in `instanceof` conditionals, in YAML and in the array-shape PHP config format**.

The `factory` argument allows developers to specify how the service should be instantiated, using the same factory syntax already supported in service definitions.

## ✅ Usage Example
```php
<?php

namespace App\Service;

use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;

#[Autoconfigure(factory: '@=service("app.factory.expression").make()')]
class WithExpressionFactory
{
    public function __construct(public readonly string $foo) {}
}

#[Autoconfigure(
    bind: ['$foo' => 'bar'],
    factory: ['@App\\Factory\\InstanceFactory', 'build']
)]
class WithInstanceMethodFactory
{
    public function __construct(public readonly string $foo) {}
}

#[Autoconfigure(
    bind: ['$foo' => 'baz'],
    factory: '@App\\Factory\\InvokableFactory'
)]
class WithInvokableFactory
{
    public function __construct(public readonly string $foo) {}
}

#[Autoconfigure(
    bind: ['$foo' => 'qux'],
    factory: [\App\Factory\StaticFactory::class, 'create']
)]
class WithStaticFactory
{
    public function __construct(public readonly string $foo) {}
}

#[Autoconfigure(
    bind: ['$foo' => 'auto'],
    factory: [null, 'fromValue']
)]
class WithSelfStaticFactory
{
    public function __construct(public readonly string $foo) {}

    public static function fromValue(string $foo): static
    {
        return new static($foo);
    }
}
```
