### PR TITLE
Fix php.net links

### DIFF
--- a/src/Symfony/Component/ErrorHandler/Tests/ErrorRenderer/HtmlErrorRendererTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/ErrorRenderer/HtmlErrorRendererTest.php
@@ -100,7 +100,7 @@ HTML;
 
     public function testRendersStackWithoutBinaryStrings()
     {
-        // make sure method arguments are available in stack traces (see https://www.php.net/manual/en/ini.core.php)
+        // make sure method arguments are available in stack traces (see https://php.net/ini.core)
         ini_set('zend.exception_ignore_args', false);
 
         $binaryData = file_get_contents(__DIR__.'/../Fixtures/pixel.png');

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -235,7 +235,7 @@ class Filesystem
      *
      * This method always throws on Windows, as the underlying PHP function is not supported.
      *
-     * @see https://www.php.net/chown
+     * @see https://php.net/chown
      *
      * @param string|int $user      A user name or number
      * @param bool       $recursive Whether change the owner recursively or not
@@ -267,7 +267,7 @@ class Filesystem
      *
      * This method always throws on Windows, as the underlying PHP function is not supported.
      *
-     * @see https://www.php.net/chgrp
+     * @see https://php.net/chgrp
      *
      * @param string|int $group     A group name or number
      * @param bool       $recursive Whether change the group recursively or not

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -139,7 +139,7 @@ class NativeSessionStorage implements SessionStorageInterface
          * ---------- Part 1
          *
          * The part `[a-zA-Z0-9,-]` is related to the PHP ini directive `session.sid_bits_per_character` defined as 6.
-         * See https://www.php.net/manual/en/session.configuration.php#ini.session.sid-bits-per-character.
+         * See https://php.net/session.configuration#ini.session.sid-bits-per-character
          * Allowed values are integers such as:
          * - 4 for range `a-f0-9`
          * - 5 for range `a-v0-9`
@@ -148,7 +148,7 @@ class NativeSessionStorage implements SessionStorageInterface
          * ---------- Part 2
          *
          * The part `{22,250}` is related to the PHP ini directive `session.sid_length`.
-         * See https://www.php.net/manual/en/session.configuration.php#ini.session.sid-length.
+         * See https://php.net/session.configuration#ini.session.sid-length
          * Allowed values are integers between 22 and 256, but we use 250 for the max.
          *
          * Where does the 250 come from?

--- a/src/Symfony/Component/Lock/Store/MongoDbStore.php
+++ b/src/Symfony/Component/Lock/Store/MongoDbStore.php
@@ -149,7 +149,7 @@ class MongoDbStore implements PersistingStoreInterface
      *
      * Non-standard parameters are removed from the URI to improve libmongoc's re-use of connections.
      *
-     * @see https://www.php.net/manual/en/mongodb.connection-handling.php
+     * @see https://php.net/mongodb.connection-handling
      */
     private function skimUri(string $uri): string
     {

--- a/src/Symfony/Component/Mime/Crypto/SMimeEncrypter.php
+++ b/src/Symfony/Component/Mime/Crypto/SMimeEncrypter.php
@@ -24,7 +24,7 @@ final class SMimeEncrypter extends SMime
 
     /**
      * @param string|string[] $certificate The path (or array of paths) of the file(s) containing the X.509 certificate(s)
-     * @param int|null        $cipher      A set of algorithms used to encrypt the message. Must be one of these PHP constants: https://www.php.net/manual/en/openssl.ciphers.php
+     * @param int|null        $cipher      A set of algorithms used to encrypt the message. Must be one of these PHP constants: https://php.net/openssl.ciphers
      */
     public function __construct(string|array $certificate, ?int $cipher = null)
     {

--- a/src/Symfony/Component/Mime/FileinfoMimeTypeGuesser.php
+++ b/src/Symfony/Component/Mime/FileinfoMimeTypeGuesser.php
@@ -26,7 +26,7 @@ class FileinfoMimeTypeGuesser implements MimeTypeGuesserInterface
     /**
      * @param string|null $magicFile A magic file to use with the finfo instance
      *
-     * @see http://www.php.net/manual/en/function.finfo-open.php
+     * @see https://php.net/finfo-open
      */
     public function __construct(?string $magicFile = null)
     {

--- a/src/Symfony/Component/RateLimiter/RateLimiterFactory.php
+++ b/src/Symfony/Component/RateLimiter/RateLimiterFactory.php
@@ -65,11 +65,11 @@ final class RateLimiterFactory
             try {
                 $nowPlusInterval = @$now->modify('+' . $interval);
             } catch (\DateMalformedStringException $e) {
-                throw new \LogicException(\sprintf('Cannot parse interval "%s", please use a valid unit as described on https://www.php.net/datetime.formats.relative.', $interval), 0, $e);
+                throw new \LogicException(\sprintf('Cannot parse interval "%s", please use a valid unit as described on https://php.net/datetime.formats#datetime.formats.relative', $interval), 0, $e);
             }
 
             if (!$nowPlusInterval) {
-                throw new \LogicException(\sprintf('Cannot parse interval "%s", please use a valid unit as described on https://www.php.net/datetime.formats.relative.', $interval));
+                throw new \LogicException(\sprintf('Cannot parse interval "%s", please use a valid unit as described on https://php.net/datetime.formats#datetime.formats.relative', $interval));
             }
 
             return $now->diff($nowPlusInterval);

--- a/src/Symfony/Component/RateLimiter/Tests/LimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/LimiterTest.php
@@ -49,7 +49,7 @@ class LimiterTest extends TestCase
     public function testWrongInterval()
     {
         $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Cannot parse interval "1 minut", please use a valid unit as described on https://www.php.net/datetime.formats.relative.');
+        $this->expectExceptionMessage('Cannot parse interval "1 minut", please use a valid unit as described on https://php.net/datetime.formats#datetime.formats.relative');
 
         $this->createFactory([
             'id' => 'test',

--- a/src/Symfony/Component/Serializer/Context/Encoder/JsonEncoderContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Encoder/JsonEncoderContextBuilder.php
@@ -28,7 +28,7 @@ final class JsonEncoderContextBuilder implements ContextBuilderInterface
     /**
      * Configures the json_encode flags bitmask.
      *
-     * @see https://www.php.net/manual/en/json.constants.php
+     * @see https://php.net/json.constants
      *
      * @param positive-int|null $options
      */
@@ -40,7 +40,7 @@ final class JsonEncoderContextBuilder implements ContextBuilderInterface
     /**
      * Configures the json_decode flags bitmask.
      *
-     * @see https://www.php.net/manual/en/json.constants.php
+     * @see https://php.net/json.constants
      *
      * @param positive-int|null $options
      */

--- a/src/Symfony/Component/Serializer/Context/Encoder/XmlEncoderContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Encoder/XmlEncoderContextBuilder.php
@@ -36,7 +36,7 @@ final class XmlEncoderContextBuilder implements ContextBuilderInterface
     /**
      * Configures node types to ignore while decoding.
      *
-     * @see https://www.php.net/manual/en/dom.constants.php
+     * @see https://php.net/dom.constants
      *
      * @param list<int>|null $decoderIgnoredNodeTypes
      */
@@ -48,7 +48,7 @@ final class XmlEncoderContextBuilder implements ContextBuilderInterface
     /**
      * Configures node types to ignore while encoding.
      *
-     * @see https://www.php.net/manual/en/dom.constants.php
+     * @see https://php.net/dom.constants
      *
      * @param list<int>|null $encoderIgnoredNodeTypes
      */
@@ -60,7 +60,7 @@ final class XmlEncoderContextBuilder implements ContextBuilderInterface
     /**
      * Configures the DOMDocument encoding.
      *
-     * @see https://www.php.net/manual/en/class.domdocument.php#domdocument.props.encoding
+     * @see https://php.net/class.domdocument#domdocument.props.encoding
      */
     public function withEncoding(?string $encoding): static
     {
@@ -70,7 +70,7 @@ final class XmlEncoderContextBuilder implements ContextBuilderInterface
     /**
      * Configures whether to encode with indentation and extra space.
      *
-     * @see https://php.net/manual/en/class.domdocument.php#domdocument.props.formatoutput
+     * @see https://php.net/class.domdocument#domdocument.props.formatoutput
      */
     public function withFormatOutput(?bool $formatOutput): static
     {
@@ -80,7 +80,7 @@ final class XmlEncoderContextBuilder implements ContextBuilderInterface
     /**
      * Configures the DOMDocument::loadXml options bitmask.
      *
-     * @see https://www.php.net/manual/en/libxml.constants.php
+     * @see https://php.net/libxml.constants
      *
      * @param positive-int|null $loadOptions
      */
@@ -92,7 +92,7 @@ final class XmlEncoderContextBuilder implements ContextBuilderInterface
     /**
      * Configures the DOMDocument::saveXml options bitmask.
      *
-     * @see https://www.php.net/manual/en/libxml.constants.php
+     * @see https://php.net/libxml.constants
      *
      * @param positive-int|null $saveOptions
      */
@@ -120,7 +120,7 @@ final class XmlEncoderContextBuilder implements ContextBuilderInterface
     /**
      * Configures whether the document will be standalone.
      *
-     * @see https://php.net/manual/en/class.domdocument.php#domdocument.props.xmlstandalone
+     * @see https://php.net/class.domdocument#domdocument.props.xmlstandalone
      */
     public function withStandalone(?bool $standalone): static
     {
@@ -138,7 +138,7 @@ final class XmlEncoderContextBuilder implements ContextBuilderInterface
     /**
      * Configures the version number of the document.
      *
-     * @see https://php.net/manual/en/class.domdocument.php#domdocument.props.xmlversion
+     * @see https://php.net/class.domdocument#domdocument.props.xmlversion
      */
     public function withVersion(?string $version): static
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

When the paramter 'interval' contains an invalid relative date string, the exception message shows an invalid URL.
This PR fixes the URLs.


