### PR TITLE
[TypeInfo] Reuse `CollectionType::mergeCollectionValueTypes` for `ConstFetchNode`

### DIFF
--- a/src/Symfony/Component/TypeInfo/Tests/TypeResolver/StringTypeResolverTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeResolver/StringTypeResolverTest.php
@@ -103,12 +103,12 @@ class StringTypeResolverTest extends TestCase
         yield [Type::int(), DummyWithConstants::class.'::DUMMY_INT_*'];
         yield [Type::int(), DummyWithConstants::class.'::DUMMY_INT_A'];
         yield [Type::float(), DummyWithConstants::class.'::DUMMY_FLOAT_*'];
-        yield [Type::bool(), DummyWithConstants::class.'::DUMMY_TRUE_*'];
-        yield [Type::bool(), DummyWithConstants::class.'::DUMMY_FALSE_*'];
+        yield [Type::true(), DummyWithConstants::class.'::DUMMY_TRUE_*'];
+        yield [Type::false(), DummyWithConstants::class.'::DUMMY_FALSE_*'];
         yield [Type::null(), DummyWithConstants::class.'::DUMMY_NULL_*'];
-        yield [Type::array(), DummyWithConstants::class.'::DUMMY_ARRAY_*'];
+        yield [Type::array(null, Type::union(Type::int(), Type::string())), DummyWithConstants::class.'::DUMMY_ARRAY_*'];
         yield [Type::enum(DummyEnum::class, Type::string()), DummyWithConstants::class.'::DUMMY_ENUM_*'];
-        yield [Type::union(Type::string(), Type::int(), Type::float(), Type::bool(), Type::null(), Type::array(), Type::enum(DummyEnum::class, Type::string())), DummyWithConstants::class.'::DUMMY_MIX_*'];
+        yield [Type::union(Type::enum(DummyEnum::class, Type::string()), Type::array(Type::mixed(), Type::union(Type::int(), Type::string())), Type::string(), Type::int(), Type::float(), Type::bool(), Type::null()), DummyWithConstants::class.'::DUMMY_MIX_*'];
 
         // identifiers
         yield [Type::bool(), 'bool'];

--- a/src/Symfony/Component/TypeInfo/TypeResolver/StringTypeResolver.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/StringTypeResolver.php
@@ -149,29 +149,11 @@ final class StringTypeResolver implements TypeResolverInterface
 
                 foreach ((new \ReflectionClass($className))->getReflectionConstants() as $const) {
                     if (preg_match('/^'.str_replace('\*', '.*', preg_quote($node->constExpr->name, '/')).'$/', $const->getName())) {
-                        $constValue = $const->getValue();
-
-                        $types[] = match (true) {
-                            true === $constValue,
-                            false === $constValue => Type::bool(),
-                            null === $constValue => Type::null(),
-                            \is_string($constValue) => Type::string(),
-                            \is_int($constValue) => Type::int(),
-                            \is_float($constValue) => Type::float(),
-                            \is_array($constValue) => Type::array(),
-                            $constValue instanceof \UnitEnum => Type::enum($constValue::class),
-                            default => Type::mixed(),
-                        };
+                        $types[] = Type::fromValue($const->getValue());
                     }
                 }
 
-                $types = array_unique($types);
-
-                if (\count($types) > 2) {
-                    return Type::union(...$types);
-                }
-
-                return $types[0] ?? Type::null();
+                return CollectionType::mergeCollectionValueTypes($types);
             }
 
             return match ($node->constExpr::class) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | https://github.com/symfony/symfony/pull/60820#discussion_r2156749262
| License       | MIT
