### PR TITLE
[Cache] Fix using a `ChainAdapter` as an adapter for a pool

### DIFF
--- a/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
+++ b/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
@@ -58,9 +58,11 @@ class CachePoolPass implements CompilerPassInterface
                 continue;
             }
             $class = $adapter->getClass();
+            $providers = $adapter->getArguments();
             while ($adapter instanceof ChildDefinition) {
                 $adapter = $container->findDefinition($adapter->getParent());
                 $class = $class ?: $adapter->getClass();
+                $providers += $adapter->getArguments();
                 if ($t = $adapter->getTag('cache.pool')) {
                     $tags[0] += $t[0];
                 }
@@ -90,7 +92,7 @@ class CachePoolPass implements CompilerPassInterface
 
             if (ChainAdapter::class === $class) {
                 $adapters = [];
-                foreach ($adapter->getArgument(0) as $provider => $adapter) {
+                foreach ($providers['index_0'] ?? $providers[0] as $provider => $adapter) {
                     if ($adapter instanceof ChildDefinition) {
                         $chainedPool = $adapter;
                     } else {

--- a/src/Symfony/Component/Cache/Tests/DependencyInjection/CachePoolPassTest.php
+++ b/src/Symfony/Component/Cache/Tests/DependencyInjection/CachePoolPassTest.php
@@ -209,7 +209,8 @@ class CachePoolPassTest extends TestCase
         $container->register('cache.adapter.apcu', ApcuAdapter::class)
             ->setArguments([null, 0, null])
             ->addTag('cache.pool');
-        $container->register('cache.chain', ChainAdapter::class)
+        $container->register('cache.adapter.chain', ChainAdapter::class);
+        $container->setDefinition('cache.chain', new ChildDefinition('cache.adapter.chain'))
             ->addArgument(['cache.adapter.array', 'cache.adapter.apcu'])
             ->addTag('cache.pool');
         $container->setDefinition('cache.app', new ChildDefinition('cache.chain'))
@@ -224,7 +225,7 @@ class CachePoolPassTest extends TestCase
         $this->assertSame('cache.chain', $appCachePool->getParent());
 
         $chainCachePool = $container->getDefinition('cache.chain');
-        $this->assertNotInstanceOf(ChildDefinition::class, $chainCachePool);
+        $this->assertInstanceOf(ChildDefinition::class, $chainCachePool);
         $this->assertCount(2, $chainCachePool->getArgument(0));
         $this->assertInstanceOf(ChildDefinition::class, $chainCachePool->getArgument(0)[0]);
         $this->assertSame('cache.adapter.array', $chainCachePool->getArgument(0)[0]->getParent());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #60579
| License       | MIT

### How to reproduce

```
symfony new --webapp --version lts 6.4
```


```yaml
# services.yaml
services:
    _defaults:
        autowire: true 
        autoconfigure: true
    my_cache.chain:
        class: Symfony\Component\Cache\Adapter\ChainAdapter
        arguments:
            - [ '@cache.adapter.array', '@cache.adapter.filesystem' ]
        tags:
            - { name: cache.pool, namespace: 'my-custom-ns' }
```

```yaml
# cache.yaml
framework:
    cache:
        pools:
            my_chain_pool:
                adapter: my_cache.chain
```

The error:

failing tests: https://github.com/symfony/symfony/actions/runs/15363463181/job/43233401667?pr=60594

```
!!  In Definition.php line 295:
!!                                                                                 
!!    The argument "0" doesn't exist in class "Symfony\Component\Cache\Adapter\ChainAdapter".  
```