### PR TITLE
Improve-callable-typing

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -576,6 +576,9 @@ class TextDescriptor extends Descriptor
         return trim($configAsString);
     }
 
+    /**
+     * @param (callable():ContainerBuilder)|null $getContainer
+     */
     private function formatControllerLink(mixed $controller, string $anchorText, ?callable $getContainer = null): string
     {
         if (null === $this->fileLinkFormatter) {

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
@@ -288,6 +288,9 @@ class XmlDescriptor extends Descriptor
         return $dom;
     }
 
+    /**
+     * @param (callable(string):bool)|null $filter
+     */
     private function getContainerServicesDocument(ContainerBuilder $container, ?string $tag = null, bool $showHidden = false, ?callable $filter = null): \DOMDocument
     {
         $dom = new \DOMDocument('1.0', 'UTF-8');

--- a/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
@@ -36,6 +36,9 @@ use Symfony\Contracts\Service\ServiceSubscriberInterface;
 class Router extends BaseRouter implements WarmableInterface, ServiceSubscriberInterface
 {
     private array $collectedParameters = [];
+    /**
+     * @var \Closure(string):mixed
+     */
     private \Closure $paramFetcher;
 
     /**

--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -234,7 +234,8 @@ class QuestionHelper extends Helper
     /**
      * Autocompletes a question.
      *
-     * @param resource $inputStream
+     * @param resource                  $inputStream
+     * @param callable(string):string[] $autocomplete
      */
     private function autocomplete(OutputInterface $output, Question $question, $inputStream, callable $autocomplete): string
     {

--- a/src/Symfony/Component/Console/Question/Question.php
+++ b/src/Symfony/Component/Console/Question/Question.php
@@ -24,8 +24,17 @@ class Question
     private ?int $attempts = null;
     private bool $hidden = false;
     private bool $hiddenFallback = true;
+    /**
+     * @var (\Closure(string):string[])|null
+     */
     private ?\Closure $autocompleterCallback = null;
+    /**
+     * @var (\Closure(mixed):mixed)|null
+     */
     private ?\Closure $validator = null;
+    /**
+     * @var (\Closure(mixed):mixed)|null
+     */
     private ?\Closure $normalizer = null;
     private bool $trimmable = true;
     private bool $multiline = false;
@@ -160,6 +169,8 @@ class Question
 
     /**
      * Gets the callback function used for the autocompleter.
+     *
+     * @return (callable(string):string[])|null
      */
     public function getAutocompleterCallback(): ?callable
     {
@@ -170,6 +181,8 @@ class Question
      * Sets the callback function used for the autocompleter.
      *
      * The callback is passed the user input as argument and should return an iterable of corresponding suggestions.
+     *
+     * @param (callable(string):string[])|null $callback
      *
      * @return $this
      */
@@ -187,6 +200,8 @@ class Question
     /**
      * Sets a validator for the question.
      *
+     * @param (callable(mixed):mixed)|null $validator
+     *
      * @return $this
      */
     public function setValidator(?callable $validator): static
@@ -198,6 +213,8 @@ class Question
 
     /**
      * Gets the validator for the question.
+     *
+     * @return (callable(mixed):mixed)|null
      */
     public function getValidator(): ?callable
     {
@@ -237,7 +254,7 @@ class Question
     /**
      * Sets a normalizer for the response.
      *
-     * The normalizer can be a callable (a string), a closure or a class implementing __invoke.
+     * @param callable(mixed):mixed $normalizer
      *
      * @return $this
      */
@@ -251,7 +268,7 @@ class Question
     /**
      * Gets the normalizer for the response.
      *
-     * The normalizer can ba a callable (a string), a closure or a class implementing __invoke.
+     * @return (callable(mixed):mixed)|null
      */
     public function getNormalizer(): ?callable
     {

--- a/src/Symfony/Component/Console/Style/StyleInterface.php
+++ b/src/Symfony/Component/Console/Style/StyleInterface.php
@@ -70,11 +70,15 @@ interface StyleInterface
 
     /**
      * Asks a question.
+     *
+     * @param (callable(mixed):mixed)|null $validator
      */
     public function ask(string $question, ?string $default = null, ?callable $validator = null): mixed;
 
     /**
      * Asks a question with the user input hidden.
+     *
+     * @param (callable(mixed):mixed)|null $validator
      */
     public function askHidden(string $question, ?callable $validator = null): mixed;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Defining a callable's shape is important to have valid static analysis.
It also improves documentation because developers no longer need to search the source code for what callable shape to use.
