### PR TITLE
[TypeInfo] Fix handling `ConstFetchNode`

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
@@ -927,7 +927,7 @@ class PhpStanExtractorTest extends TestCase
             Type::object(ParentDummy::class),
             Type::null(),
         )];
-        yield ['f', null];
+        yield ['f', Type::union(Type::string(), Type::null())];
         yield ['g', Type::array(Type::union(Type::string(), Type::int()))];
     }
 

--- a/src/Symfony/Component/PropertyInfo/composer.json
+++ b/src/Symfony/Component/PropertyInfo/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "php": ">=8.2",
         "symfony/string": "^6.4|^7.0",
-        "symfony/type-info": "~7.1.9|^7.2.2"
+        "symfony/type-info": "~7.2.8|^7.3.1"
     },
     "require-dev": {
         "symfony/serializer": "^6.4|^7.0",

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -748,6 +748,8 @@ class ObjectNormalizerTest extends TestCase
         $serializer = new Serializer([new ArrayDenormalizer(), new DateTimeNormalizer(), $normalizer]);
 
         $this->assertSame('bar', $serializer->denormalize(['foo' => 'bar'], (new class {
+            public const TEST = 'me';
+
             /** @var self::*|null */
             public $foo;
         })::class)->foo);

--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithConstants.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithConstants.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Tests\Fixtures;
+
+final class DummyWithConstants
+{
+    public const DUMMY_STRING_A = 'a';
+    public const DUMMY_INT_A = 1;
+    public const DUMMY_FLOAT_A = 1.23;
+    public const DUMMY_TRUE_A = true;
+    public const DUMMY_FALSE_A = false;
+    public const DUMMY_NULL_A = null;
+    public const DUMMY_ARRAY_A = [];
+    public const DUMMY_ENUM_A = DummyEnum::ONE;
+
+    public const DUMMY_MIX_1 = self::DUMMY_STRING_A;
+    public const DUMMY_MIX_2 = self::DUMMY_INT_A;
+    public const DUMMY_MIX_3 = self::DUMMY_FLOAT_A;
+    public const DUMMY_MIX_4 = self::DUMMY_TRUE_A;
+    public const DUMMY_MIX_5 = self::DUMMY_FALSE_A;
+    public const DUMMY_MIX_6 = self::DUMMY_NULL_A;
+    public const DUMMY_MIX_7 = self::DUMMY_ARRAY_A;
+    public const DUMMY_MIX_8 = self::DUMMY_ENUM_A;
+}

--- a/src/Symfony/Component/TypeInfo/Tests/TypeResolver/StringTypeResolverTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeResolver/StringTypeResolverTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\TypeInfo\Tests\Fixtures\Dummy;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyBackedEnum;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyCollection;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyEnum;
+use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithConstants;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithTemplates;
 use Symfony\Component\TypeInfo\Type;
 use Symfony\Component\TypeInfo\TypeContext\TypeContext;
@@ -89,6 +90,19 @@ class StringTypeResolverTest extends TestCase
         yield [Type::null(), 'null'];
         yield [Type::string(), '"string"'];
         yield [Type::true(), 'true'];
+
+        // const fetch
+        yield [Type::string(), DummyWithConstants::class.'::DUMMY_STRING_*'];
+        yield [Type::string(), DummyWithConstants::class.'::DUMMY_STRING_A'];
+        yield [Type::int(), DummyWithConstants::class.'::DUMMY_INT_*'];
+        yield [Type::int(), DummyWithConstants::class.'::DUMMY_INT_A'];
+        yield [Type::float(), DummyWithConstants::class.'::DUMMY_FLOAT_*'];
+        yield [Type::bool(), DummyWithConstants::class.'::DUMMY_TRUE_*'];
+        yield [Type::bool(), DummyWithConstants::class.'::DUMMY_FALSE_*'];
+        yield [Type::null(), DummyWithConstants::class.'::DUMMY_NULL_*'];
+        yield [Type::array(), DummyWithConstants::class.'::DUMMY_ARRAY_*'];
+        yield [Type::enum(DummyEnum::class, Type::string()), DummyWithConstants::class.'::DUMMY_ENUM_*'];
+        yield [Type::union(Type::string(), Type::int(), Type::float(), Type::bool(), Type::null(), Type::array(), Type::enum(DummyEnum::class, Type::string())), DummyWithConstants::class.'::DUMMY_MIX_*'];
 
         // identifiers
         yield [Type::bool(), 'bool'];

--- a/src/Symfony/Component/TypeInfo/TypeResolver/StringTypeResolver.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/StringTypeResolver.php
@@ -18,6 +18,7 @@ use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprIntegerNode;
 use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprNullNode;
 use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprStringNode;
 use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprTrueNode;
+use PHPStan\PhpDocParser\Ast\ConstExpr\ConstFetchNode;
 use PHPStan\PhpDocParser\Ast\Type\ArrayShapeNode;
 use PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\CallableTypeNode;
@@ -119,6 +120,47 @@ final class StringTypeResolver implements TypeResolverInterface
         }
 
         if ($node instanceof ConstTypeNode) {
+            if ($node->constExpr instanceof ConstFetchNode) {
+                $className = match (strtolower($node->constExpr->className)) {
+                    'self' => $typeContext->getDeclaringClass(),
+                    'static' => $typeContext->getCalledClass(),
+                    'parent' => $typeContext->getParentClass(),
+                    default => $node->constExpr->className,
+                };
+
+                if (!class_exists($className)) {
+                    return Type::mixed();
+                }
+
+                $types = [];
+
+                foreach ((new \ReflectionClass($className))->getReflectionConstants() as $const) {
+                    if (preg_match('/^'.str_replace('\*', '.*', preg_quote($node->constExpr->name, '/')).'$/', $const->getName())) {
+                        $constValue = $const->getValue();
+
+                        $types[] = match (true) {
+                            true === $constValue,
+                            false === $constValue => Type::bool(),
+                            null === $constValue => Type::null(),
+                            \is_string($constValue) => Type::string(),
+                            \is_int($constValue) => Type::int(),
+                            \is_float($constValue) => Type::float(),
+                            \is_array($constValue) => Type::array(),
+                            $constValue instanceof \UnitEnum => Type::enum($constValue::class),
+                            default => Type::mixed(),
+                        };
+                    }
+                }
+
+                $types = array_unique($types);
+
+                if (\count($types) > 2) {
+                    return Type::union(...$types);
+                }
+
+                return $types[0] ?? Type::null();
+            }
+
             return match ($node->constExpr::class) {
                 ConstExprArrayNode::class => Type::array(),
                 ConstExprFalseNode::class => Type::false(),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #...
| License       | MIT

I cannot upgrade to 7.3 because I get:

```
  In StringTypeResolver.php line 88:
!!                                                                                 
!!    Cannot resolve "array{requirement: ProductLicense::SYSTEM_REQUIREMENT_*, va  
!!    lue: non-empty-string}".                                                     
!!                                                                                 
!!  
!!  In StringTypeResolver.php line 142:
!!                                                                                 
!!    Unhandled "PHPStan\PhpDocParser\Ast\ConstExpr\ConstFetchNode" constant expr  
!!    ession.                                                                      
!!                                                                                 
```