### PR TITLE
[FrameworkBundle] Make `cache:warmup` warm up read-only caches

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheWarmupCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheWarmupCommand.php
@@ -72,9 +72,10 @@ EOF
             $kernel->warmUp($cacheDir);
         }
 
-        $preload = $this->cacheWarmer->warmUp($cacheDir);
-
         $buildDir = $kernel->getContainer()->getParameter('kernel.build_dir');
+
+        $preload = $this->cacheWarmer->warmUp($cacheDir, $buildDir);
+
         if ($preload && $cacheDir === $buildDir && file_exists($preloadFile = $buildDir.'/'.$kernel->getContainer()->getParameter('kernel.container_class').'.preload.php')) {
             Preloader::append($preloadFile, $preload);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59703
| License       | MIT