### PR TITLE
[WebProfilerBundle] Add blank-target to AJAX request links

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+ * Add `target="_blank"` attribute to AJAX request links to open them in a new tab
+
 7.3
 ---
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -287,6 +287,7 @@
                     profilerCell.textContent = '';
                     var profilerLink = document.createElement('a');
                     profilerLink.setAttribute('href', request.profilerUrl);
+                    profilerLink.setAttribute('target', '_blank');
                     profilerLink.textContent = request.profile;
                     profilerCell.appendChild(profilerLink);
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT


<img width="181" alt="image" src="https://github.com/user-attachments/assets/22ec471e-17b4-42b9-9403-953f640fbb35" />

Currently, clicking on a link to a profiled AJAX request in the profiler opens the details in the same browser tab. If the user navigates back, the request history is lost.

This PR adds the `target="_blank` attribute to these links, so the detailed information opens in a new tab. This preserves the profiler state in the original tab.