### PR TITLE
[FrameworkBundle] disable the Lock integration to not register the deduplicate middleware

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_bus_name_stamp.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_bus_name_stamp.php
@@ -5,6 +5,7 @@ $container->loadFromExtension('framework', [
     'http_method_override' => false,
     'handle_all_throwables' => true,
     'php_errors' => ['log' => true],
+    'lock' => false,
     'messenger' => [
         'default_bus' => 'messenger.bus.commands',
         'buses' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_bus_name_stamp.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_bus_name_stamp.xml
@@ -8,6 +8,7 @@
     <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
         <framework:php-errors log="true" />
+        <framework:lock enabled="false" />
         <framework:messenger default-bus="messenger.bus.commands">
             <framework:bus name="messenger.bus.commands" default-middleware="false">
                 <framework:middleware id="add_bus_name_stamp_middleware" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_bus_name_stamp.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_bus_name_stamp.yml
@@ -4,6 +4,7 @@ framework:
     handle_all_throwables: true
     php_errors:
         log: true
+    lock: false
     messenger:
         default_bus: messenger.bus.commands
         buses:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

similar to #60559 to fix the high deps failures