### PR TITLE
[DependencyInjection] Allow extending `#[AsAlias]` attribute

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/AsAlias.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/AsAlias.php
@@ -17,7 +17,7 @@ namespace Symfony\Component\DependencyInjection\Attribute;
  * @author Alan Poulain <contact@alanpoulain.eu>
  */
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
-final class AsAlias
+class AsAlias
 {
     /**
      * @var list<string>

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+ * Allow `#[AsAlias]` to be extended
+
 7.3
 ---
 

--- a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
@@ -216,7 +216,7 @@ abstract class FileLoader extends BaseFileLoader
             }
             $r = $this->container->getReflectionClass($class);
             $defaultAlias = 1 === \count($interfaces) ? $interfaces[0] : null;
-            foreach ($r->getAttributes(AsAlias::class) as $attr) {
+            foreach ($r->getAttributes(AsAlias::class, \ReflectionAttribute::IS_INSTANCEOF) as $attr) {
                 /** @var AsAlias $attribute */
                 $attribute = $attr->newInstance();
                 $alias = $attribute->id ?? $defaultAlias;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeAsAlias/WithCustomAsAlias.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeAsAlias/WithCustomAsAlias.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias;
+
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
+
+#[AsProductionAlias(id: AliasFooInterface::class)]
+class WithCustomAsAlias
+{
+}
+
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+final class AsProductionAlias extends AsAlias
+{
+    /**
+     * @param string|null         $id     The id of the alias
+     * @param bool                $public Whether to declare the alias public
+     */
+    public function __construct(
+        public ?string $id = null,
+        public bool $public = false,
+    ) {
+        parent::__construct($id, $public, ['prod']);
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
@@ -45,6 +45,7 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\WithAs
 use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\WithAsAliasInterface;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\WithAsAliasMultiple;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\WithAsAliasProdEnv;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\WithCustomAsAlias;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Utils\NotAService;
 
 class FileLoaderTest extends TestCase
@@ -368,6 +369,8 @@ class FileLoaderTest extends TestCase
     public static function provideResourcesWithAsAliasAttributes(): iterable
     {
         yield 'Private' => ['PrototypeAsAlias/{WithAsAlias,AliasFooInterface}.php', [AliasFooInterface::class => new Alias(WithAsAlias::class)]];
+        yield 'PrivateCustomAlias' => ['PrototypeAsAlias/{WithCustomAsAlias,AliasFooInterface}.php', [AliasFooInterface::class => new Alias(WithCustomAsAlias::class)], 'prod'];
+        yield 'PrivateCustomAliasNoMatch' => ['PrototypeAsAlias/{WithCustomAsAlias,AliasFooInterface}.php', [], 'dev'];
         yield 'Interface' => ['PrototypeAsAlias/{WithAsAliasInterface,AliasFooInterface}.php', [AliasFooInterface::class => new Alias(WithAsAliasInterface::class)]];
         yield 'Multiple' => ['PrototypeAsAlias/{WithAsAliasMultiple,AliasFooInterface}.php', [
             AliasFooInterface::class => new Alias(WithAsAliasMultiple::class, true),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Issues        | 
| License       | MIT

This allows people to extend the `#[AsAlias]` attribute with something like this:

```php
namespace App\Symfony;

use Symfony\Component\DependencyInjection\Attribute\AsAlias;

final class AsProductionAlias extends AsAlias
{
    /**
     * @param string|null         $id     The id of the alias
     * @param bool                $public Whether to declare the alias public
     */
    public function __construct(
        public ?string $id = null,
        public bool $public = false,
    ) {
        parent::__construct($id, $public, ['prod']);
    }
}
```

This is similar to a previous change I did for the `#[When]` attribute, that was accepted:
- https://github.com/symfony/symfony/pull/47196