### PR TITLE
Declare new parameters on interfaces and methods explicitly

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -19,6 +19,11 @@ Cache
 
  * Remove `CouchbaseBucketAdapter`, use `CouchbaseCollectionAdapter` instead
 
+Config
+------
+
+ * Add argument `$info` to `ArrayNodeDefinition::canBeDisabled()` and `canBeEnabled()`
+
 Console
 -------
 
@@ -56,7 +61,7 @@ Console
        // ...
    }
    ```
-
+ * Add argument `$finishedIndicator` to `ProgressIndicator::finish()`
  * Ensure closures set via `Command::setCode()` method have proper parameter and return types
 
    *Before*
@@ -124,6 +129,7 @@ DependencyInjection
     ```
  * Remove `!tagged` tag, use `!tagged_iterator` instead
  * Remove the `ContainerBuilder::getAutoconfiguredAttributes()` method, use `getAttributeAutoconfigurators()` instead to retrieve all the callbacks for a specific attribute class
+ * Add argument `$target` to `ContainerBuilder::registerAliasForArgument()`
 
 DoctrineBridge
 --------------
@@ -220,6 +226,9 @@ HttpFoundation
 
  * Remove the following deprecated session options from `NativeSessionStorage`: `referer_check`, `use_only_cookies`, `use_trans_sid`, `sid_length`, `sid_bits_per_character`, `trans_sid_hosts`, `trans_sid_tags`
  * Trigger PHP warning when using `Request::sendHeaders()` after headers have already been sent; use a `StreamedResponse` instead
+ * Add arguments `$v4Bytes` and `$v6Bytes` to `IpUtils::anonymize()`
+ * Add argument `$partitioned` to `ResponseHeaderBag::clearCookie()`
+ * Add argument `$expiration` to `UriSigner::sign()`
 
 HttpClient
 ----------
@@ -234,6 +243,7 @@ HttpKernel
  * Remove `Extension::getAnnotatedClassesToCompile()` and `Extension::addAnnotatedClassesToCompile()`
  * Remove `Kernel::getAnnotatedClassesToCompile()` and `Kernel::setAnnotatedClassCache()`
  * Make `ServicesResetter` class `final`
+ * Add argument `$logChannel` to `ErrorListener::logException()`
 
 Intl
 ----
@@ -415,6 +425,10 @@ Security
  * Remove `AbstractListener::__invoke`
  * Remove `LazyFirewallContext::__invoke()`
  * Remove `RememberMeToken::getSecret()`
+ * Add argument `$accessDecision` to `AccessDecisionManagerInterface::decide()` and `AuthorizationCheckerInterface::isGranted()`
+ * Add argument `$vote` to `VoterInterface::vote()` and `Voter::voteOnAttribute()`
+ * Add argument `$token` to `UserCheckerInterface::checkPostAuth()`
+ * Add argument `$attributes` to `UserAuthenticatorInterface::authenticateUser()`
 
 SecurityBundle
 --------------
