### PR TITLE
[EventDispatcher] Add `events` attribute of the `kernel.event_listener` tag

### DIFF
--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -28,6 +28,10 @@ DoctrineBridge
 
  * Deprecate `UniqueEntity::getRequiredOptions()` and `UniqueEntity::getDefaultOption()`
 
+EventDispatcher
+---------------
+ * Deprecate attribute `event` of the `kernel.event_listener` tag  in favor of `events` attribute
+
 FrameworkBundle
 ---------------
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1205,9 +1205,9 @@ class FrameworkExtension extends Extension
             if ($workflow['audit_trail']['enabled']) {
                 $listener = new Definition(Workflow\EventListener\AuditTrailListener::class);
                 $listener->addTag('monolog.logger', ['channel' => 'workflow']);
-                $listener->addTag('kernel.event_listener', ['event' => \sprintf('workflow.%s.leave', $name), 'method' => 'onLeave']);
-                $listener->addTag('kernel.event_listener', ['event' => \sprintf('workflow.%s.transition', $name), 'method' => 'onTransition']);
-                $listener->addTag('kernel.event_listener', ['event' => \sprintf('workflow.%s.enter', $name), 'method' => 'onEnter']);
+                $listener->addTag('kernel.event_listener', ['events' => \sprintf('workflow.%s.leave', $name), 'method' => 'onLeave']);
+                $listener->addTag('kernel.event_listener', ['events' => \sprintf('workflow.%s.transition', $name), 'method' => 'onTransition']);
+                $listener->addTag('kernel.event_listener', ['events' => \sprintf('workflow.%s.enter', $name), 'method' => 'onEnter']);
                 $listener->addArgument(new Reference('logger'));
                 $container->setDefinition(\sprintf('.%s.listener.audit_trail', $workflowId), $listener);
             }
@@ -1234,7 +1234,7 @@ class FrameworkExtension extends Extension
                     new Reference('validator', ContainerInterface::NULL_ON_INVALID_REFERENCE),
                 ]);
                 foreach ($guardsConfiguration as $eventName => $config) {
-                    $guard->addTag('kernel.event_listener', ['event' => $eventName, 'method' => 'onTransition']);
+                    $guard->addTag('kernel.event_listener', ['events' => $eventName, 'method' => 'onTransition']);
                 }
 
                 $container->setDefinition(\sprintf('.%s.listener.guard', $workflowId), $guard);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/collectors.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/collectors.php
@@ -73,7 +73,7 @@ return static function (ContainerConfigurator $container) {
             ->tag('data_collector', ['template' => '@WebProfiler/Collector/memory.html.twig', 'id' => 'memory', 'priority' => 325])
 
         ->set('data_collector.router', RouterDataCollector::class)
-            ->tag('kernel.event_listener', ['event' => KernelEvents::CONTROLLER, 'method' => 'onKernelController'])
+            ->tag('kernel.event_listener', ['events' => KernelEvents::CONTROLLER, 'method' => 'onKernelController'])
             ->tag('data_collector', ['template' => '@WebProfiler/Collector/router.html.twig', 'id' => 'router', 'priority' => 285])
 
         ->set('.data_collector.command', CommandDataCollector::class)

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/security_csrf.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/security_csrf.php
@@ -59,6 +59,6 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('framework.csrf_protection.cookie_name'),
             ])
             ->tag('monolog.logger', ['channel' => 'request'])
-            ->tag('kernel.event_listener', ['event' => 'kernel.response', 'method' => 'onKernelResponse'])
+            ->tag('kernel.event_listener', ['events' => 'kernel.response', 'method' => 'onKernelResponse'])
     ;
 };

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -509,7 +509,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $guardDefinition = $container->getDefinition('.workflow.article.listener.guard');
         $this->assertSame([
             [
-                'event' => 'workflow.article.guard.publish',
+                'events' => 'workflow.article.guard.publish',
                 'method' => 'onTransition',
             ],
         ], $guardDefinition->getTag('kernel.event_listener'));

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -24,7 +24,7 @@
         "symfony/dependency-injection": "^7.2|^8.0",
         "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/error-handler": "^7.3|^8.0",
