### PR TITLE
[VarExporter] Dump implicit-nullable types as explicit to prevent the corresponding deprecation

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -36,8 +36,6 @@ return (new PhpCsFixer\Config())
             'allow_unused_params' => true, // for future-ready params, to be replaced with https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/7377
         ],
         'header_comment' => ['header' => $fileHeaderComment],
-        // TODO: Remove once the "compiler_optimized" set includes "sprintf"
-        'native_function_invocation' => ['include' => ['@compiler_optimized', 'sprintf'], 'scope' => 'namespaced', 'strict' => true],
         'nullable_type_declaration' => true,
         'nullable_type_declaration_for_default_null_value' => true,
         'modernize_strpos' => true,

--- a/src/Symfony/Component/VarExporter/ProxyHelper.php
+++ b/src/Symfony/Component/VarExporter/ProxyHelper.php
@@ -477,7 +477,9 @@ final class ProxyHelper
             return '';
         }
         if (null === $glue) {
-            return (!$noBuiltin && $type->allowsNull() && !\in_array($name, ['mixed', 'null'], true) ? '?' : '').$types[0];
+            $defaultNull = $owner instanceof \ReflectionParameter && 'null' === rtrim(substr(explode('$'.$owner->name.' = ', (string) $owner, 2)[1] ?? '', 0, -2));
+
+            return (!$noBuiltin && ($type->allowsNull() || $defaultNull) && !\in_array($name, ['mixed', 'null'], true) ? '?' : '').$types[0];
         }
         sort($types);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

