### PR TITLE
[Runtime] fix compatibility with Symfony 7.4

### DIFF
--- a/src/Symfony/Component/Runtime/SymfonyRuntime.php
+++ b/src/Symfony/Component/Runtime/SymfonyRuntime.php
@@ -144,7 +144,11 @@ class SymfonyRuntime extends GenericRuntime
 
             if (!$application->getName() || !$console->has($application->getName())) {
                 $application->setName($_SERVER['argv'][0]);
-                $console->add($application);
+                if (method_exists($console, 'addCommand')) {
+                    $console->addCommand($application);
+                } else {
+                    $console->add($application);
+                }
             }
 
             $console->setDefaultCommand($application->getName(), true);

--- a/src/Symfony/Component/Runtime/Tests/phpt/application.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/application.php
@@ -25,7 +25,11 @@ return function (array $context) {
     });
 
     $app = new Application();
-    $app->add($command);
+    if (method_exists($app, 'addCommand')) {
+        $app->addCommand($command);
+    } else {
+        $app->add($command);
+    }
     $app->setDefaultCommand('go', true);
 
     return $app;

--- a/src/Symfony/Component/Runtime/Tests/phpt/command_list.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/command_list.php
@@ -23,7 +23,11 @@ return function (Application $app, Command $command, RuntimeInterface $runtime) 
     $command->setName('my_command');
 
     [$cmd, $args] = $runtime->getResolver(require __DIR__.'/command.php')->resolve();
-    $app->add($cmd(...$args));
+    if (method_exists($app, 'addCommand')) {
+        $app->addCommand($cmd(...$args));
+    } else {
+        $app->add($cmd(...$args));
+    }
 
     return $app;
 };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Since #60394 using `add()` is deprecated. This means that our tests can trigger deprecations on older branches when the high deps job is run. This usually is not an issue as we silence them with the `SYMFONY_DEPRECATIONS_HELPER` env var. However, phpt tests are run in a child process where the deprecation error handler of the PHPUnit bridge doesn't step in. Thus, for them deprecations are not silenced leading to failures.

We did something similar before in #60376.