### PR TITLE
[ObjectMapper] skip reading uninitialized values

### DIFF
--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -144,6 +144,11 @@ final class ObjectMapper implements ObjectMapperInterface
             }
 
             if (!$mappings && $targetRefl->hasProperty($propertyName)) {
+                $sourceProperty = $refl->getProperty($propertyName);
+                if ($refl->isInstance($source) && !$sourceProperty->isInitialized($source)) {
+                    continue;
+                }
+
                 $value = $this->getSourceValue($source, $mappedTarget, $this->getRawValue($source, $propertyName), $this->objectMap);
                 $this->storeValue($propertyName, $mapToProperties, $ctorArguments, $value);
             }

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/PartialInput/FinalInput.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/PartialInput/FinalInput.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\PartialInput;
+
+class FinalInput
+{
+    public string $uuid;
+    public string $name;
+    public ?string $email = null;
+    public ?string $website = null;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/PartialInput/PartialInput.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/PartialInput/PartialInput.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\PartialInput;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: FinalInput::class)]
+class PartialInput
+{
+    public string $uuid;
+    public string $name;
+    public ?string $email;
+    public ?string $website;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -54,6 +54,8 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty\C as Mu
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargets\A as MultipleTargetsA;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargets\C as MultipleTargetsC;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MyProxy;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\PartialInput\FinalInput;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\PartialInput\PartialInput;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\PromotedConstructor\Source as PromotedConstructorSource;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\PromotedConstructor\Target as PromotedConstructorTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\Recursion\AB;
@@ -401,5 +403,48 @@ final class ObjectMapperTest extends TestCase
         $d = $mapper->map($lazyObj, MyProxy::class);
         $this->assertSame('test', $d->name);
         $this->assertTrue($initialized);
+    }
+
+    /**
+     * @dataProvider validPartialInputProvider
+     */
+    public function testMapPartially(PartialInput $actual, FinalInput $expected)
+    {
+        $mapper = new ObjectMapper();
+        $this->assertEquals($expected, $mapper->map($actual));
+    }
+
+    public static function validPartialInputProvider(): iterable
+    {
+        $p = new PartialInput();
+        $p->uuid = '6a9eb6dd-c4dc-4746-bb99-f6bad716acb2';
+        $p->website = 'https://updated.website.com';
+
+        $f = new FinalInput();
+        $f->uuid = $p->uuid;
+        $f->website = $p->website;
+
+        yield [$p, $f];
+
+        $p = new PartialInput();
+        $p->uuid = '6a9eb6dd-c4dc-4746-bb99-f6bad716acb2';
+        $p->website = null;
+
+        $f = new FinalInput();
+        $f->uuid = $p->uuid;
+
+        yield [$p, $f];
+
+        $p = new PartialInput();
+        $p->uuid = '6a9eb6dd-c4dc-4746-bb99-f6bad716acb2';
+        $p->website = 'https://updated.website.com';
+        $p->email = 'updated@email.com';
+
+        $f = new FinalInput();
+        $f->uuid = $p->uuid;
+        $f->website = $p->website;
+        $f->email = $p->email;
+
+        yield [$p, $f];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| Issues        | Fix #60786 
| License       | MIT

The mapper would read uninitialized properties, for example this would throw trying to read `name`:

```php
#[Map(target: FinalInput::class)]
class PartialInput
{
    public string $uuid;
    public string $name;
    public ?string $email;
    public ?string $website;
}

$p = new PartialInput;
$p->uuid = '6a9eb6dd-c4dc-4746-bb99-f6bad716acb2';
$p->website = 'https://updated.website.com';

$mapper = new ObjectMapper();
$mapper->map($p);
```


