### PR TITLE
switch to Composer 2 metadata

### DIFF
--- a/.github/composer.json
+++ b/.github/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "composer/metadata-minifier": "^1.0"
+    }
+}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -92,12 +92,18 @@ jobs:
 
           # Create local composer packages for each patched components and reference them in composer.json files when cross-testing components
           if [[ ! "${{ matrix.mode }}" = *-deps ]]; then
-              php .github/build-packages.php HEAD^ $SYMFONY_VERSION src/Symfony/Bridge/PhpUnit
+              cd .github
+              composer install
+              php ./build-packages.php HEAD^ $SYMFONY_VERSION src/Symfony/Bridge/PhpUnit
+              cd ..
           else
             echo SYMFONY_DEPRECATIONS_HELPER=weak >> $GITHUB_ENV
             cp composer.json composer.json.orig
             echo -e '{\n"require":{'"$(grep phpunit-bridge composer.json)"'"php":"*"},"minimum-stability":"dev"}' > composer.json
-            php .github/build-packages.php HEAD^ $SYMFONY_VERSION $(find src/Symfony -mindepth 2 -type f -name composer.json -printf '%h\n' | grep -v src/Symfony/Component/Intl/Resources/emoji)
+            cd .github
+            composer install
+            php ./build-packages.php HEAD^ $SYMFONY_VERSION $(find src/Symfony -mindepth 2 -type f -name composer.json -printf '%h\n' | grep -v src/Symfony/Component/Intl/Resources/emoji)
+            cd ..
             mv composer.json composer.json.phpunit
             mv composer.json.orig composer.json
           fi


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

The Composer 1 metadata are no longer up-to-date and the legacy API will be turned off in August anyway: https://blog.packagist.com/shutting-down-packagist-org-support-for-composer-1-x/
