### PR TITLE
[Console][FrameworkBundle] Remove deprecated `Application::add()` methods

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -66,6 +66,24 @@ Console
 
  * Add method `isSilent()` to `OutputInterface`
 
+ * Remove deprecated `Symfony\Component\Console\Application::add()` method in favor of `Symfony\Component\Console\Application::addCommand()`
+
+   *Before*
+   ```php
+   use Symfony\Component\Console\Application;
+
+   $application = new Application();
+   $application->add(new CreateUserCommand());
+   ```
+
+   *After*
+   ```php
+   use Symfony\Component\Console\Application;
+
+   $application = new Application();
+   $application->addCommand(new CreateUserCommand());
+   ```
+
 DoctrineBridge
 --------------
 
@@ -79,6 +97,27 @@ DoctrineBridge
    *After*
    ```php
    $type = $extractor->getType(Foo::class, 'property');
+   ```
+
+FrameworkBundle
+---------------
+
+ * Remove deprecated `Symfony\Bundle\FrameworkBundle\Console\Application::add()` method in favor of `Symfony\Bundle\FrameworkBundle\Console\Application::addCommand()`
+
+   *Before*
+   ```php
+   use Symfony\Bundle\FrameworkBundle\Console\Application;
+
+   $application = new Application($kernel);
+   $application->add(new CreateUserCommand());
+   ```
+
+   *After*
+   ```php
+   use Symfony\Bundle\FrameworkBundle\Console\Application;
+
+   $application = new Application($kernel);
+   $application->addCommand(new CreateUserCommand());
    ```
 
 HttpClient

--- a/src/Symfony/Bridge/Twig/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Command/DebugCommandTest.php
@@ -304,12 +304,7 @@ TXT
         $environment = new Environment($loader);
 
         $application = new Application();
-        $command = new DebugCommand($environment, $projectDir, [], null, null);
-        if (method_exists($application, 'addCommand')) {
-            $application->addCommand($command);
-        } else {
-            $application->add($command);
-        }
+        $application->addCommand(new DebugCommand($environment, $projectDir, [], null, null));
 
         $tester = new CommandCompletionTester($application->find('debug:twig'));
         $suggestions = $tester->complete($input, 2);
@@ -344,12 +339,7 @@ TXT
         }
 
         $application = new Application();
-        $command = new DebugCommand($environment, $projectDir, $bundleMetadata, $defaultPath, null);
-        if (method_exists($application, 'addCommand')) {
-            $application->addCommand($command);
-        } else {
-            $application->add($command);
-        }
+        $application->addCommand(new DebugCommand($environment, $projectDir, $bundleMetadata, $defaultPath, null));
         $command = $application->find('debug:twig');
 
         return new CommandTester($command);

--- a/src/Symfony/Bridge/Twig/Tests/Command/LintCommandTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Command/LintCommandTest.php
@@ -179,11 +179,7 @@ class LintCommandTest extends TestCase
         $command = new LintCommand($environment);
 
         $application = new Application();
-        if (method_exists($application, 'addCommand')) {
-            $application->addCommand($command);
-        } else {
-            $application->add($command);
-        }
+        $application->addCommand($command);
 
         return $application->find('lint:twig');
     }

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Enable the property info constructor extractor by default
+ * Remove deprecated `Symfony\Bundle\FrameworkBundle\Console\Application::add()` method in favor of `Symfony\Bundle\FrameworkBundle\Console\Application::addCommand()`
 
 7.4
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -159,27 +159,9 @@ class Application extends BaseApplication
         return parent::getLongVersion().\sprintf(' (env: <comment>%s</>, debug: <comment>%s</>)', $this->kernel->getEnvironment(), $this->kernel->isDebug() ? 'true' : 'false');
     }
 
