### PR TITLE
[Serializer] improve phpdoc for normalizer

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
@@ -29,10 +29,10 @@ interface DenormalizerInterface
     /**
      * Denormalizes data back into an object of the given class.
      *
-     * @param mixed       $data    Data to restore
-     * @param string      $type    The expected class to instantiate
-     * @param string|null $format  Format the given data was extracted from
-     * @param array       $context Options available to the denormalizer
+     * @param mixed                $data    Data to restore
+     * @param string               $type    The expected class to instantiate
+     * @param string|null          $format  Format the given data was extracted from
+     * @param array<string, mixed> $context Options available to the denormalizer
      *
      * @throws BadMethodCallException   Occurs when the normalizer is not called in an expected context
      * @throws InvalidArgumentException Occurs when the arguments are not coherent or not supported
@@ -47,9 +47,10 @@ interface DenormalizerInterface
     /**
      * Checks whether the given class is supported for denormalization by this normalizer.
      *
-     * @param mixed       $data   Data to denormalize from
-     * @param string      $type   The class to which the data should be denormalized
-     * @param string|null $format The format being deserialized from
+     * @param mixed                $data    Data to denormalize from
+     * @param string               $type    The class to which the data should be denormalized
+     * @param string|null          $format  The format being deserialized from
+     * @param array<string, mixed> $context Options available to the denormalizer
      */
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool;
 

--- a/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
@@ -24,9 +24,9 @@ interface NormalizerInterface
     /**
      * Normalizes data into a set of arrays/scalars.
      *
-     * @param mixed       $data    Data to normalize
-     * @param string|null $format  Format the normalization result will be encoded as
-     * @param array       $context Context options for the normalizer
+     * @param mixed                $data    Data to normalize
+     * @param string|null          $format  Format the normalization result will be encoded as
+     * @param array<string, mixed> $context Context options for the normalizer
      *
      * @return array|string|int|float|bool|\ArrayObject|null \ArrayObject is used to make sure an empty object is encoded as an object not an array
      *
@@ -41,8 +41,9 @@ interface NormalizerInterface
     /**
      * Checks whether the given class is supported for normalization by this normalizer.
      *
-     * @param mixed       $data   Data to normalize
-     * @param string|null $format The format being (de-)serialized from or into
+     * @param mixed                $data   Data to normalize
+     * @param string|null          $format The format being (de-)serialized from or into
+     * @param array<string, mixed> $context Context options for the normalizer
      */
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | kind of
| New feature?  | no
| Deprecations? | no
| Issues        | none
| License       | MIT

The problem with the old phpdoc is that phpstan complains about the user's concrete implementation ("no value type specified in iterable type array")
Moreover, if the user adds the proper phpdoc in their concrete implementation, phpstan still complains about the concrete method not being contravariant (using strict rules)

After a Slack discussion with @stof we agreed that this small improvement could be useful, and avoid being forced to install phpstan-symfony to get the proper annotation.
