### PR TITLE
[TypeInfo] Fix type alias resolving

### DIFF
--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithTypeAliases.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithTypeAliases.php
@@ -12,11 +12,15 @@
 namespace Symfony\Component\TypeInfo\Tests\Fixtures;
 
 /**
+ * @phpstan-type CustomArray = array{0: CustomInt, 1: CustomString, 2: bool}
  * @phpstan-type CustomString = string
+ *
  * @phpstan-import-type CustomInt from DummyWithPhpDoc
  * @phpstan-import-type CustomInt from DummyWithPhpDoc as AliasedCustomInt
  *
+ * @psalm-type PsalmCustomArray = array{0: PsalmCustomInt, 1: PsalmCustomString, 2: bool}
  * @psalm-type PsalmCustomString = string
+ *
  * @psalm-import-type PsalmCustomInt from DummyWithPhpDoc
  * @psalm-import-type PsalmCustomInt from DummyWithPhpDoc as PsalmAliasedCustomInt
  */
@@ -54,8 +58,30 @@ final class DummyWithTypeAliases
 }
 
 /**
+ * @phpstan-type Foo = array{0: Bar}
+ * @phpstan-type Bar = array{0: Foo}
+ */
+final class DummyWithRecursiveTypeAliases
+{
+}
+
+/**
+ * @phpstan-type Invalid = SomethingInvalid
+ */
+final class DummyWithInvalidTypeAlias
+{
+}
+
+/**
  * @phpstan-import-type Invalid from DummyWithTypeAliases
  */
 final class DummyWithInvalidTypeAliasImport
+{
+}
+
+/**
+ * @phpstan-import-type Invalid from int
+ */
+final class DummyWithTypeAliasImportedFromInvalidClassName
 {
 }

--- a/src/Symfony/Component/TypeInfo/Tests/TypeContext/TypeContextFactoryTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeContext/TypeContextFactoryTest.php
@@ -15,9 +15,12 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\TypeInfo\Exception\LogicException;
 use Symfony\Component\TypeInfo\Tests\Fixtures\AbstractDummy;
 use Symfony\Component\TypeInfo\Tests\Fixtures\Dummy;
+use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithInvalidTypeAlias;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithInvalidTypeAliasImport;
+use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithRecursiveTypeAliases;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithTemplates;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithTypeAliases;
+use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithTypeAliasImportedFromInvalidClassName;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithUses;
 use Symfony\Component\TypeInfo\Type;
 use Symfony\Component\TypeInfo\TypeContext\TypeContextFactory;
@@ -128,27 +131,33 @@ class TypeContextFactoryTest extends TestCase
         $this->assertEquals([
             'CustomString' => Type::string(),
             'CustomInt' => Type::int(),
+            'CustomArray' => Type::arrayShape([0 => Type::int(), 1 => Type::string(), 2 => Type::bool()]),
             'AliasedCustomInt' => Type::int(),
             'PsalmCustomString' => Type::string(),
             'PsalmCustomInt' => Type::int(),
+            'PsalmCustomArray' => Type::arrayShape([0 => Type::int(), 1 => Type::string(), 2 => Type::bool()]),
             'PsalmAliasedCustomInt' => Type::int(),
         ], $this->typeContextFactory->createFromClassName(DummyWithTypeAliases::class)->typeAliases);
 
         $this->assertEquals([
             'CustomString' => Type::string(),
             'CustomInt' => Type::int(),
+            'CustomArray' => Type::arrayShape([0 => Type::int(), 1 => Type::string(), 2 => Type::bool()]),
             'AliasedCustomInt' => Type::int(),
             'PsalmCustomString' => Type::string(),
             'PsalmCustomInt' => Type::int(),
+            'PsalmCustomArray' => Type::arrayShape([0 => Type::int(), 1 => Type::string(), 2 => Type::bool()]),
             'PsalmAliasedCustomInt' => Type::int(),
         ], $this->typeContextFactory->createFromReflection(new \ReflectionClass(DummyWithTypeAliases::class))->typeAliases);
 
         $this->assertEquals([
             'CustomString' => Type::string(),
             'CustomInt' => Type::int(),
+            'CustomArray' => Type::arrayShape([0 => Type::int(), 1 => Type::string(), 2 => Type::bool()]),
             'AliasedCustomInt' => Type::int(),
             'PsalmCustomString' => Type::string(),
             'PsalmCustomInt' => Type::int(),
+            'PsalmCustomArray' => Type::arrayShape([0 => Type::int(), 1 => Type::string(), 2 => Type::bool()]),
             'PsalmAliasedCustomInt' => Type::int(),
         ], $this->typeContextFactory->createFromReflection(new \ReflectionProperty(DummyWithTypeAliases::class, 'localAlias'))->typeAliases);
     }
@@ -166,5 +175,29 @@ class TypeContextFactoryTest extends TestCase
         $this->expectExceptionMessage(\sprintf('Cannot find any "Invalid" type alias in "%s".', DummyWithTypeAliases::class));
 
         $this->typeContextFactory->createFromClassName(DummyWithInvalidTypeAliasImport::class);
