### PR TITLE
[Serializer] Remove `@internal` from `ClassMetadataInterface` and `AttributeMetadataInterface`

### DIFF
--- a/src/Symfony/Component/Serializer/Mapping/AttributeMetadataInterface.php
+++ b/src/Symfony/Component/Serializer/Mapping/AttributeMetadataInterface.php
@@ -18,8 +18,6 @@ use Symfony\Component\PropertyAccess\PropertyPath;
  *
  * Primarily, the metadata stores serialization groups.
  *
- * @internal
- *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
 interface AttributeMetadataInterface

--- a/src/Symfony/Component/Serializer/Mapping/ClassMetadataInterface.php
+++ b/src/Symfony/Component/Serializer/Mapping/ClassMetadataInterface.php
@@ -18,8 +18,6 @@ namespace Symfony\Component\Serializer\Mapping;
  *
  * There may only exist one metadata for each attribute according to its name.
  *
- * @internal
- *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
 interface ClassMetadataInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

Hi @dunglas 

I'm using the `ClassMetadataFactoryInterface` which is not internal and the method `getMetadataFor` returns a `ClassMetadataInterface` which is internal. So technically the returned value cannot be used symfony do not promise BC on it.

It seems logical to have BC on the return value then.
Same for param/return value of the ClassMetadataInterface

Is it ok for you ?