### PR TITLE
[FrameworkBundle] Fix `lint:container --resolve-env-vars`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerLintCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerLintCommandTest.php
@@ -24,27 +24,28 @@ class ContainerLintCommandTest extends AbstractWebTestCase
     /**
      * @dataProvider containerLintProvider
      */
-    public function testLintContainer(string $configFile, string $expectedOutput)
+    public function testLintContainer(string $configFile, bool $resolveEnvVars, int $expectedExitCode, string $expectedOutput)
     {
         $kernel = static::createKernel([
-            'test_case' => 'ContainerDebug',
+            'test_case' => 'ContainerLint',
             'root_config' => $configFile,
             'debug' => true,
         ]);
         $this->application = new Application($kernel);
 
         $tester = $this->createCommandTester();
-        $exitCode = $tester->execute([]);
+        $exitCode = $tester->execute(['--resolve-env-vars' => $resolveEnvVars]);
 
-        $this->assertSame(0, $exitCode);
+        $this->assertSame($expectedExitCode, $exitCode);
         $this->assertStringContainsString($expectedOutput, $tester->getDisplay());
     }
 
     public static function containerLintProvider(): array
     {
         return [
-            'default container' => ['config.yml', 'The container was linted successfully'],
-            'missing dump file' => ['no_dump.yml', 'The container was linted successfully'],
+            ['escaped_percent.yml', false, 0, 'The container was linted successfully'],
+            ['missing_env_var.yml', false, 0, 'The container was linted successfully'],
+            ['missing_env_var.yml', true, 1, 'Environment variable not found: "BAR"'],
         ];
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ContainerLint/bundles.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ContainerLint/bundles.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestBundle;
+
+return [
+    new FrameworkBundle(),
+    new TestBundle(),
+];

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ContainerLint/escaped_percent.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ContainerLint/escaped_percent.yml
@@ -1,0 +1,5 @@
+imports:
+    - { resource: ../config/default.yml }
+
+parameters:
+    percent: '%%foo%%'

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ContainerLint/missing_env_var.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ContainerLint/missing_env_var.yml
@@ -1,0 +1,5 @@
+imports:
+    - { resource: ../config/default.yml }
+
+parameters:
+    foo: '%env(BAR)%'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59028
| License       | MIT


7.2 EOL is around the corner :timer_clock: 

:warning: `--resolve-env-vars` still won’t work if you have parameters with two escaped percent signs.