### PR TITLE
[DependencyInjection] Add AsServiceLocator attribute

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AsServiceLocator/bundles.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AsServiceLocator/bundles.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+
+return [
+    new FrameworkBundle(),
+];

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AsServiceLocator/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AsServiceLocator/config.yml
@@ -1,0 +1,19 @@
+imports:
+  - { resource: ../config/default.yml }
+
+services:
+  _defaults: { public: true }
+
+  Symfony\Component\DependencyInjection\Tests\Fixtures\FooTagClass:
+    public: true
+    tags:
+      - "foo_bar"
+
+  Symfony\Component\DependencyInjection\Tests\Fixtures\BarTagClass:
+    public: true
+    tags:
+      - "foo_bar"
+
+  Symfony\Component\DependencyInjection\Tests\Fixtures\ServiceLocatorWithAttribute:
+    autoconfigure: true
+    autowire: true

--- a/src/Symfony/Component/DependencyInjection/Attribute/AsServiceLocator.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/AsServiceLocator.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Attribute;
+
+/**
+ * Declares a Service Locator.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class AsServiceLocator
+{
+    public function __construct(
+        public string $tag,
+        public string $indexAttribute = 'key',
+        public ?string $defaultIndexMethod = null,
+        public ?string $defaultPriorityMethod = null,
+        public string|array $exclude = [],
+        public bool $excludeSelf = true,
+    ) {
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Allow `#[AsAlias]` to be extended
  * Add argument `$target` to `ContainerBuilder::registerAliasForArgument()`
+ * Add `#[AsServiceLocator]` to allow service locator configuration at the class level
 
 7.3
 ---

--- a/src/Symfony/Component/DependencyInjection/Compiler/AsServiceLocatorCompilerPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AsServiceLocatorCompilerPass.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
+use Symfony\Component\DependencyInjection\Attribute\AsServiceLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class AsServiceLocatorCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $commandServices = $container->findTaggedServiceIds('container.service_locator', true);
+
+        foreach ($commandServices as $id => $tags) {
+            $definition = $container->getDefinition($id);
+            $class = $container->getParameterBag()->resolveValue($definition->getClass());
+
+            if (!$r = $container->getReflectionClass($class)) {
+                throw new \InvalidArgumentException(\sprintf('Class "%s" used for service "%s" cannot be found.', $class, $id));
+            }
+
+            if ($attribute = ($r->getAttributes(AsServiceLocator::class)[0] ?? null)) {
+                $attribute = $attribute->newInstance();
+                $definition->setArgument(0, new TaggedIteratorArgument($attribute->tag, $attribute->indexAttribute, $attribute->defaultIndexMethod, false, $attribute->defaultPriorityMethod, $attribute->exclude, $attribute->excludeSelf));
+            }
+        }
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -65,6 +65,7 @@ class PassConfig
             new AutowireRequiredMethodsPass(),
             new AutowireRequiredPropertiesPass(),
             new ResolveBindingsPass(),
+            new AsServiceLocatorCompilerPass(),
             new ServiceLocatorTagPass(),
             new DecoratorServicePass(),
             new CheckDefinitionValidityPass(),

--- a/src/Symfony/Component/DependencyInjection/Tests/Attribute/AsServiceLocatorAttributeTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Attribute/AsServiceLocatorAttributeTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Attribute;
+
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\AbstractWebTestCase;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\BarTagClass;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\FooTagClass;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\ServiceLocatorWithAttribute;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+class AsServiceLocatorAttributeTest extends AbstractWebTestCase
+{
+    protected static function createKernel(array $options = []): KernelInterface
+    {
+        return parent::createKernel(['test_case' => 'AsServiceLocator'] + $options);
+    }
+
+    public function testCanOnlySetOneParameter()
+    {
+        $container = self::getContainer();
+
+        $locator = $container->get(ServiceLocatorWithAttribute::class);
+
+        self::assertSame([FooTagClass::class, BarTagClass::class], array_values($locator->getProvidedServices()));
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/ServiceLocatorWithAttribute.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/ServiceLocatorWithAttribute.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Attribute\AsServiceLocator;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+
+#[AsServiceLocator('foo_bar')]
+final class ServiceLocatorWithAttribute extends ServiceLocator
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

Add a AsServiceLocator attribute to allow configure Service Locator in Service Class instead of services.yaml

before : 

```php
namespace App\ServiceLocator;

class MyClass extends ServiceLocator
{
}
```
```yml
    App\ServiceLocator\MyClass:
        arguments: [!tagged_iterator  { tag: 'app.mytag', index_by: 'key' }]
```


after : 
```php
namespace App\ServiceLocator;

#[AsServiceLocator('app.mytag')]
class MyClass extends ServiceLocator
{
}
```


- [x] Changelog update
- [x] Test
