### PR TITLE
[TypeInfo] use an EOL-agnostic approach to parse class uses

### DIFF
--- a/src/Symfony/Component/TypeInfo/.gitattributes
+++ b/src/Symfony/Component/TypeInfo/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
+/Tests/Fixtures/DummyWithUsesWindowsLineEndings.php text eol=crlf
 /phpunit.xml.dist export-ignore
 /.git* export-ignore

--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithUsesWindowsLineEndings.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithUsesWindowsLineEndings.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Symfony\Component\TypeInfo\Tests\Fixtures;
+
+use Symfony\Component\TypeInfo\Type;
+use \DateTimeInterface;
+use \DateTimeImmutable as DateTime;
+
+final class DummyWithUsesWindowsLineEndings
+{
+    private DateTimeInterface $createdAt;
+
+    public function setCreatedAt(DateTime $createdAt): void
+    {
+        $this->createdAt = $createdAt;
+    }
+
+    public function getType(): Type
+    {
+        throw new \LogicException('Should not be called.');
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Tests/TypeContext/TypeContextFactoryTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeContext/TypeContextFactoryTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\TypeInfo\Tests\Fixtures\AbstractDummy;
 use Symfony\Component\TypeInfo\Tests\Fixtures\Dummy;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithTemplates;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithUses;
+use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithUsesWindowsLineEndings;
 use Symfony\Component\TypeInfo\Type;
 use Symfony\Component\TypeInfo\TypeContext\TypeContextFactory;
 use Symfony\Component\TypeInfo\TypeResolver\StringTypeResolver;
@@ -80,6 +81,24 @@ class TypeContextFactoryTest extends TestCase
         $this->assertEquals($uses, $this->typeContextFactory->createFromReflection(new \ReflectionProperty(DummyWithUses::class, 'createdAt'))->uses);
         $this->assertEquals($uses, $this->typeContextFactory->createFromReflection(new \ReflectionMethod(DummyWithUses::class, 'setCreatedAt'))->uses);
         $this->assertEquals($uses, $this->typeContextFactory->createFromReflection(new \ReflectionParameter([DummyWithUses::class, 'setCreatedAt'], 'createdAt'))->uses);
+    }
+
+    public function testCollectUsesWindowsLineEndings()
+    {
+        self::assertSame(\count(file(__DIR__.'/../Fixtures/DummyWithUsesWindowsLineEndings.php')), substr_count(file_get_contents(__DIR__.'/../Fixtures/DummyWithUsesWindowsLineEndings.php'), "\r\n"));
+
+        $uses = [
+            'Type' => Type::class,
+            \DateTimeInterface::class => '\\'.\DateTimeInterface::class,
+            'DateTime' => '\\'.\DateTimeImmutable::class,
+        ];
+
+        $this->assertSame($uses, $this->typeContextFactory->createFromClassName(DummyWithUsesWindowsLineEndings::class)->uses);
+
+        $this->assertEquals($uses, $this->typeContextFactory->createFromReflection(new \ReflectionClass(DummyWithUsesWindowsLineEndings::class))->uses);
+        $this->assertEquals($uses, $this->typeContextFactory->createFromReflection(new \ReflectionProperty(DummyWithUsesWindowsLineEndings::class, 'createdAt'))->uses);
+        $this->assertEquals($uses, $this->typeContextFactory->createFromReflection(new \ReflectionMethod(DummyWithUsesWindowsLineEndings::class, 'setCreatedAt'))->uses);
+        $this->assertEquals($uses, $this->typeContextFactory->createFromReflection(new \ReflectionParameter([DummyWithUsesWindowsLineEndings::class, 'setCreatedAt'], 'createdAt'))->uses);
     }
 
     public function testCollectTemplates()

--- a/src/Symfony/Component/TypeInfo/TypeContext/TypeContextFactory.php
+++ b/src/Symfony/Component/TypeInfo/TypeContext/TypeContextFactory.php
@@ -116,7 +116,7 @@ final class TypeContextFactory
             return [];
         }
 
-        if (false === $lines = @file($fileName)) {
+        if (false === $lines = @file($fileName, \FILE_IGNORE_NEW_LINES)) {
             throw new RuntimeException(\sprintf('Unable to read file "%s".', $fileName));
         }
 
@@ -126,7 +126,7 @@ final class TypeContextFactory
         foreach ($lines as $line) {
             if (str_starts_with($line, 'use ')) {
                 $inUseSection = true;
-                $use = explode(' as ', substr($line, 4, -2), 2);
+                $use = explode(' as ', substr($line, 4, -1), 2);
 
                 $alias = 1 === \count($use) ? substr($use[0], false !== ($p = strrpos($use[0], '\\')) ? 1 + $p : 0) : $use[1];
                 $uses[$alias] = $use[0];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60906
| License       | MIT