### PR TITLE
Fixed validator translations for Albanian (sq)

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.sq.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sq.xlf
@@ -449,7 +449,7 @@
             </trans-unit>
             <trans-unit id="113">
                 <source>This URL is missing a top-level domain.</source>
-                <target state="needs-review-translation">Kësaj URL i mungon një domain i nivelit të lartë.</target>
+                <target>Kësaj URL-je i mungon një domain i nivelit të sipërm.</target>
             </trans-unit>
             <trans-unit id="114">
                 <source>This value is too short. It should contain at least one word.|This value is too short. It should contain at least {{ min }} words.</source>
@@ -477,7 +477,7 @@
             </trans-unit>
             <trans-unit id="121">
                 <source>This value is not a valid Twig template.</source>
-                <target state="needs-review-translation">Kjo vlerë nuk është një shabllon Twig i vlefshëm.</target>
+                <target>Kjo vlerë nuk është një shabllon Twig i vlefshëm.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59408 
| License       | MIT

Fixed the validator translations for Albanian.
trans-113: changed to sound more correct
trans-121: no changes needed