### PR TITLE
[TypeInfo] Fix `Type::fromValue` incorrectly setting object type instead of enum

### DIFF
--- a/src/Symfony/Component/TypeInfo/Tests/TypeFactoryTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeFactoryTest.php
@@ -254,6 +254,8 @@ class TypeFactoryTest extends TestCase
         yield [Type::object(\DateTimeImmutable::class), new \DateTimeImmutable()];
         yield [Type::object(), new \stdClass()];
         yield [Type::list(Type::object()), [new \stdClass(), new \DateTimeImmutable()]];
+        yield [Type::enum(DummyEnum::class), DummyEnum::ONE];
+        yield [Type::enum(DummyBackedEnum::class), DummyBackedEnum::ONE];
 
         // collection
         $arrayAccess = new class implements \ArrayAccess {

--- a/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
+++ b/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
@@ -412,6 +412,7 @@ trait TypeFactoryTrait
         }
 
         $type = match (true) {
+            \is_object($value) && is_subclass_of($value::class, \UnitEnum::class) => Type::enum($value::class),
             \is_object($value) => \stdClass::class === $value::class ? self::object() : self::object($value::class),
             \is_array($value) => self::builtin(TypeIdentifier::ARRAY),
             default => null,
@@ -427,8 +428,6 @@ trait TypeFactoryTrait
 
             /** @var list<Type> $valueTypes */
             $valueTypes = [];
-
-            $i = 0;
 
             foreach ($value as $k => $v) {
                 $keyTypes[] = self::fromValue($k);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #...
| License       | MIT

Tried to apply https://github.com/symfony/symfony/pull/60820#discussion_r2156719402 comment, but found some failing cases