### PR TITLE
[ObjectMapper] update promoted properties w/ an object as target

### DIFF
--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -156,6 +156,14 @@ final class ObjectMapper implements ObjectMapperInterface
             }
         }
 
+        if ($mappingToObject && $ctorArguments) {
+            foreach ($ctorArguments as $property => $value) {
+                if ($targetRefl->hasProperty($property) && $targetRefl->getProperty($property)->isPublic()) {
+                    $mapToProperties[$property] = $value;
+                }
+            }
+        }
+
         foreach ($mapToProperties as $property => $value) {
             $this->propertyAccessor ? $this->propertyAccessor->setValue($mappedTarget, $property, $value) : ($mappedTarget->{$property} = $value);
         }

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/PromotedConstructor/Source.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/PromotedConstructor/Source.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\PromotedConstructor;
+
+class Source
+{
+    public function __construct(
+        public int $id,
+        public string $name,
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/PromotedConstructor/Target.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/PromotedConstructor/Target.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\PromotedConstructor;
+
+class Target
+{
+    public function __construct(
+        public int $id,
+        public string $name,
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\ObjectMapper\Metadata\Mapping;
 use Symfony\Component\ObjectMapper\Metadata\ObjectMapperMetadataFactoryInterface;
 use Symfony\Component\ObjectMapper\Metadata\ReflectionObjectMapperMetadataFactory;
 use Symfony\Component\ObjectMapper\ObjectMapper;
+use Symfony\Component\ObjectMapper\ObjectMapperInterface;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\A;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\B;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\C;
@@ -51,6 +52,8 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty\B as Mu
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty\C as MultipleTargetPropertyC;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargets\A as MultipleTargetsA;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargets\C as MultipleTargetsC;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\PromotedConstructor\Source as PromotedConstructorSource;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\PromotedConstructor\Target as PromotedConstructorTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\Recursion\AB;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\Recursion\Dto;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ServiceLocator\A as ServiceLocatorA;
@@ -344,5 +347,25 @@ final class ObjectMapperTest extends TestCase
         $this->assertInstanceOf(TargetDto::class, $b);
         $this->assertSame('abc', $b->id);
         $this->assertNull($b->optional);
+    }
+
+    /**
+     * @dataProvider objectMapperProvider
+     */
+    public function testUpdateObjectWithConstructorPromotedProperties(ObjectMapperInterface $mapper)
+    {
+        $a = new PromotedConstructorSource(1, 'foo');
+        $b = new PromotedConstructorTarget(1, 'bar');
+        $v = $mapper->map($a, $b);
+        $this->assertSame($v->name, 'foo');
+    }
+
+    /**
+     * @return iterable<array{0: ObjectMapperInterface}>
+     */
+    public static function objectMapperProvider(): iterable
+    {
+        yield [new ObjectMapper()];
+        yield [new ObjectMapper(new ReflectionObjectMapperMetadataFactory(), PropertyAccess::createPropertyAccessor())];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| License       | MIT

When using promoted properties properties would not be mapped when the target was an object, this test case was failing: 

```php
    public function testUpdateObjectWithConstructorPromotedProperties(ObjectMapperInterface $mapper)
    {
        $a = new PromotedConstructorSource(1, 'foo');
        $b = new PromotedConstructorTarget(1, 'bar');
        $v = $mapper->map($a, $b);
        $this->assertSame($v->name, 'foo');
    }
    ```
