### PR TITLE
[Mailer] remove useless @legacy annotation

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunApiTransportTest.php
@@ -98,14 +98,8 @@ class MailgunApiTransportTest extends TestCase
         $this->assertEquals('amp-html-value', $payload['amp-html']);
     }
 
-    /**
-     * @legacy
-     */
     public function testPrefixHeaderWithH()
     {
-        $json = json_encode(['foo' => 'bar']);
-        $deliveryTime = (new \DateTimeImmutable('2020-03-20 13:01:00'))->format(\DateTimeInterface::RFC2822);
-
         $email = new Email();
         $email->getHeaders()->addTextHeader('h:bar', 'bar-value');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

this was added in #36148 and the deprecation was later on reverted in #41380