### PR TITLE
[AssetMapper] Render a more precise importmap per page

### DIFF
--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapRenderer.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapRenderer.php
@@ -96,11 +96,12 @@ class ImportMapRenderer
         }
 
         $scriptAttributes = $attributes || $this->scriptAttributes ? ' '.$this->createAttributesString($attributes) : '';
-        $importMapJson = json_encode(['imports' => $importMap], \JSON_THROW_ON_ERROR | \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_HEX_TAG);
+        $pageImportMap = array_filter($importMap, static fn (string $path):bool => \in_array($path, $modulePreloads));
+        $pageImportMapJson = json_encode(['imports' => $pageImportMap], \JSON_THROW_ON_ERROR | \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_HEX_TAG);
         $output .= <<<HTML
 
             <script type="importmap"$scriptAttributes>
-            $importMapJson
+            $pageImportMapJson
             </script>
             HTML;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

When a Twig template in a Symfony app uses AssetMapper like this:

```twig
{% block importmap %}
    {{ importmap(['app', 'search', 'packages']) }}
{% endblock %}
```

In the rendered HTML page, the `<head>` section will include this:

```html
<!-- (1) Links to the CSS files used in the page -->
<link rel="stylesheet" href="/assets/vendor/bootstrap/dist/css/bootstrap.min-FxLwN4-.css">
<link rel="stylesheet" href="/assets/styles/app-GZ-zm2A.css">
<link rel="stylesheet" href="/assets/@symfony/ux-live-component/live.min-ZJB0GOL.css">
<link rel="stylesheet" href="...">

<!-- (2) Full importmap -->
<script type="importmap" data-turbo-track="reload">
{
    "imports": {
        "app": "/assets/app-iodFN2G.js",
        "bootstrap/js/src/offcanvas": "/assets/vendor/bootstrap/js/src/offcanvas-blSHiL2.js",
        "/assets/stimulus.js": "/assets/stimulus-l2Vqto5.js",
        "@symfony/stimulus-bundle": "/assets/@symfony/stimulus-bundle/loader-kxG46ja.js",
        "...": "..."
    }
}

<!-- (3) Links to the JS files used in the page -->
<link rel="modulepreload" href="/assets/app-iodFN2G.js">
<link rel="modulepreload" href="/assets/vendor/bootstrap/js/src/offcanvas-blSHiL2.js">
<link rel="modulepreload" href="/assets/stimulus-l2Vqto5.js">
<link rel="modulepreload" href="/assets/@symfony/stimulus-bundle/loader-kxG46ja.js">
<link rel="modulepreload" href="...">

<!-- (4) Imports (the same you used in importmap() call) -->
<script type="module" data-turbo-track="reload">import 'app';import 'search';import 'packages';</script>
```

(1), (3) and (4) are already perfect: they contain only what this page needs.

(2) is problematic IMO, because it discloses ALL the importmap entries of the application, including everything you'll never use in this page. In the past we've discussed about this and I want to bring this up again.

The problem is not about adding some unnecessary contents to the page _(it's just a few bytes, so this is irrelevant)_. The problem is that the full importmap shows private things _(think of the backend, etc.)_ and things that should not be public yet _(new sections to be announced in the futurte, WIP sections, etc.)_. For these reasons, exposing all importmap entries in all pages is not OK for me.

-----

In this PR, I made some minor changes that fix this. Now, the `importmap` only includes the entries relevant for this page, hiding everything else.

It works in my tests, but I may have missed edge cases. Feedback welcome! Thanks!