### PR TITLE
[Process] Add `SYMFONY_PROCESS_IDENTIFIER` env var to all processes

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -1666,6 +1666,8 @@ class Process implements \IteratorAggregate
         $env = getenv();
         $env = ('\\' === \DIRECTORY_SEPARATOR ? array_intersect_ukey($env, $_SERVER, 'strcasecmp') : array_intersect_key($env, $_SERVER)) ?: $env;
 
+        $env += ['SYMFONY_PROCESS_IDENTIFIER' => bin2hex(random_bytes(5)];
+
         return $_ENV + ('\\' === \DIRECTORY_SEPARATOR ? array_diff_ukey($env, $_ENV, 'strcasecmp') : $env);
     }
 }

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -1666,7 +1666,7 @@ class Process implements \IteratorAggregate
         $env = getenv();
         $env = ('\\' === \DIRECTORY_SEPARATOR ? array_intersect_ukey($env, $_SERVER, 'strcasecmp') : array_intersect_key($env, $_SERVER)) ?: $env;
 
-        $env += ['SYMFONY_PROCESS_IDENTIFIER' => 'sf-'.bin2hex(random_bytes(5)];
+        $env += ['SYMFONY_PROCESS_IDENTIFIER' => 'sf-'.bin2hex(random_bytes(5))];
 
         return $_ENV + ('\\' === \DIRECTORY_SEPARATOR ? array_diff_ukey($env, $_ENV, 'strcasecmp') : $env);
     }

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -1666,7 +1666,7 @@ class Process implements \IteratorAggregate
         $env = getenv();
         $env = ('\\' === \DIRECTORY_SEPARATOR ? array_intersect_ukey($env, $_SERVER, 'strcasecmp') : array_intersect_key($env, $_SERVER)) ?: $env;
 
-        $env += ['SYMFONY_PROCESS_IDENTIFIER' => bin2hex(random_bytes(5)];
+        $env += ['SYMFONY_PROCESS_IDENTIFIER' => 'sf-'.bin2hex(random_bytes(5)];
 
         return $_ENV + ('\\' === \DIRECTORY_SEPARATOR ? array_diff_ukey($env, $_ENV, 'strcasecmp') : $env);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix NA
| License       | MIT

This PR adds seeds a new environment variable named `SYMFONY_PROCESS_IDENTIFIER` to all created processes.

**What is the motivation?**

If you spawn multiple sub processes, you might want something that uniquely differentiates them.
To give an example, I like to refer to the Symfony messenger, which is a component usually utilizing multiple php processes / or workers (they might be managed by supervisord or from the main app, which is the case for Contao CMS; also see contao/contao#8527) 

The [Symfony docs](https://symfony.com/doc/current/messenger.html#redis-transport) states:

> There should never be more than one `messenger:consume` command running with the same combination of `stream`, `group` and `consumer`, or messages could end up being handled more than once. If you run multiple queue workers, **consumer can be set to an environment variable, like `%env(MESSENGER_CONSUMER_NAME)%`, set by Supervisor (example below) or any other service used to manage the worker processes.**

We think, this is a universal requirement and might be considered added to Symfony.

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
