### PR TITLE
[PhpUnitBridge] Call Reflection*::setAccessible() only for PHP < 8.1

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/CoverageListener.php
+++ b/src/Symfony/Bridge/PhpUnit/CoverageListener.php
@@ -86,7 +86,9 @@ class CoverageListener implements TestListener
     private function addCoversForClassToAnnotationCache(Test $test, array $covers): void
     {
         $r = new \ReflectionProperty(TestUtil::class, 'annotationCache');
-        $r->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $r->setAccessible(true);
+        }
 
         $cache = $r->getValue();
         $cache = array_replace_recursive($cache, [
@@ -103,7 +105,9 @@ class CoverageListener implements TestListener
         $docBlock = Registry::getInstance()->forClassName(\get_class($test));
 
         $symbolAnnotations = new \ReflectionProperty($docBlock, 'symbolAnnotations');
-        $symbolAnnotations->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $symbolAnnotations->setAccessible(true);
+        }
 
         // Exclude internal classes; PHPUnit 9.1+ is picky about tests covering, say, a \RuntimeException
         $covers = array_filter($covers, function (string $class) {

--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Deprecation.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Deprecation.php
@@ -437,7 +437,9 @@ class Deprecation
     {
         $exception = new \Exception($this->message);
         $reflection = new \ReflectionProperty($exception, 'trace');
-        $reflection->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $reflection->setAccessible(true);
+        }
         $reflection->setValue($exception, $this->trace);
 
         return ($this->originatesFromAnObject() ? 'deprecation triggered by '.$this->originatingClass().'::'.$this->originatingMethod().":\n" : '')

--- a/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
@@ -357,7 +357,9 @@ class SymfonyTestsListenerTrait
         }
 
         $r = new \ReflectionProperty($test, 'runTestInSeparateProcess');
-        $r->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $r->setAccessible(true);
+        }
 
         return $r->getValue($test) ?? false;
     }

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/DeprecationTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/DeprecationTest.php
@@ -275,7 +275,9 @@ class DeprecationTest extends TestCase
                     $loader = require $v.'/autoload.php';
                     $reflection = new \ReflectionClass($loader);
                     $prop = $reflection->getProperty('prefixDirsPsr4');
-                    $prop->setAccessible(true);
+                    if (\PHP_VERSION_ID < 80100) {
+                        $prop->setAccessible(true);
+                    }
                     $currentValue = $prop->getValue($loader);
                     self::$prefixDirsPsr4[] = [$prop, $loader, $currentValue];
                     $currentValue['Symfony\\Bridge\\PhpUnit\\'] = [realpath(__DIR__.'/../..')];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Follow-up of https://github.com/symfony/symfony/pull/61207

There are plans to deprecate `Reflection*::setAccessible()` in PHP 8.5: https://wiki.php.net/rfc/deprecations_php_8_5#extreflection_deprecations

Thus, it might be beneficial to only call it if PHP < 8.1 is used.