### PR TITLE
[ExpressionLanguage] forbid passing `null` as allowed variables

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -142,6 +142,17 @@ DoctrineBridge
 
  * Make `ProxyCacheWarmer` class `final`
 
+ExpressionLanguage
+------------------
+
+ * Remove support for passing `null` as the allowed variable names to `ExpressionLanguage::lint()` and `Parser::lint()`,
+   pass the `IGNORE_UNKNOWN_VARIABLES` flag instead to ignore unknown variables during linting
+
+   ```diff
+   -$expressionLanguage->lint($expression, null);
+   +$expressionLanguage->lint($expression, [], ExpressionLanguage::IGNORE_UNKNOWN_VARIABLES);
+   ```
+
 Form
 ----
 

--- a/src/Symfony/Component/ExpressionLanguage/CHANGELOG.md
+++ b/src/Symfony/Component/ExpressionLanguage/CHANGELOG.md
@@ -1,6 +1,17 @@
 CHANGELOG
 =========
 
+8.0
+---
+
+ * Remove support for passing `null` as the allowed variable names to `ExpressionLanguage::lint()` and `Parser::lint()`,
+   pass the `IGNORE_UNKNOWN_VARIABLES` flag instead to ignore unknown variables during linting
+
+   ```diff
+   -$expressionLanguage->lint($expression, null);
+   +$expressionLanguage->lint($expression, [], ExpressionLanguage::IGNORE_UNKNOWN_VARIABLES);
+   ```
+
 7.2
 ---
 

--- a/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
+++ b/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
@@ -93,20 +93,13 @@ class ExpressionLanguage
     /**
      * Validates the syntax of an expression.
      *
-     * @param array|null                    $names The list of acceptable variable names in the expression
+     * @param array                         $names The list of acceptable variable names in the expression
      * @param int-mask-of<Parser::IGNORE_*> $flags
      *
      * @throws SyntaxError When the passed expression is invalid
      */
-    public function lint(Expression|string $expression, ?array $names, int $flags = 0): void
+    public function lint(Expression|string $expression, array $names, int $flags = 0): void
     {
-        if (null === $names) {
-            trigger_deprecation('symfony/expression-language', '7.1', 'Passing "null" as the second argument of "%s()" is deprecated, pass "%s\Parser::IGNORE_UNKNOWN_VARIABLES" instead as a third argument.', __METHOD__, __NAMESPACE__);
-
-            $flags |= Parser::IGNORE_UNKNOWN_VARIABLES;
-            $names = [];
-        }
-
         if ($expression instanceof ParsedExpression) {
             return;
         }

--- a/src/Symfony/Component/ExpressionLanguage/Parser.php
+++ b/src/Symfony/Component/ExpressionLanguage/Parser.php
@@ -113,15 +113,8 @@ class Parser
      *
      * @throws SyntaxError When the passed expression is invalid
      */
-    public function lint(TokenStream $stream, ?array $names = [], int $flags = 0): void
+    public function lint(TokenStream $stream, array $names = [], int $flags = 0): void
     {
-        if (null === $names) {
-            trigger_deprecation('symfony/expression-language', '7.1', 'Passing "null" as the second argument of "%s()" is deprecated, pass "%s::IGNORE_UNKNOWN_VARIABLES" instead as a third argument.', __METHOD__, __CLASS__);
-
-            $flags |= self::IGNORE_UNKNOWN_VARIABLES;
-            $names = [];
-        }
-
         $this->doParse($stream, $names, $flags);
     }
 

--- a/src/Symfony/Component/ExpressionLanguage/composer.json
+++ b/src/Symfony/Component/ExpressionLanguage/composer.json
@@ -18,7 +18,6 @@
     "require": {
         "php": ">=8.4",
         "symfony/cache": "^7.4|^8.0",
-        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/service-contracts": "^2.5|^3"
     },
     "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT
