### PR TITLE
[Cache] Add `TagAwareAdapterInterface` to `NullAdapter`

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/NullAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/NullAdapter.php
@@ -19,7 +19,7 @@ use Symfony\Contracts\Cache\NamespacedPoolInterface;
 /**
  * @author Titouan Galopin <galopintitouan@gmail.com>
  */
-class NullAdapter implements AdapterInterface, CacheInterface, NamespacedPoolInterface
+class NullAdapter implements AdapterInterface, CacheInterface, NamespacedPoolInterface, TagAwareAdapterInterface
 {
     private static \Closure $createCacheItem;
 
@@ -107,5 +107,10 @@ class NullAdapter implements AdapterInterface, CacheInterface, NamespacedPoolInt
         foreach ($keys as $key) {
             yield $key => $f($key);
         }
+    }
+
+    public function invalidateTags(array $tags): bool
+    {
+        return true;
     }
 }

--- a/src/Symfony/Component/Cache/Tests/Adapter/NullAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/NullAdapterTest.php
@@ -138,4 +138,11 @@ class NullAdapterTest extends TestCase
         $this->assertTrue($adapter->saveDeferred($item));
         $this->assertTrue($this->createCachePool()->commit());
     }
+
+    public function testInvalidateTags()
+    {
+        $adapter = $this->createCachePool();
+
+        self::assertTrue($adapter->invalidateTags(['foo']));
+    }
 }

--- a/src/Symfony/Component/Config/CHANGELOG.md
+++ b/src/Symfony/Component/Config/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+ * Add TagAwareAdapterInterface to NullAdapter
+
 7.3
 ---
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix partly #61114, #59193
| License       | MIT

The PR makes NullAdapter taggable to easier test same adapters