### PR TITLE
[Scheduler] Fix `scheduler.task` tag arguments optionality

### DIFF
--- a/src/Symfony/Component/Scheduler/DependencyInjection/AddScheduleMessengerPass.php
+++ b/src/Symfony/Component/Scheduler/DependencyInjection/AddScheduleMessengerPass.php
@@ -60,7 +60,7 @@ class AddScheduleMessengerPass implements CompilerPassInterface
                     $attribute = ($container->getReflectionClass($serviceDefinition->getClass())->getAttributes(AsCommand::class)[0] ?? null)?->newInstance();
                     $commandName = $attribute?->name ?? $serviceDefinition->getClass()::getDefaultName();
 
-                    $message = new Definition(RunCommandMessage::class, [$commandName.($tagAttributes['arguments'] ? " {$tagAttributes['arguments']}" : '')]);
+                    $message = new Definition(RunCommandMessage::class, [$commandName.(($tagAttributes['arguments'] ?? null) ? " {$tagAttributes['arguments']}" : '')]);
                 } else {
                     $message = new Definition(ServiceCallMessage::class, [$serviceId, $tagAttributes['method'] ?? '__invoke', (array) ($tagAttributes['arguments'] ?? [])]);
                 }

--- a/src/Symfony/Component/Scheduler/Tests/DependencyInjection/AddScheduleMessengerPassTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/DependencyInjection/AddScheduleMessengerPassTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\DependencyInjection;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\Scheduler\DependencyInjection\AddScheduleMessengerPass;
+
+class AddScheduleMessengerPassTest extends TestCase
+{
+    /**
+     * @dataProvider processSchedulerTaskCommandProvider
+     */
+    public function testProcessSchedulerTaskCommand(array $arguments, string $exceptedCommand)
+    {
+        $container = new ContainerBuilder();
+
+        $definition = new Definition(SchedulableCommand::class);
+        $definition->addTag('console.command');
+        $definition->addTag('scheduler.task', $arguments);
+        $container->setDefinition(SchedulableCommand::class, $definition);
+
+        (new AddScheduleMessengerPass())->process($container);
+
+        $schedulerProvider = $container->getDefinition('scheduler.provider.default');
+        $calls = $schedulerProvider->getMethodCalls();
+
+        $this->assertCount(1, $calls);
+        $this->assertCount(2, $calls[0]);
+
+        $messageDefinition = $calls[0][1][0];
+        $messageArguments = $messageDefinition->getArgument('$message');
+        $command = $messageArguments->getArgument(0);
+
+        $this->assertSame($exceptedCommand, $command);
+    }
+
+    public static function processSchedulerTaskCommandProvider(): iterable
+    {
+        yield 'no arguments' => [['trigger' => 'every', 'frequency' => '1 hour'], 'schedulable'];
+        yield 'null arguments' => [['trigger' => 'every', 'frequency' => '1 hour', 'arguments' => null], 'schedulable'];
+        yield 'empty arguments' => [['trigger' => 'every', 'frequency' => '1 hour', 'arguments' => ''], 'schedulable'];
+        yield 'test argument' => [['trigger' => 'every', 'frequency' => '1 hour', 'arguments' => 'test'], 'schedulable test'];
+    }
+}
+
+#[AsCommand(name: 'schedulable')]
+class SchedulableCommand
+{
+    public function __invoke(): void
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

According to [this comment](https://github.com/symfony/symfony/pull/60741#issuecomment-3145671618) there is a change in behaviour after #60741 which causes requiring specify `arguments` parameter when tagging `scheduler.task` manually. This pull request makes `arguments` parameter back optional.

```
$myService->tag('scheduler.task', [
    'trigger' => 'every',
    'frequency' => 15,
    'arguments' => null, // <- had to add this line to avoid a Warning: Undefined array key "arguments"
]);
```