-        "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
+        "symfony/event-dispatcher": "^7.4|^8.0",
         "symfony/http-foundation": "^7.3|^8.0",
         "symfony/http-kernel": "^7.2|^8.0",
         "symfony/polyfill-mbstring": "~1.0",

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -391,7 +391,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
             $defaultProvider = $providerIds[$normalizedName];
 
             $container->setDefinition('security.listener.'.$id.'.user_provider', new ChildDefinition('security.listener.user_provider.abstract'))
-                ->addTag('kernel.event_listener', ['dispatcher' => $firewallEventDispatcherId, 'event' => CheckPassportEvent::class, 'priority' => 2048, 'method' => 'checkPassport'])
+                ->addTag('kernel.event_listener', ['dispatcher' => $firewallEventDispatcherId, 'events' => CheckPassportEvent::class, 'priority' => 2048, 'method' => 'checkPassport'])
                 ->replaceArgument(0, new Reference($defaultProvider));
         } elseif (1 === \count($providerIds)) {
             $defaultProvider = reset($providerIds);
@@ -602,7 +602,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
         $listener->replaceArgument(2, $contextKey);
         if (null !== $firewallEventDispatcherId) {
             $listener->replaceArgument(4, new Reference($firewallEventDispatcherId));
-            $listener->addTag('kernel.event_listener', ['event' => KernelEvents::RESPONSE, 'method' => 'onKernelResponse']);
+            $listener->addTag('kernel.event_listener', ['events' => KernelEvents::RESPONSE, 'method' => 'onKernelResponse']);
         }
 
         return $this->contextListeners[$contextKey] = $listenerId;

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator.php
@@ -75,7 +75,7 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 service('security.user_providers'),
             ])
-            ->tag('kernel.event_listener', ['event' => CheckPassportEvent::class, 'priority' => 1024, 'method' => 'checkPassport'])
+            ->tag('kernel.event_listener', ['events' => CheckPassportEvent::class, 'priority' => 1024, 'method' => 'checkPassport'])
 
         ->set('security.listener.user_provider.abstract', UserProviderListener::class)
             ->abstract()

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/RegisterGlobalSecurityEventListenersPassTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/RegisterGlobalSecurityEventListenersPassTest.php
@@ -60,7 +60,7 @@ class RegisterGlobalSecurityEventListenersPassTest extends TestCase
         ]);
 
         $this->container->register('app.security_listener', \stdClass::class)
-            ->addTag('kernel.event_listener', ['method' => 'onEvent', 'event' => $configuredEvent]);
+            ->addTag('kernel.event_listener', ['method' => 'onEvent', 'events' => $configuredEvent]);
 
         $this->container->compile();
 
@@ -93,9 +93,9 @@ class RegisterGlobalSecurityEventListenersPassTest extends TestCase
         ]);
 
         $this->container->register('app.security_listener', \stdClass::class)
-            ->addTag('kernel.event_listener', ['method' => 'onLogout', 'event' => LogoutEvent::class])
-            ->addTag('kernel.event_listener', ['method' => 'onLoginSuccess', 'event' => LoginSuccessEvent::class, 'priority' => 20])
-            ->addTag('kernel.event_listener', ['method' => 'onAuthenticationSuccess', 'event' => AuthenticationEvents::AUTHENTICATION_SUCCESS]);
+            ->addTag('kernel.event_listener', ['method' => 'onLogout', 'events' => LogoutEvent::class])
+            ->addTag('kernel.event_listener', ['method' => 'onLoginSuccess', 'events' => LoginSuccessEvent::class, 'priority' => 20])
+            ->addTag('kernel.event_listener', ['method' => 'onAuthenticationSuccess', 'events' => AuthenticationEvents::AUTHENTICATION_SUCCESS]);
 
         $this->container->compile();
 
@@ -136,9 +136,9 @@ class RegisterGlobalSecurityEventListenersPassTest extends TestCase
             ->setPublic(true);
 
         $this->container->register('app.security_listener', \stdClass::class)