@@ -541,6 +555,11 @@ TypeInfo
    +$type = Type::list(Type::string());
    ```
 
+Uid
+---
+
+ * Add argument `$format` to `Uuid::isValid()`
+
 Validator
 ---------
 
@@ -553,6 +572,11 @@ VarExporter
  * Remove `LazyGhostTrait` and `LazyProxyTrait`, use native lazy objects instead
  * Remove `ProxyHelper::generateLazyGhost()`, use native lazy objects instead
 
+Webhook
+-------
+
+ * Add argument `$request` to `RequestParserInterface::createSuccessfulResponse()` and `RequestParserInterface::createRejectedResponse()`
+
 WebProfilerBundle
 -----------------
 
@@ -561,6 +585,7 @@ WebProfilerBundle
 Workflow
 --------
 
+ * Add `$nbToken` argument to `Marking::mark()` and `Marking::unmark()`
  * Remove `Event::getWorkflow()` method
 
    *Before*

--- a/src/Symfony/Component/Config/CHANGELOG.md
+++ b/src/Symfony/Component/Config/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.0
+---
+
+ * Add argument `$info` to `ArrayNodeDefinition::canBeDisabled()` and `canBeEnabled()`
+
 7.4
 ---
 

--- a/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
@@ -243,7 +243,7 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
      *
      * @return $this
      */
-    public function canBeEnabled(/* ?string $info = null */): static
+    public function canBeEnabled(?string $info = null): static
     {
         $disabledNode = $this
             ->addDefaultsIfNotSet()
@@ -263,7 +263,6 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
                     ->defaultFalse()
         ;
 
-        $info = 1 <= \func_num_args() ? func_get_arg(0) : null;
         if ($info) {
             $disabledNode->info($info);
         }
@@ -280,7 +279,7 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
      *
      * @return $this
      */
-    public function canBeDisabled(/* ?string $info = null */): static
+    public function canBeDisabled(?string $info = null): static
     {
         $enabledNode = $this
             ->addDefaultsIfNotSet()
@@ -292,7 +291,6 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
                     ->defaultTrue()
         ;
 
-        $info = 1 <= \func_num_args() ? func_get_arg(0) : null;
         if ($info) {
             $enabledNode->info($info);
         }

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Ensure closures set via `Command::setCode()` method have proper parameter and return types
  * Add method `isSilent()` to `OutputInterface`
  * Remove deprecated `Symfony\Component\Console\Application::add()` method in favor of `Symfony\Component\Console\Application::addCommand()`
+ * Add argument `$finishedIndicator` to `ProgressIndicator::finish()`
 
 7.4
 ---

--- a/src/Symfony/Component/Console/Helper/ProgressIndicator.php
+++ b/src/Symfony/Component/Console/Helper/ProgressIndicator.php
@@ -128,16 +128,9 @@ class ProgressIndicator
 
     /**
      * Finish the indicator with message.
-     *
-     * @param ?string $finishedIndicator
      */
-    public function finish(string $message/* , ?string $finishedIndicator = null */): void
+    public function finish(string $message, ?string $finishedIndicator = null): void
     {
-        $finishedIndicator = 1 < \func_num_args() ? func_get_arg(1) : null;
-        if (null !== $finishedIndicator && !\is_string($finishedIndicator)) {
-            throw new \TypeError(\sprintf('Argument 2 passed to "%s()" must be of the type string or null, "%s" given.', __METHOD__, get_debug_type($finishedIndicator)));
-        }
-
         if (!$this->started) {
             throw new LogicException('Progress indicator has not yet been started.');
         }

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Remove `#[TaggedIterator]` and `#[TaggedLocator]` attributes, replaced by `#[AutowireLocator]` and `#[AutowireIterator]`
  * Remove `ContainerBuilder::getAutoconfiguredAttributes()`, replaced by `ContainerBuilder::getAttributeAutoconfigurators()`
  * Remove `!tagged` tag, use `!tagged_iterator` instead
+ * Add argument `$target` to `ContainerBuilder::registerAliasForArgument()`
 
 7.4
 ---

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1459,13 +1459,11 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      * using camel case: "foo.bar" or "foo_bar" creates an alias bound to
      * "$fooBar"-named arguments with $type as type-hint. Such arguments will
      * receive the service $id when autowiring is used.
-     *
-     * @param ?string $target
      */
