### PR TITLE
[Contracts] replace #[TestWithJson] with #[TestWith]

### DIFF
--- a/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
+++ b/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
@@ -12,7 +12,7 @@
 namespace Symfony\Contracts\HttpClient\Test;
 
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
-use PHPUnit\Framework\Attributes\TestWithJson;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
@@ -347,8 +347,8 @@ abstract class HttpClientTestCase extends TestCase
      * @testWith [[]]
      *           [["Content-Length: 7"]]
      */
-    #[TestWithJson('[[]]')]
-    #[TestWithJson('[["Content-Length: 7"]]')]
+    #[TestWith([[]])]
+    #[TestWith([['Content-Length: 7']])]
     public function testRedirects(array $headers = [])
     {
         $client = $this->getHttpClient(__FUNCTION__);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

PHP CS fixer replaces the `@testWith` annotation with the `#[TestWithJson]` attribute, but I feel like using `#[TestWith]` makes it more obvious what we are going to test.