### PR TITLE
[Console] Make `$input` argument for `CommandTester` optional

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Add `BackedEnum` support with `#[Argument]` and `#[Option]` inputs in invokable commands
  * Allow Usages to be specified via `#[AsCommand]` attribute.
  * Allow passing invokable commands to `Symfony\Component\Console\Tester\CommandTester`
+ * Make `$input` argument for `Symfony\Component\Console\Tester\CommandTester` optional
 
 7.3
 ---

--- a/src/Symfony/Component/Console/Tester/CommandTester.php
+++ b/src/Symfony/Component/Console/Tester/CommandTester.php
@@ -47,7 +47,7 @@ class CommandTester
      *
      * @return int The command exit code
      */
-    public function execute(array $input, array $options = []): int
+    public function execute(array $input = [], array $options = []): int
     {
         // set the command name automatically if the application requires
         // this argument and no command name was passed


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

Why require an input to be passed when none is needed?

```php
new CommandTester($command)->execute([]);
```

It would look better if I could do:
```php
new CommandTester($command)->execute();
```