-    /**
-     * @deprecated since Symfony 7.4, use Application::addCommand() instead
-     */
-    public function add(Command $command): ?Command
-    {
-        trigger_deprecation('symfony/framework-bundle', '7.4', 'The "%s()" method is deprecated and will be removed in Symfony 8.0, use "%s::addCommand()" instead.', __METHOD__, self::class);
-
-        return $this->addCommand($command);
-    }
-
     public function addCommand(callable|Command $command): ?Command
     {
         $this->registerCommands();
-
-        if (!method_exists(BaseApplication::class, 'addCommand')) {
-            if (!$command instanceof Command) {
-                throw new \LogicException('Using callables as commands requires symfony/console 7.4 or higher.');
-            }
-
-            return parent::add($command);
-        }
 
         return parent::addCommand($command);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/WorkflowDumpCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/WorkflowDumpCommandTest.php
@@ -25,12 +25,7 @@ class WorkflowDumpCommandTest extends TestCase
     public function testComplete(array $input, array $expectedSuggestions)
     {
         $application = new Application();
-        $command = new WorkflowDumpCommand(new ServiceLocator([]));
-        if (method_exists($application, 'addCommand')) {
-            $application->addCommand($command);
-        } else {
-            $application->add($command);
-        }
+        $application->addCommand(new WorkflowDumpCommand(new ServiceLocator([])));
 
         $tester = new CommandCompletionTester($application->find('workflow:dump'));
         $suggestions = $tester->complete($input, 2);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/XliffLintCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/XliffLintCommandTest.php
@@ -59,12 +59,7 @@ EOF;
     {
         if (!$application) {
             $application = new BaseApplication();
-            $command = new XliffLintCommand();
-            if (method_exists($application, 'addCommand')) {
-                $application->addCommand($command);
-            } else {
-                $application->add($command);
-            }
+            $application->addCommand(new XliffLintCommand());
         }
 
         $command = $application->find('lint:xliff');

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/YamlLintCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/YamlLintCommandTest.php
@@ -107,12 +107,7 @@ EOF;
     {
         if (!$application) {
             $application = new BaseApplication();
-            $command = new YamlLintCommand();
-            if (method_exists($application, 'addCommand')) {
-                $application->addCommand($command);
-            } else {
-                $application->add($command);
-            }
+            $application->addCommand(new YamlLintCommand());
         }
 
         $command = $application->find('lint:yaml');

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -81,6 +81,7 @@
         "doctrine/persistence": "<1.3",
         "phpdocumentor/reflection-docblock": "<3.2.2",
         "phpdocumentor/type-resolver": "<1.4.0",
+        "symfony/console": "<7.4",
         "symfony/security-csrf": "<7.4",
         "symfony/serializer": "<7.4",
         "symfony/translation": "<7.4",

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -532,16 +532,6 @@ class Application implements ResetInterface
     }
 
     /**
-     * @deprecated since Symfony 7.4, use Application::addCommand() instead
-     */
-    public function add(Command $command): ?Command
-    {
-        trigger_deprecation('symfony/console', '7.4', 'The "%s()" method is deprecated and will be removed in Symfony 8.0, use "%s::addCommand()" instead.', __METHOD__, self::class);
-
-        return $this->addCommand($command);
-    }
-
-    /**
      * Adds a command object.
      *
      * If a command with the same name already exists, it will be overridden.

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Remove methods `Command::getDefaultName()` and `Command::getDefaultDescription()` in favor of the `#[AsCommand]` attribute
  * Ensure closures set via `Command::setCode()` method have proper parameter and return types
  * Add method `isSilent()` to `OutputInterface`
+ * Remove deprecated `Symfony\Component\Console\Application::add()` method in favor of `Symfony\Component\Console\Application::addCommand()`
 
 7.4
 ---

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -65,11 +65,7 @@ class Command implements SignalableCommandInterface
 
         $attribute = ((new \ReflectionClass(static::class))->getAttributes(AsCommand::class)[0] ?? null)?->newInstance();
 
-        if (null === $name) {
-            $name = $attribute?->name;
-        }
-
-        if (null !== $name) {
+        if (null !== $name ??= $attribute?->name) {
             $aliases = explode('|', $name);
 
             if ('' === $name = array_shift($aliases)) {

--- a/src/Symfony/Component/Dotenv/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/Command/DebugCommandTest.php
@@ -288,11 +288,7 @@ OUTPUT;
 
         $command = new DebugCommand($env, $projectDirectory);
         $application = new Application();
-        if (method_exists($application, 'addCommand')) {
-            $application->addCommand($command);
-        } else {
-            $application->add($command);
-        }
+        $application->addCommand($command);
         $tester = new CommandCompletionTester($application->get('debug:dotenv'));
         $this->assertSame(['FOO', 'TEST'], $tester->complete(['']));
     }

--- a/src/Symfony/Component/Dotenv/Tests/Command/DotenvDumpCommandTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/Command/DotenvDumpCommandTest.php
@@ -95,12 +95,7 @@ EOF
     private function createCommand(): CommandTester
     {
         $application = new Application();
-        $command = new DotenvDumpCommand(__DIR__);
-        if (method_exists($application, 'addCommand')) {
-            $application->addCommand($command);
-        } else {
-            $application->add($command);
-        }
+        $application->addCommand(new DotenvDumpCommand(__DIR__));
 
         return new CommandTester($application->find('dotenv:dump'));
     }

--- a/src/Symfony/Component/ErrorHandler/Tests/Command/ErrorDumpCommandTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Command/ErrorDumpCommandTest.php
@@ -102,16 +102,11 @@ class ErrorDumpCommandTest extends TestCase
         $entrypointLookup = $this->createMock(EntrypointLookupInterface::class);
 
         $application = new Application($kernel);
-        $command = new ErrorDumpCommand(
+        $application->addCommand(new ErrorDumpCommand(
             new Filesystem(),
             $errorRenderer,
             $entrypointLookup,
-        );
-        if (method_exists($application, 'addCommand')) {
-            $application->addCommand($command);
-        } else {
-            $application->add($command);
-        }
+        ));
 
         return new CommandTester($application->find('error:dump'));
     }

--- a/src/Symfony/Component/Form/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Form/Tests/Command/DebugCommandTest.php
@@ -194,11 +194,7 @@ TXT
         $formRegistry = new FormRegistry([], new ResolvedFormTypeFactory());
         $command = new DebugCommand($formRegistry);
         $application = new Application();
-        if (method_exists($application, 'addCommand')) {
-            $application->addCommand($command);
-        } else {
-            $application->add($command);
-        }
+        $application->addCommand($command);
         $tester = new CommandCompletionTester($application->get('debug:form'));
         $this->assertSame($expectedSuggestions, $tester->complete($input));
     }
@@ -282,11 +278,7 @@ TXT
         $formRegistry = new FormRegistry([], new ResolvedFormTypeFactory());
         $command = new DebugCommand($formRegistry, $namespaces, $types);
         $application = new Application();
-        if (method_exists($application, 'addCommand')) {
-            $application->addCommand($command);
-        } else {
-            $application->add($command);
-        }
+        $application->addCommand($command);
 
         return new CommandTester($application->find('debug:form'));
     }

--- a/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
@@ -59,11 +59,7 @@ class ConsumeMessagesCommandTest extends TestCase
         $command = new ConsumeMessagesCommand(new RoutableMessageBus($busLocator), $receiverLocator, new EventDispatcher());
 
         $application = new Application();
-        if (method_exists($application, 'addCommand')) {
-            $application->addCommand($command);
-        } else {
-            $application->add($command);
-        }
+        $application->addCommand($command);
         $tester = new CommandTester($application->get('messenger:consume'));
         $tester->execute([
             'receivers' => ['dummy-receiver'],
@@ -93,11 +89,7 @@ class ConsumeMessagesCommandTest extends TestCase
         $command = new ConsumeMessagesCommand(new RoutableMessageBus($busLocator), $receiverLocator, new EventDispatcher());
 
         $application = new Application();
-        if (method_exists($application, 'addCommand')) {
-            $application->addCommand($command);
-        } else {
-            $application->add($command);
-        }
+        $application->addCommand($command);
         $tester = new CommandTester($application->get('messenger:consume'));
         $tester->execute([
             'receivers' => ['dummy-receiver'],
@@ -140,11 +132,7 @@ class ConsumeMessagesCommandTest extends TestCase
         $command = new ConsumeMessagesCommand($bus, $receiverLocator, new EventDispatcher(), null, [], new ResetServicesListener($servicesResetter));
 
         $application = new Application();
-        if (method_exists($application, 'addCommand')) {
-            $application->addCommand($command);
-        } else {
-            $application->add($command);
-        }
+        $application->addCommand($command);
         $tester = new CommandTester($application->get('messenger:consume'));
         $tester->execute(array_merge([
             'receivers' => ['dummy-receiver'],
@@ -168,11 +156,7 @@ class ConsumeMessagesCommandTest extends TestCase
         $command = new ConsumeMessagesCommand(new RoutableMessageBus(new Container()), $receiverLocator, new EventDispatcher());
 
         $application = new Application();
-        if (method_exists($application, 'addCommand')) {
-            $application->addCommand($command);
-        } else {
-            $application->add($command);
-        }
+        $application->addCommand($command);
         $tester = new CommandTester($application->get('messenger:consume'));
 
         $this->expectException(InvalidOptionException::class);
@@ -210,11 +194,7 @@ class ConsumeMessagesCommandTest extends TestCase
         $command = new ConsumeMessagesCommand(new RoutableMessageBus($busLocator), $receiverLocator, new EventDispatcher());
 
         $application = new Application();
-        if (method_exists($application, 'addCommand')) {
-            $application->addCommand($command);
-        } else {
-            $application->add($command);
-        }
+        $application->addCommand($command);
         $tester = new CommandTester($application->get('messenger:consume'));
         $tester->execute([
             'receivers' => ['dummy-receiver'],
@@ -252,11 +232,7 @@ class ConsumeMessagesCommandTest extends TestCase
         );
 
         $application = new Application();
-        if (method_exists($application, 'addCommand')) {
-            $application->addCommand($command);
-        } else {
-            $application->add($command);
-        }
+        $application->addCommand($command);
         $tester = new CommandTester($application->get('messenger:consume'));
         $tester->execute([
             '--all' => true,

--- a/src/Symfony/Component/Messenger/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/DebugCommandTest.php
@@ -176,11 +176,7 @@ TXT
     {
         $command = new DebugCommand(['command_bus' => [], 'query_bus' => []]);
         $application = new Application();
-        if (method_exists($application, 'addCommand')) {
-            $application->addCommand($command);
-        } else {
-            $application->add($command);
-        }
+        $application->addCommand($command);
         $tester = new CommandCompletionTester($application->get('debug:messenger'));
         $this->assertSame($expectedSuggestions, $tester->complete($input));
     }

--- a/src/Symfony/Component/Runtime/SymfonyRuntime.php
+++ b/src/Symfony/Component/Runtime/SymfonyRuntime.php
@@ -162,11 +162,7 @@ class SymfonyRuntime extends GenericRuntime
 
             if (!$application->getName() || !$console->has($application->getName())) {
                 $application->setName($_SERVER['argv'][0]);
-                if (method_exists($console, 'addCommand')) {
-                    $console->addCommand($application);
-                } else {
-                    $console->add($application);
-                }
+                $console->addCommand($application);
             }
 
             $console->setDefaultCommand($application->getName(), true);

--- a/src/Symfony/Component/Runtime/Tests/phpt/application.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/application.php
@@ -25,11 +25,7 @@ return function (array $context) {
     });
 
     $app = new Application();
-    if (method_exists($app, 'addCommand')) {
-        $app->addCommand($command);
-    } else {
-        $app->add($command);
-    }
+    $app->addCommand($command);
     $app->setDefaultCommand('go', true);
 
     return $app;

--- a/src/Symfony/Component/Runtime/Tests/phpt/command_list.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/command_list.php
@@ -23,11 +23,7 @@ return function (Application $app, Command $command, RuntimeInterface $runtime) 
     $command->setName('my_command');
 
     [$cmd, $args] = $runtime->getResolver(require __DIR__.'/command.php')->resolve();
-    if (method_exists($app, 'addCommand')) {
-        $app->addCommand($cmd(...$args));
-    } else {
-        $app->add($cmd(...$args));
-    }
+    $app->addCommand($cmd(...$args));
 
     return $app;
 };

--- a/src/Symfony/Component/Runtime/composer.json
+++ b/src/Symfony/Component/Runtime/composer.json
@@ -27,6 +27,7 @@
         "symfony/http-kernel": "^7.4|^8.0"
     },
     "conflict": {
+        "symfony/console": "<7.4",
         "symfony/error-handler": "<7.4"
     },
     "autoload": {

--- a/src/Symfony/Component/Translation/Tests/Command/TranslationLintCommandTest.php
+++ b/src/Symfony/Component/Translation/Tests/Command/TranslationLintCommandTest.php
@@ -138,11 +138,7 @@ EOF, $display);
         $command = new TranslationLintCommand($translator, $enabledLocales);
 
         $application = new Application();
-        if (method_exists($application, 'addCommand')) {
-            $application->addCommand($command);
-        } else {
-            $application->add($command);
-        }
+        $application->addCommand($command);
 
         return $command;
     }

--- a/src/Symfony/Component/Translation/Tests/Command/TranslationPullCommandTest.php
+++ b/src/Symfony/Component/Translation/Tests/Command/TranslationPullCommandTest.php
@@ -695,12 +695,7 @@ XLIFF
     public function testComplete(array $input, array $expectedSuggestions)
     {
         $application = new Application();
-        $command = $this->createCommand($this->createMock(ProviderInterface::class), ['en', 'fr', 'it'], ['messages', 'validators'], 'en', ['loco', 'crowdin', 'lokalise']);
-        if (method_exists($application, 'addCommand')) {
-            $application->addCommand($command);
-        } else {
-            $application->add($command);
-        }
+        $application->addCommand($this->createCommand($this->createMock(ProviderInterface::class), ['en', 'fr', 'it'], ['messages', 'validators'], 'en', ['loco', 'crowdin', 'lokalise']));
 
         $tester = new CommandCompletionTester($application->get('translation:pull'));
         $suggestions = $tester->complete($input);
@@ -729,11 +724,7 @@ XLIFF
     {
         $command = $this->createCommand($provider, $locales, $domains, $defaultLocale);
         $application = new Application();
-        if (method_exists($application, 'addCommand')) {
-            $application->addCommand($command);
-        } else {
-            $application->add($command);
-        }
+        $application->addCommand($command);
 
         return new CommandTester($application->find('translation:pull'));
     }

--- a/src/Symfony/Component/Translation/Tests/Command/TranslationPushCommandTest.php
+++ b/src/Symfony/Component/Translation/Tests/Command/TranslationPushCommandTest.php
@@ -361,11 +361,7 @@ class TranslationPushCommandTest extends TranslationProviderTestCase
         );
 
         $application = new Application();
-        if (method_exists($application, 'addCommand')) {
-            $application->addCommand($command);
-        } else {
-            $application->add($command);
-        }
+        $application->addCommand($command);
         $tester = new CommandTester($application->find('translation:push'));
 
         $tester->execute(['--locales' => ['en', 'fr']]);
@@ -379,12 +375,7 @@ class TranslationPushCommandTest extends TranslationProviderTestCase
     public function testComplete(array $input, array $expectedSuggestions)
     {
         $application = new Application();
-        $command = $this->createCommand($this->createMock(ProviderInterface::class), ['en', 'fr', 'it'], ['messages', 'validators'], ['loco', 'crowdin', 'lokalise']);
-        if (method_exists($application, 'addCommand')) {
-            $application->addCommand($command);
-        } else {
-            $application->add($command);
-        }
+        $application->addCommand($this->createCommand($this->createMock(ProviderInterface::class), ['en', 'fr', 'it'], ['messages', 'validators'], ['loco', 'crowdin', 'lokalise']));
 
         $tester = new CommandCompletionTester($application->get('translation:push'));
         $suggestions = $tester->complete($input);
@@ -413,11 +404,7 @@ class TranslationPushCommandTest extends TranslationProviderTestCase
     {
         $command = $this->createCommand($provider, $locales, $domains);
         $application = new Application();
-        if (method_exists($application, 'addCommand')) {
-            $application->addCommand($command);
-        } else {
-            $application->add($command);
-        }
+        $application->addCommand($command);
 
         return new CommandTester($application->find('translation:push'));
     }

--- a/src/Symfony/Component/Translation/Tests/Command/XliffLintCommandTest.php
+++ b/src/Symfony/Component/Translation/Tests/Command/XliffLintCommandTest.php
@@ -210,12 +210,7 @@ XLIFF;
     {
         if (!$application) {
             $application = new Application();
-            $command = new XliffLintCommand(null, null, null, $requireStrictFileNames);
-            if (method_exists($application, 'addCommand')) {
-                $application->addCommand($command);
-            } else {
-                $application->add($command);
-            }
+            $application->addCommand(new XliffLintCommand(null, null, null, $requireStrictFileNames));
         }
 
         $command = $application->find('lint:xliff');

--- a/src/Symfony/Component/Uid/Tests/Command/GenerateUlidCommandTest.php
+++ b/src/Symfony/Component/Uid/Tests/Command/GenerateUlidCommandTest.php
@@ -109,12 +109,7 @@ final class GenerateUlidCommandTest extends TestCase
     public function testComplete(array $input, array $expectedSuggestions)
     {
         $application = new Application();
-        $command = new GenerateUlidCommand();
-        if (method_exists($application, 'addCommand')) {
-            $application->addCommand($command);
-        } else {
-            $application->add($command);
-        }
+        $application->addCommand(new GenerateUlidCommand());
         $tester = new CommandCompletionTester($application->get('ulid:generate'));
         $suggestions = $tester->complete($input, 2);
         $this->assertSame($expectedSuggestions, $suggestions);

--- a/src/Symfony/Component/Uid/Tests/Command/GenerateUuidCommandTest.php
+++ b/src/Symfony/Component/Uid/Tests/Command/GenerateUuidCommandTest.php
@@ -238,12 +238,7 @@ final class GenerateUuidCommandTest extends TestCase
     public function testComplete(array $input, array $expectedSuggestions)
     {
         $application = new Application();
-        $command = new GenerateUuidCommand();
-        if (method_exists($application, 'addCommand')) {
-            $application->addCommand($command);
-        } else {
-            $application->add($command);
-        }
+        $application->addCommand(new GenerateUuidCommand());
         $tester = new CommandCompletionTester($application->get('uuid:generate'));
         $suggestions = $tester->complete($input, 2);
         $this->assertSame($expectedSuggestions, $suggestions);

--- a/src/Symfony/Component/VarDumper/Resources/bin/var-dump-server
+++ b/src/Symfony/Component/VarDumper/Resources/bin/var-dump-server
@@ -60,13 +60,8 @@ $app->getDefinition()->addOption(
     new InputOption('--host', null, InputOption::VALUE_REQUIRED, 'The address the server should listen to', $defaultHost)
 );
 
-$command = new ServerDumpCommand(new DumpServer($host, $logger));
-if (method_exists($app, 'addCommand')) {
-    $app->addCommand($command);
-} else {
-    $app->add($command);
-}
-$app
+$app->addCommand($command = new ServerDumpCommand(new DumpServer($host, $logger)))
+    ->getApplication()
     ->setDefaultCommand($command->getName(), true)
     ->run($input, $output)
 ;

--- a/src/Symfony/Component/VarDumper/composer.json
+++ b/src/Symfony/Component/VarDumper/composer.json
@@ -29,6 +29,7 @@
         "twig/twig": "^3.12"
     },
     "conflict": {
+        "symfony/console": "<7.4",
         "symfony/error-handler": "<7.4"
     },
     "autoload": {

--- a/src/Symfony/Component/Yaml/Resources/bin/yaml-lint
+++ b/src/Symfony/Component/Yaml/Resources/bin/yaml-lint
@@ -42,13 +42,8 @@ if (!class_exists(Application::class)) {
     exit(1);
 }
 
-$command = new LintCommand();
-if (method_exists($app = new Application(), 'addCommand')) {
-    $app->addCommand($command);
-} else {
-    $app->add($command);
-}
-$app
+(new Application())->addCommand($command = new LintCommand())
+    ->getApplication()
     ->setDefaultCommand($command->getName(), true)
     ->run()
 ;

--- a/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
+++ b/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
@@ -180,12 +180,7 @@ YAML;
     protected function createCommand(): Command
     {
         $application = new Application();
-        $command = new LintCommand();
-        if (method_exists($application, 'addCommand')) {
-            $application->addCommand($command);
-        } else {
-            $application->add($command);
-        }
+        $application->addCommand(new LintCommand());
 
         return $application->find('lint:yaml');
     }

--- a/src/Symfony/Component/Yaml/composer.json
+++ b/src/Symfony/Component/Yaml/composer.json
@@ -23,6 +23,9 @@
     "require-dev": {
         "symfony/console": "^7.4|^8.0"
     },
+    "conflict": {
+        "symfony/console": "<7.4"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Yaml\\": "" },
         "exclude-from-classmap": [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT