### PR TITLE
[Mailer] [Resend] Add friendly name in the `to` field

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Resend/Tests/Transport/ResendApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Resend/Tests/Transport/ResendApiTransportTest.php
@@ -152,7 +152,7 @@ class ResendApiTransportTest extends TestCase
 
             $body = json_decode($options['body'], true);
             // to
-            $this->assertSame('kältetechnik@xn--kltetechnik-xyz-0kb.de', $body['to'][0]);
+            $this->assertSame('Kältetechnik Xyz <kältetechnik@xn--kltetechnik-xyz-0kb.de>', $body['to'][0]);
             // sender
             $this->assertStringContainsString('info@xn--kltetechnik-xyz-0kb.de', $body['from']);
             $this->assertStringContainsString('Kältetechnik Xyz', $body['from']);

--- a/src/Symfony/Component/Mailer/Bridge/Resend/Transport/ResendApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Resend/Transport/ResendApiTransport.php
@@ -82,7 +82,7 @@ final class ResendApiTransport extends AbstractApiTransport
     {
         $formattedAddresses = [];
         foreach ($addresses as $address) {
-            $formattedAddresses[] = $address->getEncodedAddress();
+            $formattedAddresses[] = $this->formatAddress($address);
         }
 
         if (\count($formattedAddresses) > 50) {
@@ -99,8 +99,8 @@ final class ResendApiTransport extends AbstractApiTransport
             'to' => $this->formatAddresses($this->getRecipients($email, $envelope)),
             'subject' => $email->getSubject(),
         ];
-        if ($attachements = $this->prepareAttachments($email)) {
-            $payload['attachments'] = $attachements;
+        if ($attachments = $this->prepareAttachments($email)) {
+            $payload['attachments'] = $attachments;
         }
         if ($emails = $email->getReplyTo()) {
             $payload['reply_to'] = current($this->formatAddresses($emails));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | n/a
| License       | MIT

This PR adds support for friendly email address formatting (e.g. "John Doe <john@example.com>") in the `to` field.

Although Resend's API accepts this format natively, the current implementation of the bridge does not pass it through correctly — names are silently discarded and only raw email addresses are used. This fix ensures that display names are preserved and passed to the API as intended.