-    public function registerAliasForArgument(string $id, string $type, ?string $name = null/* , ?string $target = null */): Alias
+    public function registerAliasForArgument(string $id, string $type, ?string $name = null, ?string $target = null): Alias
     {
         $parsedName = (new Target($name ??= $id))->getParsedName();
-        $target = (\func_num_args() > 3 ? func_get_arg(3) : null) ?? $name;
+        $target ??= $name;
 
         if (!preg_match('/^[a-zA-Z_\x7f-\xff]/', $parsedName)) {
             if ($id !== $name) {

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -6,6 +6,9 @@ CHANGELOG
 
  * Remove the following deprecated session options from `NativeSessionStorage`: `referer_check`, `use_only_cookies`, `use_trans_sid`, `sid_length`, `sid_bits_per_character`, `trans_sid_hosts`, `trans_sid_tags`
  * Trigger PHP warning when using `Request::sendHeaders()` after headers have already been sent; use a `StreamedResponse` instead
+ * Add arguments `$v4Bytes` and `$v6Bytes` to `IpUtils::anonymize()`
+ * Add argument `$partitioned` to `ResponseHeaderBag::clearCookie()`
+ * Add argument `$expiration` to `UriSigner::sign()`
 
 7.4
 ---

--- a/src/Symfony/Component/HttpFoundation/IpUtils.php
+++ b/src/Symfony/Component/HttpFoundation/IpUtils.php
@@ -183,11 +183,8 @@ class IpUtils
      * @param int<0, 4>  $v4Bytes
      * @param int<0, 16> $v6Bytes
      */
-    public static function anonymize(string $ip/* , int $v4Bytes = 1, int $v6Bytes = 8 */): string
+    public static function anonymize(string $ip, int $v4Bytes = 1, int $v6Bytes = 8): string
     {
-        $v4Bytes = 1 < \func_num_args() ? func_get_arg(1) : 1;
-        $v6Bytes = 2 < \func_num_args() ? func_get_arg(2) : 8;
-
         if ($v4Bytes < 0 || $v6Bytes < 0) {
             throw new \InvalidArgumentException('Cannot anonymize less than 0 bytes.');
         }

--- a/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
@@ -216,13 +216,9 @@ class ResponseHeaderBag extends HeaderBag
 
     /**
      * Clears a cookie in the browser.
-     *
-     * @param bool $partitioned
      */
-    public function clearCookie(string $name, ?string $path = '/', ?string $domain = null, bool $secure = false, bool $httpOnly = true, ?string $sameSite = null /* , bool $partitioned = false */): void
+    public function clearCookie(string $name, ?string $path = '/', ?string $domain = null, bool $secure = false, bool $httpOnly = true, ?string $sameSite = null, bool $partitioned = false): void
     {
-        $partitioned = 6 < \func_num_args() ? func_get_arg(6) : false;
-
         $this->setCookie(new Cookie($name, null, 1, $path, $domain, $secure, $httpOnly, false, $sameSite, $partitioned));
     }
 

--- a/src/Symfony/Component/HttpFoundation/UriSigner.php
+++ b/src/Symfony/Component/HttpFoundation/UriSigner.php
@@ -57,18 +57,8 @@ class UriSigner
      *
      * The expiration is added as a query string parameter.
      */
-    public function sign(string $uri/* , \DateTimeInterface|\DateInterval|int|null $expiration = null */): string
+    public function sign(string $uri, \DateTimeInterface|\DateInterval|int|null $expiration = null): string
     {
-        $expiration = null;
-
-        if (1 < \func_num_args()) {
-            $expiration = func_get_arg(1);
-        }
-
-        if (null !== $expiration && !$expiration instanceof \DateTimeInterface && !$expiration instanceof \DateInterval && !\is_int($expiration)) {
-            throw new \TypeError(\sprintf('The second argument of "%s()" must be an instance of "%s" or "%s", an integer or null (%s given).', __METHOD__, \DateTimeInterface::class, \DateInterval::class, get_debug_type($expiration)));
-        }
-
         $url = parse_url($uri);
         $params = [];
 

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -4,10 +4,11 @@ CHANGELOG
 8.0
 ---
 
-* Remove `AddAnnotatedClassesToCachePass`
-* Remove `Extension::getAnnotatedClassesToCompile()` and `Extension::addAnnotatedClassesToCompile()`
-* Remove `Kernel::getAnnotatedClassesToCompile()` and `Kernel::setAnnotatedClassCache()`
-* Make `ServicesResetter` class `final`
+ * Remove `AddAnnotatedClassesToCachePass`
+ * Remove `Extension::getAnnotatedClassesToCompile()` and `Extension::addAnnotatedClassesToCompile()`
+ * Remove `Kernel::getAnnotatedClassesToCompile()` and `Kernel::setAnnotatedClassCache()`
+ * Make `ServicesResetter` class `final`
+ * Add argument `$logChannel` to `ErrorListener::logException()`
 
 7.3
 ---

--- a/src/Symfony/Component/HttpKernel/EventListener/ErrorListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ErrorListener.php
@@ -159,15 +159,9 @@ class ErrorListener implements EventSubscriberInterface
         ];
     }
 
-    /**
-     * Logs an exception.
-     *
-     * @param ?string $logChannel
-     */
-    protected function logException(\Throwable $exception, string $message, ?string $logLevel = null/* , ?string $logChannel = null */): void
+    protected function logException(\Throwable $exception, string $message, ?string $logLevel = null, ?string $logChannel = null): void
     {
-        $logChannel = (3 < \func_num_args() ? func_get_arg(3) : null) ?? $this->resolveLogChannel($exception);
-
+        $logChannel ??= $this->resolveLogChannel($exception);
         $logLevel ??= $this->resolveLogLevel($exception);
 
         if (!$logger = $this->getLogger($logChannel)) {

--- a/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManagerInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManagerInterface.php
@@ -27,5 +27,5 @@ interface AccessDecisionManagerInterface
      * @param mixed               $object         The object to secure
      * @param AccessDecision|null $accessDecision Should be used to explain the decision
      */
-    public function decide(TokenInterface $token, array $attributes, mixed $object = null/* , ?AccessDecision $accessDecision = null */): bool;
+    public function decide(TokenInterface $token, array $attributes, mixed $object = null, ?AccessDecision $accessDecision = null): bool;
 }

--- a/src/Symfony/Component/Security/Core/Authorization/AuthorizationCheckerInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AuthorizationCheckerInterface.php
@@ -24,5 +24,5 @@ interface AuthorizationCheckerInterface
      * @param mixed               $attribute      A single attribute to vote on (can be of any type; strings, Expression and Closure instances are supported by the core)
      * @param AccessDecision|null $accessDecision Should be used to explain the decision
      */
-    public function isGranted(mixed $attribute, mixed $subject = null/* , ?AccessDecision $accessDecision = null */): bool;
+    public function isGranted(mixed $attribute, mixed $subject = null, ?AccessDecision $accessDecision = null): bool;
 }

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/AuthenticatedVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/AuthenticatedVoter.php
@@ -40,13 +40,8 @@ class AuthenticatedVoter implements CacheableVoterInterface
     ) {
     }
 
-    /**
-     * @param Vote|null $vote Should be used to explain the vote
-     */
-    public function vote(TokenInterface $token, mixed $subject, array $attributes/* , ?Vote $vote = null */): int
+    public function vote(TokenInterface $token, mixed $subject, array $attributes, ?Vote $vote = null): int
     {
-        $vote = 3 < \func_num_args() ? func_get_arg(3) : null;
-
         if ($attributes === [self::PUBLIC_ACCESS]) {
             $vote?->addReason('Access is public.');
 

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/ExpressionVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/ExpressionVoter.php
@@ -44,12 +44,8 @@ class ExpressionVoter implements CacheableVoterInterface
         return true;
     }
 
-    /**
-     * @param Vote|null $vote Should be used to explain the vote
-     */
-    public function vote(TokenInterface $token, mixed $subject, array $attributes/* , ?Vote $vote = null */): int
+    public function vote(TokenInterface $token, mixed $subject, array $attributes, ?Vote $vote = null): int
     {
-        $vote = 3 < \func_num_args() ? func_get_arg(3) : null;
         $result = VoterInterface::ACCESS_ABSTAIN;
         $variables = null;
         $failingExpressions = [];

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/RoleVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/RoleVoter.php
@@ -25,12 +25,8 @@ class RoleVoter implements CacheableVoterInterface
     ) {
     }
 
-    /**
-     * @param Vote|null $vote Should be used to explain the vote
-     */
-    public function vote(TokenInterface $token, mixed $subject, array $attributes/* , ?Vote $vote = null */): int
+    public function vote(TokenInterface $token, mixed $subject, array $attributes, ?Vote $vote = null): int
     {
-        $vote = 3 < \func_num_args() ? func_get_arg(3) : null;
         $result = VoterInterface::ACCESS_ABSTAIN;
         $roles = $this->extractRoles($token);
         $missingRoles = [];

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/Voter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/Voter.php
@@ -24,12 +24,8 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
  */
 abstract class Voter implements VoterInterface, CacheableVoterInterface
 {
-    /**
-     * @param Vote|null $vote Should be used to explain the vote
-     */
-    public function vote(TokenInterface $token, mixed $subject, array $attributes/* , ?Vote $vote = null */): int
+    public function vote(TokenInterface $token, mixed $subject, array $attributes, ?Vote $vote = null): int
     {
-        $vote = 3 < \func_num_args() ? func_get_arg(3) : null;
         // abstain vote by default in case none of the attributes are supported
         $voteResult = self::ACCESS_ABSTAIN;
 
@@ -108,5 +104,5 @@ abstract class Voter implements VoterInterface, CacheableVoterInterface
      * @param TSubject   $subject
      * @param Vote|null  $vote      Should be used to explain the vote
      */
-    abstract protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token/* , ?Vote $vote = null */): bool;
+    abstract protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?Vote $vote = null): bool;
 }

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/VoterInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/VoterInterface.php
@@ -36,5 +36,5 @@ interface VoterInterface
      *
      * @return self::ACCESS_*
      */
-    public function vote(TokenInterface $token, mixed $subject, array $attributes/* , ?Vote $vote = null */): int;
+    public function vote(TokenInterface $token, mixed $subject, array $attributes, ?Vote $vote = null): int;
 }

--- a/src/Symfony/Component/Security/Core/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Core/CHANGELOG.md
@@ -6,7 +6,10 @@ CHANGELOG
 
  * Remove `RememberMeToken::getSecret()`
  * Remove `UserInterface::eraseCredentials()` and `TokenInterface::eraseCredentials()`,
-  erase credentials e.g. using `__serialize()` instead
+   erase credentials e.g. using `__serialize()` instead
+ * Add argument `$accessDecision` to `AccessDecisionManagerInterface::decide()` and `AuthorizationCheckerInterface::isGranted()`
+ * Add argument `$vote` to `VoterInterface::vote()` and `Voter::voteOnAttribute()`
+ * Add argument `$token` to `UserCheckerInterface::checkPostAuth()`
 
 7.3
 ---

--- a/src/Symfony/Component/Security/Core/User/ChainUserChecker.php
+++ b/src/Symfony/Component/Security/Core/User/ChainUserChecker.php
@@ -29,13 +29,8 @@ final class ChainUserChecker implements UserCheckerInterface
         }
     }
 
