### PR TITLE
[Serializer] Fix `TraceableSerializer` when called from a callable inside `array_map`

### DIFF
--- a/src/Symfony/Component/Serializer/Debug/TraceableSerializer.php
+++ b/src/Symfony/Component/Serializer/Debug/TraceableSerializer.php
@@ -179,8 +179,8 @@ class TraceableSerializer implements SerializerInterface, NormalizerInterface, D
                 && $method === $trace[$i]['function']
                 && is_a($trace[$i]['class'], $interface, true)
             ) {
-                $file = $trace[$i]['file'];
-                $line = $trace[$i]['line'];
+                $file = $trace[$i]['file'] ?? $trace[$i + 1]['file'];
+                $line = $trace[$i]['line'] ?? $trace[$i + 1]['line'];
 
                 break;
             }

--- a/src/Symfony/Component/Serializer/Tests/Debug/TraceableSerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Debug/TraceableSerializerTest.php
@@ -126,6 +126,40 @@ class TraceableSerializerTest extends TestCase
         $traceableSerializer->encode('data', 'format');
         $traceableSerializer->decode('data', 'format');
     }
+
+    public function testCollectedCaller()
+    {
+        $serializer = new \Symfony\Component\Serializer\Serializer();
+
+        $collector = new SerializerDataCollector();
+        $traceableSerializer = new TraceableSerializer($serializer, $collector);
+
+        $traceableSerializer->normalize('data');
+        $collector->lateCollect();
+
+        $this->assertSame([
+            'name' => 'TraceableSerializerTest.php',
+            'file' => __FILE__,
+            'line' => __LINE__ - 6,
+        ], $collector->getData()['normalize'][0]['caller']);
+    }
+
+    public function testCollectedCallerFromArrayMap()
+    {
+        $serializer = new \Symfony\Component\Serializer\Serializer();
+
+        $collector = new SerializerDataCollector();
+        $traceableSerializer = new TraceableSerializer($serializer, $collector);
+
+        array_map([$traceableSerializer, 'normalize'], ['data']);
+        $collector->lateCollect();
+
+        $this->assertSame([
+            'name' => 'TraceableSerializerTest.php',
+            'file' => __FILE__,
+            'line' => __LINE__ - 6,
+        ], $collector->getData()['normalize'][0]['caller']);
+    }
 }
 
 class Serializer implements SerializerInterface, NormalizerInterface, DenormalizerInterface, EncoderInterface, DecoderInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

If the `TraceableSerializer` runs from a callable in an `array_map`, then the caller looses the file and the line because it was invoked. This causes a hard fail since the required items are not defined. The error is the following:
```
TraceableSerializer.php line 174:
Warning: Undefined array key "file".
```
The fix is to get the file and the line from the following array item which always is the caller class.