### PR TITLE
[HttpKernel] Avoid memory leaks cache attribute, profiler listener

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/profiling.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/profiling.php
@@ -39,6 +39,7 @@ return static function (ContainerConfigurator $container) {
                 param('profiler_listener.only_main_requests'),
             ])
             ->tag('kernel.event_subscriber')
+            ->tag('kernel.reset', ['method' => '?reset'])
 
         ->set('console_profiler_listener', ConsoleProfilerListener::class)
             ->args([

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
@@ -146,6 +146,7 @@ return static function (ContainerConfigurator $container) {
 
         ->set('controller.cache_attribute_listener', CacheAttributeListener::class)
             ->tag('kernel.event_subscriber')
+            ->tag('kernel.reset', ['method' => '?reset'])
 
         ->set('controller.helper', ControllerHelper::class)
             ->tag('container.service_subscriber')

--- a/src/Symfony/Component/HttpKernel/EventListener/CacheAttributeListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/CacheAttributeListener.php
@@ -182,6 +182,12 @@ class CacheAttributeListener implements EventSubscriberInterface
         ];
     }
 
+    public function reset(): void
+    {
+        $this->lastModified = new \SplObjectStorage();
+        $this->etags = new \SplObjectStorage();
+    }
+
     private function getExpressionLanguage(): ExpressionLanguage
     {
         return $this->expressionLanguage ??= class_exists(ExpressionLanguage::class)

--- a/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
@@ -129,8 +129,14 @@ class ProfilerListener implements EventSubscriberInterface
             $this->profiler->saveProfile($this->profiles[$request]);
         }
 
+        $this->reset();
+    }
+
+    public function reset(): void
+    {
         $this->profiles = new \SplObjectStorage();
         $this->parents = new \SplObjectStorage();
+        $this->exception = null;
     }
 
     public static function getSubscribedEvents(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | 
| License       | MIT


<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
For the current moment, if the `onKernelTerminate` / `onKernelResponse` methods won't be called, the listener's state won't be reset between requests.

~~Please let me know if this should be considered as a new feature - to retarget PR to the 7.3 branch~~

~~Similar to PR #60933~~
