### PR TITLE
[Security] Fix added $token argument to UserCheckerInterface::checkPostAuth()

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -986,7 +986,7 @@ class TestUserChecker implements UserCheckerInterface
     {
     }
 
-    public function checkPostAuth(UserInterface $user): void
+    public function checkPostAuth(UserInterface $user, ?TokenInterface $token = null): void
     {
     }
 }

--- a/src/Symfony/Component/Security/Core/User/ChainUserChecker.php
+++ b/src/Symfony/Component/Security/Core/User/ChainUserChecker.php
@@ -29,16 +29,15 @@ final class ChainUserChecker implements UserCheckerInterface
         }
     }
 
-    public function checkPostAuth(UserInterface $user /* , TokenInterface $token */): void
+    /**
+     * @param ?TokenInterface $token
+     */
+    public function checkPostAuth(UserInterface $user /* , ?TokenInterface $token = null */): void
     {
         $token = 1 < \func_num_args() ? func_get_arg(1) : null;
 
         foreach ($this->checkers as $checker) {
-            if ($token instanceof TokenInterface) {
-                $checker->checkPostAuth($user, $token);
-            } else {
-                $checker->checkPostAuth($user);
-            }
+            $checker->checkPostAuth($user, $token);
         }
     }
 }

--- a/src/Symfony/Component/Security/Core/User/InMemoryUserChecker.php
+++ b/src/Symfony/Component/Security/Core/User/InMemoryUserChecker.php
@@ -33,7 +33,10 @@ class InMemoryUserChecker implements UserCheckerInterface
         }
     }
 
-    public function checkPostAuth(UserInterface $user): void
+    /**
+     * @param ?TokenInterface $token
+     */
+    public function checkPostAuth(UserInterface $user /* , ?TokenInterface $token = null */): void
     {
     }
 }

--- a/src/Symfony/Component/Security/Core/User/UserCheckerInterface.php
+++ b/src/Symfony/Component/Security/Core/User/UserCheckerInterface.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Security\Core\User;
 
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AccountStatusException;
 
 /**
@@ -33,7 +34,9 @@ interface UserCheckerInterface
     /**
      * Checks the user account after authentication.
      *
+     * @param ?TokenInterface $token
+     *
      * @throws AccountStatusException
      */
-    public function checkPostAuth(UserInterface $user /* , TokenInterface $token */): void;
+    public function checkPostAuth(UserInterface $user /* , ?TokenInterface $token = null */): void;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

An added argument must be optional and must be declared using `@param`, which will allow spotting all places that have to be updated in cascade. This PR fixes all that. Not sure how we messed up so badly in #57773 :sweat_smile: 