### PR TITLE
[Console] Allow setting aliases & hidden via command name passed to the constructor

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+ * Allow setting aliases and the hidden flag via the command name passed to the constructor
+
 7.3
 ---
 

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -97,13 +97,13 @@ class Command implements SignalableCommandInterface
             if (self::class !== (new \ReflectionMethod($this, 'getDefaultName'))->class) {
                 trigger_deprecation('symfony/console', '7.3', 'Overriding "Command::getDefaultName()" in "%s" is deprecated and will be removed in Symfony 8.0, use the #[AsCommand] attribute instead.', static::class);
 
-                $defaultName = static::getDefaultName();
+                $name = static::getDefaultName();
             } else {
-                $defaultName = $attribute?->name;
+                $name = $attribute?->name;
             }
         }
 
-        if (null === $name && null !== $name = $defaultName) {
+        if (null !== $name) {
             $aliases = explode('|', $name);
 
             if ('' === $name = array_shift($aliases)) {

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -205,6 +205,19 @@ class CommandTest extends TestCase
         $this->assertEquals(['name1'], $command->getAliases(), '->setAliases() sets the aliases');
     }
 
+    /**
+     * @testWith ["name|alias1|alias2", "name", ["alias1", "alias2"], false]
+     *           ["|alias1|alias2", "alias1", ["alias2"], true]
+     */
+    public function testSetAliasesAndHiddenViaName(string $name, string $expectedName, array $expectedAliases, bool $expectedHidden)
+    {
+        $command = new Command($name);
+
+        self::assertSame($expectedName, $command->getName());
+        self::assertSame($expectedHidden, $command->isHidden());
+        self::assertSame($expectedAliases, $command->getAliases());
+    }
+
     public function testGetSynopsis()
     {
         $command = new \TestCommand();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony/pull/60394#discussion_r2129158928
| License       | MIT

Currently, setting an alias and/or marking a command as hidden via the name doesn't work when the name is passed as a constructor argument. For example:

```php
$command = new MyCommand('name|alias');
```

This issue was noticed while working on #60394 as mentioned in the comment there: https://github.com/symfony/symfony/pull/60394#discussion_r2129158928.