### PR TITLE
Add support for UnitEnum as parameter type for IsGranted attribute

### DIFF
--- a/src/Symfony/Component/Security/Http/Attribute/IsGranted.php
+++ b/src/Symfony/Component/Security/Http/Attribute/IsGranted.php
@@ -25,14 +25,14 @@ use Symfony\Component\HttpFoundation\Request;
 final class IsGranted
 {
     /**
-     * @param string|Expression|\Closure(IsGrantedContext, mixed $subject):bool $attribute The attribute that will be checked against a given authentication token and optional subject
-     * @param array|string|Expression|\Closure(array<string,mixed>, Request):mixed|null $subject An optional subject - e.g. the current object being voted on
-     * @param string|null $message       A custom message when access is not granted
-     * @param int|null    $statusCode    If set, will throw HttpKernel's HttpException with the given $statusCode; if null, Security\Core's AccessDeniedException will be used
-     * @param int|null    $exceptionCode If set, will add the exception code to thrown exception
+     * @param string|Expression|\UnitEnum|\Closure(IsGrantedContext, mixed $subject):bool $attribute  The attribute that will be checked against a given authentication token and optional subject
+     * @param array|string|Expression|\Closure(array<string,mixed>, Request):mixed|null   $subject    An optional subject - e.g. the current object being voted on
+     * @param string|null                                                                 $message    A custom message when access is not granted
+     * @param int|null                                                                    $statusCode If set, will throw HttpKernel's HttpException with the given $statusCode; if null, Security\Core's AccessDeniedException will be used
+     * @param int|null
      */
     public function __construct(
-        public string|Expression|\Closure $attribute,
+        public string|Expression|\UnitEnum|\Closure $attribute,
         public array|string|Expression|\Closure|null $subject = null,
         public ?string $message = null,
         public ?int $statusCode = null,

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -3,7 +3,7 @@ CHANGELOG
 
 7.4
 ---
-
+ * Add support for Enums in `#[IsGranted]`
  * Add support for union types with `#[CurrentUser]`
  * Deprecate callable firewall listeners, extend `AbstractListener` or implement `FirewallListenerInterface` instead
  * Deprecate `AbstractListener::__invoke`


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #61235 
| License       | MIT

Added support for UnitEnum as parameter type for `#[IsGranted]`
