### PR TITLE
[HttpFoundation] Simplify UriSigner::verify to use match

### DIFF
--- a/src/Symfony/Component/HttpFoundation/UriSigner.php
+++ b/src/Symfony/Component/HttpFoundation/UriSigner.php
@@ -121,19 +121,12 @@ class UriSigner
         $uri = self::normalize($uri);
         $status = $this->doVerify($uri);
 
-        if (self::STATUS_VALID === $status) {
-            return;
-        }
-
-        if (self::STATUS_MISSING === $status) {
-            throw new UnsignedUriException();
-        }
-
-        if (self::STATUS_INVALID === $status) {
-            throw new UnverifiedSignedUriException();
-        }
-
-        throw new ExpiredSignedUriException();
+        match ($status) {
+            self::STATUS_VALID => null,
+            self::STATUS_INVALID => throw new UnverifiedSignedUriException(),
+            self::STATUS_EXPIRED => throw new ExpiredSignedUriException(),
+            default => throw new UnsignedUriException(),
+        };
     }
 
     private function computeHash(string $uri): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4 
| Bug fix?      |no
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

Simplify UriSigner::verify to use match.

/cc @kbond what do you think?