### PR TITLE
Remove unused trait

### DIFF
--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/Passport/Badge/UserBadgeTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/Passport/Badge/UserBadgeTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Security\Http\Tests\Authenticator\Passport\Badge;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Bridge\PhpUnit\ExpectUserDeprecationMessageTrait;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
@@ -23,8 +22,6 @@ use function Symfony\Component\String\u;
 
 class UserBadgeTest extends TestCase
 {
-    use ExpectUserDeprecationMessageTrait;
-
     public function testUserNotFound()
     {
         $badge = new UserBadge('dummy', fn () => null);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? |no
| Issues        | 
| License       | MIT

The `ExpectUserDeprecationMessageTrait` is unused after f599e20e5dc5076e637bc1fca699ba19ed969118