### PR TITLE
[TypeInfo] Fix merging collection value types with union types

### DIFF
--- a/src/Symfony/Component/TypeInfo/Tests/TypeResolver/StringTypeResolverTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeResolver/StringTypeResolverTest.php
@@ -79,6 +79,7 @@ class StringTypeResolverTest extends TestCase
         yield [Type::arrayShape(['foo' => Type::bool()], sealed: false), 'array{foo: bool, ...}'];
         yield [Type::arrayShape(['foo' => Type::bool()], extraKeyType: Type::int(), extraValueType: Type::string()), 'array{foo: bool, ...<int, string>}'];
         yield [Type::arrayShape(['foo' => Type::bool()], extraValueType: Type::int()), 'array{foo: bool, ...<int>}'];
+        yield [Type::arrayShape(['foo' => Type::union(Type::bool(), Type::float(), Type::int(), Type::null(), Type::string()), 'bar' => Type::string()]), 'array{foo: scalar|null, bar: string}'];
 
         // object shape
         yield [Type::object(), 'object{foo: true, bar: false}'];

--- a/src/Symfony/Component/TypeInfo/Type/CollectionType.php
+++ b/src/Symfony/Component/TypeInfo/Type/CollectionType.php
@@ -65,25 +65,27 @@ class CollectionType extends Type implements WrappingTypeInterface
         $boolTypes = [];
         $objectTypes = [];
 
-        foreach ($types as $t) {
-            // cannot create an union with a standalone type
-            if ($t->isIdentifiedBy(TypeIdentifier::MIXED)) {
-                return Type::mixed();
+        foreach ($types as $type) {
+            foreach (($type instanceof UnionType ? $type->getTypes() : [$type]) as $t) {
+                // cannot create an union with a standalone type
+                if ($t->isIdentifiedBy(TypeIdentifier::MIXED)) {
+                    return Type::mixed();
+                }
+
+                if ($t->isIdentifiedBy(TypeIdentifier::TRUE, TypeIdentifier::FALSE, TypeIdentifier::BOOL)) {
+                    $boolTypes[] = $t;
+
+                    continue;
+                }
+
+                if ($t->isIdentifiedBy(TypeIdentifier::OBJECT)) {
+                    $objectTypes[] = $t;
+
+                    continue;
+                }
+
+                $normalizedTypes[] = $t;
             }
-
-            if ($t->isIdentifiedBy(TypeIdentifier::TRUE, TypeIdentifier::FALSE, TypeIdentifier::BOOL)) {
-                $boolTypes[] = $t;
-
-                continue;
-            }
-
-            if ($t->isIdentifiedBy(TypeIdentifier::OBJECT)) {
-                $objectTypes[] = $t;
-
-                continue;
-            }
-
-            $normalizedTypes[] = $t;
         }
 
         $boolTypes = array_unique($boolTypes);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60620
| License       | MIT

Fix merging collection values types. To be properly merged, union types need to be spread, and it was not the case.