### PR TITLE
[Serializer] Fix `readonly` property initialization from incorrect scope

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Serializer\Normalizer;
 
 use Symfony\Component\PropertyAccess\Exception\UninitializedPropertyException;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
+use Symfony\Component\Serializer\Exception\LogicException;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorResolverInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
@@ -202,7 +203,22 @@ class PropertyNormalizer extends AbstractObjectNormalizer
             return;
         }
 
-        $reflectionProperty->setValue($object, $value);
+        if (!$reflectionProperty->isReadOnly()) {
+            $reflectionProperty->setValue($object, $value);
+
+            return;
+        }
+
+        if (!$reflectionProperty->isInitialized($object)) {
+            $declaringClass = $reflectionProperty->getDeclaringClass();
+            $declaringClass->getProperty($reflectionProperty->getName())->setValue($object, $value);
+
+            return;
+        }
+
+        if ($reflectionProperty->getValue($object) !== $value) {
+            throw new LogicException(\sprintf('Attempting to change readonly property "%s"::$%s.', $object::class, $reflectionProperty->getName()));
+        }
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/BookDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/BookDummy.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+class BookDummy
+{
+    public function __construct(
+        public private(set) string $title,
+        public protected(set) string $author,
+        protected private(set) int $pubYear,
+    ) {
+    }
+
+    public function getPubYear(): int
+    {
+        return $this->pubYear;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/ChildClassDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/ChildClassDummy.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+readonly class ChildClassDummy extends ParentClassDummy
+{
+    public string $childProp;
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/ParentClassDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/ParentClassDummy.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+readonly class ParentClassDummy
+{
+    private string $parentProp;
+
+    public function getParentProp(): string
+    {
+        return $this->parentProp;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/SpecialBookDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/SpecialBookDummy.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+class SpecialBookDummy extends BookDummy
+{
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -30,10 +30,12 @@ use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Component\Serializer\Tests\Fixtures\Attributes\GroupDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Attributes\GroupDummyChild;
+use Symfony\Component\Serializer\Tests\Fixtures\ChildClassDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Dummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Php74Dummy;
 use Symfony\Component\Serializer\Tests\Fixtures\PropertyCircularReferenceDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\PropertySiblingHolder;
+use Symfony\Component\Serializer\Tests\Fixtures\SpecialBookDummy;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\CacheableObjectAttributesTestTrait;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\CallbacksTestTrait;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\CircularReferenceTestTrait;
@@ -172,6 +174,39 @@ class PropertyNormalizerTest extends TestCase
         );
         $this->assertEquals('foo', $obj->foo);
         $this->assertEquals('bar', $obj->getBar());
+    }
+
+    /**
+     * @requires PHP 8.2
+     */
+    public function testDenormalizeWithReadOnlyClass()
+    {
+        /** @var ChildClassDummy $object */
+        $object = $this->normalizer->denormalize(
+            ['parentProp' => 'parentProp', 'childProp' => 'childProp'],
+            ChildClassDummy::class,
+            'any'
+        );
+
+        $this->assertSame('parentProp', $object->getParentProp());
+        $this->assertSame('childProp', $object->childProp);
+    }
+
+    /**
+     * @requires PHP 8.4
+     */
+    public function testDenormalizeWithAsymmetricPropertyVisibility()
+    {
+        /** @var SpecialBookDummy $object */
+        $object = $this->normalizer->denormalize(
+            ['title' => 'life', 'author' => 'Santiago San Martin', 'pubYear' => 2000],
+            SpecialBookDummy::class,
+            'any'
+        );
+
+        $this->assertSame('life', $object->title);
+        $this->assertSame('Santiago San Martin', $object->author);
+        $this->assertSame(2000, $object->getPubYear());
     }
 
     public function testNormalizeWithParentClass()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60846 
| License       | MIT

Readonly properties couldn't be initialized during denormalization due to scope restrictions. This change checks if a property is `readonly` and uninitialized, if so, it sets the value using the declaring class's scope.

Also added a safety check to throw a `LogicException` if a `readonly` property is already initialized, to avoid accidental mutation.