### PR TITLE
[Translation] Remove deprecated `escape` parameter from `CsvFileLoader`

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -352,6 +352,21 @@ Serializer
  * Remove `AdvancedNameConverterInterface`, use `NameConverterInterface` instead
  * Remove the `CompiledClassMetadataFactory` and `CompiledClassMetadataCacheWarmer` classes
 
+Translation
+-----------
+
+ * Remove the `$escape` parameter from `CsvFileLoader::setCsvControl()`
+
+   ```diff
+   use Symfony\Component\Translation\Loader\CsvFileLoader;
+
+   $loader = new CsvFileLoader();
+   
+   // Set CSV control characters including escape character
+   -$loader->setCsvControl(';', '"', '\\');
+   +$loader->setCsvControl(';', '"');
+   ```
+
 TwigBridge
 ----------
 

--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.0
+---
+
+ * Remove the `$escape` parameter from `CsvFileLoader::setCsvControl()`
+
 7.3
 ---
 

--- a/src/Symfony/Component/Translation/Loader/CsvFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/CsvFileLoader.php
@@ -22,10 +22,6 @@ class CsvFileLoader extends FileLoader
 {
     private string $delimiter = ';';
     private string $enclosure = '"';
-    /**
-     * @deprecated since Symfony 7.2, to be removed in 8.0
-     */
-    private string $escape = '';
 
     protected function loadResource(string $resource): array
     {
@@ -38,7 +34,7 @@ class CsvFileLoader extends FileLoader
         }
 
         $file->setFlags(\SplFileObject::READ_CSV | \SplFileObject::SKIP_EMPTY);
-        $file->setCsvControl($this->delimiter, $this->enclosure, $this->escape);
+        $file->setCsvControl($this->delimiter, $this->enclosure, '');
 
         foreach ($file as $data) {
             if (false === $data) {
@@ -54,16 +50,11 @@ class CsvFileLoader extends FileLoader
     }
 
     /**
-     * Sets the delimiter, enclosure, and escape character for CSV.
+     * Sets the delimiter and enclosure character for CSV.
      */
-    public function setCsvControl(string $delimiter = ';', string $enclosure = '"', string $escape = ''): void
+    public function setCsvControl(string $delimiter = ';', string $enclosure = '"'): void
     {
         $this->delimiter = $delimiter;
         $this->enclosure = $enclosure;
-        if ('' !== $escape) {
-            trigger_deprecation('symfony/translation', '7.2', 'The "escape" parameter of the "%s" method is deprecated. It will be removed in 8.0.', __METHOD__);
-        }
-
-        $this->escape = $escape;
     }
 }

--- a/src/Symfony/Component/Translation/Tests/Loader/CsvFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/CsvFileLoaderTest.php
@@ -58,14 +58,4 @@ class CsvFileLoaderTest extends TestCase
         (new CsvFileLoader())->load('http://example.com/resources.csv', 'en', 'domain1');
     }
 
-    /**
-     * @group legacy
-     */
-    public function testEscapeCharInCsvControlIsDeprecated()
-    {
-        $loader = new CsvFileLoader();
-
-        $this->expectUserDeprecationMessage('Since symfony/translation 7.2: The "escape" parameter of the "Symfony\Component\Translation\Loader\CsvFileLoader::setCsvControl" method is deprecated. It will be removed in 8.0.');
-        $loader->setCsvControl(';', '"', '\\');
-    }
 }

--- a/src/Symfony/Component/Translation/composer.json
+++ b/src/Symfony/Component/Translation/composer.json
@@ -17,7 +17,6 @@
     ],
     "require": {
         "php": ">=8.4",
-        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/polyfill-mbstring": "^1.0",
         "symfony/translation-contracts": "^2.5|^3.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | --
| License       | MIT
