### PR TITLE
[Uid] Improve entropy of the increment for UUIDv7

### DIFF
--- a/src/Symfony/Component/Uid/UuidV7.php
+++ b/src/Symfony/Component/Uid/UuidV7.php
@@ -60,7 +60,7 @@ class UuidV7 extends Uuid implements TimeBasedUidInterface
 
         if ($time > self::$time || (null !== $mtime && $time !== self::$time)) {
             randomize:
-            self::$rand = unpack('n*', isset(self::$seed) ? random_bytes(10) : self::$seed = random_bytes(16));
+            self::$rand = unpack('S*', isset(self::$seed) ? random_bytes(10) : self::$seed = random_bytes(16));
             self::$rand[1] &= 0x03FF;
             self::$time = $time;
         } else {
@@ -76,7 +76,7 @@ class UuidV7 extends Uuid implements TimeBasedUidInterface
             // 24-bit number in the self::$seedParts list and decrement self::$seedIndex.
 
             if (!self::$seedIndex) {
-                $s = unpack('l*', self::$seed = hash('sha512', self::$seed, true));
+                $s = unpack(\PHP_INT_SIZE >= 8 ? 'L*' : 'l*', self::$seed = hash('sha512', self::$seed, true));
                 $s[] = ($s[1] >> 8 & 0xFF0000) | ($s[2] >> 16 & 0xFF00) | ($s[3] >> 24 & 0xFF);
                 $s[] = ($s[4] >> 8 & 0xFF0000) | ($s[5] >> 16 & 0xFF00) | ($s[6] >> 24 & 0xFF);
                 $s[] = ($s[7] >> 8 & 0xFF0000) | ($s[8] >> 16 & 0xFF00) | ($s[9] >> 24 & 0xFF);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Looks like we're missing the sign bit when computing the random increments on x64.