### PR TITLE
[Console] Fix `TreeHelper::addChild` when providing a string

### DIFF
--- a/src/Symfony/Component/Console/Helper/TreeNode.php
+++ b/src/Symfony/Component/Console/Helper/TreeNode.php
@@ -58,7 +58,7 @@ final class TreeNode implements \Countable, \IteratorAggregate
     public function addChild(self|string|callable $node): self
     {
         if (\is_string($node)) {
-            $node = new self($node, $this);
+            $node = new self($node);
         }
 
         $this->children[] = $node;

--- a/src/Symfony/Component/Console/Tests/Helper/TreeHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TreeHelperTest.php
@@ -195,6 +195,26 @@ Root
 TREE, self::normalizeLineBreaks(trim($output->fetch())));
     }
 
+    public function testRenderNodeWithMultipleChildrenWithStringConversion()
+    {
+        $rootNode = new TreeNode('Root');
+
+        $rootNode->addChild('Child 1');
+        $rootNode->addChild('Child 2');
+        $rootNode->addChild('Child 3');
+
+        $output = new BufferedOutput();
+        $tree = TreeHelper::createTree($output, $rootNode);
+
+        $tree->render();
+        $this->assertSame(<<<TREE
+Root
+├── Child 1
+├── Child 2
+└── Child 3
+TREE, self::normalizeLineBreaks(trim($output->fetch())));
+    }
+
     public function testRenderTreeWithDuplicateNodeNames()
     {
         $rootNode = new TreeNode('Root');

--- a/src/Symfony/Component/Console/Tests/Helper/TreeNodeTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TreeNodeTest.php
@@ -34,6 +34,24 @@ class TreeNodeTest extends TestCase
         $this->assertSame($child, iterator_to_array($root->getChildren())[0]);
     }
 
+    public function testAddingChildrenAsString()
+    {
+        $root = new TreeNode('Root');
+
+        $root->addChild('Child 1');
+        $root->addChild('Child 2');
+
+        $this->assertSame(2, iterator_count($root->getChildren()));
+
+        $children = iterator_to_array($root->getChildren());
+
+        $this->assertSame(0, iterator_count($children[0]->getChildren()));
+        $this->assertSame(0, iterator_count($children[1]->getChildren()));
+
+        $this->assertSame('Child 1', $children[0]->getValue());
+        $this->assertSame('Child 2', $children[1]->getValue());
+    }
+
     public function testAddingChildrenWithGenerators()
     {
         $root = new TreeNode('Root');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | --
| License       | MIT

When using the tree helper, the method addChild allow to pass a string instead of an instance of TreeNode, for example : 

```php
$rootNode = new TreeNode('Root');
$rootNode->addChild('Child 1');
$rootNode->addChild('Child 2');
$rootNode->addChild('Child 3');
$tree = TreeHelper::createTree($output, $rootNode);
$tree->render();
```

This method was creating the TreeNode from the string and using the parent as the children iterator, leading to an error like `LogicException: Cycle detected at node: "Child 1"`

This commit remove this second parameter.