### PR TITLE
[DoctrineBridge] Restore compatibility with Doctrine ODM

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Bridge\Doctrine\Validator\Constraints;
 
-use Doctrine\ORM\Mapping\ClassMetadata as OrmClassMetadata;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectManager;
@@ -93,7 +92,7 @@ class UniqueEntityValidator extends ConstraintValidator
                 throw new ConstraintDefinitionException(sprintf('The field "%s" is not mapped by Doctrine, so it cannot be validated for uniqueness.', $fieldName));
             }
 
-            if (property_exists(OrmClassMetadata::class, 'propertyAccessors')) {
+            if (property_exists($class, 'propertyAccessors')) {
                 $fieldValue = $class->propertyAccessors[$fieldName]->getValue($entity);
             } else {
                 $fieldValue = $class->reflFields[$fieldName]->getValue($entity);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60921
| License       | MIT

Ensure that the metadata class being inspected is an instance of Doctrine\ORM\Mapping\ClassMetadata to fix ODM integration when both ODM and ORM packages are installed in the same Symfony project.