### PR TITLE
[Form] Fix `keep_as_list` when data is not an array

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
@@ -199,7 +199,13 @@ class ResizeFormListener implements EventSubscriberInterface
         }
 
         if ($this->keepAsList) {
-            $formReindex = [];
+            $formReindex = $dataKeys = [];
+            foreach ($data as $key => $value) {
+                $dataKeys[] = $key;
+            }
+            foreach ($dataKeys as $key) {
+                unset($data[$key]);
+            }
             foreach ($form as $name => $child) {
                 $formReindex[] = $child;
                 $form->remove($name);
@@ -208,8 +214,8 @@ class ResizeFormListener implements EventSubscriberInterface
                 $form->add($index, $this->type, array_replace([
                     'property_path' => '['.$index.']',
                 ], $this->options));
+                $data[$index] = $child->getData();
             }
-            $data = array_values($data);
         }
 
         $event->setData($data);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
@@ -310,7 +310,7 @@ class ResizeFormListenerTest extends TestCase
         $this->assertArrayNotHasKey(2, $event->getData());
     }
 
-    public function testOnSubmitDealsWithArrayBackedIteratorAggregate()
+    public function testOnSubmitDealsWithDoctrineCollection()
     {
         $this->builder->add($this->getBuilder('1'));
 
@@ -321,6 +321,19 @@ class ResizeFormListenerTest extends TestCase
 
         $this->assertArrayNotHasKey(0, $event->getData());
         $this->assertArrayNotHasKey(2, $event->getData());
+    }
+
+    public function testKeepAsListWorksWithTraversableArrayAccess()
+    {
+        $this->builder->add($this->getBuilder('1'));
+
+        $data = new \ArrayIterator([0 => 'first', 1 => 'second', 2 => 'third']);
+        $event = new FormEvent($this->builder->getForm(), $data);
+        $listener = new ResizeFormListener(TextType::class, keepAsList: true);
+        $listener->onSubmit($event);
+
+        $this->assertCount(1, $event->getData());
+        $this->assertArrayHasKey(0, $event->getData());
     }
 
     public function testOnSubmitDeleteEmptyNotCompoundEntriesIfAllowDelete()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix part of #57430
| License       | MIT

The `CollectionType` handles not only arrays but also `ArrayAccess&Traversable`. However when setting its `keep_as_list` option, `array_values` would then be called and crash.

To avoid this, this PR reindexes the data by getting its keys and unsetting them. This is because unsetting in a loop can produce counter-intuitive results; e.g. [`ArrayIterator` would skip indexes](https://www.php.net/manual/en/arrayiterator.offsetunset.php).

Note that #57430 mentions another issue that would be fixed by #59910.