### PR TITLE
[HttpFoundation] Revert " Emit PHP warning when `Response::sendHeaders()` is called while output has already been sent"

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -317,11 +317,6 @@ class Response
     {
         // headers have already been sent by the developer
         if (headers_sent()) {
-            if (!\in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
-                $statusCode ??= $this->statusCode;
-                header(\sprintf('HTTP/%s %s %s', $this->version, $statusCode, $this->statusText), true, $statusCode);
-            }
-
             return $this;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60603
| License       | MIT

This reverts commit cf554e1be6338c1176832dd4cdf713d88d3144ad, reversing changes made to 392d0c9c407d6b06a072600fe9dc2a779b231ce0.

Let's revert as this change is too disruptive for a minor version (and I'm also going to replace this by a deprecation on 7.4 so that we can throw the warning in 8.0)