### PR TITLE
[Scheduler] Fix `#[AsCronTask]` not passing arguments to command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Messenger/DummyCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Messenger/DummyCommand.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Scheduler\Attribute\AsCronTask;
+
+#[AsCronTask(expression: '* * * * *', schedule: 'dummy_command')]
+#[AsCronTask(expression: '0 * * * *', arguments: 'test', schedule: 'dummy_command')]
+#[AsCommand(name: 'test:dummy-command')]
+class DummyCommand extends Command
+{
+    public static array $calls = [];
+
+    public function configure(): void
+    {
+        $this->addArgument('dummy-argument', InputArgument::OPTIONAL);
+    }
+
+    public function execute(InputInterface $input, ?OutputInterface $output = null): int
+    {
+        self::$calls[__FUNCTION__][] = $input->getArgument('dummy-argument');
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Scheduler/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Scheduler/config.yml
@@ -16,6 +16,9 @@ services:
     Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\DummyTaskWithCustomReceiver:
         autoconfigure: true
 
+    Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\DummyCommand:
+        autoconfigure: true
+
     clock:
         synthetic: true
 

--- a/src/Symfony/Component/Scheduler/DependencyInjection/AddScheduleMessengerPass.php
+++ b/src/Symfony/Component/Scheduler/DependencyInjection/AddScheduleMessengerPass.php
@@ -58,7 +58,9 @@ class AddScheduleMessengerPass implements CompilerPassInterface
                 if ($serviceDefinition->hasTag('console.command')) {
                     /** @var AsCommand|null $attribute */
                     $attribute = ($container->getReflectionClass($serviceDefinition->getClass())->getAttributes(AsCommand::class)[0] ?? null)?->newInstance();
-                    $message = new Definition(RunCommandMessage::class, [$attribute?->name ?? $serviceDefinition->getClass()::getDefaultName().(empty($tagAttributes['arguments']) ? '' : " {$tagAttributes['arguments']}")]);
+                    $commandName = $attribute?->name ?? $serviceDefinition->getClass()::getDefaultName();
+
+                    $message = new Definition(RunCommandMessage::class, [$commandName.($tagAttributes['arguments'] ? " {$tagAttributes['arguments']}" : '')]);
                 } else {
                     $message = new Definition(ServiceCallMessage::class, [$serviceId, $tagAttributes['method'] ?? '__invoke', (array) ($tagAttributes['arguments'] ?? [])]);
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This MR fixes passing `AsCronTask` arguments to `Command`. Reproduced can be by following command. It wont receive `--all` option or any other argument specified in `AsCronTask` when executed by Scheduler.
```
#[AsCommand(name: 'debug:as-cron-task')]
#[AsCronTask('* * * * *', arguments: '--all')]
class SampleCommand extends Command
{
    protected function configure(): void
    {
        $this->addOption('all', null, InputOption::VALUE_NONE);
    }

    protected function execute(InputInterface $input, OutputInterface $output): int
    {
        dump($input->getOption('all'));

        return Command::SUCCESS;
    }
}
```

Fix description: When command name was found in `AsCommand` attribute then attributes were not appended to message definition due to missing brackets.