### PR TITLE
[Translation] Add `StaticMessage`

### DIFF
--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Deprecate `TranslatableMessage::__toString`
+ * Add `Symfony\Component\Translation\StaticMessage`
 
 7.3
 ---

--- a/src/Symfony/Component/Translation/StaticMessage.php
+++ b/src/Symfony/Component/Translation/StaticMessage.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation;
+
+use Symfony\Contracts\Translation\TranslatableInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class StaticMessage implements TranslatableInterface
+{
+    public function __construct(
+        private string $message,
+    ) {
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    public function trans(TranslatorInterface $translator, ?string $locale = null): string
+    {
+        return $this->getMessage();
+    }
+}

--- a/src/Symfony/Component/Translation/Tests/StaticMessageTest.php
+++ b/src/Symfony/Component/Translation/Tests/StaticMessageTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Translation\Loader\ArrayLoader;
+use Symfony\Component\Translation\StaticMessage;
+use Symfony\Component\Translation\Translator;
+
+class StaticMessageTest extends TestCase
+{
+    public function testTrans()
+    {
+        $translator = new Translator('en');
+        $translator->addLoader('array', new ArrayLoader());
+        $translator->addResource('array', [
+            'Symfony is great!' => 'Symfony est super !',
+        ], 'fr', '');
+
+        $translatable = new StaticMessage('Symfony is great!');
+
+        $this->assertSame('Symfony is great!', $translatable->trans($translator, 'fr'));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

When working with translation, it's "classic" to have library with the following logic:
```php
if ($message instanceof Translatable) {
    $message->trans($translator);
} else {
    $translator->trans($message, domain: 'OpenSourceBundle');
}
```
Then if the user doesn't want the text to be translated, he cannot.

A useful and simple way would be to support `new TranslatableMessage($text, domain: false)` but as recommended, it might be better to introduce a special class for this, the StaticMessage