-            ->addTag('kernel.event_listener', ['method' => 'onLogout', 'event' => LogoutEvent::class])
-            ->addTag('kernel.event_listener', ['method' => 'onLoginSuccess', 'event' => LoginSuccessEvent::class, 'priority' => 20])
-            ->addTag('kernel.event_listener', ['method' => 'onAuthenticationSuccess', 'event' => AuthenticationEvents::AUTHENTICATION_SUCCESS]);
+            ->addTag('kernel.event_listener', ['method' => 'onLogout', 'events' => LogoutEvent::class])
+            ->addTag('kernel.event_listener', ['method' => 'onLoginSuccess', 'events' => LoginSuccessEvent::class, 'priority' => 20])
+            ->addTag('kernel.event_listener', ['method' => 'onAuthenticationSuccess', 'events' => AuthenticationEvents::AUTHENTICATION_SUCCESS]);
 
         $this->container->compile();
 
@@ -165,9 +165,9 @@ class RegisterGlobalSecurityEventListenersPassTest extends TestCase
             ->setPublic(true);
 
         $this->container->register('app.security_listener', \stdClass::class)
-            ->addTag('kernel.event_listener', ['method' => 'onLogout', 'event' => LogoutEvent::class, 'dispatcher' => 'security.event_dispatcher.main'])
-            ->addTag('kernel.event_listener', ['method' => 'onLoginSuccess', 'event' => LoginSuccessEvent::class, 'priority' => 20])
-            ->addTag('kernel.event_listener', ['method' => 'onAuthenticationSuccess', 'event' => AuthenticationEvents::AUTHENTICATION_SUCCESS]);
+            ->addTag('kernel.event_listener', ['method' => 'onLogout', 'events' => LogoutEvent::class, 'dispatcher' => 'security.event_dispatcher.main'])
+            ->addTag('kernel.event_listener', ['method' => 'onLoginSuccess', 'events' => LoginSuccessEvent::class, 'priority' => 20])
+            ->addTag('kernel.event_listener', ['method' => 'onAuthenticationSuccess', 'events' => AuthenticationEvents::AUTHENTICATION_SUCCESS]);
 
         $this->container->compile();
 

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -23,7 +23,7 @@
         "symfony/config": "^7.3|^8.0",
         "symfony/dependency-injection": "^6.4.11|^7.1.4|^8.0",
         "symfony/deprecation-contracts": "^2.5|^3",
-        "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
+        "symfony/event-dispatcher": "^7.4|^8.0",
         "symfony/http-kernel": "^6.4|^7.0|^8.0",
         "symfony/http-foundation": "^6.4|^7.0|^8.0",
         "symfony/password-hasher": "^6.4|^7.0|^8.0",

--- a/src/Symfony/Component/EventDispatcher/Attribute/AsEventListener.php
+++ b/src/Symfony/Component/EventDispatcher/Attribute/AsEventListener.php
@@ -20,16 +20,18 @@ namespace Symfony\Component\EventDispatcher\Attribute;
 class AsEventListener
 {
     /**
-     * @param string|null $event      The event name to listen to
-     * @param string|null $method     The method to run when the listened event is triggered
-     * @param int         $priority   The priority of this listener if several are declared for the same event
-     * @param string|null $dispatcher The service id of the event dispatcher to listen to
+     * @param string|null       $event      The event name to listen to
+     * @param string|null       $method     The method to run when the listened event is triggered
+     * @param int               $priority   The priority of this listener if several are declared for the same event
+     * @param string|null       $dispatcher The service id of the event dispatcher to listen to
+     * @param array|string|null $events     The event or events name to listen to
      */
     public function __construct(
         public ?string $event = null,
         public ?string $method = null,
         public int $priority = 0,
         public ?string $dispatcher = null,
+        public array|string|null $events = null,
     ) {
     }
 }

--- a/src/Symfony/Component/EventDispatcher/CHANGELOG.md
+++ b/src/Symfony/Component/EventDispatcher/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.4
+---
+ * Add `events` attribute of the `kernel.event_listener` tag
+ * Deprecated the `event` attribute of the `kernel.event_listener` tag
+
 6.0
 ---
 

