### PR TITLE
 [JsonStreamer] Add `include_null_properties` option

### DIFF
--- a/src/Symfony/Component/JsonStreamer/CHANGELOG.md
+++ b/src/Symfony/Component/JsonStreamer/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Remove `nikic/php-parser` dependency
  * Add `_current_object` to the context passed to value transformers during write operations
+ * Add `include_null_properties` option to encode the properties with `null` value
 
 7.3
 ---

--- a/src/Symfony/Component/JsonStreamer/JsonStreamWriter.php
+++ b/src/Symfony/Component/JsonStreamer/JsonStreamWriter.php
@@ -29,7 +29,10 @@ use Symfony\Component\TypeInfo\TypeResolver\TypeResolver;
 /**
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  *
- * @implements StreamWriterInterface<array<string, mixed>>
+ * @implements StreamWriterInterface<array{
+ *     include_null_properties?: bool,
+ *     ...<string, mixed>,
+ * }>
  *
  * @experimental
  */

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Model/DummyWithDollarNamedProperties.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Model/DummyWithDollarNamedProperties.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Component\JsonStreamer\Tests\Fixtures\Model;
+
+use Symfony\Component\JsonStreamer\Attribute\StreamedName;
+
+class DummyWithDollarNamedProperties
+{
+    #[StreamedName('$foo')]
+    public bool $foo = true;
+
+    #[StreamedName('{$foo->bar}')]
+    public bool $bar = true;
+}

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/double_nested_list.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/double_nested_list.php
@@ -5,36 +5,41 @@
  */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
-        yield '[';
-        $prefix = '';
+        yield "[";
+        $prefix1 = '';
         foreach ($data as $value1) {
-            yield $prefix;
-            yield '{"dummies":[';
-            $prefix = '';
+            $prefix2 = '';
+            yield "{$prefix1}{{$prefix2}\"dummies\":";
+            yield "[";
+            $prefix3 = '';
             foreach ($value1->dummies as $value2) {
-                yield $prefix;
-                yield '{"dummies":[';
-                $prefix = '';
+                $prefix4 = '';
+                yield "{$prefix3}{{$prefix4}\"dummies\":";
+                yield "[";
+                $prefix5 = '';
                 foreach ($value2->dummies as $value3) {
-                    yield $prefix;
-                    yield '{"id":';
+                    $prefix6 = '';
+                    yield "{$prefix5}{{$prefix6}\"id\":";
                     yield \json_encode($value3->id, \JSON_THROW_ON_ERROR, 506);
-                    yield ',"name":';
+                    $prefix6 = ',';
+                    yield "{$prefix6}\"name\":";
                     yield \json_encode($value3->name, \JSON_THROW_ON_ERROR, 506);
-                    yield '}';
-                    $prefix = ',';
+                    yield "}";
+                    $prefix5 = ',';
                 }
-                yield '],"customProperty":';
+                $prefix4 = ',';
+                yield "]{$prefix4}\"customProperty\":";
                 yield \json_encode($value2->customProperty, \JSON_THROW_ON_ERROR, 508);
-                yield '}';
-                $prefix = ',';
+                yield "}";
+                $prefix3 = ',';
             }
-            yield '],"stringProperty":';
+            $prefix2 = ',';
+            yield "]{$prefix2}\"stringProperty\":";
             yield \json_encode($value1->stringProperty, \JSON_THROW_ON_ERROR, 510);
-            yield '}';
-            $prefix = ',';
+            yield "}";
+            $prefix1 = ',';
         }
-        yield ']';
+        yield "]";
     } catch (\JsonException $e) {
         throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
     }

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nested_list.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nested_list.php
@@ -5,27 +5,30 @@
  */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
-        yield '[';
-        $prefix = '';
+        yield "[";
+        $prefix1 = '';
         foreach ($data as $value1) {
-            yield $prefix;
-            yield '{"dummies":[';
-            $prefix = '';
+            $prefix2 = '';
+            yield "{$prefix1}{{$prefix2}\"dummies\":";
+            yield "[";
+            $prefix3 = '';
             foreach ($value1->dummies as $value2) {
-                yield $prefix;
-                yield '{"id":';
+                $prefix4 = '';
+                yield "{$prefix3}{{$prefix4}\"id\":";
                 yield \json_encode($value2->id, \JSON_THROW_ON_ERROR, 508);
-                yield ',"name":';
+                $prefix4 = ',';
+                yield "{$prefix4}\"name\":";
                 yield \json_encode($value2->name, \JSON_THROW_ON_ERROR, 508);
-                yield '}';
-                $prefix = ',';
+                yield "}";
+                $prefix3 = ',';
             }
-            yield '],"customProperty":';
+            $prefix2 = ',';
+            yield "]{$prefix2}\"customProperty\":";
             yield \json_encode($value1->customProperty, \JSON_THROW_ON_ERROR, 510);
-            yield '}';
-            $prefix = ',';
+            yield "}";
+            $prefix1 = ',';
         }
