### PR TITLE
[Messenger] Firebird Database - incompatibility with expected lowercase columns

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
@@ -32,6 +32,7 @@ use Doctrine\DBAL\Schema\SchemaDiff;
 use Doctrine\DBAL\Schema\Synchronizer\SchemaSynchronizer;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Types;
+use Satag\DoctrineFirebirdDriver\Platforms\FirebirdPlatform;
 use Symfony\Component\Messenger\Exception\InvalidArgumentException;
 use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Contracts\Service\ResetInterface;
@@ -404,7 +405,9 @@ class Connection implements ResetInterface
 
         $alias .= '.';
 
-        if (!$this->driverConnection->getDatabasePlatform() instanceof OraclePlatform) {
+        if (!$this->driverConnection->getDatabasePlatform() instanceof FirebirdPlatform
+            && !$this->driverConnection->getDatabasePlatform() instanceof OraclePlatform
+        ) {
             return $queryBuilder->select($alias.'*');
         }
 


### PR DESCRIPTION
Firebird Database -  incompatibility with expected lowercase columns

| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61171
| License       | MIT

Fix ensures, for Firebird databases, the column names are consistently converted to lowercase before being processed by Doctrine Messenger. This resolves the incompatibility by providing Messenger with the expected lowercase column names, regardless of how Firebird returns them.

Because the FirebirdPlatform is not part of the doctrine/dbal package, I was unable to use instanceof for platform detection. Instead, I implemented a string comparison to check for Firebird as the database platform.
