### PR TITLE
[Messenger] Add `--exclude-receivers` to `messenger:consume` command

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 7.4
 ---
 
+ * Add `--exclude-receivers` option to the `messenger:consume command`
  * Allow any `ServiceResetterInterface` implementation in `ResetServicesListener`
 
 7.3


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Docs          | https://github.com/symfony/symfony-docs/pull/21165
| License       | MIT

This PR adds a new `--exclude-receivers` (shortcut `-et`) option to the `messenger:consume` command. This option allows users to exclude specific transports/receivers from being consumed when using the `--all` flag.

**What it does and why it's needed:**
- When running `messenger:consume --all`, you may want to skip certain transports (example the failed transports) without having to list all the others manually. The new `--exclude-receivers` option makes this possible.
- This improves flexibility and usability for complex Messenger setups.

**How it works:**
```bash
php bin/console messenger:consume --all --exclude-receivers=queues1 --exclude-receivers=queues2
```
This will consume messages from all transports except `queues1` and `queues2`.

**Behavior:**
- The `--exclude-queues` option can only be used with `--all`. If used without `--all`, an `InvalidOptionException` is thrown.
- If all queues are excluded, a `RuntimeException` is thrown to prevent running the command with no receivers.

**Before:**
- No way to exclude specific receivers when using `--all`.

**After:**
- You can now exclude queues with `--exclude-receivers` when using `--all`.

**Tests:**
- Unit tests have been added to cover the new option, its validation, and edge cases.

