### PR TITLE
[FrameworkBundle][SecurityBundle] Remove deprecated rate limiter factory autowiring aliases

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -152,6 +152,33 @@ FrameworkBundle
    $application->addCommand(new CreateUserCommand());
    ```
 
+ * Remove deprecated rate limiter factory autowiring aliases
+
+   *Before*
+   ```php
+   use Symfony\Component\RateLimiter\RateLimiterFactory;
+
+   public function __construct(
+       private RateLimiterFactory $anonymousApiLimiter,
+       private RateLimiterFactory $authenticatedApiLimiter,
+   ) {
+   }
+   ```
+
+   *After*
+   ```php
+   use Symfony\Component\RateLimiter\RateLimiterFactory;
+   use Symfony\Component\DependencyInjection\Attribute\Target;
+
+   public function __construct(
+       #[Target('limiter.anonymous_api')]
+       private RateLimiterFactory $anonymousApiLimiter,
+       #[Target('limiter.authenticated_api')]
+       private RateLimiterFactory $authenticatedApiLimiter,
+   ) {
+   }
+   ```
+
 HttpClient
 ----------
 

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.0
 ---
 
+ * Remove deprecated rate limiter factory autowiring aliases
  * Enable the property info constructor extractor by default
  * Remove deprecated `Symfony\Bundle\FrameworkBundle\Console\Application::add()` method in favor of `Symfony\Bundle\FrameworkBundle\Console\Application::addCommand()`
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -3301,17 +3301,7 @@ class FrameworkExtension extends Extension
             $limiterConfig['id'] = $name;
             $limiter->replaceArgument(0, $limiterConfig);
 
-            $factoryAlias = $container->registerAliasForArgument($limiterId, RateLimiterFactory::class, $name.'.limiter');
-
-            if (interface_exists(RateLimiterFactoryInterface::class)) {
-                $container->registerAliasForArgument($limiterId, RateLimiterFactoryInterface::class, $name.'.limiter');
-                $factoryAlias->setDeprecated('symfony/framework-bundle', '7.3', \sprintf('The "%%alias_id%%" autowiring alias is deprecated and will be removed in 8.0, use "%s $%s" instead.', RateLimiterFactoryInterface::class, (new Target($name.'.limiter'))->getParsedName()));
-                $internalAliasId = \sprintf('.%s $%s.limiter', RateLimiterFactory::class, $name);
-
-                if ($container->hasAlias($internalAliasId)) {
-                    $container->getAlias($internalAliasId)->setDeprecated('symfony/framework-bundle', '7.3', \sprintf('The "%%alias_id%%" autowiring alias is deprecated and will be removed in 8.0, use "%s $%s" instead.', RateLimiterFactoryInterface::class, (new Target($name.'.limiter'))->getParsedName()));
-                }
-            }
+            $container->registerAliasForArgument($limiterId, interface_exists(RateLimiterFactoryInterface::class) ? RateLimiterFactoryInterface::class : RateLimiterFactory::class, $name.'.limiter');
         }
 
         if ($compoundLimiters && !class_exists(CompoundRateLimiterFactory::class)) {

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.0
 ---
 
+ * Remove deprecated rate limiter factory autowiring aliases
  * Remove `LazyFirewallContext::__invoke()`
 
 7.4

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LoginThrottlingFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LoginThrottlingFactory.php
@@ -117,18 +117,9 @@ class LoginThrottlingFactory implements AuthenticatorFactoryInterface
         $limiterConfig['id'] = $name;
         $limiter->replaceArgument(0, $limiterConfig);
 
-        $factoryAlias = $container->registerAliasForArgument($limiterId, RateLimiterFactory::class, $name.'.limiter');
-
         if (interface_exists(RateLimiterFactoryInterface::class)) {
             $container->registerAliasForArgument($limiterId, RateLimiterFactoryInterface::class, $name.'.limiter');
             $container->registerAliasForArgument($limiterId, RateLimiterFactoryInterface::class, $name);
-            $factoryAlias->setDeprecated('symfony/security-bundle', '7.4', \sprintf('The "%%alias_id%%" autowiring alias is deprecated and will be removed in 8.0, use "%s $%s" instead.', RateLimiterFactoryInterface::class, (new Target($name.'.limiter'))->getParsedName()));
-
-            $internalAliasId = \sprintf('.%s $%s.limiter', RateLimiterFactory::class, $name);
-
-            if ($container->hasAlias($internalAliasId)) {
-                $container->getAlias($internalAliasId)->setDeprecated('symfony/security-bundle', '7.4', \sprintf('The "%%alias_id%%" autowiring alias is deprecated and will be removed in 8.0, use "%s $%s" instead.', RateLimiterFactoryInterface::class, (new Target($name.'.limiter'))->getParsedName()));
-            }
         }
     }
 }

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 8.0
 ---
 
- * [BC BREAK] Change default value of `default_protocol` option in `UrlType` from `'http'` to `null`
+ * Change default value of `default_protocol` option in `UrlType` from `'http'` to `null`
 
 7.4
 ---

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -1,11 +1,6 @@
 CHANGELOG
 =========
 
-8.0
----
-
- * Change default value of `default_protocol` option in `UrlType` from `'http'` to `null`
-
 7.4
 ---
 

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.0
+---
+
+ * [BC BREAK] Change default value of `default_protocol` option in `UrlType` from `'http'` to `null`
+
 7.4
 ---
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/UrlType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/UrlType.php
@@ -39,11 +39,7 @@ class UrlType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'default_protocol' => static function (Options $options) {
-                trigger_deprecation('symfony/form', '7.1', 'Not configuring the "default_protocol" option when using the UrlType is deprecated. It will default to "null" in 8.0.');
-
-                return 'http';
-            },
+            'default_protocol' => null,
             'invalid_message' => 'Please enter a valid URL.',
         ]);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | --
| License       | MIT
