### PR TITLE
[ObjectMapper] Correctly manage constructor initialization

### DIFF
--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -146,7 +146,7 @@ final class ObjectMapper implements ObjectMapperInterface
             }
         }
 
-        if (!$mappingToObject && $ctorArguments && $constructor) {
+        if (!$mappingToObject && !$map?->transform && $constructor) {
             try {
                 $mappedTarget->__construct(...$ctorArguments);
             } catch (\ReflectionException $e) {

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InitializedConstructor/A.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InitializedConstructor/A.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\InitializedConstructor;
+
+class A
+{
+    public array $tags = ['foo', 'bar'];
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InitializedConstructor/B.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InitializedConstructor/B.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\InitializedConstructor;
+
+class B
+{
+    public array $tags;
+
+    public function __construct()
+    {
+        $this->tags = [];
+    }
+
+    public function addTag($tag)
+    {
+        $this->tags[] = $tag;
+    }
+
+    public function removeTag($tag)
+    {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -32,6 +32,8 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\Flatten\TargetUser;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\Flatten\User;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\Flatten\UserProfile;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\HydrateObject\SourceOnly;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\InitializedConstructor\A as InitializedConstructorA;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\InitializedConstructor\B as InitializedConstructorB;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\InstanceCallback\A as InstanceCallbackA;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\InstanceCallback\B as InstanceCallbackB;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\InstanceCallbackWithArguments\A as InstanceCallbackWithArgumentsA;
@@ -145,6 +147,15 @@ final class ObjectMapperTest extends TestCase
         $this->assertSame($mapped->relation->recursion, $mapped);
         $this->assertInstanceOf(RecursiveDto::class, $mapped);
         $this->assertInstanceOf(RelationDto::class, $mapped->relation);
+    }
+
+    public function testMapWithInitializedConstructor()
+    {
+        $a = new InitializedConstructorA();
+        $mapper = new ObjectMapper(propertyAccessor: PropertyAccess::createPropertyAccessor());
+        $b = $mapper->map($a, InitializedConstructorB::class);
+        $this->assertInstanceOf(InitializedConstructorB::class, $b);
+        $this->assertEquals($b->tags, ['foo', 'bar']);
     }
 
     public function testMapToWithInstanceHook()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60797 Fix #60807
| License       | MIT

Currently the ObjectMapper cannot support empty constructor initialization, which is particularly useful for Doctrine collections:

```php
class Article
{
    #[ORM\ManyToMany(targetEntity: Tag::class)]
    private Collection $tags;

    public function __construct()
    {
        $this->tags = new ArrayCollection();
    }

    public function addTag($tag)
    {
         // ...
    }

    public function removeTag($tag)
    {
         // ...
    }
}
```

This kind of error is thrown by the PropertyAccessor:

> Symfony\Component\PropertyAccess\Exception\UninitializedPropertyException: The property "Symfony\Component\ObjectMapper\Tests\Fixtures\InitializedConstructor\B::$tags" is not readable because it is typed "array". You should initialize it or declare a default value instead.

This PR fixes this but also another related issue (#60807): since an "empty" (no constructor arguments) constructor is always called, the class-level transformation test does not pass anymore:

> Symfony\Component\ObjectMapper\Tests\ObjectMapperTest::testMapToWithInstanceHook
ArgumentCountError: Too few arguments to function Symfony\Component\ObjectMapper\Tests\Fixtures\InstanceCallback\B::__construct(), 0 passed in /home/workspace/symfony/symfony/src/Symfony/Component/ObjectMapper/ObjectMapper.php on line 151 and exactly 1 expected

To solve this, a check is done on `map?->transform`.