### PR TITLE
[DoctrineBridge] [WIP] Add `comparator` option to `UniqueEntity` constraint

### DIFF
--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Deprecate `UniqueEntity::getRequiredOptions()` and `UniqueEntity::getDefaultOption()`
+ * Add `comparator` option to `UniqueEntity`
 
 7.3
 ---

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
@@ -70,6 +71,18 @@ class UniqueEntityTest extends TestCase
         $constraint = new UniqueEntity(['value' => 'email']);
 
         $this->assertSame('email', $constraint->fields);
+    }
+
+    public function testOnlyOneOfIdentifierFielsOrComparatorAreAllowed()
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('Only "identifierFieldNames" or "comparator" can be used at the same time.');
+
+        new UniqueEntity(
+            fields: ['field'],
+            identifierFieldNames: ['identifier'],
+            comparator: function () {},
+        );
     }
 }
 

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
@@ -1432,7 +1432,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
     public function testCheckForUniquenessIsDelegatedToComparator()
     {
-        $comparatorAsBeenCalled = false;
+        $comparatorHasBeenCalled = false;
 
         $entity = new Person(1, 'Foo');
 
@@ -1446,8 +1446,8 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
             message: 'myMessage',
             em: self::EM_NAME,
             entityClass: Person::class,
-            comparator: function ($value, $foundEntity) use ($dto, $entity, &$comparatorAsBeenCalled) {
-                $comparatorAsBeenCalled = true;
+            comparator: function ($value, $foundEntity) use ($dto, $entity, &$comparatorHasBeenCalled) {
+                $comparatorHasBeenCalled = true;
 
                 $this->assertSame($value, $dto);
                 $this->assertSame($foundEntity, $entity);
@@ -1462,7 +1462,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
         $this->validator->validate($dto, $constraint);
 
-        $this->assertTrue($comparatorAsBeenCalled);
+        $this->assertTrue($comparatorHasBeenCalled);
 
         $this->assertNoViolation();
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
@@ -1429,4 +1429,41 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
         $this->assertNoViolation();
     }
+
+    public function testCheckForUniquenessIsDelegatedToComparator()
+    {
+        $comparatorAsBeenCalled = false;
+
+        $entity = new Person(1, 'Foo');
+
+        $this->em->persist($entity);
+        $this->em->flush();
+
+        $dto = new UpdateEmployeeProfile(2, 'Foo');
+
+        $constraint = new UniqueEntity(
+            fields: ['name'],
+            message: 'myMessage',
+            em: self::EM_NAME,
+            entityClass: Person::class,
+            comparator: function ($value, $foundEntity) use ($dto, $entity, &$comparatorAsBeenCalled) {
+                $comparatorAsBeenCalled = true;
+
+                $this->assertSame($value, $dto);
+                $this->assertSame($foundEntity, $entity);
+
+                // Usually, using `'identifierFieldNames' => ['id'],` would fail validation
+                // because the ids don't match. The comparator specifically allows for
+                // overwriting this behavior.
+
+                return true;
+            },
+        );
+
+        $this->validator->validate($dto, $constraint);
+
+        $this->assertTrue($comparatorAsBeenCalled);
+
+        $this->assertNoViolation();
+    }
 }

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntity.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\Doctrine\Validator\Constraints;
 
 use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 
 /**
  * Constraint for the Unique Entity validator.
@@ -37,6 +38,7 @@ class UniqueEntity extends Constraint
     public ?string $errorPath = null;
     public bool|array|string $ignoreNull = true;
     public array $identifierFieldNames = [];
+    public ?\Closure $comparator = null;
 
     /**
      * @param array|string         $fields           The combination of fields that must contain unique values or a set of options
@@ -46,6 +48,9 @@ class UniqueEntity extends Constraint
      * @param string|null          $repositoryMethod The repository method to check uniqueness instead of findBy. The method will receive as its argument
      *                                               a fieldName => value associative array according to the fields option configuration
      * @param string|null          $errorPath        Bind the constraint violation to this field instead of the first one in the fields option configuration
+     * @param callable|null        $comparator       A custom callback to check the uniqueness of the found entity. The first parameter will
+     *                                               be the object this constraint is applied to, the second parameter will be the found entity. The callback
+     *                                               should return true if both are considered to be the same.
      */
     #[HasNamedArguments]
     public function __construct(
@@ -58,6 +63,7 @@ class UniqueEntity extends Constraint
         ?string $errorPath = null,
         bool|string|array|null $ignoreNull = null,
         ?array $identifierFieldNames = null,
+        ?callable $comparator = null,
         ?array $groups = null,
         $payload = null,
         ?array $options = null,
@@ -89,6 +95,11 @@ class UniqueEntity extends Constraint
         $this->errorPath = $errorPath ?? $this->errorPath;
         $this->ignoreNull = $ignoreNull ?? $this->ignoreNull;
         $this->identifierFieldNames = $identifierFieldNames ?? $this->identifierFieldNames;
+        $this->comparator = $comparator === null ? $this->comparator : $comparator(...);
+
+        if ($this->identifierFieldNames !== [] && $this->comparator !== null) {
+            throw new ConstraintDefinitionException('Only "identifierFieldNames" or "comparator" can be used at the same time.');
+        }
     }
 
     /**

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntity.php
@@ -95,9 +95,9 @@ class UniqueEntity extends Constraint
         $this->errorPath = $errorPath ?? $this->errorPath;
         $this->ignoreNull = $ignoreNull ?? $this->ignoreNull;
         $this->identifierFieldNames = $identifierFieldNames ?? $this->identifierFieldNames;
-        $this->comparator = $comparator === null ? $this->comparator : $comparator(...);
+        $this->comparator = null === $comparator ? $this->comparator : $comparator(...);
 
-        if ($this->identifierFieldNames !== [] && $this->comparator !== null) {
+        if ([] !== $this->identifierFieldNames && null !== $this->comparator) {
             throw new ConstraintDefinitionException('Only "identifierFieldNames" or "comparator" can be used at the same time.');
         }
     }

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -186,29 +186,33 @@ class UniqueEntityValidator extends ConstraintValidator
         /* If a single entity matched the query criteria, which is the same as
          * the entity being updated by validated object, the criteria is unique.
          */
-        if (!$isValueEntity && !empty($constraint->identifierFieldNames) && 1 === \count($result)) {
-            $fieldValues = $this->getFieldValues($value, $class, $constraint->identifierFieldNames);
-            if (array_values($class->getIdentifierFieldNames()) != array_values($constraint->identifierFieldNames)) {
-                throw new ConstraintDefinitionException(\sprintf('The "%s" entity identifier field names should be "%s", not "%s".', $entityClass, implode(', ', $class->getIdentifierFieldNames()), implode(', ', $constraint->identifierFieldNames)));
-            }
-
-            $entityMatched = true;
-
-            foreach ($constraint->identifierFieldNames as $identifierFieldName) {
-                $propertyValue = $this->getPropertyValue($entityClass, $identifierFieldName, current($result));
-                if ($fieldValues[$identifierFieldName] instanceof \Stringable) {
-                    $fieldValues[$identifierFieldName] = (string) $fieldValues[$identifierFieldName];
+        if (!$isValueEntity && 1 === \count($result)) {
+            if (!empty($constraint->identifierFieldNames)) {
+                $fieldValues = $this->getFieldValues($value, $class, $constraint->identifierFieldNames);
+                if (array_values($class->getIdentifierFieldNames()) != array_values($constraint->identifierFieldNames)) {
+                    throw new ConstraintDefinitionException(\sprintf('The "%s" entity identifier field names should be "%s", not "%s".', $entityClass, implode(', ', $class->getIdentifierFieldNames()), implode(', ', $constraint->identifierFieldNames)));
                 }
-                if ($propertyValue instanceof \Stringable) {
-                    $propertyValue = (string) $propertyValue;
-                }
-                if ($fieldValues[$identifierFieldName] !== $propertyValue) {
-                    $entityMatched = false;
-                    break;
-                }
-            }
 
-            if ($entityMatched) {
+                $entityMatched = true;
+
+                foreach ($constraint->identifierFieldNames as $identifierFieldName) {
+                    $propertyValue = $this->getPropertyValue($entityClass, $identifierFieldName, current($result));
+                    if ($fieldValues[$identifierFieldName] instanceof \Stringable) {
+                        $fieldValues[$identifierFieldName] = (string) $fieldValues[$identifierFieldName];
+                    }
+                    if ($propertyValue instanceof \Stringable) {
+                        $propertyValue = (string) $propertyValue;
+                    }
+                    if ($fieldValues[$identifierFieldName] !== $propertyValue) {
+                        $entityMatched = false;
+                        break;
+                    }
+                }
+
+                if ($entityMatched) {
+                    return;
+                }
+            } elseif (!empty($constraint->comparator) && ($constraint->comparator)($value, current($result))) {
                 return;
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Doc PR    | https://github.com/symfony/symfony-docs/pull/21256
| License       | MIT

This pull request adds a new configuration option `comparator` to the `UniqueEntity` constraint. The callback, if supplied, is used instead of working through `identifierFieldNames`, to establish equality between the found entity and the data on the validated object.
This allows custom behavior in those edge-cases where the default equality check after stringification is not enough.

The following is an example of how this works:

```php
// src/Entity/BlogPostTranslation.php
namespace App\Entity;

use Doctrine\ORM\Mapping as ORM;
use App\ValueObject\Locale;

#[ORM\Entity]
#[ORM\UniqueConstraint(fields: ['locale', 'slug'])]
class BlogPostTranslation
{
    #[ORM\Id]
    #[ORM\ManyToOne(targetEntity: BlogPost::class, inversedBy: 'translations')]
    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
    private BlogPost $post;

    #[ORM\Id]
    #[ORM\Column(type: 'locale', nullable: false)]
    private Locale $locale;

    #[ORM\Column(nullable: false)]
    private string $slug;

    // ...
}

// src/Form/Data/BlogPostTranslationFormData.php
namespace App\Form\Data;

use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
use Symfony\Component\Uid\Uuid;
use Symfony\Component\Validator\Constraints\NotBlank;
use App\Entity\BlogPostTranslation;

#[UniqueEntity(
    fields: ['locale', 'slug'],
    message: 'This slug is already used by another post in this language.',
    entityClass: BlogPostTranslation::class,
    // `identifierFieldNames` cannot be used, as, even though the `BlogPostTranslation` entity
    // would be found, the equality check of `postId === (string) post` would fail.
    // identifierFieldNames: [
    //     'postId' => 'post',
    //     'locale' => 'locale',
    // ],
    // instead, a comparator can be provided.
    comparator: [BlogPostTranslationFormData::class, 'compare'],
    errorPath: 'slug'
)]
class BlogPostTranslationFormData
{
    public function __construct(
        public readonly Uuid $postId,
        public readonly string $locale,

        #[NotBlank]
        public ?string $slug = null,
    ) {}

    public static function compare(self $subject, BlogPostTranslation $foundEntity): bool
    {
        return $foundEntity->getPost()->getId()->equals($this->postId)
            && $foundEntity->getLocale()->toValue() === $this->locale;
    }
}
```

Without such functionality, one currently has two options:

1. Assign the "full" entity to the DTO, instead of just the id.
2. Have that entity implement `\Stringable`.

Both are problematic in some cases:

- Solution 1. is not a workable option if one deals with DTOs that should be serializable (for example CQRS commands)
- Solution 2. seems like a hack and isn't really semantic in most cases. Why should an entity be stringable to its id?

Todos:

- [ ] probably add more tests
- [x] submit changes to the documentation
- [x] add entry to CHANGELOG
- [ ] gather feedback for my changes

This being my first contribution I'm aware that I probably missed a few guidelines - though I tried to follow https://symfony.com/doc/current/contributing/code/pull_requests.html closely. Please don't hesitate to point those out, or if this functionality is in general not wanted!