### PR TITLE
[FrameworkBundle] Decouple ControllerResolverTest from HttpKernel

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerResolverTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerResolverTest.php
@@ -11,15 +11,15 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Controller;
 
+use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface as Psr11ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerResolver;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Tests\Controller\ContainerControllerResolverTest;
 
-class ControllerResolverTest extends ContainerControllerResolverTest
+class ControllerResolverTest extends TestCase
 {
     public function testAbstractControllerGetsContainerWhenNotSet()
     {
@@ -110,11 +110,6 @@ class ControllerResolverTest extends ContainerControllerResolverTest
         }
 
         return new ControllerResolver($container, $logger);
-    }
-
-    protected function createMockParser()
-    {
-        return $this->createMock(ControllerNameParser::class);
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Using non-public API for cross-components test case dependencies complicates maintenance.