### PR TITLE
[Messenger] Remove fix `NoAutoAckStamp` handling in `Worker::flush()`

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Fixtures/DummyReceiver.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/DummyReceiver.php
@@ -63,4 +63,9 @@ class DummyReceiver implements ReceiverInterface
     {
         return $this->acknowledgedEnvelopes;
     }
+
+    public function getRejectedEnvelopes(): array
+    {
+        return $this->rejectedEnvelopes;
+    }
 }

--- a/src/Symfony/Component/Messenger/Worker.php
+++ b/src/Symfony/Component/Messenger/Worker.php
@@ -257,9 +257,9 @@ class Worker
             [$envelope, $transportName] = $unacks[$batchHandler];
             try {
                 $this->bus->dispatch($envelope->with(new FlushBatchHandlersStamp($force)));
-                $envelope = $envelope->withoutAll(NoAutoAckStamp::class);
                 unset($unacks[$batchHandler], $batchHandler);
             } catch (\Throwable $e) {
+                $envelope = $envelope->withoutAll(NoAutoAckStamp::class);
                 $this->acks[] = [$transportName, $envelope, $e];
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

## Description

This PR removes unused code in the `Worker::flush()` method where an envelope modification was never used.

## Changes

- Removed the line `$envelope = $envelope->withoutAll(NoAutoAckStamp::class);` which was modifying a local variable that was immediately discarded
- Moved the `NoAutoAckStamp` removal to the catch block where it's actually needed

## Why this change?

The line was unused code because:
1. If `dispatch()` succeeds: The modified envelope is never used (foreach continues/ends)
2. If `dispatch()` throws: The line is never reached

Moving the stamp removal to the `catch` block ensures that envelopes stored for acknowledgment have clean state - they shouldn't contain a "no auto ack" stamp when they're about to be acknowledged.