### PR TITLE
[TwigBridge] Remove `DebugCommand` deprecation

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -1,0 +1,12 @@
+UPGRADE FROM 7.4 to 8.0
+=======================
+
+Symfony 7.4 and Symfony 8.0 are released simultaneously at the end of November 2025. According to the Symfony
+release process, both versions have the same features, but Symfony 8.0 doesn't include any deprecated features.
+To upgrade, make sure to resolve all deprecation notices.
+Read more about this in the [Symfony documentation](https://symfony.com/doc/8.0/setup/upgrade_major.html).
+
+TwigBridge
+----------
+
+ * Remove `text` format from the `debug:twig` command, use the `txt` format instead

--- a/src/Symfony/Bridge/Twig/Command/DebugCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/DebugCommand.php
@@ -93,13 +93,7 @@ EOF
             throw new InvalidArgumentException(\sprintf('Argument "name" not supported, it requires the Twig loader "%s".', FilesystemLoader::class));
         }
 
-        $format = $input->getOption('format');
-        if ('text' === $format) {
-            trigger_deprecation('symfony/twig-bridge', '7.2', 'The "text" format is deprecated, use "txt" instead.');
-
-            $format = 'txt';
-        }
-        match ($format) {
+        match ($input->getOption('format')) {
             'txt' => $name ? $this->displayPathsText($io, $name) : $this->displayGeneralText($io, $filter),
             'json' => $name ? $this->displayPathsJson($io, $name) : $this->displayGeneralJson($io, $filter),
             default => throw new InvalidArgumentException(\sprintf('Supported formats are "%s".', implode('", "', $this->getAvailableFormatOptions()))),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT
