### PR TITLE
[FrameworkBundle] Add support for union types on `#[AsEventListener]`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG
  * Add support for configuring workflow places with glob patterns matching consts/backed enums
  * Add support for configuring the `CachingHttpClient`
  * Add support for weighted transitions in workflows
+ * Add support for union types with `Symfony\Component\EventDispatcher\Attribute\AsEventListener`
 
 7.3
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -774,13 +774,32 @@ class FrameworkExtension extends Extension
 
         $container->registerAttributeForAutoconfiguration(AsEventListener::class, static function (ChildDefinition $definition, AsEventListener $attribute, \ReflectionClass|\ReflectionMethod $reflector) {
             $tagAttributes = get_object_vars($attribute);
-            if ($reflector instanceof \ReflectionMethod) {
-                if (isset($tagAttributes['method'])) {
-                    throw new LogicException(\sprintf('AsEventListener attribute cannot declare a method on "%s::%s()".', $reflector->class, $reflector->name));
-                }
-                $tagAttributes['method'] = $reflector->getName();
+
+            if (!$reflector instanceof \ReflectionMethod) {
+                $definition->addTag('kernel.event_listener', $tagAttributes);
+
+                return;
             }
-            $definition->addTag('kernel.event_listener', $tagAttributes);
+
+            if (isset($tagAttributes['method'])) {
+                throw new LogicException(\sprintf('AsEventListener attribute cannot declare a method on "%s::%s()".', $reflector->class, $reflector->name));
+            }
+
+            $tagAttributes['method'] = $reflector->getName();
+
+            if (!$eventArg = $reflector->getParameters()[0] ?? null) {
+                throw new LogicException(\sprintf('AsEventListener attribute requires the first argument of "%s::%s()" to be an event object.', $reflector->class, $reflector->name));
+            }
+
+            $types = ($type = $eventArg->getType() instanceof \ReflectionUnionType ? $eventArg->getType()->getTypes() : [$eventArg->getType()]) ?: [];
+
+            foreach ($types as $type) {
+                if ($type instanceof \ReflectionNamedType && !$type->isBuiltin()) {
+                    $tagAttributes['event'] = $type->getName();
+
+                    $definition->addTag('kernel.event_listener', $tagAttributes);
+                }
+            }
         });
         $container->registerAttributeForAutoconfiguration(AsController::class, static function (ChildDefinition $definition, AsController $attribute): void {
             $definition->addTag('controller.service_arguments');

--- a/src/Symfony/Component/EventDispatcher/Tests/Fixtures/DummyEvent.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/Fixtures/DummyEvent.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\EventDispatcher\Tests\Fixtures;
+
+final class DummyEvent
+{
+}

--- a/src/Symfony/Component/EventDispatcher/Tests/Fixtures/TaggedUnionTypeListener.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/Fixtures/TaggedUnionTypeListener.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\EventDispatcher\Tests\Fixtures;
+
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+final class TaggedUnionTypeListener
+{
+    #[AsEventListener]
+    public function onUnionEvent(CustomEvent|DummyEvent $event): void
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #61218
| License       | MIT

This is an alternative implementation to support union types, related to issue #61218 and PR #61222.
It duplicates `kernel.event_listener` tags.

I'm not sure how to add tests for this — could you advise?