### PR TITLE
[Mailer] Add compatibility for Mailtrap's sandbox

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailtrap/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Mailtrap/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+ * Add compatibility for Mailtrap's sandbox with new DSN scheme
+
 7.2
 ---
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailtrap/README.md
+++ b/src/Symfony/Component/Mailer/Bridge/Mailtrap/README.md
@@ -9,13 +9,17 @@ Configuration example:
 # SMTP
 MAILER_DSN=mailtrap+smtp://PASSWORD@default
 
-# API
+# API (Live)
 MAILER_DSN=mailtrap+api://TOKEN@default
+
+# API (Sandbox)
+MAILER_DSN=mailtrap+sandbox://TOKEN@default?inboxId=INBOX_ID
 ```
 
 where:
  - `PASSWORD` is your Mailtrap SMTP Password
  - `TOKEN` is your Mailtrap Server Token
+ - `INBOX_ID` is your Mailtrap sandbox inbox's ID
 
 Resources
 ---------

--- a/src/Symfony/Component/Mailer/Bridge/Mailtrap/Tests/Transport/MailtrapApiSandboxTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailtrap/Tests/Transport/MailtrapApiSandboxTransportTest.php
@@ -1,0 +1,139 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\Mailtrap\Tests\Transport;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+use Symfony\Component\Mailer\Bridge\Mailtrap\Transport\MailtrapApiSandboxTransport;
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mailer\Exception\TransportException;
+use Symfony\Component\Mailer\Header\MetadataHeader;
+use Symfony\Component\Mailer\Header\TagHeader;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+class MailtrapApiSandboxTransportTest extends TestCase
+{
+    #[DataProvider('getTransportData')]
+    public function testToString(MailtrapApiSandboxTransport $transport, string $expected)
+    {
+        $this->assertSame($expected, (string) $transport);
+    }
+
+    public static function getTransportData(): array
+    {
+        return [
+            [
+                new MailtrapApiSandboxTransport('KEY', 123456),
+                'mailtrap+sandbox://sandbox.api.mailtrap.io/?inboxId=123456',
+            ],
+            [
+                (new MailtrapApiSandboxTransport('KEY', 123456))->setHost('example.com'),
+                'mailtrap+sandbox://example.com/?inboxId=123456',
+            ],
+            [
+                (new MailtrapApiSandboxTransport('KEY', 123456))->setHost('example.com')->setPort(99),
+                'mailtrap+sandbox://example.com:99/?inboxId=123456',
+            ],
+            [
+                new MailtrapApiSandboxTransport('KEY', 123456),
+                'mailtrap+sandbox://sandbox.api.mailtrap.io/?inboxId=123456',
+            ],
+        ];
+    }
+
+    public function testSend()
+    {
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $this->assertSame('POST', $method);
+            $this->assertSame('https://sandbox.api.mailtrap.io/api/send/123456', $url);
+
+            $body = json_decode($options['body'], true);
+            $this->assertSame(['email' => 'fabpot@symfony.com', 'name' => 'Fabien'], $body['from']);
+            $this->assertSame([['email' => 'kevin@symfony.com', 'name' => 'Kevin']], $body['to']);
+            $this->assertSame('Hello!', $body['subject']);
+            $this->assertSame('Hello There!', $body['text']);
+
+            return new JsonMockResponse([], [
+                'http_code' => 200,
+            ]);
+        });
+
+        $transport = new MailtrapApiSandboxTransport('KEY', 123456, $client);
+
+        $mail = new Email();
+        $mail->subject('Hello!')
+            ->to(new Address('kevin@symfony.com', 'Kevin'))
+            ->from(new Address('fabpot@symfony.com', 'Fabien'))
+            ->text('Hello There!');
+
+        $transport->send($mail);
+    }
+
+    public function testSendThrowsForErrorResponse()
+    {
+        $client = new MockHttpClient(static fn (string $method, string $url, array $options): ResponseInterface => new JsonMockResponse(['errors' => ['i\'m a teapot']], [
+            'http_code' => 418,
+        ]));
+        $transport = new MailtrapApiSandboxTransport('KEY', 123456, $client);
+        $transport->setPort(8984);
+
+        $mail = new Email();
+        $mail->subject('Hello!')
+            ->to(new Address('kevin@symfony.com', 'Kevin'))
+            ->from(new Address('fabpot@symfony.com', 'Fabien'))
+            ->text('Hello There!');
+
+        $this->expectException(HttpTransportException::class);
+        $this->expectExceptionMessage('Unable to send email: "i\'m a teapot" (status code 418).');
+        $transport->send($mail);
+    }
+
+    public function testTagAndMetadataHeaders()
+    {
+        $email = new Email();
+        $email->getHeaders()->add(new TagHeader('password-reset'));
+        $email->getHeaders()->add(new MetadataHeader('Color', 'blue'));
+        $email->getHeaders()->add(new MetadataHeader('Client-ID', '12345'));
+        $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
+
+        $transport = new MailtrapApiSandboxTransport('ACCESS_KEY', 123456);
+        $method = new \ReflectionMethod(MailtrapApiSandboxTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertArrayNotHasKey('Headers', $payload);
+        $this->assertArrayHasKey('category', $payload);
+        $this->assertArrayHasKey('custom_variables', $payload);
+
+        $this->assertSame('password-reset', $payload['category']);
+        $this->assertSame(['Color' => 'blue', 'Client-ID' => '12345'], $payload['custom_variables']);
+    }
+
+    public function testMultipleTagsAreNotAllowed()
+    {
+        $email = new Email();
+        $email->getHeaders()->add(new TagHeader('tag1'));
+        $email->getHeaders()->add(new TagHeader('tag2'));
+        $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
+
+        $transport = new MailtrapApiSandboxTransport('ACCESS_KEY', 123456);
+        $method = new \ReflectionMethod(MailtrapApiSandboxTransport::class, 'getPayload');
+
+        $this->expectException(TransportException::class);
+
+        $method->invoke($transport, $email, $envelope);
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/Mailtrap/Tests/Transport/MailtrapTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailtrap/Tests/Transport/MailtrapTransportFactoryTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Mailer\Bridge\Mailtrap\Tests\Transport;
 
 use Psr\Log\NullLogger;
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\Mailer\Bridge\Mailtrap\Transport\MailtrapApiSandboxTransport;
 use Symfony\Component\Mailer\Bridge\Mailtrap\Transport\MailtrapApiTransport;
 use Symfony\Component\Mailer\Bridge\Mailtrap\Transport\MailtrapSmtpTransport;
 use Symfony\Component\Mailer\Bridge\Mailtrap\Transport\MailtrapTransportFactory;
@@ -34,6 +35,11 @@ class MailtrapTransportFactoryTest extends AbstractTransportFactoryTestCase
     {
         yield [
             new Dsn('mailtrap+api', 'default'),
+            true,
+        ];
+
+        yield [
+            new Dsn('mailtrap+sandbox', 'default'),
             true,
         ];
 
@@ -73,6 +79,16 @@ class MailtrapTransportFactoryTest extends AbstractTransportFactoryTestCase
         ];
 
         yield [
+            new Dsn('mailtrap+sandbox', 'default', self::USER, null, null, ['inboxId' => '123456']),
+            new MailtrapApiSandboxTransport(self::USER, 123456, new MockHttpClient(), null, $logger),
+        ];
+
+        yield [
+            new Dsn('mailtrap+sandbox', 'example.com', self::USER, null, 8080, ['inboxId' => '123456']),
+            (new MailtrapApiSandboxTransport(self::USER, 123456, new MockHttpClient(), null, $logger))->setHost('example.com')->setPort(8080),
+        ];
+
+        yield [
             new Dsn('mailtrap', 'default', self::USER),
             new MailtrapSmtpTransport(self::USER, null, $logger),
         ];
@@ -92,7 +108,7 @@ class MailtrapTransportFactoryTest extends AbstractTransportFactoryTestCase
     {
         yield [
             new Dsn('mailtrap+foo', 'default', self::USER),
-            'The "mailtrap+foo" scheme is not supported; supported schemes for mailer "mailtrap" are: "mailtrap", "mailtrap+api", "mailtrap+smtp", "mailtrap+smtps".',
+            'The "mailtrap+foo" scheme is not supported; supported schemes for mailer "mailtrap" are: "mailtrap", "mailtrap+api", "mailtrap+sandbox", "mailtrap+smtp", "mailtrap+smtps".',
         ];
     }
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailtrap/Transport/MailtrapApiSandboxTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailtrap/Transport/MailtrapApiSandboxTransport.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\Mailtrap\Transport;
+
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Kieran Cross
+ */
+final class MailtrapApiSandboxTransport extends MailtrapApiTransport
+{
+    protected const HOST = 'sandbox.api.mailtrap.io';
+
+    public function __construct(
+        #[\SensitiveParameter] private string $token,
+        private int $inboxId,
+        ?HttpClientInterface $client = null,
+        ?EventDispatcherInterface $dispatcher = null,
+        ?LoggerInterface $logger = null,
+    ) {
+        parent::__construct($token, $client, $dispatcher, $logger);
+    }
+
+    public function __toString(): string
+    {
+        return \sprintf('mailtrap+sandbox://%s%s/?inboxId=%u', $this->host ?: static::HOST, $this->port ? ':'.$this->port : '', $this->inboxId);
+    }
+
+    protected function getEndpoint(): string
+    {
+        return parent::getEndpoint().'/'.$this->inboxId;
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/Mailtrap/Transport/MailtrapApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailtrap/Transport/MailtrapApiTransport.php
@@ -30,9 +30,9 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-final class MailtrapApiTransport extends AbstractApiTransport
+class MailtrapApiTransport extends AbstractApiTransport
 {
-    private const HOST = 'send.api.mailtrap.io';
+    protected const HOST = 'send.api.mailtrap.io';
     private const HEADERS_TO_BYPASS = ['from', 'to', 'cc', 'bcc', 'subject', 'content-type', 'sender'];
 
     public function __construct(
@@ -46,12 +46,12 @@ final class MailtrapApiTransport extends AbstractApiTransport
 
     public function __toString(): string
     {
-        return \sprintf('mailtrap+api://%s', $this->getEndpoint());
+        return \sprintf('mailtrap+api://%s%s', $this->host ?: static::HOST, $this->port ? ':'.$this->port : '');
     }
 
     protected function doSendApi(SentMessage $sentMessage, Email $email, Envelope $envelope): ResponseInterface
     {
-        $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/api/send', [
+        $response = $this->client->request('POST', 'https://'.$this->getEndpoint(), [
             'json' => $this->getPayload($email, $envelope),
             'auth_bearer' => $this->token,
         ]);
@@ -143,8 +143,8 @@ final class MailtrapApiTransport extends AbstractApiTransport
         return array_filter(['email' => $address->getEncodedAddress(), 'name' => $address->getName()]);
     }
 
-    private function getEndpoint(): ?string
+    protected function getEndpoint(): string
     {
-        return ($this->host ?: self::HOST).($this->port ? ':'.$this->port : '');
+        return ($this->host ?: static::HOST).($this->port ? ':'.$this->port : '').'/api/send';
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailtrap/Transport/MailtrapTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailtrap/Transport/MailtrapTransportFactory.php
@@ -26,11 +26,15 @@ final class MailtrapTransportFactory extends AbstractTransportFactory
         $scheme = $dsn->getScheme();
         $user = $this->getUser($dsn);
 
-        if ('mailtrap+api' === $scheme) {
+        if ('mailtrap+api' === $scheme || 'mailtrap+sandbox' === $scheme) {
             $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
             $port = $dsn->getPort();
 
-            return (new MailtrapApiTransport($user, $this->client, $this->dispatcher, $this->logger))->setHost($host)->setPort($port);
+            if ('mailtrap+api' === $scheme) {
+                return (new MailtrapApiTransport($user, $this->client, $this->dispatcher, $this->logger))->setHost($host)->setPort($port);
+            } else {
+                return (new MailtrapApiSandboxTransport($user, $dsn->getOption('inboxId'), $this->client, $this->dispatcher, $this->logger))->setHost($host)->setPort($port);
+            }
         }
 
         if ('mailtrap+smtp' === $scheme || 'mailtrap+smtps' === $scheme || 'mailtrap' === $scheme) {
@@ -42,6 +46,6 @@ final class MailtrapTransportFactory extends AbstractTransportFactory
 
     protected function getSupportedSchemes(): array
     {
-        return ['mailtrap', 'mailtrap+api', 'mailtrap+smtp', 'mailtrap+smtps'];
+        return ['mailtrap', 'mailtrap+api', 'mailtrap+sandbox', 'mailtrap+smtp', 'mailtrap+smtps'];
     }
 }


### PR DESCRIPTION
Mailtrap's sandbox requires the Inbox ID to be passed as part of the URI, which has previously been neglected.

| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | n/a
| License       | MIT

Previously #61305 but I messed up when re-basing to 7.4.

Updates with appropriate tests and changelog. 
