### PR TITLE
[PropertyInfo] replace PHPUnit annotations with attributes

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
@@ -59,9 +59,7 @@ class PhpStanExtractorTest extends TestCase
         $this->phpDocExtractor = new PhpDocExtractor();
     }
 
-    /**
-     * @dataProvider typesProvider
-     */
+    #[DataProvider('typesProvider')]
     public function testExtract(string $property, ?Type $type)
     {
         $this->assertEquals($type, $this->extractor->getType(Dummy::class, $property));
@@ -110,9 +108,7 @@ class PhpStanExtractorTest extends TestCase
         $this->assertNull($this->extractor->getType(PhpStanOmittedParamTagTypeDocBlock::class, 'omittedType'));
     }
 
-    /**
-     * @dataProvider invalidTypesProvider
-     */
+    #[DataProvider('invalidTypesProvider')]
     public function testInvalid(string $property)
     {
         $this->assertNull($this->extractor->getType(InvalidDummy::class, $property));
@@ -130,9 +126,7 @@ class PhpStanExtractorTest extends TestCase
         yield 'baz' => ['baz'];
     }
 
-    /**
-     * @dataProvider typesWithNoPrefixesProvider
-     */
+    #[DataProvider('typesWithNoPrefixesProvider')]
     public function testExtractTypesWithNoPrefixes(string $property, ?Type $type)
     {
         $noPrefixExtractor = new PhpStanExtractor([], [], []);
@@ -173,9 +167,7 @@ class PhpStanExtractorTest extends TestCase
         yield ['staticSetter', null];
     }
 
-    /**
-     * @dataProvider provideCollectionTypes
-     */
+    #[DataProvider('provideCollectionTypes')]
     public function testExtractCollection($property, ?Type $type)
     {
         $this->testExtract($property, $type);
@@ -193,9 +185,7 @@ class PhpStanExtractorTest extends TestCase
         yield ['arrayWithKeysAndComplexValue', Type::dict(Type::nullable(Type::array(Type::nullable(Type::string()), Type::int()))), null, null];
     }
 
-    /**
-     * @dataProvider typesWithCustomPrefixesProvider
-     */
+    #[DataProvider('typesWithCustomPrefixesProvider')]
     public function testExtractTypesWithCustomPrefixes(string $property, ?Type $type)
     {
         $customExtractor = new PhpStanExtractor(['add', 'remove'], ['is', 'can']);
@@ -238,9 +228,7 @@ class PhpStanExtractorTest extends TestCase
         yield ['staticSetter', null];
     }
 
-    /**
-     * @dataProvider dockBlockFallbackTypesProvider
-     */
+    #[DataProvider('dockBlockFallbackTypesProvider')]
     public function testDocBlockFallback(string $property, ?Type $type)
     {
         $this->assertEquals($type, $this->extractor->getType(DockBlockFallback::class, $property));
@@ -256,9 +244,7 @@ class PhpStanExtractorTest extends TestCase
         yield ['protMut', Type::bool()];
     }
 
-    /**
-     * @dataProvider propertiesDefinedByTraitsProvider
-     */
+    #[DataProvider('propertiesDefinedByTraitsProvider')]
     public function testPropertiesDefinedByTraits(string $property, ?Type $type)
     {
         $this->assertEquals($type, $this->extractor->getType(DummyUsingTrait::class, $property));
@@ -275,9 +261,7 @@ class PhpStanExtractorTest extends TestCase
         yield ['dummyInAnotherNamespace', Type::object(DummyInAnotherNamespace::class)];
     }
 
-    /**
-     * @dataProvider propertiesStaticTypeProvider
-     */
+    #[DataProvider('propertiesStaticTypeProvider')]
     public function testPropertiesStaticType(string $class, string $property, ?Type $type)
     {
         $this->assertEquals($type, $this->extractor->getType($class, $property));
@@ -303,17 +287,13 @@ class PhpStanExtractorTest extends TestCase
         $this->extractor->getType(ParentDummy::class, 'parentAnnotationNoParent');
     }
 
-    /**
-     * @dataProvider constructorTypesProvider
-     */
+    #[DataProvider('constructorTypesProvider')]
     public function testExtractConstructorTypes(string $property, ?Type $type)
     {
         $this->assertEquals($type, $this->extractor->getTypeFromConstructor(ConstructorDummy::class, $property));
     }
 
-    /**
-     * @dataProvider constructorTypesProvider
-     */
+    #[DataProvider('constructorTypesProvider')]
     public function testExtractConstructorTypesReturnNullOnEmptyDocBlock(string $property)
     {
         $this->assertNull($this->extractor->getTypeFromConstructor(ConstructorDummyWithoutDocBlock::class, $property));
@@ -331,9 +311,7 @@ class PhpStanExtractorTest extends TestCase
         yield ['ddd', null];
     }
 
-    /**
-     * @dataProvider unionTypesProvider
-     */
+    #[DataProvider('unionTypesProvider')]
     public function testExtractorUnionTypes(string $property, ?Type $type)
     {
         $this->assertEquals($type, $this->extractor->getType(DummyUnionType::class, $property));
@@ -364,9 +342,7 @@ class PhpStanExtractorTest extends TestCase
         yield ['g', Type::array(Type::union(Type::string(), Type::int()))];
     }
 
-    /**
-     * @dataProvider pseudoTypesProvider
-     */
+    #[DataProvider('pseudoTypesProvider')]
     public function testPseudoTypes(string $property, ?Type $type)
     {
         $this->assertEquals($type, $this->extractor->getType(PhpStanPseudoTypesDummy::class, $property));
@@ -412,9 +388,7 @@ class PhpStanExtractorTest extends TestCase
         $this->assertEquals($phpDocType->getClassName(), $phpStanType->getClassName());
     }
 
-    /**
-     * @dataProvider intRangeTypeProvider
-     */
+    #[DataProvider('intRangeTypeProvider')]
     public function testExtractorIntRangeType(string $property, ?Type $type)
     {
         $this->assertEquals($type, $this->extractor->getType(IntRangeDummy::class, $property));
@@ -430,9 +404,7 @@ class PhpStanExtractorTest extends TestCase
         yield ['c', Type::int()];
     }
 
-    /**
-     * @dataProvider php80TypesProvider
-     */
+    #[DataProvider('php80TypesProvider')]
     public function testExtractPhp80Type(string $class, string $property, ?Type $type)
     {
         $this->assertEquals($type, $this->extractor->getType($class, $property));
@@ -449,9 +421,7 @@ class PhpStanExtractorTest extends TestCase
         yield [Php80PromotedDummy::class, 'promoted', null];
     }
 
-    /**
-     * @dataProvider allowPrivateAccessProvider
-     */
+    #[DataProvider('allowPrivateAccessProvider')]
     public function testAllowPrivateAccess(bool $allowPrivateAccess, Type $expectedType)
     {
         $extractor = new PhpStanExtractor(allowPrivateAccess: $allowPrivateAccess);
@@ -475,9 +445,7 @@ class PhpStanExtractorTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider genericsProvider
-     */
+    #[DataProvider('genericsProvider')]
     public function testGenerics(string $property, Type $expectedType)
     {
         $this->assertEquals($expectedType, $this->extractor->getType(DummyGeneric::class, $property));
@@ -506,9 +474,7 @@ class PhpStanExtractorTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider descriptionsProvider
-     */
+    #[DataProvider('descriptionsProvider')]
     public function testGetDescriptions(string $property, ?string $shortDescription, ?string $longDescription)
     {
         $this->assertEquals($shortDescription, $this->extractor->getShortDescription(Dummy::class, $property));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT