### PR TITLE
[Console] Add support for Invokable Commands in `CommandTester`

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -552,22 +552,7 @@ class Application implements ResetInterface
         $this->init();
 
         if (!$command instanceof Command) {
-            if (!\is_object($command) || $command instanceof \Closure) {
-                throw new InvalidArgumentException(\sprintf('The command must be an instance of "%s" or an invokable object.', Command::class));
-            }
-
-            /** @var AsCommand $attribute */
-            $attribute = ((new \ReflectionObject($command))->getAttributes(AsCommand::class)[0] ?? null)?->newInstance()
-                ?? throw new LogicException(\sprintf('The command must use the "%s" attribute.', AsCommand::class));
-
-            $command = (new Command($attribute->name))
-                ->setDescription($attribute->description ?? '')
-                ->setHelp($attribute->help ?? '')
-                ->setCode($command);
-
-            foreach ($attribute->usages as $usage) {
-                $command->addUsage($usage);
-            }
+            $command = new Command(null, $command);
         }
 
         $command->setApplication($this);

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -8,7 +8,8 @@ CHANGELOG
  * Introduce `Symfony\Component\Console\Application::addCommand()` to simplify using invokable commands when the component is used standalone
  * Deprecate `Symfony\Component\Console\Application::add()` in favor of `Symfony\Component\Console\Application::addCommand()`
  * Add `BackedEnum` support with `#[Argument]` and `#[Option]` inputs in invokable commands
- * Allow Usages to be specified via #[AsCommand] attribute.
+ * Allow Usages to be specified via `#[AsCommand]` attribute.
+ * Allow passing invokable commands to `Symfony\Component\Console\Tester\CommandTester`
 
 7.3
 ---

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -87,9 +87,30 @@ class Command implements SignalableCommandInterface
      *
      * @throws LogicException When the command name is empty
      */
-    public function __construct(?string $name = null)
+    public function __construct(?string $name = null, ?callable $code = null)
     {
         $this->definition = new InputDefinition();
+
+        if ($code !== null) {
+            if (!\is_object($code) || $code instanceof \Closure) {
+                throw new InvalidArgumentException(\sprintf('The command must be an instance of "%s" or an invokable object.', Command::class));
+            }
+
+            /** @var AsCommand $attribute */
+            $attribute = ((new \ReflectionObject($code))->getAttributes(AsCommand::class)[0] ?? null)?->newInstance()
+                ?? throw new LogicException(\sprintf('The command must use the "%s" attribute.', AsCommand::class));
+
+            $this->setName($name ?? $attribute->name)
+                ->setDescription($attribute->description ?? '')
+                ->setHelp($attribute->help ?? '')
+                ->setCode($code);
+
+            foreach ($attribute->usages as $usage) {
+                $this->addUsage($usage);
+            }
+
+            return;
+        }
 
         $attribute = ((new \ReflectionClass(static::class))->getAttributes(AsCommand::class)[0] ?? null)?->newInstance();
 

--- a/src/Symfony/Component/Console/Tester/CommandTester.php
+++ b/src/Symfony/Component/Console/Tester/CommandTester.php
@@ -24,9 +24,12 @@ class CommandTester
 {
     use TesterTrait;
 
+    private Command $command;
+
     public function __construct(
-        private Command $command,
+        callable|Command $command,
     ) {
+        $this->command = $command instanceof Command ? $command : new Command(null, $command);
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -48,6 +48,8 @@ use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\SignalRegistry\SignalRegistry;
 use Symfony\Component\Console\Terminal;
 use Symfony\Component\Console\Tester\ApplicationTester;
+use Symfony\Component\Console\Tests\Fixtures\InvokableExtendingCommandTestCommand;
+use Symfony\Component\Console\Tests\Fixtures\InvokableTestCommand;
 use Symfony\Component\Console\Tests\Fixtures\MockableAppliationWithTerminalWidth;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -257,7 +259,7 @@ class ApplicationTest extends TestCase
         $application->addCommand($foo = new InvokableTestCommand());
         $commands = $application->all();
 
-        $this->assertInstanceOf(Command::class, $command = $commands['invokable']);
+        $this->assertInstanceOf(Command::class, $command = $commands['invokable:test']);
         $this->assertEquals(new InvokableCommand($command, $foo), (new \ReflectionObject($command))->getProperty('code')->getValue($command));
     }
 
@@ -2567,14 +2569,6 @@ class DisabledCommand extends Command
     public function isEnabled(): bool
     {
         return false;
-    }
-}
-
-#[AsCommand(name: 'invokable')]
-class InvokableTestCommand
-{
-    public function __invoke(): int
-    {
     }
 }
 

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -27,6 +27,7 @@ use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Console\Tests\Fixtures\InvokableTestCommand;
 
 class CommandTest extends TestCase
 {
@@ -302,6 +303,13 @@ class CommandTest extends TestCase
         $tester->execute([], ['interactive' => true]);
 
         $this->assertEquals('interact called'.\PHP_EOL.'execute called'.\PHP_EOL, $tester->getDisplay(), '->run() calls the interact() method if the input is interactive');
+    }
+
+    public function testInvokableCommand()
+    {
+        $tester = new CommandTester(new InvokableTestCommand());
+
+        $this->assertSame(Command::SUCCESS, $tester->execute([]));
     }
 
     public function testRunNonInteractive()

--- a/src/Symfony/Component/Console/Tests/Fixtures/InvokableExtendingCommandTestCommand.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/InvokableExtendingCommandTestCommand.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symfony\Component\Console\Tests\Fixtures;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+
+#[AsCommand('invokable:test')]
+class InvokableExtendingCommandTestCommand extends Command
+{
+    public function __invoke(): int
+    {
+        return Command::SUCCESS;
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/InvokableTestCommand.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/InvokableTestCommand.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symfony\Component\Console\Tests\Fixtures;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+
+#[AsCommand('invokable:test')]
+class InvokableTestCommand
+{
+    public function __invoke(): int
+    {
+        return Command::SUCCESS;
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
@@ -23,6 +23,8 @@ use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Console\Tests\Fixtures\InvokableExtendingCommandTestCommand;
+use Symfony\Component\Console\Tests\Fixtures\InvokableTestCommand;
 
 class CommandTesterTest extends TestCase
 {
@@ -266,5 +268,25 @@ class CommandTesterTest extends TestCase
         );
 
         $this->assertSame('foo', $tester->getErrorOutput());
+    }
+
+    public function testAInvokableCommand()
+    {
+        $command = new InvokableTestCommand();
+
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+
+        $tester->assertCommandIsSuccessful();
+    }
+
+    public function testAInvokableExtendedCommand()
+    {
+        $command = new InvokableExtendingCommandTestCommand();
+
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+
+        $tester->assertCommandIsSuccessful();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

I'm trying out the amazing new [Invokable Commands](https://symfony.com/blog/new-in-symfony-7-3-invokable-commands-and-input-attributes) introduced in Symfony 7.3 but I noticed that I could use it together with the CommandTester. It was also not possible to manually add these type of commands to the Application.

I'm not sure what the best approach is with this. As I'm changing the signature of the methods this might be considered a breaking change. Or it might not, as I'm widening the type from Command to object.

Please advise what the best approach would be to introduce something like this. Thanks 🙏 

/cc @yceruto @chalasr 