### PR TITLE
[FrameworkBundle] Add tests for `secrets:decrypt-to-local`, `encrypt-from-local`, and `generate-keys` commands

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/SecretsDecryptToLocalCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/SecretsDecryptToLocalCommandTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Command\SecretsDecryptToLocalCommand;
+use Symfony\Bundle\FrameworkBundle\Secrets\SodiumVault;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @requires extension sodium
+ */
+class SecretsDecryptToLocalCommandTest extends TestCase
+{
+    private string $mainDir;
+    private string $localDir;
+
+    protected function setUp(): void
+    {
+        $this->mainDir = sys_get_temp_dir().'/sf_secrets/main/';
+        $this->localDir = sys_get_temp_dir().'/sf_secrets/local/';
+
+        $fs = new Filesystem();
+        $fs->remove([$this->mainDir, $this->localDir]);
+
+        $mainVault = new SodiumVault($this->mainDir);
+        $mainVault->generateKeys();
+        $mainVault->seal('FOO_SECRET', 'super_secret_value');
+
+        $localVault = new SodiumVault($this->localDir);
+        $localVault->generateKeys();
+    }
+
+    protected function tearDown(): void
+    {
+        (new Filesystem())->remove([$this->mainDir, $this->localDir]);
+    }
+
+    public function testSecretsAreDecryptedAndStoredInLocalVault()
+    {
+        $mainVault = new SodiumVault($this->mainDir);
+        $localVault = new SodiumVault($this->localDir);
+        $tester = new CommandTester(new SecretsDecryptToLocalCommand($mainVault, $localVault));
+
+        $this->assertSame(0, $tester->execute([]));
+        $this->assertStringContainsString('1 secret found in the vault.', $tester->getDisplay());
+        $this->assertStringContainsString('Secret "FOO_SECRET" encrypted', $tester->getDisplay());
+
+        $this->assertArrayHasKey('FOO_SECRET', $localVault->list(true));
+        $this->assertSame('super_secret_value', $localVault->reveal('FOO_SECRET'));
+    }
+
+    public function testExistingLocalSecretsAreSkippedWithoutForce()
+    {
+        $mainVault = new SodiumVault($this->mainDir);
+        $localVault = new SodiumVault($this->localDir);
+        $localVault->seal('FOO_SECRET', 'old_value');
+        $tester = new CommandTester(new SecretsDecryptToLocalCommand($mainVault, $localVault));
+
+        $this->assertSame(0, $tester->execute([]));
+        $this->assertStringContainsString('1 secret is already overridden in the local vault and will be skipped.', $tester->getDisplay());
+        $this->assertSame('old_value', $localVault->reveal('FOO_SECRET'));
+    }
+
+    public function testForceOptionOverridesLocalSecrets()
+    {
+        $mainVault = new SodiumVault($this->mainDir);
+        $localVault = new SodiumVault($this->localDir);
+        $localVault->seal('FOO_SECRET', 'old_value');
+        $tester = new CommandTester(new SecretsDecryptToLocalCommand($mainVault, $localVault));
+
+        $this->assertSame(0, $tester->execute(['--force' => true]));
+        $this->assertStringContainsString('Secret "FOO_SECRET" encrypted', $tester->getDisplay());
+        $this->assertSame('super_secret_value', $localVault->reveal('FOO_SECRET'));
+    }
+
+    public function testFailsGracefullyWhenLocalVaultIsDisabled()
+    {
+        $mainVault = new SodiumVault($this->mainDir);
+        $tester = new CommandTester(new SecretsDecryptToLocalCommand($mainVault, null));
+
+        $this->assertSame(1, $tester->execute([]));
+        $this->assertStringContainsString('The local vault is disabled.', $tester->getDisplay());
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/SecretsEncryptFromLocalCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/SecretsEncryptFromLocalCommandTest.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Command\SecretsEncryptFromLocalCommand;
+use Symfony\Bundle\FrameworkBundle\Secrets\AbstractVault;
+use Symfony\Bundle\FrameworkBundle\Secrets\SodiumVault;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @requires extension sodium
+ */
+class SecretsEncryptFromLocalCommandTest extends TestCase
+{
+    private string $vaultDir;
+    private string $localVaultDir;
+    private Filesystem $fs;
+
+    protected function setUp(): void
+    {
+        $this->vaultDir = sys_get_temp_dir().'/sf_secrets/vault_'.uniqid();
+        $this->localVaultDir = sys_get_temp_dir().'/sf_secrets/local_'.uniqid();
+        $this->fs = new Filesystem();
+        $this->fs->remove([$this->vaultDir, $this->localVaultDir]);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->fs->remove([$this->vaultDir, $this->localVaultDir]);
+    }
+
+    public function testFailsWhenLocalVaultIsDisabled()
+    {
+        $vault = $this->createMock(AbstractVault::class);
+        $command = new SecretsEncryptFromLocalCommand($vault, null);
+        $tester = new CommandTester($command);
+
+        $this->assertSame(1, $tester->execute([]));
+        $this->assertStringContainsString('The local vault is disabled.', $tester->getDisplay());
+    }
+
+    public function testEncryptsLocalOverrides()
+    {
+        $vault = new SodiumVault($this->vaultDir);
+        $vault->generateKeys();
+
+        $localVault = new SodiumVault($this->localVaultDir);
+        $localVault->generateKeys();
+
+        $vault->seal('MY_SECRET', 'prod-value');
+        $localVault->seal('MY_SECRET', 'local-value');
+
+        $command = new SecretsEncryptFromLocalCommand($vault, $localVault);
+        $tester = new CommandTester($command);
+
+        $exitCode = $tester->execute([]);
+        $this->assertSame(0, $exitCode);
+
+        $revealed = $vault->reveal('MY_SECRET');
+        $this->assertSame('local-value', $revealed);
+    }
+
+    public function testDoesNotSealIfSameValue()
+    {
+        $vault = new SodiumVault($this->vaultDir);
+        $vault->generateKeys();
+
+        $localVault = new SodiumVault($this->localVaultDir);
+        $localVault->generateKeys();
+
+        $vault->seal('SHARED_SECRET', 'same-value');
+        $localVault->seal('SHARED_SECRET', 'same-value');
+
+        $command = new SecretsEncryptFromLocalCommand($vault, $localVault);
+        $tester = new CommandTester($command);
+
+        $exitCode = $tester->execute([]);
+        $this->assertSame(0, $exitCode);
+
+        $revealed = $vault->reveal('SHARED_SECRET');
+        $this->assertSame('same-value', $revealed);
+    }
+
+    public function testFailsIfLocalSecretIsMissing()
+    {
+        $vault = new SodiumVault($this->vaultDir);
+        $vault->generateKeys();
+
+        $localVault = new SodiumVault($this->localVaultDir);
+        $localVault->generateKeys();
+
+        $vault->seal('MISSING_IN_LOCAL', 'prod-only');
+
+        $command = new SecretsEncryptFromLocalCommand($vault, $localVault);
+        $tester = new CommandTester($command);
+
+        $this->assertSame(1, $tester->execute([]));
+        $this->assertStringContainsString('Secret "MISSING_IN_LOCAL" not found', $tester->getDisplay());
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/SecretsGenerateKeysCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/SecretsGenerateKeysCommandTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Command\SecretsGenerateKeysCommand;
+use Symfony\Bundle\FrameworkBundle\Secrets\AbstractVault;
+use Symfony\Bundle\FrameworkBundle\Secrets\SodiumVault;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @requires extension sodium
+ */
+class SecretsGenerateKeysCommandTest extends TestCase
+{
+    private string $secretsDir;
+    private const ENC_KEY_FILE = 'test.encrypt.public.php';
+    private const DEC_KEY_FILE = 'test.decrypt.private.php';
+
+    protected function setUp(): void
+    {
+        $this->secretsDir = sys_get_temp_dir().'/sf_secrets/test/';
+        (new Filesystem())->remove($this->secretsDir);
+    }
+
+    protected function tearDown(): void
+    {
+        (new Filesystem())->remove($this->secretsDir);
+    }
+
+    public function testItGeneratesSodiumKeys()
+    {
+        $vault = new SodiumVault($this->secretsDir);
+        $tester = new CommandTester(new SecretsGenerateKeysCommand($vault));
+
+        $this->assertSame(0, $tester->execute([]));
+        $this->assertKeysExistAndReadable();
+    }
+
+    public function testItRotatesSodiumKeysWhenRequested()
+    {
+        $vault = new SodiumVault($this->secretsDir);
+        $tester = new CommandTester(new SecretsGenerateKeysCommand($vault));
+
+        $this->assertSame(0, $tester->execute(['--rotate' => true]));
+        $this->assertKeysExistAndReadable();
+    }
+
+    public function testItFailsGracefullyWhenLocalVaultIsDisabled()
+    {
+        $vault = $this->createMock(AbstractVault::class);
+        $tester = new CommandTester(new SecretsGenerateKeysCommand($vault));
+
+        $this->assertSame(1, $tester->execute(['--local' => true]));
+        $this->assertStringContainsString('The local vault is disabled.', $tester->getDisplay());
+    }
+
+    public function testFailsWhenKeysAlreadyExistAndRotateNotPassed()
+    {
+        $vault = new SodiumVault($this->secretsDir);
+        $vault->generateKeys();
+
+        $command = new SecretsGenerateKeysCommand($vault);
+        $tester = new CommandTester($command);
+
+        $this->assertSame(1, $tester->execute([]));
+        $this->assertStringContainsString('Sodium keys already exist at', $tester->getDisplay());
+    }
+
+    private function assertKeysExistAndReadable(): void
+    {
+        $encPath = $this->secretsDir.'/'.self::ENC_KEY_FILE;
+        $decPath = $this->secretsDir.'/'.self::DEC_KEY_FILE;
+
+        $this->assertFileExists($encPath, 'Encryption key file does not exist.');
+        $this->assertFileExists($decPath, 'Decryption key file does not exist.');
+        $this->assertNotFalse(@file_get_contents($encPath), 'Encryption key file is not readable.');
+        $this->assertNotFalse(@file_get_contents($decPath), 'Decryption key file is not readable.');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | no
| License       | MIT

Add tests for the following console commands:

* `secrets:generate-keys`
* `secrets:encrypt-from-local`
* `secrets:decrypt-to-local`
