### PR TITLE
[Serializer] add `can` to the accessor prefixes recognized by the `AttributeLoader`

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+ * Add support for `can*()` methods to `AttributeLoader`
+
 7.3
 ---
 

--- a/src/Symfony/Component/Serializer/Mapping/Loader/AttributeLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AttributeLoader.php
@@ -114,7 +114,7 @@ class AttributeLoader implements LoaderInterface
                 continue; /*  matches the BC behavior in `Symfony\Component\Serializer\Normalizer\ObjectNormalizer::extractAttributes` */
             }
 
-            $accessorOrMutator = preg_match('/^(get|is|has|set)(.+)$/i', $method->name, $matches);
+            $accessorOrMutator = preg_match('/^(get|is|has|set|can)(.+)$/i', $method->name, $matches);
             if ($accessorOrMutator && !ctype_lower($matches[2][0])) {
                 $attributeName = lcfirst($matches[2]);
 

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/IgnoreDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/IgnoreDummy.php
@@ -28,4 +28,10 @@ class IgnoreDummy
     {
         return $this->ignored2;
     }
+
+    #[Ignore]
+    public function canBeIgnored(): bool
+    {
+        return true;
+    }
 }

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AttributeLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AttributeLoaderTest.php
@@ -153,6 +153,7 @@ class AttributeLoaderTest extends TestCase
         $attributesMetadata = $classMetadata->getAttributesMetadata();
         $this->assertTrue($attributesMetadata['ignored1']->isIgnored());
         $this->assertTrue($attributesMetadata['ignored2']->isIgnored());
+        $this->assertTrue($attributesMetadata['beIgnored']->isIgnored());
     }
 
     public function testLoadContextsPropertiesPromoted()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61021 
| License       | MIT

The ObjectNormalizer already recognizes `canX` as an accessor and "generates" a property for that, the AttributeLoader does not, so #[Ignore] attributes on `canX` are ignored, the return value is encoded in the normalized data.

We just add the `can` prefix ot the list of accepted accessor prefixes, so the AttributeLoader now also recognized these.

I adapted a test that _seemd to me_ to fit the best. If you'd prefer a dedicated test for that, I can do that, too.