### PR TITLE
[Console] Expand LockableTrait API

### DIFF
--- a/src/Symfony/Component/Console/Command/LockableTrait.php
+++ b/src/Symfony/Component/Console/Command/LockableTrait.php
@@ -32,7 +32,7 @@ trait LockableTrait
     /**
      * Locks a command.
      */
-    private function lock(?string $name = null, bool $blocking = false, float $ttl = 300.0, bool $authRelease = true): bool
+    private function lock(?string $name = null, bool $blocking = false, float $ttl = 300.0, bool $autoRelease = true): bool
     {
         if (!class_exists(SemaphoreStore::class)) {
             throw new LogicException('To enable the locking feature you must install the symfony/lock component. Try running "composer require symfony/lock".');
@@ -62,7 +62,7 @@ trait LockableTrait
             }
         }
 
-        $this->lock = $this->lockFactory->createLock($name, $ttl, $authRelease);
+        $this->lock = $this->lockFactory->createLock($name, $ttl, $autoRelease);
         if (!$this->lock->acquire($blocking)) {
             $this->lock = null;
 

--- a/src/Symfony/Component/Console/Command/LockableTrait.php
+++ b/src/Symfony/Component/Console/Command/LockableTrait.php
@@ -32,7 +32,7 @@ trait LockableTrait
     /**
      * Locks a command.
      */
-    private function lock(?string $name = null, bool $blocking = false): bool
+    private function lock(?string $name = null, bool $blocking = false, float $ttl = 300.0, bool $authRelease = true): bool
     {
         if (!class_exists(SemaphoreStore::class)) {
             throw new LogicException('To enable the locking feature you must install the symfony/lock component. Try running "composer require symfony/lock".');
@@ -62,7 +62,7 @@ trait LockableTrait
             }
         }
 
-        $this->lock = $this->lockFactory->createLock($name);
+        $this->lock = $this->lockFactory->createLock($name, $ttl, $authRelease);
         if (!$this->lock->acquire($blocking)) {
             $this->lock = null;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

This change safely extends the lock() method to allow manual control over lock release in the parent process.
This is necessary when the main process forks: the previously introduced automatic lock release (enabled by default) triggers upon the destruction of the lock object. As a result, when a forked child process terminates, it unintentionally releases the lock for all processes.

This update ensures that lock release can be explicitly managed to avoid premature unlocking in such scenarios.