### PR TITLE
[JsonStreamer] Provide current object to value transformers 

### DIFF
--- a/src/Symfony/Component/JsonStreamer/CHANGELOG.md
+++ b/src/Symfony/Component/JsonStreamer/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Remove `nikic/php-parser` dependency
+ * Add `_current_object` to the context passed to value transformers during write operations
 
 7.3
 ---

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_value_transformer.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_value_transformer.php
@@ -6,13 +6,13 @@
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
         yield '{"id":';
-        yield \json_encode($valueTransformers->get('Symfony\Component\JsonStreamer\Tests\Fixtures\ValueTransformer\DoubleIntAndCastToStringValueTransformer')->transform($data->id, $options), \JSON_THROW_ON_ERROR, 511);
+        yield \json_encode($valueTransformers->get('Symfony\Component\JsonStreamer\Tests\Fixtures\ValueTransformer\DoubleIntAndCastToStringValueTransformer')->transform($data->id, ['_current_object' => $data] + $options), \JSON_THROW_ON_ERROR, 511);
         yield ',"active":';
-        yield \json_encode($valueTransformers->get('Symfony\Component\JsonStreamer\Tests\Fixtures\ValueTransformer\BooleanToStringValueTransformer')->transform($data->active, $options), \JSON_THROW_ON_ERROR, 511);
+        yield \json_encode($valueTransformers->get('Symfony\Component\JsonStreamer\Tests\Fixtures\ValueTransformer\BooleanToStringValueTransformer')->transform($data->active, ['_current_object' => $data] + $options), \JSON_THROW_ON_ERROR, 511);
         yield ',"name":';
         yield \json_encode(strtolower($data->name), \JSON_THROW_ON_ERROR, 511);
         yield ',"range":';
-        yield \json_encode(Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithValueTransformerAttributes::concatRange($data->range, $options), \JSON_THROW_ON_ERROR, 511);
+        yield \json_encode(Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithValueTransformerAttributes::concatRange($data->range, ['_current_object' => $data] + $options), \JSON_THROW_ON_ERROR, 511);
         yield '}';
     } catch (\JsonException $e) {
         throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);

--- a/src/Symfony/Component/JsonStreamer/ValueTransformer/ValueTransformerInterface.php
+++ b/src/Symfony/Component/JsonStreamer/ValueTransformer/ValueTransformerInterface.php
@@ -23,7 +23,10 @@ use Symfony\Component\TypeInfo\Type;
 interface ValueTransformerInterface
 {
     /**
-     * @param array<string, mixed> $options
+     * @param array{
+     *     _current_object?: object, // When writing stream: the object holding the current property
+     *     ...<string, mixed>,
+     * } $options
      */
     public function transform(mixed $value, array $options = []): mixed;
 

--- a/src/Symfony/Component/JsonStreamer/Write/StreamWriterGenerator.php
+++ b/src/Symfony/Component/JsonStreamer/Write/StreamWriterGenerator.php
@@ -138,7 +138,7 @@ final class StreamWriterGenerator
                 foreach ($propertyMetadata->getNativeToStreamValueTransformer() as $valueTransformer) {
                     if (\is_string($valueTransformer)) {
                         $valueTransformerServiceAccessor = "\$valueTransformers->get('$valueTransformer')";
-                        $propertyAccessor = "{$valueTransformerServiceAccessor}->transform($propertyAccessor, \$options)";
+                        $propertyAccessor = "{$valueTransformerServiceAccessor}->transform($propertyAccessor, ['_current_object' => $accessor] + \$options)";
 
                         continue;
                     }
@@ -152,7 +152,7 @@ final class StreamWriterGenerator
                     $functionName = !$functionReflection->getClosureCalledClass()
                         ? $functionReflection->getName()
                         : \sprintf('%s::%s', $functionReflection->getClosureCalledClass()->getName(), $functionReflection->getName());
-                    $arguments = $functionReflection->isUserDefined() ? "$propertyAccessor, \$options" : $propertyAccessor;
+                    $arguments = $functionReflection->isUserDefined() ? "$propertyAccessor, ['_current_object' => $accessor] + \$options" : $propertyAccessor;
 
                     $propertyAccessor = "$functionName($arguments)";
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Issues        | 
| License       | MIT

A new attempt to https://github.com/symfony/symfony/pull/59281.

As discussed with @soyuka, it is really important to have access to the current object during stream writing.
Without that, it'll for example be impossible for API Platform to generate resource IRIs (https://github.com/api-platform/core/blob/main/src/Metadata/IriConverterInterface.php#L46).

This PR makes is available in value transformers' `$context` under the `_current_object` key.