### PR TITLE
[Serializer] Make data provider return type match its PHPDoc

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -576,7 +576,7 @@ class AbstractObjectNormalizerTest extends TestCase
     /**
      * @return iterable<array{0: mixed, 1: bool}>
      */
-    public static function provideInvalidDiscriminatorTypes(): array
+    public static function provideInvalidDiscriminatorTypes(): iterable
     {
         $toStringObject = new class {
             public function __toString()
@@ -585,14 +585,12 @@ class AbstractObjectNormalizerTest extends TestCase
             }
         };
 
-        return [
-            [[], true],
-            [new \stdClass(), true],
-            [123, true],
-            [false, true],
-            ['first', false],
-            [$toStringObject, false],
-        ];
+        yield [[], true];
+        yield [new \stdClass(), true];
+        yield [123, true];
+        yield [false, true];
+        yield ['first', false];
+        yield [$toStringObject, false];
     }
 
     public function testDenormalizeWithDiscriminatorMapUsesCorrectClassname()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Fix CI failures like https://github.com/symfony/symfony/actions/runs/16549261399/job/46801686089?pr=60568#step:7:27