### PR TITLE
[Console] fix profiler with overridden `run()` method

### DIFF
--- a/src/Symfony/Component/Console/Command/TraceableCommand.php
+++ b/src/Symfony/Component/Console/Command/TraceableCommand.php
@@ -283,7 +283,7 @@ final class TraceableCommand extends Command implements SignalableCommandInterfa
         $event = $this->stopwatch->start($this->getName(), 'command');
 
         try {
-            $this->exitCode = parent::run($input, $output);
+            $this->exitCode = $this->command->run($input, $output);
         } finally {
             $event->stop();
 

--- a/src/Symfony/Component/Console/Tests/Command/TraceableCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/TraceableCommandTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\TraceableCommand;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Console\Tests\Fixtures\LoopExampleCommand;
+use Symfony\Component\Stopwatch\Stopwatch;
+
+class TraceableCommandTest extends TestCase
+{
+    private Application $application;
+
+    protected function setUp(): void
+    {
+        $this->application = new Application();
+        $this->application->add(new LoopExampleCommand());
+    }
+
+    public function testRunIsOverriddenWithoutProfile()
+    {
+        $command = $this->application->find('app:loop:example');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([]);
+        $commandTester->assertCommandIsSuccessful();
+
+        $output = $commandTester->getDisplay();
+        $this->assertLoopOutputCorrectness($output);
+    }
+
+    public function testRunIsNotOverriddenWithProfile()
+    {
+        // Simulate the bug environment by wrapping
+        // our command in TraceableCommand, which is what Symfony does
+        // when you use the --profile option.
+        $command = new LoopExampleCommand();
+        $traceableCommand = new TraceableCommand($command, new Stopwatch());
+
+        $this->application->add($traceableCommand);
+
+        $commandTester = new CommandTester($traceableCommand);
+        $commandTester->execute([]);
+        $commandTester->assertCommandIsSuccessful();
+
+        $output = $commandTester->getDisplay();
+        $this->assertLoopOutputCorrectness($output);
+    }
+
+    public function assertLoopOutputCorrectness(string $output)
+    {
+        self::assertMatchesRegularExpression('~3/3\s+\[▓+]\s+100%~u', $output);
+        self::assertStringContainsString('Loop finished.', $output);
+        self::assertEquals(3, substr_count($output, 'Hello world'));
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/AbstractLoopCommand.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/AbstractLoopCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Fixtures;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+abstract class AbstractLoopCommand extends Command
+{
+    public function run(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $contexts = [1, 2, 3];
+        $io->progressStart(count($contexts));
+        $code = self::SUCCESS;
+
+        foreach ($contexts as $ignored) {
+            $io->progressAdvance();
+            try {
+                parent::run($input, $output);
+            } catch (\Throwable) {
+                $code = self::FAILURE;
+            }
+        }
+        $io->progressFinish();
+        $output->writeln("\nLoop finished.");
+
+        return $code;
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/LoopExampleCommand.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/LoopExampleCommand.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Fixtures;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand('app:loop:example')]
+class LoopExampleCommand extends AbstractLoopCommand
+{
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $output->writeln(' Hello world');
+
+        return Command::SUCCESS;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61134
| License       | MIT

When a command overrides the `run()` method, using the `--profile` option would bypass this custom logic. This was caused by `TraceableCommand` calling `parent::run()` instead of delegating the call to the decorated command.

This change ensures `$this->command->run()` is called, preserving the overridden logic and allowing the profiler to work as expected.