### PR TITLE
[DoctrineBridge] require PropertyInfo 8.0+ in the Doctrine bridge

### DIFF
--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -40,7 +40,7 @@
         "symfony/lock": "^7.4|^8.0",
         "symfony/messenger": "^7.4|^8.0",
         "symfony/property-access": "^7.4|^8.0",
-        "symfony/property-info": "^7.4|^8.0",
+        "symfony/property-info": "^8.0",
         "symfony/security-core": "^7.4|^8.0",
         "symfony/stopwatch": "^7.4|^8.0",
         "symfony/translation": "^7.4|^8.0",
@@ -53,7 +53,8 @@
         "doctrine/collections": "<1.8",
         "doctrine/dbal": "<3.6",
         "doctrine/lexer": "<1.1",
-        "doctrine/orm": "<2.15"
+        "doctrine/orm": "<2.15",
+        "symfony/property-info": "<8.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Bridge\\Doctrine\\": "" },

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/PropertyInfoLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/PropertyInfoLoaderTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\PropertyAccessExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyListExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
+use Symfony\Component\PropertyInfo\Type as LegacyType;
 use Symfony\Component\TypeInfo\Type;
 use Symfony\Component\Validator\Constraints\All;
 use Symfony\Component\Validator\Constraints\Iban;
@@ -61,6 +62,7 @@ class PropertyInfoLoaderTest extends TestCase
             private int $i = 0;
             private int $j = 0;
             private array $types;
+            private array $legacyTypes;
 
             public function getType(string $class, string $property, array $context = []): ?Type
             {
@@ -83,6 +85,29 @@ class PropertyInfoLoaderTest extends TestCase
                 ++$this->i;
 
                 return $type;
+            }
+
+            public function getTypes(string $class, string $property, array $context = []): ?array
+            {
+                $this->legacyTypes ??= [
+                    [new LegacyType('string', true)],
+                    [new LegacyType('string')],
+                    [new LegacyType('string', true), new LegacyType('int'), new LegacyType('bool')],
+                    [new LegacyType('object', true, Entity::class)],
+                    [new LegacyType('array', true, null, true, null, new LegacyType('object', false, Entity::class))],
+                    [new LegacyType('array', true, null, true)],
+                    [new LegacyType('float', true)], // The existing constraint is float
+                    [new LegacyType('string', true)],
+                    [new LegacyType('string', true)],
+                    [new LegacyType('array', true, null, true, null, new LegacyType('float'))],
+                    [new LegacyType('string')],
+                    [new LegacyType('string')],
+                ];
+
+                $legacyType = $this->legacyTypes[$this->j];
+                ++$this->j;
+
+                return $legacyType;
             }
         };
 
@@ -215,6 +240,11 @@ class PropertyInfoLoaderTest extends TestCase
             {
                 return Type::string();
             }
+
+            public function getTypes(string $class, string $property, array $context = []): ?array
+            {
+                return [new LegacyType('string')];
+            }
         };
 
         $propertyAccessExtractor = $this->createMock(PropertyAccessExtractorInterface::class);
@@ -248,6 +278,11 @@ class PropertyInfoLoaderTest extends TestCase
                 public function getType(string $class, string $property, array $context = []): ?Type
                 {
                     return Type::string();
+                }
+
+                public function getTypes(string $class, string $property, array $context = []): ?array
+                {
+                    return [new LegacyType('string')];
                 }
             };
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

due to the `DoctrineExtractor::getTypes()` method being removed in #60726 the `DoctrineExtractor` class is not compatible with PropertyInfo < 8.0