--- a/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php
+++ b/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php
@@ -66,32 +66,52 @@ class RegisterListenersPass implements CompilerPassInterface
             $noPreload = 0;
 
             foreach ($events as $event) {
+                if (isset($event['event'])) {
+                    trigger_deprecation('symfony/event-dispatcher', '7.4', 'The "event" attribute of the `kernel.event_listener` tag is deprecated and will be removed in Symfony 8.0. Use "events" attribute instead.');
+                    if (isset($event['events'])) {
+                        throw new InvalidArgumentException('Cannot use both "event" and "events" attributes of the `kernel.event_listener` tag.');
+                    }
+                    $event['events'] = $event['event'];
+                }
                 $priority = $event['priority'] ?? 0;
 
-                if (!isset($event['event'])) {
+                if (!isset($event['events'])) {
                     if ($container->getDefinition($id)->hasTag('kernel.event_subscriber')) {
                         continue;
                     }
 
                     $event['method'] ??= '__invoke';
-                    $event['event'] = $this->getEventFromTypeDeclaration($container, $id, $event['method']);
+                    $event['events'] = $this->getEventFromTypeDeclaration($container, $id, $event['method']);
                 }
-
-                $event['event'] = $aliases[$event['event']] ?? $event['event'];
+                $event['events'] = array_map(fn (string $event) => $aliases[$event] ?? $event, (array) $event['events']);
 
                 if (!isset($event['method'])) {
-                    $event['method'] = 'on'.preg_replace_callback([
-                        '/(?<=\b|_)[a-z]/i',
-                        '/[^a-z0-9]/i',
-                    ], fn ($matches) => strtoupper($matches[0]), $event['event']);
-                    $event['method'] = preg_replace('/[^a-z0-9]/i', '', $event['method']);
+                    $class = $container->getDefinition($id)->getClass();
+                    $reflectionClass = null !== $class ? $container->getReflectionClass($class, false) : null;
+                    foreach ($event['events'] as $eventName) {
+                        $methodName = 'on'.preg_replace_callback([
+                            '/(?<=\b|_)[a-z]/i',
+                            '/[^a-z0-9]/i',
+                        ], fn ($matches) => strtoupper($matches[0]), $eventName);
+                        $methodName = preg_replace('/[^a-z0-9]/i', '', $methodName);
 
-                    if (null !== ($class = $container->getDefinition($id)->getClass()) && ($r = $container->getReflectionClass($class, false)) && !$r->hasMethod($event['method'])) {
-                        if (!$r->hasMethod('__invoke')) {
-                            throw new InvalidArgumentException(\sprintf('None of the "%s" or "__invoke" methods exist for the service "%s". Please define the "method" attribute on "kernel.event_listener" tags.', $event['method'], $id));
+                        if ($reflectionClass) {
+                            if ($reflectionClass->hasMethod($methodName)) {
+                                $event['method'] = $methodName;
+                                break;
+                            }
+                            if ($reflectionClass->hasMethod('__invoke')) {
+                                $event['method'] = '__invoke';
+                                break;
+                            }
+                        } else {
+                            $event['method'] = $methodName;
+                            break;
                         }
+                    }
 
-                        $event['method'] = '__invoke';
+                    if (!isset($event['method'])) {
+                        throw new InvalidArgumentException(\sprintf('None of the "%s" or "__invoke" methods exist for the service "%s". Please define the "method" attribute on "kernel.event_listener" tags.', $methodName, $id));
                     }
                 }
 
@@ -100,12 +120,13 @@ class RegisterListenersPass implements CompilerPassInterface
                     $dispatcherDefinition = $container->findDefinition($event['dispatcher']);
                 }
 
-                $dispatcherDefinition->addMethodCall('addListener', [$event['event'], [new ServiceClosureArgument(new Reference($id)), $event['method']], $priority]);
-
-                if (isset($this->hotPathEvents[$event['event']])) {
-                    $container->getDefinition($id)->addTag('container.hot_path');
-                } elseif (isset($this->noPreloadEvents[$event['event']])) {
-                    ++$noPreload;
+                foreach ($event['events'] as $eventName) {
+                    $dispatcherDefinition->addMethodCall('addListener', [$eventName, [new ServiceClosureArgument(new Reference($id)), $event['method']], $priority]);
+                    if (isset($this->hotPathEvents[$eventName])) {
+                        $container->getDefinition($id)->addTag('container.hot_path');
+                    } elseif (isset($this->noPreloadEvents[$eventName])) {
+                        ++$noPreload;
+                    }
                 }
             }
 
@@ -167,21 +188,43 @@ class RegisterListenersPass implements CompilerPassInterface
         }
     }
 
-    private function getEventFromTypeDeclaration(ContainerBuilder $container, string $id, string $method): string
+    /**
+     * @return string[]
+     */
+    private function getEventFromTypeDeclaration(ContainerBuilder $container, string $id, string $method): array
     {
         if (
             null === ($class = $container->getDefinition($id)->getClass())
             || !($r = $container->getReflectionClass($class, false))
             || !$r->hasMethod($method)
             || 1 > ($m = $r->getMethod($method))->getNumberOfParameters()
-            || !($type = $m->getParameters()[0]->getType()) instanceof \ReflectionNamedType
-            || $type->isBuiltin()
-            || Event::class === ($name = $type->getName())
         ) {
-            throw new InvalidArgumentException(\sprintf('Service "%s" must define the "event" attribute on "kernel.event_listener" tags.', $id));
+            throw new InvalidArgumentException(\sprintf('Service "%s" must define the "events" attribute on "kernel.event_listener" tags.', $id));
         }
 
-        return $name;
+        $type = $m->getParameters()[0]->getType();
+        if ($type instanceof \ReflectionNamedType) {
+            if ($type->isBuiltin() || Event::class === ($name = $type->getName())) {
+                throw new InvalidArgumentException(\sprintf('Service "%s" must define the "events" attribute on "kernel.event_listener" tags.', $id));
+            }
+
+            return [$name];
+        }
+
+        if ($type instanceof \ReflectionUnionType) {
+            $types = [];
+            foreach ($type->getTypes() as $type) {
+                if (!$type->isBuiltin()) {
+                    $types[] = $type->getName();
+                }
+            }
+
+            if ($types) {
+                return $types;
+            }
+        }
+
+        throw new InvalidArgumentException(\sprintf('Service "%s" must define the "events" attribute on "kernel.event_listener" tags.', $id));
     }
 }
 

