### PR TITLE
[Security] conflict with event-subscriber v8

### DIFF
--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": ">=8.2",
         "symfony/deprecation-contracts": "^2.5|^3",
+        "symfony/event-dispatcher": "^6.4|^7.0",
         "symfony/http-foundation": "^6.4|^7.0|^8.0",
         "symfony/http-kernel": "^6.4|^7.0|^8.0",
         "symfony/polyfill-mbstring": "~1.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`Http\Firewall` doesn't have return types in v7.4 to make upgrades smoother, but this also means that this class is not compatible with `EventSubscriberInterface` v8 since we added return types there.