### PR TITLE
[Serializer] Fix normalizing objects with accessors having the same name as a property

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -100,24 +100,21 @@ class ObjectNormalizer extends AbstractObjectNormalizer
             $attributeName = null;
 
             // ctype_lower check to find out if method looks like accessor but actually is not, e.g. hash, cancel
-            if (3 < \strlen($name) && !ctype_lower($name[3]) && match ($name[0]) {
-                'g' => str_starts_with($name, 'get'),
-                'h' => str_starts_with($name, 'has'),
-                'c' => str_starts_with($name, 'can'),
+            if (match ($name[0]) {
+                'g' => str_starts_with($name, 'get') && isset($name[$i = 3]),
+                'h' => str_starts_with($name, 'has') && isset($name[$i = 3]),
+                'c' => str_starts_with($name, 'can') && isset($name[$i = 3]),
+                'i' => str_starts_with($name, 'is') && isset($name[$i = 2]),
                 default => false,
-            }) {
-                // getters, hassers and canners
-                $attributeName = substr($name, 3);
+            } && !ctype_lower($name[$i])) {
+                if ($reflClass->hasProperty($name)) {
+                    $attributeName = $name;
+                } else {
+                    $attributeName = substr($name, $i);
 
-                if (!$reflClass->hasProperty($attributeName)) {
-                    $attributeName = lcfirst($attributeName);
-                }
-            } elseif ('is' !== $name && str_starts_with($name, 'is') && !ctype_lower($name[2])) {
-                // issers
-                $attributeName = substr($name, 2);
-
-                if (!$reflClass->hasProperty($attributeName)) {
-                    $attributeName = lcfirst($attributeName);
+                    if (!$reflClass->hasProperty($attributeName)) {
+                        $attributeName = lcfirst($attributeName);
+                    }
                 }
             }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -955,6 +955,20 @@ class ObjectNormalizerTest extends TestCase
             123 => 321,
         ], $normalized);
     }
+
+    public function testNormalizeObjectWithBooleanPropertyAndIsserMethodWithSameName()
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
+        $normalizer = new ObjectNormalizer($classMetadataFactory);
+
+        $object = new ObjectWithBooleanPropertyAndIsserWithSameName();
+        $normalized = $normalizer->normalize($object);
+
+        $this->assertSame([
+            'foo' => 'foo',
+            'isFoo' => true,
+        ], $normalized);
+    }
 }
 
 class ProxyObjectDummy extends ObjectDummy
@@ -1295,5 +1309,21 @@ class ObjectWithAccessorishMethods
     public function isolate()
     {
         $this->accessorishCalled = true;
+    }
+}
+
+class ObjectWithBooleanPropertyAndIsserWithSameName
+{
+    private $foo = 'foo';
+    private $isFoo = true;
+
+    public function getFoo()
+    {
+        return $this->foo;
+    }
+
+    public function isFoo()
+    {
+        return $this->isFoo;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61096
| License       | MIT

# Notes
Although technically this is a bugfix and its pretty much an edge-case, this may affect existing projects and may alter their serialization results. So it could be a breaking change.

Edit: Also see comments below for further edge cases.

# Before/After comparison
```php
class MyClass {
  private string $owner = 'foo';
  private bool $isOwner = true;

  public function getOwner(): string {
    return $this->owner;
  }

  public function setOwner(string $owner): void {
    $this->owner = $owner;
  }

  public function isOwner(): bool {
    return $this->isOwner;
  }

  public function setIsOwner(bool $isOwner): void {
    $this->isOwner = $isOwner;
  }
}

$classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
$normalizer = new ObjectNormalizer($classMetadataFactory);

$object = new MyClass();
$normalized = $normalizer->normalize($object);
```

### Before this PR
It was normalized as:
```php
[
  'owner' => 'foo',
]
```
Removing the `$owner` property and getters would result in:
```php
[
  'owner' => true,
]
```

### After this PR
It will be normalized as:
```php
[
  'owner' => 'foo',
  'isOwner'  => true,
]
```