### PR TITLE
[Lock] Fallback to `eval` when `LOAD` fails due to missing script

### DIFF
--- a/src/Symfony/Component/Lock/Store/RedisStore.php
+++ b/src/Symfony/Component/Lock/Store/RedisStore.php
@@ -294,7 +294,13 @@ class RedisStore implements SharedLockStoreInterface
             }
         }
 
-        $this->handlePredisError(fn () => $this->redis->script('LOAD', $script));
+        if ($this->redis->getConnection() instanceof \Predis\Connection\Cluster\ClusterInterface) {
+            foreach ($this->redis as $connection) {
+                $this->handlePredisError(fn () => $connection->script('LOAD', $script));
+            }
+        } else {
+            $this->handlePredisError(fn () => $this->redis->script('LOAD', $script));
+        }
 
         return $this->handlePredisError(fn () => $this->redis->evalSha($scriptSha, 1, $resource, ...$args));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59795 
| License       | MIT


* First attempts to execute the script using `evalSha`.
* If the script is missing (NOSCRIPT), tries to load it using script `LOAD`.
* If script `LOAD` is not supported, falls back to `eval`.

