### PR TITLE
[VarDumper] Fix dumping LazyObjectState when using VarExporter v8

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/SymfonyCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/SymfonyCaster.php
@@ -90,12 +90,14 @@ class SymfonyCaster
 
         $instance = $a['realInstance'] ?? null;
 
-        $a = ['status' => new ConstStub(match ($a['status']) {
-            LazyObjectState::STATUS_INITIALIZED_FULL => 'INITIALIZED_FULL',
-            LazyObjectState::STATUS_INITIALIZED_PARTIAL => 'INITIALIZED_PARTIAL',
-            LazyObjectState::STATUS_UNINITIALIZED_FULL => 'UNINITIALIZED_FULL',
-            LazyObjectState::STATUS_UNINITIALIZED_PARTIAL => 'UNINITIALIZED_PARTIAL',
-        }, $a['status'])];
+        if (isset($a['status'])) { // forward-compat with Symfony 8
+            $a = ['status' => new ConstStub(match ($a['status']) {
+                LazyObjectState::STATUS_INITIALIZED_FULL => 'INITIALIZED_FULL',
+                LazyObjectState::STATUS_INITIALIZED_PARTIAL => 'INITIALIZED_PARTIAL',
+                LazyObjectState::STATUS_UNINITIALIZED_FULL => 'UNINITIALIZED_FULL',
+                LazyObjectState::STATUS_UNINITIALIZED_PARTIAL => 'UNINITIALIZED_PARTIAL',
+            }, $a['status'])];
+        }
 
         if ($instance) {
             $a['realInstance'] = $instance;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT
