### PR TITLE
[HttpFoundation] Trigger PHP warning when using `Request::sendHeaders()` after headers have already been sent

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -218,6 +218,7 @@ HttpFoundation
 --------------
 
  * Remove the following deprecated session options from `NativeSessionStorage`: `referer_check`, `use_only_cookies`, `use_trans_sid`, `sid_length`, `sid_bits_per_character`, `trans_sid_hosts`, `trans_sid_tags`
+ * Trigger PHP warning when using `Request::sendHeaders()` after headers have already been sent; use a `StreamedResponse` instead
 
 HttpClient
 ----------

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Remove the following deprecated session options from `NativeSessionStorage`: `referer_check`, `use_only_cookies`, `use_trans_sid`, `sid_length`, `sid_bits_per_character`, `trans_sid_hosts`, `trans_sid_tags`
+ * Trigger PHP warning when using `Request::sendHeaders()` after headers have already been sent; use a `StreamedResponse` instead
 
 7.4
 ---

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -319,8 +319,7 @@ class Response
         if (headers_sent()) {
             if (!\in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
                 $statusCode ??= $this->statusCode;
-                trigger_deprecation('symfony/http-foundation', '7.4', 'Trying to use "%s::sendHeaders()" after headers have already been sent is deprecated will throw a PHP warning in 8.0. Use a "StreamedResponse" instead.', static::class);
-                // header(\sprintf('HTTP/%s %s %s', $this->version, $statusCode, $this->statusText), true, $statusCode);
+                header(\sprintf('HTTP/%s %s %s', $this->version, $statusCode, $this->statusText), true, $statusCode);
             }
 
             return $this;

--- a/src/Symfony/Component/HttpFoundation/composer.json
+++ b/src/Symfony/Component/HttpFoundation/composer.json
@@ -17,7 +17,6 @@
     ],
     "require": {
         "php": ">=8.4",
-        "symfony/deprecation-contracts": "^2.5|^3.0",
         "symfony/polyfill-mbstring": "^1.1"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT
