### PR TITLE
[HttpFoundation] Add `application/soap+xml`

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1912,7 +1912,7 @@ class Request
             'css' => ['text/css'],
             'json' => ['application/json', 'application/x-json'],
             'jsonld' => ['application/ld+json'],
-            'xml' => ['text/xml', 'application/xml', 'application/x-xml'],
+            'xml' => ['text/xml', 'application/xml', 'application/x-xml', 'application/soap+xml'],
             'rdf' => ['application/rdf+xml'],
             'atom' => ['application/atom+xml'],
             'rss' => ['application/rss+xml'],

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -528,7 +528,7 @@ class RequestTest extends TestCase
             ['css', ['text/css']],
             ['json', ['application/json', 'application/x-json']],
             ['jsonld', ['application/ld+json']],
-            ['xml', ['text/xml', 'application/xml', 'application/x-xml']],
+            ['xml', ['text/xml', '$', 'application/x-xml', 'application/soap+xml']],
             ['rdf', ['application/rdf+xml']],
             ['atom', ['application/atom+xml']],
             ['form', ['application/x-www-form-urlencoded', 'multipart/form-data']],

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -528,7 +528,7 @@ class RequestTest extends TestCase
             ['css', ['text/css']],
             ['json', ['application/json', 'application/x-json']],
             ['jsonld', ['application/ld+json']],
-            ['xml', ['text/xml', '$', 'application/x-xml', 'application/soap+xml']],
+            ['xml', ['text/xml', 'application/xml', 'application/x-xml', 'application/soap+xml']],
             ['rdf', ['application/rdf+xml']],
             ['atom', ['application/atom+xml']],
             ['form', ['application/x-www-form-urlencoded', 'multipart/form-data']],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #...
| License       | MIT

Added application/soap+xml as a format. This ensures that getContentTypeFormat() returns 'xml' instead of null.