### PR TITLE
[DoctrineBridge] Reject fields UniqueEntity cannot query with the default repository method

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -13,6 +13,13 @@ Crowdin Translation Provider
 
  * Add `$projectId` constructor parameter to `CrowdinProvider`
 
+DoctrineBridge
+--------------
+
+ * `UniqueEntity` now throws a `ConstraintDefinitionException` when a checked field holds an array or is a to-many
+   association and the default `findBy` repository method is used. Such fields were silently validated against a
+   query that could not match. Use the `repositoryMethod` option to provide a method that can query them
+
 FrameworkBundle
 ---------------
 

--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add IterableToArrayCollectionTransformer for ObjectMapper
+ * Throw a `ConstraintDefinitionException` from `UniqueEntity` when a checked field holds an array or is a to-many association, instead of building a query that cannot match
 
 8.1
 ---

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/ToManyEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/ToManyEntity.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\OneToMany;
+
+#[Entity]
+class ToManyEntity
+{
+    /** @var Collection<int, ToOneEntity> */
+    #[OneToMany(targetEntity: ToOneEntity::class, mappedBy: 'parent')]
+    public Collection $children;
+
+    public function __construct(
+        #[Id, Column(type: 'integer')]
+        public int $id,
+    ) {
+        $this->children = new ArrayCollection();
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/ToOneEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/ToOneEntity.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\ManyToOne;
+
+#[Entity]
+class ToOneEntity
+{
+    public function __construct(
+        #[Id, Column(type: 'integer')]
+        public int $id,
+
+        #[ManyToOne(targetEntity: ToManyEntity::class, inversedBy: 'children')]
+        public ?ToManyEntity $parent = null,
+    ) {
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
@@ -39,6 +39,8 @@ use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdNoToStringEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdStringWrapperNameEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdWithPrivateNameEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleStringIdEntity;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\ToManyEntity;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\ToOneEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\Type\StringWrapper;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\Type\StringWrapperType;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\UpdateCompositeIntIdEntity;
@@ -112,6 +114,8 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $schemaTool = new SchemaTool($em);
         $schemaTool->createSchema([
             $em->getClassMetadata(SingleIntIdEntity::class),
+            $em->getClassMetadata(ToManyEntity::class),
+            $em->getClassMetadata(ToOneEntity::class),
             $em->getClassMetadata(SingleIntIdWithPrivateNameEntity::class),
             $em->getClassMetadata(SingleIntIdNoToStringEntity::class),
             $em->getClassMetadata(DoubleNameEntity::class),
@@ -1117,6 +1121,47 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
     }
 
     // TODO remove this in Symfony 9.0 (or earlier, when dropping support for symfony/validator < 8.1)
+    public function testArrayValuedFieldIsRejectedByTheDefaultRepositoryMethod()
+    {
+        $constraint = new UniqueEntity(message: 'myMessage', fields: ['phoneNumbers'], em: self::EM_NAME);
+
+        $entity = new SingleIntIdEntity(1, 'foo');
+        $entity->phoneNumbers = [123, 456];
+
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('The field "phoneNumbers" holds an array, which the default "findBy" repository method turns into an "IN" clause instead of an equality check.');
+
+        $this->validate($entity, $constraint);
+    }
+
+    public function testScalarValueInAnArrayCapableFieldIsAccepted()
+    {
+        $constraint = new UniqueEntity(message: 'myMessage', fields: ['phoneNumbers'], em: self::EM_NAME);
+
+        $entity = new SingleIntIdEntity(1, 'foo');
+        $entity->phoneNumbers = 'dark-mode';
+
+        $this->em->persist($entity);
+        $this->em->flush();
+
+        $this->validate($entity, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function testToManyAssociationIsRejectedByTheDefaultRepositoryMethod()
+    {
+        $constraint = new UniqueEntity(message: 'myMessage', fields: ['children'], em: self::EM_NAME);
+
+        $entity = new ToManyEntity(1);
+        $entity->children->add(new ToOneEntity(1));
+
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('The field "children" is a to-many association, which the default "findBy" repository method cannot query.');
+
+        $this->validate($entity, $constraint);
+    }
+
     protected function validate(mixed $value, Constraint $constraint): void
     {
         if (method_exists(parent::class, 'validate')) {

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -106,6 +106,14 @@ class UniqueEntityValidator extends ConstraintValidator
             $criteria[$fieldName] = $fieldValue;
 
             if (\is_object($criteria[$fieldName]) && $class->hasAssociation($fieldName)) {
+                if ($class->isCollectionValuedAssociation($fieldName)) {
+                    if ('findBy' === $constraint->repositoryMethod) {
+                        throw new ConstraintDefinitionException(\sprintf('The field "%s" is a to-many association, which the default "findBy" repository method cannot query. Use the "repositoryMethod" option to provide a method that can.', $fieldName));
+                    }
+
+                    continue;
+                }
+
                 /* Ensure the Proxy is initialized before using reflection to
                  * read its identifiers. This is necessary because the wrapped
                  * getter methods in the Proxy are being bypassed.
@@ -149,6 +157,12 @@ class UniqueEntityValidator extends ConstraintValidator
          * - One entity returned the uniqueness depends on the current entity.
          */
         if ('findBy' === $constraint->repositoryMethod) {
+            foreach ($criteria as $fieldName => $fieldValue) {
+                if (\is_array($fieldValue)) {
+                    throw new ConstraintDefinitionException(\sprintf('The field "%s" holds an array, which the default "findBy" repository method turns into an "IN" clause instead of an equality check. Use the "repositoryMethod" option to provide a method that can query it.', $fieldName));
+                }
+            }
+
             $arguments = [$criteria, null, 2];
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT

`findBy()` reads any array criteria value as an `IN (...)` list rather than as a single value routed through the field's type, so a `UniqueEntity` constraint on an array-valued field built a query that could never match. Captured SQL on the base branch:

| field | value | generated SQL |
| --- | --- | --- |
| `simple_array` | `['foo','bar']` | `WHERE simpleArray IN (?, ?)` with both parameters NULL |
| `json` | `['key' => 'value', 'list' => [1,2,3]]` | `WHERE json IN (?, ?, ?, ?)`, the nested array flattened |
| `json` | `'plain'` | `WHERE json = '"plain"'`, correct |

The failure is silent: no rows match, so no violation is reported and the application believes it has a uniqueness rule that it does not.

To-many associations fail differently. `$em->initializeObject()` throws `Class "Doctrine\Common\Collections\ArrayCollection" is not a valid entity or mapped super class` for a plain `ArrayCollection`, which is the normal case for an unpersisted entity being validated in a form, and `findBy()` cannot query the inverse side of an association at all.

Both are now rejected with a `ConstraintDefinitionException` pointing at the `repositoryMethod` option, which is the supported way to check such fields. To-many fields also stop being passed to `initializeObject()`, so `repositoryMethod` finally works for them.

Reworked during review, with two changes of approach:

* **the check is on the runtime value, not the declared column type.** Keying off `Types::SIMPLE_ARRAY` and `Types::JSON` missed DBAL's own `JSON_OBJECT`, `JSONB` and `JSONB_OBJECT`, and every user-defined type whose PHP representation is an array. It also rejected `json` columns holding a scalar, which work correctly today. Checking `is_array($fieldValue)` covers all of them and leaves the working case alone;
* **no DBAL dependency.** `doctrine/dbal` is `require-dev` only for this bridge; the runtime requirement is `doctrine/persistence`, and `UniqueEntityValidator` is deliberately persistence-agnostic. A class-constant fetch autoloads, so referencing `Types` made every `UniqueEntity` validation fatal on a MongoDB ODM install with no DBAL. The association check likewise uses `ClassMetadata::isCollectionValuedAssociation()` from `doctrine/persistence` rather than the ORM's `ClassMetadata` constants, so it also applies to ODM.

The result is 14 added lines and no new imports.

Tests: an array-valued field and a to-many association both raise the new exception and both fail on a clean 8.2, the second with the old Doctrine mapping error. A `json` column holding a scalar is asserted to keep validating, which is the case the earlier type-based check regressed. Two small fixtures were needed for the to-many case, since the bridge had no `OneToMany` entity; both pass `SchemaValidator`.
