### PR TITLE
[DoctrineBridge] Prevent idle connection listener from running on subrequest

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Middleware/IdleConnection/Listener.php
+++ b/src/Symfony/Bridge/Doctrine/Middleware/IdleConnection/Listener.php
@@ -14,6 +14,7 @@ namespace Symfony\Bridge\Doctrine\Middleware\IdleConnection;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 final class Listener implements EventSubscriberInterface
@@ -29,6 +30,9 @@ final class Listener implements EventSubscriberInterface
 
     public function onKernelRequest(RequestEvent $event): void
     {
+        if (HttpKernelInterface::MAIN_REQUEST !== $event->getRequestType()) {
+            return;
+        }
         $timestamp = time();
 
         foreach ($this->connectionExpiries as $name => $expiry) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Original PR https://github.com/symfony/symfony/pull/53214 has a bug.
Story:
- do a main request
- **begin** database transaction
- do subrequest
- IdleTransaction closes connection in subrequest
- continue working in main request
- **commit** and get error NoActiveTransaction