### PR TITLE
[Webhook] Allow configurators to be customized via Transport

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
@@ -105,6 +105,7 @@ class UnusedTagsPass implements CompilerPassInterface
         'validator.constraint_validator',
         'validator.group_provider',
         'validator.initializer',
+        'webhook.configurator',
         'workflow',
         'object_mapper.transform_callable',
         'object_mapper.condition_callable',

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/webhook.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/webhook.php
@@ -26,17 +26,17 @@ return static function (ContainerConfigurator $container) {
         ->set('webhook.transport', Transport::class)
             ->args([
                 service('http_client'),
-                service('webhook.headers_configurator'),
-                service('webhook.body_configurator.json'),
-                service('webhook.signer'),
+                tagged_iterator('webhook.configurator'),
             ])
 
         ->set('webhook.headers_configurator', HeadersConfigurator::class)
+            ->tag('webhook.configurator')
 
         ->set('webhook.body_configurator.json', JsonBodyConfigurator::class)
             ->args([
                 abstract_arg('payload serializer'),
             ])
+            ->tag('webhook.configurator')
 
         ->set('webhook.payload_serializer.json', NativeJsonPayloadSerializer::class)
 
@@ -46,6 +46,7 @@ return static function (ContainerConfigurator $container) {
             ])
 
         ->set('webhook.signer', HeaderSignatureConfigurator::class)
