### PR TITLE
[Form] Fix handling the empty string in NumberToLocalizedStringTransformer

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformer.php
@@ -33,14 +33,14 @@ class MoneyToLocalizedStringTransformer extends NumberToLocalizedStringTransform
     /**
      * Transforms a normalized format into a localized money string.
      *
-     * @param int|float|null $value Normalized number
+     * @param int|float|string|null $value Normalized number
      *
      * @throws TransformationFailedException if the given value is not numeric or
      *                                       if the value cannot be transformed
      */
     public function transform(mixed $value): string
     {
-        if (null !== $value && 1 !== $this->divisor) {
+        if (null !== $value && '' !== $value && 1 !== $this->divisor) {
             if (!is_numeric($value)) {
                 throw new TransformationFailedException('Expected a numeric.');
             }

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php
@@ -43,14 +43,14 @@ class NumberToLocalizedStringTransformer implements DataTransformerInterface
     /**
      * Transforms a number type into localized number.
      *
-     * @param int|float|null $value Number value
+     * @param int|float|string|null $value Number value
      *
      * @throws TransformationFailedException if the given value is not numeric
      *                                       or if the value cannot be transformed
      */
     public function transform(mixed $value): string
     {
-        if (null === $value) {
+        if (null === $value || '' === $value) {
             return '';
         }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformerTest.php
@@ -54,6 +54,13 @@ class MoneyToLocalizedStringTransformerTest extends TestCase
         $transformer->transform('abcd');
     }
 
+    public function testTransformEmptyString()
+    {
+        $transformer = new MoneyToLocalizedStringTransformer(null, null, null, 100);
+
+        $this->assertSame('', $transformer->transform(''));
+    }
+
     public function testTransformEmpty()
     {
         $transformer = new MoneyToLocalizedStringTransformer();

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
@@ -49,6 +49,7 @@ class NumberToLocalizedStringTransformerTest extends TestCase
     {
         return [
             [null, '', 'de_AT'],
+            ['', '', 'de_AT'],
             [1, '1', 'de_AT'],
             [1.5, '1,5', 'de_AT'],
             [1234.5, '1234,5', 'de_AT'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

The NumberToLocalizedStringTransformer only tests for null, but if the value is an empty string then the test for is_numeric fails. This change makes the reverseTransform and transform methods both test for null or empty strings 
