### PR TITLE
[JsonStreamer] update `.gitattributes` paths for `JsonStreamer`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,7 +7,7 @@
 /src/Symfony/Component/Translation/Bridge export-ignore
 /src/Symfony/Component/Emoji/Resources/data/* linguist-generated=true
 /src/Symfony/Component/Intl/Resources/data/*/* linguist-generated=true
-/src/Symfony/Component/JsonEncoder/Tests/Fixtures/encoder/* linguist-generated=true
-/src/Symfony/Component/JsonEncoder/Tests/Fixtures/decoder/* linguist-generated=true
+/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/* linguist-generated=true
+/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/* linguist-generated=true
 /src/Symfony/**/.github/workflows/close-pull-request.yml linguist-generated=true
 /src/Symfony/**/.github/PULL_REQUEST_TEMPLATE.md linguist-generated=true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | no
| License       | MIT

`JsonEncoder` was renamed to `JsonStreamer`, but `.gitattributes` paths were not updated.
