### PR TITLE
Fix Exception on empty JSON login: BadCredentials message too generic

### DIFF
--- a/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
@@ -148,7 +148,7 @@ class JsonLoginAuthenticator implements InteractiveAuthenticatorInterface
             $credentials['username'] = $this->propertyAccessor->getValue($data, $this->options['username_path']);
 
             if (!\is_string($credentials['username']) || '' === $credentials['username']) {
-                throw new BadRequestHttpException('The key "username" must be a non-empty string.');
+                throw new BadCredentialsException('The key "username" must be a non-empty string.');
             }
         } catch (AccessException $e) {
             throw new BadRequestHttpException(\sprintf('The key "%s" must be provided.', $this->options['username_path']), $e);
@@ -159,7 +159,7 @@ class JsonLoginAuthenticator implements InteractiveAuthenticatorInterface
             $this->propertyAccessor->setValue($data, $this->options['password_path'], null);
 
             if (!\is_string($credentials['password']) || '' === $credentials['password']) {
-                throw new BadRequestHttpException('The key "password" must be a non-empty string.');
+                throw new BadCredentialsException('The key "password" must be a non-empty string.');
             }
         } catch (AccessException $e) {
             throw new BadRequestHttpException(\sprintf('The key "%s" must be provided.', $this->options['password_path']), $e);

--- a/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Security\Http\Authenticator;
 
+use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -147,7 +148,7 @@ class JsonLoginAuthenticator implements InteractiveAuthenticatorInterface
             $credentials['username'] = $this->propertyAccessor->getValue($data, $this->options['username_path']);
 
             if (!\is_string($credentials['username']) || '' === $credentials['username']) {
-                throw new BadRequestHttpException(\sprintf('The key "%s" must be a non-empty string.', $this->options['username_path']));
+                throw new BadRequestHttpException('The key "username" must be a non-empty string.');
             }
         } catch (AccessException $e) {
             throw new BadRequestHttpException(\sprintf('The key "%s" must be provided.', $this->options['username_path']), $e);
@@ -158,7 +159,7 @@ class JsonLoginAuthenticator implements InteractiveAuthenticatorInterface
             $this->propertyAccessor->setValue($data, $this->options['password_path'], null);
 
             if (!\is_string($credentials['password']) || '' === $credentials['password']) {
-                throw new BadRequestHttpException(\sprintf('The key "%s" must be a non-empty string.', $this->options['password_path']));
+                throw new BadRequestHttpException('The key "password" must be a non-empty string.');
             }
         } catch (AccessException $e) {
             throw new BadRequestHttpException(\sprintf('The key "%s" must be provided.', $this->options['password_path']), $e);

--- a/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Security\Http\Authenticator;
 
-use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -22,6 +21,7 @@ use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4 for features / 6.4, 7.2, or 7.3 for bug fixes
| Bug fix?      | yes/no
| New feature?  | yes/no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | yes/no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

<!--
This PR updates the `JsonLoginAuthenticator` to throw a more specific `BadCredentialsException` when either the username or password is empty or missing in the JSON login payload.
-->
