### PR TITLE
[HttpKernel][Security] Refactor: use `getAttributes` with argument

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/CacheAttributeListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/CacheAttributeListener.php
@@ -51,7 +51,7 @@ class CacheAttributeListener implements EventSubscriberInterface
     {
         $request = $event->getRequest();
 
-        if (!\is_array($attributes = $request->attributes->get('_cache') ?? $event->getAttributes()[Cache::class] ?? null)) {
+        if (!$attributes = $request->attributes->get('_cache') ?? $event->getAttributes(Cache::class)) {
             return;
         }
 

--- a/src/Symfony/Component/Security/Http/EventListener/IsCsrfTokenValidAttributeListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/IsCsrfTokenValidAttributeListener.php
@@ -35,8 +35,7 @@ final class IsCsrfTokenValidAttributeListener implements EventSubscriberInterfac
 
     public function onKernelControllerArguments(ControllerArgumentsEvent $event): void
     {
-        /** @var IsCsrfTokenValid[] $attributes */
-        if (!\is_array($attributes = $event->getAttributes()[IsCsrfTokenValid::class] ?? null)) {
+        if (!$attributes = $event->getAttributes(IsCsrfTokenValid::class)) {
             return;
         }
 

--- a/src/Symfony/Component/Security/Http/EventListener/IsGrantedAttributeListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/IsGrantedAttributeListener.php
@@ -39,8 +39,7 @@ class IsGrantedAttributeListener implements EventSubscriberInterface
 
     public function onKernelControllerArguments(ControllerArgumentsEvent $event): void
     {
-        /** @var IsGranted[] $attributes */
-        if (!\is_array($attributes = $event->getAttributes()[IsGranted::class] ?? null)) {
+        if (!$attributes = $event->getAttributes(IsGranted::class)) {
             return;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | no
| License       | MIT

Refactored code to consistently use `$event->getAttributes($className)` instead of accessing the full array. This simplifies attribute retrieval and improves readability.

[Reference](https://github.com/symfony/symfony/pull/60395#discussion_r2086639526)