### PR TITLE
[Messenger] Allow any `ServiceResetterInterface` implementation in `ResetServicesListener`

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+ * Allow any `ServiceResetterInterface` implementation in `ResetServicesListener`
+
 7.3
 ---
 

--- a/src/Symfony/Component/Messenger/EventListener/ResetServicesListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/ResetServicesListener.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Messenger\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter;
+use Symfony\Component\HttpKernel\DependencyInjection\ServicesResetterInterface;
 use Symfony\Component\Messenger\Event\WorkerRunningEvent;
 use Symfony\Component\Messenger\Event\WorkerStoppedEvent;
 
@@ -22,7 +22,7 @@ use Symfony\Component\Messenger\Event\WorkerStoppedEvent;
 class ResetServicesListener implements EventSubscriberInterface
 {
     public function __construct(
-        private ServicesResetter $servicesResetter,
+        private ServicesResetterInterface $servicesResetter,
     ) {
     }
 

--- a/src/Symfony/Component/Messenger/composer.json
+++ b/src/Symfony/Component/Messenger/composer.json
@@ -26,7 +26,7 @@
         "symfony/console": "^7.2|^8.0",
         "symfony/dependency-injection": "^6.4|^7.0|^8.0",
         "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
-        "symfony/http-kernel": "^6.4|^7.0|^8.0",
+        "symfony/http-kernel": "^7.3|^8.0",
         "symfony/process": "^6.4|^7.0|^8.0",
         "symfony/property-access": "^6.4|^7.0|^8.0",
         "symfony/lock": "^6.4|^7.0|^8.0",
@@ -42,7 +42,7 @@
         "symfony/event-dispatcher": "<6.4",
         "symfony/event-dispatcher-contracts": "<2.5",
         "symfony/framework-bundle": "<6.4",
-        "symfony/http-kernel": "<6.4",
+        "symfony/http-kernel": "<7.3",
         "symfony/lock": "<6.4",
         "symfony/serializer": "<6.4"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | no 
| License       | MIT

### Summary

This PR updates the `ResetServicesListener` to depend on the `ServicesResetterInterface` instead of the concrete `ServicesResetter` class.