### PR TITLE
[Ldap][Security] Remove deprecated `eraseCredentials()` from (User|Token)Interface

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -87,6 +87,11 @@ HttpClient
  * Remove support for amphp/http-client < 5
  * Remove setLogger() methods on decorators; configure the logger on the wrapped client directly instead
 
+Ldap
+----
+
+ * Remove `LdapUser::eraseCredentials()` in favor of `__serialize()`
+
 OptionsResolver
 ---------------
 
@@ -206,6 +211,26 @@ PropertyInfo
        // ...
    }
    ```
+
+Security
+--------
+
+ * Remove `UserInterface::eraseCredentials()` and `TokenInterface::eraseCredentials()`;
+   erase credentials e.g. using `__serialize()` instead:
+
+  ```diff
+  -public function eraseCredentials(): void
+  -{
+  -}
+  +// If your eraseCredentials() method was used to empty a "password" property:
+  +public function __serialize(): array
+  +{
+  +    $data = (array) $this;
+  +    unset($data["\0".self::class."\0password"]);
+  +
+  +    return $data;
+  +}
+  ```
 
 TwigBridge
 ----------

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/User.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/User.php
@@ -45,11 +45,6 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         return $this->name;
     }
 
-    #[\Deprecated]
-    public function eraseCredentials(): void
-    {
-    }
-
     public function equals(UserInterface $user)
     {
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SecurityTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SecurityTest.php
@@ -249,11 +249,6 @@ final class UserWithoutEquatable implements UserInterface, PasswordAuthenticated
     {
         return $this->enabled;
     }
-
-    #[\Deprecated]
-    public function eraseCredentials(): void
-    {
-    }
 }
 
 class ForceLoginController

--- a/src/Symfony/Component/Ldap/CHANGELOG.md
+++ b/src/Symfony/Component/Ldap/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.0
+---
+
+ * Remove `LdapUser::eraseCredentials()` in favor of `__serialize()`
+
 7.3
 ---
 

--- a/src/Symfony/Component/Ldap/Security/LdapUser.php
+++ b/src/Symfony/Component/Ldap/Security/LdapUser.php
@@ -60,15 +60,6 @@ class LdapUser implements UserInterface, PasswordAuthenticatedUserInterface, Equ
         return $this->identifier;
     }
 
-    /**
-     * @deprecated since Symfony 7.3
-     */
-    #[\Deprecated(since: 'symfony/ldap 7.3')]
-    public function eraseCredentials(): void
-    {
-        $this->password = null;
-    }
-
     public function getExtraFields(): array
     {
         return $this->extraFields;

--- a/src/Symfony/Component/PasswordHasher/Tests/Fixtures/TestLegacyPasswordAuthenticatedUser.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Fixtures/TestLegacyPasswordAuthenticatedUser.php
@@ -35,11 +35,6 @@ final class TestLegacyPasswordAuthenticatedUser implements LegacyPasswordAuthent
         return $this->roles;
     }
 
-    #[\Deprecated]
-    public function eraseCredentials(): void
-    {
-    }
-
     public function getUserIdentifier(): string
     {
         return $this->username;

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -56,20 +56,6 @@ abstract class AbstractToken implements TokenInterface, \Serializable
     }
 
     /**
-     * Removes sensitive information from the token.
-     *
-     * @deprecated since Symfony 7.3, erase credentials using the "__serialize()" method instead
-     */
-    public function eraseCredentials(): void
-    {
-        trigger_deprecation('symfony/security-core', '7.3', \sprintf('The "%s::eraseCredentials()" method is deprecated and will be removed in 8.0, erase credentials using the "__serialize()" method instead.', TokenInterface::class));
-
-        if ($this->getUser() instanceof UserInterface) {
-            $this->getUser()->eraseCredentials();
-        }
-    }
-
-    /**
      * Returns all the necessary state of the object for serialization purposes.
      *
      * There is no need to serialize any entry, they should be returned as-is.

--- a/src/Symfony/Component/Security/Core/Authentication/Token/NullToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/NullToken.php
@@ -43,14 +43,6 @@ class NullToken implements TokenInterface
         return '';
     }
 
-    /**
-     * @deprecated since Symfony 7.3
-     */
-    #[\Deprecated(since: 'symfony/security-core 7.3')]
-    public function eraseCredentials(): void
-    {
-    }
-
     public function getAttributes(): array
     {
         return [];

--- a/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php
@@ -57,13 +57,6 @@ interface TokenInterface extends \Stringable
      */
     public function setUser(UserInterface $user): void;
 
-    /**
-     * Removes sensitive information from the token.
-     *
-     * @deprecated since Symfony 7.3; erase credentials using the "__serialize()" method instead
-     */
-    public function eraseCredentials(): void;
-
     public function getAttributes(): array;
 
     /**

--- a/src/Symfony/Component/Security/Core/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Core/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+8.0
+---
+
+ * Remove `UserInterface::eraseCredentials()` and `TokenInterface::eraseCredentials()`,
+  erase credentials e.g. using `__serialize()` instead
+
 7.3
 ---
 

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationTrustResolverTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationTrustResolverTest.php
@@ -119,11 +119,6 @@ class FakeCustomToken implements TokenInterface
     {
     }
 
-    #[\Deprecated]
-    public function eraseCredentials(): void
-    {
-    }
-
     public function getAttributes(): array
     {
     }

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/AbstractTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/AbstractTokenTest.php
@@ -37,22 +37,6 @@ class AbstractTokenTest extends TestCase
         yield [new InMemoryUser('fabien', null), 'fabien'];
     }
 
-    /**
-     * @group legacy
-     */
-    public function testEraseCredentials()
-    {
-        $token = new ConcreteToken(['ROLE_FOO']);
-
-        $user = $this->createMock(UserInterface::class);
-        $user->expects($this->once())->method('eraseCredentials');
-        $token->setUser($user);
-
-        $this->expectUserDeprecationMessage(\sprintf('Since symfony/security-core 7.3: The "%s::eraseCredentials()" method is deprecated and will be removed in 8.0, erase credentials using the "__serialize()" method instead.', TokenInterface::class));
-
-        $token->eraseCredentials();
-    }
-
     public function testSerialize()
     {
         $token = new ConcreteToken(['ROLE_FOO', 'ROLE_BAR']);

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/Fixtures/CustomUser.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/Fixtures/CustomUser.php
@@ -35,9 +35,4 @@ final class CustomUser implements UserInterface
     {
         return null;
     }
-
-    #[\Deprecated]
-    public function eraseCredentials(): void
-    {
-    }
 }

--- a/src/Symfony/Component/Security/Core/Tests/User/InMemoryUserTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/InMemoryUserTest.php
@@ -56,17 +56,6 @@ class InMemoryUserTest extends TestCase
         $this->assertFalse($user->isEnabled());
     }
 
-    /**
-     * @group legacy
-     */
-    public function testEraseCredentials()
-    {
-        $user = new InMemoryUser('fabien', 'superpass');
-        $this->expectUserDeprecationMessage(\sprintf('Unsilenced deprecation: Method %s::eraseCredentials() is deprecated since symfony/security-core 7.3', InMemoryUser::class));
-        $user->eraseCredentials();
-        $this->assertEquals('superpass', $user->getPassword());
-    }
-
     public function testToString()
     {
         $user = new InMemoryUser('fabien', 'superpass');

--- a/src/Symfony/Component/Security/Core/User/InMemoryUser.php
+++ b/src/Symfony/Component/Security/Core/User/InMemoryUser.php
@@ -74,14 +74,6 @@ final class InMemoryUser implements UserInterface, PasswordAuthenticatedUserInte
         return $this->enabled;
     }
 
-    /**
-     * @deprecated since Symfony 7.3
-     */
-    #[\Deprecated(since: 'symfony/security-core 7.3')]
-    public function eraseCredentials(): void
-    {
-    }
-
     public function isEqualTo(UserInterface $user): bool
     {
         if (!$user instanceof self) {

--- a/src/Symfony/Component/Security/Core/User/OAuth2User.php
+++ b/src/Symfony/Component/Security/Core/User/OAuth2User.php
@@ -63,8 +63,4 @@ class OAuth2User implements UserInterface
     {
         return (string) ($this->sub ?? $this->username);
     }
-
-    public function eraseCredentials(): void
-    {
-    }
 }

--- a/src/Symfony/Component/Security/Core/User/OidcUser.php
+++ b/src/Symfony/Component/Security/Core/User/OidcUser.php
@@ -71,14 +71,6 @@ class OidcUser implements UserInterface
         return (string) ($this->userIdentifier ?? $this->getSub());
     }
 
-    /**
-     * @deprecated since Symfony 7.3
-     */
-    #[\Deprecated(since: 'symfony/security-core 7.3')]
-    public function eraseCredentials(): void
-    {
-    }
-
     public function getSub(): ?string
     {
         return $this->sub;

--- a/src/Symfony/Component/Security/Core/User/UserInterface.php
+++ b/src/Symfony/Component/Security/Core/User/UserInterface.php
@@ -48,16 +48,6 @@ interface UserInterface
     public function getRoles(): array;
 
     /**
-     * Removes sensitive data from the user.
-     *
-     * This is important if, at any given point, sensitive information like
-     * the plain-text password is stored on this object.
-     *
-     * @deprecated since Symfony 7.3, erase credentials using the "__serialize()" method instead
-     */
-    public function eraseCredentials(): void;
-
-    /**
      * Returns the identifier for this user (e.g. username or email address).
      *
      * @return non-empty-string

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/AuthenticatorManagerBCTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/AuthenticatorManagerBCTest.php
@@ -205,32 +205,6 @@ class AuthenticatorManagerBCTest extends TestCase
     }
 
     /**
-     * @dataProvider provideEraseCredentialsData
-     *
-     * @group legacy
-     */
-    public function testEraseCredentials($eraseCredentials)
-    {
-        $authenticator = $this->createAuthenticator();
-        $this->request->attributes->set('_security_authenticators', [$authenticator]);
-
-        $authenticator->expects($this->any())->method('authenticate')->willReturn(new SelfValidatingPassport(new UserBadge('wouter', fn () => $this->user)));
-
-        $authenticator->expects($this->any())->method('createToken')->willReturn($this->token);
-
-        $this->token->expects($eraseCredentials ? $this->once() : $this->never())->method('eraseCredentials');
-
-        $manager = $this->createManager([$authenticator], 'main', $eraseCredentials, hideUserNotFoundExceptions: true);
-        $manager->authenticateRequest($this->request);
-    }
-
-    public static function provideEraseCredentialsData()
-    {
-        yield [true];
-        yield [false];
-    }
-
-    /**
      * @group legacy
      */
     public function testAuthenticateRequestCanModifyTokenFromEvent()

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/AuthenticatorManagerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/AuthenticatorManagerTest.php
@@ -187,45 +187,6 @@ class AuthenticatorManagerTest extends TestCase
         $manager->authenticateRequest($this->request);
     }
 
-    /**
-     * @group legacy
-     *
-     * @dataProvider provideEraseCredentialsData
-     */
-    public function testEraseCredentials($eraseCredentials)
-    {
-        $authenticator = $this->createAuthenticator();
-        $this->request->attributes->set('_security_authenticators', [$authenticator]);
-
-        $authenticator->expects($this->any())->method('authenticate')->willReturn(new SelfValidatingPassport(new UserBadge('wouter', fn () => $this->user)));
-
-        $token = new class extends AbstractToken {
-            public $erased = false;
-
-            public function eraseCredentials(): void
-            {
-                $this->erased = true;
-            }
-        };
-
-        $authenticator->expects($this->any())->method('createToken')->willReturn($token);
-
-        if ($eraseCredentials) {
-            $this->expectUserDeprecationMessage(\sprintf('Since symfony/security-http 7.3: Implementing "%s@anonymous::eraseCredentials()" is deprecated since Symfony 7.3; add the #[\Deprecated] attribute on the method to signal its either empty or that you moved the logic elsewhere, typically to the "__serialize()" method.', AbstractToken::class));
-        }
-
-        $manager = $this->createManager([$authenticator], 'main', $eraseCredentials, exposeSecurityErrors: ExposeSecurityLevel::None);
-        $manager->authenticateRequest($this->request);
-
-        $this->assertSame($eraseCredentials, $token->erased);
-    }
-
-    public static function provideEraseCredentialsData()
-    {
-        yield [true];
-        yield [false];
-    }
-
     public function testAuthenticateRequestCanModifyTokenFromEvent()
     {
         $authenticator = $this->createAuthenticator();

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/PasswordMigratingListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/PasswordMigratingListenerTest.php
@@ -164,11 +164,6 @@ class DummyTestPasswordAuthenticatedUser extends TestPasswordAuthenticatedUser
         return [];
     }
 
-    #[\Deprecated]
-    public function eraseCredentials(): void
-    {
-    }
-
     public function getUserIdentifier(): string
     {
     }

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
@@ -598,11 +598,6 @@ class CustomToken implements TokenInterface
         return $this->getUserIdentifier();
     }
 
-    #[\Deprecated]
-    public function eraseCredentials(): void
-    {
-    }
-
     public function getAttributes(): array
     {
         return [];

--- a/src/Symfony/Component/Security/Http/Tests/Fixtures/CustomUser.php
+++ b/src/Symfony/Component/Security/Http/Tests/Fixtures/CustomUser.php
@@ -39,10 +39,6 @@ final class CustomUser implements UserInterface, PasswordAuthenticatedUserInterf
         return $this->password ?? null;
     }
 
-    public function eraseCredentials(): void
-    {
-    }
-
     public function __serialize(): array
     {
         $data = (array) $this;

--- a/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
@@ -312,11 +312,6 @@ class TestLoginLinkHandlerUser implements UserInterface
     {
         return $this->username;
     }
-
-    #[\Deprecated]
-    public function eraseCredentials(): void
-    {
-    }
 }
 
 class TestLoginLinkHandlerUserProvider implements UserProviderInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | #59682 
| License       | MIT

We didn't deprecate the config option + container parameter from SecurityBundle nor the corresponding `AuthenticatorManager` constructor param, I propose to keep them no-op and deprecate them in 8.1 (mainly because `AuthenticatorManager` already deprecates a boolean parameter in 7.3 which makes deprecating the parameter complicates the bc layer and upgrade path significantly).