-        yield ']';
+        yield "]";
     } catch (\JsonException $e) {
         throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
     }

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/null.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/null.php
@@ -5,7 +5,7 @@
  */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
-        yield 'null';
+        yield "null";
     } catch (\JsonException $e) {
         throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
     }

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nullable_backed_enum.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nullable_backed_enum.php
@@ -8,7 +8,7 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $valueTra
         if ($data instanceof \Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum) {
             yield \json_encode($data->value, \JSON_THROW_ON_ERROR, 512);
         } elseif (null === $data) {
-            yield 'null';
+            yield "null";
         } else {
             throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value.', \get_debug_type($data)));
         }

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nullable_object.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nullable_object.php
@@ -6,13 +6,15 @@
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
         if ($data instanceof \Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes) {
-            yield '{"@id":';
+            $prefix1 = '';
+            yield "{{$prefix1}\"@id\":";
             yield \json_encode($data->id, \JSON_THROW_ON_ERROR, 511);
-            yield ',"name":';
+            $prefix1 = ',';
+            yield "{$prefix1}\"name\":";
             yield \json_encode($data->name, \JSON_THROW_ON_ERROR, 511);
-            yield '}';
+            yield "}";
         } elseif (null === $data) {
-            yield 'null';
+            yield "null";
         } else {
             throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value.', \get_debug_type($data)));
         }

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nullable_object_dict.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nullable_object_dict.php
@@ -6,21 +6,22 @@
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
         if (\is_array($data)) {
-            yield '{';
-            $prefix = '';
+            yield "{";
+            $prefix1 = '';
             foreach ($data as $key1 => $value1) {
                 $key1 = \substr(\json_encode($key1), 1, -1);
-                yield "{$prefix}\"{$key1}\":";
-                yield '{"@id":';
+                $prefix2 = '';
+                yield "{$prefix1}\"{$key1}\":{{$prefix2}\"@id\":";
                 yield \json_encode($value1->id, \JSON_THROW_ON_ERROR, 510);
-                yield ',"name":';
+                $prefix2 = ',';
+                yield "{$prefix2}\"name\":";
                 yield \json_encode($value1->name, \JSON_THROW_ON_ERROR, 510);
-                yield '}';
-                $prefix = ',';
+                yield "}";
+                $prefix1 = ',';
             }
-            yield '}';
+            yield "}";
         } elseif (null === $data) {
-            yield 'null';
+            yield "null";
         } else {
             throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value.', \get_debug_type($data)));
         }

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nullable_object_list.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nullable_object_list.php
@@ -6,20 +6,21 @@
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
         if (\is_array($data)) {
-            yield '[';
-            $prefix = '';
+            yield "[";
+            $prefix1 = '';
             foreach ($data as $value1) {
-                yield $prefix;
-                yield '{"@id":';
+                $prefix2 = '';
+                yield "{$prefix1}{{$prefix2}\"@id\":";
                 yield \json_encode($value1->id, \JSON_THROW_ON_ERROR, 510);
-                yield ',"name":';
+                $prefix2 = ',';
+                yield "{$prefix2}\"name\":";
                 yield \json_encode($value1->name, \JSON_THROW_ON_ERROR, 510);
-                yield '}';
-                $prefix = ',';
+                yield "}";
+                $prefix1 = ',';
             }
-            yield ']';
+            yield "]";
         } elseif (null === $data) {
-            yield 'null';
+            yield "null";
         } else {
             throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value.', \get_debug_type($data)));
         }

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_dict.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_dict.php
@@ -5,19 +5,20 @@
  */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
