### PR TITLE
[TypeInfo] Fix `Type::fromValue` with empty array

### DIFF
--- a/src/Symfony/Component/TypeInfo/Tests/TypeFactoryTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeFactoryTest.php
@@ -276,6 +276,7 @@ class TypeFactoryTest extends TestCase
             }
         };
 
+        yield [Type::array(Type::mixed()), []];
         yield [Type::list(Type::int()), [1, 2, 3]];
         yield [Type::dict(Type::bool()), ['a' => true, 'b' => false]];
         yield [Type::array(Type::string()), [1 => 'foo', 'bar' => 'baz']];

--- a/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
+++ b/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
@@ -444,7 +444,7 @@ trait TypeFactoryTrait
 
             $valueType = $valueTypes ? CollectionType::mergeCollectionValueTypes($valueTypes) : Type::mixed();
 
-            return self::collection($type, $valueType, $keyType, \is_array($value) && array_is_list($value));
+            return self::collection($type, $valueType, $keyType, \is_array($value) && [] !== $value && array_is_list($value));
         }
 
         if ($value instanceof \ArrayAccess) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #...
| License       | MIT

Without this, it fails with `Symfony\Component\TypeInfo\Exception\InvalidArgumentException: "int|string" is not a valid list key type.`