### PR TITLE
Fix potential typo in PHPDoc of `SessionInterface`

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/SessionInterface.php
+++ b/src/Symfony/Component/HttpFoundation/Session/SessionInterface.php
@@ -50,7 +50,7 @@ interface SessionInterface
     /**
      * Invalidates the current session.
      *
-     * Clears all session attributes and flashes and regenerates the
+     * Clears all session attributes and flushes and regenerates the
      * session and deletes the old session from persistence.
      *
      * @param int|null $lifetime Sets the cookie lifetime for the session cookie. A null value


### PR DESCRIPTION
I'm not entirely sure, and I'm not a native English speaker, but it sounds strange to me.