### PR TITLE
Move property accessor phpdoc to interface

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -109,11 +109,6 @@ class PropertyAccessor implements PropertyAccessorInterface
         return $propertyValues[\count($propertyValues) - 1][self::VALUE];
     }
 
-    /**
-     * @template T of object|array
-     * @param T $objectOrArray
-     * @param-out ($objectOrArray is array ? array : T) $objectOrArray
-     */
     public function setValue(object|array &$objectOrArray, string|PropertyPathInterface $propertyPath, mixed $value): void
     {
         if (\is_object($objectOrArray) && (false === strpbrk((string) $propertyPath, '.[') || $objectOrArray instanceof \stdClass && property_exists($objectOrArray, $propertyPath))) {

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessorInterface.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessorInterface.php
@@ -39,6 +39,12 @@ interface PropertyAccessorInterface
      *
      * If neither is found, an exception is thrown.
      *
+     * @template T of object|array
+     *
+     * @param T $objectOrArray
+     *
+     * @param-out ($objectOrArray is array ? array : T) $objectOrArray
+     *
      * @throws Exception\InvalidArgumentException If the property path is invalid
      * @throws Exception\AccessException          If a property/index does not exist or is not public
      * @throws Exception\UnexpectedTypeException  If a value within the path is neither object nor array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

This gives the same help for static analyser than https://github.com/symfony/symfony/pull/60374 but for the Interface.
I targeted the 7.2 branch since it's the one the phpdoc was introduced.

I copy the explanation:
> This pull request was made to help static code analyzers understand that when calling PropertyAccessor::setValue, this will > not change the type of the passed $objectOrArray.
> At the moment static analysis will point out that the value of $objectOrArray can be any object or an array after calling the > setValue method, which is of course not the case.

> The solution comes directly from this closed PHPStan issue: https://github.com/phpstan/phpstan/issues/12399
> (Other tools like Psalm also support @param-out)

According to the Interface description this behavior shouldn't be restricted to PropertyAccessor but should be enforced/described in the interface too.