### PR TITLE
[ObjectMapper] Add `ObjectMapperAwareInterface` to set the owning object mapper instance

### DIFF
--- a/src/Symfony/Component/ObjectMapper/CHANGELOG.md
+++ b/src/Symfony/Component/ObjectMapper/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+ * Add `ObjectMapperAwareInterface` to set the owning object mapper instance
+
 7.3
 ---
 

--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -28,7 +28,7 @@ use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
  *
  * @author Antoine Bluchet <soyuka@gmail.com>
  */
-final class ObjectMapper implements ObjectMapperInterface
+final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInterface
 {
     /**
      * Tracks recursive references.
@@ -40,6 +40,7 @@ final class ObjectMapper implements ObjectMapperInterface
         private readonly ?PropertyAccessorInterface $propertyAccessor = null,
         private readonly ?ContainerInterface $transformCallableLocator = null,
         private readonly ?ContainerInterface $conditionCallableLocator = null,
+        private ?ObjectMapperInterface $objectMapper = null,
     ) {
     }
 
@@ -211,7 +212,7 @@ final class ObjectMapper implements ObjectMapperInterface
             } elseif ($objectMap->contains($value)) {
                 $value = $objectMap[$value];
             } else {
-                $value = $this->map($value, $mapTo->target);
+                $value = ($this->objectMapper ?? $this)->map($value, $mapTo->target);
             }
         }
 
@@ -326,5 +327,13 @@ final class ObjectMapper implements ObjectMapperInterface
         }
 
         return $targetRefl;
+    }
+
+    public function withObjectMapper(ObjectMapperInterface $objectMapper): static
+    {
+        $clone = clone $this;
+        $clone->objectMapper = $objectMapper;
+
+        return $clone;
     }
 }

--- a/src/Symfony/Component/ObjectMapper/ObjectMapperAwareInterface.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapperAwareInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper;
+
+/**
+ * @experimental
+ *
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ */
+interface ObjectMapperAwareInterface
+{
+    /**
+     * Sets the owning ObjectMapper object.
+     */
+    public function withObjectMapper(ObjectMapperInterface $objectMapper): static;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Feature?      | yes
| Issues        | Fix #61119
| License       | MIT

Because the Object Mapper calls itself and we don't offer the possibility to change the owning object mapper, its hard to change the behavior on embedded objects (you could with a transform callable but it is redundant and adds lots of complexity). 
With this change the ObjectMapper can use a decorated instance and we can easily provide a way to make things like #61119 work. Inside API Platform we have the same issue where we want to re-use values that have been previously mapped to existing entities, we don't want to create new classes. This is achievable with decorating the ObjectMapper but works on relations only if the called mapper inside the mapper is configurable.

Let me know how I should write the DI in the FrameworkBundle for this as it'd be nice if it worked with decoration pattern without user interactions.