### PR TITLE
[Console] Add getter for the original command "code" object

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 7.4
 ---
 
- * Add `Command::getCode()` to get the code set via `setCode()`.
+ * Add `Command::getCode()` to get the code set via `setCode()`
  * Allow setting aliases and the hidden flag via the command name passed to the constructor
  * Introduce `Symfony\Component\Console\Application::addCommand()` to simplify using invokable commands when the component is used standalone
  * Deprecate `Symfony\Component\Console\Application::add()` in favor of `Symfony\Component\Console\Application::addCommand()`

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 7.4
 ---
 
+ * Add `Command::getCode()` to get the code set via `setCode()`.
  * Allow setting aliases and the hidden flag via the command name passed to the constructor
  * Introduce `Symfony\Component\Console\Application::addCommand()` to simplify using invokable commands when the component is used standalone
  * Deprecate `Symfony\Component\Console\Application::add()` in favor of `Symfony\Component\Console\Application::addCommand()`

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -357,6 +357,16 @@ class Command implements SignalableCommandInterface
     }
 
     /**
+     * Gets the code that is executed by the command.
+     *
+     * @return ?callable null if the code has not been set with setCode()
+     */
+    public function getCode(): ?callable
+    {
+        return $this->code?->getCode();
+    }
+
+    /**
      * Sets the code to execute when running this command.
      *
      * If this method is used, it overrides the code defined

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -464,6 +464,8 @@ class CommandTest extends TestCase
         $this->assertStringContainsString('usage1', $command->getUsages()[0]);
         $this->assertTrue($command->isHidden());
         $this->assertSame(['f'], $command->getAliases());
+        // Standard commands don't have code.
+        $this->assertNull($command->getCode());
     }
 
     #[IgnoreDeprecations]

--- a/src/Symfony/Component/Console/Tests/Command/InvokableCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/InvokableCommandTest.php
@@ -27,6 +27,7 @@ use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Tests\Fixtures\InvokableTestCommand;
 
 class InvokableCommandTest extends TestCase
 {
@@ -291,6 +292,14 @@ class InvokableCommandTest extends TestCase
         $this->expectExceptionMessage('The command "foo" must return an integer value in the "__invoke" method, but "null" was returned.');
 
         $command->run(new ArrayInput([]), new NullOutput());
+    }
+
+    public function testGetCode()
+    {
+        $invokableTestCommand = new InvokableTestCommand();
+        $command = new Command(null, $invokableTestCommand);
+
+        $this->assertSame($invokableTestCommand, $command->getCode());
     }
 
     #[DataProvider('provideInputArguments')]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

I'm playing with Invokable Commands and am seeing a limitation which is bothersome. Attributes attached to the invokable class are lost by the time we have a  `Command` added to the Application. Consider an invokable class like below. The #[CLI\FieldLabels] and #[CLI\DefaultFields] Attributes are not retrievable from the Command. That is, there is no easy way to access the actual InvokableCommand object instead of the [wrapping Command](https://github.com/symfony/symfony/blob/a384c231a0051c0ac10e89c2a0516343f9fd3187/src/Symfony/Component/Console/Application.php#L553).

With this PR, Attributes become accessible via `$command->getCode()->getCallable()`

```php
namespace Drush\Commands\core;

#[AsCommand(
    name: 'twig:unused',
    description: 'Find potentially unused Twig templates.',
    aliases: ['twu'],
)]
#[CLI\FieldLabels(labels: ['template' => 'Template', 'compiled' => 'Compiled'])]
#[CLI\DefaultFields(fields: ['template', 'compiled'])]
final class TwigUnusedCommand
{
    public function __invoke(
        #[Argument(description: 'A comma delimited list of paths to recursively search')] string $searchpaths,
        InputInterface $input,
        OutputInterface $output
    ): int
    {
        $data = $this->doExecute($searchpaths);
        $this->writeFormattedOutput($input, $output, $data);
        return Command::SUCCESS;
    }
}
```