### PR TITLE
[WebProfilerBundle] Show `EventSource` requests in debug toolbar

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add support for the `QUERY` HTTP method in the profiler
+ * Add support for Server-Sent Events / `EventSource` requests in the debug toolbar
 
 7.3
 ---

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -295,6 +295,51 @@
             };
 
             {% if excluded_ajax_paths is defined %}
+            if (window.EventSource) {
+                var oldEventSource = window.EventSource;
+                window.EventSource = function (url, options) {
+                    var es = new oldEventSource(url, options);
+                    if (!url.match(new RegExp({{ excluded_ajax_paths|json_encode|raw }}))) {
+                        var stackElement = {
+                            error: false,
+                            url: url,
+                            method: 'GET',
+                            type: 'event-stream',
+                            start: new Date()
+                        };
+
+                        var idx = requestStack.push(stackElement) - 1;
+                        startAjaxRequest(idx);
+                        addEventListener(es, 'error', function () {
+                            stackElement.error = true;
+                            finishAjaxRequest(idx);
+                        });
+                        addEventListener(es, 'open', function () {
+                            stackElement.statusCode = 200;
+                            stackElement.toolbarReplaceFinished = false;
+                            stackElement.toolbarReplace = true;
+                        });
+                        addEventListener(es, 'symfony:debug:started', function (event) {
+                            var items = event.data.split('\n');
+                            stackElement.profile = items[0];
+                            stackElement.profilerUrl = items[1];
+                        });
+                        addEventListener(es, 'symfony:debug:error', function (event) {
+                            stackElement.error = true;
+                            stackElement.statusCode = event.data;
+                            finishAjaxRequest(idx);
+                        });
+                        addEventListener(es, 'symfony:debug:finished', function () {
+                            stackElement.duration = new Date() - stackElement.start;
+                            stackElement.toolbarReplaceFinished = false;
+                            stackElement.toolbarReplace = true;
+                            finishAjaxRequest(idx);
+                        });
+                    }
+
+                    return es;
+                };
+            }
             if (window.fetch && window.fetch.polyfill === undefined) {
                 var oldFetch = window.fetch;
                 window.fetch = function () {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues | Related to #57288
| License       | MIT

Show requests originated from js `EventSource` (Server-Sent Events) in the web debug toolbar.

By using custom event type we should be able to avoid interfering with any app logic.
