### PR TITLE
[DependencyInjection][FrameworkBundle] Use php-serialize to dump the container for debug/lint commands

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/BuildDebugContainerTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/BuildDebugContainerTrait.php
@@ -39,7 +39,9 @@ trait BuildDebugContainerTrait
             return $this->container;
         }
 
-        if (!$kernel->isDebug() || !$kernel->getContainer()->getParameter('debug.container.dump') || !(new ConfigCache($kernel->getContainer()->getParameter('debug.container.dump'), true))->isFresh()) {
+        $file = $kernel->isDebug() ? $kernel->getContainer()->getParameter('debug.container.dump') : false;
+
+        if (!$file || !(new ConfigCache($file, true))->isFresh()) {
             $buildContainer = \Closure::bind(function () {
                 $this->initializeBundles();
 
@@ -57,13 +59,17 @@ trait BuildDebugContainerTrait
                 return $containerBuilder;
             }, $kernel, $kernel::class);
             $container = $buildContainer();
-            (new XmlFileLoader($container, new FileLocator()))->load($kernel->getContainer()->getParameter('debug.container.dump'));
-            $locatorPass = new ServiceLocatorTagPass();
-            $locatorPass->process($container);
 
-            $container->getCompilerPassConfig()->setBeforeOptimizationPasses([]);
-            $container->getCompilerPassConfig()->setOptimizationPasses([]);
-            $container->getCompilerPassConfig()->setBeforeRemovingPasses([]);
+            if (str_ends_with($file, '.xml') && is_file(substr_replace($file, '.ser', -4))) {
+                $dumpedContainer = unserialize(file_get_contents(substr_replace($file, '.ser', -4)));
+                $container->setDefinitions($dumpedContainer->getDefinitions());
+                $container->setAliases($dumpedContainer->getAliases());
+                $container->__construct($dumpedContainer->getParameterBag());
+            } else {
+                (new XmlFileLoader($container, new FileLocator()))->load($file);
+                $locatorPass = new ServiceLocatorTagPass();
+                $locatorPass->process($container);
+            }
         }
 
         return $this->container = $container;

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ContainerBuilderDebugDumpPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ContainerBuilderDebugDumpPass.php
@@ -13,8 +13,11 @@ namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\ResolveEnvPlaceholdersPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Dumper\XmlDumper;
+use Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBag;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * Dumps the ContainerBuilder to a cache file so that it can be used by
@@ -31,9 +34,38 @@ class ContainerBuilderDebugDumpPass implements CompilerPassInterface
             return;
         }
 
