### PR TITLE
[Serializer] Allows to instantiate property when creating a `NotNormalizableValueException`

### DIFF
--- a/src/Symfony/Component/Serializer/Exception/NotNormalizableValueException.php
+++ b/src/Symfony/Component/Serializer/Exception/NotNormalizableValueException.php
@@ -22,6 +22,19 @@ class NotNormalizableValueException extends UnexpectedValueException
     private bool $useMessageForUser = false;
 
     /**
+     * @param list<string|\Stringable>|null $expectedTypes
+     */
+    public function __construct(string $message = '', int $code = 0, ?\Throwable $previous = null, ?string $currentType = null, ?array $expectedTypes = null, ?string $path = null, bool $useMessageForUser = false)
+    {
+        parent::__construct($message, $code, $previous);
+
+        $this->currentType = $currentType;
+        $this->expectedTypes = $expectedTypes ? array_map(strval(...), $expectedTypes) : $expectedTypes;
+        $this->path = $path;
+        $this->useMessageForUser = $useMessageForUser;
+    }
+
+    /**
      * @param list<string|\Stringable> $expectedTypes
      * @param bool                     $useMessageForUser If the message passed to this exception is something that can be shown
      *                                                    safely to your user. In other words, avoid catching other exceptions and
@@ -29,14 +42,7 @@ class NotNormalizableValueException extends UnexpectedValueException
      */
     public static function createForUnexpectedDataType(string $message, mixed $data, array $expectedTypes, ?string $path = null, bool $useMessageForUser = false, int $code = 0, ?\Throwable $previous = null): self
     {
-        $self = new self($message, $code, $previous);
-
-        $self->currentType = get_debug_type($data);
-        $self->expectedTypes = array_map(strval(...), $expectedTypes);
-        $self->path = $path;
-        $self->useMessageForUser = $useMessageForUser;
-
-        return $self;
+        return new self($message, $code, $previous, get_debug_type($data), $expectedTypes, $path, $useMessageForUser);
     }
 
     public function getCurrentType(): ?string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

Currently when writing `throw new NotNormalizableValueException(...)` we cannot set all the existing property of the NotNormalizableValueException. For instance, we cannot set the property path while it would be really useful.