### PR TITLE
[Messenger] allow `DeduplicateStamp` to be serialized

### DIFF
--- a/src/Symfony/Component/Messenger/Stamp/DeduplicateStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/DeduplicateStamp.php
@@ -19,15 +19,13 @@ final class DeduplicateStamp implements StampInterface
     private Key $key;
 
     public function __construct(
-        string $key,
+        private string $resource,
         private ?float $ttl = 300.0,
         private bool $onlyDeduplicateInQueue = false,
     ) {
         if (!class_exists(Key::class)) {
             throw new LogicException(\sprintf('You cannot use the "%s" as the Lock component is not installed. Try running "composer require symfony/lock".', self::class));
         }
-
-        $this->key = new Key($key);
     }
 
     public function onlyDeduplicateInQueue(): bool
@@ -37,11 +35,21 @@ final class DeduplicateStamp implements StampInterface
 
     public function getKey(): Key
     {
-        return $this->key;
+        return $this->key ??= new Key($this->resource);
     }
 
     public function getTtl(): ?float
     {
         return $this->ttl;
+    }
+
+    public function __serialize(): array
+    {
+        return [$this->resource, $this->ttl, $this->onlyDeduplicateInQueue];
+    }
+
+    public function __unserialize(array $data): void
+    {
+        [$this->resource, $this->ttl, $this->onlyDeduplicateInQueue] = $data;
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Stamp/DeduplicateStampTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Stamp/DeduplicateStampTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Stamp;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Lock\Key;
+use Symfony\Component\Messenger\Stamp\DeduplicateStamp;
+
+class DeduplicateStampTest extends TestCase
+{
+    public function testSerializeUnserialize()
+    {
+        $stamp = new DeduplicateStamp('id', 300.0, true);
+
+        $this->assertEquals(new Key('id'), $stamp->getKey());
+        $this->assertSame(300.0, $stamp->getTtl());
+        $this->assertTrue($stamp->onlyDeduplicateInQueue());
+
+        $stamp = unserialize(serialize($stamp));
+
+        $this->assertEquals(new Key('id'), $stamp->getKey());
+        $this->assertSame(300.0, $stamp->getTtl());
+        $this->assertTrue($stamp->onlyDeduplicateInQueue());
+
+        $stamp->getKey()->markUnserializable();
+
+        $stamp = unserialize(serialize($stamp));
+
+        $this->assertEquals(new Key('id'), $stamp->getKey());
+        $this->assertSame(300.0, $stamp->getTtl());
+        $this->assertTrue($stamp->onlyDeduplicateInQueue());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Possible solution for #60667
| License       | MIT

I'm not 100% sure this is the proper solution as `Key` state would be lost during serialization. I don't know enough about the Lock component to know if this is a problem in this case.