-        $cache = new ConfigCache($container->getParameter('debug.container.dump'), true);
-        if (!$cache->isFresh()) {
-            $cache->write((new XmlDumper($container))->dump(), $container->getResources());
+        $file = $container->getParameter('debug.container.dump');
+        $cache = new ConfigCache($file, true);
+        if ($cache->isFresh()) {
+            return;
+        }
+        $cache->write((new XmlDumper($container))->dump(), $container->getResources());
+
+        if (!str_ends_with($file, '.xml')) {
+            return;
+        }
+
+        $file = substr_replace($file, '.ser', -4);
+
+        try {
+            $dump = new ContainerBuilder(clone $container->getParameterBag());
+            $dump->setDefinitions(unserialize(serialize($container->getDefinitions())));
+            $dump->setAliases($container->getAliases());
+
+            if (($bag = $container->getParameterBag()) instanceof EnvPlaceholderParameterBag) {
+                (new ResolveEnvPlaceholdersPass(null))->process($dump);
+                $dump->__construct(new EnvPlaceholderParameterBag($container->resolveEnvPlaceholders($bag->all())));
+            }
+
+            $fs = new Filesystem();
+            $fs->dumpFile($file, serialize($dump));
+            $fs->chmod($file, 0666, umask());
+        } catch (\Throwable $e) {
+            $container->getCompiler()->log($this, $e->getMessage());
+            // ignore serialization and file-system errors
+            if (file_exists($file)) {
+                @unlink($file);
+            }
         }
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Alias.php
+++ b/src/Symfony/Component/DependencyInjection/Alias.php
@@ -103,4 +103,20 @@ class Alias
     {
         return $this->id;
     }
+
+    public function __serialize(): array
+    {
+        $data = [];
+        foreach ((array) $this as $k => $v) {
+            if (!$v) {
+                continue;
+            }
+            if (false !== $i = strrpos($k, "\0")) {
+                $k = substr($k, 1 + $i);
+            }
+            $data[$k] = $v;
+        }
+
+        return $data;
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Argument/AbstractArgument.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/AbstractArgument.php
@@ -16,6 +16,8 @@ namespace Symfony\Component\DependencyInjection\Argument;
  */
 final class AbstractArgument
 {
+    use ArgumentTrait;
+
     private string $text;
     private string $context = '';
 

--- a/src/Symfony/Component/DependencyInjection/Argument/ArgumentTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/ArgumentTrait.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Argument;
+
+/**
+ * Helps reduce the size of the dumped container when using php-serialize.
+ *
+ * @internal
+ */
+trait ArgumentTrait
+{
+    public function __serialize(): array
+    {
+        $data = [];
+        foreach ((array) $this as $k => $v) {
+            if (null === $v) {
+                continue;
+            }
+            if (false !== $i = strrpos($k, "\0")) {
+                $k = substr($k, 1 + $i);
+            }
+            $data[$k] = $v;
+        }
+
+        return $data;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Argument/BoundArgument.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/BoundArgument.php
@@ -16,21 +16,29 @@ namespace Symfony\Component\DependencyInjection\Argument;
  */
 final class BoundArgument implements ArgumentInterface
 {
+    use ArgumentTrait;
+
     public const SERVICE_BINDING = 0;
     public const DEFAULTS_BINDING = 1;
     public const INSTANCEOF_BINDING = 2;
 
     private static int $sequence = 0;
 
+    private mixed $value = null;
     private ?int $identifier = null;
     private ?bool $used = null;
+    private int $type = 0;
+    private ?string $file = null;
 
     public function __construct(
-        private mixed $value,
+        mixed $value,
         bool $trackUsage = true,
-        private int $type = 0,
-        private ?string $file = null,
+        int $type = 0,
+        ?string $file = null,
     ) {
+        $this->value = $value;
+        $this->type = $type;
+        $this->file = $file;
         if ($trackUsage) {
             $this->identifier = ++self::$sequence;
         } else {

--- a/src/Symfony/Component/DependencyInjection/Argument/IteratorArgument.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/IteratorArgument.php
@@ -18,6 +18,8 @@ namespace Symfony\Component\DependencyInjection\Argument;
  */
 class IteratorArgument implements ArgumentInterface
 {
+    use ArgumentTrait;
+
     private array $values;
 
     public function __construct(array $values)

--- a/src/Symfony/Component/DependencyInjection/Argument/ServiceClosureArgument.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/ServiceClosureArgument.php
@@ -20,6 +20,8 @@ use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
  */
 class ServiceClosureArgument implements ArgumentInterface
 {
+    use ArgumentTrait;
+
     private array $values;
 
     public function __construct(mixed $value)

--- a/src/Symfony/Component/DependencyInjection/Argument/ServiceLocatorArgument.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/ServiceLocatorArgument.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\DependencyInjection\Argument;
 
+use Symfony\Component\DependencyInjection\Loader\Configurator\Traits\ArgumentTrait;
+
 /**
  * Represents a closure acting as a service locator.
  *
@@ -18,6 +20,8 @@ namespace Symfony\Component\DependencyInjection\Argument;
  */
 class ServiceLocatorArgument implements ArgumentInterface
 {
+    use ArgumentTrait;
+
     private array $values;
     private ?TaggedIteratorArgument $taggedIteratorArgument = null;
 

--- a/src/Symfony/Component/DependencyInjection/Argument/TaggedIteratorArgument.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/TaggedIteratorArgument.php
@@ -18,9 +18,9 @@ namespace Symfony\Component\DependencyInjection\Argument;
  */
 class TaggedIteratorArgument extends IteratorArgument
 {
-    private mixed $indexAttribute;
-    private ?string $defaultIndexMethod;
-    private ?string $defaultPriorityMethod;
+    private mixed $indexAttribute = null;
+    private ?string $defaultIndexMethod = null;
+    private ?string $defaultPriorityMethod = null;
 
     /**
      * @param string      $tag                   The name of the tag identifying the target services

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveEnvPlaceholdersPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveEnvPlaceholdersPass.php
@@ -20,25 +20,35 @@ class ResolveEnvPlaceholdersPass extends AbstractRecursivePass
 {
     protected bool $skipScalars = false;
 
+    /**
+     * @param string|true|null $format A sprintf() format returning the replacement for each env var name or
+     *                                 null to resolve back to the original "%env(VAR)%" format or
+     *                                 true to resolve to the actual values of the referenced env vars
+     */
+    public function __construct(
+        private string|bool|null $format = true,
+    ) {
+    }
+
     protected function processValue(mixed $value, bool $isRoot = false): mixed
     {
         if (\is_string($value)) {
-            return $this->container->resolveEnvPlaceholders($value, true);
+            return $this->container->resolveEnvPlaceholders($value, $this->format);
         }
         if ($value instanceof Definition) {
             $changes = $value->getChanges();
             if (isset($changes['class'])) {
-                $value->setClass($this->container->resolveEnvPlaceholders($value->getClass(), true));
+                $value->setClass($this->container->resolveEnvPlaceholders($value->getClass(), $this->format));
             }
             if (isset($changes['file'])) {
-                $value->setFile($this->container->resolveEnvPlaceholders($value->getFile(), true));
+                $value->setFile($this->container->resolveEnvPlaceholders($value->getFile(), $this->format));
             }
         }
 
         $value = parent::processValue($value, $isRoot);
 
         if ($value && \is_array($value) && !$isRoot) {
-            $value = array_combine($this->container->resolveEnvPlaceholders(array_keys($value), true), $value);
+            $value = array_combine($this->container->resolveEnvPlaceholders(array_keys($value), $this->format), $value);
         }
 
         return $value;

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -820,4 +820,20 @@ class Definition
     {
         return (bool) $this->errors;
     }
+
+    public function __serialize(): array
+    {
+        $data = [];
+        foreach ((array) $this as $k => $v) {
+            if (false !== $i = strrpos($k, "\0")) {
+                $k = substr($k, 1 + $i);
+            }
+            if (!$v xor 'shared' === $k) {
+                continue;
+            }
+            $data[$k] = $v;
+        }
+
+        return $data;
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Reference.php
+++ b/src/Symfony/Component/DependencyInjection/Reference.php
@@ -34,6 +34,22 @@ class Reference
      */
     public function getInvalidBehavior(): int
     {
-        return $this->invalidBehavior;
+        return $this->invalidBehavior ??= ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE;
+    }
+
+    public function __serialize(): array
+    {
+        $data = [];
+        foreach ((array) $this as $k => $v) {
+            if (false !== $i = strrpos($k, "\0")) {
+                $k = substr($k, 1 + $i);
+            }
+            if ('invalidBehavior' === $k && ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE === $v) {
+                continue;
+            }
+            $data[$k] = $v;
+        }
+
+        return $data;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterServiceSubscribersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterServiceSubscribersPassTest.php
@@ -452,7 +452,7 @@ class RegisterServiceSubscribersPassTest extends TestCase
             'autowired' => new ServiceClosureArgument(new TypedReference('service.id', 'stdClass', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, 'autowired', [new Autowire(service: 'service.id')])),
             'autowired.nullable' => new ServiceClosureArgument(new TypedReference('service.id', 'stdClass', ContainerInterface::IGNORE_ON_INVALID_REFERENCE, 'autowired.nullable', [new Autowire(service: 'service.id')])),
             'autowired.parameter' => new ServiceClosureArgument('foobar'),
-            'autowire.decorated' => new ServiceClosureArgument(new Reference('.service_locator.oNVewcO.inner', ContainerInterface::NULL_ON_INVALID_REFERENCE)),
+            'autowire.decorated' => new ServiceClosureArgument(new Reference('.service_locator.Di.wrC8.inner', ContainerInterface::NULL_ON_INVALID_REFERENCE)),
             'target' => new ServiceClosureArgument(new TypedReference('stdClass', 'stdClass', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, 'target', [new Target('someTarget')])),
         ];
         $this->assertEquals($expected, $container->getDefinition((string) $locator->getFactory()[0])->getArgument(0));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

To unlock #60568 this uses `serialize()` to dump the container, next to the XML dump.