### PR TITLE
[DependencyInjection] Remove unused and non-existent Factory attribute use

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/StaticConstructorAutoconfigure.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/StaticConstructorAutoconfigure.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
 
 use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
-use Symfony\Component\DependencyInjection\Attribute\Factory;
 
 #[Autoconfigure(bind: ['$foo' => 'foo'], constructor: 'create')]
 class StaticConstructorAutoconfigure


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | No
| License       | MIT

**I'm not sure if this should be for the 6.4 or 7.4 branch**
**I'm not sure if this should be considered a bug or not**

This PR removes an unused `use` statement:

```php
use Symfony\Component\DependencyInjection\Attribute\Factory;
```
This class is not referenced anywhere in the file and does not exist in the current codebase, so it can safely be removed.