### PR TITLE
[FrameworkBundle] Prepare session in functional tests

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Deprecate `Symfony\Bundle\FrameworkBundle\Console\Application::add()` in favor of `Symfony\Bundle\FrameworkBundle\Console\Application::addCommand()`
  * Add `assertEmailAddressNotContains()` to the `MailerAssertionsTrait`
  * Add `framework.type_info.aliases` option
+ * Add `KernelBrowser::getSession()`
 
 7.3
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/KernelBrowser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/KernelBrowser.php
@@ -18,6 +18,7 @@ use Symfony\Component\BrowserKit\History;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\HttpKernelBrowser;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\HttpKernel\Profiler\Profile as HttpProfile;
@@ -61,6 +62,35 @@ class KernelBrowser extends HttpKernelBrowser
         }
 
         return $this->getContainer()->get('profiler')->loadProfileFromResponse($this->response);
+    }
+
+    public function getSession(): ?SessionInterface
+    {
+        $container = $this->getContainer();
+
+        if (!$container->has('session.factory')) {
+            return null;
+        }
+
+        $session = $container->get('session.factory')->createSession();
+
+        $cookieJar = $this->getCookieJar();
+        $cookie = $cookieJar->get($session->getName());
+
+        if ($cookie instanceof Cookie) {
+            $session->setId($cookie->getValue());
+        }
+
+        $session->start();
+
+        if (!$cookie instanceof Cookie) {
+            $domains = array_unique(array_map(fn (Cookie $cookie) => $cookie->getName() === $session->getName() ? $cookie->getDomain() : '', $cookieJar->all())) ?: [''];
+            foreach ($domains as $domain) {
+                $cookieJar->set(new Cookie($session->getName(), $session->getId(), domain: $domain));
+            }
+        }
+
+        return $session;
     }
 
     /**
@@ -116,19 +146,12 @@ class KernelBrowser extends HttpKernelBrowser
         $container = $this->getContainer();
         $container->get('security.untracked_token_storage')->setToken($token);
 
-        if (!$container->has('session.factory')) {
+        if (!$session = $this->getSession()) {
             return $this;
         }
 
-        $session = $container->get('session.factory')->createSession();
         $session->set('_security_'.$firewallContext, serialize($token));
         $session->save();
-
-        $domains = array_unique(array_map(fn (Cookie $cookie) => $cookie->getName() === $session->getName() ? $cookie->getDomain() : '', $this->getCookieJar()->all())) ?: [''];
-        foreach ($domains as $domain) {
-            $cookie = new Cookie($session->getName(), $session->getId(), null, null, $domain);
-            $this->getCookieJar()->set($cookie);
-        }
 
         return $this;
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SessionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SessionTest.php
@@ -45,6 +45,20 @@ class SessionTest extends AbstractWebTestCase
         // prove cleared session
         $crawler = $client->request('GET', '/session');
         $this->assertStringContainsString('You are new here and gave no name.', $crawler->text());
+
+        // prepare session programatically
+        $session = $client->getSession();
+        $session->set('name', 'drak');
+        $session->save();
+
+        // ensure session can be saved multiple times without being reset
+        $session = $client->getSession();
+        $session->set('foo', 'bar');
+        $session->save();
+
+        // prove remembered name from programatically prepared session
+        $crawler = $client->request('GET', '/session');
+        $this->assertStringContainsString('Welcome back drak, nice to meet you.', $crawler->text());
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #46023
| License       | MIT
| Doc PR | https://github.com/symfony/symfony-docs/pull/21352 |

Hello,

I propose to add a `getSession()` method to the `KernelBrowser` class to be able to prepare the session before sending a HTTP request in a functionnal test. It could be used to preset CSRF tokens, A/B testing data, user preferences, or any stateful information required for the test.

I also propose to use `getSession()` in the `loginUser()` method. Then, the session could be preset either before or after the login, without risking to be overwritten.

```php
public function testForm()
{
    $client = self::createClient();
    $client->loginUser(new InMemoryUser('admin', null));

    $session = $client->getSession();
    $session->set('_csrf/form', '123456789');
    $session->set('foo', 'bar');
    $session->save();

    $client->request('POST', '/form', ['form' => ['_token' => '123456789']]);
}
```
In this example, the session will contain : 
```php
array:3 [
  "_security_main" => "O:52:"Symfony\Bundle\FrameworkBundle\Test\TestBrowserToken":2:{i:0;s:4:"main";i:1;a:5:{i:0;O:49:"Symfony\Component\Security\Core\User\InMemoryUser":4:{s:59:"\x00Symfony\Component\Security\Core\User\InMemoryUser\x00username";s:5:"admin";s:59:"\x00Symfony\Component\Security\Core\User\InMemoryUser\x00password";N;s:56:"\x00Symfony\Component\Security\Core\User\InMemoryUser\x00roles";a:0:{}s:58:"\x00Symfony\Component\Security\Core\User\InMemoryUser\x00enabled";b:1;}i:1;b:1;i:2;N;i:3;a:0:{}i:4;a:0:{}}}",
  "_csrf/form" => "123456789",
  "foo" => "bar"
]
```

Thanks in advance for your feedbacks 😄 