### PR TITLE
[FrameworkBundle] Fixes getting a type error when the secret you are trying to reveal could not be decrypted

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/SecretsRevealCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/SecretsRevealCommand.php
@@ -62,6 +62,10 @@ EOF
                 $io->error(\sprintf('The secret "%s" does not exist.', $name));
 
                 return self::INVALID;
+            } elseif (null === $secrets[$name]) {
+                $io->error(\sprintf('The secret "%s" could not be decrypted.', $name));
+
+                return self::INVALID;
             }
 
             $io->writeln($secrets[$name]);

--- a/src/Symfony/Bundle/FrameworkBundle/Secrets/AbstractVault.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Secrets/AbstractVault.php
@@ -31,6 +31,9 @@ abstract class AbstractVault
 
     abstract public function remove(string $name): bool;
 
+    /**
+     * @return array<string, string|null>
+     */
     abstract public function list(bool $reveal = false): array;
 
     protected function validateName(string $name): void

--- a/src/Symfony/Bundle/FrameworkBundle/Secrets/DotenvVault.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Secrets/DotenvVault.php
@@ -89,13 +89,13 @@ class DotenvVault extends AbstractVault
 
         foreach ($_ENV as $k => $v) {
             if ('' !== ($v ?? '') && preg_match('/^\w+$/D', $k)) {
-                $secrets[$k] = $reveal ? $v : null;
+                $secrets[$k] = \is_string($v) && $reveal ? $v : null;
             }
         }
 
         foreach ($_SERVER as $k => $v) {
             if ('' !== ($v ?? '') && preg_match('/^\w+$/D', $k)) {
-                $secrets[$k] = $reveal ? $v : null;
+                $secrets[$k] = \is_string($v) && $reveal ? $v : null;
             }
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/SecretsRevealCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/SecretsRevealCommandTest.php
@@ -46,6 +46,19 @@ class SecretsRevealCommandTest extends TestCase
         $this->assertStringContainsString('The secret "undefinedKey" does not exist.', trim($tester->getDisplay(true)));
     }
 
+    public function testFailedDecrypt()
+    {
+        $vault = $this->createMock(AbstractVault::class);
+        $vault->method('list')->willReturn(['secretKey' => null]);
+
+        $command = new SecretsRevealCommand($vault);
+
+        $tester = new CommandTester($command);
+        $this->assertSame(Command::INVALID, $tester->execute(['name' => 'secretKey']));
+
+        $this->assertStringContainsString('The secret "secretKey" could not be decrypted.', trim($tester->getDisplay(true)));
+    }
+
     /**
      * @backupGlobals enabled
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Fixes getting a type error when the secret you are trying to reveal could not be decrypted.
```txt
In SymfonyStyle.php line 322:
                                                                                                                                                                                                                                    
  Symfony\Component\Console\Style\SymfonyStyle::writeln(): Argument #1 ($messages) must be of type Traversable|array|string, null given, called in /Users/jworman/PhpstormProjects/gtx/vendor/symfony/framework-bundle/Command/Sec  
  retsRevealCommand.php on line 67                                                                                                                                                                                                  
                                                                                                                                                                                                                                    
```

Not sure if this is considered a bug fix or a new feature
