### PR TITLE
[Console] fix backwards-compatibility with overridden add() methods

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -1352,8 +1352,14 @@ class Application implements ResetInterface
         }
         $this->initialized = true;
 
+        if ((new \ReflectionMethod($this, 'add'))->getDeclaringClass()->getName() !== (new \ReflectionMethod($this, 'addCommand'))->getDeclaringClass()->getName()) {
+            $adder = $this->add(...);
+        } else {
+            $adder = $this->addCommand(...);
+        }
+
         foreach ($this->getDefaultCommands() as $command) {
-            $this->addCommand($command);
+            $adder($command);
         }
     }
 }

--- a/src/Symfony/Component/Runtime/SymfonyRuntime.php
+++ b/src/Symfony/Component/Runtime/SymfonyRuntime.php
@@ -162,10 +162,11 @@ class SymfonyRuntime extends GenericRuntime
 
             if (!$application->getName() || !$console->has($application->getName())) {
                 $application->setName($_SERVER['argv'][0]);
-                if (method_exists($console, 'addCommand')) {
-                    $console->addCommand($application);
-                } else {
+
+                if (!method_exists($console, 'addCommand') || (new \ReflectionMethod($console, 'add'))->getDeclaringClass()->getName() !== (new \ReflectionMethod($console, 'addCommand'))->getDeclaringClass()->getName()) {
                     $console->add($application);
+                } else {
+                    $console->addCommand($application);
                 }
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

The current (wrong) behaviour can be observed in the high deps job on the `7.3` branch: https://github.com/symfony/symfony/actions/runs/15662516138/job/44122290781#step:9:9940

The reason for the failure is that the `Application` class in `init()` no longer calls `add()` which is overridden in the extending `Application` class from FrameworkBundle doing the container-based command registration.
