### PR TITLE
[Config] Fix GeneratedConfigTest not being able to generate snapshots anymore

### DIFF
--- a/src/Symfony/Component/Config/Tests/Builder/GeneratedConfigTest.php
+++ b/src/Symfony/Component/Config/Tests/Builder/GeneratedConfigTest.php
@@ -159,10 +159,12 @@ class GeneratedConfigTest extends TestCase
      */
     private function generateConfigBuilder(string $configurationClass, ?string &$outputDir = null)
     {
-        $outputDir = tempnam(sys_get_temp_dir(), 'sf_config_builder_');
-        unlink($outputDir);
-        mkdir($outputDir);
-        $this->tempDir[] = $outputDir;
+        if (null === $outputDir) {
+            $outputDir = tempnam(sys_get_temp_dir(), 'sf_config_builder_');
+            unlink($outputDir);
+            mkdir($outputDir);
+            $this->tempDir[] = $outputDir;
+        }
 
         $configuration = new $configurationClass();
         $rootNode = $configuration->getConfigTreeBuilder()->buildTree();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61139
| License       | MIT

PR #57614 Removed multiple uses of `uniqid`. In the specific PR changes were made to the GeneratedConfigTest, to change how the directory was built for the config.

This inadvertedly broke the generating of snapshot files, due to the outputDir being changed to a by reference argument, and always overwriting the value to a temp dir. (While the snapshot files should not be written to a temp dir)
