### PR TITLE
[Security] Deprecate callable firewall listeners

### DIFF
--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -27,3 +27,10 @@ HttpFoundation
 --------------
 
  * Deprecate using `Request::sendHeaders()` after headers have already been sent; use a `StreamedResponse` instead
+
+Security
+--------
+
+ * Deprecate callable firewall listeners, extend `AbstractListener` or implement `FirewallListenerInterface` instead
+ * Deprecate `AbstractListener::__invoke`
+ * Deprecate `LazyFirewallContext::__invoke()`

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -22,6 +22,7 @@ CHANGELOG
     ) {
     }
     ```
+ * Deprecate `LazyFirewallContext::__invoke()`
 
 7.3
 ---

--- a/src/Symfony/Bundle/SecurityBundle/Debug/TraceableFirewallListener.php
+++ b/src/Symfony/Bundle/SecurityBundle/Debug/TraceableFirewallListener.php
@@ -16,6 +16,7 @@ use Symfony\Bundle\SecurityBundle\Security\FirewallContext;
 use Symfony\Bundle\SecurityBundle\Security\LazyFirewallContext;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\Security\Http\Authenticator\Debug\TraceableAuthenticatorManagerListener;
+use Symfony\Component\Security\Http\Firewall\AbstractListener;
 use Symfony\Component\Security\Http\Firewall\FirewallListenerInterface;
 use Symfony\Contracts\Service\ResetInterface;
 
@@ -88,7 +89,11 @@ final class TraceableFirewallListener extends FirewallListener implements ResetI
         }
 
         foreach ($requestListeners as $listener) {
-            $listener($event);
+            if (!$listener instanceof FirewallListenerInterface) {
+                $listener($event);
+            } elseif (false !== $listener->supports($event->getRequest())) {
+                $listener->authenticate($event);
+            }
 
             if ($event->hasResponse()) {
                 break;

--- a/src/Symfony/Bundle/SecurityBundle/Security/FirewallContext.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/FirewallContext.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\SecurityBundle\Security;
 
 use Symfony\Component\Security\Http\Firewall\ExceptionListener;
+use Symfony\Component\Security\Http\Firewall\FirewallListenerInterface;
 use Symfony\Component\Security\Http\Firewall\LogoutListener;
 
 /**
@@ -39,7 +40,7 @@ class FirewallContext
     }
 
     /**
-     * @return iterable<mixed, callable>
+     * @return iterable<mixed, FirewallListenerInterface|callable>
      */
     public function getListeners(): iterable
     {

--- a/src/Symfony/Bundle/SecurityBundle/Security/LazyFirewallContext.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/LazyFirewallContext.php
@@ -11,9 +11,11 @@
 
 namespace Symfony\Bundle\SecurityBundle\Security;
 
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Http\Event\LazyResponseEvent;
+use Symfony\Component\Security\Http\Firewall\AbstractListener;
 use Symfony\Component\Security\Http\Firewall\ExceptionListener;
 use Symfony\Component\Security\Http\Firewall\FirewallListenerInterface;
 use Symfony\Component\Security\Http\Firewall\LogoutListener;
@@ -23,7 +25,7 @@ use Symfony\Component\Security\Http\Firewall\LogoutListener;
  *
  * @author Nicolas Grekas <p@tchwork.com>
  */
-class LazyFirewallContext extends FirewallContext
+class LazyFirewallContext extends FirewallContext implements FirewallListenerInterface
 {
     public function __construct(
         iterable $listeners,
@@ -40,19 +42,26 @@ class LazyFirewallContext extends FirewallContext
         return [$this];
     }
 
-    public function __invoke(RequestEvent $event): void
+    public function supports(Request $request): ?bool
+    {
+        return true;
+    }
+
+    public function authenticate(RequestEvent $event): void
     {
         $listeners = [];
         $request = $event->getRequest();
         $lazy = $request->isMethodCacheable();
 
         foreach (parent::getListeners() as $listener) {
-            if (!$lazy || !$listener instanceof FirewallListenerInterface) {
+            if (!$listener instanceof FirewallListenerInterface) {
+                trigger_deprecation('symfony/security-http', '7.4', 'Using a callable as firewall listener is deprecated, extend "%s" or implement "%s" instead.', AbstractListener::class, FirewallListenerInterface::class);
+
                 $listeners[] = $listener;
-                $lazy = $lazy && $listener instanceof FirewallListenerInterface;
+                $lazy = false;
             } elseif (false !== $supports = $listener->supports($request)) {
                 $listeners[] = [$listener, 'authenticate'];
-                $lazy = null === $supports;
+                $lazy = $lazy && null === $supports;
             }
         }
 
@@ -74,5 +83,20 @@ class LazyFirewallContext extends FirewallContext
                 $listener($event);
             }
         });
+    }
+
+    public static function getPriority(): int
+    {
+        return 0;
+    }
+
+    /**
+     * @deprecated since Symfony 7.4, to be removed in 8.0
+     */
+    public function __invoke(RequestEvent $event): void
+    {
+        trigger_deprecation('symfony/security-bundle', '7.4', 'The "%s()" method is deprecated since Symfony 7.4 and will be removed in 8.0.', __METHOD__);
+
+        $this->authenticate($event);
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -22,6 +22,7 @@
         "symfony/clock": "^6.4|^7.0|^8.0",
         "symfony/config": "^7.3|^8.0",
         "symfony/dependency-injection": "^6.4.11|^7.1.4|^8.0",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
         "symfony/http-kernel": "^6.4|^7.0|^8.0",
         "symfony/http-foundation": "^6.4|^7.0|^8.0",

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+ * Deprecate callable firewall listeners, extend `AbstractListener` or implement `FirewallListenerInterface` instead
+ * Deprecate `AbstractListener::__invoke`
+
 7.3
 ---
 

--- a/src/Symfony/Component/Security/Http/Firewall.php
+++ b/src/Symfony/Component/Security/Http/Firewall.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Security\Http\Firewall\AbstractListener;
 use Symfony\Component\Security\Http\Firewall\ExceptionListener;
 use Symfony\Component\Security\Http\Firewall\FirewallListenerInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -123,6 +124,8 @@ class Firewall implements EventSubscriberInterface
     {
         foreach ($listeners as $listener) {
             if (!$listener instanceof FirewallListenerInterface) {
+                trigger_deprecation('symfony/security-http', '7.4', 'Using a callable as firewall listener is deprecated, extend "%s" or implement "%s" instead.', AbstractListener::class, FirewallListenerInterface::class);
+            
                 $listener($event);
             } elseif (false !== $listener->supports($event->getRequest())) {
                 $listener->authenticate($event);
@@ -134,8 +137,8 @@ class Firewall implements EventSubscriberInterface
         }
     }
 
-    private function getListenerPriority(object $logoutListener): int
+    private function getListenerPriority(object $listener): int
     {
-        return $logoutListener instanceof FirewallListenerInterface ? $logoutListener->getPriority() : 0;
+        return $listener instanceof FirewallListenerInterface ? $listener->getPriority() : 0;
     }
 }

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractListener.php
@@ -20,8 +20,13 @@ use Symfony\Component\HttpKernel\Event\RequestEvent;
  */
 abstract class AbstractListener implements FirewallListenerInterface
 {
+    /**
+     * @deprecated since Symfony 7.4, to be removed in 8.0
+     */
     final public function __invoke(RequestEvent $event): void
     {
+        trigger_deprecation('symfony/security-http', '7.4', 'The "%s()" method is deprecated since Symfony 7.4 and will be removed in 8.0.', __METHOD__);
+
         if (false !== $this->supports($event->getRequest())) {
             $this->authenticate($event);
         }

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/AccessListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/AccessListenerTest.php
@@ -68,7 +68,8 @@ class AccessListenerTest extends TestCase
 
         $this->expectException(AccessDeniedException::class);
 
-        $listener(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
+        $this->assertTrue($listener->supports($request));
+        $listener->authenticate(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
     }
 
     public function testHandleWhenThereIsNoAccessMapEntryMatchingTheRequest()
@@ -95,7 +96,8 @@ class AccessListenerTest extends TestCase
             $accessMap
         );
 
-        $listener(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
+        $this->assertNull($listener->supports($request));
+        $listener->authenticate(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
     }
 
     public function testHandleWhenAccessMapReturnsEmptyAttributes()
@@ -124,7 +126,8 @@ class AccessListenerTest extends TestCase
 
         $event = new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
 
-        $listener(new LazyResponseEvent($event));
+        $this->assertNull($listener->supports($request));
+        $listener->authenticate(new LazyResponseEvent($event));
     }
 
     public function testHandleWhenTheSecurityTokenStorageHasNoToken()
@@ -154,7 +157,8 @@ class AccessListenerTest extends TestCase
 
         $this->expectException(AccessDeniedException::class);
 
-        $listener(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
+        $this->assertTrue($listener->supports($request));
+        $listener->authenticate(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
     }
 
     public function testHandleWhenPublicAccessIsAllowed()
@@ -182,7 +186,8 @@ class AccessListenerTest extends TestCase
             false
         );
 
-        $listener(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
+        $this->assertNull($listener->supports($request));
+        $listener->authenticate(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
     }
 
     public function testHandleWhenPublicAccessWhileAuthenticated()
@@ -212,7 +217,8 @@ class AccessListenerTest extends TestCase
             false
         );
 
-        $listener(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
+        $this->assertNull($listener->supports($request));
+        $listener->authenticate(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
     }
 
     public function testHandleMWithultipleAttributesShouldBeHandledAsAnd()
@@ -246,7 +252,8 @@ class AccessListenerTest extends TestCase
             $accessMap
         );
 
-        $listener(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
+        $this->assertTrue($listener->supports($request));
+        $listener->authenticate(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
     }
 
     public function testLazyPublicPagesShouldNotAccessTokenStorage()
@@ -263,7 +270,9 @@ class AccessListenerTest extends TestCase
         ;
 
         $listener = new AccessListener($tokenStorage, $this->createMock(AccessDecisionManagerInterface::class), $accessMap, false);
-        $listener(new LazyResponseEvent(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST)));
+
+        $this->assertNull($listener->supports($request));
+        $listener->authenticate(new LazyResponseEvent(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST)));
     }
 
     public function testConstructWithTrueExceptionOnNoToken()

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ChannelListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ChannelListenerTest.php
@@ -39,12 +39,8 @@ class ChannelListenerTest extends TestCase
             ->willReturn([[], 'http'])
         ;
 
-        $event = new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
-
         $listener = new ChannelListener($accessMap);
-        $listener($event);
-
-        $this->assertNull($event->getResponse());
+        $this->assertFalse($listener->supports($request));
     }
 
     public function testHandleWithSecuredRequestAndHttpsChannel()
@@ -64,12 +60,8 @@ class ChannelListenerTest extends TestCase
             ->willReturn([[], 'https'])
         ;
 
-        $event = new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
-
         $listener = new ChannelListener($accessMap);
-        $listener($event);
-
-        $this->assertNull($event->getResponse());
+        $this->assertFalse($listener->supports($request));
     }
 
     public function testHandleWithNotSecuredRequestAndHttpsChannel()
@@ -92,7 +84,9 @@ class ChannelListenerTest extends TestCase
         $event = new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
 
         $listener = new ChannelListener($accessMap);
-        $listener($event);
+        $this->assertTrue($listener->supports($request));
+
+        $listener->authenticate($event);
 
         $response = $event->getResponse();
         $this->assertInstanceOf(RedirectResponse::class, $response);
@@ -119,7 +113,9 @@ class ChannelListenerTest extends TestCase
         $event = new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
 
         $listener = new ChannelListener($accessMap);
-        $listener($event);
+        $this->assertTrue($listener->supports($request));
+
+        $listener->authenticate($event);
 
         $response = $event->getResponse();
         $this->assertInstanceOf(RedirectResponse::class, $response);

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
@@ -179,7 +179,7 @@ class ContextListenerTest extends TestCase
             ->with(null);
 
         $listener = new ContextListener($tokenStorage, [], 'key123');
-        $listener(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
+        $listener->authenticate(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
     }
 
     public static function provideInvalidToken()
@@ -203,7 +203,7 @@ class ContextListenerTest extends TestCase
             ->method('addListener')
             ->with(KernelEvents::RESPONSE, $listener->onKernelResponse(...));
 
-        $listener(new RequestEvent($this->createMock(HttpKernelInterface::class), new Request(), HttpKernelInterface::MAIN_REQUEST));
+        $listener->authenticate(new RequestEvent($this->createMock(HttpKernelInterface::class), new Request(), HttpKernelInterface::MAIN_REQUEST));
     }
 
     public function testOnKernelResponseListenerRemovesItself()
@@ -236,7 +236,7 @@ class ContextListenerTest extends TestCase
         $tokenStorage->expects($this->once())->method('setToken')->with(null);
 
         $listener = new ContextListener($tokenStorage, [], 'key123');
-        $listener(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
+        $listener->authenticate(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
     }
 
     public function testIfTokenIsDeauthenticated()
@@ -262,7 +262,7 @@ class ContextListenerTest extends TestCase
         $request->cookies->set('MOCKSESSID', true);
 
         $listener = new ContextListener($tokenStorage, [new NotSupportingUserProvider(true), new NotSupportingUserProvider(false), new SupportingUserProvider($refreshedUser)], 'context_key');
-        $listener(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
+        $listener->authenticate(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
 
         $this->assertInstanceOf(CustomToken::class, $tokenStorage->getToken());
         $this->assertSame($refreshedUser, $tokenStorage->getToken()->getUser());
@@ -270,7 +270,6 @@ class ContextListenerTest extends TestCase
 
     public function testIfTokenIsNotDeauthenticated()
     {
-        $tokenStorage = new TokenStorage();
         $badRefreshedUser = new InMemoryUser('foobar', 'baz');
         $goodRefreshedUser = new InMemoryUser('foobar', 'bar');
         $tokenStorage = $this->handleEventWithPreviousSession([new SupportingUserProvider($badRefreshedUser), new SupportingUserProvider($goodRefreshedUser)], $goodRefreshedUser);
@@ -326,7 +325,7 @@ class ContextListenerTest extends TestCase
 
         $tokenStorage = new TokenStorage();
         $listener = new ContextListener($tokenStorage, [], 'context_key', null, null, null, $tokenStorage->getToken(...));
-        $listener(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
+        $listener->authenticate(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
 
         $this->assertSame($usageIndex, $session->getUsageIndex());
     }
@@ -348,7 +347,7 @@ class ContextListenerTest extends TestCase
         $tokenStorage = new TokenStorage();
 
         $listener = new ContextListener($tokenStorage, [], 'context_key', null, null, null, $tokenStorage->getToken(...));
-        $listener(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
+        $listener->authenticate(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
 
         $listener->onKernelResponse(new ResponseEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST, new Response()));
     }
@@ -370,7 +369,7 @@ class ContextListenerTest extends TestCase
         $listener = new ContextListener($tokenStorage, [], 'session', null, $dispatcher, null, $tokenStorage->getToken(...));
         $this->assertSame([], $dispatcher->getListeners());
 
-        $listener(new RequestEvent($httpKernel, $request, HttpKernelInterface::MAIN_REQUEST));
+        $listener->authenticate(new RequestEvent($httpKernel, $request, HttpKernelInterface::MAIN_REQUEST));
         $this->assertNotEmpty($dispatcher->getListeners());
 
         $listener->onKernelResponse(new ResponseEvent($httpKernel, $request, HttpKernelInterface::MAIN_REQUEST, new Response()));
@@ -468,7 +467,7 @@ class ContextListenerTest extends TestCase
 
         $listener = new ContextListener($tokenStorage, $userProviders, 'context_key', null, null, null, $sessionTrackerEnabler);
 
-        $listener(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
+        $listener->authenticate(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
 
         if (null !== $user) {
             ++$usageIndex;

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/SwitchUserListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/SwitchUserListenerTest.php
@@ -61,10 +61,7 @@ class SwitchUserListenerTest extends TestCase
     public function testEventIsIgnoredIfUsernameIsNotPassedWithTheRequest()
     {
         $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager);
-        $listener($this->event);
-
-        $this->assertNull($this->event->getResponse());
-        $this->assertNull($this->tokenStorage->getToken());
+        $this->assertFalse($listener->supports($this->event->getRequest()));
     }
 
     public function testExitUserThrowsAuthenticationExceptionIfNoCurrentToken()
@@ -75,7 +72,8 @@ class SwitchUserListenerTest extends TestCase
 
         $this->expectException(AuthenticationCredentialsNotFoundException::class);
 
-        $listener($this->event);
+        $this->assertTrue($listener->supports($this->event->getRequest()));
+        $listener->authenticate($this->event);
     }
 
     public function testExitUserThrowsAuthenticationExceptionIfOriginalTokenCannotBeFound()
@@ -89,7 +87,8 @@ class SwitchUserListenerTest extends TestCase
 
         $this->expectException(AuthenticationCredentialsNotFoundException::class);
 
-        $listener($this->event);
+        $this->assertTrue($listener->supports($this->event->getRequest()));
+        $listener->authenticate($this->event);
     }
 
     public function testExitUserUpdatesToken()
@@ -100,7 +99,8 @@ class SwitchUserListenerTest extends TestCase
         $this->request->query->set('_switch_user', SwitchUserListener::EXIT_VALUE);
 
         $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager);
-        $listener($this->event);
+        $this->assertTrue($listener->supports($this->event->getRequest()));
+        $listener->authenticate($this->event);
 
         $this->assertSame([], $this->request->query->all());
         $this->assertSame('', $this->request->server->get('QUERY_STRING'));
@@ -134,7 +134,8 @@ class SwitchUserListenerTest extends TestCase
         ;
 
         $listener = new SwitchUserListener($this->tokenStorage, $userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager, null, '_switch_user', 'ROLE_ALLOWED_TO_SWITCH', $dispatcher);
-        $listener($this->event);
+        $this->assertTrue($listener->supports($this->event->getRequest()));
+        $listener->authenticate($this->event);
     }
 
     public function testSwitchUserIsDisallowed()
@@ -153,7 +154,8 @@ class SwitchUserListenerTest extends TestCase
 
         $this->expectException(AccessDeniedException::class);
 
-        $listener($this->event);
+        $this->assertTrue($listener->supports($this->event->getRequest()));
+        $listener->authenticate($this->event);
     }
 
     public function testSwitchUserTurnsAuthenticationExceptionTo403()
@@ -170,7 +172,8 @@ class SwitchUserListenerTest extends TestCase
 
         $this->expectException(AccessDeniedException::class);
 
-        $listener($this->event);
+        $this->assertTrue($listener->supports($this->event->getRequest()));
+        $listener->authenticate($this->event);
     }
 
     public function testSwitchUser()
@@ -188,7 +191,8 @@ class SwitchUserListenerTest extends TestCase
             ->method('checkPostAuth')->with($this->callback(fn ($user) => 'kuba' === $user->getUserIdentifier()), $token);
 
         $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager);
-        $listener($this->event);
+        $this->assertTrue($listener->supports($this->event->getRequest()));
+        $listener->authenticate($this->event);
 
         $this->assertSame([], $this->request->query->all());
         $this->assertSame('', $this->request->server->get('QUERY_STRING'));
@@ -217,7 +221,8 @@ class SwitchUserListenerTest extends TestCase
             ->method('checkPostAuth')->with($targetsUser);
 
         $listener = new SwitchUserListener($tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager, null, '_switch_user', 'ROLE_ALLOWED_TO_SWITCH', null, false);
-        $listener($this->event);
+        $this->assertTrue($listener->supports($this->event->getRequest()));
+        $listener->authenticate($this->event);
 
         $this->assertSame([], $this->request->query->all());
         $this->assertSame('', $this->request->server->get('QUERY_STRING'));
@@ -243,7 +248,8 @@ class SwitchUserListenerTest extends TestCase
             ->method('checkPostAuth')->with($this->callback(fn ($argUser) => $user->isEqualTo($argUser)));
 
         $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager);
-        $listener($this->event);
+        $this->assertTrue($listener->supports($this->event->getRequest()));
+        $listener->authenticate($this->event);
 
         $this->assertSame([], $this->request->query->all());
         $this->assertSame('', $this->request->server->get('QUERY_STRING'));
@@ -270,7 +276,8 @@ class SwitchUserListenerTest extends TestCase
             ->method('checkPostAuth')->with($targetsUser);
 
         $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager);
-        $listener($this->event);
+        $this->assertTrue($listener->supports($this->event->getRequest()));
+        $listener->authenticate($this->event);
 
         $this->assertSame('page=3&section=2', $this->request->server->get('QUERY_STRING'));
         $this->assertInstanceOf(UsernamePasswordToken::class, $this->tokenStorage->getToken());
@@ -308,7 +315,8 @@ class SwitchUserListenerTest extends TestCase
             );
 
         $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager, null, '_switch_user', 'ROLE_ALLOWED_TO_SWITCH', $dispatcher);
-        $listener($this->event);
+        $this->assertTrue($listener->supports($this->event->getRequest()));
+        $listener->authenticate($this->event);
 
         $this->assertSame($replacedToken, $this->tokenStorage->getToken());
     }
@@ -321,7 +329,8 @@ class SwitchUserListenerTest extends TestCase
 
         $this->expectException(AuthenticationCredentialsNotFoundException::class);
 
-        $listener($this->event);
+        $this->assertTrue($listener->supports($this->event->getRequest()));
+        $listener->authenticate($this->event);
     }
 
     public function testSwitchUserStateless()
@@ -340,7 +349,8 @@ class SwitchUserListenerTest extends TestCase
             ->method('checkPostAuth')->with($targetsUser);
 
         $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager, null, '_switch_user', 'ROLE_ALLOWED_TO_SWITCH', null, true);
-        $listener($this->event);
+        $this->assertTrue($listener->supports($this->event->getRequest()));
+        $listener->authenticate($this->event);
 
         $this->assertInstanceOf(UsernamePasswordToken::class, $this->tokenStorage->getToken());
         $this->assertFalse($this->event->hasResponse());
@@ -371,6 +381,7 @@ class SwitchUserListenerTest extends TestCase
         ;
 
         $listener = new SwitchUserListener($this->tokenStorage, $userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager, null, '_switch_user', 'ROLE_ALLOWED_TO_SWITCH', $dispatcher);
-        $listener($this->event);
+        $this->assertTrue($listener->supports($this->event->getRequest()));
+        $listener->authenticate($this->event);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | N/A
| License       | MIT

After spending some time in the Security component it occurred to me callable firewall listeners are obsolete now that we got the `FirewallListenerInterface`. Their deprecation has already been suggested (like in https://github.com/symfony/symfony/pull/34627#issuecomment-559245393 or https://github.com/symfony/symfony/pull/38751#pullrequestreview-517557545), so this PR does it.