### PR TITLE
[Form][PhpUnitBridge] Remove usage of noop `ReflectionProperty::setAccessible()`

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/CoverageListener.php
+++ b/src/Symfony/Bridge/PhpUnit/CoverageListener.php
@@ -86,7 +86,6 @@ class CoverageListener implements TestListener
     private function addCoversForClassToAnnotationCache(Test $test, array $covers): void
     {
         $r = new \ReflectionProperty(TestUtil::class, 'annotationCache');
-        $r->setAccessible(true);
 
         $cache = $r->getValue();
         $cache = array_replace_recursive($cache, [
@@ -103,7 +102,6 @@ class CoverageListener implements TestListener
         $docBlock = Registry::getInstance()->forClassName(\get_class($test));
 
         $symbolAnnotations = new \ReflectionProperty($docBlock, 'symbolAnnotations');
-        $symbolAnnotations->setAccessible(true);
 
         // Exclude internal classes; PHPUnit 9.1+ is picky about tests covering, say, a \RuntimeException
         $covers = array_filter($covers, function (string $class) {

--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Deprecation.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Deprecation.php
@@ -437,7 +437,6 @@ class Deprecation
     {
         $exception = new \Exception($this->message);
         $reflection = new \ReflectionProperty($exception, 'trace');
-        $reflection->setAccessible(true);
         $reflection->setValue($exception, $this->trace);
 
         return ($this->originatesFromAnObject() ? 'deprecation triggered by '.$this->originatingClass().'::'.$this->originatingMethod().":\n" : '')

--- a/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
@@ -357,7 +357,6 @@ class SymfonyTestsListenerTrait
         }
 
         $r = new \ReflectionProperty($test, 'runTestInSeparateProcess');
-        $r->setAccessible(true);
 
         return $r->getValue($test) ?? false;
     }

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/DeprecationTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/DeprecationTest.php
@@ -275,7 +275,6 @@ class DeprecationTest extends TestCase
                     $loader = require $v.'/autoload.php';
                     $reflection = new \ReflectionClass($loader);
                     $prop = $reflection->getProperty('prefixDirsPsr4');
-                    $prop->setAccessible(true);
                     $currentValue = $prop->getValue($loader);
                     self::$prefixDirsPsr4[] = [$prop, $loader, $currentValue];
                     $currentValue['Symfony\\Bridge\\PhpUnit\\'] = [realpath(__DIR__.'/../..')];

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
@@ -420,7 +420,6 @@ class ContainerTest extends TestCase
         $container->compile();
 
         $r = new \ReflectionMethod($container, 'getEnv');
-        $r->setAccessible(true);
         $this->assertNull($r->invoke($container, 'FOO'));
     }
 
@@ -436,7 +435,6 @@ class ContainerTest extends TestCase
         $container->compile();
 
         $r = new \ReflectionMethod($container, 'getEnv');
-        $r->setAccessible(true);
         $this->assertNull($r->invoke($container, 'FOO'));
     }
 }

--- a/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
@@ -34,7 +34,6 @@ class ErrorHandlerTest extends TestCase
     protected function tearDown(): void
     {
         $r = new \ReflectionProperty(ErrorHandler::class, 'exitCode');
-        $r->setAccessible(true);
         $r->setValue(null, 0);
     }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
@@ -754,7 +754,6 @@ class NumberToLocalizedStringTransformerTest extends TestCase
         // Use reflection to test the private round() method directly
         $reflection = new \ReflectionClass($transformer);
         $roundMethod = $reflection->getMethod('round');
-        $roundMethod->setAccessible(true);
 
         $int = \PHP_INT_MAX - 1;
         $result = $roundMethod->invoke($transformer, $int);

--- a/src/Symfony/Component/Mailer/Tests/Transport/SendmailTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/SendmailTransportTest.php
@@ -94,7 +94,6 @@ class SendmailTransportTest extends TestCase
         $sendmailTransport->send($mail, $envelope);
 
         $streamProperty = new \ReflectionProperty(SendmailTransport::class, 'stream');
-        $streamProperty->setAccessible(true);
         $stream = $streamProperty->getValue($sendmailTransport);
         $this->assertNull($stream->stream);
     }
@@ -112,10 +111,8 @@ class SendmailTransportTest extends TestCase
         }
 
         $streamProperty = new \ReflectionProperty(SendmailTransport::class, 'stream');
-        $streamProperty->setAccessible(true);
         $stream = $streamProperty->getValue($sendmailTransport);
         $innerStreamProperty = new \ReflectionProperty(ProcessStream::class, 'stream');
-        $innerStreamProperty->setAccessible(true);
         $this->assertNull($innerStreamProperty->getValue($stream));
     }
 
@@ -127,7 +124,6 @@ class SendmailTransportTest extends TestCase
 
         $sendmailTransport = new SendmailTransport(self::FAKE_INTERACTIVE_SENDMAIL);
         $transportProperty = new \ReflectionProperty(SendmailTransport::class, 'transport');
-        $transportProperty->setAccessible(true);
 
         // Replace the transport with an anonymous consumer that trigger the stream methods
         $transportProperty->setValue($sendmailTransport, new class($transportProperty->getValue($sendmailTransport)->getStream()) extends SmtpTransport {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

As of PHP 8.1.0, calling this method has no effect; all properties are accessible by default. Symfony 7.x requires PHP 8.2+.

https://www.php.net/manual/en/reflectionproperty.setaccessible.php

**Notes:** 
- `Component/ErrorHandler/Internal/TentativeTypes.php` is auto-generated, didn't touch it.
- ~~targeted 7.3 because support for 7.2 ends in a few days.~~ 
- [now targets 6.4](https://github.com/symfony/symfony/pull/61207#issuecomment-3108882814)
