### PR TITLE
[Mailer] Add MicrosoftGraph API Transport

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2887,6 +2887,7 @@ class FrameworkExtension extends Extension
             MailerBridge\Mailomat\Transport\MailomatTransportFactory::class => 'mailer.transport_factory.mailomat',
             MailerBridge\MailPace\Transport\MailPaceTransportFactory::class => 'mailer.transport_factory.mailpace',
             MailerBridge\Mailchimp\Transport\MandrillTransportFactory::class => 'mailer.transport_factory.mailchimp',
+            MailerBridge\MicrosoftGraph\Transport\MicrosoftGraphTransportFactory::class => 'mailer.transport_factory.microsoftgraph',
             MailerBridge\Postal\Transport\PostalTransportFactory::class => 'mailer.transport_factory.postal',
             MailerBridge\Postmark\Transport\PostmarkTransportFactory::class => 'mailer.transport_factory.postmark',
             MailerBridge\Mailtrap\Transport\MailtrapTransportFactory::class => 'mailer.transport_factory.mailtrap',

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer_transports.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer_transports.php
@@ -24,6 +24,7 @@ use Symfony\Component\Mailer\Bridge\Mailjet\Transport\MailjetTransportFactory;
 use Symfony\Component\Mailer\Bridge\Mailomat\Transport\MailomatTransportFactory;
 use Symfony\Component\Mailer\Bridge\MailPace\Transport\MailPaceTransportFactory;
 use Symfony\Component\Mailer\Bridge\Mailtrap\Transport\MailtrapTransportFactory;
+use Symfony\Component\Mailer\Bridge\MicrosoftGraph\Transport\MicrosoftGraphTransportFactory;
 use Symfony\Component\Mailer\Bridge\Postal\Transport\PostalTransportFactory;
 use Symfony\Component\Mailer\Bridge\Postmark\Transport\PostmarkTransportFactory;
 use Symfony\Component\Mailer\Bridge\Resend\Transport\ResendTransportFactory;
