### PR TITLE
Avoid unnecessary redirect and traffic on the php.net links by adding www.

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -444,7 +444,7 @@ class FrameworkExtension extends Extension
 
         if ($this->readConfigEnabled('session', $container, $config['session'])) {
             if (!\extension_loaded('session')) {
-                throw new LogicException('Session support cannot be enabled as the session extension is not installed. See https://php.net/session.installation for instructions.');
+                throw new LogicException('Session support cannot be enabled as the session extension is not installed. See https://www.php.net/session.installation for instructions.');
             }
 
             $this->registerSessionConfiguration($config['session'], $container, $loader);

--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -48,7 +48,7 @@ trait RedisTrait
         'redis_sentinel' => null,
         'dbindex' => 0,
         'failover' => 'none',
-        'ssl' => null, // see https://php.net/context.ssl
+        'ssl' => null, // see https://www.php.net/context.ssl
     ];
     private \Redis|Relay|\RedisArray|\RedisCluster|\Predis\ClientInterface $redis;
     private MarshallerInterface $marshaller;

--- a/src/Symfony/Component/ErrorHandler/Tests/ErrorRenderer/HtmlErrorRendererTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/ErrorRenderer/HtmlErrorRendererTest.php
@@ -100,7 +100,7 @@ HTML;
 
     public function testRendersStackWithoutBinaryStrings()
     {
-        // make sure method arguments are available in stack traces (see https://php.net/ini.core)
+        // make sure method arguments are available in stack traces (see https://www.php.net/ini.core)
         ini_set('zend.exception_ignore_args', false);
 
         $binaryData = file_get_contents(__DIR__.'/../Fixtures/pixel.png');

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -235,7 +235,7 @@ class Filesystem
      *
      * This method always throws on Windows, as the underlying PHP function is not supported.
      *
-     * @see https://php.net/chown
+     * @see https://www.php.net/chown
      *
      * @param string|int $user      A user name or number
      * @param bool       $recursive Whether change the owner recursively or not
@@ -267,7 +267,7 @@ class Filesystem
      *
      * This method always throws on Windows, as the underlying PHP function is not supported.
      *
-     * @see https://php.net/chgrp
+     * @see https://www.php.net/chgrp
      *
      * @param string|int $group     A group name or number
      * @param bool       $recursive Whether change the group recursively or not
@@ -311,7 +311,7 @@ class Filesystem
 
         if (!self::box('rename', $origin, $target)) {
             if (is_dir($origin)) {
-                // See https://bugs.php.net/54097 & https://php.net/rename#113943
+                // See https://bugs.php.net/54097 & https://www.php.net/rename#113943
                 $this->mirror($origin, $target, null, ['override' => $overwrite, 'delete' => $overwrite]);
                 $this->remove($origin);
 

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
@@ -138,7 +138,7 @@ class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
                 $dateTime = new \DateTime(sprintf('@%s', $timestamp));
             }
             // set timezone separately, as it would be ignored if set via the constructor,
-            // see https://php.net/datetime.construct
+            // see https://www.php.net/datetime.construct
             $dateTime->setTimezone(new \DateTimeZone($this->outputTimezone));
         } catch (\Exception $e) {
             throw new TransformationFailedException($e->getMessage(), $e->getCode(), $e);

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
@@ -54,7 +54,7 @@ class DateTimeToStringTransformer extends BaseDateTimeTransformer
         $this->generateFormat = $format;
         $this->parseFormat = $parseFormat ?? $format;
 
-        // See https://php.net/datetime.createfromformat
+        // See https://www.php.net/datetime.createfromformat
         // The character "|" in the format makes sure that the parts of a date
         // that are *not* specified in the format are reset to the corresponding
         // values from 1970-01-01 00:00:00 instead of the current time.

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -195,7 +195,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
      * @param int                                     $filter  FILTER_* constant
      * @param int|array{flags?: int, options?: array} $options Flags from FILTER_* constants
      *
-     * @see https://php.net/filter-var
+     * @see https://www.php.net/filter-var
      */
     public function filter(string $key, mixed $default = null, int $filter = \FILTER_DEFAULT, mixed $options = []): mixed
     {

--- a/src/Symfony/Component/HttpFoundation/ServerBag.php
+++ b/src/Symfony/Component/HttpFoundation/ServerBag.php
@@ -74,7 +74,7 @@ class ServerBag extends ParameterBag
                     /*
                      * XXX: Since there is no PHP_AUTH_BEARER in PHP predefined variables,
                      *      I'll just set $headers['AUTHORIZATION'] here.
-                     *      https://php.net/reserved.variables.server
+                     *      https://www.php.net/reserved.variables.server
                      */
                     $headers['AUTHORIZATION'] = $authorizationHeader;
                 }

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MemcachedSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MemcachedSessionHandler.php
@@ -15,7 +15,7 @@ namespace Symfony\Component\HttpFoundation\Session\Storage\Handler;
  * Memcached based session storage handler based on the Memcached class
  * provided by the PHP memcached extension.
  *
- * @see https://php.net/memcached
+ * @see https://www.php.net/memcached
  *
  * @author Drak <drak@zikula.org>
  */

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
@@ -24,7 +24,7 @@ use MongoDB\Driver\Query;
  * @author Markus Bachmann <markus.bachmann@bachi.biz>
  * @author Jérôme Tamarelle <jerome@tamarelle.net>
  *
- * @see https://php.net/mongodb
+ * @see https://www.php.net/mongodb
  */
 class MongoDbSessionHandler extends AbstractSessionHandler
 {

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeFileSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeFileSessionHandler.php
@@ -23,7 +23,7 @@ class NativeFileSessionHandler extends \SessionHandler
      *                              Default null will leave setting as defined by PHP.
      *                              '/path', 'N;/path', or 'N;octal-mode;/path
      *
-     * @see https://php.net/session.configuration#ini.session.save-path for further details.
+     * @see https://www.php.net/session.configuration#ini.session.save-path for further details.
      *
      * @throws \InvalidArgumentException On invalid $savePath
      * @throws \RuntimeException         When failing to create the save directory

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -35,7 +35,7 @@ use Doctrine\DBAL\Types\Types;
  * Saving it in a character column could corrupt the data. You can use createTable()
  * to initialize a correctly defined table.
  *
- * @see https://php.net/sessionhandlerinterface
+ * @see https://www.php.net/sessionhandlerinterface
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Michael Williams <michael.williams@funsational.com>

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -59,7 +59,7 @@ class NativeSessionStorage implements SessionStorageInterface
      *
      * List of options for $options array with their defaults.
      *
-     * @see https://php.net/session.configuration for options
+     * @see https://www.php.net/session.configuration for options
      * but we omit 'session.' from the beginning of the keys for convenience.
      *
      * ("auto_start", is not supported as it tells PHP to start a session before
@@ -139,7 +139,7 @@ class NativeSessionStorage implements SessionStorageInterface
          * ---------- Part 1
          *
          * The part `[a-zA-Z0-9,-]` is related to the PHP ini directive `session.sid_bits_per_character` defined as 6.
-         * See https://php.net/session.configuration#ini.session.sid-bits-per-character
+         * See https://www.php.net/session.configuration#ini.session.sid-bits-per-character
          * Allowed values are integers such as:
          * - 4 for range `a-f0-9`
          * - 5 for range `a-v0-9`
@@ -148,7 +148,7 @@ class NativeSessionStorage implements SessionStorageInterface
          * ---------- Part 2
          *
          * The part `{22,250}` is related to the PHP ini directive `session.sid_length`.
-         * See https://php.net/session.configuration#ini.session.sid-length
+         * See https://www.php.net/session.configuration#ini.session.sid-length
          * Allowed values are integers between 22 and 256, but we use 250 for the max.
          *
          * Where does the 250 come from?
@@ -346,7 +346,7 @@ class NativeSessionStorage implements SessionStorageInterface
      *
      * @param array $options Session ini directives [key => value]
      *
-     * @see https://php.net/session.configuration
+     * @see https://www.php.net/session.configuration
      *
      * @return void
      */
@@ -388,9 +388,9 @@ class NativeSessionStorage implements SessionStorageInterface
      * or pass in a \SessionHandler instance which configures session.save_handler in the
      * constructor, for a template see NativeFileSessionHandler.
      *
-     * @see https://php.net/session-set-save-handler
-     * @see https://php.net/sessionhandlerinterface
-     * @see https://php.net/sessionhandler
+     * @see https://www.php.net/session-set-save-handler
+     * @see https://www.php.net/sessionhandlerinterface
+     * @see https://www.php.net/sessionhandler
      *
      * @return void
      *

--- a/src/Symfony/Component/HttpKernel/Attribute/MapQueryParameter.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/MapQueryParameter.php
@@ -22,7 +22,7 @@ use Symfony\Component\HttpKernel\Controller\ArgumentResolver\QueryParameterValue
 final class MapQueryParameter extends ValueResolver
 {
     /**
-     * @see https://php.net/manual/filter.constants for filter, flags and options
+     * @see https://www.php.net/manual/filter.constants for filter, flags and options
      *
      * @param string|null $name The name of the query parameter. If null, the name of the argument in the controller will be used.
      */

--- a/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
@@ -126,7 +126,7 @@ class Profiler implements ResetInterface
      * @param string|null   $end    The end date to search to
      * @param \Closure|null $filter A filter to apply on the list of tokens
      *
-     * @see https://php.net/datetime.formats for the supported date/time formats
+     * @see https://www.php.net/datetime.formats for the supported date/time formats
      */
     public function find(?string $ip, ?string $url, ?int $limit, ?string $method, ?string $start, ?string $end, ?string $statusCode = null/* , \Closure $filter = null */): array
     {

--- a/src/Symfony/Component/Intl/Locale.php
+++ b/src/Symfony/Component/Intl/Locale.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Intl;
 
 if (!class_exists(\Locale::class)) {
-    throw new \LogicException(sprintf('You cannot use the "%s\Locale" class as the "intl" extension is not installed. See https://php.net/intl.', __NAMESPACE__));
+    throw new \LogicException(sprintf('You cannot use the "%s\Locale" class as the "intl" extension is not installed. See https://www.php.net/intl.', __NAMESPACE__));
 }
 
 /**

--- a/src/Symfony/Component/Intl/Transliterator/EmojiTransliterator.php
+++ b/src/Symfony/Component/Intl/Transliterator/EmojiTransliterator.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Intl\Transliterator;
 use Symfony\Component\Intl\Util\GzipStreamWrapper;
 
 if (!class_exists(\Transliterator::class)) {
-    throw new \LogicException(sprintf('You cannot use the "%s\EmojiTransliterator" class as the "intl" extension is not installed. See https://php.net/intl.', __NAMESPACE__));
+    throw new \LogicException(sprintf('You cannot use the "%s\EmojiTransliterator" class as the "intl" extension is not installed. See https://www.php.net/intl.', __NAMESPACE__));
 } else {
     /**
      * @internal

--- a/src/Symfony/Component/Lock/Store/MongoDbStore.php
+++ b/src/Symfony/Component/Lock/Store/MongoDbStore.php
@@ -149,7 +149,7 @@ class MongoDbStore implements PersistingStoreInterface
      *
      * Non-standard parameters are removed from the URI to improve libmongoc's re-use of connections.
      *
-     * @see https://php.net/mongodb.connection-handling
+     * @see https://www.php.net/mongodb.connection-handling
      */
     private function skimUri(string $uri): string
     {

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -51,7 +51,7 @@ class Connection
         'read_timeout' => 0.0, //  Float, value in seconds (optional, default is 0 meaning unlimited)
         'retry_interval' => 0, //  Int, value in milliseconds (optional, default is 0)
         'persistent_id' => null, // String, persistent connection id (optional, default is NULL meaning not persistent)
-        'ssl' => null, // see https://php.net/context.ssl
+        'ssl' => null, // see https://www.php.net/context.ssl
     ];
 
     private \Redis|Relay|\RedisCluster|\Closure $redis;

--- a/src/Symfony/Component/Mime/Crypto/SMimeEncrypter.php
+++ b/src/Symfony/Component/Mime/Crypto/SMimeEncrypter.php
@@ -24,7 +24,7 @@ final class SMimeEncrypter extends SMime
 
     /**
      * @param string|string[] $certificate The path (or array of paths) of the file(s) containing the X.509 certificate(s)
-     * @param int|null        $cipher      A set of algorithms used to encrypt the message. Must be one of these PHP constants: https://php.net/openssl.ciphers
+     * @param int|null        $cipher      A set of algorithms used to encrypt the message. Must be one of these PHP constants: https://www.php.net/openssl.ciphers
      */
     public function __construct(string|array $certificate, ?int $cipher = null)
     {

--- a/src/Symfony/Component/Mime/FileinfoMimeTypeGuesser.php
+++ b/src/Symfony/Component/Mime/FileinfoMimeTypeGuesser.php
@@ -26,7 +26,7 @@ class FileinfoMimeTypeGuesser implements MimeTypeGuesserInterface
     /**
      * @param string|null $magicFile A magic file to use with the finfo instance
      *
-     * @see https://php.net/finfo-open
+     * @see https://www.php.net/finfo-open
      */
     public function __construct(?string $magicFile = null)
     {

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -496,7 +496,7 @@ class Process implements \IteratorAggregate
     /**
      * Sends a POSIX signal to the process.
      *
-     * @param int $signal A valid POSIX signal (see https://php.net/pcntl.constants)
+     * @param int $signal A valid POSIX signal (see https://www.php.net/pcntl.constants)
      *
      * @return $this
      *
@@ -1178,7 +1178,7 @@ class Process implements \IteratorAggregate
     /**
      * Defines options to pass to the underlying proc_open().
      *
-     * @see https://php.net/proc_open for the options supported by PHP.
+     * @see https://www.php.net/proc_open for the options supported by PHP.
      *
      * Enabling the "create_new_console" option allows a subprocess to continue
      * to run after the main process exited, on both Windows and *nix
@@ -1435,7 +1435,7 @@ class Process implements \IteratorAggregate
     /**
      * Sends a POSIX signal to the process.
      *
-     * @param int  $signal         A valid POSIX signal (see https://php.net/pcntl.constants)
+     * @param int  $signal         A valid POSIX signal (see https://www.php.net/pcntl.constants)
      * @param bool $throwException Whether to throw exception in case signal failed
      *
      * @throws LogicException   In case the process is not running

--- a/src/Symfony/Component/RateLimiter/RateLimiterFactory.php
+++ b/src/Symfony/Component/RateLimiter/RateLimiterFactory.php
@@ -65,11 +65,11 @@ final class RateLimiterFactory
             try {
                 $nowPlusInterval = @$now->modify('+' . $interval);
             } catch (\DateMalformedStringException $e) {
-                throw new \LogicException(\sprintf('Cannot parse interval "%s", please use a valid unit as described on https://php.net/datetime.formats#datetime.formats.relative', $interval), 0, $e);
+                throw new \LogicException(\sprintf('Cannot parse interval "%s", please use a valid unit as described on https://www.php.net/datetime.formats#datetime.formats.relative', $interval), 0, $e);
             }
 
             if (!$nowPlusInterval) {
-                throw new \LogicException(\sprintf('Cannot parse interval "%s", please use a valid unit as described on https://php.net/datetime.formats#datetime.formats.relative', $interval));
+                throw new \LogicException(\sprintf('Cannot parse interval "%s", please use a valid unit as described on https://www.php.net/datetime.formats#datetime.formats.relative', $interval));
             }
 
             return $now->diff($nowPlusInterval);

--- a/src/Symfony/Component/RateLimiter/Tests/LimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/LimiterTest.php
@@ -49,7 +49,7 @@ class LimiterTest extends TestCase
     public function testWrongInterval()
     {
         $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Cannot parse interval "1 minut", please use a valid unit as described on https://php.net/datetime.formats#datetime.formats.relative');
+        $this->expectExceptionMessage('Cannot parse interval "1 minut", please use a valid unit as described on https://www.php.net/datetime.formats#datetime.formats.relative');
 
         $this->createFactory([
             'id' => 'test',

--- a/src/Symfony/Component/Scheduler/RecurringMessage.php
+++ b/src/Symfony/Component/Scheduler/RecurringMessage.php
@@ -43,7 +43,7 @@ final class RecurringMessage implements MessageProviderInterface
      * @param MessageProviderInterface|object $message A message provider that yields messages or a static message that will be dispatched on every trigger
      *
      * @see https://en.wikipedia.org/wiki/ISO_8601#Durations
-     * @see https://php.net/datetime.formats#datetime.formats.relative
+     * @see https://www.php.net/datetime.formats#datetime.formats.relative
      */
     public static function every(string|int|\DateInterval $frequency, object $message, string|\DateTimeImmutable|null $from = null, string|\DateTimeImmutable $until = new \DateTimeImmutable('3000-01-01')): self
     {

--- a/src/Symfony/Component/Serializer/Context/Encoder/JsonEncoderContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Encoder/JsonEncoderContextBuilder.php
@@ -28,7 +28,7 @@ final class JsonEncoderContextBuilder implements ContextBuilderInterface
     /**
      * Configures the json_encode flags bitmask.
      *
-     * @see https://php.net/json.constants
+     * @see https://www.php.net/json.constants
      *
      * @param positive-int|null $options
      */
@@ -40,7 +40,7 @@ final class JsonEncoderContextBuilder implements ContextBuilderInterface
     /**
      * Configures the json_decode flags bitmask.
      *
-     * @see https://php.net/json.constants
+     * @see https://www.php.net/json.constants
      *
      * @param positive-int|null $options
      */

--- a/src/Symfony/Component/Serializer/Context/Encoder/XmlEncoderContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Encoder/XmlEncoderContextBuilder.php
@@ -36,7 +36,7 @@ final class XmlEncoderContextBuilder implements ContextBuilderInterface
     /**
      * Configures node types to ignore while decoding.
      *
-     * @see https://php.net/dom.constants
+     * @see https://www.php.net/dom.constants
      *
      * @param list<int>|null $decoderIgnoredNodeTypes
      */
@@ -48,7 +48,7 @@ final class XmlEncoderContextBuilder implements ContextBuilderInterface
     /**
      * Configures node types to ignore while encoding.
      *
-     * @see https://php.net/dom.constants
+     * @see https://www.php.net/dom.constants
      *
      * @param list<int>|null $encoderIgnoredNodeTypes
      */
@@ -60,7 +60,7 @@ final class XmlEncoderContextBuilder implements ContextBuilderInterface
     /**
      * Configures the DOMDocument encoding.
      *
-     * @see https://php.net/class.domdocument#domdocument.props.encoding
+     * @see https://www.php.net/class.domdocument#domdocument.props.encoding
      */
     public function withEncoding(?string $encoding): static
     {
@@ -70,7 +70,7 @@ final class XmlEncoderContextBuilder implements ContextBuilderInterface
     /**
      * Configures whether to encode with indentation and extra space.
      *
-     * @see https://php.net/class.domdocument#domdocument.props.formatoutput
+     * @see https://www.php.net/class.domdocument#domdocument.props.formatoutput
      */
     public function withFormatOutput(?bool $formatOutput): static
     {
@@ -80,7 +80,7 @@ final class XmlEncoderContextBuilder implements ContextBuilderInterface
     /**
      * Configures the DOMDocument::loadXml options bitmask.
      *
-     * @see https://php.net/libxml.constants
+     * @see https://www.php.net/libxml.constants
      *
      * @param positive-int|null $loadOptions
      */
@@ -92,7 +92,7 @@ final class XmlEncoderContextBuilder implements ContextBuilderInterface
     /**
      * Configures the DOMDocument::saveXml options bitmask.
      *
-     * @see https://php.net/libxml.constants
+     * @see https://www.php.net/libxml.constants
      *
      * @param positive-int|null $saveOptions
      */
@@ -120,7 +120,7 @@ final class XmlEncoderContextBuilder implements ContextBuilderInterface
     /**
      * Configures whether the document will be standalone.
      *
-     * @see https://php.net/class.domdocument#domdocument.props.xmlstandalone
+     * @see https://www.php.net/class.domdocument#domdocument.props.xmlstandalone
      */
     public function withStandalone(?bool $standalone): static
     {
@@ -138,7 +138,7 @@ final class XmlEncoderContextBuilder implements ContextBuilderInterface
     /**
      * Configures the version number of the document.
      *
-     * @see https://php.net/class.domdocument#domdocument.props.xmlversion
+     * @see https://www.php.net/class.domdocument#domdocument.props.xmlversion
      */
     public function withVersion(?string $version): static
     {

--- a/src/Symfony/Component/Serializer/Context/Normalizer/DateIntervalNormalizerContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Normalizer/DateIntervalNormalizerContextBuilder.php
@@ -27,7 +27,7 @@ final class DateIntervalNormalizerContextBuilder implements ContextBuilderInterf
     /**
      * Configures the format of the interval.
      *
-     * @see https://php.net/manual/en/dateinterval.format.php
+     * @see https://www.php.net/manual/en/dateinterval.format.php
      */
     public function withFormat(?string $format): static
     {

--- a/src/Symfony/Component/Serializer/Encoder/JsonDecode.php
+++ b/src/Symfony/Component/Serializer/Encoder/JsonDecode.php
@@ -83,7 +83,7 @@ class JsonDecode implements DecoderInterface
      *
      * @throws NotEncodableValueException
      *
-     * @see https://php.net/json_decode
+     * @see https://www.php.net/json_decode
      */
     public function decode(string $data, string $format, array $context = []): mixed
     {

--- a/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
@@ -66,7 +66,7 @@ abstract class AbstractComparisonValidator extends ConstraintValidator
 
         // Convert strings to date-time objects if comparing to another date-time object
         // This allows to compare with any date/time value supported by date-time constructors:
-        // https://php.net/datetime.formats
+        // https://www.php.net/datetime.formats
         if (\is_string($comparedValue) && $value instanceof \DateTimeInterface) {
             try {
                 $comparedValue = new $value($comparedValue);

--- a/src/Symfony/Component/Validator/Constraints/RangeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/RangeValidator.php
@@ -67,7 +67,7 @@ class RangeValidator extends ConstraintValidator
         // Convert strings to DateTimes if comparing another DateTime
         // This allows to compare with any date/time value supported by
         // the DateTime constructor:
-        // https://php.net/datetime.formats
+        // https://www.php.net/datetime.formats
         if ($value instanceof \DateTimeInterface) {
             if (\is_string($min)) {
                 try {

--- a/src/Symfony/Component/Validator/Tests/Constraints/IpValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IpValidatorTest.php
@@ -363,7 +363,7 @@ class IpValidatorTest extends ConstraintValidatorTestCase
     {
         // Quoting after official filter documentation:
         // "FILTER_FLAG_NO_RES_RANGE = This flag does not apply to IPv6 addresses."
-        // Full description: https://php.net/filter.filters.flags
+        // Full description: https://www.php.net/filter.filters.flags
         return self::getInvalidIpsV6();
     }
 

--- a/src/Symfony/Component/VarExporter/LazyGhostTrait.php
+++ b/src/Symfony/Component/VarExporter/LazyGhostTrait.php
@@ -25,7 +25,7 @@ trait LazyGhostTrait
      * Creates a lazy-loading ghost instance.
      *
      * Skipped properties should be indexed by their array-cast identifier, see
-     * https://php.net/manual/language.types.array#language.types.array.casting
+     * https://www.php.net/manual/language.types.array#language.types.array.casting
      *
      * @param (\Closure(static):void   $initializer       The closure should initialize the object it receives as argument
      * @param array<string, true>|null $skippedProperties An array indexed by the properties to skip, a.k.a. the ones

--- a/src/Symfony/Contracts/HttpClient/HttpClientInterface.php
+++ b/src/Symfony/Contracts/HttpClient/HttpClientInterface.php
@@ -56,7 +56,7 @@ interface HttpClientInterface
         'max_duration' => 0,    // float - the maximum execution time (in seconds) for the request+response as a whole;
                                 //   a value lower than or equal to 0 means it is unlimited
         'bindto' => '0',        // string - the interface or the local socket to bind to
-        'verify_peer' => true,  // see https://php.net/context.ssl for the following options
+        'verify_peer' => true,  // see https://www.php.net/context.ssl for the following options
         'verify_host' => true,
         'cafile' => null,
         'capath' => null,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes/no
| New feature?  | yes/no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | yes/no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

The links were shorten in https://github.com/symfony/symfony/pull/61037 to not include the language. But we should still keep the `www.` to avoid unnessary redirects and traffic. Keep things green.

Not sure if we could create a fabbot rule for this.