### PR TITLE
[DependencyInjection] Improve docblock on compile()

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -742,10 +742,11 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      *  * The parameter bag is frozen;
      *  * Extension loading is disabled.
      *
-     * @param bool $resolveEnvPlaceholders Whether %env()% parameters should be resolved using the current
-     *                                     env vars or be replaced by uniquely identifiable placeholders.
-     *                                     Set to "true" when you want to use the current ContainerBuilder
-     *                                     directly, keep to "false" when the container is dumped instead.
+     * @param bool $resolveEnvPlaceholders Whether %env()% parameters should be resolved at build time using
+     *                                     the current env var values (true), or be resolved at runtime based
+     *                                     on the environment (false). In general, this should be set to "true"
+     *                                     when you want to use the current ContainerBuilder directly, and to
+     *                                     "false" when the container is dumped instead.
      *
      * @return void
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

This is just a documentation fix to make the `$resolveEnvPlaceholders` parameter more self-explanatory.  Its current form confused me greatly and I had it set wrong because I was confused.