### PR TITLE
[Validator] Add missing HasNamedArguments to some constraints

### DIFF
--- a/src/Symfony/Component/Security/Core/Validator/Constraints/UserPassword.php
+++ b/src/Symfony/Component/Security/Core/Validator/Constraints/UserPassword.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Security\Core\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
@@ -25,6 +26,7 @@ class UserPassword extends Constraint
     public string $message = 'This value should be the user\'s current password.';
     public string $service = 'security.validator.user_password';
 
+    #[HasNamedArguments]
     public function __construct(?array $options = null, ?string $message = null, ?string $service = null, ?array $groups = null, mixed $payload = null)
     {
         parent::__construct($options, $groups, $payload);

--- a/src/Symfony/Component/Validator/Constraints/AtLeastOneOf.php
+++ b/src/Symfony/Component/Validator/Constraints/AtLeastOneOf.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 /**
@@ -39,6 +40,7 @@ class AtLeastOneOf extends Composite
      * @param string|null                                $messageCollection       Failure message for All and Collection inner constraints
      * @param bool|null                                  $includeInternalMessages Whether to include inner constraint messages (defaults to true)
      */
+    #[HasNamedArguments]
     public function __construct(mixed $constraints = null, ?array $groups = null, mixed $payload = null, ?string $message = null, ?string $messageCollection = null, ?bool $includeInternalMessages = null)
     {
         if (\is_array($constraints) && !array_is_list($constraints)) {

--- a/src/Symfony/Component/Validator/Constraints/Composite.php
+++ b/src/Symfony/Component/Validator/Constraints/Composite.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 
@@ -49,6 +50,7 @@ abstract class Composite extends Constraint
      * cached. When constraints are loaded from the cache, no more group
      * checks need to be done.
      */
+    #[HasNamedArguments]
     public function __construct(mixed $options = null, ?array $groups = null, mixed $payload = null)
     {
         parent::__construct($options, $groups, $payload);

--- a/src/Symfony/Component/Validator/Constraints/Compound.php
+++ b/src/Symfony/Component/Validator/Constraints/Compound.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 
@@ -24,6 +25,7 @@ abstract class Compound extends Composite
     /** @var Constraint[] */
     public array $constraints = [];
 
+    #[HasNamedArguments]
     public function __construct(mixed $options = null, ?array $groups = null, mixed $payload = null)
     {
         if (isset($options[$this->getCompositeOption()])) {

--- a/src/Symfony/Component/Validator/Constraints/GroupSequence.php
+++ b/src/Symfony/Component/Validator/Constraints/GroupSequence.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
+
 /**
  * A sequence of validation groups.
  *
@@ -75,6 +77,7 @@ class GroupSequence
      *
      * @param array<string|string[]|GroupSequence> $groups The groups in the sequence
      */
+    #[HasNamedArguments]
     public function __construct(array $groups)
     {
         $this->groups = $groups['value'] ?? $groups;

--- a/src/Symfony/Component/Validator/Constraints/Image.php
+++ b/src/Symfony/Component/Validator/Constraints/Image.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
+
 /**
  * Validates that a file (or a path to a file) is a valid image.
  *
@@ -118,6 +120,7 @@ class Image extends File
      *
      * @see https://www.iana.org/assignments/media-types/media-types.xhtml Existing media types
      */
+    #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
         int|string|null $maxSize = null,

--- a/src/Symfony/Component/Validator/Constraints/Sequentially.php
+++ b/src/Symfony/Component/Validator/Constraints/Sequentially.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 /**
@@ -28,6 +29,7 @@ class Sequentially extends Composite
      * @param Constraint[]|array<string,mixed>|null $constraints An array of validation constraints
      * @param string[]|null                         $groups
      */
+    #[HasNamedArguments]
     public function __construct(mixed $constraints = null, ?array $groups = null, mixed $payload = null)
     {
         if (\is_array($constraints) && !array_is_list($constraints)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | Fix #60838
| License       | MIT

Add missing `HasNamedArguments` attribute on `__construct(...)` to fix symfony 7.4 deprecation