### PR TITLE
[Translation] Remove `TranslatableMessage::__toString()` method, use `trans()` or `getMessage()` instead

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -512,7 +512,7 @@ Translation
    -$loader->setCsvControl(';', '"', '\\');
    +$loader->setCsvControl(';', '"');
    ```
-
+ * Remove `TranslatableMessage::__toString()` method, use `trans()` or `getMessage()` instead
  * Make `DataCollectorTranslator` class `final`
  * Remove `ProviderFactoryTestCase`, extend `AbstractProviderFactoryTestCase` instead
 

--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Remove the `$escape` parameter from `CsvFileLoader::setCsvControl()`
  * Make `DataCollectorTranslator` class `final`
  * Remove `ProviderFactoryTestCase`, extend `AbstractProviderFactoryTestCase` instead
+ * Remove `TranslatableMessage::__toString()` method, use `trans()` or `getMessage()` instead
 
 7.4
 ---

--- a/src/Symfony/Component/Translation/Tests/TranslatableTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatableTest.php
@@ -42,14 +42,6 @@ class TranslatableTest extends TestCase
         $this->assertSame($expected, $translatable->trans($translator, 'fr'));
     }
 
-    /**
-     * @group legacy
-     */
-    public function testToString()
-    {
-        $this->assertSame('Symfony is great!', (string) new TranslatableMessage('Symfony is great!'));
-    }
-
     public static function getTransTests()
     {
         return [

--- a/src/Symfony/Component/Translation/TranslatableMessage.php
+++ b/src/Symfony/Component/Translation/TranslatableMessage.php
@@ -26,16 +26,6 @@ class TranslatableMessage implements TranslatableInterface
     ) {
     }
 
-    /**
-     * @deprecated since Symfony 7.4
-     */
-    public function __toString(): string
-    {
-        trigger_deprecation('symfony/translation', '7.4', 'Method "%s()" is deprecated.', __METHOD__);
-
-        return $this->getMessage();
-    }
-
     public function getMessage(): string
     {
         return $this->message;

--- a/src/Symfony/Component/Translation/composer.json
+++ b/src/Symfony/Component/Translation/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4",
         "symfony/polyfill-mbstring": "^1.0",
-        "symfony/translation-contracts": "^2.5|^3.0"
+        "symfony/translation-contracts": "^3.6.1"
     },
     "require-dev": {
         "nikic/php-parser": "^5.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT
