### PR TITLE
[DependencyInjection] Remove deprecated `ContainerBuilder::getAutoconfiguredAttributes()`

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -109,6 +109,8 @@ DependencyInjection
     }
     ```
 
+ * Remove the `ContainerBuilder::getAutoconfiguredAttributes()` method, use `getAttributeAutoconfigurators()` instead to retrieve all the callbacks for a specific attribute class
+
 DoctrineBridge
 --------------
 

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Remove `#[TaggedIterator]` and `#[TaggedLocator]` attributes, replaced by `#[AutowireLocator]` and `#[AutowireIterator]`
+ * Remove `ContainerBuilder::getAutoconfiguredAttributes()`, replaced by `ContainerBuilder::getAttributeAutoconfigurators()`
 
 7.4
 ---

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1489,27 +1489,6 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     }
 
     /**
-     * @return array<class-string, callable>
-     *
-     * @deprecated Use {@see getAttributeAutoconfigurators()} instead
-     */
-    public function getAutoconfiguredAttributes(): array
-    {
-        trigger_deprecation('symfony/dependency-injection', '7.3', 'The "%s()" method is deprecated, use "getAttributeAutoconfigurators()" instead.', __METHOD__);
-
-        $autoconfiguredAttributes = [];
-        foreach ($this->autoconfiguredAttributes as $attribute => $configurators) {
-            if (count($configurators) > 1) {
-                throw new LogicException(\sprintf('The "%s" attribute has %d configurators. Use "getAttributeAutoconfigurators()" to get all of them.', $attribute, count($configurators)));
-            }
-
-            $autoconfiguredAttributes[$attribute] = $configurators[0];
-        }
-
-        return $autoconfiguredAttributes;
-    }
-
-    /**
      * @return array<class-string, callable[]>
      */
     public function getAttributeAutoconfigurators(): array

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -842,25 +842,6 @@ class ContainerBuilderTest extends TestCase
         $this->assertSame([AsTaggedItem::class => [$c1, $c2]], $container->getAttributeAutoconfigurators());
     }
 
-    /**
-     * @group legacy
-     */
-    public function testGetAutoconfiguredAttributes()
-    {
-        $container = new ContainerBuilder();
-        $container->registerAttributeForAutoconfiguration(AsTaggedItem::class, $c = static function () {});
-
-        $this->expectUserDeprecationMessage('Since symfony/dependency-injection 7.3: The "Symfony\Component\DependencyInjection\ContainerBuilder::getAutoconfiguredAttributes()" method is deprecated, use "getAttributeAutoconfigurators()" instead.');
-        $configurators = $container->getAutoconfiguredAttributes();
-        $this->assertSame($c, $configurators[AsTaggedItem::class]);
-
-        // Method call fails with more than one configurator for a given attribute
-        $container->registerAttributeForAutoconfiguration(AsTaggedItem::class, $c = static function () {});
-
-        $this->expectException(LogicException::class);
-        $container->getAutoconfiguredAttributes();
-    }
-
     public function testResolveEnvValues()
     {
         $_ENV['DUMMY_ENV_VAR'] = 'du%%y';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | #60011
| License       | MIT

In #60011, the method `ContainerBuilder::getAutoconfiguredAttributes()` has been deprecated and replaced by `getAttributeAutoconfigurators()` to support multiple callbacks per attribute class.
