### PR TITLE
[JsonStreamer] lazyGhostsDir should be optional

### DIFF
--- a/src/Symfony/Component/JsonStreamer/JsonStreamReader.php
+++ b/src/Symfony/Component/JsonStreamer/JsonStreamReader.php
@@ -45,7 +45,7 @@ final class JsonStreamReader implements StreamReaderInterface
         private ContainerInterface $valueTransformers,
         PropertyMetadataLoaderInterface $propertyMetadataLoader,
         string $streamReadersDir,
-        string $lazyGhostsDir,
+        ?string $lazyGhostsDir = null,
     ) {
         $this->streamReaderGenerator = new StreamReaderGenerator($propertyMetadataLoader, $streamReadersDir);
         $this->instantiator = new Instantiator();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

At least to make FWB v8 compatible with JS v7.4