### PR TITLE
[WebProfilerBundle] Fix typos in routing config deprecation messages

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/profiler.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/profiler.php
@@ -16,7 +16,7 @@ return function (RoutingConfigurator $routes): void {
     foreach (debug_backtrace(\DEBUG_BACKTRACE_PROVIDE_OBJECT) as $trace) {
         if (isset($trace['object']) && $trace['object'] instanceof XmlFileLoader && 'doImport' === $trace['function']) {
             if (__DIR__ === dirname(realpath($trace['args'][3]))) {
-                trigger_deprecation('symfony/routing', '7.3', 'The "profiler.xml" routing configuration file is deprecated, import "profile.php" instead.');
+                trigger_deprecation('symfony/routing', '7.3', 'The "profiler.xml" routing configuration file is deprecated, import "profiler.php" instead.');
 
                 break;
             }

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/wdt.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/wdt.php
@@ -16,7 +16,7 @@ return function (RoutingConfigurator $routes): void {
     foreach (debug_backtrace(\DEBUG_BACKTRACE_PROVIDE_OBJECT) as $trace) {
         if (isset($trace['object']) && $trace['object'] instanceof XmlFileLoader && 'doImport' === $trace['function']) {
             if (__DIR__ === dirname(realpath($trace['args'][3]))) {
-                trigger_deprecation('symfony/routing', '7.3', 'The "xdt.xml" routing configuration file is deprecated, import "xdt.php" instead.');
+                trigger_deprecation('symfony/routing', '7.3', 'The "wdt.xml" routing configuration file is deprecated, import "wdt.php" instead.');
 
                 break;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Fixes some typos in the deprecation messages introduced in https://github.com/symfony/symfony/pull/60232.