-        yield '{';
-        $prefix = '';
+        yield "{";
+        $prefix1 = '';
         foreach ($data as $key1 => $value1) {
             $key1 = \substr(\json_encode($key1), 1, -1);
-            yield "{$prefix}\"{$key1}\":";
-            yield '{"@id":';
+            $prefix2 = '';
+            yield "{$prefix1}\"{$key1}\":{{$prefix2}\"@id\":";
             yield \json_encode($value1->id, \JSON_THROW_ON_ERROR, 510);
-            yield ',"name":';
+            $prefix2 = ',';
+            yield "{$prefix2}\"name\":";
             yield \json_encode($value1->name, \JSON_THROW_ON_ERROR, 510);
-            yield '}';
-            $prefix = ',';
+            yield "}";
+            $prefix1 = ',';
         }
-        yield '}';
+        yield "}";
     } catch (\JsonException $e) {
         throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
     }

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_in_object.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_in_object.php
@@ -5,17 +5,25 @@
  */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
-        yield '{"name":';
+        $prefix1 = '';
+        yield "{{$prefix1}\"name\":";
         yield \json_encode($data->name, \JSON_THROW_ON_ERROR, 511);
-        yield ',"otherDummyOne":{"@id":';
+        $prefix1 = ',';
+        yield "{$prefix1}\"otherDummyOne\":";
+        $prefix2 = '';
+        yield "{{$prefix2}\"@id\":";
         yield \json_encode($data->otherDummyOne->id, \JSON_THROW_ON_ERROR, 510);
-        yield ',"name":';
+        $prefix2 = ',';
+        yield "{$prefix2}\"name\":";
         yield \json_encode($data->otherDummyOne->name, \JSON_THROW_ON_ERROR, 510);
-        yield '},"otherDummyTwo":{"id":';
+        yield "}{$prefix1}\"otherDummyTwo\":";
+        $prefix2 = '';
+        yield "{{$prefix2}\"id\":";
         yield \json_encode($data->otherDummyTwo->id, \JSON_THROW_ON_ERROR, 510);
-        yield ',"name":';
+        $prefix2 = ',';
+        yield "{$prefix2}\"name\":";
         yield \json_encode($data->otherDummyTwo->name, \JSON_THROW_ON_ERROR, 510);
-        yield '}}';
+        yield "}}";
     } catch (\JsonException $e) {
         throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
     }

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_iterable.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_iterable.php
@@ -5,19 +5,20 @@
  */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
-        yield '{';
-        $prefix = '';
+        yield "{";
+        $prefix1 = '';
         foreach ($data as $key1 => $value1) {
             $key1 = is_int($key1) ? $key1 : \substr(\json_encode($key1), 1, -1);
-            yield "{$prefix}\"{$key1}\":";
-            yield '{"id":';
+            $prefix2 = '';
+            yield "{$prefix1}\"{$key1}\":{{$prefix2}\"id\":";
             yield \json_encode($value1->id, \JSON_THROW_ON_ERROR, 510);
-            yield ',"name":';
+            $prefix2 = ',';
+            yield "{$prefix2}\"name\":";
             yield \json_encode($value1->name, \JSON_THROW_ON_ERROR, 510);
-            yield '}';
-            $prefix = ',';
+            yield "}";
+            $prefix1 = ',';
         }
-        yield '}';
+        yield "}";
     } catch (\JsonException $e) {
         throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
     }

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_list.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_list.php
@@ -5,18 +5,19 @@
  */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
-        yield '[';
-        $prefix = '';
+        yield "[";
+        $prefix1 = '';
         foreach ($data as $value1) {
-            yield $prefix;
-            yield '{"@id":';
+            $prefix2 = '';
+            yield "{$prefix1}{{$prefix2}\"@id\":";
             yield \json_encode($value1->id, \JSON_THROW_ON_ERROR, 510);
-            yield ',"name":';
+            $prefix2 = ',';
+            yield "{$prefix2}\"name\":";
             yield \json_encode($value1->name, \JSON_THROW_ON_ERROR, 510);
-            yield '}';
-            $prefix = ',';
+            yield "}";
+            $prefix1 = ',';
         }
-        yield ']';
+        yield "]";
     } catch (\JsonException $e) {
         throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
     }

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_dollar_named_properties.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_dollar_named_properties.php
@@ -1,16 +1,16 @@
 <?php
 
 /**
- * @param Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes $data
+ * @param Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDollarNamedProperties $data
  */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
         $prefix1 = '';
-        yield "{{$prefix1}\"@id\":";
-        yield \json_encode($data->id, \JSON_THROW_ON_ERROR, 511);
+        yield "{{$prefix1}\"\$foo\":";
+        yield $data->foo ? 'true' : 'false';
         $prefix1 = ',';
