### PR TITLE
[FrameworkBundle] Enable the property-info constructor extractor by default

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.0
+---
+
+ * Enable the property info constructor extractor by default
+
 7.3
 ---
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1281,19 +1281,10 @@ class Configuration implements ConfigurationInterface
                     ->children()
                         ->booleanNode('with_constructor_extractor')
                             ->info('Registers the constructor extractor.')
+                            ->defaultTrue()
                         ->end()
                     ->end()
                 ->end()
-            ->end()
-            ->validate()
-                ->ifTrue(fn ($v) => $v['property_info']['enabled'] && !isset($v['property_info']['with_constructor_extractor']))
-                ->then(function ($v) {
-                    $v['property_info']['with_constructor_extractor'] = false;
-
-                    trigger_deprecation('symfony/framework-bundle', '7.3', 'Not setting the "property_info.with_constructor_extractor" option explicitly is deprecated because its default value will change in version 8.0.');
-
-                    return $v;
-                })
             ->end()
         ;
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -826,7 +826,8 @@ class ConfigurationTest extends TestCase
             ],
             'property_info' => [
                 'enabled' => !class_exists(FullStack::class),
-            ] + (!class_exists(FullStack::class) ? ['with_constructor_extractor' => false] : []),
+                'with_constructor_extractor' => true,
+            ],
             'router' => [
                 'enabled' => false,
                 'default_uri' => null,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
@@ -74,10 +74,7 @@ $container->loadFromExtension('framework', [
             ],
         ],
     ],
-    'property_info' => [
-        'enabled' => true,
-        'with_constructor_extractor' => true,
-    ],
+    'property_info' => true,
     'type_info' => true,
     'ide' => 'file%%link%%format',
     'request' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/property_info.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/property_info.php
@@ -7,6 +7,5 @@ $container->loadFromExtension('framework', [
     'php_errors' => ['log' => true],
     'property_info' => [
         'enabled' => true,
-        'with_constructor_extractor' => false,
     ],
 ]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/property_info_without_constructor_extractor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/property_info_without_constructor_extractor.php
@@ -7,6 +7,6 @@ $container->loadFromExtension('framework', [
     'php_errors' => ['log' => true],
     'property_info' => [
         'enabled' => true,
-        'with_constructor_extractor' => true,
+        'with_constructor_extractor' => false,
     ],
 ]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_auto_mapping.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_auto_mapping.php
@@ -5,10 +5,7 @@ $container->loadFromExtension('framework', [
     'http_method_override' => false,
     'handle_all_throwables' => true,
     'php_errors' => ['log' => true],
-    'property_info' => [
-        'enabled' => true,
-        'with_constructor_extractor' => true,
-    ],
+    'property_info' => ['enabled' => true],
     'validation' => [
         'email_validation_mode' => 'html5',
         'auto_mapping' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
@@ -44,7 +44,7 @@
                 </framework:default-context>
             </framework:named-serializer>
         </framework:serializer>
-        <framework:property-info with-constructor-extractor="true" />
+        <framework:property-info />
         <framework:type-info />
         <framework:json-streamer />
     </framework:config>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/property_info.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/property_info.xml
@@ -8,6 +8,6 @@
     <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
         <framework:php-errors log="true" />
-        <framework:property-info enabled="true" with-constructor-extractor="false" />
+        <framework:property-info enabled="true" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/property_info_without_constructor_extractor.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/property_info_without_constructor_extractor.xml
@@ -8,6 +8,6 @@
     <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
         <framework:php-errors log="true" />
-        <framework:property-info enabled="true" with-constructor-extractor="true" />
+        <framework:property-info enabled="true" with-constructor-extractor="false" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_auto_mapping.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_auto_mapping.xml
@@ -6,7 +6,7 @@
     <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
         <framework:php-errors log="true" />
-        <framework:property-info enabled="true" with-constructor-extractor="true" />
+        <framework:property-info enabled="true" />
         <framework:validation email-validation-mode="html5">
             <framework:auto-mapping namespace="App\">
                 <framework:service>foo</framework:service>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
@@ -64,8 +64,7 @@ framework:
                  default_context:
                      enable_max_depth: false
     type_info: ~
-    property_info:
-        with_constructor_extractor: true
+    property_info: ~
     ide: file%%link%%format
     request:
         formats:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/property_info.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/property_info.yml
@@ -6,4 +6,3 @@ framework:
         log: true
     property_info:
         enabled: true
-        with_constructor_extractor: false

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/property_info_without_constructor_extractor.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/property_info_without_constructor_extractor.yml
@@ -6,4 +6,4 @@ framework:
         log: true
     property_info:
         enabled: true
-        with_constructor_extractor: true
+        with_constructor_extractor: false

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_auto_mapping.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_auto_mapping.yml
@@ -4,9 +4,7 @@ framework:
   handle_all_throwables: true
   php_errors:
     log: true
-  property_info:
-    enabled: true
-    with_constructor_extractor: true
+  property_info: { enabled: true }
   validation:
     email_validation_mode: html5
     auto_mapping:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -1773,14 +1773,14 @@ abstract class FrameworkExtensionTestCase extends TestCase
     {
         $container = $this->createContainerFromFile('property_info');
         $this->assertTrue($container->has('property_info'));
-        $this->assertFalse($container->has('property_info.constructor_extractor'));
+        $this->assertTrue($container->has('property_info.constructor_extractor'));
     }
 
-    public function testPropertyInfoWithConstructorExtractorEnabled()
+    public function testPropertyInfoWithConstructorExtractorDisabled()
     {
-        $container = $this->createContainerFromFile('property_info_with_constructor_extractor');
+        $container = $this->createContainerFromFile('property_info_without_constructor_extractor');
         $this->assertTrue($container->has('property_info'));
-        $this->assertTrue($container->has('property_info.constructor_extractor'));
+        $this->assertFalse($container->has('property_info.constructor_extractor'));
     }
 
     public function testPropertyInfoCacheActivated()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ApiAttributesTest/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ApiAttributesTest/config.yml
@@ -5,6 +5,4 @@ framework:
     serializer:
         enabled: true
     validation: true
-    property_info:
-        enabled: true
-        with_constructor_extractor: true
+    property_info: { enabled: true }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ContainerDump/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ContainerDump/config.yml
@@ -15,8 +15,6 @@ framework:
     translator: true
     validation: true
     serializer: true
-    property_info:
-        enabled: true
-        with_constructor_extractor: true
+    property_info: true
     csrf_protection: true
     form: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Serializer/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Serializer/config.yml
@@ -10,9 +10,7 @@ framework:
         max_depth_handler: Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Serializer\MaxDepthHandler
         default_context:
             enable_max_depth: true
-    property_info:
-        enabled: true
-        with_constructor_extractor: true
+    property_info: { enabled: true }
 
 services:
     serializer.alias:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Enable the constructor extractor by default & remove the related deprecation.