### PR TITLE
[Security] Remove deprecated `RememberMeToken::getSecret()`

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -388,6 +388,7 @@ Security
  * Remove callable firewall listeners support, extend `AbstractListener` or implement `FirewallListenerInterface` instead
  * Remove `AbstractListener::__invoke`
  * Remove `LazyFirewallContext::__invoke()`
+ * Remove `RememberMeToken::getSecret()`
 
 SecurityBundle
 --------------

--- a/src/Symfony/Component/Security/Core/Authentication/Token/RememberMeToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/RememberMeToken.php
@@ -21,8 +21,6 @@ use Symfony\Component\Security\Core\User\UserInterface;
  */
 class RememberMeToken extends AbstractToken
 {
-    private ?string $secret = null;
-
     /**
      * @throws \InvalidArgumentException
      */
@@ -31,11 +29,6 @@ class RememberMeToken extends AbstractToken
         private string $firewallName,
     ) {
         parent::__construct($user->getRoles());
-
-        if (\func_num_args() > 2) {
-            trigger_deprecation('symfony/security-core', '7.2', 'The "$secret" argument of "%s()" is deprecated.', __METHOD__);
-            $this->secret = func_get_arg(2);
-        }
 
         if (!$firewallName) {
             throw new InvalidArgumentException('$firewallName must not be empty.');
@@ -49,25 +42,14 @@ class RememberMeToken extends AbstractToken
         return $this->firewallName;
     }
 
-    /**
-     * @deprecated since Symfony 7.2
-     */
-    public function getSecret(): string
-    {
-        trigger_deprecation('symfony/security-core', '7.2', 'The "%s()" method is deprecated.', __METHOD__);
-
-        return $this->secret ??= base64_encode(random_bytes(8));
-    }
-
     public function __serialize(): array
     {
-        // $this->firewallName should be kept at index 1 for compatibility with payloads generated before Symfony 8
-        return [$this->secret, $this->firewallName, parent::__serialize()];
+        return [null, $this->firewallName, parent::__serialize()];
     }
 
     public function __unserialize(array $data): void
     {
-        [$this->secret, $this->firewallName, $parentData] = $data;
+        [, $this->firewallName, $parentData] = $data;
         $parentData = \is_array($parentData) ? $parentData : unserialize($parentData);
         parent::__unserialize($parentData);
     }

--- a/src/Symfony/Component/Security/Core/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Core/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.0
 ---
 
+ * Remove `RememberMeToken::getSecret()`
  * Remove `UserInterface::eraseCredentials()` and `TokenInterface::eraseCredentials()`,
   erase credentials e.g. using `__serialize()` instead
 

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/RememberMeTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/RememberMeTokenTest.php
@@ -27,17 +27,6 @@ class RememberMeTokenTest extends TestCase
         $this->assertSame($user, $token->getUser());
     }
 
-    /**
-     * @group legacy
-     */
-    public function testSecret()
-    {
-        $user = $this->getUser();
-        $token = new RememberMeToken($user, 'fookey', 'foo');
-
-        $this->assertEquals('foo', $token->getSecret());
-    }
-
     protected function getUser($roles = ['ROLE_FOO'])
     {
         $user = $this->createMock(UserInterface::class);

--- a/src/Symfony/Component/Security/Core/composer.json
+++ b/src/Symfony/Component/Security/Core/composer.json
@@ -17,7 +17,6 @@
     ],
     "require": {
         "php": ">=8.4",
-        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/event-dispatcher-contracts": "^2.5|^3",
         "symfony/password-hasher": "^7.4|^8.0",
         "symfony/service-contracts": "^2.5|^3"

--- a/src/Symfony/Component/Security/Http/Authenticator/RememberMeAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/RememberMeAuthenticator.php
@@ -43,34 +43,12 @@ use Symfony\Component\Security\Http\RememberMe\ResponseListener;
  */
 class RememberMeAuthenticator implements InteractiveAuthenticatorInterface
 {
-    private string $secret;
-    private TokenStorageInterface $tokenStorage;
-    private string $cookieName;
-    private ?LoggerInterface $logger;
-
-    /**
-     * @param TokenStorageInterface $tokenStorage
-     * @param string                $cookieName
-     * @param ?LoggerInterface      $logger
-     */
     public function __construct(
         private RememberMeHandlerInterface $rememberMeHandler,
-        #[\SensitiveParameter] TokenStorageInterface|string $tokenStorage,
-        string|TokenStorageInterface $cookieName,
-        LoggerInterface|string|null $logger = null,
+        private TokenStorageInterface $tokenStorage,
+        private string $cookieName,
+        private ?LoggerInterface $logger = null,
     ) {
-        if (\is_string($tokenStorage)) {
-            trigger_deprecation('symfony/security-http', '7.2', 'The "$secret" argument of "%s()" is deprecated.', __METHOD__);
-
-            $this->secret = $tokenStorage;
-            $tokenStorage = $cookieName;
-            $cookieName = $logger;
-            $logger = \func_num_args() > 4 ? func_get_arg(4) : null;
-        }
-
-        $this->tokenStorage = $tokenStorage;
-        $this->cookieName = $cookieName;
-        $this->logger = $logger;
     }
 
     public function supports(Request $request): ?bool
@@ -109,10 +87,6 @@ class RememberMeAuthenticator implements InteractiveAuthenticatorInterface
 
     public function createToken(Passport $passport, string $firewallName): TokenInterface
     {
-        if (isset($this->secret)) {
-            return new RememberMeToken($passport->getUser(), $firewallName, $this->secret);
-        }
-
         return new RememberMeToken($passport->getUser(), $firewallName);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | --
| License       | MIT
