### PR TITLE
[VarDumper] Avoid deprecated call in PgSqlCaster

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/PgSqlCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/PgSqlCaster.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\VarDumper\Caster;
 use Symfony\Component\VarDumper\Cloner\Stub;
 
 /**
- * Casts pqsql resources to array representation.
+ * Casts pgsql resources to array representation.
  *
  * @author Nicolas Grekas <p@tchwork.com>
  *
@@ -142,9 +142,9 @@ class PgSqlCaster
                 'name' => pg_field_name($result, $i),
                 'table' => sprintf('%s (OID: %s)', pg_field_table($result, $i), pg_field_table($result, $i, true)),
                 'type' => sprintf('%s (OID: %s)', pg_field_type($result, $i), pg_field_type_oid($result, $i)),
-                'nullable' => (bool) pg_field_is_null($result, $i),
+                'nullable' => (bool) (\PHP_VERSION_ID >= 80300 ? pg_field_is_null($result, null, $i) : pg_field_is_null($result, $i)),
                 'storage' => pg_field_size($result, $i).' bytes',
-                'display' => pg_field_prtlen($result, $i).' chars',
+                'display' => (\PHP_VERSION_ID >= 80300 ? pg_field_prtlen($result, null, $i) : pg_field_prtlen($result, $i)).' chars',
             ];
             if (' (OID: )' === $field['table']) {
                 $field['table'] = null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| License       | MIT

Deprecated since PHP 8.4: https://github.com/php/php-src/commit/beaf1e814a3e8886ebcc59a050b5a5d6a0a46368
