### PR TITLE
[Contract] Provide BC path to have TranslatableInterface extends Stringable

### DIFF
--- a/src/Symfony/Contracts/CHANGELOG.md
+++ b/src/Symfony/Contracts/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.7
+---
+
+* Add `TranslatableInterface::__toString()`
+
 3.6
 ---
 

--- a/src/Symfony/Contracts/Translation/TranslatableInterface.php
+++ b/src/Symfony/Contracts/Translation/TranslatableInterface.php
@@ -13,6 +13,8 @@ namespace Symfony\Contracts\Translation;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @method string __toString()
  */
 interface TranslatableInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #...
| License       | MIT

When looking at the TranslatableInterface implementation provided by Symfony
https://github.com/symfony/symfony/blob/565964db79035599622512e53a89ef2d8e1c2a8a/src/Symfony/Component/Translation/TranslatableMessage.php#L20, 
there is extra methods provided:
- GetMessage
- GetParamters
- GetDomain
- __toString

What is useful with the toString method is the fact that if we encounter an error with some message, we can provide an explicit error "An error occurred with the message Foo" with something like
```
sprintf('An error occurred with the message %s', (string) $message);
```

But when writing an application, we're supposed to support TranslatableInterface which does not have the `__toString` method in it so it's technically wrong to cast it to string.

I feel like having `TranslatableInterface extends Stringable` would be
- Useful
- Easy to implements for custom TranslatableInterface

So I propose to softly-add this in 7.4, and introduce the BC break for 8.0.
(Not sure how it works for the symfony/contracts repository ; which branch I should target)