### PR TITLE
[Validator] Allow mixed root on `CompoundConstraintTestCase` validator

### DIFF
--- a/src/Symfony/Component/Validator/Test/CompoundConstraintTestCase.php
+++ b/src/Symfony/Component/Validator/Test/CompoundConstraintTestCase.php
@@ -35,7 +35,7 @@ abstract class CompoundConstraintTestCase extends TestCase
     protected ValidatorInterface $validator;
     protected ?ConstraintViolationListInterface $violationList = null;
     protected ExecutionContextInterface $context;
-    protected string $root;
+    protected mixed $root;
 
     private mixed $validatedValue;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

The CompoundConstraintTestCase is currently defining a `protected string $root`, forcing the root to be a "string".
Testing compound constraints where the root is something different is triggering Static-Analysis (phpstan) warings or (worst) casting the `$root` to a string, causing PHP errors.

In the given code: the `$root` is passed to the ExecutionContext, which has the following constructor signature: `__construct(private ValidatorInterface $validator, private mixed $root, private TranslatorInterface $translator, ...)`, thus `mixed` can be safely used in the `CompoundConstraintTestCase` class too.
