### PR TITLE
[Filesystem] Add `readFileInChunks` method to read files in fixed-size chunks

### DIFF
--- a/src/Symfony/Component/Filesystem/CHANGELOG.md
+++ b/src/Symfony/Component/Filesystem/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+ * Add the `Filesystem::readFileInChunks()` method
+
 7.1
 ---
 

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -728,6 +728,57 @@ class Filesystem
         return $content;
     }
 
+    /**
+     * Reads a file in fixed-size chunks and yields them one at a time.
+     *
+     * @param string $filename The full path to the file
+     *
+     * @return \Traversable<string> Yields file content as strings in chunks
+     *
+     * @throws IOException If the file cannot be opened or read, or if it's a directory
+     */
+    public function readFileInChunks(string $filename, int $size = 8192): \Traversable
+    {
+        if (is_dir($filename)) {
+            throw new IOException(\sprintf('Failed to read file "%s": It is a directory.', $filename));
+        }
+
+        $stream = self::box('fopen', $filename, 'rb');
+        if (false === $stream) {
+            throw new IOException(\sprintf('Failed to open file "%s": "%s"', $filename, self::$lastError ?? 'Unknown error'), 0, null, $filename);
+        }
+
+        return $this->yieldStreamChunks($stream, $size);
+    }
+
+    /**
+     * @param resource $stream A readable stream resource
+     */
+    private function yieldStreamChunks($stream, int $size): \Traversable
+    {
+        if (!\is_resource($stream)) {
+            throw new InvalidArgumentException('The stream is not a resource.');
+        }
+
+        try {
+            while (!feof($stream)) {
+                $chunk = self::box('fread', $stream, $size);
+
+                if (false === $chunk) {
+                    throw new IOException(\sprintf('Error reading from stream: "%s"', self::$lastError ?? 'Unknown error'));
+                }
+
+                if ('' === $chunk) {
+                    break;
+                }
+
+                yield $chunk;
+            }
+        } finally {
+            self::box('fclose', $stream);
+        }
+    }
+
     private function toIterable(string|iterable $files): iterable
     {
         return is_iterable($files) ? $files : [$files];

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -1852,6 +1852,56 @@ class FilesystemTest extends FilesystemTestCase
         $this->filesystem->readFile(__DIR__);
     }
 
+    /**
+     * @dataProvider provideValidChunkSizes
+     */
+    public function testReadFileInChunks(int $chunkSize)
+    {
+        $licenseFile = \dirname(__DIR__).'/LICENSE';
+        $expectedContent = file_get_contents($licenseFile);
+
+        $chunks = '';
+        foreach ($this->filesystem->readFileInChunks($licenseFile, $chunkSize) as $chunk) {
+            $this->assertLessThanOrEqual($chunkSize, \strlen($chunk));
+            $chunks .= $chunk;
+        }
+
+        $this->assertSame($expectedContent, $chunks);
+    }
+
+    public static function provideValidChunkSizes(): array
+    {
+        return [
+            '512 B chunk' => [512],
+            '1 KB chunk' => [1024],
+            '2 KB chunk' => [2048],
+            '4 KB chunk' => [4096],
+            '8 KB chunk' => [8192],
+        ];
+    }
+
+    public function testReadFileInChunksNonExistent()
+    {
+        $this->expectException(IOException::class);
+        $this->expectExceptionMessageMatches(\sprintf(
+            '#^Failed to open file ".+%1$sTests/invalid"\\: #',
+            preg_quote(\DIRECTORY_SEPARATOR)
+        ));
+
+        $this->filesystem->readFileInChunks(__DIR__.'/invalid');
+    }
+
+    public function testReadFileInChunksFromDirectory()
+    {
+        $this->expectException(IOException::class);
+        $this->expectExceptionMessageMatches(\sprintf(
+            '#^Failed to read file ".+%sTests"\\: It is a directory\\.$#',
+            preg_quote(\DIRECTORY_SEPARATOR)
+        ));
+
+        $this->filesystem->readFileInChunks(__DIR__);
+    }
+
     public function testReadUnreadableFile()
     {
         $this->markAsSkippedIfChmodIsMissing();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | no
| License       | MIT

### Description
This PR introduces a new `readFileInChunks()` method to the `Filesystem` component, which provides a memory-efficient way to read large files by yielding fixed-size chunks of data.

### Motivation
Reading large files all at once can consume excessive memory and potentially kill the process, especially in constrained environments. This method avoids that by yielding smaller chunks, making it safer and more efficient for large file handling.

### Example
```php
foreach ($filesystem->readFileInChunks('/path/to/large-file.txt') as $chunk) {
    // Process $chunk (string of up to 8192 bytes by default)
}
```