### PR TITLE
[FrameworkBundle] Escape parameters when serializing ContainerBuilders

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ContainerBuilderDebugDumpPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ContainerBuilderDebugDumpPass.php
@@ -54,7 +54,7 @@ class ContainerBuilderDebugDumpPass implements CompilerPassInterface
 
             if (($bag = $container->getParameterBag()) instanceof EnvPlaceholderParameterBag) {
                 (new ResolveEnvPlaceholdersPass(null))->process($dump);
-                $dump->__construct(new EnvPlaceholderParameterBag($container->resolveEnvPlaceholders($bag->all())));
+                $dump->__construct(new EnvPlaceholderParameterBag($container->resolveEnvPlaceholders($this->escapeParameters($bag->all()))));
             }
 
             $fs = new Filesystem();
@@ -67,5 +67,19 @@ class ContainerBuilderDebugDumpPass implements CompilerPassInterface
                 @unlink($file);
             }
         }
+    }
+
+    private function escapeParameters(array $parameters): array
+    {
+        $params = [];
+        foreach ($parameters as $k => $v) {
+            $params[$k] = match (true) {
+                \is_array($v) => $this->escapeParameters($v),
+                \is_string($v) => str_replace('%', '%%', $v),
+                default => $v,
+            };
+        }
+
+        return $params;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerLintCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerLintCommandTest.php
@@ -44,6 +44,7 @@ class ContainerLintCommandTest extends AbstractWebTestCase
     {
         return [
             ['escaped_percent.yml', false, 0, 'The container was linted successfully'],
+            ['escaped_percent.yml', true, 0, 'The container was linted successfully'],
             ['missing_env_var.yml', false, 0, 'The container was linted successfully'],
             ['missing_env_var.yml', true, 1, 'Environment variable not found: "BAR"'],
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Since the `XmlDumper` didn’t escape uncompiled containers’ parameters, there was no way to differentiate a parameter placeholder from its escaped counterpart (e.g. `%%foo%%` and `%foo%` both are dumped as `%foo%`). This could make `lint:container --resolve-env-vars` fail in some cases.

This PR doesn’t change the `XmlDumper` to keep BC, but alter the way `ContainerBuilder`s are serialized by #60597 as it didn’t get released yet.