### PR TITLE
[FrameworkBundle] don't register `SchedulerTriggerNormalizer` without `symfony/serializer`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2297,7 +2297,7 @@ class FrameworkExtension extends Extension
         }
 
         // BC layer Scheduler < 7.3
-        if (!class_exists(SchedulerTriggerNormalizer::class)) {
+        if (!ContainerBuilder::willBeAvailable('symfony/serializer', DenormalizerInterface::class, ['symfony/framework-bundle', 'symfony/scheduler']) || !class_exists(SchedulerTriggerNormalizer::class)) {
             $container->removeDefinition('serializer.normalizer.scheduler_trigger');
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

This was reported on the Symfony Slack.