### PR TITLE
[Doctrine][FrameworkBundle][Serializer][Validator] Increase minimum version of type-info component

### DIFF
--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -39,7 +39,7 @@
         "symfony/security-core": "^6.4|^7.0",
         "symfony/stopwatch": "^6.4|^7.0",
         "symfony/translation": "^6.4|^7.0",
-        "symfony/type-info": "^7.1",
+        "symfony/type-info": "^7.1.8",
         "symfony/uid": "^6.4|^7.0",
         "symfony/validator": "^6.4|^7.0",
         "symfony/var-dumper": "^6.4|^7.0",

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -64,7 +64,7 @@
         "symfony/string": "^6.4|^7.0",
         "symfony/translation": "^6.4|^7.0",
         "symfony/twig-bundle": "^6.4|^7.0",
-        "symfony/type-info": "^7.1",
+        "symfony/type-info": "^7.1.8",
         "symfony/validator": "^6.4|^7.0",
         "symfony/workflow": "^6.4|^7.0",
         "symfony/yaml": "^6.4|^7.0",

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -38,7 +38,7 @@
         "symfony/property-access": "^6.4|^7.0",
         "symfony/property-info": "^6.4|^7.0",
         "symfony/translation-contracts": "^2.5|^3",
-        "symfony/type-info": "^7.1",
+        "symfony/type-info": "^7.1.8",
         "symfony/uid": "^6.4|^7.0",
         "symfony/validator": "^6.4|^7.0",
         "symfony/var-dumper": "^6.4|^7.0",

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -39,7 +39,7 @@
         "symfony/property-access": "^6.4|^7.0",
         "symfony/property-info": "^6.4|^7.0",
         "symfony/translation": "^6.4.3|^7.0.3",
-        "symfony/type-info": "^7.1",
+        "symfony/type-info": "^7.1.8",
         "egulias/email-validator": "^2.1.10|^3|^4"
     },
     "conflict": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | n/a
| License       | MIT

Hey there :wave: 

If I execute `composer update --prefer-lowest` in our project, I have a problem while checking the code with PHPStan. This is because the `type-info` component will be installed with version `7.1.0`. But this version is not yet compatible with `phpstan/phpdoc-parser` in version 2. This happened with `7.1.8`. 

So my suggestion for fixing this problem is to increase the minimum version of the `type-info` component dependency in the other components, as we do not depend on the `type-info` component directly, but on the `serializer` and `validator` component instead. 

We are using Symfony 7.2 in our project, so I targeted the bugfix to this branch, but if it would be applicable, I can also set this to 7.1. 

Thanks for having a look at this and I am looking for feedback :slightly_smiling_face: :+1: 

Best regards

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
