### PR TITLE
[OptionsResolver] Optimize splitOutsideParenthesis() - 5.9x faster

### DIFF
--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -1215,33 +1215,29 @@ class OptionsResolver implements Options
      */
     private function splitOutsideParenthesis(string $type): array
     {
-        $parts = [];
-        $currentPart = '';
-        $parenthesisLevel = 0;
+        return preg_split(<<<'EOF'
+                /
+                # Define a recursive subroutine for matching balanced parentheses
+                (?(DEFINE)
+                    (?<balanced>
+                        \(                          # Match an opening parenthesis
+                        (?:                         # Start a non-capturing group for the contents
+                            [^()]                   # Match any character that is not a parenthesis
+                            |                       # OR
+                            (?&balanced)            # Recursively match a nested balanced group
+                        )*                          # Repeat the group for all contents
+                        \)                          # Match the final closing parenthesis
+                    )
+                )
 
-        $typeLength = \strlen($type);
-        for ($i = 0; $i < $typeLength; ++$i) {
-            $char = $type[$i];
+                # Match any balanced parenthetical group, then skip it
+                (?&balanced)(*SKIP)(*FAIL)          # Use the defined subroutine and discard the match
 
-            if ('(' === $char) {
-                ++$parenthesisLevel;
-            } elseif (')' === $char) {
-                --$parenthesisLevel;
-            }
+                | # OR
 
-            if ('|' === $char && 0 === $parenthesisLevel) {
-                $parts[] = $currentPart;
-                $currentPart = '';
-            } else {
-                $currentPart .= $char;
-            }
-        }
-
-        if ('' !== $currentPart) {
-            $parts[] = $currentPart;
-        }
-
-        return $parts;
+                \|                                  # Match the pipe delimiter (only if not inside a skipped group)
+                /x
+        EOF, $type);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #59354 <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT


This PR optimises the `splitOutsideParenthesis` method in `OptionsResolver.php`, achieving a 5.9x performance improvement.

I discovered this method as a performance hotspot while benchmarking a large Symfony form with many fields. Profiling revealed that `splitOutsideParenthesis` was consuming a significant portion of the form processing time.

The `splitOutsideParenthesis` method (introduced in [PR #59354](https://github.com/symfony/symfony/pull/59354)) is called frequently during options resolution and has several performance bottlenecks:

1. Character-by-character string concatenation creates new string objects on each iteration (particularly inefficient in PHP due to copy-on-write behavior)
2. All input strings are processed the same way, regardless of complexity - no fast path for simple types
3. Multiple conditional checks per character

## Test Methodology

Here's how all performance measurements were conducted:

- **Benchmark tool**: hyperfine (10 runs with 1 warmup run)
- **Test iterations**: 100,000 iterations per test case
- **Test data**: 16 different type patterns:
    - Simple types: `string`, `int`, `bool`, `array`
    - Union types: `string|int`, `string|int|bool`, `string|int|bool|array`
    - Parentheses types: `string|(int|bool)`, `(string|int)|bool`
    - Nested types: `string|(int|(bool|float))`, `(string|int)|(bool|float)`
    - Array types: `string[]`, `int[]`
    - Class types: `MyClass`, `\\Namespace\\Class`
    - Complex union: `string|int|bool|array|object|resource|callable`

Each optimisation was tested in isolation to measure its individual impact, then all optimisations were combined for the final benchmark.

## Optimisations

### 1. Fast Path for Simple Types (No Pipes)

Most type declarations are simple types like `string`, `int`, `MyClass`, etc. without any union types.

**Implementation:**
```php
if (!\str_contains($type, '|')) {
    return [$type];
}
```

### 2. Fast Path for Union Types (No Parentheses)

Common union types like `string|int|bool` don't need complex parsing - PHP's `explode()` is much faster.

**Implementation:**
```php
if (!\str_contains($type, '(') && !\str_contains($type, ')')) {
    return \explode('|', $type);
}
```

### 3. Eliminate String Concatenation

String concatenation in loops creates memory overhead. Using `substr()` avoids creating intermediate strings.

**Implementation:**
```php
// Instead of: $currentPart .= $char;
// Use: $parts[] = \substr($type, $start, $i - $start);
```

### 4. Switch Statement Optimisation

Eliminates Multiple conditional checks per character.

**Implementation:**
```php
switch ($char) {
    case '(':
        ++$parenthesisLevel;
        break;
    case ')':
        --$parenthesisLevel;
        break;
    case '|':
        // ...
}
```

## Benchmark Results

### Individual Optimisation Impact

Testing each optimisation in isolation:

```bash
hyperfine --warmup 1 --runs 10 \
  --sort=command \
  --reference 'php test_original.php' \
  'php test_opt1_fast_path_simple.php' \
  'php test_opt2_fast_path_union.php' \
  'php test_opt3_no_string_concat.php'  \
  'php test_opt4_switch_statement.php'
```

```
Relative speed comparison
        1.00          php test_original.php
        1.23 ±  0.02  php test_opt1_fast_path_simple.php
        1.95 ±  0.04  php test_opt2_fast_path_union.php
        1.13 ±  0.03  php test_opt3_no_string_concat.php
        1.35 ±  0.03  php test_opt4_switch_statement.php
```

### Combined Optimisation Impact

Combining all optimisations:

```bash
hyperfine --warmup 1 --runs 10 \
  --sort=command \
  --reference 'php test_original.php' \
  'php test_optimised.php'
```
```
Relative speed comparison
        1.00          php test_original.php
        2.91 ±  0.03  php test_optimised.php
```

## Further Optimization: Regex Solution

After achieving the 2.91x improvement with manual optimizations, I explored regex-based solutions for even better performance as suggested by @dunglas. 
The challenge was maintaining correctness for deeply nested union types.

### Final Solution: Recursive Regex

The solution uses PCRE's `(?(DEFINE)` syntax to create a recursive pattern supporting unlimited nesting:

### Final Benchmark Results

Updated test data includes a complex deep nesting case: `complex|(nested|(types|(with|(deep|nesting))))|arrays[]|(more|(complex|types))`

```bash
hyperfine --warmup 1 --runs 10 --reference 'php test_original.php' \
  'php test_optimized.php' 'php test_recursive_final.php'
```

```
Summary
  php test_original.php ran
    5.85 ± 0.11 times slower than php test_recursive_final.php
    2.57 ± 0.12 times slower than php test_optimized.php
```
