### PR TITLE
[Serializer] remove return type from `AbstractObjectNormalizer::getAllowedAttributes()`

### DIFF
--- a/.github/expected-missing-return-types.diff
+++ b/.github/expected-missing-return-types.diff
@@ -11594,6 +11594,13 @@ diff --git a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalize
 +    abstract protected function setAttributeValue(object $object, string $attribute, mixed $value, ?string $format = null, array $context = []): void;
  
      /**
+@@ -767,5 +767,5 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
+     }
+
+-    protected function getAllowedAttributes(string|object $classOrObject, array $context, bool $attributesAsString = false)
++    protected function getAllowedAttributes(string|object $classOrObject, array $context, bool $attributesAsString = false): array|bool
+     {
+         if (false === $allowedAttributes = parent::getAllowedAttributes($classOrObject, $context, $attributesAsString)) {
 diff --git a/src/Symfony/Component/Serializer/Normalizer/DenormalizableInterface.php b/src/Symfony/Component/Serializer/Normalizer/DenormalizableInterface.php
 --- a/src/Symfony/Component/Serializer/Normalizer/DenormalizableInterface.php
 +++ b/src/Symfony/Component/Serializer/Normalizer/DenormalizableInterface.php

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -766,7 +766,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
         return $context;
     }
 
-    protected function getAllowedAttributes(string|object $classOrObject, array $context, bool $attributesAsString = false): array|bool
+    protected function getAllowedAttributes(string|object $classOrObject, array $context, bool $attributesAsString = false)
     {
         if (false === $allowedAttributes = parent::getAllowedAttributes($classOrObject, $context, $attributesAsString)) {
             return false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60957
| License       | MIT
