### PR TITLE
[DoctrineBridge] Remove support for auto-mapping Doctrine entities to controller arguments

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -139,7 +139,7 @@ DoctrineBridge
    ```php
    $type = $extractor->getType(Foo::class, 'property');
    ```
-
+ * Remove support for auto-mapping Doctrine entities to controller arguments; use explicit mapping instead
  * Make `ProxyCacheWarmer` class `final`
 
 ExpressionLanguage

--- a/src/Symfony/Bridge/Doctrine/ArgumentResolver/EntityValueResolver.php
+++ b/src/Symfony/Bridge/Doctrine/ArgumentResolver/EntityValueResolver.php
@@ -189,9 +189,6 @@ final class EntityValueResolver implements ValueResolverInterface
             }
 
             return $criteria;
-        } elseif (null === $mapping) {
-            trigger_deprecation('symfony/doctrine-bridge', '7.1', 'Relying on auto-mapping for Doctrine entities is deprecated for argument $%s of "%s": declare the mapping using either the #[MapEntity] attribute or mapped route parameters.', $argument->getName(), method_exists($argument, 'getControllerName') ? $argument->getControllerName() : 'n/a');
-            $mapping = $request->attributes->keys();
         }
 
         if ($mapping && array_is_list($mapping)) {

--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.0
 ---
 
+ * Remove support for auto-mapping Doctrine entities to controller arguments; use explicit mapping instead
  * Make `ProxyCacheWarmer` class `final`
 
 7.4

--- a/src/Symfony/Bridge/Doctrine/Tests/ArgumentResolver/EntityValueResolverTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ArgumentResolver/EntityValueResolverTest.php
@@ -64,9 +64,6 @@ class EntityValueResolverTest extends TestCase
         $this->assertSame([], $resolver->resolve($request, $argument));
     }
 
-    /**
-     * @group legacy
-     */
     public function testResolveWithNoIdAndDataOptional()
     {
         $manager = $this->createMock(ObjectManager::class);
@@ -247,9 +244,6 @@ class EntityValueResolverTest extends TestCase
         yield ['foo'];
     }
 
-    /**
-     * @group legacy
-     */
     public function testResolveGuessOptional()
     {
         $manager = $this->createMock(ObjectManager::class);
@@ -262,11 +256,7 @@ class EntityValueResolverTest extends TestCase
         $argument = $this->createArgument('stdClass', new MapEntity(), 'arg', true);
 
         $metadata = $this->createMock(ClassMetadata::class);
-        $manager->expects($this->once())
-            ->method('getClassMetadata')
-            ->with('stdClass')
-            ->willReturn($metadata);
-
+        $manager->expects($this->never())->method('getClassMetadata');
         $manager->expects($this->never())->method('getRepository');
 
         $this->expectException(NearMissValueResolverException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT
