### PR TITLE
[Console] Restore `SHELL_VERBOSITY` after a command is ran

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -186,6 +186,8 @@ class Application implements ResetInterface
             }
         }
 
+        $prevShellVerbosity = getenv('SHELL_VERBOSITY');
+
         try {
             $this->configureIO($input, $output);
 
@@ -222,6 +224,22 @@ class Application implements ResetInterface
                 if ($finalHandler !== $renderException) {
                     $phpHandler[0]->setExceptionHandler($finalHandler);
                 }
+            }
+
+            // SHELL_VERBOSITY is set by Application::configureIO so we need to unset/reset it
+            // to its previous value to avoid one command verbosity to spread to other commands
+            if (false === $prevShellVerbosity) {
+                if (\function_exists('putenv')) {
+                    @putenv('SHELL_VERBOSITY');
+                }
+                unset($_ENV['SHELL_VERBOSITY']);
+                unset($_SERVER['SHELL_VERBOSITY']);
+            } else {
+                if (\function_exists('putenv')) {
+                    @putenv('SHELL_VERBOSITY='.$prevShellVerbosity);
+                }
+                $_ENV['SHELL_VERBOSITY'] = $prevShellVerbosity;
+                $_SERVER['SHELL_VERBOSITY'] = $prevShellVerbosity;
             }
         }
 