--- a/src/Symfony/Component/EventDispatcher/Tests/DependencyInjection/RegisterListenersPassTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/DependencyInjection/RegisterListenersPassTest.php
@@ -23,6 +23,7 @@ use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\EventDispatcher\DependencyInjection\AddEventAliasesPass;
 use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\Tests\Fixtures\BizEvent;
 use Symfony\Component\EventDispatcher\Tests\Fixtures\CustomEvent;
 use Symfony\Component\EventDispatcher\Tests\Fixtures\TaggedInvokableListener;
 use Symfony\Component\EventDispatcher\Tests\Fixtures\TaggedMultiListener;
@@ -169,10 +170,10 @@ class RegisterListenersPassTest extends TestCase
         $container = new ContainerBuilder();
 
         $container->register('foo', SubscriberService::class)->addTag('kernel.event_subscriber', []);
-        $container->register('bar')->addTag('kernel.event_listener', ['event' => 'cold_event']);
+        $container->register('bar')->addTag('kernel.event_listener', ['events' => 'cold_event']);
         $container->register('baz')
-            ->addTag('kernel.event_listener', ['event' => 'event'])
-            ->addTag('kernel.event_listener', ['event' => 'cold_event']);
+            ->addTag('kernel.event_listener', ['events' => 'event'])
+            ->addTag('kernel.event_listener', ['events' => 'cold_event']);
         $container->register('event_dispatcher', 'stdClass');
 
         (new RegisterListenersPass())
@@ -206,14 +207,15 @@ class RegisterListenersPassTest extends TestCase
             public function onFooBar()
             {
             }
-        }))->addTag('kernel.event_listener', ['event' => 'foo.bar']);
-        $container->register('bar', InvokableListenerService::class)->addTag('kernel.event_listener', ['event' => 'foo.bar']);
-        $container->register('baz', InvokableListenerService::class)->addTag('kernel.event_listener', ['event' => 'event']);
+        }))->addTag('kernel.event_listener', ['events' => 'foo.bar']);
+        $container->register('bar', InvokableListenerService::class)->addTag('kernel.event_listener', ['events' => 'foo.bar']);
+        $container->register('baz', InvokableListenerService::class)->addTag('kernel.event_listener', ['events' => 'event']);
+        $container->register('biz', InvokableListenerService::class)->addTag('kernel.event_listener', ['events' => [CustomEvent::class, BizEvent::class]]);
         $container->register('zar', \get_class(new class {
             public function onFooBarZar()
             {
             }
-        }))->addTag('kernel.event_listener', ['event' => 'foo.bar_zar']);
+        }))->addTag('kernel.event_listener', ['events' => 'foo.bar_zar']);
         $container->register('event_dispatcher', \stdClass::class);
 
         $registerListenersPass = new RegisterListenersPass();
