### PR TITLE
[Security] remove no longer needed conflict rule on symfony/event-dispatcher

### DIFF
--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -41,7 +41,6 @@
     },
     "conflict": {
         "symfony/clock": "<6.4",
-        "symfony/event-dispatcher": "<6.4",
         "symfony/http-client-contracts": "<3.0",
         "symfony/security-bundle": "<6.4",
         "symfony/security-csrf": "<6.4"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT