### PR TITLE
[Mailer] Modify  SmtpTransport so that SentMessage contains Mailersend message id when that transport is used

### DIFF
--- a/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
@@ -156,7 +156,7 @@ class SmtpTransport extends AbstractTransport
     {
         $regexps = [
             '/250 Ok (?P<id>[0-9a-f-]+)\r?$/mis',
-            '/250 Ok:? queued as (?P<id>[A-Z0-9]+)\r?$/mis',
+            '/250 (Ok:?|Message) queued as (?P<id>[A-Z0-9]+)\r?$/mis',
         ];
         $matches = [];
         foreach ($regexps as $regexp) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  6.4, 
| Bug fix?      | yes
| Issues        | Fix #60678
| License       | MIT

Change to regex in SmtpTransport::parseMessageId() so that it will capture Mailersend message id from $mtaResult.

(Hope I did this correctly).
