### PR TITLE
Silence E_DEPRECATED and E_USER_DEPRECATED

### DIFF
--- a/src/Symfony/Component/ErrorHandler/Debug.php
+++ b/src/Symfony/Component/ErrorHandler/Debug.php
@@ -20,7 +20,7 @@ class Debug
 {
     public static function enable(): ErrorHandler
     {
-        error_reporting(-1);
+        error_reporting(\E_ALL & ~\E_DEPRECATED & ~\E_USER_DEPRECATED);
 
         if (!\in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
             ini_set('display_errors', 0);

--- a/src/Symfony/Component/Runtime/Internal/BasicErrorHandler.php
+++ b/src/Symfony/Component/Runtime/Internal/BasicErrorHandler.php
@@ -20,7 +20,7 @@ class BasicErrorHandler
 {
     public static function register(bool $debug): void
     {
-        error_reporting(-1);
+        error_reporting(\E_ALL & ~\E_DEPRECATED & ~\E_USER_DEPRECATED);
 
         if (!\in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
             ini_set('display_errors', $debug);

--- a/src/Symfony/Component/Runtime/Internal/SymfonyErrorHandler.php
+++ b/src/Symfony/Component/Runtime/Internal/SymfonyErrorHandler.php
@@ -30,7 +30,7 @@ class SymfonyErrorHandler
             return;
         }
 
-        error_reporting(-1);
+        error_reporting(\E_ALL & ~\E_DEPRECATED & ~\E_USER_DEPRECATED);
 
         if (!\in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
             ini_set('display_errors', $debug);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60528
| License       | MIT

This change works around https://github.com/php/php-src/issues/17422

This shouldn't change much in practice because we report both not-silenced and silenced deprecations, except for the case when the native php error handler is triggered, which is what happens at this opcache stage, see https://github.com/php/php-src/pull/18541 also.