### PR TITLE
[Console][QuestionHelper] add optional timeout for human interaction

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
  * Allow Usages to be specified via `#[AsCommand]` attribute.
  * Allow passing invokable commands to `Symfony\Component\Console\Tester\CommandTester`
  * Add `#[Input]` attribute to support DTOs in commands
+ * Add optional timeout for interaction in `QuestionHelper`
 
 7.3
 ---

--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -502,6 +502,18 @@ class QuestionHelper extends Helper
      */
     private function readInput($inputStream, Question $question): string|false
     {
+        if (null !== $question->getTimeout() && $this->isInteractiveInput($inputStream)) {
+            $read = [$inputStream];
+            $write = null;
+            $except = null;
+            $timeoutSeconds = $question->getTimeout();
+            $changedStreams = stream_select($read, $write, $except, $timeoutSeconds);
+
+            if (0 === $changedStreams) {
+                throw new MissingInputException(\sprintf('Timed out after waiting for input for %d second%s.', $timeoutSeconds, 1 === $timeoutSeconds ? '' : 's'));
+            }
+        }
+
         if (!$question->isMultiline()) {
             $cp = $this->setIOCodepage();
             $ret = fgets($inputStream, 4096);

--- a/src/Symfony/Component/Console/Question/Question.php
+++ b/src/Symfony/Component/Console/Question/Question.php
@@ -38,6 +38,7 @@ class Question
     private ?\Closure $normalizer = null;
     private bool $trimmable = true;
     private bool $multiline = false;
+    private ?int $timeout = null;
 
     /**
      * @param string                     $question The question to ask to the user
@@ -81,6 +82,27 @@ class Question
     public function setMultiline(bool $multiline): static
     {
         $this->multiline = $multiline;
+
+        return $this;
+    }
+
+    /**
+     * Returns the timeout in seconds.
+     */
+    public function getTimeout(): ?int
+    {
+        return $this->timeout;
+    }
+
+    /**
+     * Sets the maximum time the user has to answer the question.
+     * If the user does not answer within this time, an exception will be thrown.
+     *
+     * @return $this
+     */
+    public function setTimeout(?int $seconds): static
+    {
+        $this->timeout = $seconds;
 
         return $this;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no 
| Issues        | None
| License       | MIT

**About:**
- Adds timeout functionality to console questions, allowing developers to set a maximum time limit for user input. 
- Our usecase is that some developers added interactive questions inside opened db transactions. Without timeout, it can lead to hours long trx if somebody forgets to repond and keeps the terminal open.
- The feature is backward compatible - existing code continues to work without timeouts unless explicitly set.


