### PR TITLE
[ObjectMapper] Fix class-level transformation has wrong source class

### DIFF
--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -70,7 +70,7 @@ final class ObjectMapper implements ObjectMapperInterface
 
         $mappedTarget = $mappingToObject ? $target : $targetRefl->newInstanceWithoutConstructor();
         if ($map && $map->transform) {
-            $mappedTarget = $this->applyTransforms($map, $mappedTarget, $mappedTarget, null);
+            $mappedTarget = $this->applyTransforms($map, $mappedTarget, $source, null);
 
             if (!\is_object($mappedTarget)) {
                 throw new MappingTransformException(\sprintf('Cannot map "%s" to a non-object target of type "%s".', get_debug_type($source), get_debug_type($mappedTarget)));

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InstanceCallbackWithArguments/A.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InstanceCallbackWithArguments/A.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\InstanceCallbackWithArguments;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: B::class, transform: [B::class, 'newInstance'])]
+class A
+{
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InstanceCallbackWithArguments/B.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InstanceCallbackWithArguments/B.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\InstanceCallbackWithArguments;
+
+class B
+{
+    public mixed $transformValue;
+    public object $transformSource;
+
+    public static function newInstance(mixed $value, object $source): self
+    {
+        $b = new self();
+        $b->transformValue = $value;
+        $b->transformSource = $source;
+
+        return $b;
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -34,6 +34,8 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\Flatten\UserProfile;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\HydrateObject\SourceOnly;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\InstanceCallback\A as InstanceCallbackA;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\InstanceCallback\B as InstanceCallbackB;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\InstanceCallbackWithArguments\A as InstanceCallbackWithArgumentsA;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\InstanceCallbackWithArguments\B as InstanceCallbackWithArgumentsB;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\AToBMapper;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\MapStructMapperMetadataFactory;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\Source;
@@ -153,6 +155,16 @@ final class ObjectMapperTest extends TestCase
         $this->assertInstanceOf(InstanceCallbackB::class, $b);
         $this->assertSame($b->getId(), 1);
         $this->assertSame($b->name, 'test');
+    }
+
+    public function testMapToWithInstanceHookWithArguments()
+    {
+        $a = new InstanceCallbackWithArgumentsA();
+        $mapper = new ObjectMapper();
+        $b = $mapper->map($a);
+        $this->assertInstanceOf(InstanceCallbackWithArgumentsB::class, $b);
+        $this->assertSame($a, $b->transformSource);
+        $this->assertInstanceOf(InstanceCallbackWithArgumentsB::class, $b->transformValue);
     }
 
     public function testMapStruct()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60827
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
