### PR TITLE
[PhpUnitBridge] Skip bootstrap for PHPUnit >=10

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/bootstrap.php
+++ b/src/Symfony/Bridge/PhpUnit/bootstrap.php
@@ -14,7 +14,11 @@ use Doctrine\Deprecations\Deprecation;
 use Symfony\Bridge\PhpUnit\DeprecationErrorHandler;
 
 // Detect if we need to serialize deprecations to a file.
-if (in_array(\PHP_SAPI, ['cli', 'phpdbg'], true) && $file = getenv('SYMFONY_DEPRECATIONS_SERIALIZE')) {
+if (
+    // Skip if we're using PHPUnit >=10
+    !class_exists(PHPUnit\Metadata\Metadata::class)
+    && in_array(\PHP_SAPI, ['cli', 'phpdbg'], true) && $file = getenv('SYMFONY_DEPRECATIONS_SERIALIZE')
+) {
     DeprecationErrorHandler::collectDeprecations($file);
 
     return;
@@ -46,6 +50,10 @@ if (!class_exists(AnnotationRegistry::class, false) && class_exists(AnnotationRe
     }
 }
 
-if ('disabled' !== getenv('SYMFONY_DEPRECATIONS_HELPER')) {
+if (
+    // Skip if we're using PHPUnit >=10
+    !class_exists(PHPUnit\Metadata\Metadata::class, false)
+    && 'disabled' !== getenv('SYMFONY_DEPRECATIONS_HELPER')
+) {
     DeprecationErrorHandler::register(getenv('SYMFONY_DEPRECATIONS_HELPER'));
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/recipes/pull/1425#issuecomment-2931968338
| License       | MIT

As suggested by @wouterj, this will skip the bootstrap file that is automatically [required by the bridge's `composer.json`](https://github.com/symfony/symfony/blob/158dff8106151b943fad16f85bcf8b70b7bb1178/src/Symfony/Bridge/PhpUnit/composer.json#L32).

I'm not sure whether to skip the entire file or only the part that registers the `DeprecationErrorHandler`.