### PR TITLE
[Validator] fix BC layer for Expression constraint from options array

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Expression.php
+++ b/src/Symfony/Component/Validator/Constraints/Expression.php
@@ -64,6 +64,7 @@ class Expression extends Constraint
             trigger_deprecation('symfony/validator', '7.3', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
 
             $options = array_merge($expression, $options ?? []);
+            $expression = null;
         } else {
             if (\is_array($options)) {
                 trigger_deprecation('symfony/validator', '7.3', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);

--- a/src/Symfony/Component/Validator/Tests/Constraints/ExpressionTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ExpressionTest.php
@@ -41,6 +41,18 @@ class ExpressionTest extends TestCase
         self::assertSame('some attached data', $cConstraint->payload);
         self::assertFalse($cConstraint->negate);
     }
+
+    /**
+     * @group legacy
+     */
+    public function testInitializeWithOptionsArray()
+    {
+        $constraint = new Expression([
+            'expression' => '!this.getParent().get("field2").getData()',
+        ]);
+
+        $this->assertSame('!this.getParent().get("field2").getData()', $constraint->expression);
+    }
 }
 
 class ExpressionDummy


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

see e.g. https://github.com/symfony/symfony/actions/runs/16165806927/job/45627315188#step:8:7084