--- a/src/Symfony/Component/Console/Tester/ApplicationTester.php
+++ b/src/Symfony/Component/Console/Tester/ApplicationTester.php
@@ -47,37 +47,17 @@ class ApplicationTester
      */
     public function run(array $input, array $options = []): int
     {
-        $prevShellVerbosity = getenv('SHELL_VERBOSITY');
-
-        try {
-            $this->input = new ArrayInput($input);
-            if (isset($options['interactive'])) {
-                $this->input->setInteractive($options['interactive']);
-            }
-
-            if ($this->inputs) {
-                $this->input->setStream(self::createStream($this->inputs));
-            }
-
-            $this->initOutput($options);
-
-            return $this->statusCode = $this->application->run($this->input, $this->output);
-        } finally {
-            // SHELL_VERBOSITY is set by Application::configureIO so we need to unset/reset it
-            // to its previous value to avoid one test's verbosity to spread to the following tests
-            if (false === $prevShellVerbosity) {
-                if (\function_exists('putenv')) {
-                    @putenv('SHELL_VERBOSITY');
-                }
-                unset($_ENV['SHELL_VERBOSITY']);
-                unset($_SERVER['SHELL_VERBOSITY']);
-            } else {
-                if (\function_exists('putenv')) {
-                    @putenv('SHELL_VERBOSITY='.$prevShellVerbosity);
-                }
-                $_ENV['SHELL_VERBOSITY'] = $prevShellVerbosity;
-                $_SERVER['SHELL_VERBOSITY'] = $prevShellVerbosity;
-            }
+        $this->input = new ArrayInput($input);
+        if (isset($options['interactive'])) {
+            $this->input->setInteractive($options['interactive']);
         }
+
+        if ($this->inputs) {
+            $this->input->setStream(self::createStream($this->inputs));
+        }
+
+        $this->initOutput($options);
+
+        return $this->statusCode = $this->application->run($this->input, $this->output);
     }
 }

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -37,6 +37,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\Output;
@@ -831,7 +832,7 @@ class ApplicationTest extends TestCase
 
         try {
             $tester->run(['command' => 'boom']);
-            $this->fail('The exception is not catched.');
+            $this->fail('The exception is not caught.');
         } catch (\Throwable $e) {
             $this->assertInstanceOf(\Error::class, $e);
             $this->assertSame('This is an error.', $e->getMessage());
@@ -2462,6 +2463,102 @@ class ApplicationTest extends TestCase
         $application->add(new LazyCommand($command->getName(), [], '', false, fn () => $command, true));
 
         return $application;
+    }
+
+    public function testShellVerbosityIsRestoredAfterCommandExecutionWithInitialValue()
+    {
+        // Set initial SHELL_VERBOSITY
+        putenv('SHELL_VERBOSITY=-2');
+        $_ENV['SHELL_VERBOSITY'] = '-2';
+        $_SERVER['SHELL_VERBOSITY'] = '-2';
+
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->register('foo')
+            ->setCode(function (InputInterface $input, OutputInterface $output): int {
+                $output->write('SHELL_VERBOSITY: '.$_SERVER['SHELL_VERBOSITY']);
+
+                return 0;
+            });
+
+        $input = new ArrayInput(['command' => 'foo', '--verbose' => 3]);
+        $output = new BufferedOutput();
+
+        $application->run($input, $output);
+
+        $this->assertSame('SHELL_VERBOSITY: 3', $output->fetch());
+        $this->assertSame('-2', getenv('SHELL_VERBOSITY'));
+        $this->assertSame('-2', $_ENV['SHELL_VERBOSITY']);
+        $this->assertSame('-2', $_SERVER['SHELL_VERBOSITY']);
+
+        // Clean up for other tests
+        putenv('SHELL_VERBOSITY');
+        unset($_ENV['SHELL_VERBOSITY']);
+        unset($_SERVER['SHELL_VERBOSITY']);
+    }
+
+    public function testShellVerbosityIsRemovedAfterCommandExecutionWhenNotSetInitially()
+    {
+        // Ensure SHELL_VERBOSITY is not set initially
+        putenv('SHELL_VERBOSITY');
+        unset($_ENV['SHELL_VERBOSITY']);
+        unset($_SERVER['SHELL_VERBOSITY']);
+
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->register('foo')
+            ->setCode(function (InputInterface $input, OutputInterface $output): int {
+                $output->write('SHELL_VERBOSITY: '.$_SERVER['SHELL_VERBOSITY']);
+
+                return 0;
+            });
+
+        $input = new ArrayInput(['command' => 'foo', '--verbose' => 3]);
+        $output = new BufferedOutput();
+
+        $application->run($input, $output);
+
+        $this->assertSame('SHELL_VERBOSITY: 3', $output->fetch());
+        $this->assertFalse(getenv('SHELL_VERBOSITY'));
+        $this->assertArrayNotHasKey('SHELL_VERBOSITY', $_ENV);
+        $this->assertArrayNotHasKey('SHELL_VERBOSITY', $_SERVER);
+    }
+
+    public function testShellVerbosityDoesNotLeakBetweenCommandExecutions()
+    {
+        // Ensure no initial SHELL_VERBOSITY
+        putenv('SHELL_VERBOSITY');
+        unset($_ENV['SHELL_VERBOSITY']);
+        unset($_SERVER['SHELL_VERBOSITY']);
+
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->register('verbose-cmd')
+            ->setCode(function (InputInterface $input, OutputInterface $output): int {
+                $output->write('SHELL_VERBOSITY: '.$_SERVER['SHELL_VERBOSITY']);
+
+                return 0;
+            });
+        $application->register('normal-cmd')
+            ->setCode(function (InputInterface $input, OutputInterface $output): int {
+                $output->write('SHELL_VERBOSITY: '.$_SERVER['SHELL_VERBOSITY']);
+
+                return 0;
+            });
+
+        $output = new BufferedOutput();
+
+        $application->run(new ArrayInput(['command' => 'verbose-cmd', '--verbose' => true]), $output);
+
+        $this->assertSame('SHELL_VERBOSITY: 1', $output->fetch(), 'SHELL_VERBOSITY should be set to 1 for verbose command');
+        $this->assertFalse(getenv('SHELL_VERBOSITY'), 'SHELL_VERBOSITY should not be set after first command');
+
+        $application->run(new ArrayInput(['command' => 'normal-cmd']), $output);
+
+        $this->assertSame('SHELL_VERBOSITY: 0', $output->fetch(), 'SHELL_VERBOSITY should not leak to second command');
+        $this->assertFalse(getenv('SHELL_VERBOSITY'), 'SHELL_VERBOSITY should not leak to second command');
+        $this->assertArrayNotHasKey('SHELL_VERBOSITY', $_ENV);
+        $this->assertArrayNotHasKey('SHELL_VERBOSITY', $_SERVER);
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT

---

Considereing the following code:

```php
require __DIR__.'/vendor/autoload.php';

use Symfony\Component\Console\Application;
use Symfony\Component\Console\Attribute\AsCommand;
use Symfony\Component\Console\Input\ArgvInput;
use Symfony\Component\Console\Output\OutputInterface;

#[AsCommand('a')]
class A
{
    public function __invoke(OutputInterface $output)
    {
        $output->writeln('Command A executed');

        return 0;
    }
}

#[AsCommand('b')]
class B
{
    public function __invoke(OutputInterface $output)
    {
        $output->writeln('Command B executed');

        return 0;
    }
}

#[AsCommand('main')]
class Main
{
    public function __construct(
        private Application $app
    ) {}

    public function __invoke(OutputInterface $output)
    {
        $this->app->setAutoExit(false);

        $this->app->run(new ArgvInput([__FILE__, 'a', '--quiet']));

        $this->app->run(new ArgvInput([__FILE__, 'b']));

        $output->writeln('Main command executed');

        return 0;
    }
}

$app = new Application();
$app->addCommand(new A());
$app->addCommand(new B());
$app->addCommand(new Main($app));

$app->run();
```

Without this patch, 
* the output of B command is not displayed. It should be!
* But the output `Main command executed` is. It should be, it's correct. But it's hard to understand. the current $output has already been configured, and it's not silenced by `--quiet` yet