-        yield "{$prefix1}\"name\":";
-        yield \json_encode($data->name, \JSON_THROW_ON_ERROR, 511);
+        yield "{$prefix1}\"{\$foo->bar}\":";
+        yield $data->bar ? 'true' : 'false';
         yield "}";
     } catch (\JsonException $e) {
         throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_union.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_union.php
@@ -5,17 +5,22 @@
  */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
-        yield '{"value":';
-        if ($data->value instanceof \Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum) {
-            yield \json_encode($data->value->value, \JSON_THROW_ON_ERROR, 511);
-        } elseif (null === $data->value) {
-            yield 'null';
-        } elseif (\is_string($data->value)) {
-            yield \json_encode($data->value, \JSON_THROW_ON_ERROR, 511);
-        } else {
-            throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value.', \get_debug_type($data->value)));
+        $prefix1 = '';
+        yield "{";
+        if (null === $data->value && ($options['include_null_properties'] ?? false)) {
+            yield "{$prefix1}\"value\":null";
         }
-        yield '}';
+        if (null !== $data->value) {
+            yield "{$prefix1}\"value\":";
+            if ($data->value instanceof \Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum) {
+                yield \json_encode($data->value->value, \JSON_THROW_ON_ERROR, 511);
+            } elseif (\is_string($data->value)) {
+                yield \json_encode($data->value, \JSON_THROW_ON_ERROR, 511);
+            } else {
+                throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value.', \get_debug_type($data->value)));
+            }
+        }
+        yield "}";
     } catch (\JsonException $e) {
         throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
     }

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_value_transformer.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_value_transformer.php
@@ -5,15 +5,17 @@
  */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
-        yield '{"id":';
+        $prefix1 = '';
+        yield "{{$prefix1}\"id\":";
         yield \json_encode($valueTransformers->get('Symfony\Component\JsonStreamer\Tests\Fixtures\ValueTransformer\DoubleIntAndCastToStringValueTransformer')->transform($data->id, ['_current_object' => $data] + $options), \JSON_THROW_ON_ERROR, 511);
-        yield ',"active":';
+        $prefix1 = ',';
+        yield "{$prefix1}\"active\":";
         yield \json_encode($valueTransformers->get('Symfony\Component\JsonStreamer\Tests\Fixtures\ValueTransformer\BooleanToStringValueTransformer')->transform($data->active, ['_current_object' => $data] + $options), \JSON_THROW_ON_ERROR, 511);
-        yield ',"name":';
+        yield "{$prefix1}\"name\":";
         yield \json_encode(strtolower($data->name), \JSON_THROW_ON_ERROR, 511);
-        yield ',"range":';
+        yield "{$prefix1}\"range\":";
         yield \json_encode(Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithValueTransformerAttributes::concatRange($data->range, ['_current_object' => $data] + $options), \JSON_THROW_ON_ERROR, 511);
-        yield '}';
+        yield "}";
     } catch (\JsonException $e) {
         throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
     }

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/self_referencing_object.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/self_referencing_object.php
@@ -8,15 +8,16 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $valueTra
         if ($depth >= 512) {
             throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException('Maximum stack depth exceeded');
         }
