### PR TITLE
[Ldap] Fix `LdapUser::isEqualTo`

### DIFF
--- a/src/Symfony/Component/Ldap/Security/LdapUser.php
+++ b/src/Symfony/Component/Ldap/Security/LdapUser.php
@@ -47,7 +47,7 @@ class LdapUser implements UserInterface, PasswordAuthenticatedUserInterface, Equ
 
     public function getPassword(): ?string
     {
-        return $this->password;
+        return $this->password ?? null;
     }
 
     public function getSalt(): ?string
@@ -89,7 +89,7 @@ class LdapUser implements UserInterface, PasswordAuthenticatedUserInterface, Equ
             return false;
         }
 
-        if ($this->getPassword() !== $user->getPassword()) {
+        if (($this->getPassword() ?? $user->getPassword()) !== $user->getPassword()) {
             return false;
         }
 

--- a/src/Symfony/Component/Ldap/Tests/Security/LdapUserTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Security/LdapUserTest.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Ldap\Tests\Security;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Ldap\Entry;
+use Symfony\Component\Ldap\Security\LdapUser;
+
+class LdapUserTest extends TestCase
+{
+    public function testIsEqualToWorksOnUnserializedUser()
+    {
+        $user = new LdapUser(new Entry('uid=jonhdoe,ou=MyBusiness,dc=symfony,dc=com', []), 'jonhdoe', 'p455w0rd');
+        $unserializedUser = unserialize(serialize($user));
+
+        $this->assertTrue($unserializedUser->isEqualTo($user));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60454
| License       | MIT

Since #59682 `LdapUser`s’ password no longer is serialized in the session, which means that `isEqualTo` will crash when trying to access it.

This PR makes `getPassword` returns `null` by default to fix this, and update `isEqualTo` to apply #59539’s logic.