+    }
+
+    public function testThrowWhenCannotResolveTypeAlias()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Cannot resolve "Invalid" type alias.');
+
+        $this->typeContextFactory->createFromClassName(DummyWithInvalidTypeAlias::class);
+    }
+
+    public function testThrowWhenTypeAliasNotImportedFromValidClassName()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Type alias "Invalid" is not imported from a valid class name.');
+
+        $this->typeContextFactory->createFromClassName(DummyWithTypeAliasImportedFromInvalidClassName::class);
+    }
+
+    public function testThrowWhenImportingRecursiveTypeAliases()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Cannot resolve "Bar" type alias.');
+
+        $this->typeContextFactory->createFromClassName(DummyWithRecursiveTypeAliases::class)->typeAliases;
     }
 }

--- a/src/Symfony/Component/TypeInfo/TypeContext/TypeContextFactory.php
+++ b/src/Symfony/Component/TypeInfo/TypeContext/TypeContextFactory.php
@@ -199,32 +199,85 @@ final class TypeContextFactory
         }
 
         $aliases = [];
-        foreach ($this->getPhpDocNode($rawDocNode)->getTagsByName('@psalm-type') + $this->getPhpDocNode($rawDocNode)->getTagsByName('@phpstan-type') as $tag) {
-            if (!$tag->value instanceof TypeAliasTagValueNode) {
-                continue;
-            }
-
-            $aliases[$tag->value->alias] = $this->stringTypeResolver->resolve((string) $tag->value->type, $typeContext);
-        }
+        $resolvedAliases = [];
 
         foreach ($this->getPhpDocNode($rawDocNode)->getTagsByName('@psalm-import-type') + $this->getPhpDocNode($rawDocNode)->getTagsByName('@phpstan-import-type') as $tag) {
             if (!$tag->value instanceof TypeAliasImportTagValueNode) {
                 continue;
             }
 
-            /** @var ObjectType $importedType */
-            $importedType = $this->stringTypeResolver->resolve((string) $tag->value->importedFrom, $typeContext);
-            $importedTypeContext = $this->createFromClassName($importedType->getClassName());
-
-            $typeAlias = $importedTypeContext->typeAliases[$tag->value->importedAlias] ?? null;
-            if (!$typeAlias) {
-                throw new LogicException(\sprintf('Cannot find any "%s" type alias in "%s".', $tag->value->importedAlias, $importedType->getClassName()));
+            $importedFromType = $this->stringTypeResolver->resolve((string) $tag->value->importedFrom, $typeContext);
+            if (!$importedFromType instanceof ObjectType) {
+                throw new LogicException(\sprintf('Type alias "%s" is not imported from a valid class name.', $tag->value->importedAlias));
             }
 
-            $aliases[$tag->value->importedAs ?? $tag->value->importedAlias] = $typeAlias;
+            $importedFromContext = $this->createFromClassName($importedFromType->getClassName());
+
+            $typeAlias = $importedFromContext->typeAliases[$tag->value->importedAlias] ?? null;
+            if (!$typeAlias) {
+                throw new LogicException(\sprintf('Cannot find any "%s" type alias in "%s".', $tag->value->importedAlias, $importedFromType->getClassName()));
+            }
+
+            $resolvedAliases[$tag->value->importedAs ?? $tag->value->importedAlias] = $typeAlias;
         }
 
-        return $aliases;
+        foreach ($this->getPhpDocNode($rawDocNode)->getTagsByName('@psalm-type') + $this->getPhpDocNode($rawDocNode)->getTagsByName('@phpstan-type') as $tag) {
+            if (!$tag->value instanceof TypeAliasTagValueNode) {
+                continue;
+            }
+
+            $aliases[$tag->value->alias] = (string) $tag->value->type;
+        }
+
+        return $this->resolveTypeAliases($aliases, $resolvedAliases, $typeContext);
+    }
+
+    /**
+     * @param array<string, string> $toResolve
+     * @param array<string, Type>   $resolved
+     *
+     * @return array<string, Type>
+     */
+    private function resolveTypeAliases(array $toResolve, array $resolved, TypeContext $typeContext): array
+    {
+        if (!$toResolve) {
+            return [];
+        }
+
+        $typeContext = new TypeContext(
+            $typeContext->calledClassName,
+            $typeContext->declaringClassName,
+            $typeContext->namespace,
+            $typeContext->uses,
+            $typeContext->templates,
+            $typeContext->typeAliases + $resolved,
+        );
+
+        $succeeded = false;
+        $lastFailure = null;
+        $lastFailingAlias = null;
+
+        foreach ($toResolve as $alias => $type) {
+            try {
+                $resolved[$alias] = $this->stringTypeResolver->resolve($type, $typeContext);
+                unset($toResolve[$alias]);
+                $succeeded = true;
+            } catch (UnsupportedException $lastFailure) {
+                $lastFailingAlias = $alias;
+            }
+        }
+
+        // nothing has succeeded, the result won't be different from the
+        // previous one, we can stop here.
+        if (!$succeeded) {
+            throw new LogicException(\sprintf('Cannot resolve "%s" type alias.', $lastFailingAlias), 0, $lastFailure);
+        }
+
+        if ($toResolve) {
+            return $this->resolveTypeAliases($toResolve, $resolved, $typeContext);
+        }
+
+        return $resolved;
     }
 
     private function getPhpDocNode(string $rawDocNode): PhpDocNode


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fixes #60598, fixes #60657
| License       | MIT

Take other type aliases into account when resolving type aliases, no matter the order they're defined.
