### PR TITLE
[HttpFoundation] Fix deprecation in tests on PHP 8.5

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/StreamedResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/StreamedResponseTest.php
@@ -32,7 +32,7 @@ class StreamedResponseTest extends TestCase
 
         $buffer = '';
         ob_start(function (string $chunk) use (&$buffer) {
-            $buffer .= $chunk;
+            return $buffer .= $chunk;
         });
         $callback();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

  3x: ob_flush(): Returning a non-string result from user output handler {closure:Symfony\Component\HttpFoundation\Tests\StreamedResponseTest::testConstructorWithChunks():34} is deprecated
    3x in StreamedResponseTest::testConstructorWithChunks from Symfony\Component\HttpFoundation\Tests

  1x: ob_get_clean(): Returning a non-string result from user output handler {closure:Symfony\Component\HttpFoundation\Tests\StreamedResponseTest::testConstructorWithChunks():34} is deprecated
    1x in StreamedResponseTest::testConstructorWithChunks from Symfony\Component\HttpFoundation\Tests