### PR TITLE
[SecurityBundle] Don't break `security.http_utils` service decoration

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/AddSessionDomainConstraintPass.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/AddSessionDomainConstraintPass.php
@@ -38,7 +38,7 @@ class AddSessionDomainConstraintPass implements CompilerPassInterface
             $domainRegexp = (empty($sessionOptions['cookie_secure']) ? 'https?://' : 'https://').$domainRegexp;
         }
 
-        $container->findDefinition('security.http_utils')
+        $container->getDefinition('security.http_utils')
             ->addArgument(\sprintf('{^%s$}i', $domainRegexp))
             ->addArgument($secureDomainRegexp);
     }

--- a/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
+++ b/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
@@ -88,7 +88,7 @@ class SecurityBundle extends Bundle
         $extension->addUserProviderFactory(new LdapFactory());
         $container->addCompilerPass(new AddExpressionLanguageProvidersPass());
         $container->addCompilerPass(new AddSecurityVotersPass());
-        $container->addCompilerPass(new AddSessionDomainConstraintPass(), PassConfig::TYPE_BEFORE_REMOVING);
+        $container->addCompilerPass(new AddSessionDomainConstraintPass());
         $container->addCompilerPass(new CleanRememberMeVerifierPass());
         $container->addCompilerPass(new RegisterCsrfFeaturesPass());
         $container->addCompilerPass(new RegisterTokenUsageTrackingPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 200);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT


---

Actually, this service is really hard to override. My use case: I want to preserve a parameter in the URL. I ended with the following code, and I'm not happy with it

```php
<?php

namespace App\Security\HttpUtils;

use App\Site\SiteContext;
use Symfony\Component\DependencyInjection\Attribute\AsDecorator;
use Symfony\Component\DependencyInjection\Attribute\Autowire;
use Symfony\Component\HttpFoundation\Request;
use Symfony\Component\HttpFoundation\RequestMatcherInterface;
use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
use Symfony\Component\Security\Http\HttpUtils as SymfonyHttpUtils;

#[AsDecorator('security.http_utils')]
final class HttpUtils extends SymfonyHttpUtils
{
    public function __construct(
        private readonly SiteContext $siteContext,
        ?UrlGeneratorInterface $urlGenerator = null,
        #[Autowire(service: 'router')]
        UrlMatcherInterface|RequestMatcherInterface|null $urlMatcher = null,
        // See https://github.com/symfony/symfony/pull/60803
        ?string $domainRegexp = null,
        ?string $secureDomainRegexp = null,
    ) {
        parent::__construct($urlGenerator, $urlMatcher, $domainRegexp, $secureDomainRegexp);
    }

    public function generateUri(Request $request, string $path): string
    {
        $uri = parent::generateUri($request, $path);

        $site = $this->siteContext->currentSite;
        if (!$site) {
            return $uri;
        }

        $position = strpos($uri, '?');
        if ($position === false) {
            return $uri . '?site=' . $site->id;
        }

        parse_str(parse_url($uri, PHP_URL_QUERY) ?? '', $queryParams);
        if (array_key_exists('site', $queryParams)) {
            return $uri;
        }

        return substr($uri, 0, $position + 1) . 'site=' . $site->id . '&' . substr($uri, $position + 1);
    }

}
```

This is not a real decorator. And I cannot do that, since the original service call itself

---

>[!CAUTION]
>I believe my patch is good, but with it I cannot achieve anymore what I need to do 😬

Instead, I could change the class with a compiler pass