### PR TITLE
[FrameworkBundle] fix `lint:container` command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerLintCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerLintCommand.php
@@ -80,7 +80,7 @@ final class ContainerLintCommand extends Command
 
         $kernel = $this->getApplication()->getKernel();
         $container = $kernel->getContainer();
-        $file = $container->isDebug() ? $container->getParameter('debug.container.dump') : false;
+        $file = $kernel->isDebug() ? $container->getParameter('debug.container.dump') : false;
 
         if (!$file || !(new ConfigCache($file, true))->isFresh()) {
             if (!$kernel instanceof Kernel) {

--- a/src/Symfony/Component/DependencyInjection/Alias.php
+++ b/src/Symfony/Component/DependencyInjection/Alias.php
@@ -17,12 +17,14 @@ class Alias
 {
     private const DEFAULT_DEPRECATION_TEMPLATE = 'The "%alias_id%" service alias is deprecated. You should stop using it, as it will be removed in the future.';
 
+    private bool $public = false;
     private array $deprecation = [];
 
     public function __construct(
         private string $id,
-        private bool $public = false,
+        bool $public = false,
     ) {
+        $this->public = $public;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60920
| License       | MIT

This PR resolves two issues related to the `lint:container` command:

1) Incorrect use of `isDebug()` method: The `isDebug() `method was being called on the `$container`, but this method does not exist there. The correct call should be on the `$kernel` instance.

2) Issue during container unserialization: When unserializing the dumped container to retrieve the `ContainerBuilder`,  problem was with the service aliases. The `public` property was not correctly initialized because the constructor is bypassed during unserialization.
