### PR TITLE
[ErrorHandler][FrameworkBundle] Leverage `get_error_handler()`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,7 @@
         "symfony/polyfill-intl-normalizer": "~1.0",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/polyfill-php83": "^1.28",
+        "symfony/polyfill-php85": "^1.32",
         "symfony/polyfill-uuid": "^1.15"
     },
     "replace": {

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -103,8 +103,7 @@ class FrameworkBundle extends Bundle
         $_ENV['DOCTRINE_DEPRECATIONS'] = $_SERVER['DOCTRINE_DEPRECATIONS'] ??= 'trigger';
 
         if (class_exists(SymfonyRuntime::class)) {
-            $handler = set_error_handler('var_dump');
-            restore_error_handler();
+            $handler = get_error_handler();
         } else {
             $handler = [ErrorHandler::register(null, false)];
         }

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -28,6 +28,7 @@
         "symfony/http-foundation": "^7.3|^8.0",
         "symfony/http-kernel": "^7.2|^8.0",
         "symfony/polyfill-mbstring": "~1.0",
+        "symfony/polyfill-php85": "^1.32",
         "symfony/filesystem": "^7.1|^8.0",
         "symfony/finder": "^6.4|^7.0|^8.0",
         "symfony/routing": "^6.4|^7.0|^8.0"

--- a/src/Symfony/Component/ErrorHandler/ErrorHandler.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorHandler.php
@@ -116,11 +116,12 @@ class ErrorHandler
             $handler = new static();
         }
 
-        if (null === $prev = set_error_handler([$handler, 'handleError'])) {
-            restore_error_handler();
+        if (null === $prev = get_error_handler()) {
             // Specifying the error types earlier would expose us to https://bugs.php.net/63206
             set_error_handler([$handler, 'handleError'], $handler->thrownErrors | $handler->loggedErrors);
             $handler->isRoot = true;
+        } else {
+            set_error_handler([$handler, 'handleError']);
         }
 
         if ($handlerIsNew && \is_array($prev) && $prev[0] instanceof self) {
@@ -362,9 +363,8 @@ class ErrorHandler
     private function reRegister(int $prev): void
     {
         if ($prev !== ($this->thrownErrors | $this->loggedErrors)) {
-            $handler = set_error_handler(static fn () => null);
+            $handler = get_error_handler();
             $handler = \is_array($handler) ? $handler[0] : null;
-            restore_error_handler();
             if ($handler === $this) {
                 restore_error_handler();
                 if ($this->isRoot) {

--- a/src/Symfony/Component/ErrorHandler/composer.json
+++ b/src/Symfony/Component/ErrorHandler/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": ">=8.2",
         "psr/log": "^1|^2|^3",
+        "symfony/polyfill-php85": "^1.32",
         "symfony/var-dumper": "^6.4|^7.0|^8.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

PHP 8.5 will allow us to get the current error handler without replacing it temporarily. This PR makes use of this new function by leveraging our polyfill.
