### PR TITLE
[HttpFoundation] Use lowercase utf-8 as default response charset

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -261,7 +261,7 @@ class Response
             }
 
             // Fix Content-Type
-            $charset = $this->charset ?: 'UTF-8';
+            $charset = $this->charset ?: 'utf-8';
             if (!$headers->has('Content-Type')) {
                 $headers->set('Content-Type', 'text/html; charset='.$charset);
             } elseif (0 === stripos($headers->get('Content-Type') ?? '', 'text/') && false === stripos($headers->get('Content-Type') ?? '', 'charset')) {

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
@@ -63,7 +63,7 @@ class ResponseTest extends ResponseTestCase
     public function testGetCharset()
     {
         $response = new Response();
-        $charsetOrigin = 'UTF-8';
+        $charsetOrigin = 'utf-8';
         $response->setCharset($charsetOrigin);
         $charset = $response->getCharset();
         $this->assertEquals($charsetOrigin, $charset);
@@ -534,7 +534,7 @@ class ResponseTest extends ResponseTestCase
         $response = new Response('foo');
         $response->prepare(new Request());
 
-        $this->assertSame('text/html; charset=UTF-8', $response->headers->get('Content-Type'));
+        $this->assertSame('text/html; charset=utf-8', $response->headers->get('Content-Type'));
     }
 
     public function testContentTypeCharset()
@@ -545,7 +545,7 @@ class ResponseTest extends ResponseTestCase
         // force fixContentType() to be called
         $response->prepare(new Request());
 
-        $this->assertEquals('text/css; charset=UTF-8', $response->headers->get('Content-Type'));
+        $this->assertEquals('text/css; charset=utf-8', $response->headers->get('Content-Type'));
     }
 
     public function testContentTypeIsNull()
@@ -565,7 +565,7 @@ class ResponseTest extends ResponseTestCase
 
         $response->prepare(new Request());
 
-        $this->assertEquals('text/plain; charset=UTF-8', $response->headers->get('content-type'));
+        $this->assertEquals('text/plain; charset=utf-8', $response->headers->get('content-type'));
     }
 
     public function testPrepareDoesNothingIfRequestFormatIsNotDefined()
@@ -574,7 +574,7 @@ class ResponseTest extends ResponseTestCase
 
         $response->prepare(new Request());
 
-        $this->assertEquals('text/html; charset=UTF-8', $response->headers->get('content-type'));
+        $this->assertEquals('text/html; charset=utf-8', $response->headers->get('content-type'));
     }
 
     /**
@@ -588,7 +588,7 @@ class ResponseTest extends ResponseTestCase
         $request->headers->set('Accept', 'application/json');
         $response->prepare($request);
 
-        $this->assertSame('text/html; charset=UTF-8', $response->headers->get('content-type'));
+        $this->assertSame('text/html; charset=utf-8', $response->headers->get('content-type'));
     }
 
     public function testPrepareSetContentType()
@@ -1021,7 +1021,7 @@ class ResponseTest extends ResponseTestCase
 
         $setters = [
             'setProtocolVersion' => '1.0',
-            'setCharset' => 'UTF-8',
+            'setCharset' => 'utf-8',
             'setPublic' => null,
             'setPrivate' => null,
             'setDate' => $this->createDateTimeNow(),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | N/A
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Per the recommendations I found on https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Type#media-type and https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.1, it seems that using the lowercase variant is considered to be preferable.

An alternative approach would be to actually convert any charset argument to lowercase, which I would also be willing to implement if preferable. However, this is slightly more invasive, although it should function practically equivalent on any (modern) browser.