### PR TITLE
[FrameworkBundle] Deprecate `loose` as an email validation mode

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1020,7 +1020,7 @@ class Configuration implements ConfigurationInterface
                             ->validate()->castToArray()->end()
                         ->end()
                         ->scalarNode('translation_domain')->defaultValue('validators')->end()
-                        ->enumNode('email_validation_mode')->values((class_exists(Email::class) ? Email::VALIDATION_MODES : ['html5-allow-no-tld', 'html5', 'strict']) + ['loose'])->defaultValue('html5')->end()
+                        ->enumNode('email_validation_mode')->values(class_exists(Email::class) ? Email::VALIDATION_MODES : ['html5-allow-no-tld', 'html5', 'strict'])->defaultValue('html5')->end()
                         ->arrayNode('mapping')
                             ->addDefaultsIfNotSet()
                             ->fixXmlConfig('path')

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1630,10 +1630,6 @@ class FrameworkExtension extends Extension
             throw new LogicException('Validation support cannot be enabled as the Validator component is not installed. Try running "composer require symfony/validator".');
         }
 
-        if (!isset($config['email_validation_mode'])) {
-            $config['email_validation_mode'] = 'loose';
-        }
-
         $loader->load('validator.php');
 
         $validatorBuilder = $container->getDefinition('validator.builder');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| License       | MIT

Follow up to https://github.com/symfony/symfony/pull/60705 to deprecate the `loose` email validation config, which is not supported. It is only allowed in 7.0 -> 7.3 for backwards compatibility with existing configs. This will need to be rebased after that PR is merged, which will also involve removing a test that will now fail.

I could not find a `UPGRADE-7.4.md` or a `7.4` section in `FrameworkBundle/CHANGELOG.md`. Should I add one?