-        yield '{"@self":';
-        if ($data->self instanceof \Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummy) {
-            yield from $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummy']($data->self, $depth + 1);
-        } elseif (null === $data->self) {
-            yield 'null';
-        } else {
-            throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value.', \get_debug_type($data->self)));
+        $prefix1 = '';
+        yield "{";
+        if (null === $data->self && ($options['include_null_properties'] ?? false)) {
+            yield "{$prefix1}\"@self\":null";
         }
-        yield '}';
+        if (null !== $data->self) {
+            yield "{$prefix1}\"@self\":";
+            yield from $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummy']($data->self, $depth + 1);
+        }
+        yield "}";
     };
     try {
         yield from $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummy']($data, 0);

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/union.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/union.php
@@ -6,20 +6,22 @@
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
         if (\is_array($data)) {
-            yield '[';
-            $prefix = '';
+            yield "[";
+            $prefix1 = '';
             foreach ($data as $value1) {
-                yield $prefix;
+                yield "{$prefix1}";
                 yield \json_encode($value1->value, \JSON_THROW_ON_ERROR, 511);
-                $prefix = ',';
+                $prefix1 = ',';
             }
-            yield ']';
+            yield "]";
         } elseif ($data instanceof \Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes) {
-            yield '{"@id":';
+            $prefix1 = '';
+            yield "{{$prefix1}\"@id\":";
             yield \json_encode($data->id, \JSON_THROW_ON_ERROR, 511);
-            yield ',"name":';
+            $prefix1 = ',';
+            yield "{$prefix1}\"name\":";
             yield \json_encode($data->name, \JSON_THROW_ON_ERROR, 511);
-            yield '}';
+            yield "}";
         } elseif (\is_int($data)) {
             yield \json_encode($data, \JSON_THROW_ON_ERROR, 512);
         } else {

--- a/src/Symfony/Component/JsonStreamer/Tests/JsonStreamWriterTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/JsonStreamWriterTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithArray;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDateTimes;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDollarNamedProperties;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithGenerics;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNestedArray;
@@ -81,7 +82,7 @@ class JsonStreamWriterTest extends TestCase
         $this->assertWritten('{"value":"foo"}', $dummy, Type::object(DummyWithUnionProperties::class));
 
         $dummy->value = null;
-        $this->assertWritten('{"value":null}', $dummy, Type::object(DummyWithUnionProperties::class));
+        $this->assertWritten('{}', $dummy, Type::object(DummyWithUnionProperties::class));
     }
 
     public function testWriteCollection()
@@ -238,7 +239,18 @@ class JsonStreamWriterTest extends TestCase
     {
         $dummy = new DummyWithNullableProperties();
 
-        $this->assertWritten('{"name":null,"enum":null}', $dummy, Type::object(DummyWithNullableProperties::class));
+        $this->assertWritten('{}', $dummy, Type::object(DummyWithNullableProperties::class));
+
+        $dummy->name = 'name';
+
+        $this->assertWritten('{"name":"name"}', $dummy, Type::object(DummyWithNullableProperties::class));
+        $this->assertWritten('{"name":"name","enum":null}', $dummy, Type::object(DummyWithNullableProperties::class), options: ['include_null_properties' => true]);
+
+        $dummy->name = null;
+        $dummy->enum = DummyBackedEnum::ONE;
+
+        $this->assertWritten('{"enum":1}', $dummy, Type::object(DummyWithNullableProperties::class));
+        $this->assertWritten('{"name":null,"enum":1}', $dummy, Type::object(DummyWithNullableProperties::class), options: ['include_null_properties' => true]);
     }
 
     public function testWriteObjectWithDateTimes()
@@ -253,6 +265,11 @@ class JsonStreamWriterTest extends TestCase
             Type::object(DummyWithDateTimes::class),
             options: [DateTimeToStringValueTransformer::FORMAT_KEY => 'Y-m-d'],
         );
+    }
+
+    public function testWriteObjectWithDollarNamedProperties()
+    {
+        $this->assertWritten('{"$foo":true,"{$foo->bar}":true}', new DummyWithDollarNamedProperties(), Type::object(DummyWithDollarNamedProperties::class));
     }
 
     /**

--- a/src/Symfony/Component/JsonStreamer/Tests/Write/StreamWriterGeneratorTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Write/StreamWriterGeneratorTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyEnum;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithArray;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDollarNamedProperties;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNestedArray;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithOtherDummies;
@@ -110,6 +111,7 @@ class StreamWriterGeneratorTest extends TestCase
         yield ['object_in_object', Type::object(DummyWithOtherDummies::class)];
         yield ['object_with_value_transformer', Type::object(DummyWithValueTransformerAttributes::class)];
         yield ['self_referencing_object', Type::object(SelfReferencingDummy::class)];
+        yield ['object_with_dollar_named_properties', Type::object(DummyWithDollarNamedProperties::class)];
 
         yield ['union', Type::union(Type::int(), Type::list(Type::enum(DummyBackedEnum::class)), Type::object(DummyWithNameAttributes::class))];
         yield ['object_with_union', Type::object(DummyWithUnionProperties::class)];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

A really common use case in APIs is to be able to skip properties with `null` value (for instance, this use case is required to make the JsonStreamer component working with API Platform).

~This PR adds the option `skip_null_properties` that allow to skip `null` properties during stream writing.~
~This PR skips properties with `nulln` values during stream writing.~
This PR adds the option `include_null_properties` that allow to encode `null` properties during stream writing.


This requires to define dynamic object prefixes (such as `''` and `','`). That's why the PHP generated code has been updated to merge as many prefixes as possible in raw strings and therefore yield a bit bigger chunks.
