### PR TITLE
[Intl] Fix locale validator when canonicalize is true

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/LocaleValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LocaleValidator.php
@@ -47,7 +47,7 @@ class LocaleValidator extends ConstraintValidator
             $value = \Locale::canonicalize($value);
         }
 
-        if (!Locales::exists($value)) {
+        if (null === $value || !Locales::exists($value)) {
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ value }}', $this->formatValue($inputValue))
                 ->setCode(Locale::NO_SUCH_LOCALE_ERROR)

--- a/src/Symfony/Component/Validator/Tests/Constraints/LocaleValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LocaleValidatorTest.php
@@ -91,6 +91,21 @@ class LocaleValidatorTest extends ConstraintValidatorTestCase
         ];
     }
 
+    public function testTooLongLocale()
+    {
+        $constraint = new Locale([
+            'message' => 'myMessage',
+        ]);
+
+        $locale = str_repeat('a', (\defined('INTL_MAX_LOCALE_LEN') ? \INTL_MAX_LOCALE_LEN : 85) + 1);
+        $this->validator->validate($locale, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '"' . $locale . '"')
+            ->setCode(Locale::NO_SUCH_LOCALE_ERROR)
+            ->assertRaised();
+    }
+
     /**
      * @dataProvider getUncanonicalizedLocales
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4,7.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

When canonicalize is set to true, and the value passed to the validator is not a valid locale, ext-intl Locale::canonicalize should return null.

This is not the case with ICU <76, and this method returns an empty string.
But with the latest ICU lib, this method really returns null.

The problem is with `Locales::exists()` which only accept non null string.

This commit handles the returned null value in the validator.