### PR TITLE
[Dotenv] Remove `DebugCommand::$defaultName` and `$defaultDescription`

### DIFF
--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -463,14 +463,6 @@ class CommandTest extends TestCase
         $this->assertSame(['f'], $command->getAliases());
     }
 
-    public function testAttributeOverridesProperty()
-    {
-        $command = new MyAnnotatedCommand();
-
-        $this->assertSame('my:command', $command->getName());
-        $this->assertSame('This is a command I wrote all by myself', $command->getDescription());
-    }
-
     public function testDefaultCommand()
     {
         $apl = new Application();
@@ -507,10 +499,3 @@ class Php8Command2 extends Command
 {
 }
 
-#[AsCommand(name: 'my:command', description: 'This is a command I wrote all by myself')]
-class MyAnnotatedCommand extends Command
-{
-    protected static $defaultName = 'i-shall-be-ignored';
-
-    protected static $defaultDescription = 'This description should be ignored.';
-}

--- a/src/Symfony/Component/Dotenv/Command/DebugCommand.php
+++ b/src/Symfony/Component/Dotenv/Command/DebugCommand.php
@@ -30,16 +30,6 @@ use Symfony\Component\Dotenv\Dotenv;
 #[AsCommand(name: 'debug:dotenv', description: 'List all dotenv files with variables and values')]
 final class DebugCommand extends Command
 {
-    /**
-     * @deprecated since Symfony 6.1
-     */
-    protected static $defaultName = 'debug:dotenv';
-
-    /**
-     * @deprecated since Symfony 6.1
-     */
-    protected static $defaultDescription = 'List all dotenv files with variables and values';
-
     public function __construct(
         private string $kernelEnvironment,
         private string $projectDirectory,

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.0
+---
+
+ * Remove `$defaultName` and `$defaultDescription` properties from `DebugCommand` command, configuration is done through the `#[AsCommand]` attribute
+
 7.4
 ---
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The command is configured by the `#[AsCommand]` attribute. The public static properties were kept for only for backward compatibility.

No upgrade instruction needed.