### PR TITLE
[TwigBundle] fix preload unlinked class BinaryOperatorExpressionParser

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.php
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.php
@@ -36,6 +36,7 @@ use Symfony\Bundle\TwigBundle\DependencyInjection\Configurator\EnvironmentConfig
 use Symfony\Bundle\TwigBundle\TemplateIterator;
 use Twig\Cache\FilesystemCache;
 use Twig\Environment;
+use Twig\ExpressionParser\Infix\BinaryOperatorExpressionParser;
 use Twig\Extension\CoreExtension;
 use Twig\Extension\DebugExtension;
 use Twig\Extension\EscaperExtension;
@@ -62,6 +63,7 @@ return static function (ContainerConfigurator $container) {
             ->tag('container.preload', ['class' => EscaperExtension::class])
             ->tag('container.preload', ['class' => OptimizerExtension::class])
             ->tag('container.preload', ['class' => StagingExtension::class])
+            ->tag('container.preload', ['class' => BinaryOperatorExpressionParser::class])
             ->tag('container.preload', ['class' => ExtensionSet::class])
             ->tag('container.preload', ['class' => Template::class])
             ->tag('container.preload', ['class' => TemplateWrapper::class])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  |no 
| Deprecations? | no 
| Issues        | Fix https://github.com/twigphp/Twig/issues/4647
| License       | MIT

### Problem
Upgrading Twig from `v3.20.0` to `v3.21.1` causes PHP preload errors on startup:

```
PHP Warning:  Can't preload unlinked
class Twig\ExpressionParser\Infix\BinaryOperatorExpressionParser@anonymous: 
Unknown parent Twig\ExpressionParser\Infix\BinaryOperatorExpressionParser
in /var/www/html/vendor/twig/twig/src/ExtensionSet.php on line 528
```
### Details
Branch: `5.4`
- Twig `v3.20.0` works without error ✅
- Twig `v3.21.1` produces the error above ❌

### Solution
Applying same changes that were made in https://github.com/symfony/symfony/pull/60859