### PR TITLE
[Workflow] Remove deprecated `Event::getWorkflow()`

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -493,6 +493,78 @@ VarExporter
  * Remove `LazyGhostTrait` and `LazyProxyTrait`, use native lazy objects instead
  * Remove `ProxyHelper::generateLazyGhost()`, use native lazy objects instead
 
+Workflow
+--------
+
+ * Remove `Event::getWorkflow()` method
+
+   *Before*
+   ```php
+   use Symfony\Component\Workflow\Attribute\AsCompletedListener;
+   use Symfony\Component\Workflow\Event\CompletedEvent;
+
+   class MyListener
+   {
+       #[AsCompletedListener('my_workflow', 'to_state2')]
+       public function terminateOrder(CompletedEvent $event): void
+       {
+           $subject = $event->getSubject();
+           if ($event->getWorkflow()->can($subject, 'to_state3')) {
+               $event->getWorkflow()->apply($subject, 'to_state3');
+           }
+       }
+   }
+   ```
+
+   *After*
+   ```php
+   use Symfony\Component\DependencyInjection\Attribute\Target;
+   use Symfony\Component\Workflow\Attribute\AsCompletedListener;
+   use Symfony\Component\Workflow\Event\CompletedEvent;
+   use Symfony\Component\Workflow\WorkflowInterface;
+
+   class MyListener
+   {
+       public function __construct(
+           #[Target('my_workflow')]
+           private readonly WorkflowInterface $workflow,
+       ) {
+       }
+
+       #[AsCompletedListener('my_workflow', 'to_state2')]
+       public function terminateOrder(CompletedEvent $event): void
+       {
+           $subject = $event->getSubject();
+           if ($this->workflow->can($subject, 'to_state3')) {
+               $this->workflow->apply($subject, 'to_state3');
+           }
+       }
+   }
+   ```
+
+   *Or*
+   ```php
+   use Symfony\Component\DependencyInjection\ServiceLocator;
+   use Symfony\Component\DependencyInjection\Attribute\AutowireLocator;
+   use Symfony\Component\Workflow\Attribute\AsTransitionListener;
+   use Symfony\Component\Workflow\Event\TransitionEvent;
+
+   class GenericListener
+   {
+       public function __construct(
+           #[AutowireLocator('workflow', 'name')]
+           private ServiceLocator $workflows
+       ) {
+       }
+
+       #[AsTransitionListener]
+       public function doSomething(TransitionEvent $event): void
+       {
+           $workflow = $this->workflows->get($event->getWorkflowName());
+       }
+   }
+   ```
+
 Yaml
 ----
 

--- a/src/Symfony/Component/Workflow/CHANGELOG.md
+++ b/src/Symfony/Component/Workflow/CHANGELOG.md
@@ -1,6 +1,78 @@
 CHANGELOG
 =========
 
+8.0
+---
+
+ * Remove `Event::getWorkflow()` method
+
+   *Before*
+   ```php
+   use Symfony\Component\Workflow\Attribute\AsCompletedListener;
+   use Symfony\Component\Workflow\Event\CompletedEvent;
+
+   class MyListener
+   {
+       #[AsCompletedListener('my_workflow', 'to_state2')]
+       public function terminateOrder(CompletedEvent $event): void
+       {
+           $subject = $event->getSubject();
+           if ($event->getWorkflow()->can($subject, 'to_state3')) {
+               $event->getWorkflow()->apply($subject, 'to_state3');
+           }
+       }
+   }
+   ```
+
+   *After*
+   ```php
+   use Symfony\Component\DependencyInjection\Attribute\Target;
+   use Symfony\Component\Workflow\Attribute\AsCompletedListener;
+   use Symfony\Component\Workflow\Event\CompletedEvent;
+   use Symfony\Component\Workflow\WorkflowInterface;
+
+   class MyListener
+   {
+       public function __construct(
+           #[Target('my_workflow')]
+           private readonly WorkflowInterface $workflow,
+       ) {
+       }
+
+       #[AsCompletedListener('my_workflow', 'to_state2')]
+       public function terminateOrder(CompletedEvent $event): void
+       {
+           $subject = $event->getSubject();
+           if ($this->workflow->can($subject, 'to_state3')) {
+               $this->workflow->apply($subject, 'to_state3');
+           }
+       }
+   }
+   ```
+
+   *Or*
+   ```php
+   use Symfony\Component\DependencyInjection\ServiceLocator;
+   use Symfony\Component\DependencyInjection\Attribute\AutowireLocator;
+   use Symfony\Component\Workflow\Attribute\AsTransitionListener;
+   use Symfony\Component\Workflow\Event\TransitionEvent;
+
+   class GenericListener
+   {
+       public function __construct(
+           #[AutowireLocator('workflow', 'name')]
+           private ServiceLocator $workflows
+       ) {
+       }
+
+       #[AsTransitionListener]
+       public function doSomething(TransitionEvent $event): void
+       {
+           $workflow = $this->workflows->get($event->getWorkflowName());
+       }
+   }
+   ```
+
 7.3
 ---
 

--- a/src/Symfony/Component/Workflow/Event/Event.php
+++ b/src/Symfony/Component/Workflow/Event/Event.php
@@ -46,16 +46,6 @@ class Event extends BaseEvent
         return $this->transition;
     }
 
-    /**
-     * @deprecated since Symfony 7.3, inject the workflow in the constructor where you need it
-     */
-    public function getWorkflow(): WorkflowInterface
-    {
-        trigger_deprecation('symfony/workflow', '7.3', 'The "%s()" method is deprecated, inject the workflow in the constructor where you need it.', __METHOD__);
-
-        return $this->workflow;
-    }
-
     public function getWorkflowName(): string
     {
         return $this->workflow->getName();

--- a/src/Symfony/Component/Workflow/composer.json
+++ b/src/Symfony/Component/Workflow/composer.json
@@ -20,8 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=8.4",
-        "symfony/deprecation-contracts": "2.5|^3"
+        "php": ">=8.4"
     },
     "require-dev": {
         "psr/log": "^1|^2|^3",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT