### PR TITLE
[DependencyInjection] Fix `ServiceLocatorTagPass` indexes handling

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/AsTaggedItem.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/AsTaggedItem.php
@@ -20,8 +20,8 @@ namespace Symfony\Component\DependencyInjection\Attribute;
 class AsTaggedItem
 {
     /**
-     * @param string|null $index    The property or method to use to index the item in the locator
-     * @param int|null    $priority The priority of the item; the higher the number, the earlier the tagged service will be located in the locator
+     * @param string|null $index    The property or method to use to index the item in the iterator/locator
+     * @param int|null    $priority The priority of the item; the higher the number, the earlier the tagged service will be located in the iterator/locator
      */
     public function __construct(
         public ?string $index = null,

--- a/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
@@ -87,8 +87,7 @@ trait PriorityTaggedServiceTrait
                 if (null === $index && null === $defaultIndex && $defaultPriorityMethod && $class) {
                     $defaultIndex = PriorityTaggedServiceUtil::getDefault($container, $serviceId, $class, $defaultIndexMethod ?? 'getDefaultName', $tagName, $indexAttribute, $checkTaggedItem);
                 }
-                $decorated = $definition->getTag('container.decorator')[0]['id'] ?? null;
-                $index = $index ?? $defaultIndex ?? $defaultIndex = $decorated ?? $serviceId;
+                $index ??= $defaultIndex ??= $definition->getTag('container.decorator')[0]['id'] ?? $serviceId;
 
                 $services[] = [$priority, ++$i, $index, $serviceId, $class];
             }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ServiceLocatorTagPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ServiceLocatorTagPassTest.php
@@ -86,6 +86,26 @@ class ServiceLocatorTagPassTest extends TestCase
         $this->assertSame(CustomDefinition::class, \get_class($locator('inlines.service')));
     }
 
+    public function testServiceListIsOrdered()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('bar', CustomDefinition::class);
+        $container->register('baz', CustomDefinition::class);
+
+        $container->register('foo', ServiceLocator::class)
+            ->setArguments([[
+                new Reference('baz'),
+                new Reference('bar'),
+            ]])
+            ->addTag('container.service_locator')
+        ;
+
+        (new ServiceLocatorTagPass())->process($container);
+
+        $this->assertSame(['bar', 'baz'], array_keys($container->getDefinition('foo')->getArgument(0)));
+    }
+
     public function testServiceWithKeyOverwritesPreviousInheritedKey()
     {
         $container = new ContainerBuilder();
@@ -170,6 +190,27 @@ class ServiceLocatorTagPassTest extends TestCase
         $this->assertSame(TestDefinition2::class, $locator('baz')::class);
     }
 
+    public function testTaggedServicesKeysAreKept()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('bar', TestDefinition1::class)->addTag('test_tag', ['index' => 0]);
+        $container->register('baz', TestDefinition2::class)->addTag('test_tag', ['index' => 1]);
+
+        $container->register('foo', ServiceLocator::class)
+            ->setArguments([new TaggedIteratorArgument('test_tag', 'index', null, true)])
+            ->addTag('container.service_locator')
+        ;
+
+        (new ServiceLocatorTagPass())->process($container);
+
+        /** @var ServiceLocator $locator */
+        $locator = $container->get('foo');
+
+        $this->assertSame(TestDefinition1::class, $locator(0)::class);
+        $this->assertSame(TestDefinition2::class, $locator(1)::class);
+    }
+
     public function testIndexedByServiceIdWithDecoration()
     {
         $container = new ContainerBuilder();
@@ -201,6 +242,24 @@ class ServiceLocatorTagPassTest extends TestCase
         static::assertInstanceOf(DecoratedService::class, $locator->get(Service::class));
     }
 
+    public function testServicesKeysAreKept()
+    {
+        $container = new ContainerBuilder();
+        $container->register('service-1');
+        $container->register('service-2');
+        $container->register('service-3');
+
+        $locator = ServiceLocatorTagPass::register($container, [
+            new Reference('service-1'),
+            'service-2' => new Reference('service-2'),
+            'foo' => new Reference('service-3'),
+        ]);
+        $locator = $container->getDefinition($locator);
+        $factories = $locator->getArguments()[0];
+
+        static::assertSame([0, 'service-2', 'foo'], array_keys($factories));
+    }
+
     public function testDefinitionOrderIsTheSame()
     {
         $container = new ContainerBuilder();
@@ -208,8 +267,8 @@ class ServiceLocatorTagPassTest extends TestCase
         $container->register('service-2');
 
         $locator = ServiceLocatorTagPass::register($container, [
-            new Reference('service-2'),
-            new Reference('service-1'),
+            'service-2' => new Reference('service-2'),
+            'service-1' => new Reference('service-1'),
         ]);
         $locator = $container->getDefinition($locator);
         $factories = $locator->getArguments()[0];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60651 
| License       | MIT

#50578 changed the `ServiceLocatorTagPass`’ behavior so that if the map is a list, its indexes always are replaced by the corresponding reference ID, even if they come from the `PriorityTaggedServiceTrait`. That means if your service map ends up as a list because e.g. your `default_index_method` returned contiguous integers, its indexes will be replaced.

This PR reverts this change so that it works the same than v6.