### PR TITLE
[Security] Support union type for `#[CurrentUser]` attribute

### DIFF
--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 7.4
 ---
 
+ * Add support for union types with `#[CurrentUser]`
  * Deprecate callable firewall listeners, extend `AbstractListener` or implement `FirewallListenerInterface` instead
  * Deprecate `AbstractListener::__invoke`
 

--- a/src/Symfony/Component/Security/Http/Controller/UserValueResolver.php
+++ b/src/Symfony/Component/Security/Http/Controller/UserValueResolver.php
@@ -57,6 +57,13 @@ final class UserValueResolver implements ValueResolverInterface
             return [$user];
         }
 
+        $types = explode('|', $argument->getType());
+        foreach ($types as $type) {
+            if ($user instanceof $type) {
+                return [$user];
+            }
+        }
+
         throw new AccessDeniedException(\sprintf('The logged-in user is an instance of "%s" but a user of type "%s" is expected.', $user::class, $argument->getType()));
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Controller/UserValueResolverTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Controller/UserValueResolverTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\User\InMemoryUser;
+use Symfony\Component\Security\Core\User\OAuth2User;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
 use Symfony\Component\Security\Http\Controller\UserValueResolver;
@@ -105,6 +106,19 @@ class UserValueResolverTest extends TestCase
 
         $resolver = new UserValueResolver($tokenStorage);
         $metadata = new ArgumentMetadata('foo', InMemoryUser::class, false, false, null, false, [new CurrentUser()]);
+
+        $this->assertSame([$user], $resolver->resolve(Request::create('/'), $metadata));
+    }
+
+    public function testResolveSucceedsWithUnionTypedAttribute()
+    {
+        $user = new InMemoryUser('username', 'password');
+        $token = new UsernamePasswordToken($user, 'provider');
+        $tokenStorage = new TokenStorage();
+        $tokenStorage->setToken($token);
+
+        $resolver = new UserValueResolver($tokenStorage);
+        $metadata = new ArgumentMetadata('foo', InMemoryUser::class.'|'.OAuth2User::class, false, false, null, false, [new CurrentUser()]);
 
         $this->assertSame([$user], $resolver->resolve(Request::create('/'), $metadata));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #...
| License       | MIT


Currently `#[CurrentUser] User1|User2 $user` doesn't work.