### PR TITLE
[Security] Document `FirewallListenerInterface` as a firewall listener type

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Security/FirewallContext.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/FirewallContext.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\SecurityBundle\Security;
 
 use Symfony\Component\Security\Http\Firewall\ExceptionListener;
+use Symfony\Component\Security\Http\Firewall\FirewallListenerInterface;
 use Symfony\Component\Security\Http\Firewall\LogoutListener;
 
 /**
@@ -28,7 +29,7 @@ class FirewallContext
     private ?FirewallConfig $config;
 
     /**
-     * @param iterable<mixed, callable> $listeners
+     * @param iterable<mixed, callable|FirewallListenerInterface> $listeners
      */
     public function __construct(iterable $listeners, ?ExceptionListener $exceptionListener = null, ?LogoutListener $logoutListener = null, ?FirewallConfig $config = null)
     {
@@ -47,7 +48,7 @@ class FirewallContext
     }
 
     /**
-     * @return iterable<mixed, callable>
+     * @return iterable<mixed, callable|FirewallListenerInterface>
      */
     public function getListeners(): iterable
     {

--- a/src/Symfony/Component/Security/Http/FirewallMap.php
+++ b/src/Symfony/Component/Security/Http/FirewallMap.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Security\Http;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 use Symfony\Component\Security\Http\Firewall\ExceptionListener;
+use Symfony\Component\Security\Http\Firewall\FirewallListenerInterface;
 use Symfony\Component\Security\Http\Firewall\LogoutListener;
 
 /**
@@ -25,12 +26,12 @@ use Symfony\Component\Security\Http\Firewall\LogoutListener;
 class FirewallMap implements FirewallMapInterface
 {
     /**
-     * @var list<array{RequestMatcherInterface, list<callable>, ExceptionListener|null, LogoutListener|null}>
+     * @var list<array{RequestMatcherInterface, list<callable|FirewallListenerInterface>, ExceptionListener|null, LogoutListener|null}>
      */
     private array $map = [];
 
     /**
-     * @param list<callable> $listeners
+     * @param list<callable|FirewallListenerInterface> $listeners
      *
      * @return void
      */

--- a/src/Symfony/Component/Security/Http/FirewallMapInterface.php
+++ b/src/Symfony/Component/Security/Http/FirewallMapInterface.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Http;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Http\Firewall\ExceptionListener;
+use Symfony\Component\Security\Http\Firewall\FirewallListenerInterface;
 use Symfony\Component\Security\Http\Firewall\LogoutListener;
 
 /**
@@ -35,7 +36,7 @@ interface FirewallMapInterface
      * If there is no logout listener, the third element of the outer array
      * must be null.
      *
-     * @return array{iterable<mixed, callable>, ExceptionListener, LogoutListener}
+     * @return array{iterable<mixed, callable|FirewallListenerInterface>, ExceptionListener, LogoutListener}
      */
     public function getListeners(Request $request);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | N/A
| License       | MIT

This PR updates PHPDocs regarding firewall listeners, since implementations of `FirewallListenerInterface` aren’t necessarily callables.