### PR TITLE
[DoctrineBridge] use native lazy objects on PHP 8.4+ when available

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/DoctrineTestHelper.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DoctrineTestHelper.php
@@ -58,9 +58,11 @@ final class DoctrineTestHelper
     {
         $config = ORMSetup::createConfiguration(true);
         $config->setEntityNamespaces(['SymfonyTestsDoctrine' => 'Symfony\Bridge\Doctrine\Tests\Fixtures']);
-        $config->setAutoGenerateProxyClasses(true);
-        $config->setProxyDir(sys_get_temp_dir());
-        $config->setProxyNamespace('SymfonyTests\Doctrine');
+        if (\PHP_VERSION_ID < 80400 || !method_exists($config, 'enableNativeLazyObjects')) {
+            $config->setAutoGenerateProxyClasses(true);
+            $config->setProxyDir(sys_get_temp_dir());
+            $config->setProxyNamespace('SymfonyTests\Doctrine');
+        }
         $config->setMetadataDriverImpl(new AttributeDriver([__DIR__.'/../Tests/Fixtures' => 'Symfony\Bridge\Doctrine\Tests\Fixtures'], true));
         if (class_exists(DefaultSchemaManagerFactory::class)) {
             $config->setSchemaManagerFactory(new DefaultSchemaManagerFactory());

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
@@ -45,7 +45,11 @@ class DoctrineExtractorTest extends TestCase
             $config->setSchemaManagerFactory(new DefaultSchemaManagerFactory());
         }
         if (!class_exists(\Doctrine\Persistence\Mapping\Driver\AnnotationDriver::class)) { // doctrine/persistence >= 3.0
-            $config->setLazyGhostObjectEnabled(true);
+            if (\PHP_VERSION_ID >= 80400 && method_exists($config, 'enableNativeLazyObjects')) {
+                $config->enableNativeLazyObjects(true);
+            } else {
+                $config->setLazyGhostObjectEnabled(true);
+            }
         }
 
         $eventManager = new EventManager();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

following the changes from doctrine/orm#12005 and doctrine/orm#12020