### PR TITLE
[Contracts] Rename `printf()` to `vsprintf()` in Deprecation documentation

### DIFF
--- a/src/Symfony/Contracts/Deprecation/README.md
+++ b/src/Symfony/Contracts/Deprecation/README.md
@@ -12,7 +12,7 @@ The function requires at least 3 arguments:
  - the name of the Composer package that is triggering the deprecation
  - the version of the package that introduced the deprecation
  - the message of the deprecation
- - more arguments can be provided: they will be inserted in the message using `printf()` formatting
+ - more arguments can be provided: they will be inserted in the message using `vsprintf()` formatting
 
 Example:
 ```php


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

I'm not sure if that's really relevant, but since the code uses `vsprintf()` it may be worth to mention the right function.