### PR TITLE
[FrameworkBundle] Fix cache warmers tests

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/SerializerCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/SerializerCacheWarmerTest.php
@@ -21,6 +21,23 @@ use Symfony\Component\Serializer\Mapping\Loader\YamlFileLoader;
 
 class SerializerCacheWarmerTest extends TestCase
 {
+    private PhpArrayAdapter $arrayPool;
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        if (isset($this->arrayPool)) {
+            $this->arrayPool->clear();
+            unset($this->arrayPool);
+        }
+    }
+
+    private function getArrayPool(string $file): PhpArrayAdapter
+    {
+        return $this->arrayPool = new PhpArrayAdapter($file, new NullAdapter());
+    }
+
     /**
      * @dataProvider loaderProvider
      */
@@ -34,7 +51,7 @@ class SerializerCacheWarmerTest extends TestCase
 
         $this->assertFileExists($file);
 
-        $arrayPool = new PhpArrayAdapter($file, new NullAdapter());
+        $arrayPool = $this->getArrayPool($file);
 
         $this->assertTrue($arrayPool->getItem('Symfony_Bundle_FrameworkBundle_Tests_Fixtures_Serialization_Person')->isHit());
         $this->assertTrue($arrayPool->getItem('Symfony_Bundle_FrameworkBundle_Tests_Fixtures_Serialization_Author')->isHit());
@@ -56,7 +73,7 @@ class SerializerCacheWarmerTest extends TestCase
         $this->assertFileExists($file);
         $this->assertFileDoesNotExist($cacheDir.'/cache-serializer.php');
 
-        $arrayPool = new PhpArrayAdapter($file, new NullAdapter());
+        $arrayPool = $this->getArrayPool($file);
 
         $this->assertTrue($arrayPool->getItem('Symfony_Bundle_FrameworkBundle_Tests_Fixtures_Serialization_Person')->isHit());
         $this->assertTrue($arrayPool->getItem('Symfony_Bundle_FrameworkBundle_Tests_Fixtures_Serialization_Author')->isHit());
@@ -75,10 +92,10 @@ class SerializerCacheWarmerTest extends TestCase
 
         $this->assertFileDoesNotExist($file);
 
-        $arrayPool = new PhpArrayAdapter($file, new NullAdapter());
+        $arrayPool = $this->getArrayPool($file);
 
-        $this->assertTrue($arrayPool->getItem('Symfony_Bundle_FrameworkBundle_Tests_Fixtures_Serialization_Person')->isHit());
-        $this->assertTrue($arrayPool->getItem('Symfony_Bundle_FrameworkBundle_Tests_Fixtures_Serialization_Author')->isHit());
+        $this->assertFalse($arrayPool->getItem('Symfony_Bundle_FrameworkBundle_Tests_Fixtures_Serialization_Person')->isHit());
+        $this->assertFalse($arrayPool->getItem('Symfony_Bundle_FrameworkBundle_Tests_Fixtures_Serialization_Author')->isHit());
     }
 
     public static function loaderProvider(): array

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/ValidatorCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/ValidatorCacheWarmerTest.php
@@ -20,6 +20,23 @@ use Symfony\Component\Validator\ValidatorBuilder;
 
 class ValidatorCacheWarmerTest extends TestCase
 {
+    private PhpArrayAdapter $arrayPool;
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        if (isset($this->arrayPool)) {
+            $this->arrayPool->clear();
+            unset($this->arrayPool);
+        }
+    }
+
+    private function getArrayPool(string $file): PhpArrayAdapter
+    {
+        return $this->arrayPool = new PhpArrayAdapter($file, new NullAdapter());
+    }
+
     public function testWarmUp()
     {
         $validatorBuilder = new ValidatorBuilder();
@@ -36,7 +53,7 @@ class ValidatorCacheWarmerTest extends TestCase
 
         $this->assertFileExists($file);
 
-        $arrayPool = new PhpArrayAdapter($file, new NullAdapter());
+        $arrayPool = $this->getArrayPool($file);
 
         $this->assertTrue($arrayPool->getItem('Symfony.Bundle.FrameworkBundle.Tests.Fixtures.Validation.Person')->isHit());
         $this->assertTrue($arrayPool->getItem('Symfony.Bundle.FrameworkBundle.Tests.Fixtures.Validation.Author')->isHit());
@@ -61,7 +78,7 @@ class ValidatorCacheWarmerTest extends TestCase
         $this->assertFileExists($file);
         $this->assertFileDoesNotExist($cacheDir.'/cache-validator.php');
 
-        $arrayPool = new PhpArrayAdapter($file, new NullAdapter());
+        $arrayPool = $this->getArrayPool($file);
 
         $this->assertTrue($arrayPool->getItem('Symfony.Bundle.FrameworkBundle.Tests.Fixtures.Validation.Person')->isHit());
         $this->assertTrue($arrayPool->getItem('Symfony.Bundle.FrameworkBundle.Tests.Fixtures.Validation.Author')->isHit());
@@ -83,10 +100,10 @@ class ValidatorCacheWarmerTest extends TestCase
 
         $this->assertFileDoesNotExist($file);
 
-        $arrayPool = new PhpArrayAdapter($file, new NullAdapter());
+        $arrayPool = $this->getArrayPool($file);
 
-        $this->assertTrue($arrayPool->getItem('Symfony.Bundle.FrameworkBundle.Tests.Fixtures.Validation.Person')->isHit());
-        $this->assertTrue($arrayPool->getItem('Symfony.Bundle.FrameworkBundle.Tests.Fixtures.Validation.Author')->isHit());
+        $this->assertFalse($arrayPool->getItem('Symfony.Bundle.FrameworkBundle.Tests.Fixtures.Validation.Person')->isHit());
+        $this->assertFalse($arrayPool->getItem('Symfony.Bundle.FrameworkBundle.Tests.Fixtures.Validation.Author')->isHit());
     }
 
     public function testWarmUpWithAnnotations()
@@ -103,7 +120,7 @@ class ValidatorCacheWarmerTest extends TestCase
 
         $this->assertFileExists($file);
 
-        $arrayPool = new PhpArrayAdapter($file, new NullAdapter());
+        $arrayPool = $this->getArrayPool($file);
 
         $item = $arrayPool->getItem('Symfony.Bundle.FrameworkBundle.Tests.Fixtures.Validation.Category');
         $this->assertTrue($item->isHit());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

While updating tests for #60568 I saw `SerializerCacheWarmerTest` and `ValidatorCacheWarmerTest`’s `testWarmUpWithoutBuilDir` fail. Since there will be no warm up without a build directory it was weird a cache item could get hit in that case.

Turns out that was because the `PhpArrayAdapter`’s `$valuesCache` would retain them from previous tests.

This PR adds a `getArrayPool` method to the test cases which allows them to clear it on tearDown, so that tests don’t impact each other. Alternatively they could clear their own adapter or pass it different files, but this seemed the safest approach to me.