+            ->tag('webhook.configurator')
 
         ->set('webhook.messenger.send_handler', SendWebhookHandler::class)
             ->args([

--- a/src/Symfony/Component/Webhook/Server/Transport.php
+++ b/src/Symfony/Component/Webhook/Server/Transport.php
@@ -21,21 +21,35 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 class Transport implements TransportInterface
 {
+    private array $configurators = [];
+
     public function __construct(
         private readonly HttpClientInterface $client,
-        private readonly RequestConfiguratorInterface $headers,
-        private readonly RequestConfiguratorInterface $body,
-        private readonly RequestConfiguratorInterface $signer,
+        ...$params
     ) {
+        if (1 === count($params) && $params[0] instanceof \Traversable) {
+            $this->configurators = iterator_to_array($params[0]);
+        } elseif (3 === count($params)) {
+            trigger_deprecation('symfony/webhook', '7.3', 'Individual configurators for webhook transport is deprecated, use an iterable instead.');
+
+            $this->configurators = [
+                $params[0],
+                $params[1],
+                $params[2],
+            ];
+        } else {
+            throw new \InvalidArgumentException(sprintf('Expected a single Traversable argument or three configurators, got %d arguments.', count($params)));
+        }
     }
 
     public function send(Subscriber $subscriber, RemoteEvent $event): void
     {
         $options = new HttpOptions();
+        $secret = $subscriber->getSecret();
 
-        $this->headers->configure($event, $subscriber->getSecret(), $options);
-        $this->body->configure($event, $subscriber->getSecret(), $options);
-        $this->signer->configure($event, $subscriber->getSecret(), $options);
+        foreach ($this->configurators as $configurator) {
+            $configurator->configure($event, $secret, $options);
+        }
 
         $this->client->request('POST', $subscriber->getUrl(), $options->toArray());
     }

--- a/src/Symfony/Component/Webhook/Tests/Server/TransportTest.php
+++ b/src/Symfony/Component/Webhook/Tests/Server/TransportTest.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Webhook\Tests\Server;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectUserDeprecationMessageTrait;
+use Symfony\Component\HttpClient\HttpOptions;
+use Symfony\Component\RemoteEvent\RemoteEvent;
+use Symfony\Component\Webhook\Server\RequestConfiguratorInterface;
+use Symfony\Component\Webhook\Server\Transport;
+use Symfony\Component\Webhook\Subscriber;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class TransportTest extends TestCase
+{
+    use ExpectUserDeprecationMessageTrait;
+
+    public function testCanBeInstantiated()
+    {
+        $client = $this->createMock(HttpClientInterface::class);
+        $client->expects($this->once())
+            ->method('request')
+            ->with(
+                'POST',
+                'https://example.com/webhook',
+                $this->isType('array')
+            );
+
+        $subscriber = $this->createMock(Subscriber::class);
+        $subscriber->expects($this->once())->method('getSecret')->willReturn('some-secret');
+        $subscriber->expects($this->once())->method('getUrl')->willReturn('https://example.com/webhook');
+
+        $event = $this->createMock(RemoteEvent::class);
+
+        $configuratorOne = $this->createMock(RequestConfiguratorInterface::class);
+        $configuratorOne->expects($this->once())
+            ->method('configure')
+            ->with($event, 'some-secret', $this->isInstanceOf(HttpOptions::class));
+
+        $configuratorTwo = $this->createMock(RequestConfiguratorInterface::class);
+        $configuratorTwo->expects($this->once())
+            ->method('configure')
+            ->with($event, 'some-secret', $this->isInstanceOf(HttpOptions::class));
+
+        $transport = new Transport($client, new \ArrayIterator([
+            $configuratorOne,
+            $configuratorTwo,
+        ]));
+
+        $transport->send($subscriber, $event);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testCanBeInstantiatedWithDeprecatedOptions()
+    {
+        $client = $this->createMock(HttpClientInterface::class);
+        $client->expects($this->once())
+            ->method('request')
+            ->with(
+                'POST',
+                'https://example.com/webhook',
+                $this->isType('array')
+            );
+
+        $subscriber = $this->createMock(Subscriber::class);
+        $subscriber->expects($this->once())->method('getSecret')->willReturn('some-secret');
+        $subscriber->expects($this->once())->method('getUrl')->willReturn('https://example.com/webhook');
+
+        $event = $this->createMock(RemoteEvent::class);
+
+        $headerConfigurator = $this->createMock(RequestConfiguratorInterface::class);
+        $headerConfigurator->expects($this->once())
+            ->method('configure')
+            ->with($event, 'some-secret', $this->isInstanceOf(HttpOptions::class));
+
+        $bodyConfigurator = $this->createMock(RequestConfiguratorInterface::class);
+        $bodyConfigurator->expects($this->once())
+            ->method('configure')
+            ->with($event, 'some-secret', $this->isInstanceOf(HttpOptions::class));
+
+        $signerConfigurator = $this->createMock(RequestConfiguratorInterface::class);
+        $signerConfigurator->expects($this->once())
+            ->method('configure')
+            ->with($event, 'some-secret', $this->isInstanceOf(HttpOptions::class));
+
+        $event = $this->createMock(RemoteEvent::class);
+
+        $this->expectUserDeprecationMessage('Since symfony/webhook 7.3: Individual configurators for webhook transport is deprecated, use an iterable instead.');
+
+        $transport = new Transport($client, $headerConfigurator, $bodyConfigurator, $signerConfigurator);
+        $transport->send($subscriber, $event);
+    }
+}

--- a/src/Symfony/Component/Webhook/composer.json
+++ b/src/Symfony/Component/Webhook/composer.json
@@ -20,7 +20,8 @@
         "symfony/http-foundation": "^6.4|^7.0|^8.0",
         "symfony/http-kernel": "^6.4|^7.0|^8.0",
         "symfony/messenger": "^6.4|^7.0|^8.0",
-        "symfony/remote-event": "^6.4|^7.0|^8.0"
+        "symfony/remote-event": "^6.4|^7.0|^8.0",
+        "symfony/deprecation-contracts": "^2.5|^3"
     },
     "require-dev": {
         "symfony/http-client": "^6.4|^7.0|^8.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | None
| License       | MIT

This makes the configurators extensible for the webhook transport service, in as much as it is simple to tag new configurators which can customize the http options.

This can be useful if you need to customize the webhook HTTP request, or any functionality implemented in a custom HttpClient. This customization can be done by inspecting the particular RemoteEvent.

- 🔒 Do not break backward compatibility:
  https://symfony.com/bc

This will be a BC break for anyone who has already customized or used this Transport, unsure if that's acceptable.

There are not unit tests for this service, unsure if this is a design decision or some would be welcome as part of this change.
