### PR TITLE
[HttpKernel] Remove outdated phpdoc

### DIFF
--- a/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadata.php
+++ b/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadata.php
@@ -46,8 +46,6 @@ class ArgumentMetadata
 
     /**
      * Returns the type of the argument.
-     *
-     * The type is the PHP class in 5.5+ and additionally the basic type in PHP 7.0+.
      */
     public function getType(): ?string
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

`ArgumentMetadataFactory` now always use `\ReflectionParameter` type
