### PR TITLE
[TypeInfo] Fix imported-only alias resolving

### DIFF
--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithTypeAliases.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithTypeAliases.php
@@ -58,6 +58,17 @@ final class DummyWithTypeAliases
 }
 
 /**
+ * @phpstan-import-type CustomInt from DummyWithPhpDoc
+ */
+final class DummyWithImportedOnlyTypeAliases
+{
+    /**
+     * @var CustomInt
+     */
+    public mixed $externalAlias;
+}
+
+/**
  * @phpstan-type Foo = array{0: Bar}
  * @phpstan-type Bar = array{0: Foo}
  */

--- a/src/Symfony/Component/TypeInfo/Tests/TypeContext/TypeContextFactoryTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeContext/TypeContextFactoryTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\TypeInfo\Exception\LogicException;
 use Symfony\Component\TypeInfo\Tests\Fixtures\AbstractDummy;
 use Symfony\Component\TypeInfo\Tests\Fixtures\Dummy;
+use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithImportedOnlyTypeAliases;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithInvalidTypeAlias;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithInvalidTypeAliasImport;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithRecursiveTypeAliases;
@@ -179,6 +180,10 @@ class TypeContextFactoryTest extends TestCase
             'PsalmCustomArray' => Type::arrayShape([0 => Type::int(), 1 => Type::string(), 2 => Type::bool()]),
             'PsalmAliasedCustomInt' => Type::int(),
         ], $this->typeContextFactory->createFromReflection(new \ReflectionProperty(DummyWithTypeAliases::class, 'localAlias'))->typeAliases);
+
+        $this->assertEquals([
+            'CustomInt' => Type::int(),
+        ], $this->typeContextFactory->createFromReflection(new \ReflectionClass(DummyWithImportedOnlyTypeAliases::class))->typeAliases);
     }
 
     public function testDoNotCollectTypeAliasesWhenToStringTypeResolver()

--- a/src/Symfony/Component/TypeInfo/TypeContext/TypeContextFactory.php
+++ b/src/Symfony/Component/TypeInfo/TypeContext/TypeContextFactory.php
@@ -241,7 +241,7 @@ final class TypeContextFactory
     private function resolveTypeAliases(array $toResolve, array $resolved, TypeContext $typeContext): array
     {
         if (!$toResolve) {
-            return [];
+            return $resolved;
         }
 
         $typeContext = new TypeContext(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60997 
| License       | MIT

Fix type alias resolving when aliases are only coming from imports.