### PR TITLE
[JsonPath] Always use brackets notation with `JsonPath::key()`

### DIFF
--- a/src/Symfony/Component/JsonPath/JsonPath.php
+++ b/src/Symfony/Component/JsonPath/JsonPath.php
@@ -30,7 +30,9 @@ final class JsonPath
 
     public function key(string $key): static
     {
-        return new self($this->path.(str_ends_with($this->path, '..') ? '' : '.').$key);
+        $escaped = $this->escapeKey($key);
+
+        return new self($this->path.'["'.$escaped.'"]');
     }
 
     public function index(int $index): static
@@ -79,5 +81,26 @@ final class JsonPath
     public function __toString(): string
     {
         return $this->path;
+    }
+
+    private function escapeKey(string $key): string
+    {
+        $key = strtr($key, [
+            '\\' => '\\\\',
+            '"' => '\\"',
+            "\n" => '\\n',
+            "\r" => '\\r',
+            "\t" => '\\t',
+            "\b" => '\\b',
+            "\f" => '\\f'
+        ]);
+
+        for ($i = 0; $i <= 31; $i++) {
+            if ($i < 8 || $i > 13) {
+                $key = str_replace(chr($i), sprintf('\\u%04x', $i), $key);
+            }
+        }
+
+        return $key;
     }
 }

--- a/src/Symfony/Component/JsonPath/Tests/JsonPathTest.php
+++ b/src/Symfony/Component/JsonPath/Tests/JsonPathTest.php
@@ -23,8 +23,8 @@ class JsonPathTest extends TestCase
             ->index(0)
             ->key('address');
 
-        $this->assertSame('$.users[0].address', (string) $path);
-        $this->assertSame('$.users[0].address..city', (string) $path->deepScan()->key('city'));
+        $this->assertSame('$["users"][0]["address"]', (string) $path);
+        $this->assertSame('$["users"][0]["address"]..["city"]', (string) $path->deepScan()->key('city'));
     }
 
     public function testBuildWithFilter()
@@ -33,7 +33,7 @@ class JsonPathTest extends TestCase
         $path = $path->key('users')
             ->filter('@.age > 18');
 
-        $this->assertSame('$.users[?(@.age > 18)]', (string) $path);
+        $this->assertSame('$["users"][?(@.age > 18)]', (string) $path);
     }
 
     public function testAll()
@@ -42,7 +42,7 @@ class JsonPathTest extends TestCase
         $path = $path->key('users')
             ->all();
 
-        $this->assertSame('$.users[*]', (string) $path);
+        $this->assertSame('$["users"][*]', (string) $path);
     }
 
     public function testFirst()
@@ -51,7 +51,7 @@ class JsonPathTest extends TestCase
         $path = $path->key('users')
             ->first();
 
-        $this->assertSame('$.users[0]', (string) $path);
+        $this->assertSame('$["users"][0]', (string) $path);
     }
 
     public function testLast()
@@ -60,6 +60,47 @@ class JsonPathTest extends TestCase
         $path = $path->key('users')
             ->last();
 
-        $this->assertSame('$.users[-1]', (string) $path);
+        $this->assertSame('$["users"][-1]', (string) $path);
+    }
+
+    /**
+     * @dataProvider provideKeysToEscape
+     */
+    public function testEscapedKey(string $key, string $expectedPath)
+    {
+        $path = new JsonPath();
+        $path = $path->key($key);
+
+        $this->assertSame($expectedPath, (string) $path);
+    }
+
+    public static function provideKeysToEscape(): iterable
+    {
+        yield ['simple_key', '$["simple_key"]'];
+        yield ['key"with"quotes', '$["key\\"with\\"quotes"]'];
+        yield ['path\\backslash', '$["path\\backslash"]'];
+        yield ['mixed\\"case', '$["mixed\\\\\\"case"]'];
+        yield ['unicode_🔑', '$["unicode_🔑"]'];
+        yield ['"quotes_only"', '$["\\"quotes_only\\""]'];
+        yield ['\\\\multiple\\\\backslashes', '$["\\\\\\\\multiple\\\\\\backslashes"]'];
+        yield ["control\x00\x1f\x1echar", '$["control\u0000\u001f\u001echar"]'];
+
+        yield ['key"with\\"mixed', '$["key\\"with\\\\\\"mixed"]'];
+        yield ['\\"complex\\"case\\"', '$["\\\\\\"complex\\\\\\"case\\\\\\""]'];
+        yield ['json_like":{"value":"test"}', '$["json_like\\":{\\"value\\":\\"test\\"}"]'];
+        yield ['C:\\Program Files\\"App Name"', '$["C:\\\\Program Files\\\\\\"App Name\\""]'];
+
+        yield ['key_with_é_accents', '$["key_with_é_accents"]'];
+        yield ['unicode_→_arrows', '$["unicode_→_arrows"]'];
+        yield ['chinese_中文_key', '$["chinese_中文_key"]'];
+
+        yield ['', '$[""]'];
+        yield [' ', '$[" "]'];
+        yield ['   spaces   ', '$["   spaces   "]'];
+        yield ["\t\n\r", '$["\\t\\n\\r"]'];
+        yield ["control\x00char", '$["control\u0000char"]'];
+        yield ["newline\nkey", '$["newline\\nkey"]'];
+        yield ["tab\tkey", '$["tab\\tkey"]'];
+        yield ["carriage\rreturn", '$["carriage\\rreturn"]'];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60664
| License       | MIT

As explained in the issue, the dot notation can lead to invalid paths when used with some identifiers (for example, when it contains a `-`). The issue gives the following example:

```php
use Symfony\Component\JsonPath\JsonCrawler;
use Symfony\Component\JsonPath\JsonPath;

$jsonPathExpression = (string) (new JsonPath)->key('some-prop');

dump((new JsonCrawler('{"some-prop": "example value"}'))->find($jsonPathExpression));
```

Let's always use the brackets notation in `JsonPath::key()`. Dot notation is only a shorthand to the verbose brackets version and this solves the problem without having to do further analysis on the key.

Added a few tests to ensure the brackets notation works well too.