### PR TITLE
[JsonStreamer] fix expected stream to native value transformers

### DIFF
--- a/src/Symfony/Component/JsonStreamer/Tests/Mapping/Read/AttributePropertyMetadataLoaderTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Mapping/Read/AttributePropertyMetadataLoaderTest.php
@@ -44,8 +44,8 @@ class AttributePropertyMetadataLoaderTest extends TestCase
         $this->assertEquals([
             'id' => new PropertyMetadata('id', Type::string(), [], [DivideStringAndCastToIntValueTransformer::class]),
             'active' => new PropertyMetadata('active', Type::string(), [], [StringToBooleanValueTransformer::class]),
-            'name' => new PropertyMetadata('name', Type::string(), [], [\Closure::fromCallable('strtolower')]),
-            'range' => new PropertyMetadata('range', Type::string(), [], [\Closure::fromCallable(DummyWithValueTransformerAttributes::concatRange(...))]),
+            'name' => new PropertyMetadata('name', Type::string(), [], [\Closure::fromCallable('strtoupper')]),
+            'range' => new PropertyMetadata('range', Type::string(), [], [\Closure::fromCallable(DummyWithValueTransformerAttributes::explodeRange(...))]),
         ], $loader->load(DummyWithValueTransformerAttributes::class));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

This was probably a copy-and-paste mistake from the corresponding write test. With PHPUnit < 12.0 this isn't an issue as closure are not considered when testing for equality. This changes with PHPUnit 12 where `sebastian/comparator` 7 is used which also compares closures.
