### PR TITLE
[FrameworkBundle] Fix block type from `OK` to `ERROR` when local vault is disabled in `SecretsGenerateKeysCommand`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/SecretsGenerateKeysCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/SecretsGenerateKeysCommand.php
@@ -67,7 +67,7 @@ EOF
         $vault = $input->getOption('local') ? $this->localVault : $this->vault;
 
         if (null === $vault) {
-            $io->success('The local vault is disabled.');
+            $io->error('The local vault is disabled.');
 
             return 1;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | no
| License       | MIT

Minor: fix block type from `OK` to `ERROR` when local vault is disabled in `SecretsDecryptToLocalCommand`

References:
* [SecretsDecryptToLocalCommand](https://github.com/symfony/symfony/blob/7.4/src/Symfony/Bundle/FrameworkBundle/Command/SecretsDecryptToLocalCommand.php#L60)
* [SecretsEncryptFromLocalCommand](https://github.com/symfony/symfony/blob/7.4/src/Symfony/Bundle/FrameworkBundle/Command/SecretsEncryptFromLocalCommand.php#L54)