### PR TITLE
[DependencyInjection] Deprecate registering a service without a class when its id is a non-existing FQCN

### DIFF
--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -22,6 +22,7 @@ DependencyInjection
 -------------------
 
  * Add argument `$target` to `ContainerBuilder::registerAliasForArgument()`
+ * Deprecate registering a service without a class when its id is a non-existing FQCN
 
 DoctrineBridge
 --------------

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Allow `#[AsAlias]` to be extended
  * Add argument `$target` to `ContainerBuilder::registerAliasForArgument()`
+ * Deprecate registering a service without a class when its id is a non-existing FQCN
 
 7.3
 ---

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveClassPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveClassPass.php
@@ -23,20 +23,23 @@ class ResolveClassPass implements CompilerPassInterface
     public function process(ContainerBuilder $container): void
     {
         foreach ($container->getDefinitions() as $id => $definition) {
-            if ($definition->isSynthetic() || null !== $definition->getClass()) {
+            if ($definition->isSynthetic()
+                || null !== $definition->getClass()
+                || !preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+(?:\\\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+)++$/', $id)
+            ) {
                 continue;
             }
-            if (preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+(?:\\\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+)++$/', $id)) {
-                if (!class_exists($id) && !interface_exists($id)) {
-                    $error = $definition instanceof ChildDefinition ?
-                        'has a parent but no class, and its name looks like a FQCN. Either the class is missing or you want to inherit it from the parent service' :
-                        'name looks like a FQCN but the class does not exist';
-
-                    throw new InvalidArgumentException("Service definition \"{$id}\" {$error}. To resolve this ambiguity, please rename this service to a non-FQCN (e.g. using dots), or create the missing class.");
-                }
-
+            if (class_exists($id) || interface_exists($id, false)) {
                 $definition->setClass($id);
+                continue;
             }
+            if ($definition instanceof ChildDefinition) {
+                throw new InvalidArgumentException(\sprintf('Service definition "%s" has a parent but no class, and its name looks like a FQCN. Either the class is missing or you want to inherit it from the parent service. To resolve this ambiguity, please rename this service to a non-FQCN (e.g. using dots), or create the missing class.', $id));
+            }
+
+            trigger_deprecation('symfony/dependency-injection', '7.4', 'Service id "%s" looks like a FQCN but no corresponding class or interface exists. To resolve this ambiguity, please rename this service to a non-FQCN (e.g. using dots), or create the missing class or interface.', $id);
+            // throw new InvalidArgumentException(\sprintf('Service id "%s" looks like a FQCN but no corresponding class or interface exists. To resolve this ambiguity, please rename this service to a non-FQCN (e.g. using dots), or create the missing class or interface.'), $id);
+            $definition->setClass($id);
         }
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/BindTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/BindTrait.php
@@ -24,7 +24,7 @@ trait BindTrait
      * injected in the matching parameters (of the constructor, of methods
      * called and of controller actions).
      *
-     * @param string $nameOrFqcn A parameter name with its "$" prefix, or an FQCN
+     * @param string $nameOrFqcn A parameter name with its "$" prefix, or a FQCN
      * @param mixed  $valueOrRef The value or reference to bind
      *
      * @return $this

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveClassPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveClassPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\ResolveClassPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -20,6 +21,8 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\CaseSensitiveClass;
 
 class ResolveClassPassTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     /**
      * @dataProvider provideValidClassId
      */
@@ -93,10 +96,14 @@ class ResolveClassPassTest extends TestCase
         (new ResolveClassPass())->process($container);
     }
 
+    /**
+     * @group legacy
+     */
     public function testInvalidClassNameDefinition()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Service definition "Acme\UnknownClass" name looks like a FQCN but the class does not exist. To resolve this ambiguity, please rename this service to a non-FQCN (e.g. using dots), or create the missing class.');
+        // $this->expectException(InvalidArgumentException::class);
+        // $this->expectExceptionMessage('Service id "Acme\UnknownClass" looks like a FQCN but no corresponding class or interface exists. To resolve this ambiguity, please rename this service to a non-FQCN (e.g. using dots), or create the missing class or interface.');
+        $this->expectDeprecation('Since symfony/dependency-injection 7.4: Service id "Acme\UnknownClass" looks like a FQCN but no corresponding class or interface exists. To resolve this ambiguity, please rename this service to a non-FQCN (e.g. using dots), or create the missing class or interface.');
         $container = new ContainerBuilder();
         $container->register('Acme\UnknownClass');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

#61215 might be too disruptive. This turns the exception into a deprecation.