### PR TITLE
[JsonPath] Add `CrawlerFactoryInterface` and `JsonCrawlerFactory`

### DIFF
--- a/src/Symfony/Component/JsonPath/CHANGELOG.md
+++ b/src/Symfony/Component/JsonPath/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+ * Add `CrawlerFactoryInterface` and `JsonCrawlerFactory`
+
 7.3
 ---
 

--- a/src/Symfony/Component/JsonPath/CrawlerFactoryInterface.php
+++ b/src/Symfony/Component/JsonPath/CrawlerFactoryInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonPath;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ *
+ * @experimental
+ */
+interface CrawlerFactoryInterface
+{
+    /**
+     * @param string|resource $data
+     */
+    public function createFromData(mixed $data): CrawlerInterface;
+}

--- a/src/Symfony/Component/JsonPath/CrawlerInterface.php
+++ b/src/Symfony/Component/JsonPath/CrawlerInterface.php
@@ -19,7 +19,7 @@ use Symfony\Component\JsonPath\Exception\JsonCrawlerException;
  *
  * @experimental
  */
-interface JsonCrawlerInterface
+interface CrawlerInterface
 {
     /**
      * @return list<array|string|float|int|bool|null>

--- a/src/Symfony/Component/JsonPath/JsonCrawler.php
+++ b/src/Symfony/Component/JsonPath/JsonCrawler.php
@@ -28,7 +28,7 @@ use Symfony\Component\JsonStreamer\Read\Splitter;
  *
  * @experimental
  */
-final class JsonCrawler implements JsonCrawlerInterface
+final class JsonCrawler implements CrawlerInterface
 {
     private const RFC9535_FUNCTIONS = [
         'length' => true,
@@ -40,12 +40,14 @@ final class JsonCrawler implements JsonCrawlerInterface
 
     /**
      * @param resource|string $raw
+     *
+     * @throws \TypeError When the input is not a string or a resource
      */
     public function __construct(
         private readonly mixed $raw,
     ) {
         if (!\is_string($raw) && !\is_resource($raw)) {
-            throw new InvalidArgumentException(\sprintf('Expected string or resource, got "%s".', get_debug_type($raw)));
+            throw new \TypeError(\sprintf('Expected string or resource, got "%s".', get_debug_type($raw)));
         }
     }
 

--- a/src/Symfony/Component/JsonPath/JsonCrawlerFactory.php
+++ b/src/Symfony/Component/JsonPath/JsonCrawlerFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonPath;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ *
+ * @experimental
+ */
+final class JsonCrawlerFactory implements CrawlerFactoryInterface
+{
+    /**
+     * @throws \TypeError When the data is not a string or a resource
+     */
+    public function createFromData(mixed $data): JsonCrawler
+    {
+        return new JsonCrawler($data);
+    }
+}

--- a/src/Symfony/Component/JsonPath/Tests/JsonCrawlerFactoryTest.php
+++ b/src/Symfony/Component/JsonPath/Tests/JsonCrawlerFactoryTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonPath\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\JsonPath\JsonCrawlerFactory;
+
+class JsonCrawlerFactoryTest extends TestCase
+{
+    public function testCreateCrawler()
+    {
+        $factory = new JsonCrawlerFactory();
+        $crawler = $factory->createFromData('{"foo": "bar"}');
+
+        $this->assertSame(['bar'], $crawler->find('$.foo'), '->createFromData() provides data to the crawler');
+    }
+}

--- a/src/Symfony/Component/JsonPath/Tests/JsonCrawlerTest.php
+++ b/src/Symfony/Component/JsonPath/Tests/JsonCrawlerTest.php
@@ -22,7 +22,7 @@ class JsonCrawlerTest extends TestCase
 {
     public function testNotStringOrResourceThrows()
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(\TypeError::class);
         $this->expectExceptionMessage('Expected string or resource, got "int".');
 
         new JsonCrawler(42);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

New try after https://github.com/symfony/symfony/pull/60083.

To propose the best integration with FrameworkBundle and upcoming features (like injecting new custom functions for filtering), we need a way to inject a crawler in services.

This PR proposes a new factory like the other PR, without the FrameworkBundle integration. We'll do this in a second time.

There were many discussions on which approach to choose: either a separate factory or a factory directly included in the Crawler itself. It seems the separate factory [is the preferred way](https://github.com/symfony/symfony/pull/60083#discussion_r2057665818), but no consensus is found yet. I personally prefer the separate factory as well, but the debate is still open 🙂 