### PR TITLE
[Serializer][VarDumper] Remove require php 8.2 from tests

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -178,9 +178,6 @@ class PropertyNormalizerTest extends TestCase
         $this->assertEquals('bar', $obj->getBar());
     }
 
-    /**
-     * @requires PHP 8.2
-     */
     public function testDenormalizeWithReadOnlyClass()
     {
         /** @var ChildClassDummy $object */

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
@@ -404,9 +404,6 @@ EOTXT
         );
     }
 
-    /**
-     * @requires PHP 8.2
-     */
     public function testNullReturnType()
     {
         $className = Php82NullStandaloneReturnType::class;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | no
| License       | MIT

[Reference](https://github.com/symfony/symfony/pull/61189)