### PR TITLE
[HttpFoundation] Add support for structured MIME suffix

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Deprecate using `Request::sendHeaders()` after headers have already been sent; use a `StreamedResponse` instead
  * Add support for the `QUERY` HTTP method
+ * Add support for structured MIME suffix
 
 7.3
 ---

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -527,6 +527,37 @@ b'])]
             ['rdf', ['application/rdf+xml']],
             ['atom', ['application/atom+xml']],
             ['form', ['application/x-www-form-urlencoded', 'multipart/form-data']],
+            ['rss', ['application/rss+xml']],
+            ['soap', ['application/soap+xml']],
+            ['html', ['application/xhtml+xml']],
+            ['problem', ['application/problem+json']],
+            ['hal', ['application/hal+json', 'application/hal+xml']],
+            ['jsonapi', ['application/vnd.api+json']],
+            ['yaml', ['application/x-yaml', 'text/yaml']],
+            ['wbxml', ['application/vnd.wap.wbxml']],
+        ];
+    }
+
+    /**
+     * @dataProvider getFormatWithSubtypeFallbackProvider
+     */
+    public function testGetFormatFromMimeTypeWithSubtypeFallback($expectedFormat, $mimeTypes)
+    {
+        $request = new Request();
+        foreach ($mimeTypes as $mime) {
+            $this->assertEquals($expectedFormat, $request->getFormat($mime, true));
+        }
+    }
+
+    public static function getFormatWithSubtypeFallbackProvider()
+    {
+        return [
+            ['cbor', ['application/example+cbor']],
+            ['asn1', ['application/ber-stream+ber', 'application/secure-data+der']],
+            ['zip', ['application/foobar+zip']],
+            ['tlv', ['application/device-config+tlv']],
+            ['pdf', ['application/pdf']],
+            ['csv', ['text/csv']],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #61213
| License       | MIT

Extended MIME type handling in `Request::getFormat()` to support structured suffixes like `application/soap+xml`. Introduced a private method to define fallback formats based on RFC specifications. Updated the test suite accordingly.
It adds supports for common mime types:

* `soap`: application/soap+xml (instead of `xml`)
* `problem`: application/problem+json
* `hal`: application/hal+json, application/hal+xml
* `jsonapi`: application/vnd.api+json
* `yaml`: text/yaml, application/x-yaml
* `wbxml`: application/vnd.wap.wbxml
* `pdf`: application/pdf
* `csv`: text/csv