### PR TITLE
[Mailer][Brevo] Update Webhook IPs

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Brevo/Webhook/BrevoRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/Webhook/BrevoRequestParser.php
@@ -35,9 +35,9 @@ final class BrevoRequestParser extends AbstractRequestParser
         return new ChainRequestMatcher([
             new MethodRequestMatcher('POST'),
             new IsJsonRequestMatcher(),
-            // https://developers.brevo.com/docs/how-to-use-webhooks#securing-your-webhooks
+            // https://help.brevo.com/hc/en-us/articles/15127404548498-Brevo-IP-ranges-List-of-publicly-exposed-services
             // localhost is added for testing
-            new IpsRequestMatcher(['185.107.232.1/24', '1.179.112.1/20', '172.246.240.1/20', '127.0.0.1']),
+            new IpsRequestMatcher(['1.179.112.0/20', '172.246.240.0/20', '127.0.0.1']),
         ]);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes (not really, but should be in the next patch to me)
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #... 
| License       | MIT

Regarding official Brevo documentation the IP range for webhook changed
Source : https://help.brevo.com/hc/en-us/articles/15127404548498-Brevo-IP-ranges-List-of-publicly-exposed-services

Should also be applied on 7.3 version

Thank you so much for your hard work Symfony team ♥
