### PR TITLE
[Validator] Add missing Polish plural form for filename length validator

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.pl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.pl.xlf
@@ -404,7 +404,7 @@
             </trans-unit>
             <trans-unit id="104">
                 <source>The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</source>
-                <target>Nazwa pliku jest za długa. Powinna mieć {{ filename_max_length }} znak lub mniej.|Nazwa pliku jest za długa. Powinna mieć {{ filename_max_length }} znaków lub mniej.</target>
+                <target>Nazwa pliku jest za długa. Powinna mieć {{ filename_max_length }} znak lub mniej.|Nazwa pliku jest za długa. Powinna mieć {{ filename_max_length }} znaki lub mniej.|Nazwa pliku jest za długa. Powinna mieć {{ filename_max_length }} znaków lub mniej.</target>
             </trans-unit>
             <trans-unit id="105">
                 <source>The password strength is too low. Please use a stronger password.</source>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | None
| License       | MIT

Fixed the Polish translation for filename length validation message by adding all three required plural forms (instead of two).

Problem:
Locale set to `pl`. If the validation `Symfony\Component\Validator\Constraints\File` was triggered for the example configuration:
```
new File([
    'filenameMaxLength' => 100,
])
```

the exception `SymfonyComponentTranslationExceptionInvalidArgumentException` is thrown if the file name exceeds 100 characters. The exact message is:

> Unable to choose a translation for "Nazwa pliku jest za długa. Powinna mieć {{ filename_max_length }} znak lub mniej.|Nazwa pliku jest za długa. Powinna mieć {{ filename_max_length }} znaków lub mniej." with locale "pl" for value "100". Double check that this translation has the correct plural options (e.g. "There is one apple|There are %count% apples").

The cause is a missing third plural form: the original translation contained only two forms.