-    /**
-     * @param ?TokenInterface $token
-     */
-    public function checkPostAuth(UserInterface $user /* , ?TokenInterface $token = null */): void
+    public function checkPostAuth(UserInterface $user, ?TokenInterface $token = null): void
     {
-        $token = 1 < \func_num_args() ? func_get_arg(1) : null;
-
         foreach ($this->checkers as $checker) {
             $checker->checkPostAuth($user, $token);
         }

--- a/src/Symfony/Component/Security/Core/User/InMemoryUserChecker.php
+++ b/src/Symfony/Component/Security/Core/User/InMemoryUserChecker.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Security\Core\User;
 
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\DisabledException;
 
 /**
@@ -33,10 +34,7 @@ class InMemoryUserChecker implements UserCheckerInterface
         }
     }
 
-    /**
-     * @param ?TokenInterface $token
-     */
-    public function checkPostAuth(UserInterface $user /* , ?TokenInterface $token = null */): void
+    public function checkPostAuth(UserInterface $user, ?TokenInterface $token = null): void
     {
     }
 }

--- a/src/Symfony/Component/Security/Core/User/UserCheckerInterface.php
+++ b/src/Symfony/Component/Security/Core/User/UserCheckerInterface.php
@@ -34,9 +34,7 @@ interface UserCheckerInterface
     /**
      * Checks the user account after authentication.
      *
-     * @param ?TokenInterface $token
-     *
      * @throws AccountStatusException
      */
