### PR TITLE
[Validator] Remove exclusion of Constraints/Validator/ExpressionLanguageSyntaxValidator

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.php
@@ -73,7 +73,6 @@ return static function (ContainerConfigurator $container) {
             ])
 
         ->load('Symfony\Component\Validator\Constraints\\', $validatorsDir.'/*Validator.php')
-            ->exclude($validatorsDir.'/ExpressionLanguageSyntaxValidator.php')
             ->abstract()
             ->tag('container.excluded')
             ->tag('validator.constraint_validator')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |8.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

🛠️ Validation Component removed the ExpressionLanguageSyntaxValidator so it is no longer loaded in the service container.
The method used to exclude the service stands on the fact that the class file exists, this cause an exception