### PR TITLE
[Semaphore] Enabled usage of `EVALSHA` and `LOAD SCRIPT` over regular `EVAL`

### DIFF
--- a/src/Symfony/Component/Semaphore/CHANGELOG.md
+++ b/src/Symfony/Component/Semaphore/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+ * RedisStore uses `EVALSHA` over `EVAL` when evaluating LUA scripts
+
 7.3
 ---
 

--- a/src/Symfony/Component/Semaphore/Exception/SemaphoreStorageException.php
+++ b/src/Symfony/Component/Semaphore/Exception/SemaphoreStorageException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Semaphore\Exception;
+
+/**
+ * SemaphoreStorageException is thrown when an issue happens during the manipulation of a semaphore in a store.
+ *
+ * @author Santiago San Martin <sanmartindev@gmail.com>
+ */
+class SemaphoreStorageException extends \RuntimeException implements ExceptionInterface
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | no
| License       | MIT

This PR updates the Semaphore component to use `EVALSHA` instead of `EVAL` when evaluating Lua scripts, following the same approach introduced in a previous [PR](https://github.com/symfony/symfony/pull/58533) for the Lock component. Reusing the cached `SHA` improves performance and avoids sending the full script each time.