### PR TITLE
[ObjectMapper] Fix test using LazyObjectInterface

### DIFF
--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/LazyFoo.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/LazyFoo.php
@@ -11,12 +11,28 @@
 
 namespace Symfony\Component\ObjectMapper\Tests\Fixtures;
 
-use Symfony\Component\VarExporter\LazyGhostTrait;
 use Symfony\Component\VarExporter\LazyObjectInterface;
 
 class LazyFoo extends \stdClass implements LazyObjectInterface
 {
-    use LazyGhostTrait;
+    private bool $initialized = false;
 
-    public string $name = 'foo';
+    public function isLazyObjectInitialized(bool $partial = false): bool
+    {
+        return $this->initialized;
+    }
+
+    public function initializeLazyObject(): object
+    {
+        $this->initialized = true;
+
+        return $this;
+    }
+
+    public function resetLazyObject(): bool
+    {
+        $this->initialized = false;
+
+        return true;
+    }
 }

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -371,9 +371,6 @@ final class ObjectMapperTest extends TestCase
         yield [new ObjectMapper(new ReflectionObjectMapperMetadataFactory(), PropertyAccess::createPropertyAccessor())];
     }
 
-    /**
-     * @group legacy
-     */
     public function testMapInitializesLazyObject()
     {
         $lazy = new LazyFoo();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Instead of #61191 and #61192