### PR TITLE
[BrowserKit] Add PHPUnit constraints: `BrowserHistoryIsOnFirstPage` and `BrowserHistoryIsOnLastPage`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/BrowserKitAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/BrowserKitAssertionsTrait.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\Constraint\LogicalAnd;
 use PHPUnit\Framework\Constraint\LogicalNot;
 use PHPUnit\Framework\ExpectationFailedException;
 use Symfony\Component\BrowserKit\AbstractBrowser;
+use Symfony\Component\BrowserKit\History;
 use Symfony\Component\BrowserKit\Test\Constraint as BrowserKitConstraint;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -120,6 +121,38 @@ trait BrowserKitAssertionsTrait
     public static function assertBrowserNotHasCookie(string $name, string $path = '/', ?string $domain = null, string $message = ''): void
     {
         self::assertThatForClient(new LogicalNot(new BrowserKitConstraint\BrowserHasCookie($name, $path, $domain)), $message);
+    }
+
+    public static function assertBrowserHistoryIsOnFirstPage(string $message = ''): void
+    {
+        if (!method_exists(History::class, 'isFirstPage')) {
+            throw new \LogicException('The `assertBrowserHistoryIsOnFirstPage` method requires symfony/browser-kit >= 7.4.');
+        }
+        self::assertThatForClient(new BrowserKitConstraint\BrowserHistoryIsOnFirstPage(), $message);
+    }
+
+    public static function assertBrowserHistoryIsNotOnFirstPage(string $message = ''): void
+    {
+        if (!method_exists(History::class, 'isFirstPage')) {
+            throw new \LogicException('The `assertBrowserHistoryIsNotOnFirstPage` method requires symfony/browser-kit >= 7.4.');
+        }
+        self::assertThatForClient(new LogicalNot(new BrowserKitConstraint\BrowserHistoryIsOnFirstPage()), $message);
+    }
+
+    public static function assertBrowserHistoryIsOnLastPage(string $message = ''): void
+    {
+        if (!method_exists(History::class, 'isLastPage')) {
+            throw new \LogicException('The `assertBrowserHistoryIsOnLastPage` method requires symfony/browser-kit >= 7.4.');
+        }
+        self::assertThatForClient(new BrowserKitConstraint\BrowserHistoryIsOnLastPage(), $message);
+    }
+
+    public static function assertBrowserHistoryIsNotOnLastPage(string $message = ''): void
+    {
+        if (!method_exists(History::class, 'isLastPage')) {
+            throw new \LogicException('The `assertBrowserHistoryIsNotOnLastPage` method requires symfony/browser-kit >= 7.4.');
+        }
+        self::assertThatForClient(new LogicalNot(new BrowserKitConstraint\BrowserHistoryIsOnLastPage()), $message);
     }
 
     public static function assertBrowserCookieValueSame(string $name, string $expectedValue, bool $raw = false, string $path = '/', ?string $domain = null, string $message = ''): void

--- a/src/Symfony/Component/BrowserKit/CHANGELOG.md
+++ b/src/Symfony/Component/BrowserKit/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `isFirstPage()` and `isLastPage()` methods to the History class for checking navigation boundaries
+ * Add PHPUnit constraints: `BrowserHistoryIsOnFirstPage` and `BrowserHistoryIsOnLastPage`
 
 6.4
 ---

--- a/src/Symfony/Component/BrowserKit/Test/Constraint/BrowserHistoryIsOnFirstPage.php
+++ b/src/Symfony/Component/BrowserKit/Test/Constraint/BrowserHistoryIsOnFirstPage.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\BrowserKit\Test\Constraint;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use Symfony\Component\BrowserKit\AbstractBrowser;
+
+final class BrowserHistoryIsOnFirstPage extends Constraint
+{
+    public function toString(): string
+    {
+        return 'is on the first page';
+    }
+
+    protected function matches($other): bool
+    {
+        if (!$other instanceof AbstractBrowser) {
+            throw new \LogicException('Can only test on an AbstractBrowser instance.');
+        }
+
+        return $other->getHistory()->isFirstPage();
+    }
+
+    protected function failureDescription($other): string
+    {
+        return 'the Browser history '.$this->toString();
+    }
+}

--- a/src/Symfony/Component/BrowserKit/Test/Constraint/BrowserHistoryIsOnLastPage.php
+++ b/src/Symfony/Component/BrowserKit/Test/Constraint/BrowserHistoryIsOnLastPage.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\BrowserKit\Test\Constraint;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use Symfony\Component\BrowserKit\AbstractBrowser;
+
+final class BrowserHistoryIsOnLastPage extends Constraint
+{
+    public function toString(): string
+    {
+        return 'is on the last page';
+    }
+
+    protected function matches($other): bool
+    {
+        if (!$other instanceof AbstractBrowser) {
+            throw new \LogicException('Can only test on an AbstractBrowser instance.');
+        }
+
+        return $other->getHistory()->isLastPage();
+    }
+
+    protected function failureDescription($other): string
+    {
+        return 'the Browser history '.$this->toString();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | no
| License       | MIT

This PR introduces two new PHPUnit constraints to improve testing of browser navigation history state:

- `BrowserHistoryIsOnFirstPage`
- `BrowserHistoryIsOnLastPage`

These constraints allow asserting the current state of the `AbstractBrowser` history using the following new assertion methods:

```php
$this->assertBrowserHistoryIsOnFirstPage();
$this->assertBrowserHistoryIsNotOnFirstPage();
$this->assertBrowserHistoryIsOnLastPage();
$this->assertBrowserHistoryIsNotOnLastPage();
```