-    public function checkPostAuth(UserInterface $user /* , ?TokenInterface $token = null */): void;
+    public function checkPostAuth(UserInterface $user, ?TokenInterface $token = null): void;
 }

--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\Security\Http\Authentication;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\AuthenticationEvents;
@@ -66,10 +65,8 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
      * @param BadgeInterface[]     $badges     Optionally, pass some Passport badges to use for the manual login
      * @param array<string, mixed> $attributes Optionally, pass some Passport attributes to use for the manual login
      */
-    public function authenticateUser(UserInterface $user, AuthenticatorInterface $authenticator, Request $request, array $badges = [] /* , array $attributes = [] */): ?Response
+    public function authenticateUser(UserInterface $user, AuthenticatorInterface $authenticator, Request $request, array $badges = [], array $attributes = []): ?Response
     {
-        $attributes = 4 < \func_num_args() ? func_get_arg(4) : [];
-
         // create an authentication token for the User
         $passport = new SelfValidatingPassport(new UserBadge($user->getUserIdentifier(), fn () => $user), $badges);
         foreach ($attributes as $k => $v) {

--- a/src/Symfony/Component/Security/Http/Authentication/UserAuthenticatorInterface.php
+++ b/src/Symfony/Component/Security/Http/Authentication/UserAuthenticatorInterface.php
@@ -29,5 +29,5 @@ interface UserAuthenticatorInterface
      * @param BadgeInterface[]     $badges     Optionally, pass some Passport badges to use for the manual login
      * @param array<string, mixed> $attributes Optionally, pass some Passport attributes to use for the manual login
      */
-    public function authenticateUser(UserInterface $user, AuthenticatorInterface $authenticator, Request $request, array $badges = [] /* , array $attributes = [] */): ?Response;
+    public function authenticateUser(UserInterface $user, AuthenticatorInterface $authenticator, Request $request, array $badges = [], array $attributes = []): ?Response;
 }

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Throw a `BadCredentialsException` when passing an empty string as `$userIdentifier` argument to `UserBadge` constructor
  * Accept only `ExposeSecurityLevel` enums for `AuthenticatorManager`'s `$exposeSecurityErrors` argument
  * Respectively accept only `AlgorithmManager` and `JWKSet` for `OidcTokenHandler`'s `$signatureAlgorithm` and `$signatureKeyset` arguments
+ * Add argument `$attributes` to `UserAuthenticatorInterface::authenticateUser()`
 
 7.4
 ---

--- a/src/Symfony/Component/Uid/CHANGELOG.md
+++ b/src/Symfony/Component/Uid/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.0
+---
+
+ * Add argument `$format` to `Uuid::isValid()`
+
 7.4
 ---
 

--- a/src/Symfony/Component/Uid/Uuid.php
+++ b/src/Symfony/Component/Uid/Uuid.php
@@ -127,10 +127,8 @@ class Uuid extends AbstractUid
     /**
      * @param int-mask-of<Uuid::FORMAT_*> $format
      */
-    public static function isValid(string $uuid /* , int $format = self::FORMAT_RFC_9562 */): bool
+    public static function isValid(string $uuid, int $format = self::FORMAT_RFC_9562): bool
     {
-        $format = 1 < \func_num_args() ? func_get_arg(1) : self::FORMAT_RFC_9562;
-
         if (36 === \strlen($uuid) && !($format & self::FORMAT_RFC_9562)) {
             return false;
         }

--- a/src/Symfony/Component/Webhook/CHANGELOG.md
+++ b/src/Symfony/Component/Webhook/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.0
+---
+
+ * Add argument `$request` to `RequestParserInterface::createSuccessfulResponse()` and `RequestParserInterface::createRejectedResponse()`
+
 7.2
 ---
 

--- a/src/Symfony/Component/Webhook/Client/AbstractRequestParser.php
+++ b/src/Symfony/Component/Webhook/Client/AbstractRequestParser.php
@@ -29,18 +29,12 @@ abstract class AbstractRequestParser implements RequestParserInterface
         return $this->doParse($request, $secret);
     }
 
-    /**
-     * @param Request|null $request The original request that was received by the webhook controller
-     */
-    public function createSuccessfulResponse(/* ?Request $request = null */): Response
+    public function createSuccessfulResponse(?Request $request = null): Response
     {
         return new Response('', 202);
     }
 
-    /**
-     * @param Request|null $request The original request that was received by the webhook controller
-     */
-    public function createRejectedResponse(string $reason/* , ?Request $request = null */): Response
+    public function createRejectedResponse(string $reason, ?Request $request = null): Response
     {
         return new Response($reason, 406);
     }

--- a/src/Symfony/Component/Webhook/Client/RequestParserInterface.php
+++ b/src/Symfony/Component/Webhook/Client/RequestParserInterface.php
@@ -33,10 +33,10 @@ interface RequestParserInterface
     /**
      * @param Request|null $request The original request that was received by the webhook controller
      */
-    public function createSuccessfulResponse(/* ?Request $request = null */): Response;
+    public function createSuccessfulResponse(?Request $request = null): Response;
 
     /**
      * @param Request|null $request The original request that was received by the webhook controller
      */
-    public function createRejectedResponse(string $reason/* , ?Request $request = null */): Response;
+    public function createRejectedResponse(string $reason, ?Request $request = null): Response;
 }

