### PR TITLE
[Config] Fix support for attributes on class constants and enum cases

### DIFF
--- a/src/Symfony/Component/Config/Resource/ReflectionClassResource.php
+++ b/src/Symfony/Component/Config/Resource/ReflectionClassResource.php
@@ -135,6 +135,14 @@ class ReflectionClassResource implements SelfCheckingResourceInterface
             yield print_r($class->getConstants(), true);
         }
 
+        foreach ($class->getReflectionConstants() as $constant) {
+            foreach ($constant->getAttributes() as $a) {
+                $attributes[] = [$a->getName(), (string) $a];
+            }
+            yield $constant->name.print_r($attributes, true);
+            $attributes = [];
+        }
+
         if (!$class->isInterface()) {
             $defaults = $class->getDefaultProperties();
 

--- a/src/Symfony/Component/Config/Tests/Resource/ReflectionClassResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/ReflectionClassResourceTest.php
@@ -216,6 +216,30 @@ EOPHP;
         TestServiceWithStaticProperty::$initializedObject = new TestServiceWithStaticProperty();
         $this->assertTrue($res->isFresh(0));
     }
+
+    public function testEnum()
+    {
+        $res = new ReflectionClassResource($enum = new \ReflectionClass(SomeEnum::class));
+        $r = new \ReflectionClass(ReflectionClassResource::class);
+        $generateSignature = $r->getMethod('generateSignature')->getClosure($res);
+        $actual = implode("\n", iterator_to_array($generateSignature($enum)));
+        $this->assertStringContainsString('UnitEnum', $actual);
+        $this->assertStringContainsString('TestAttribute', $actual);
+        $this->assertStringContainsString('Beta', $actual);
+    }
+
+    public function testBackedEnum()
+    {
+        $res = new ReflectionClassResource($enum = new \ReflectionClass(SomeBackedEnum::class));
+        $r = new \ReflectionClass(ReflectionClassResource::class);
+        $generateSignature = $r->getMethod('generateSignature')->getClosure($res);
+        $actual = implode("\n", iterator_to_array($generateSignature($enum)));
+        $this->assertStringContainsString('UnitEnum', $actual);
+        $this->assertStringContainsString('BackedEnum', $actual);
+        $this->assertStringContainsString('TestAttribute', $actual);
+        $this->assertStringContainsString('Beta', $actual);
+        $this->assertStringContainsString('beta', $actual);
+    }
 }
 
 interface DummyInterface
@@ -261,4 +285,20 @@ class TestServiceSubscriber implements ServiceSubscriberInterface
 class TestServiceWithStaticProperty
 {
     public static object $initializedObject;
+}
+
+enum SomeEnum
+{
+    case Alpha;
+
+    #[TestAttribute]
+    case Beta;
+}
+
+enum SomeBackedEnum: string
+{
+    case Alpha = 'alpha';
+
+    #[TestAttribute]
+    case Beta = 'beta';
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Issues        |
| License       | MIT

I'm using ReflectionClassResource in a project to track changes of files. I noticed that attributes on enum cases were not tracked properly. The cases were visible, because the enum cases are available as class constants. 

But the attributes were missing.

This solves the problem. 

Not sure if we should see this as a bug or feature. I think it's a bug. 