### PR TITLE
[Mailer] [Transport] Send clone of `RawMessage` instance in `RoundRobinTransport`

### DIFF
--- a/src/Symfony/Component/Mailer/Transport/RoundRobinTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/RoundRobinTransport.php
@@ -52,7 +52,7 @@ class RoundRobinTransport implements TransportInterface
 
         while ($transport = $this->getNextTransport()) {
             try {
-                return $transport->send($message, $envelope);
+                return $transport->send(clone $message, $envelope);
             } catch (TransportExceptionInterface $e) {
                 $exception ??= new TransportException('All transports failed.');
                 $exception->appendDebug(sprintf("Transport \"%s\": %s\n", $transport, $e->getDebug()));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

When using an implementation of the `TransportInterface`, a common pattern (especially for mass bulk mailing services) is to use headers to communicate various pieces of metadata or settings to the receiving server for processing. Such options or headers might be very specific to the type of service used. Real world examples of such applications are https://github.com/symfony/mailgun-mailer/blob/7.2/Transport/MailgunApiTransport.php#L89 or https://www.reddit.com/r/symfony/comments/1cn32jx/add_header_based_on_transport/?rdt=36882.

However, when using such a transport as one of the transports in the `RoundRobinTransport` (or by extension the `FailoverTransport`), this may result in certain headers intended for transport service A to also be sent to transport service B if the former fails. Although this will likely be harmless in most cases, it may cause issues as the one described in https://github.com/laravel/framework/issues/51872 (and https://stackoverflow.com/questions/78660310/why-the-failover-first-driver-fails-and-inline-attachment-image-path-is-wrong-in).

To prevent alterations to the message that happen within the scope of a specific transport to leak to another, this PR proposes to use a clone of the `RawMessage` instance whenever attempting a new transport service. This should ensure that any transport-specific manipulations should not leak to a next transport.

Note this is mostly a behavioral change, which I don't think should break any existing use case, but may considered to be noteworthy enough to list it somewhere. It may also even be considered a bug fix; if so, and it is better to target `7.3` or `6.4` instead, please let me know.