### PR TITLE
[Mailer] Add `assertEmailAddressNotContains`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Deprecate `Symfony\Bundle\FrameworkBundle\Console\Application::add()` in favor of `Symfony\Bundle\FrameworkBundle\Console\Application::addCommand()`
+ * Add `assertEmailAddressNotContains()` to the `MailerAssertionsTrait`
 
 7.3
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Test/MailerAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/MailerAssertionsTrait.php
@@ -90,6 +90,11 @@ trait MailerAssertionsTrait
         self::assertThat($email, new MimeConstraint\EmailAddressContains($headerName, $expectedValue), $message);
     }
 
+    public static function assertEmailAddressNotContains(RawMessage $email, string $headerName, string $expectedValue, string $message = ''): void
+    {
+        self::assertThat($email, new LogicalNot(new MimeConstraint\EmailAddressContains($headerName, $expectedValue)), $message);
+    }
+
     public static function assertEmailSubjectContains(RawMessage $email, string $expectedValue, string $message = ''): void
     {
         self::assertThat($email, new MimeConstraint\EmailSubjectContains($expectedValue), $message);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/MailerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/MailerTest.php
@@ -99,6 +99,7 @@ class MailerTest extends AbstractWebTestCase
         $this->assertEmailHtmlBodyContains($email, 'Foo');
         $this->assertEmailHtmlBodyNotContains($email, 'Bar');
         $this->assertEmailAttachmentCount($email, 1);
+        $this->assertEmailAddressNotContains($email, 'To', 'thomas@symfony.com');
 
         $email = $this->getMailerMessage($second);
         $this->assertEmailSubjectContains($email, 'Foo');
@@ -106,5 +107,7 @@ class MailerTest extends AbstractWebTestCase
         $this->assertEmailAddressContains($email, 'To', 'fabien@symfony.com');
         $this->assertEmailAddressContains($email, 'To', 'thomas@symfony.com');
         $this->assertEmailAddressContains($email, 'Reply-To', 'me@symfony.com');
+        $this->assertEmailAddressNotContains($email, 'To', 'helene@symfony.com');
+        $this->assertEmailAddressNotContains($email, 'Reply-To', 'helene@symfony.com');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | No
| License       | MIT

This PR introduces a new assertion method `assertEmailAddressNotContains()` to the `MailerAssertionsTrait`.

The new method complements the existing `assertEmailAddressContains()` by allowing developers to assert that a specific email address **does not** appear in a given header. This addition brings the `assertEmailAddressContains`  in line with other similar assertion pairs already available in the trait, such as:

- `assertEmailTextBodyContains` / `assertEmailTextBodyNotContains`
- `assertEmailHtmlBodyContains` / `assertEmailHtmlBodyNotContains`
- `assertEmailSubjectContains` / `assertEmailSubjectNotContains`

### Example usage
```php
$this->assertEmailAddressNotContains($email, 'To', 'test@test.com');
```