### PR TITLE
[Messenger] Remove `text` format when using the `messenger:stats` command

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -249,6 +249,11 @@ Mailer
 
  * Remove `TransportFactoryTestCase`, extend `AbstractTransportFactoryTestCase` instead
 
+Messenger
+---------
+
+ * Remove `text` format when using the `messenger:stats` command
+
 Notifier
 --------
 

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.0
+---
+
+ * Remove `text` format when using the `messenger:stats` command; use `txt` instead
+
 7.4
 ---
 

--- a/src/Symfony/Component/Messenger/Command/StatsCommand.php
+++ b/src/Symfony/Component/Messenger/Command/StatsCommand.php
@@ -65,11 +65,6 @@ EOF
         $io = new SymfonyStyle($input, $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output);
 
         $format = $input->getOption('format');
-        if ('text' === $format) {
-            trigger_deprecation('symfony/messenger', '7.2', 'The "text" format is deprecated, use "txt" instead.');
-
-            $format = 'txt';
-        }
         if (!\in_array($format, $this->getAvailableFormatOptions(), true)) {
             throw new InvalidArgumentException('Invalid output format.');
         }

--- a/src/Symfony/Component/Messenger/composer.json
+++ b/src/Symfony/Component/Messenger/composer.json
@@ -18,8 +18,7 @@
     "require": {
         "php": ">=8.4",
         "psr/log": "^1|^2|^3",
-        "symfony/clock": "^7.4|^8.0",
-        "symfony/deprecation-contracts": "^2.5|^3"
+        "symfony/clock": "^7.4|^8.0"
     },
     "require-dev": {
         "psr/cache": "^1.0|^2.0|^3.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Use `txt` instead.