### PR TITLE
[FrameworkBundle] Add functional tests for `ContainerLintCommand`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerLintCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerLintCommandTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
+
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @group functional
+ */
+class ContainerLintCommandTest extends AbstractWebTestCase
+{
+    private Application $application;
+
+    /**
+     * @dataProvider containerLintProvider
+     */
+    public function testLintContainer(string $configFile, string $expectedOutput)
+    {
+        $kernel = static::createKernel([
+            'test_case' => 'ContainerDebug',
+            'root_config' => $configFile,
+            'debug' => true,
+        ]);
+        $this->application = new Application($kernel);
+
+        $tester = $this->createCommandTester();
+        $exitCode = $tester->execute([]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertStringContainsString($expectedOutput, $tester->getDisplay());
+    }
+
+    public static function containerLintProvider(): array
+    {
+        return [
+            'default container' => ['config.yml', 'The container was linted successfully'],
+            'missing dump file' => ['no_dump.yml', 'The container was linted successfully'],
+        ];
+    }
+
+    private function createCommandTester(): CommandTester
+    {
+        return new CommandTester($this->application->get('lint:container'));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | no
| License       | MIT

This PR adds a new functional test class for the `lint:container` command. It addresses a gap from a previous [PR](https://github.com/symfony/symfony/pull/60942) where the command logic was updated to fix bugs but no corresponding tests were included due to time constraints.