@@ -248,6 +250,22 @@ class RegisterListenersPassTest extends TestCase
             [
                 'addListener',
                 [
+                    CustomEvent::class,
+                    [new ServiceClosureArgument(new Reference('biz')), '__invoke'],
+                    0,
+                ],
+            ],
+            [
+                'addListener',
+                [
+                    BizEvent::class,
+                    [new ServiceClosureArgument(new Reference('biz')), '__invoke'],
+                    0,
+                ],
+            ],
+            [
+                'addListener',
+                [
                     'foo.bar_zar',
                     [new ServiceClosureArgument(new Reference('zar')), 'onFooBarZar'],
                     0,
@@ -264,7 +282,7 @@ class RegisterListenersPassTest extends TestCase
 
         $container = new ContainerBuilder();
 
-        $container->register('foo', \stdClass::class)->addTag('kernel.event_listener', ['event' => 'foo.bar']);
+        $container->register('foo', \stdClass::class)->addTag('kernel.event_listener', ['events' => 'foo.bar']);
         $container->register('event_dispatcher', \stdClass::class);
 
         $registerListenersPass = new RegisterListenersPass();
@@ -347,8 +365,64 @@ class RegisterListenersPassTest extends TestCase
             [
                 'addListener',
                 [
+                    CustomEvent::class,
+                    [new ServiceClosureArgument(new Reference('foo')), 'onMultipleEvents'],
+                    10,
+                ],
+            ],
+            [
+                'addListener',
+                [
+                    'foo',
+                    [new ServiceClosureArgument(new Reference('foo')), 'onMultipleEvents'],
+                    10,
+                ],
+            ],
+            [
+                'addListener',
+                [
+                    'bar',
+                    [new ServiceClosureArgument(new Reference('foo')), 'onMultipleEvents'],
+                    10,
+                ],
+            ],
+            [
+                'addListener',
+                [
+                    CustomEvent::class,
+                    [new ServiceClosureArgument(new Reference('foo')), '__invoke'],
+                    0,
+                ],
+            ],
+            [
+                'addListener',
+                [
+                    BizEvent::class,
+                    [new ServiceClosureArgument(new Reference('foo')), '__invoke'],
+                    0,
+                ],
+            ],
+            [
+                'addListener',
+                [
                     'baz',
                     [new ServiceClosureArgument(new Reference('foo')), 'onBazEvent'],
+                    0,
+                ],
+            ],
+            [
+                'addListener',
+                [
+                    BizEvent::class,
+                    [new ServiceClosureArgument(new Reference('foo')), 'onMultipleEventsWithSomeInvalids'],
+                    0,
+                ],
+            ],
+            [
+                'addListener',
+                [
+                    CustomEvent::class,
+                    [new ServiceClosureArgument(new Reference('foo')), 'onMultipleEventsWithSomeInvalids'],
                     0,
                 ],
             ],
@@ -361,8 +435,8 @@ class RegisterListenersPassTest extends TestCase
         $container = new ContainerBuilder();
         $eventAliases = [AliasedEvent::class => 'aliased_event'];
         $container->setParameter('event_dispatcher.event_aliases', $eventAliases);
-        $container->register('foo', InvokableListenerService::class)->addTag('kernel.event_listener', ['event' => AliasedEvent::class, 'method' => 'onEvent']);
-        $container->register('bar', InvokableListenerService::class)->addTag('kernel.event_listener', ['event' => CustomEvent::class, 'method' => 'onEvent']);
+        $container->register('foo', InvokableListenerService::class)->addTag('kernel.event_listener', ['events' => AliasedEvent::class, 'method' => 'onEvent']);
+        $container->register('bar', InvokableListenerService::class)->addTag('kernel.event_listener', ['events' => CustomEvent::class, 'method' => 'onEvent']);
         $container->register('event_dispatcher');
 
         $customEventAlias = [CustomEvent::class => 'custom_event'];
@@ -437,7 +511,7 @@ class RegisterListenersPassTest extends TestCase
         $container->register('event_dispatcher');
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Service "foo" must define the "event" attribute on "kernel.event_listener" tags.');
+        $this->expectExceptionMessage('Service "foo" must define the "events" attribute on "kernel.event_listener" tags.');
 
         $registerListenersPass = new RegisterListenersPass();
         $registerListenersPass->process($container);
@@ -450,7 +524,7 @@ class RegisterListenersPassTest extends TestCase
         $container->register('event_dispatcher');
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Service "foo" must define the "event" attribute on "kernel.event_listener" tags.');
+        $this->expectExceptionMessage('Service "foo" must define the "events" attribute on "kernel.event_listener" tags.');
 
         $registerListenersPass = new RegisterListenersPass();
         $registerListenersPass->process($container);
@@ -463,7 +537,7 @@ class RegisterListenersPassTest extends TestCase
         $container->register('event_dispatcher');
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Service "foo" must define the "event" attribute on "kernel.event_listener" tags.');
+        $this->expectExceptionMessage('Service "foo" must define the "events" attribute on "kernel.event_listener" tags.');
 
         $registerListenersPass = new RegisterListenersPass();
         $registerListenersPass->process($container);
@@ -475,7 +549,7 @@ class RegisterListenersPassTest extends TestCase
         $container->register('subscriber', IncompleteSubscriber::class)
             ->addTag('kernel.event_subscriber')
             ->addTag('kernel.event_listener')
-            ->addTag('kernel.event_listener', ['event' => 'bar', 'method' => 'onBar'])
+            ->addTag('kernel.event_listener', ['events' => 'bar', 'method' => 'onBar'])
         ;
         $container->register('event_dispatcher');
 

--- a/src/Symfony/Component/EventDispatcher/Tests/Fixtures/BizEvent.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/Fixtures/BizEvent.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\EventDispatcher\Tests\Fixtures;
+
+final class BizEvent
+{
+}

--- a/src/Symfony/Component/EventDispatcher/Tests/Fixtures/TaggedMultiListener.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/Fixtures/TaggedMultiListener.php
@@ -13,9 +13,11 @@ namespace Symfony\Component\EventDispatcher\Tests\Fixtures;
 
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 
-#[AsEventListener(event: CustomEvent::class, method: 'onCustomEvent')]
-#[AsEventListener(event: 'foo', priority: 42)]
-#[AsEventListener(event: 'bar', method: 'onBarEvent')]
+#[AsEventListener(events: CustomEvent::class, method: 'onCustomEvent')]
+#[AsEventListener(events: 'foo', priority: 42)]
+#[AsEventListener(events: 'bar', method: 'onBarEvent')]
+#[AsEventListener(events: [CustomEvent::class, 'foo', 'bar'], method: 'onMultipleEvents', priority: 10)]
+#[AsEventListener(events: [CustomEvent::class, BizEvent::class])]
 final class TaggedMultiListener
 {
     public function onCustomEvent(CustomEvent $event): void
@@ -30,8 +32,21 @@ final class TaggedMultiListener
     {
     }
 
-    #[AsEventListener(event: 'baz')]
+    #[AsEventListener(events: 'baz')]
     public function onBazEvent(): void
+    {
+    }
+
+    public function onMultipleEvents(): void
+    {
+    }
+
+    #[AsEventListener]
+    public function onMultipleEventsWithSomeInvalids(BizEvent|CustomEvent|string|int $event): void
+    {
+    }
+
+    public function __invoke()
     {
     }
 }

--- a/src/Symfony/Component/EventDispatcher/composer.json
+++ b/src/Symfony/Component/EventDispatcher/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": ">=8.2",
-        "symfony/event-dispatcher-contracts": "^2.5|^3"
+        "symfony/event-dispatcher-contracts": "^2.5|^3",
+        "symfony/deprecation-contracts": "^2.5|^3"
     },
     "require-dev": {
         "symfony/dependency-injection": "^6.4|^7.0|^8.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | Fix #61218
| License       | MIT

### Added

- Support for the new `events` attribute in the `kernel.event_listener` tag, enabling registration of a listener for multiple events at once.

### Deprecated

- The `event` attribute in `kernel.event_listener` is now deprecated and will be removed in Symfony 8.0.
  - Using the `event` attribute will trigger a deprecation warning.
  - Defining both `event` and `events` will throw an `InvalidArgumentException` to avoid configuration conflicts.
