### PR TITLE
[HttpKernel] Fix Symfony 7.3 end of maintenance date

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -80,7 +80,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
     public const RELEASE_VERSION = 1;
     public const EXTRA_VERSION = 'DEV';
 
-    public const END_OF_MAINTENANCE = '05/2025';
+    public const END_OF_MAINTENANCE = '01/2026';
     public const END_OF_LIFE = '01/2026';
 
     public function __construct(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | #60618
| License       | MIT

the end of maintenance date was somehow forgotten during the 7.3.0 release process

as before
https://github.com/symfony/symfony/pull/41461

![obraz](https://github.com/user-attachments/assets/6affc7ed-caff-4d07-b08d-534141909a36)
