### PR TITLE
[VarDumper] Use unique identifier for `RequestContextProvider`

### DIFF
--- a/src/Symfony/Component/VarDumper/Dumper/ContextProvider/CliContextProvider.php
+++ b/src/Symfony/Component/VarDumper/Dumper/ContextProvider/CliContextProvider.php
@@ -26,7 +26,7 @@ final class CliContextProvider implements ContextProviderInterface
 
         return [
             'command_line' => $commandLine = implode(' ', $_SERVER['argv'] ?? []),
-            'identifier' => hash('crc32b', $commandLine.$_SERVER['REQUEST_TIME_FLOAT']),
+            'identifier' => hash('xxh128', $commandLine.'@'.$_SERVER['REQUEST_TIME_FLOAT']),
         ];
     }
 }

--- a/src/Symfony/Component/VarDumper/Dumper/ContextProvider/RequestContextProvider.php
+++ b/src/Symfony/Component/VarDumper/Dumper/ContextProvider/RequestContextProvider.php
@@ -45,7 +45,7 @@ final class RequestContextProvider implements ContextProviderInterface
             'uri' => $request->getUri(),
             'method' => $request->getMethod(),
             'controller' => $controller ? $this->cloner->cloneVar($controller) : $controller,
-            'identifier' => spl_object_hash($request),
+            'identifier' => hash('xxh128', spl_object_id($request).'@'.$_SERVER['REQUEST_TIME_FLOAT']),
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #61130  <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

Creates unique identifier for vardumper when running `bin/console server:dump` / `bin/console server:dump --format=html`. The fix in the `RequestContextProvider` now uses `hash('crc32b')` in combination with `$_SERVER['REQUEST_TIME_FLOAT']`, which is the same as the `CliContextProvider`.