### PR TITLE
[Console] Adding more helpful error messages to the Questionhelper

### DIFF
--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -271,7 +271,7 @@ class QuestionHelper extends Helper
             // as opposed to fgets(), fread() returns an empty string when the stream content is empty, not false.
             if (false === $c || ('' === $ret && '' === $c && null === $question->getDefault())) {
                 shell_exec('stty '.$sttyMode);
-                throw new MissingInputException('Aborted.');
+                throw new MissingInputException('Aborted while asking: '.$question->getQuestion());
             } elseif ("\177" === $c) { // Backspace Character
                 if (0 === $numMatches && 0 !== $i) {
                     --$i;

--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -750,7 +750,7 @@ EOD;
     public function testAskThrowsExceptionOnMissingInputForChoiceQuestion()
     {
         $this->expectException(MissingInputException::class);
-        $this->expectExceptionMessage('Aborted.');
+        $this->expectExceptionMessage('Aborted while asking: Choice');
         (new QuestionHelper())->ask($this->createStreamableInputInterfaceMock($this->getInputStream('')), $this->createOutputInterface(), new ChoiceQuestion('Choice', ['a', 'b']));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

When trying to debug, having an error like this is not very helpful:
```text
1) Sylius\Bundle\GridBundle\Tests\Functional\Maker\MakeGridTest::it_can_create_grids_interactively
Symfony\Component\Console\Exception\MissingInputException: Aborted.

symfony/console/Helper/QuestionHelper.php:273
symfony/console/Helper/QuestionHelper.php:139
symfony/console/Helper/QuestionHelper.php:65
symfony/console/Helper/QuestionHelper.php:473
symfony/console/Helper/QuestionHelper.php:67
symfony/console/Style/SymfonyStyle.php:307
symfony/console/Style/SymfonyStyle.php:247
```

When trying to debug where the error is actually coming from. More helpful would be:
```text
1) Sylius\Bundle\GridBundle\Tests\Functional\Maker\MakeGridTest::it_can_create_grids_interactively
Symfony\Component\Console\Exception\MissingInputException: Aborted while asking: Entity class to create a grid for
```