### PR TITLE
[Cache] RedisTrait::doFetch should use pipeline with GET's instead of MGET for Relay\Cluster

### DIFF
--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -434,7 +434,7 @@ trait RedisTrait
 
         $result = [];
 
-        if ($this->redis instanceof \Predis\ClientInterface && ($this->redis->getConnection() instanceof ClusterInterface || $this->redis->getConnection() instanceof Predis2ClusterInterface)) {
+        if (($this->redis instanceof \Predis\ClientInterface && ($this->redis->getConnection() instanceof ClusterInterface || $this->redis->getConnection() instanceof Predis2ClusterInterface)) || $this->redis instanceof RelayCluster) {
             $values = $this->pipeline(function () use ($ids) {
                 foreach ($ids as $id) {
                     yield 'get' => [$id];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Issues        | Fix #...
| License       | MIT

🛠️ `Relay\Cluster` should be expected to operate with >1 master nodes, and therefore its not safe to use `mget` when fetching the ids in `RedisTrait::doFetch(array $ids)` as they are not guaranteed to be on a same hash slot.

This change makes `doFetch` use pipeline with `GET` commands when `$this->redis instanceof RelayCluster`
