### PR TITLE
[Intl] Add missing currency (NOK) localization (en_NO)

### DIFF
--- a/src/Symfony/Component/Intl/Resources/data/currencies/en_NO.php
+++ b/src/Symfony/Component/Intl/Resources/data/currencies/en_NO.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'Names' => [
+        'NOK' => [
+            'kr',
+            'Norwegian Krone',
+        ],
+    ],
+];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

While doing work for Intl component I noticed that this file was being generated and left unstaged. I am not sure if the last time I bumped ICU I forgot to stage this or not (my IDE hides unstaged files by default) but it is a tiny fix for future ICU updates. 
