### PR TITLE
[ObjectMapper] handle non existing property errors

### DIFF
--- a/src/Symfony/Component/ObjectMapper/Exception/NoSuchPropertyException.php
+++ b/src/Symfony/Component/ObjectMapper/Exception/NoSuchPropertyException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Exception;
+
+/**
+ * Thrown when a property cannot be found.
+ *
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ */
+class NoSuchPropertyException extends MappingException
+{
+}

--- a/src/Symfony/Component/ObjectMapper/ObjectMapperInterface.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapperInterface.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\ObjectMapper;
 
 use Symfony\Component\ObjectMapper\Exception\MappingException;
 use Symfony\Component\ObjectMapper\Exception\MappingTransformException;
+use Symfony\Component\ObjectMapper\Exception\NoSuchPropertyException;
 
 /**
  * Object to object mapper.
@@ -33,6 +34,7 @@ interface ObjectMapperInterface
      *
      * @throws MappingException          When the mapping configuration is wrong
      * @throws MappingTransformException When a transformation on an object does not return an object
+     * @throws NoSuchPropertyException   When a property does not exist
      */
     public function map(object $source, object|string|null $target = null): object;
 }

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/DefaultValueStdClass/TargetDto.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/DefaultValueStdClass/TargetDto.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\DefaultValueStdClass;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+class TargetDto
+{
+    public function __construct(
+        public string  $id,
+        #[Map(source: 'optional', if: [self::class, 'isDefined'])]
+        public ?string $optional = null,
+    ) {
+    }
+
+    public static function isDefined($source): bool
+    {
+        return isset($source);
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\ObjectMapper\Exception\MappingException;
 use Symfony\Component\ObjectMapper\Exception\MappingTransformException;
+use Symfony\Component\ObjectMapper\Exception\NoSuchPropertyException;
 use Symfony\Component\ObjectMapper\Metadata\Mapping;
 use Symfony\Component\ObjectMapper\Metadata\ObjectMapperMetadataFactoryInterface;
 use Symfony\Component\ObjectMapper\Metadata\ReflectionObjectMapperMetadataFactory;
@@ -28,6 +29,7 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\DeeperRecursion\Recursive;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\DeeperRecursion\RecursiveDto;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\DeeperRecursion\Relation;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\DeeperRecursion\RelationDto;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\DefaultValueStdClass\TargetDto;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\Flatten\TargetUser;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\Flatten\User;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\Flatten\UserProfile;
@@ -236,8 +238,17 @@ final class ObjectMapperTest extends TestCase
         $mapped = $mapper->map($a, SourceOnly::class);
         $this->assertInstanceOf(SourceOnly::class, $mapped);
         $this->assertSame('test', $mapped->mappedName);
+    }
 
+    public function testSourceOnlyWithMagicMethods()
+    {
+        $mapper = new ObjectMapper();
         $a = new class {
+            public function __isset($key): bool
+            {
+                return 'name' === $key;
+            }
+
             public function __get(string $key): string
             {
                 return match ($key) {
@@ -302,5 +313,25 @@ final class ObjectMapperTest extends TestCase
         $this->assertEquals('test', $c->bar);
         $this->assertEquals('donotmap', $c->foo);
         $this->assertEquals('foo', $c->doesNotExistInTargetB);
+    }
+
+    public function testDefaultValueStdClass()
+    {
+        $this->expectException(NoSuchPropertyException::class);
+        $u = new \stdClass();
+        $u->id = 'abc';
+        $mapper = new ObjectMapper();
+        $b = $mapper->map($u, TargetDto::class);
+    }
+
+    public function testDefaultValueStdClassWithPropertyInfo()
+    {
+        $u = new \stdClass();
+        $u->id = 'abc';
+        $mapper = new ObjectMapper(propertyAccessor: PropertyAccess::createPropertyAccessorBuilder()->disableExceptionOnInvalidPropertyPath()->getPropertyAccessor());
+        $b = $mapper->map($u, TargetDto::class);
+        $this->assertInstanceOf(TargetDto::class, $b);
+        $this->assertSame('abc', $b->id);
+        $this->assertNull($b->optional);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #60848
| License       | MIT

The property accessor allows to ignore exceptions when a property does not exist. Without the property accessor we now throw a proper exception when the property does not exist (as opposed to the PHP Warning it'd trigger otherwise). I think its better to thrown then to hide the error in that particular case. 

This fixes #60848 providing a working solution and a better DX, especially that in PHP the behavior of dynamic properties is to avoid them as much as possible. 