--- a/src/Symfony/Component/Workflow/CHANGELOG.md
+++ b/src/Symfony/Component/Workflow/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.0
 ---
 
+ * Add `$nbToken` argument to `Marking::mark()` and `Marking::unmark()`
  * Remove `Event::getWorkflow()` method
 
    *Before*

--- a/src/Symfony/Component/Workflow/Marking.php
+++ b/src/Symfony/Component/Workflow/Marking.php
@@ -32,14 +32,10 @@ class Marking
     }
 
     /**
-     * @param int $nbToken
-     *
      * @psalm-param int<1, max> $nbToken
      */
-    public function mark(string $place /* , int $nbToken = 1 */): void
+    public function mark(string $place, int $nbToken = 1): void
     {
-        $nbToken = 1 < \func_num_args() ? func_get_arg(1) : 1;
-
         if ($nbToken < 1) {
             throw new \InvalidArgumentException(\sprintf('The number of tokens must be greater than 0, "%s" given.', $nbToken));
         }
@@ -49,14 +45,10 @@ class Marking
     }
 
     /**
-     * @param int $nbToken
-     *
      * @psalm-param int<1, max> $nbToken
      */
-    public function unmark(string $place /* , int $nbToken = 1 */): void
+    public function unmark(string $place, int $nbToken = 1): void
     {
-        $nbToken = 1 < \func_num_args() ? func_get_arg(1) : 1;
-
         if ($nbToken < 1) {
             throw new \InvalidArgumentException(\sprintf('The number of tokens must be greater than 0, "%s" given.', $nbToken));
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

 * Add argument `$info` to `ArrayNodeDefinition::canBeDisabled()` and `canBeEnabled()`
 * Add argument `$finishedIndicator` to `ProgressIndicator::finish()`
 * Add argument `$target` to `ContainerBuilder::registerAliasForArgument()`
 * Add arguments `$v4Bytes` and `$v6Bytes` to `IpUtils::anonymize()`
 * Add argument `$partitioned` to `ResponseHeaderBag::clearCookie()`
 * Add argument `$expiration` to `UriSigner::sign()`
 * Add argument `$logChannel` to `ErrorListener::logException()`
 * Add argument `$accessDecision` to `AccessDecisionManagerInterface::decide()` and `AuthorizationCheckerInterface::isGranted()`
 * Add argument `$vote` to `VoterInterface::vote()` and `Voter::voteOnAttribute()`
 * Add argument `$token` to `UserCheckerInterface::checkPostAuth()`
 * Add argument `$attributes` to `UserAuthenticatorInterface::authenticateUser()`
 * Add argument `$format` to `Uuid::isValid()`
 * Add argument `$request` to `RequestParserInterface::createSuccessfulResponse()` and `RequestParserInterface::createRejectedResponse()`
 * Add `$nbToken` argument to `Marking::mark()` and `Marking::unmark()`
