### PR TITLE
[Messenger] Allow handler locator to be set

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+* Allow handler locator to be set by applications
+
 7.3
 ---
 

--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -165,9 +165,13 @@ class MessengerPass implements CompilerPassInterface
         $container->addDefinitions($definitions);
 
         foreach ($busIds as $bus) {
-            $container->register($locatorId = $bus.'.messenger.handlers_locator', HandlersLocator::class)
-                ->setArgument(0, $handlersLocatorMappingByBus[$bus] ?? [])
-            ;
+            $locatorId = $bus.'.messenger.handlers_locator';
+            if (!$container->has($locatorId)) {
+                $container->register($locatorId, HandlersLocator::class)
+                    ->setArgument(0, $handlersLocatorMappingByBus[$bus] ?? [])
+                ;
+            }
+
             if ($container->has($handleMessageId = $bus.'.middleware.handle_message')) {
                 $container->getDefinition($handleMessageId)
                     ->replaceArgument(0, new Reference($locatorId))

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
@@ -809,6 +809,17 @@ class MessengerPassTest extends TestCase
         ], $container->getDefinition('console.command.messenger_debug')->getArgument(0));
     }
 
+    public function testCanOverrideHandlersLocator()
+    {
+        $container = $this->getContainerBuilder($busId = 'message_bus');
+
+        $container->register($busId. '.messenger.handlers_locator', \stdClass::class);
+
+        (new MessengerPass())->process($container);
+
+        $this->assertSame(\stdClass::class, $container->getDefinition($busId. '.messenger.handlers_locator')->getClass());
+    }
+
     private function getContainerBuilder(string $busId = 'message_bus'): ContainerBuilder
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
Hi,

I'd like to use the `HandleMessageMiddleware` but use a different locator to get the handlers of the messages. The `HandleMessageMiddleware` uses an interface but I can't see how to define a different implementation as the compiler pass  sets this argument per bus.

I could define my own version of the `handle_message` middleware and provide the dependancy but this means I can no longer use the `default_middleware` configuration. 
By checking if the locator already exists it means the application could define the `HandlersLocatorInterface` implementation that is used by defining something like this in their services.yaml: `{$busName}.messenger.handlers_locator: '@Application\Middleware\HandlersLocator'`

Would be great to hear if there's maybe a better way to do this or if I've missed a detail on how to provide the `HandlersLocatorInterface`

| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

