### PR TITLE
[Routing] Add exact positive int requirement

### DIFF
--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Allow query-specific parameters in `UrlGenerator` using `_query`
+ * Add EXACT_POSITIVE_INT as routing requirement
 
 7.3
 ---

--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -5,7 +5,7 @@ CHANGELOG
 ---
 
  * Allow query-specific parameters in `UrlGenerator` using `_query`
- * Add EXACT_POSITIVE_INT as routing requirement
+ * Add `Requirement::EXACT_POSITIVE_INT` to validate positive numbers not contained into strings
 
 7.3
 ---

--- a/src/Symfony/Component/Routing/Requirement/Requirement.php
+++ b/src/Symfony/Component/Routing/Requirement/Requirement.php
@@ -21,7 +21,8 @@ enum Requirement
     public const DATE_YMD = '[0-9]{4}-(?:0[1-9]|1[012])-(?:0[1-9]|[12][0-9]|(?<!02-)3[01])'; // YYYY-MM-DD
     public const DIGITS = '[0-9]+';
     public const MONGODB_ID = '[0-9a-f]{24}';
-    public const POSITIVE_INT = '[1-9][0-9]*';
+    public const EXACT_POSITIVE_INT = '^[1-9][0-9]*$'; // Matches "12"
+    public const POSITIVE_INT = '[1-9][0-9]*'; // Matches "a12b"
     public const UID_BASE32 = '[0-9A-HJKMNP-TV-Z]{26}';
     public const UID_BASE58 = '[1-9A-HJ-NP-Za-km-z]{22}';
     public const UID_RFC4122 = '[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}';

--- a/src/Symfony/Component/Routing/Tests/Requirement/RequirementTest.php
+++ b/src/Symfony/Component/Routing/Tests/Requirement/RequirementTest.php
@@ -168,6 +168,7 @@ class RequirementTest extends TestCase
      *              ["42"]
      *              ["42198"]
      *              ["999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999"]
+     *              ["a3.14sgf"]
      */
     public function testPositiveIntOK(string $digits)
     {
@@ -189,6 +190,37 @@ class RequirementTest extends TestCase
     {
         $this->assertDoesNotMatchRegularExpression(
             (new Route('/{digits}', [], ['digits' => Requirement::POSITIVE_INT]))->compile()->getRegex(),
+            '/'.$digits,
+        );
+    }
+
+    /**
+     * @testWith    ["1"]
+     *              ["42"]
+     *              ["42198"]
+     *              ["999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999"]
+     */
+    public function testExactPositiveIntOK(string $digits)
+    {
+        $this->assertMatchesRegularExpression(
+            (new Route('/{digits}', [], ['digits' => Requirement::EXACT_POSITIVE_INT]))->compile()->getRegex(),
+            '/'.$digits,
+        );
+    }
+
+    /**
+     * @testWith    [""]
+     *              ["0"]
+     *              ["045"]
+     *              ["foo"]
+     *              ["-1"]
+     *              ["3.14"]
+     *              ["a3.14sgf"]
+     */
+    public function testExactPositiveIntKO(string $digits)
+    {
+        $this->assertDoesNotMatchRegularExpression(
+            (new Route('/{digits}', [], ['digits' => Requirement::EXACT_POSITIVE_INT]))->compile()->getRegex(),
             '/'.$digits,
         );
     }

--- a/src/Symfony/Component/Routing/Tests/Requirement/RequirementTest.php
+++ b/src/Symfony/Component/Routing/Tests/Requirement/RequirementTest.php
@@ -168,7 +168,7 @@ class RequirementTest extends TestCase
      *              ["42"]
      *              ["42198"]
      *              ["999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999"]
-     *              ["a3.14sgf"]
+     *              ["a123sgf"]
      */
     public function testPositiveIntOK(string $digits)
     {
@@ -215,7 +215,7 @@ class RequirementTest extends TestCase
      *              ["foo"]
      *              ["-1"]
      *              ["3.14"]
-     *              ["a3.14sgf"]
+     *              ["a123sgf"]
      */
     public function testExactPositiveIntKO(string $digits)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

The 
`public const POSITIVE_INT = '[1-9][0-9]*';`

Matches a positive int, but also a positive int contained into a non numeric string, so given:
```
"1"
"a1"
"a1a"
```
1 will be matched in all of the strings.

In order to not break backward compatibility I Implemented a new expression `EXACT_POSITIVE_INT` to allow to match only positive int that are not into non numeric strings.