### PR TITLE
[Runtime] fix forward-compatibility with Symfony 8

### DIFF
--- a/src/Symfony/Component/Runtime/SymfonyRuntime.php
+++ b/src/Symfony/Component/Runtime/SymfonyRuntime.php
@@ -163,7 +163,7 @@ class SymfonyRuntime extends GenericRuntime
             if (!$application->getName() || !$console->has($application->getName())) {
                 $application->setName($_SERVER['argv'][0]);
 
-                if (!method_exists($console, 'addCommand') || (new \ReflectionMethod($console, 'add'))->getDeclaringClass()->getName() !== (new \ReflectionMethod($console, 'addCommand'))->getDeclaringClass()->getName()) {
+                if (!method_exists($console, 'addCommand') || method_exists($console, 'add') && (new \ReflectionMethod($console, 'add'))->getDeclaringClass()->getName() !== (new \ReflectionMethod($console, 'addCommand'))->getDeclaringClass()->getName()) {
                     $console->add($application);
                 } else {
                     $console->addCommand($application);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

see the failures on the `8.0` branch, on the `7.4` branch our CI didn't catch this as Composer isn't yet compatible with version 8 of the Console component and thus does install version 7.4 on the high deps job