### PR TITLE
[Brevo Mailer] Webhook IP Addresses have changed

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Brevo/Webhook/BrevoRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/Webhook/BrevoRequestParser.php
@@ -37,7 +37,7 @@ final class BrevoRequestParser extends AbstractRequestParser
             new IsJsonRequestMatcher(),
             // https://developers.brevo.com/docs/how-to-use-webhooks#securing-your-webhooks
             // localhost is added for testing
-            new IpsRequestMatcher(['185.107.232.1/24', '1.179.112.1/20', '127.0.0.1']),
+            new IpsRequestMatcher(['185.107.232.1/24', '1.179.112.1/20', '172.246.240.1/20', '127.0.0.1']),
         ]);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

So first I recognized multiple `RejectWebhookExceptions`. Then I checked my access logs and realized that webhook from Brevo can also come from the '172.246.240.1/20' IP range.

This is also documented here: https://help.brevo.com/hc/en-us/articles/15127404548498-Brevo-IP-ranges-List-of-publicly-exposed-services

This new IP range must have been added later this year, it hasn't been there in January, for instance: https://web.archive.org/web/20250125161029/https://help.brevo.com/hc/en-us/articles/15127404548498-Brevo-IP-ranges-List-of-publicly-exposed-services

So this PR adds the new IP range for ingress webhook validation.

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
