### PR TITLE
[WebProfilerBundle] Increase compatibility of toolbar with Turbo

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -413,11 +413,7 @@
                 renderAjaxRequests: renderAjaxRequests,
 
                 getSfwdt: function(token) {
-                    if (!this.sfwdt) {
-                        this.sfwdt = document.getElementById('sfwdt' + token);
-                    }
-
-                    return this.sfwdt;
+                    return document.getElementById('sfwdt' + token);
                 },
 
                 load: function(selector, url, onSuccess, onError, options) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | -
| License       | MIT

If you use [Turbo](https://turbo.hotwired.dev/) in your Symfony project together with the `symfony/web-profiler-bundle`, there is one little annoyance: after every Turbo Drive navigation, the profiler's toolbar will be always open and the toggle button will not actually open/close it. Only after a full refresh does the button work again.

This is because of the following code: 

https://github.com/symfony/symfony/blob/74895de13e0df9f4991d82a9c9cd956aee1c326c/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig#L416-L420

During a Turbo Drive navigation, the global `Sfjs` object will stay (which is fine) - and so will its `this.sfwdt` variable of course. Thus `this.sfwdt` will always contain the reference to the toolbar of the first (non-Drive) request and therefore `this.getSfwdt(token)` will always return that - instead of the new toolbar.

This PR simply removes the `this.sfwdt` variable. Any performance gains from storing the reference to the toolbar is negligible anyway, since `getElementById()` should be fast enough.