@@ -60,6 +61,7 @@ return static function (ContainerConfigurator $container) {
         'mailjet' => MailjetTransportFactory::class,
         'mailomat' => MailomatTransportFactory::class,
         'mailpace' => MailPaceTransportFactory::class,
+        'microsoftgraph' => MicrosoftGraphTransportFactory::class,
         'native' => NativeTransportFactory::class,
         'null' => NullTransportFactory::class,
         'postal' => PostalTransportFactory::class,

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/.gitattributes
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/.gitattributes
@@ -1,0 +1,3 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/.gitignore
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+composer.lock
+phpunit.xml

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+7.4
+---
+
+ * Add the bridge

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/LICENSE
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2025-present Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/README.md
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/README.md
@@ -1,0 +1,53 @@
+Microsoft Graph API Mailer
+==========================
+
+Provides [Microsoft Graph API Email](https://learn.microsoft.com/en-us/graph/api/user-sendmail) integration for Symfony Mailer.
+
+Prerequisites
+-------------
+
+You will need to:
+* Register an application in your Microsoft Azure portal,
+* Grant this application the Microsoft Graph `Mail.Send` permission,
+* Create a secret for that app.
+
+Configuration example
+---------------------
+
+```env
+# MAILER
+MAILER_DSN=microsoftgraph+api://CLIENT_APP_ID:CLIENT_APP_SECRET@default?tenantId=TENANT_ID
+```
+
+This will default to `graph.microsoft.com` for the Graph API and `login.microsoftonline.com` for authentication.
+
+If you need to use third parties operated or specific regions Microsoft services (China, US Government, etc.), you can specify the Graph Endpoint and the Auth Endpoint explicitly.
+
+```env
+# MAILER e.g. for China
+MAILER_DSN=microsoftgraph+api://CLIENT_APP_ID:CLIENT_APP_SECRET@microsoftgraph.chinacloudapi.cn?tenantId=TENANT_ID&authEndpoint=login.partner.microsoftonline.cn
+```
+
+The exact URLs can be found in the Microsoft documentation:
+* [Graph Endpoints](https://learn.microsoft.com/en-us/graph/deployments#microsoft-graph-and-graph-explorer-service-root-endpoints)
+* [Auth Endpoints](https://learn.microsoft.com/en-us/entra/identity-platform/authentication-national-cloud#microsoft-entra-authentication-endpoints)
+
+You can also specify to not save the messages to sent items using the `noSave` parameter:
+
+```env
+# MAILER
+MAILER_DSN=microsoftgraph+api://CLIENT_APP_ID:CLIENT_APP_SECRET@default?tenantId=TENANT_ID&noSave=true
+```
+
+Troubleshooting
+---------------
+
+Beware that the sender email address needs to be an address of an account inside your tenant.
+
+Resources
+---------
+
+ * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+ * [Report issues](https://github.com/symfony/symfony/issues) and
+   [send Pull Requests](https://github.com/symfony/symfony/pulls)
+   in the [main Symfony repository](https://github.com/symfony/symfony)

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Tests/TokenManagerMock.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Tests/TokenManagerMock.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\MicrosoftGraph\Tests;
+
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\Mailer\Bridge\MicrosoftGraph\TokenManager;
+
+class TokenManagerMock extends TokenManager
+{
+    public function __construct()
+    {
+        parent::__construct('', '', '', '', '', new MockHttpClient());
+    }
+
+    public function getToken(): string
+    {
+        return 'ACCESSTOKEN';
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Tests/TokenManagerTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Tests/TokenManagerTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\MicrosoftGraph\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Clock\Clock;
+use Symfony\Component\Clock\MockClock;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Mailer\Bridge\MicrosoftGraph\TokenManager;
+use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+class TokenManagerTest extends TestCase
+{
+    public function testTokenRetrieved()
+    {
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $this->assertSame('POST', $method);
+            $this->assertSame('https://auth/tenant/oauth2/v2.0/token', $url);
+
+            parse_str($options['body'], $body);
+            $this->assertSame('client', $body['client_id']);
+            $this->assertSame('key', $body['client_secret']);
+            $this->assertSame('https://graph/.default', $body['scope']);
+            $this->assertSame('client_credentials', $body['grant_type']);
+
+            return new JsonMockResponse(['access_token' => 'ACCESSTOKEN', 'expires_in' => 3599]);
+        });
+
+        $manager = new TokenManager('graph', 'auth', 'tenant', 'client', 'key', $client);
+
+        $manager->getToken();
+    }
+
+    public function testTokenCached()
+    {
+        $counter = 0;
+        $client = new MockHttpClient(function () use (&$counter): ResponseInterface {
+            ++$counter;
+
+            return new JsonMockResponse(['access_token' => 't'.$counter, 'expires_in' => 3599]);
+        });
+
+        $manager = new TokenManager('graph', 'auth', 'tenant', 'client', 'key', $client);
+        $this->assertSame('t1', $manager->getToken());
+        $this->assertSame('t1', $manager->getToken());
+
+        $this->assertSame(1, $counter);
+    }
+
+    public function testTokenExpired()
+    {
+        $counter = 0;
+        $client = new MockHttpClient(function () use (&$counter): ResponseInterface {
+            ++$counter;
+
+            return new JsonMockResponse(['access_token' => 't'.$counter, 'expires_in' => 3599]);
+        });
+
+        Clock::set(new MockClock('2025-07-31 11:00'));
+        $manager = new TokenManager('graph', 'auth', 'tenant', 'client', 'key', $client);
+        $this->assertSame('t1', $manager->getToken());
+        Clock::set(new MockClock('2025-07-31 11:30'));
+        $this->assertSame('t1', $manager->getToken());
+        Clock::set(new MockClock('2025-07-31 12:00'));
+        $this->assertSame('t2', $manager->getToken());
+
+        $this->assertSame(2, $counter);
+    }
+
+    public function testNonSuccessCodeThrown()
+    {
+        $client = new MockHttpClient(fn (): ResponseInterface => new MockResponse('', ['http_code' => 503]));
+
+        $manager = new TokenManager('graph', 'auth', 'tenant', 'client', 'key', $client);
+
+        $this->expectException(HttpTransportException::class);
+        $this->expectExceptionMessageMatches('/^Unable to authenticate/');
+        $manager->getToken();
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Tests/Transport/MicrosoftGraphApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Tests/Transport/MicrosoftGraphApiTransportTest.php
@@ -1,0 +1,285 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\MicrosoftGraph\Tests\Transport;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Mailer\Bridge\MicrosoftGraph\Tests\TokenManagerMock;
+use Symfony\Component\Mailer\Bridge\MicrosoftGraph\Transport\MicrosoftGraphApiTransport;
+use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+class MicrosoftGraphApiTransportTest extends TestCase
+{
+    #[DataProvider('getTransportData')]
+    public function testToString(MicrosoftGraphApiTransport $transport, string $expected)
+    {
+        $this->assertSame($expected, (string) $transport);
+    }
+
+    public static function getTransportData(): array
+    {
+        return [
+            [
+                new MicrosoftGraphApiTransport('graph.ms.com', new TokenManagerMock(), false),
+                'microsoftgraph+api://graph.ms.com',
+            ],
+        ];
+    }
+
+    public function testSend()
+    {
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $this->assertSame('POST', $method);
+            $this->assertSame('https://graph/v1.0/users/fabpot@symfony.com/sendMail', $url);
+
+            $this->assertNotEmpty($options['normalized_headers']['authorization']);
+
+            $message = json_decode($options['body'], true)['message'];
+
+            $this->assertSame('Fabien', $message['sender']['emailAddress']['name']);
+            $this->assertSame('fabpot@symfony.com', $message['sender']['emailAddress']['address']);
+
+            $this->assertSame('Hello!', $message['subject']);
+
+            $mailBody = $message['body'];
+            $this->assertSame('Hello There!', $mailBody['content']);
+            $this->assertSame('text', $mailBody['contentType']);
+
+            $this->assertSame('normal', $message['importance']);
+
+            $this->assertCount(1, $message['toRecipients']);
+            $this->assertSame('Bob', $message['toRecipients'][0]['emailAddress']['name']);
+            $this->assertSame('bob@symfony.com', $message['toRecipients'][0]['emailAddress']['address']);
+
+            $this->assertCount(1, $message['replyTo']);
+            $this->assertArrayNotHasKey('name', $message['replyTo'][0]['emailAddress']);
+            $this->assertSame('bob@symfony.com', $message['replyTo'][0]['emailAddress']['address']);
+
+            $attachment = $message['attachments'][0];
+            $this->assertSame('#microsoft.graph.fileAttachment', $attachment['@odata.type']);
+            $this->assertSame('Hello There!', $attachment['name']);
+            $this->assertSame(base64_encode('content'), $attachment['contentBytes']);
+            $this->assertSame('text/plain', $attachment['contentType']);
+            $this->assertArrayNotHasKey('contentId', $attachment);
+            $this->assertArrayNotHasKey('isInline', $attachment);
+
+            return new MockResponse('', ['http_code' => 202]);
+        });
+
+        $transport = new MicrosoftGraphApiTransport('graph', new TokenManagerMock(), false, $client);
+
+        $mail = new Email();
+        $mail->subject('Hello!')
+            ->to(new Address('bob@symfony.com', 'Bob'))
+            ->from(new Address('fabpot@symfony.com', 'Fabien'))
+            ->replyTo('bob@symfony.com')
+            ->text('Hello There!')
+            ->attach('content', 'Hello There!', 'text/plain');
+
+        $transport->send($mail);
+    }
+
+    public function testCcBcc()
+    {
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $this->assertSame('POST', $method);
+            $this->assertSame('https://graph/v1.0/users/fabpot@symfony.com/sendMail', $url);
+
+            $message = json_decode($options['body'], true)['message'];
+
+            $this->assertCount(1, $message['ccRecipients']);
+            $this->assertSame('Alice', $message['ccRecipients'][0]['emailAddress']['name']);
+            $this->assertSame('alice-cc@symfony.com', $message['ccRecipients'][0]['emailAddress']['address']);
+
+            $this->assertCount(1, $message['bccRecipients']);
+            $this->assertSame('Alice', $message['bccRecipients'][0]['emailAddress']['name']);
+            $this->assertSame('alice-bcc@symfony.com', $message['bccRecipients'][0]['emailAddress']['address']);
+
+            return new MockResponse('', ['http_code' => 202]);
+        });
+
+        $transport = new MicrosoftGraphApiTransport('graph', new TokenManagerMock(), false, $client);
+
+        $mail = new Email();
+        $mail->subject('Hello!')
+            ->to(new Address('bob@symfony.com', 'Bob'))
+            ->from(new Address('fabpot@symfony.com', 'Fabien'))
+            ->cc(new Address('alice-cc@symfony.com', 'Alice'))
+            ->bcc(new Address('alice-bcc@symfony.com', 'Alice'))
+            ->text('Hello world');
+
+        $transport->send($mail);
+    }
+
+    public function testHtmlBody()
+    {
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $this->assertSame('POST', $method);
+            $this->assertSame('https://graph/v1.0/users/fabpot@symfony.com/sendMail', $url);
+
+            $message = json_decode($options['body'], true)['message'];
+
+            $mailBody = $message['body'];
+            $this->assertSame('<html>Hello There!</html>', $mailBody['content']);
+            $this->assertSame('html', $mailBody['contentType']);
+
+            return new MockResponse('', ['http_code' => 202]);
+        });
+
+        $transport = new MicrosoftGraphApiTransport('graph', new TokenManagerMock(), false, $client);
+
+        $mail = new Email();
+        $mail->subject('Hello!')
+            ->to(new Address('bob@symfony.com', 'Bob'))
+            ->from(new Address('fabpot@symfony.com', 'Fabien'))
+            ->html('<html>Hello There!</html>');
+
+        $transport->send($mail);
+    }
+
+    public function testEmbeddedAttachment()
+    {
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $this->assertSame('POST', $method);
+            $this->assertSame('https://graph/v1.0/users/fabpot@symfony.com/sendMail', $url);
+
+            $message = json_decode($options['body'], true)['message'];
+
+            $attachment = $message['attachments'][0];
+            $this->assertSame('Embedded content', $attachment['contentId']);
+            $this->assertTrue($attachment['isInline']);
+
+            return new MockResponse('', ['http_code' => 202]);
+        });
+
+        $transport = new MicrosoftGraphApiTransport('graph', new TokenManagerMock(), false, $client);
+
+        $mail = new Email();
+        $mail->subject('Hello!')
+            ->to(new Address('bob@symfony.com', 'Bob'))
+            ->from(new Address('fabpot@symfony.com', 'Fabien'))
+            ->embed('content', 'Embedded content', 'text/plain');
+
+        $transport->send($mail);
+    }
+
+    public function testRespectsNoSaveParameter()
+    {
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $this->assertSame('POST', $method);
+            $this->assertSame('https://graph/v1.0/users/fabpot@symfony.com/sendMail', $url);
+
+            $body = json_decode($options['body'], true);
+
+            $this->assertFalse($body['saveToSentItems']);
+
+            return new MockResponse('', ['http_code' => 202]);
+        });
+
+        $transport = new MicrosoftGraphApiTransport('graph', new TokenManagerMock(), true, $client);
+
+        $mail = new Email();
+        $mail->subject('Hello!')
+            ->to(new Address('bob@symfony.com', 'Bob'))
+            ->from(new Address('fabpot@symfony.com', 'Fabien'))
+            ->text('Hello There!');
+
+        $transport->send($mail);
+    }
+
+    public function testCustomHeader()
+    {
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $this->assertSame('POST', $method);
+            $this->assertSame('https://graph/v1.0/users/fabpot@symfony.com/sendMail', $url);
+
+            $message = json_decode($options['body'], true)['message'];
+
+            $headers = $message['internetMessageHeaders'];
+            $this->assertCount(1, $headers);
+            $this->assertSame('X-Something', $headers[0]['name']);
+            $this->assertSame('HeaderValue', $headers[0]['value']);
+
+            return new MockResponse('', ['http_code' => 202]);
+        });
+
+        $transport = new MicrosoftGraphApiTransport('graph', new TokenManagerMock(), true, $client);
+
+        $mail = new Email();
+        $mail->subject('Hello!')
+            ->to(new Address('bob@symfony.com', 'Bob'))
+            ->from(new Address('fabpot@symfony.com', 'Fabien'))
+            ->text('Hello There!');
+        $mail->getHeaders()->addHeader('X-Something', 'HeaderValue');
+
+        $transport->send($mail);
+    }
+
+    #[DataProvider('importanceProvider')]
+    public function testImportance(string $expected, int $priority)
+    {
+        $client = new MockHttpClient(function (string $method, string $url, array $options) use ($expected): ResponseInterface {
+            $this->assertSame('POST', $method);
+            $this->assertSame('https://graph/v1.0/users/fabpot@symfony.com/sendMail', $url);
+
+            $message = json_decode($options['body'], true)['message'];
+
+            $this->assertSame($expected, $message['importance']);
+
+            return new MockResponse('', ['http_code' => 202]);
+        });
+
+        $transport = new MicrosoftGraphApiTransport('graph', new TokenManagerMock(), true, $client);
+
+        $mail = new Email();
+        $mail->subject('Hello!')
+            ->to(new Address('bob@symfony.com', 'Bob'))
+            ->from(new Address('fabpot@symfony.com', 'Fabien'))
+            ->text('Hello There!')
+            ->priority($priority);
+
+        $transport->send($mail);
+    }
+
+    public static function importanceProvider(): iterable
+    {
+        yield ['high', Email::PRIORITY_HIGHEST];
+        yield ['high', Email::PRIORITY_HIGH];
+        yield ['normal', Email::PRIORITY_NORMAL];
+        yield ['low', Email::PRIORITY_LOW];
+        yield ['low', Email::PRIORITY_LOWEST];
+    }
+
+    public function testNonSuccessCodeThrown()
+    {
+        $client = new MockHttpClient(fn (): ResponseInterface => new MockResponse('', ['http_code' => 503]));
+
+        $transport = new MicrosoftGraphApiTransport('graph', new TokenManagerMock(), true, $client);
+
+        $mail = new Email();
+        $mail->subject('Hello!')
+            ->to(new Address('bob@symfony.com', 'Bob'))
+            ->from(new Address('fabpot@symfony.com', 'Fabien'))
+            ->text('Hello There!');
+        $mail->getHeaders()->addHeader('X-Prio', 1);
+
+        $this->expectException(HttpTransportException::class);
+        $this->expectExceptionMessageMatches('/^Unable to send an email/');
+
+        $transport->send($mail);
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Tests/Transport/MicrosoftGraphTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Tests/Transport/MicrosoftGraphTransportFactoryTest.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\MicrosoftGraph\Tests\Transport;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\Mailer\Bridge\MicrosoftGraph\TokenManager;
+use Symfony\Component\Mailer\Bridge\MicrosoftGraph\Transport\MicrosoftGraphApiTransport;
+use Symfony\Component\Mailer\Bridge\MicrosoftGraph\Transport\MicrosoftGraphTransportFactory;
+use Symfony\Component\Mailer\Exception\InvalidArgumentException;
+use Symfony\Component\Mailer\Test\AbstractTransportFactoryTestCase;
+use Symfony\Component\Mailer\Test\IncompleteDsnTestTrait;
+use Symfony\Component\Mailer\Transport\Dsn;
+use Symfony\Component\Mailer\Transport\TransportFactoryInterface;
+
+class MicrosoftGraphTransportFactoryTest extends AbstractTransportFactoryTestCase
+{
+    use IncompleteDsnTestTrait;
+
+    protected const TENANT = 't3nant';
+
+    public function getFactory(): TransportFactoryInterface
+    {
+        return new MicrosoftGraphTransportFactory(null, new MockHttpClient(), new NullLogger());
+    }
+
+    public static function supportsProvider(): iterable
+    {
+        yield [
+            new Dsn('microsoftgraph+api', 'default'),
+            true,
+        ];
+    }
+
+    public static function createProvider(): iterable
+    {
+        $mockClient = new MockHttpClient();
+
+        yield [
+            new Dsn('microsoftgraph+api', 'default', self::USER, self::PASSWORD, null, ['tenantId' => self::TENANT]),
+            new MicrosoftGraphApiTransport('graph.microsoft.com', new TokenManager('graph.microsoft.com', 'login.microsoftonline.com', self::TENANT, self::USER, self::PASSWORD, $mockClient), false, $mockClient, null, new NullLogger()),
+        ];
+        yield [
+            new Dsn('microsoftgraph+api', 'other.ms.com', self::USER, self::PASSWORD, null, ['tenantId' => self::TENANT, 'authEndpoint' => 'auth.ms.com']),
+            new MicrosoftGraphApiTransport('other.ms.com', new TokenManager('other.ms.com', 'auth.ms.com', self::TENANT, self::USER, self::PASSWORD, $mockClient), false, $mockClient, null, new NullLogger()),
+        ];
+        yield [
+            new Dsn('microsoftgraph+api', 'default', self::USER, self::PASSWORD, null, ['tenantId' => self::TENANT, 'noSave' => true]),
+            new MicrosoftGraphApiTransport('graph.microsoft.com', new TokenManager('graph.microsoft.com', 'login.microsoftonline.com', self::TENANT, self::USER, self::PASSWORD, $mockClient), true, $mockClient, null, new NullLogger()),
+        ];
+    }
+
+    public static function unsupportedSchemeProvider(): iterable
+    {
+        yield [
+            new Dsn('microsoft+foo', 'default', self::USER, self::PASSWORD),
+            'The "microsoft+foo" scheme is not supported; supported schemes for mailer "microsoft graph api" are: "microsoftgraph+api".',
+        ];
+    }
+
+    public static function incompleteDsnProvider(): iterable
+    {
+        yield [new Dsn('microsoftgraph+api', 'default')];
+        yield [new Dsn('microsoftgraph+api', 'default', self::USER)];
+        yield [new Dsn('microsoftgraph+api', 'default', null, self::PASSWORD)];
+        yield [new Dsn('microsoftgraph+api', 'default', self::USER, self::PASSWORD)];
+        yield [new Dsn('microsoftgraph+api', 'non-default', self::USER, self::PASSWORD, null, ['tenantId' => self::TENANT])];
+    }
+
+    #[DataProvider('invalidHttpDsnProvider')]
+    public function testValidatesHttpNotProvided(string $graph, string $auth, string $failingType)
+    {
+        $factory = $this->getFactory();
+        $dsn = new Dsn('microsoftgraph+api', $graph, self::USER, self::PASSWORD, null, ['tenantId' => self::TENANT, 'authEndpoint' => $auth]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($failingType.' endpoint needs to be provided without http(s)://.');
+        $factory->create($dsn);
+    }
+
+    public static function invalidHttpDsnProvider(): iterable
+    {
+        yield ['http://graph', 'auth', 'Graph'];
+        yield ['https://graph', 'auth', 'Graph'];
+        yield ['graph', 'http://auth', 'Auth'];
+        yield ['graph', 'https://auth', 'Auth'];
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/TokenManager.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/TokenManager.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\MicrosoftGraph;
+
+use Symfony\Component\Clock\DatePoint;
+use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class TokenManager
+{
+    private ?string $token = null;
+    private ?DatePoint $tokenExpires = null;
+
+    /**
+     * @param string $graphEndpoint Graph API URL to which to POST emails
+     * @param string $authEndpoint  Authentication URL
+     * @param string $tenantId      Microsoft Azure tenant identifier
+     * @param string $appId         Microsoft Azure app registration ID
+     * @param string $appSecret     Microsoft Azure app registration secret
+     */
+    public function __construct(
+        private readonly string $graphEndpoint,
+        private readonly string $authEndpoint,
+        private readonly string $tenantId,
+        private readonly string $appId,
+        #[\SensitiveParameter] private readonly string $appSecret,
+        private readonly HttpClientInterface $client,
+    ) {
+    }
+
+    public function getToken(): string
+    {
+        if (null !== $this->token && $this->tokenExpires > new DatePoint()) {
+            return $this->token;
+        }
+
+        $endpoint = "https://$this->authEndpoint/$this->tenantId/oauth2/v2.0/token";
+        $response = $this->client->request('POST', $endpoint, [
+            'body' => [
+                'client_id' => $this->appId,
+                'client_secret' => $this->appSecret,
+                'scope' => "https://$this->graphEndpoint/.default",
+                'grant_type' => 'client_credentials',
+            ],
+        ]);
+
+        try {
+            $statusCode = $response->getStatusCode();
+        } catch (TransportExceptionInterface $e) {
+            throw new HttpTransportException('Could not reach the remote Microsoft authentication server.', $response, 0, $e);
+        }
+
+        if (200 !== $statusCode) {
+            throw new HttpTransportException('Unable to authenticate: '.$response->getContent(false).\sprintf(' (code %d).', $statusCode), $response);
+        }
+
+        $tokenData = $response->toArray();
+        $this->token = $tokenData['access_token'];
+        $this->tokenExpires = new DatePoint("+{$tokenData['expires_in']} seconds");
+
+        return $this->token;
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphApiTransport.php
@@ -1,0 +1,199 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\MicrosoftGraph\Transport;
+
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Mailer\Bridge\MicrosoftGraph\TokenManager;
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mailer\SentMessage;
+use Symfony\Component\Mailer\Transport\AbstractApiTransport;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+class MicrosoftGraphApiTransport extends AbstractApiTransport
+{
+    private const USER_ENDPOINT = '%s/v1.0/users/%s/sendMail';
+
+    /**
+     * @param string $graphEndpoint Graph API URL to which to POST emails
+     * @param bool   $noSave        Whether the skip saving the send message in the Sent Items box
+     */
+    public function __construct(
+        private readonly string $graphEndpoint,
+        private readonly TokenManager $tokenManager,
+        private readonly bool $noSave,
+        ?HttpClientInterface $client = null,
+        ?EventDispatcherInterface $dispatcher = null,
+        ?LoggerInterface $logger = null,
+    ) {
+        parent::__construct($client, $dispatcher, $logger);
+    }
+
+    public function __toString(): string
+    {
+        return \sprintf('microsoftgraph+api://%s', $this->graphEndpoint);
+    }
+
+    protected function doSendApi(SentMessage $sentMessage, Email $email, Envelope $envelope): ResponseInterface
+    {
+        $endpoint = \sprintf('https://'.self::USER_ENDPOINT, $this->graphEndpoint, $envelope->getSender()->getAddress());
+        $payload = $this->getPayload($email, $envelope);
+
+        $response = $this->client->request('POST', $endpoint, [
+            'json' => $payload,
+            'auth_bearer' => $this->tokenManager->getToken(),
+        ]);
+
+        try {
+            $statusCode = $response->getStatusCode();
+        } catch (TransportExceptionInterface $e) {
+            throw new HttpTransportException('Could not reach the remote Microsoft server.', $response, 0, $e);
+        }
+
+        if (202 !== $statusCode) {
+            throw new HttpTransportException('Unable to send an email: '.$response->getContent(false).\sprintf(' (code %d).', $statusCode), $response);
+        }
+
+        return $response;
+    }
+
+    private function getPayload(Email $email, Envelope $envelope): array
+    {
+        $message = [
+            'sender' => $this->getEmailAddress($envelope->getSender()),
+            'subject' => $email->getSubject(),
+            'body' => $this->getBodyPayload($email),
+            'importance' => $this->getImportanceLevel($email),
+            'toRecipients' => array_map($this->getEmailAddress(...), $email->getTo()),
+        ];
+
+        if ($email->getFrom()) {
+            // Microsoft only supports a single from
+            $message['from'] = $this->getEmailAddress($email->getFrom()[0]);
+        }
+
+        if ($attachments = $this->getMessageAttachments($email)) {
+            $message['attachments'] = $attachments;
+        }
+
+        if ($bcc = array_map($this->getEmailAddress(...), $email->getBcc())) {
+            $message['bccRecipients'] = $bcc;
+        }
+
+        if ($cc = array_map($this->getEmailAddress(...), $email->getCc())) {
+            $message['ccRecipients'] = $cc;
+        }
+
+        if ($headers = $this->getMessageCustomHeaders($email)) {
+            $message['internetMessageHeaders'] = $headers;
+        }
+
+        if ($replyTo = array_map($this->getEmailAddress(...), $email->getReplyTo())) {
+            $message['replyTo'] = $replyTo;
+        }
+
+        $data['message'] = $message;
+        if ($this->noSave) {
+            $data['saveToSentItems'] = false;
+        }
+
+        return $data;
+    }
+
+    private function getBodyPayload(Email $email): array
+    {
+        // Microsoft message can either be HTML or text, but not both
+        if ($email->getHtmlBody()) {
+            return [
+                'content' => $email->getHtmlBody(),
+                'contentType' => 'html',
+            ];
+        }
+
+        return [
+            'content' => $email->getTextBody(),
+            'contentType' => 'text',
+        ];
+    }
+
+    private function getEmailAddress(Address $address): array
+    {
+        $data = ['address' => $address->getAddress()];
+
+        if ($address->getName()) {
+            $data['name'] = $address->getName();
+        }
+
+        return ['emailAddress' => $data];
+    }
+
+    private function getMessageAttachments(Email $email): array
+    {
+        $attachments = [];
+        foreach ($email->getAttachments() as $attachment) {
+            $headers = $attachment->getPreparedHeaders();
+            $filename = $headers->getHeaderParameter('Content-Disposition', 'filename');
+            $disposition = $headers->getHeaderBody('Content-Disposition');
+
+            $attr = [
+                '@odata.type' => '#microsoft.graph.fileAttachment',
+                'name' => $filename,
+                'contentBytes' => base64_encode($attachment->getBody()),
+                'contentType' => $headers->get('Content-Type')->getBody(),
+            ];
+
+            if ('inline' === $disposition) {
+                $attr['contentId'] = $filename;
+                $attr['isInline'] = true;
+            }
+
+            $attachments[] = $attr;
+        }
+
+        return $attachments;
+    }
+
+    private function getMessageCustomHeaders(Email $email): array
+    {
+        $headers = [];
+
+        $headersToBypass = ['x-ms-client-request-id', 'operation-id', 'authorization', 'x-ms-content-sha256', 'received', 'dkim-signature', 'content-transfer-encoding', 'from', 'to', 'cc', 'bcc', 'subject', 'content-type', 'reply-to'];
+
+        foreach ($email->getHeaders()->all() as $name => $header) {
+            if (\in_array($name, $headersToBypass, true)) {
+                continue;
+            }
+            $headers[] = [
+                'name' => $header->getName(),
+                'value' => $header->getBodyAsString(),
+            ];
+        }
+
+        return $headers;
+    }
+
+    private function getImportanceLevel(Email $email): string
+    {
+        return match ($email->getPriority()) {
+            Email::PRIORITY_HIGHEST,
+            Email::PRIORITY_HIGH => 'high',
+            Email::PRIORITY_LOW,
+            Email::PRIORITY_LOWEST => 'low',
+            default => 'normal',
+        };
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransportFactory.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\MicrosoftGraph\Transport;
+
+use Symfony\Component\Mailer\Bridge\MicrosoftGraph\TokenManager;
+use Symfony\Component\Mailer\Exception\IncompleteDsnException;
+use Symfony\Component\Mailer\Exception\InvalidArgumentException;
+use Symfony\Component\Mailer\Exception\UnsupportedSchemeException;
+use Symfony\Component\Mailer\Transport\AbstractTransportFactory;
+use Symfony\Component\Mailer\Transport\Dsn;
+use Symfony\Component\Mailer\Transport\TransportInterface;
+
+class MicrosoftGraphTransportFactory extends AbstractTransportFactory
+{
+    public function create(Dsn $dsn): TransportInterface
+    {
+        if ('microsoftgraph+api' !== $dsn->getScheme()) {
+            throw new UnsupportedSchemeException($dsn, 'microsoft graph api', $this->getSupportedSchemes());
+        }
+
+        if (null === $tenantId = $dsn->getOption('tenantId')) {
+            throw new IncompleteDsnException('Transport "microsoftgraph+api" requires the "tenant" option.');
+        }
+
+        $graphEndpoint = $dsn->getHost();
+        $authEndpoint = $dsn->getOption('authEndpoint');
+        if ('default' === $graphEndpoint) {
+            $graphEndpoint = 'graph.microsoft.com';
+            if (null === $authEndpoint) {
+                $authEndpoint = 'login.microsoftonline.com';
+            }
+        }
+
+        if (null === $authEndpoint) {
+            throw new IncompleteDsnException('Transport "microsoftgraph+api" requires the "authEndpoint" option when not using the default graph endpoint.');
+        }
+
+        if (preg_match('#^https?://#', $authEndpoint)) {
+            throw new InvalidArgumentException('Auth endpoint needs to be provided without "http(s)://".');
+        }
+
+        if (preg_match('#^https?://#', $graphEndpoint)) {
+            throw new InvalidArgumentException('Graph endpoint needs to be provided without "http(s)://".');
+        }
+
+        $tokenManager = new TokenManager($graphEndpoint, $authEndpoint, $tenantId, $this->getUser($dsn), $this->getPassword($dsn), $this->client);
+
+        return new MicrosoftGraphApiTransport($graphEndpoint, $tokenManager, $dsn->getBooleanOption('noSave'), $this->client, $this->dispatcher, $this->logger);
+    }
+
+    protected function getSupportedSchemes(): array
+    {
+        return ['microsoftgraph+api'];
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/composer.json
@@ -1,0 +1,39 @@
+{
+    "name": "symfony/microsoft-graph-mailer",
+    "type": "symfony-mailer-bridge",
+    "description": "Symfony Microsoft Graph Mailer Bridge",
+    "keywords": [],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Bob van de Vijver",
+            "homepage": "https://github.com/bobvandevijver"
+        },
+        {
+            "name": "Kevin Nguyen",
+            "homepage": "https://github.com/nguyenk"
+        },
+        {
+            "name": "The Coding Machine",
+            "homepage": "https://github.com/thecodingmachine"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=8.2",
+        "symfony/clock": "^7.4|^8.0",
+        "symfony/http-client": "^6.4|^7.0|^8.0",
+        "symfony/mailer": "^7.4|^8.0"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Component\\Mailer\\Bridge\\MicrosoftGraph\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev"
+}

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/phpunit.xml.dist
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/phpunit.xml.dist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/9.3/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony Microsoft Graph Mailer Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage>
+        <include>
+            <directory>./</directory>
+        </include>
+        <exclude>
+            <directory>./Resources</directory>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </coverage>
+</phpunit>

--- a/src/Symfony/Component/Mailer/Exception/UnsupportedSchemeException.php
+++ b/src/Symfony/Component/Mailer/Exception/UnsupportedSchemeException.php
@@ -76,6 +76,10 @@ class UnsupportedSchemeException extends LogicException
             'class' => Bridge\Mailtrap\Transport\MailtrapTransportFactory::class,
             'package' => 'symfony/mailtrap-mailer',
         ],
+        'microsoftgraph' => [
+            'class' => Bridge\MicrosoftGraph\Transport\MicrosoftGraphTransportFactory::class,
+            'package' => 'symfony/microsoft-graph-mailer',
+        ],
         'resend' => [
             'class' => Bridge\Resend\Transport\ResendTransportFactory::class,
             'package' => 'symfony/resend-mailer',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Alternative for #60408 <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->

Add a new Mailer bridge for the Microsoft Graph API, but without adding the complete Microsoft SDK as we're talking about just two HTTP POST requests.

I continued the work done in #60408 and kept the names mentioned there in the composer definition, but this implementation has been made from scratch, is based on the existing Azure Bridge and supports more features such as priority and inline attachments.