### PR TITLE
[AssetMapper] Remove `ImportMapConfigReader::splitPackageNameAndFilePath()`

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -6,6 +6,11 @@ release process, both versions have the same features, but Symfony 8.0 doesn't i
 To upgrade, make sure to resolve all deprecation notices.
 Read more about this in the [Symfony documentation](https://symfony.com/doc/8.0/setup/upgrade_major.html).
 
+AssetMapper
+-----------
+
+ * Remove `ImportMapConfigReader::splitPackageNameAndFilePath()`, use `ImportMapEntry::splitPackageNameAndFilePath()` instead
+
 Console
 -------
 

--- a/src/Symfony/Component/AssetMapper/CHANGELOG.md
+++ b/src/Symfony/Component/AssetMapper/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.0
+---
+
+ * Remove `ImportMapConfigReader::splitPackageNameAndFilePath()`, use `ImportMapEntry::splitPackageNameAndFilePath()` instead
+
 7.3
 ---
 

--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapConfigReader.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapConfigReader.php
@@ -174,23 +174,4 @@ class ImportMapConfigReader
     {
         return \dirname($this->importMapConfigPath);
     }
-
-    /**
-     * @deprecated since Symfony 7.1, use ImportMapEntry::splitPackageNameAndFilePath() instead
-     */
-    public static function splitPackageNameAndFilePath(string $packageName): array
-    {
-        trigger_deprecation('symfony/asset-mapper', '7.1', 'The method "%s()" is deprecated and will be removed in 8.0. Use ImportMapEntry::splitPackageNameAndFilePath() instead.', __METHOD__);
-
-        $filePath = '';
-        $i = strpos($packageName, '/');
-
-        if ($i && (!str_starts_with($packageName, '@') || $i = strpos($packageName, '/', $i + 1))) {
-            // @vendor/package/filepath or package/filepath
-            $filePath = substr($packageName, $i);
-            $packageName = substr($packageName, 0, $i);
-        }
-
-        return [$packageName, $filePath];
-    }
 }

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapConfigReaderTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapConfigReaderTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\AssetMapper\Tests\ImportMap;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Bridge\PhpUnit\ExpectUserDeprecationMessageTrait;
 use Symfony\Component\AssetMapper\ImportMap\ImportMapConfigReader;
 use Symfony\Component\AssetMapper\ImportMap\ImportMapEntries;
 use Symfony\Component\AssetMapper\ImportMap\ImportMapEntry;
@@ -22,8 +21,6 @@ use Symfony\Component\Filesystem\Filesystem;
 
 class ImportMapConfigReaderTest extends TestCase
 {
-    use ExpectUserDeprecationMessageTrait;
-
     private Filesystem $filesystem;
 
     protected function setUp(): void
@@ -161,14 +158,5 @@ EOF;
         $entry = $configReader->findRootImportMapEntry('file2');
         $this->assertSame('file2', $entry->importName);
         $this->assertSame('file2.js', $entry->path);
-    }
-
-    /**
-     * @group legacy
-     */
-    public function testDeprecatedMethodTriggerDeprecation()
-    {
-        $this->expectUserDeprecationMessage('Since symfony/asset-mapper 7.1: The method "Symfony\Component\AssetMapper\ImportMap\ImportMapConfigReader::splitPackageNameAndFilePath()" is deprecated and will be removed in 8.0. Use ImportMapEntry::splitPackageNameAndFilePath() instead.');
-        ImportMapConfigReader::splitPackageNameAndFilePath('foo');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT