### PR TITLE
[SecurityBundle] Remove deprecated `hide_user_not_found` option

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -330,6 +330,20 @@ Security
  * Remove `AbstractListener::__invoke`
  * Remove `LazyFirewallContext::__invoke()`
 
+SecurityBundle
+--------------
+
+ * Remove the deprecated `hide_user_not_found` configuration option, use `expose_security_errors` instead
+
+   ```diff
+    # config/packages/security.yaml
+    security:
+   -    hide_user_not_found: false
+   +    expose_security_errors: true
+   ```
+
+   Note: `expose_security_errors: true` is equivalent to `hide_user_not_found: false`. The logic is inverted.
+
 Serializer
 ----------
 

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.0
 ---
 
+ * Remove the deprecated `hide_user_not_found` configuration option, use `expose_security_errors` instead
  * Remove `LazyFirewallContext::__invoke()`
 
 7.4

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -56,28 +56,11 @@ class MainConfiguration implements ConfigurationInterface
 
         $rootNode
             ->docUrl('https://symfony.com/doc/{version:major}.{version:minor}/reference/configuration/security.html', 'symfony/security-bundle')
-            ->beforeNormalization()
-                ->always()
-                ->then(function ($v) {
-                    if (isset($v['hide_user_not_found']) && isset($v['expose_security_errors'])) {
-                        throw new InvalidConfigurationException('You cannot use both "hide_user_not_found" and "expose_security_errors" at the same time.');
-                    }
-
-                    if (isset($v['hide_user_not_found']) && !isset($v['expose_security_errors'])) {
-                        $v['expose_security_errors'] = $v['hide_user_not_found'] ? ExposeSecurityLevel::None : ExposeSecurityLevel::All;
-                    }
-
-                    return $v;
-                })
-            ->end()
             ->children()
                 ->scalarNode('access_denied_url')->defaultNull()->example('/foo/error403')->end()
                 ->enumNode('session_fixation_strategy')
                     ->values([SessionAuthenticationStrategy::NONE, SessionAuthenticationStrategy::MIGRATE, SessionAuthenticationStrategy::INVALIDATE])
                     ->defaultValue(SessionAuthenticationStrategy::MIGRATE)
-                ->end()
-                ->booleanNode('hide_user_not_found')
-                    ->setDeprecated('symfony/security-bundle', '7.3', 'The "%node%" option is deprecated and will be removed in 8.0. Use the "expose_security_errors" option instead.')
                 ->end()
                 ->enumNode('expose_security_errors')
                     ->beforeNormalization()->ifString()->then(fn ($v) => ExposeSecurityLevel::tryFrom($v))->end()

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/MainConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/MainConfigurationTest.php
@@ -259,42 +259,4 @@ class MainConfigurationTest extends TestCase
         yield [['expose_security_errors' => 'all'], ExposeSecurityLevel::All];
     }
 
-    /**
-     * @dataProvider provideHideUserNotFoundLegacyData
-     *
-     * @group legacy
-     */
-    public function testExposeSecurityErrorsWithLegacyConfig(array $config, ExposeSecurityLevel $expectedExposeSecurityErrors, ?bool $expectedHideUserNotFound)
-    {
-        $this->expectUserDeprecationMessage('Since symfony/security-bundle 7.3: The "hide_user_not_found" option is deprecated and will be removed in 8.0. Use the "expose_security_errors" option instead.');
-
-        $config = array_merge(static::$minimalConfig, $config);
-
-        $processor = new Processor();
-        $configuration = new MainConfiguration([], []);
-        $processedConfig = $processor->processConfiguration($configuration, [$config]);
-
-        $this->assertEquals($expectedExposeSecurityErrors, $processedConfig['expose_security_errors']);
-        $this->assertEquals($expectedHideUserNotFound, $processedConfig['hide_user_not_found']);
-    }
-
-    public static function provideHideUserNotFoundLegacyData(): iterable
-    {
-        yield [['hide_user_not_found' => true], ExposeSecurityLevel::None, true];
-        yield [['hide_user_not_found' => false], ExposeSecurityLevel::All, false];
-    }
-
-    public function testCannotUseHideUserNotFoundAndExposeSecurityErrorsAtTheSameTime()
-    {
-        $processor = new Processor();
-        $configuration = new MainConfiguration([], []);
-
-        $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessage('You cannot use both "hide_user_not_found" and "expose_security_errors" at the same time.');
-
-        $processor->processConfiguration($configuration, [static::$minimalConfig + [
-            'hide_user_not_found' => true,
-            'expose_security_errors' => ExposeSecurityLevel::None,
-        ]]);
-    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | --
| License       | MIT