### PR TITLE
[HttpKernel] Avoid memory leak profiler

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/profiling.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/profiling.php
@@ -37,6 +37,7 @@ return static function (ContainerConfigurator $container) {
                 param('profiler_listener.only_main_requests'),
             ])
             ->tag('kernel.event_subscriber')
+            ->tag('kernel.reset', ['method' => 'reset'])
 
         ->set('console_profiler_listener', ConsoleProfilerListener::class)
             ->args([

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -26,7 +26,7 @@
         "symfony/error-handler": "^6.1|^7.0",
         "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
         "symfony/http-foundation": "^6.4|^7.0",
-        "symfony/http-kernel": "^6.4",
+        "symfony/http-kernel": "^6.4.23",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/filesystem": "^5.4|^6.0|^7.0",
         "symfony/finder": "^5.4|^6.0|^7.0",

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 6.4
 ---
 
+ * `Symfony\Component\HttpKernel\EventListener\ProfilerListener` is now resettable to prevent memory leaks
  * Support backed enums in #[MapQueryParameter]
  * `BundleInterface` no longer extends `ContainerAwareInterface`
  * Add optional `$className` parameter to `ControllerEvent::getAttributes()`

--- a/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
@@ -22,6 +22,7 @@ use Symfony\Component\HttpKernel\Event\TerminateEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\Profiler\Profile;
 use Symfony\Component\HttpKernel\Profiler\Profiler;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * ProfilerListener collects data for the current request by listening to the kernel events.
@@ -30,7 +31,7 @@ use Symfony\Component\HttpKernel\Profiler\Profiler;
  *
  * @final
  */
-class ProfilerListener implements EventSubscriberInterface
+class ProfilerListener implements EventSubscriberInterface, ResetInterface
 {
     private Profiler $profiler;
     private ?RequestMatcherInterface $matcher;
@@ -135,8 +136,7 @@ class ProfilerListener implements EventSubscriberInterface
             $this->profiler->saveProfile($this->profiles[$request]);
         }
 
-        $this->profiles = new \SplObjectStorage();
-        $this->parents = new \SplObjectStorage();
+        $this->reset();
     }
 
     public static function getSubscribedEvents(): array
@@ -146,5 +146,12 @@ class ProfilerListener implements EventSubscriberInterface
             KernelEvents::EXCEPTION => ['onKernelException', 0],
             KernelEvents::TERMINATE => ['onKernelTerminate', -1024],
         ];
+    }
+
+    public function reset(): void
+    {
+        $this->profiles = new \SplObjectStorage();
+        $this->parents = new \SplObjectStorage();
+        $this->exception = null;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | 
| License       | MIT


<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
For the current moment, if the `onKernelTerminate` method won't be called, the listener's state won't be reset between requests.

Please let me know if this should be considered as a new feature - to retarget PR to the 7.3 branch
