### PR TITLE
[JsonStreamer] Add PHPDoc to generated code

### DIFF
--- a/src/Symfony/Component/JsonStreamer/Read/PhpGenerator.php
+++ b/src/Symfony/Component/JsonStreamer/Read/PhpGenerator.php
@@ -51,6 +51,9 @@ final class PhpGenerator
         if ($decodeFromStream) {
             return $this->line('<?php', $context)
                 .$this->line('', $context)
+                .$this->line('/**', $context)
+                .$this->line(' * @return '.$dataModel->getType(), $context)
+                .$this->line(' */', $context)
                 .$this->line('return static function (mixed $stream, \\'.ContainerInterface::class.' $valueTransformers, \\'.LazyInstantiator::class.' $instantiator, array $options): mixed {', $context)
                 .$providers
                 .($this->canBeDecodedWithJsonDecode($dataModel, $decodeFromStream)
@@ -61,6 +64,9 @@ final class PhpGenerator
 
         return $this->line('<?php', $context)
             .$this->line('', $context)
+            .$this->line('/**', $context)
+            .$this->line(' * @return '.$dataModel->getType(), $context)
+            .$this->line(' */', $context)
             .$this->line('return static function (string|\\Stringable $string, \\'.ContainerInterface::class.' $valueTransformers, \\'.Instantiator::class.' $instantiator, array $options): mixed {', $context)
             .$providers
             .($this->canBeDecodedWithJsonDecode($dataModel, $decodeFromStream)

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/backed_enum.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/backed_enum.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum
+ */
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
     $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum'] = static function ($data) {
         return \Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum::from($data);

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/backed_enum.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/backed_enum.stream.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum
+ */
 return static function (mixed $stream, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
     $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum'] = static function ($stream, $offset, $length) {
         return \Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum::from(\Symfony\Component\JsonStreamer\Read\Decoder::decodeStream($stream, $offset, $length));

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/dict.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/dict.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return array<string,mixed>
+ */
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
     return \Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string);
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/dict.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/dict.stream.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return array<string,mixed>
+ */
 return static function (mixed $stream, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
     $providers['array<string,mixed>'] = static function ($stream, $offset, $length) use ($options, $valueTransformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitDict($stream, $offset, $length);

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/iterable.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/iterable.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return iterable
+ */
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
     return \Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string);
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/iterable.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/iterable.stream.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return iterable
+ */
 return static function (mixed $stream, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
     $providers['iterable'] = static function ($stream, $offset, $length) use ($options, $valueTransformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitDict($stream, $offset, $length);

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/list.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/list.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return array<int,mixed>
+ */
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
     return \Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string);
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/list.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/list.stream.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return array<int,mixed>
+ */
 return static function (mixed $stream, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
     $providers['array<int,mixed>'] = static function ($stream, $offset, $length) use ($options, $valueTransformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitList($stream, $offset, $length);

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/mixed.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/mixed.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return mixed
+ */
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
     return \Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string);
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/mixed.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/mixed.stream.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return mixed
+ */
 return static function (mixed $stream, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
     return \Symfony\Component\JsonStreamer\Read\Decoder::decodeStream($stream, 0, null);
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/null.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/null.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return null
+ */
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
     return \Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string);
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/null.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/null.stream.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return null
+ */
 return static function (mixed $stream, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
     return \Symfony\Component\JsonStreamer\Read\Decoder::decodeStream($stream, 0, null);
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_backed_enum.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_backed_enum.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null
+ */
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
     $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum'] = static function ($data) {
         return \Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum::from($data);

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_backed_enum.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_backed_enum.stream.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null
+ */
 return static function (mixed $stream, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
     $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum'] = static function ($stream, $offset, $length) {
         return \Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum::from(\Symfony\Component\JsonStreamer\Read\Decoder::decodeStream($stream, $offset, $length));

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy|null
+ */
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
     $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy'] = static function ($data) use ($options, $valueTransformers, $instantiator, &$providers) {
         return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy::class, \array_filter(['id' => $data['id'] ?? '_symfony_missing_value', 'name' => $data['name'] ?? '_symfony_missing_value'], static function ($v) {

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object.stream.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy|null
+ */
 return static function (mixed $stream, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
     $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy'] = static function ($stream, $offset, $length) use ($options, $valueTransformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitDict($stream, $offset, $length);

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object_dict.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object_dict.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return array<string,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null
+ */
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
     $providers['array<string,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>'] = static function ($data) use ($options, $valueTransformers, $instantiator, &$providers) {
         $iterable = static function ($data) use ($options, $valueTransformers, $instantiator, &$providers) {

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object_dict.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object_dict.stream.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return array<string,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null
+ */
 return static function (mixed $stream, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
     $providers['array<string,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>'] = static function ($stream, $offset, $length) use ($options, $valueTransformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitDict($stream, $offset, $length);

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object_list.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object_list.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null
+ */
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
     $providers['array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>'] = static function ($data) use ($options, $valueTransformers, $instantiator, &$providers) {
         $iterable = static function ($data) use ($options, $valueTransformers, $instantiator, &$providers) {

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object_list.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object_list.stream.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null
+ */
 return static function (mixed $stream, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
     $providers['array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>'] = static function ($stream, $offset, $length) use ($options, $valueTransformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitList($stream, $offset, $length);

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy
+ */
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
     $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy'] = static function ($data) use ($options, $valueTransformers, $instantiator, &$providers) {
         return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy::class, \array_filter(['id' => $data['id'] ?? '_symfony_missing_value', 'name' => $data['name'] ?? '_symfony_missing_value'], static function ($v) {

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object.stream.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy
+ */
 return static function (mixed $stream, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
     $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy'] = static function ($stream, $offset, $length) use ($options, $valueTransformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitDict($stream, $offset, $length);

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_dict.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_dict.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return array<string,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>
+ */
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
     $providers['array<string,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>'] = static function ($data) use ($options, $valueTransformers, $instantiator, &$providers) {
         $iterable = static function ($data) use ($options, $valueTransformers, $instantiator, &$providers) {

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_dict.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_dict.stream.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return array<string,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>
+ */
 return static function (mixed $stream, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
     $providers['array<string,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>'] = static function ($stream, $offset, $length) use ($options, $valueTransformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitDict($stream, $offset, $length);

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_in_object.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_in_object.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithOtherDummies
+ */
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
     $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithOtherDummies'] = static function ($data) use ($options, $valueTransformers, $instantiator, &$providers) {
         return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithOtherDummies::class, \array_filter(['name' => $data['name'] ?? '_symfony_missing_value', 'otherDummyOne' => \array_key_exists('otherDummyOne', $data) ? $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes']($data['otherDummyOne']) : '_symfony_missing_value', 'otherDummyTwo' => \array_key_exists('otherDummyTwo', $data) ? $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy']($data['otherDummyTwo']) : '_symfony_missing_value'], static function ($v) {

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_in_object.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_in_object.stream.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithOtherDummies
+ */
 return static function (mixed $stream, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
     $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithOtherDummies'] = static function ($stream, $offset, $length) use ($options, $valueTransformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitDict($stream, $offset, $length);

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_iterable.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_iterable.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return iterable<int|string,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>
+ */
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
     $providers['iterable<int|string,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>'] = static function ($data) use ($options, $valueTransformers, $instantiator, &$providers) {
         $iterable = static function ($data) use ($options, $valueTransformers, $instantiator, &$providers) {

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_iterable.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_iterable.stream.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return iterable<int|string,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>
+ */
 return static function (mixed $stream, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
     $providers['iterable<int|string,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>'] = static function ($stream, $offset, $length) use ($options, $valueTransformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitDict($stream, $offset, $length);

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_list.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_list.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>
+ */
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
     $providers['array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>'] = static function ($data) use ($options, $valueTransformers, $instantiator, &$providers) {
         $iterable = static function ($data) use ($options, $valueTransformers, $instantiator, &$providers) {

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_list.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_list.stream.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>
+ */
 return static function (mixed $stream, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
     $providers['array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>'] = static function ($stream, $offset, $length) use ($options, $valueTransformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitList($stream, $offset, $length);

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_nullable_properties.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_nullable_properties.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNullableProperties
+ */
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
     $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNullableProperties'] = static function ($data) use ($options, $valueTransformers, $instantiator, &$providers) {
         return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNullableProperties::class, \array_filter(['name' => $data['name'] ?? '_symfony_missing_value', 'enum' => \array_key_exists('enum', $data) ? $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null']($data['enum']) : '_symfony_missing_value'], static function ($v) {

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_nullable_properties.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_nullable_properties.stream.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNullableProperties
+ */
 return static function (mixed $stream, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
     $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNullableProperties'] = static function ($stream, $offset, $length) use ($options, $valueTransformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitDict($stream, $offset, $length);

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_union.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_union.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithUnionProperties
+ */
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
     $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithUnionProperties'] = static function ($data) use ($options, $valueTransformers, $instantiator, &$providers) {
         return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithUnionProperties::class, \array_filter(['value' => \array_key_exists('value', $data) ? $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null|string']($data['value']) : '_symfony_missing_value'], static function ($v) {

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_union.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_union.stream.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithUnionProperties
+ */
 return static function (mixed $stream, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
     $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithUnionProperties'] = static function ($stream, $offset, $length) use ($options, $valueTransformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitDict($stream, $offset, $length);

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_value_transformer.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_value_transformer.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithValueTransformerAttributes
+ */
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
     $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithValueTransformerAttributes'] = static function ($data) use ($options, $valueTransformers, $instantiator, &$providers) {
         return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithValueTransformerAttributes::class, \array_filter(['id' => $valueTransformers->get('Symfony\Component\JsonStreamer\Tests\Fixtures\ValueTransformer\DivideStringAndCastToIntValueTransformer')->transform($data['id'] ?? '_symfony_missing_value', $options), 'active' => $valueTransformers->get('Symfony\Component\JsonStreamer\Tests\Fixtures\ValueTransformer\StringToBooleanValueTransformer')->transform($data['active'] ?? '_symfony_missing_value', $options), 'name' => strtoupper($data['name'] ?? '_symfony_missing_value'), 'range' => Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithValueTransformerAttributes::explodeRange($data['range'] ?? '_symfony_missing_value', $options)], static function ($v) {

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_value_transformer.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_value_transformer.stream.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithValueTransformerAttributes
+ */
 return static function (mixed $stream, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
     $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithValueTransformerAttributes'] = static function ($stream, $offset, $length) use ($options, $valueTransformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitDict($stream, $offset, $length);

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/scalar.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/scalar.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return int
+ */
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
     return \Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string);
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/scalar.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/scalar.stream.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return int
+ */
 return static function (mixed $stream, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
     return \Symfony\Component\JsonStreamer\Read\Decoder::decodeStream($stream, 0, null);
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/union.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/union.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes|array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>|int
+ */
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
     $providers['array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>'] = static function ($data) use ($options, $valueTransformers, $instantiator, &$providers) {
         $iterable = static function ($data) use ($options, $valueTransformers, $instantiator, &$providers) {

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/union.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/union.stream.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes|array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>|int
+ */
 return static function (mixed $stream, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
     $providers['array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>'] = static function ($stream, $offset, $length) use ($options, $valueTransformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitList($stream, $offset, $length);

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/backed_enum.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/backed_enum.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @param Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum $data
+ */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
         yield \json_encode($data->value, \JSON_THROW_ON_ERROR, 512);

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/bool.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/bool.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @param bool $data
+ */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
         yield $data ? 'true' : 'false';

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/bool_list.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/bool_list.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @param array<int,bool> $data
+ */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
         yield \json_encode($data, \JSON_THROW_ON_ERROR, 512);

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/dict.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/dict.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @param array<string,mixed> $data
+ */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
         yield \json_encode($data, \JSON_THROW_ON_ERROR, 512);

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/iterable.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/iterable.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @param iterable $data
+ */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
         yield \json_encode($data, \JSON_THROW_ON_ERROR, 512);

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/list.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/list.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @param array<int,mixed> $data
+ */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
         yield \json_encode($data, \JSON_THROW_ON_ERROR, 512);

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/mixed.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/mixed.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @param mixed $data
+ */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
         yield \json_encode($data, \JSON_THROW_ON_ERROR, 512);

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/null.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/null.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @param null $data
+ */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
         yield 'null';

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/null_list.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/null_list.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @param array<int,null> $data
+ */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
         yield \json_encode($data, \JSON_THROW_ON_ERROR, 512);

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nullable_backed_enum.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nullable_backed_enum.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @param Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null $data
+ */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
         if ($data instanceof \Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum) {

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nullable_object.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nullable_object.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @param Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes|null $data
+ */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
         if ($data instanceof \Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes) {

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nullable_object_dict.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nullable_object_dict.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @param array<string,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes>|null $data
+ */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
         if (\is_array($data)) {

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nullable_object_list.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nullable_object_list.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @param array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes>|null $data
+ */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
         if (\is_array($data)) {

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @param Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes $data
+ */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
         yield '{"@id":';

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_dict.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_dict.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @param array<string,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes> $data
+ */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
         yield '{';

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_in_object.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_in_object.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @param Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithOtherDummies $data
+ */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
         yield '{"name":';

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_iterable.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_iterable.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @param iterable<int|string,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy> $data
+ */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
         yield '{';

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_list.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_list.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @param array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes> $data
+ */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
         yield '[';

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_union.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_union.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @param Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithUnionProperties $data
+ */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
         yield '{"value":';

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_value_transformer.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_value_transformer.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @param Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithValueTransformerAttributes $data
+ */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
         yield '{"id":';

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/scalar.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/scalar.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @param int $data
+ */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
         yield \json_encode($data, \JSON_THROW_ON_ERROR, 512);

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/self_referencing_object.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/self_referencing_object.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @param Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummy $data
+ */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummy'] = static function ($data, $depth) use ($valueTransformers, $options, &$generators) {
         if ($depth >= 512) {

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/union.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/union.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @param Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes|array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>|int $data
+ */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
         if (\is_array($data)) {

--- a/src/Symfony/Component/JsonStreamer/Write/PhpGenerator.php
+++ b/src/Symfony/Component/JsonStreamer/Write/PhpGenerator.php
@@ -61,6 +61,9 @@ final class PhpGenerator
 
         return $this->line('<?php', $context)
             .$this->line('', $context)
+            .$this->line('/**', $context)
+            .$this->line(' * @param '.$dataModel->getType().' $data', $context)
+            .$this->line(' */', $context)
             .$this->line('return static function (mixed $data, \\'.ContainerInterface::class.' $valueTransformers, array $options): \\Traversable {', $context)
             .implode('', $generators)
             .$this->line('    try {', $context)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

In order to ease debugging of generated code, it is useful to know which type is related to a given generated PHP file.
That's why this PR add some PHPDoc in order know which type is handled.