### PR TITLE
[Messenger] Fix `BatchHandlerTrait::flush()` ignoring `force` parameter

### DIFF
--- a/src/Symfony/Component/Messenger/Handler/BatchHandlerTrait.php
+++ b/src/Symfony/Component/Messenger/Handler/BatchHandlerTrait.php
@@ -20,10 +20,17 @@ trait BatchHandlerTrait
 
     public function flush(bool $force): void
     {
-        if ($jobs = $this->jobs) {
-            $this->jobs = [];
-            $this->process($jobs);
+        if (empty($this->jobs)) {
+            return;
         }
+
+        if (!$force && !$this->shouldFlush()) {
+            return;
+        }
+
+        $jobs = $this->jobs;
+        $this->jobs = [];
+        $this->process($jobs);
     }
 
     /**

--- a/src/Symfony/Component/Messenger/Tests/Middleware/HandleMessageMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/HandleMessageMiddlewareTest.php
@@ -323,6 +323,54 @@ class HandleMessageMiddlewareTest extends MiddlewareTestCase
         $this->assertSame([$message], $handler->processedMessages);
     }
 
+    public function testBatchHandlerFlushFalseDoesNotFlushPartialBatch()
+    {
+        $handler = new class implements BatchHandlerInterface {
+            public array $processedMessages = [];
+
+            use BatchHandlerTrait;
+
+            public function __invoke(DummyMessage $message, ?Acknowledger $ack = null)
+            {
+                return $this->handle($message, $ack);
+            }
+
+            private function getBatchSize(): int
+            {
+                return 3;
+            }
+
+            private function process(array $jobs): void
+            {
+                $this->processedMessages = array_column($jobs, 0);
+
+                foreach ($jobs as [$job, $ack]) {
+                    $ack->ack($job);
+                }
+            }
+        };
+
+        $middleware = new HandleMessageMiddleware(new HandlersLocator([
+            DummyMessage::class => [new HandlerDescriptor($handler)],
+        ]));
+
+        $ack = static function () {};
+
+        $message = new DummyMessage('Hey');
+        $envelope = $middleware->handle(new Envelope($message, [new AckStamp($ack)]), new StackMiddleware());
+
+        $this->assertEmpty($handler->processedMessages);
+        $this->assertCount(1, $envelope->all(NoAutoAckStamp::class));
+
+        $handler->flush(false);
+
+        $this->assertEmpty($handler->processedMessages);
+
+        $handler->flush(true);
+
+        $this->assertSame([$message], $handler->processedMessages);
+    }
+
     public function testHandlerArgumentsStamp()
     {
         $message = new DummyMessage('Hey');

--- a/src/Symfony/Component/Messenger/Tests/WorkerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/WorkerTest.php
@@ -523,10 +523,12 @@ class WorkerTest extends TestCase
     {
         $expectedMessages = [
             new DummyMessage('Hey'),
+            new DummyMessage('There'),
         ];
 
         $receiver = new DummyReceiver([
             [new Envelope($expectedMessages[0])],
+            [new Envelope($expectedMessages[1])],
             [],
         ]);
 
@@ -541,11 +543,9 @@ class WorkerTest extends TestCase
         $dispatcher = new EventDispatcher();
         $dispatcher->addListener(WorkerRunningEvent::class, function (WorkerRunningEvent $event) use ($receiver) {
             static $i = 0;
-            if (1 < ++$i) {
+            if (2 < ++$i) {
                 $event->getWorker()->stop();
-                $this->assertSame(1, $receiver->getAcknowledgeCount());
-            } else {
-                $this->assertSame(0, $receiver->getAcknowledgeCount());
+                $this->assertSame(2, $receiver->getAcknowledgeCount());
             }
         });
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61292
| License       | MIT

The flush() method was ignoring the $force parameter and always flushing when jobs existed, violating the `BatchHandlerInterface` contract which states flushing "can be skipped if not" forced.

This caused inefficient batching behavior where flush(false) calls during worker idle periods would prematurely process partial batches instead of waiting for the batch size threshold to be reached.

## What it does

Fixes `BatchHandlerTrait::flush(bool $force)` to respect the `$force` parameter:

- **Before**: `flush(false)` and `flush(true)` behaved identically - always flushed when jobs existed
- **After**: `flush(false)` only flushes when `shouldFlush()` returns true (batch size reached)

## Example

```php
$handler = new MyBatchHandler(); // batch size: 3

// Add 1 message (batch not full)
$handler->handle($message, $ack);

// Before fix: Would flush the 1 message
// After fix: Does not flush (waits for batch to fill)
$handler->flush(false);

// Always flushes (unchanged behavior)
$handler->flush(true);
```

## Impact

This fixes the Worker's flush behavior during idle periods:
- `Worker::run()` calls `flush(false)` when no messages are handled
- Previously this would flush partial batches, defeating batching efficiency
- Now respects the intended batching behavior per the interface contract