### PR TITLE
[HttpClient] return early if handle has been cleaned up before

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/AmpResponseV5.php
+++ b/src/Symfony/Component/HttpClient/Response/AmpResponseV5.php
@@ -240,6 +240,10 @@ final class AmpResponseV5 implements ResponseInterface, StreamableInterface
             $body = $response->getBody();
 
             while (true) {
+                if (!isset($multi->openHandles[$id])) {
+                    return;
+                }
+
                 $multi->openHandles[$id]->complete();
                 $multi->openHandles[$id] = new DeferredFuture();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

When a request has been cleaned up by the PHP process there still can be an event that will later on try to generate the response. Previously this lead to a warning like `Undefined array key "bg"`.

spotted in #58370 where this makes the test fail with PHPUnit 11.5: https://github.com/symfony/symfony/actions/runs/16051022174/job/45293445147#step:9:3827