### PR TITLE
[FrameworkBundle] Fix allow `loose` as an email validation mode

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1067,7 +1067,7 @@ class Configuration implements ConfigurationInterface
                             ->validate()->castToArray()->end()
                         ->end()
                         ->scalarNode('translation_domain')->defaultValue('validators')->end()
-                        ->enumNode('email_validation_mode')->values((class_exists(Email::class) ? Email::VALIDATION_MODES : ['html5-allow-no-tld', 'html5', 'strict']) + ['loose'])->end()
+                        ->enumNode('email_validation_mode')->values(array_merge(class_exists(Email::class) ? Email::VALIDATION_MODES : ['html5-allow-no-tld', 'html5', 'strict'], ['loose']))->end()
                         ->arrayNode('mapping')
                             ->addDefaultsIfNotSet()
                             ->fixXmlConfig('path')

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/PhpFrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/PhpFrameworkExtensionTest.php
@@ -272,5 +272,6 @@ class PhpFrameworkExtensionTest extends FrameworkExtensionTestCase
         foreach (Email::VALIDATION_MODES as $mode) {
             yield [$mode];
         }
+        yield ['loose'];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

After upgrading to Symfony 7.2.7 we observe this error:

```
In EnumNode.php line 82:
                                                                               
  The value "loose" is not allowed for path "framework.validation.email_valid  
  ation_mode". Permissible values: "html5-allow-no-tld", "html5", "strict"     
                                                                               
```

Our configuration is:

```yaml
framework:
    ...
    validation:
        ...
        email_validation_mode: loose
```

From `bin/console config:dump-reference framework` we observe:

```
framework:
...
    validation:
        ...
        email_validation_mode: html5 # One of "html5-allow-no-tld"; "html5"; "strict"
```

After this change, the above error no longer occurs and expected allowed values are observed:

```
$ php bin/console config:dump-reference framework
framework:
...
    validation:
        ...
        email_validation_mode: ~ # One of "html5-allow-no-tld"; "html5"; "strict"; "loose"
```

See https://github.com/symfony/symfony/pull/60373 and https://github.com/symfony/symfony/pull/60365 where the previous code was introduced.
