### PR TITLE
[FrameworkBundle] ensureKernelShutdown in KernelTestCase::tearDownAfterClass

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -45,6 +45,14 @@ abstract class KernelTestCase extends TestCase
         static::$booted = false;
     }
 
+    public static function tearDownAfterClass(): void
+    {
+        static::ensureKernelShutdown();
+        static::$class = null;
+        static::$kernel = null;
+        static::$booted = false;
+    }
+
     /**
      * @throws \RuntimeException
      * @throws \LogicException


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | None
| License       | MIT

Comes from https://github.com/symfony/symfony/pull/60564

This PR performs the following change: In `KernelTestCase`, the kernel is shut down after every test, as per the `static::ensureKernelShutdown()` call in the `tearDown` function. However, if one was to perform any extra code in their `tearDownAfterClass` and call `getContainer`, it would boot up a new kernel, which would then be left dangling. The main issue with that is that when the next Test class is executed, there would already be a booted kernel, so it could happen that it was pointing to dangling resources.

By adding this call to `static::ensureKernelShutdown` in the `tearDownAfterClass`, we can ensure that no dangling kernels are left even after the test class has finished.