### PR TITLE
[ExpressionLanguage] Fix dumping of null safe operator

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
@@ -141,12 +141,13 @@ class GetAttrNode extends Node
 
     public function toArray(): array
     {
+        $nullSafe = $this->nodes['attribute'] instanceof ConstantNode && $this->nodes['attribute']->isNullSafe;
         switch ($this->attributes['type']) {
             case self::PROPERTY_CALL:
-                return [$this->nodes['node'], '.', $this->nodes['attribute']];
+                return [$this->nodes['node'], $nullSafe ? '?.' : '.', $this->nodes['attribute']];
 
             case self::METHOD_CALL:
-                return [$this->nodes['node'], '.', $this->nodes['attribute'], '(', $this->nodes['arguments'], ')'];
+                return [$this->nodes['node'], $nullSafe ? '?.' : '.', $this->nodes['attribute'], '(', $this->nodes['arguments'], ')'];
 
             case self::ARRAY_CALL:
                 return [$this->nodes['node'], '[', $this->nodes['attribute'], ']'];

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
@@ -383,9 +383,9 @@ class ExpressionLanguageTest extends TestCase
 
     public static function provideInvalidNullSafe()
     {
-        yield ['foo?.bar.baz', (object) ['bar' => null], 'Unable to get property "baz" of non-object "foo.bar".'];
-        yield ['foo?.bar["baz"]', (object) ['bar' => null], 'Unable to get an item of non-array "foo.bar".'];
-        yield ['foo?.bar["baz"].qux.quux', (object) ['bar' => ['baz' => null]], 'Unable to get property "qux" of non-object "foo.bar["baz"]".'];
+        yield ['foo?.bar.baz', (object) ['bar' => null], 'Unable to get property "baz" of non-object "foo?.bar".'];
+        yield ['foo?.bar["baz"]', (object) ['bar' => null], 'Unable to get an item of non-array "foo?.bar".'];
+        yield ['foo?.bar["baz"].qux.quux', (object) ['bar' => ['baz' => null]], 'Unable to get property "qux" of non-object "foo?.bar["baz"]".'];
     }
 
     /**

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/FunctionNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/FunctionNodeTest.php
@@ -34,7 +34,7 @@ class FunctionNodeTest extends AbstractNodeTestCase
     public static function getDumpData(): array
     {
         return [
-            ['foo("bar")', new FunctionNode('foo', new Node([new ConstantNode('bar')])), ['foo' => static::getCallables()]],
+            ['foo("bar")', new FunctionNode('foo', new Node([new ConstantNode('bar')]))],
         ];
     }
 

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/GetAttrNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/GetAttrNodeTest.php
@@ -15,6 +15,7 @@ use Symfony\Component\ExpressionLanguage\Node\ArrayNode;
 use Symfony\Component\ExpressionLanguage\Node\ConstantNode;
 use Symfony\Component\ExpressionLanguage\Node\GetAttrNode;
 use Symfony\Component\ExpressionLanguage\Node\NameNode;
+use Symfony\Component\ExpressionLanguage\Node\ArgumentsNode;
 
 class GetAttrNodeTest extends AbstractNodeTestCase
 {
@@ -50,10 +51,12 @@ class GetAttrNodeTest extends AbstractNodeTestCase
             ['foo[0]', new GetAttrNode(new NameNode('foo'), new ConstantNode(0), self::getArrayNode(), GetAttrNode::ARRAY_CALL)],
             ['foo["b"]', new GetAttrNode(new NameNode('foo'), new ConstantNode('b'), self::getArrayNode(), GetAttrNode::ARRAY_CALL)],
 
-            ['foo.foo', new GetAttrNode(new NameNode('foo'), new NameNode('foo'), self::getArrayNode(), GetAttrNode::PROPERTY_CALL), ['foo' => new Obj()]],
+            ['foo.foo', new GetAttrNode(new NameNode('foo'), new NameNode('foo'), self::getArrayNode(), GetAttrNode::PROPERTY_CALL)],
 
-            ['foo.foo({"b": "a", 0: "b"})', new GetAttrNode(new NameNode('foo'), new NameNode('foo'), self::getArrayNode(), GetAttrNode::METHOD_CALL), ['foo' => new Obj()]],
+            ['foo.foo({"b": "a", 0: "b"})', new GetAttrNode(new NameNode('foo'), new NameNode('foo'), self::getArrayNode(), GetAttrNode::METHOD_CALL)],
             ['foo[index]', new GetAttrNode(new NameNode('foo'), new NameNode('index'), self::getArrayNode(), GetAttrNode::ARRAY_CALL)],
+
+            ['foo?.foo()', new GetAttrNode(new NameNode('foo'), new ConstantNode('foo', true, true), new ArgumentsNode(), GetAttrNode::METHOD_CALL)],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | n/a
| License       | MIT

I noticed that when you dump an expression that uses null safe operator, the returned string doesn't maintain the null safe operator.

```php
> (new ExpressionLanguage())->parse('user?.foo', ['user'])->getNodes()->dump()
= "user.foo"
```

I would have expected `user?.foo` to be returned instead. 


(I've also fixed some test data providers cases - `getDumpData` provider should only generate cases with 2 elements but some tests are including a third argument. So I went ahead and removed them)
