### PR TITLE
[HttpFoundation] Add `#[\NoDiscard]` attribute to `UriSigner` check methods

### DIFF
--- a/src/Symfony/Component/HttpFoundation/UriSigner.php
+++ b/src/Symfony/Component/HttpFoundation/UriSigner.php
@@ -98,11 +98,13 @@ class UriSigner
      * Checks that a URI contains the correct hash.
      * Also checks if the URI has not expired (If you used expiration during signing).
      */
+    #[\NoDiscard]
     public function check(string $uri): bool
     {
         return self::STATUS_VALID === $this->doVerify($uri);
     }
 
+    #[\NoDiscard]
     public function checkRequest(Request $request): bool
     {
         return self::STATUS_VALID === $this->doVerify(self::normalize($request));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Issues        | Kind of fixed and related to: https://github.com/symfony/symfony/pull/54297
| License       | MIT

There are sure more services which may be interesting but want to start with this one to discuss if we adopt:

https://wiki.php.net/rfc/marking_return_value_as_important

In the symfony workspace.

As I know there is nothing wrong to add a attribute which may not exist at that PHP version which we already had in the past with the ReturnTypeWillChange attributes.

