### PR TITLE
Refactor: use `Command` constants instead of raw integers for return codes

### DIFF
--- a/src/Symfony/Bridge/Monolog/Command/ServerLogCommand.php
+++ b/src/Symfony/Bridge/Monolog/Command/ServerLogCommand.php
@@ -120,7 +120,7 @@ EOF
             $this->displayLog($output, $clientId, $record);
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function getLogs($socket): iterable

--- a/src/Symfony/Bridge/Twig/Command/DebugCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/DebugCommand.php
@@ -105,7 +105,7 @@ EOF
             default => throw new InvalidArgumentException(\sprintf('Supported formats are "%s".', implode('", "', $this->getAvailableFormatOptions()))),
         };
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void

--- a/src/Symfony/Bridge/Twig/Command/LintCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/LintCommand.php
@@ -208,7 +208,7 @@ EOF
             $io->warning(\sprintf('%d Twig files have valid syntax and %d contain errors.', \count($filesInfo) - $errors, $errors));
         }
 
-        return !$deprecations && !$errors ? 0 : 1;
+        return !$deprecations && !$errors ? Command::SUCCESS : Command::FAILURE;
     }
 
     private function displayJson(OutputInterface $output, array $filesInfo): int
@@ -227,7 +227,7 @@ EOF
 
         $output->writeln(json_encode($filesInfo, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
 
-        return min($errors, 1);
+        return $errors === 0 ? Command::SUCCESS : Command::FAILURE;
     }
 
     private function renderDeprecation(SymfonyStyle $output, int $line, string $message, string $file, ?GithubActionReporter $githubReporter): void

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Allow using their name without added suffix when using `#[Target]` for custom services
  * Deprecate `Symfony\Bundle\FrameworkBundle\Console\Application::add()` in favor of `Symfony\Bundle\FrameworkBundle\Console\Application::addCommand()`
  * Add `assertEmailAddressNotContains()` to the `MailerAssertionsTrait`
+ * Refactor Symfony Console Commands to use predefined constants (e.g., `Command::SUCCESS`) instead of hardcoded integer return values (0, 1, etc.)
 
 7.3
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
@@ -91,7 +91,7 @@ EOT
 
         $io->table([], $rows);
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private static function formatPath(string $path, string $baseDir): string

--- a/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
@@ -116,7 +116,7 @@ EOT
 
         $rows = [];
         $copyUsed = false;
-        $exitCode = 0;
+        $exitCode = Command::SUCCESS;
         $validAssetDirs = [];
         foreach ($kernel->getBundles() as $bundle) {
             if (!is_dir($originDir = $bundle->getPath().'/Resources/public') && !is_dir($originDir = $bundle->getPath().'/public')) {
@@ -154,7 +154,7 @@ EOT
                     $rows[] = [\sprintf('<fg=yellow;options=bold>%s</>', '\\' === \DIRECTORY_SEPARATOR ? 'WARNING' : '!'), $message, $method];
                 }
             } catch (\Exception $e) {
-                $exitCode = 1;
+                $exitCode = Command::FAILURE;
                 $rows[] = [\sprintf('<fg=red;options=bold>%s</>', '\\' === \DIRECTORY_SEPARATOR ? 'ERROR' : "\xE2\x9C\x98" /* HEAVY BALLOT X (U+2718) */), $message, $e->getMessage()];
             }
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -201,7 +201,7 @@ EOF
 
         $io->success(\sprintf('Cache for the "%s" environment (debug=%s) was successfully cleared.', $kernel->getEnvironment(), var_export($kernel->isDebug(), true)));
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function isNfs(string $dir): bool

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CachePoolClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CachePoolClearCommand.php
@@ -123,12 +123,12 @@ EOF
         }
 
         if ($failure) {
-            return 1;
+            return Command::FAILURE;
         }
 
         $io->success('Cache was successfully cleared.');
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CachePoolDeleteCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CachePoolDeleteCommand.php
@@ -65,7 +65,7 @@ EOF
         if (!$cachePool->hasItem($key)) {
             $io->note(\sprintf('Cache item "%s" does not exist in cache pool "%s".', $key, $pool));
 
-            return 0;
+            return Command::SUCCESS;
         }
 
         if (!$cachePool->deleteItem($key)) {
@@ -74,7 +74,7 @@ EOF
 
         $io->success(\sprintf('Cache item "%s" was successfully deleted.', $key));
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CachePoolInvalidateTagsCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CachePoolInvalidateTagsCommand.php
@@ -91,12 +91,12 @@ final class CachePoolInvalidateTagsCommand extends Command
         if ($errors) {
             $io->error('Done but with errors.');
 
-            return 1;
+            return Command::FAILURE;
         }
 
         $io->success('Successfully invalidated cache tags.');
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CachePoolListCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CachePoolListCommand.php
@@ -50,6 +50,6 @@ EOF
 
         $io->table(['Pool name'], array_map(fn ($pool) => [$pool], $this->poolNames));
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CachePoolPruneCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CachePoolPruneCommand.php
@@ -58,6 +58,6 @@ EOF
 
         $io->success('Successfully pruned cache pool(s).');
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheWarmupCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheWarmupCommand.php
@@ -78,6 +78,6 @@ EOF
 
         $io->success(\sprintf('Cache for the "%s" environment (debug=%s) was successfully warmed.', $kernel->getEnvironment(), var_export($kernel->isDebug(), true)));
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -209,7 +209,7 @@ EOF
             }
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerLintCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerLintCommand.php
@@ -56,7 +56,7 @@ final class ContainerLintCommand extends Command
         } catch (RuntimeException $e) {
             $errorIo->error($e->getMessage());
 
-            return 2;
+            return Command::INVALID;
         }
 
         $container->setParameter('container.build_time', time());
@@ -66,12 +66,12 @@ final class ContainerLintCommand extends Command
         } catch (InvalidArgumentException $e) {
             $errorIo->error($e->getMessage());
 
-            return 1;
+            return Command::FAILURE;
         }
 
         $io->success('The container was linted successfully: all services are injected with values that are compatible with their type declarations.');
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function getContainerBuilder(bool $resolveEnvVars): ContainerBuilder

--- a/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php
@@ -81,7 +81,7 @@ EOF
         if (!$this->dispatchers->has($dispatcherServiceName)) {
             $io->getErrorStyle()->error(\sprintf('Event dispatcher "%s" is not available.', $dispatcherServiceName));
 
-            return 1;
+            return Command::FAILURE;
         }
 
         $dispatcher = $this->dispatchers->get($dispatcherServiceName);
@@ -95,7 +95,7 @@ EOF
                 if (0 === \count($events)) {
                     $io->getErrorStyle()->warning(\sprintf('The event "%s" does not have any registered listeners.', $event));
 
-                    return 0;
+                    return Command::SUCCESS;
                 } elseif (1 === \count($events)) {
                     $options = ['event' => $events[array_key_first($events)]];
                 } else {
@@ -115,7 +115,7 @@ EOF
         $options['output'] = $io;
         $helper->describe($io, $dispatcher, $options);
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void

--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
@@ -99,7 +99,7 @@ EOF
                     'method' => $method,
                 ]);
 
-                return 0;
+                return Command::SUCCESS;
             }
 
             if (!$route && $matchingRoutes) {
@@ -131,7 +131,7 @@ EOF
             ]);
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function findRouteNameContaining(string $name, RouteCollection $routes, string $method): array

--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterMatchCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterMatchCommand.php
@@ -109,9 +109,9 @@ EOF
         if (!$matches) {
             $io->error(\sprintf('None of the routes match the path "%s"', $input->getArgument('path_info')));
 
-            return 1;
+            return Command::FAILURE;
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/SecretsDecryptToLocalCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/SecretsDecryptToLocalCommand.php
@@ -59,7 +59,7 @@ EOF
         if (null === $this->localVault) {
             $io->error('The local vault is disabled.');
 
-            return 1;
+            return Command::FAILURE;
         }
 
         $secrets = $this->vault->list(true);
@@ -96,9 +96,9 @@ EOF
         }
 
         if ($hadErrors) {
-            return 1;
+            return Command::FAILURE;
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/SecretsEncryptFromLocalCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/SecretsEncryptFromLocalCommand.php
@@ -53,7 +53,7 @@ EOF
         if (null === $this->localVault) {
             $io->error('The local vault is disabled.');
 
-            return 1;
+            return Command::FAILURE;
         }
 
         foreach ($this->vault->list(true) as $name => $value) {
@@ -64,10 +64,10 @@ EOF
             } elseif (null !== $message = $this->localVault->getLastMessage()) {
                 $io->error($message);
 
-                return 1;
+                return Command::FAILURE;
             }
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/SecretsGenerateKeysCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/SecretsGenerateKeysCommand.php
@@ -65,7 +65,7 @@ EOF
         if (null === $vault) {
             $io->error('The local vault is disabled.');
 
-            return 1;
+            return Command::FAILURE;
         }
 
         if (!$input->getOption('rotate')) {
@@ -76,12 +76,12 @@ EOF
                     $io->caution('DO NOT COMMIT THE DECRYPTION KEY FOR THE PROD ENVIRONMENT⚠️');
                 }
 
-                return 0;
+                return Command::SUCCESS;
             }
 
             $io->warning($vault->getLastMessage());
 
-            return 1;
+            return Command::FAILURE;
         }
 
         $secrets = [];
@@ -89,7 +89,7 @@ EOF
             if (null === $value) {
                 $io->error($vault->getLastMessage());
 
-                return 1;
+                return Command::FAILURE;
             }
 
             $secrets[$name] = $value;
@@ -98,7 +98,7 @@ EOF
         if (!$vault->generateKeys(true)) {
             $io->warning($vault->getLastMessage());
 
-            return 1;
+            return Command::FAILURE;
         }
 
         $io->success($vault->getLastMessage());
@@ -115,6 +115,6 @@ EOF
             $io->caution('DO NOT COMMIT THE DECRYPTION KEY FOR THE PROD ENVIRONMENT⚠️');
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/SecretsListCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/SecretsListCommand.php
@@ -96,6 +96,6 @@ EOF
 
         $io->comment("Local values override secret values.\nUse <info>secrets:set --local</info> to define them.");
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/SecretsRemoveCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/SecretsRemoveCommand.php
@@ -61,7 +61,7 @@ EOF
         if (null === $vault) {
             $io->success('The local vault is disabled.');
 
-            return 1;
+            return Command::FAILURE;
         }
 
         if ($vault->remove($name = $input->getArgument('name'))) {
@@ -74,7 +74,7 @@ EOF
             $io->comment('Note that this secret is overridden in the local vault.');
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void

--- a/src/Symfony/Bundle/FrameworkBundle/Command/SecretsSetCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/SecretsSetCommand.php
@@ -80,13 +80,13 @@ EOF
         if (null === $vault) {
             $io->error('The local vault is disabled.');
 
-            return 1;
+            return Command::FAILURE;
         }
 
         if ($this->localVault === $vault && !\array_key_exists($name, $this->vault->list())) {
             $io->error(\sprintf('Secret "%s" does not exist in the vault, you cannot override it locally.', $name));
 
-            return 1;
+            return Command::FAILURE;
         }
 
         if (0 < $random = $input->getOption('random') ?? 16) {
@@ -131,7 +131,7 @@ EOF
             $io->comment('Note that this secret is overridden in the local vault.');
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void

--- a/src/Symfony/Bundle/FrameworkBundle/Command/WorkflowDumpCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/WorkflowDumpCommand.php
@@ -111,7 +111,7 @@ EOF
         ];
         $output->writeln($dumper->dump($definition, $marking, $options));
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void

--- a/src/Symfony/Bundle/SecurityBundle/Command/DebugFirewallCommand.php
+++ b/src/Symfony/Bundle/SecurityBundle/Command/DebugFirewallCommand.php
@@ -84,7 +84,7 @@ EOF
         if (null === $name) {
             $this->displayFirewallList($io);
 
-            return 0;
+            return Command::SUCCESS;
         }
 
         $serviceId = \sprintf('security.firewall.map.context.%s', $name);
@@ -92,7 +92,7 @@ EOF
         if (!$this->contexts->has($serviceId)) {
             $io->error(\sprintf('Firewall %s was not found. Available firewalls are: %s', $name, implode(', ', $this->firewallNames)));
 
-            return 1;
+            return Command::FAILURE;
         }
 
         /** @var FirewallContext $context */
@@ -110,7 +110,7 @@ EOF
 
         $this->displayAuthenticators($name, $io);
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     protected function displayFirewallList(SymfonyStyle $io): void

--- a/src/Symfony/Component/AssetMapper/Command/AssetMapperCompileCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/AssetMapperCompileCommand.php
@@ -94,7 +94,7 @@ EOT
             ));
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function shortenPath(string $path): string

--- a/src/Symfony/Component/AssetMapper/Command/DebugAssetMapperCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/DebugAssetMapperCommand.php
@@ -132,7 +132,7 @@ EOT
             $io->warning('No assets found.');
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     /**

--- a/src/Symfony/Component/Console/Command/CompleteCommand.php
+++ b/src/Symfony/Component/Console/Command/CompleteCommand.php
@@ -162,10 +162,10 @@ final class CompleteCommand extends Command
                 throw $e;
             }
 
-            return 2;
+            return Command::INVALID;
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function createCompletionInput(InputInterface $input): CompletionInput

--- a/src/Symfony/Component/Console/Command/DumpCompletionCommand.php
+++ b/src/Symfony/Component/Console/Command/DumpCompletionCommand.php
@@ -86,7 +86,7 @@ EOH
         if ($input->getOption('debug')) {
             $this->tailDebugLog($commandName, $output);
 
-            return 0;
+            return Command::SUCCESS;
         }
 
         $shell = $input->getArgument('shell') ?? self::guessShell();
@@ -103,12 +103,12 @@ EOH
                 $output->writeln(\sprintf('<error>Shell not detected, Symfony shell completion only supports "%s").</>', implode('", "', $supportedShells)));
             }
 
-            return 2;
+            return Command::INVALID;
         }
 
         $output->write(str_replace(['{{ COMMAND_NAME }}', '{{ VERSION }}'], [$commandName, CompleteCommand::COMPLETION_API_VERSION], file_get_contents($completionFile)));
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private static function guessShell(): string

--- a/src/Symfony/Component/Console/Command/HelpCommand.php
+++ b/src/Symfony/Component/Console/Command/HelpCommand.php
@@ -71,6 +71,6 @@ EOF
 
         unset($this->command);
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Symfony/Component/Console/Command/ListCommand.php
+++ b/src/Symfony/Component/Console/Command/ListCommand.php
@@ -67,6 +67,6 @@ EOF
             'short' => $input->getOption('short'),
         ]);
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Symfony/Component/Dotenv/Command/DebugCommand.php
+++ b/src/Symfony/Component/Dotenv/Command/DebugCommand.php
@@ -74,7 +74,7 @@ EOT
         if (!\array_key_exists('SYMFONY_DOTENV_VARS', $_SERVER)) {
             $io->error('Dotenv component is not initialized.');
 
-            return 1;
+            return Command::FAILURE;
         }
 
         if (!$filePath = $_SERVER['SYMFONY_DOTENV_PATH'] ?? null) {
@@ -123,7 +123,7 @@ EOT
             $io->warning(\sprintf('No variables match the given filter "%s".', $nameFilter));
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void

--- a/src/Symfony/Component/Dotenv/Command/DotenvDumpCommand.php
+++ b/src/Symfony/Component/Dotenv/Command/DotenvDumpCommand.php
@@ -86,7 +86,7 @@ EOF;
 
         $output->writeln(\sprintf('Successfully dumped .env files in <info>.env.local.php</> for the <info>%s</> environment.', $env));
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function loadEnv(string $dotenvPath, string $env, array $config): array

--- a/src/Symfony/Component/Form/Command/DebugCommand.php
+++ b/src/Symfony/Component/Form/Command/DebugCommand.php
@@ -140,7 +140,7 @@ EOF
         $options['show_deprecated'] = $input->getOption('show-deprecated');
         $helper->describe($io, $object, $options);
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function getFqcnTypeClass(InputInterface $input, SymfonyStyle $io, string $shortClassName): string

--- a/src/Symfony/Component/Mailer/Command/MailerTestCommand.php
+++ b/src/Symfony/Component/Mailer/Command/MailerTestCommand.php
@@ -68,6 +68,6 @@ EOF
 
         $this->transport->send($message);
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
@@ -262,7 +262,7 @@ EOF
             $this->worker = null;
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void

--- a/src/Symfony/Component/Messenger/Command/DebugCommand.php
+++ b/src/Symfony/Component/Messenger/Command/DebugCommand.php
@@ -97,7 +97,7 @@ EOF
             }
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function formatConditions(array $options): string

--- a/src/Symfony/Component/Messenger/Command/SetupTransportsCommand.php
+++ b/src/Symfony/Component/Messenger/Command/SetupTransportsCommand.php
@@ -80,7 +80,7 @@ EOF
             }
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void

--- a/src/Symfony/Component/Messenger/Command/StatsCommand.php
+++ b/src/Symfony/Component/Messenger/Command/StatsCommand.php
@@ -103,7 +103,7 @@ EOF
             'json' => $this->outputJson($io, $outputTable, $uncountableTransports),
         };
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function outputText(SymfonyStyle $io, array $outputTable, array $uncountableTransports): void

--- a/src/Symfony/Component/Messenger/Command/StopWorkersCommand.php
+++ b/src/Symfony/Component/Messenger/Command/StopWorkersCommand.php
@@ -59,6 +59,6 @@ EOF
 
         $io->success('Signal successfully sent to stop any running workers.');
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Symfony/Component/PasswordHasher/Command/UserPasswordHashCommand.php
+++ b/src/Symfony/Component/PasswordHasher/Command/UserPasswordHashCommand.php
@@ -115,7 +115,7 @@ EOF
             if (!$input->isInteractive()) {
                 $errorIo->error('The password must not be empty.');
 
-                return 1;
+                return Command::FAILURE;
             }
             $passwordQuestion = $this->createPasswordQuestion();
             $password = $errorIo->askQuestion($passwordQuestion);
@@ -155,7 +155,7 @@ EOF
 
         $errorIo->success('Password hashing succeeded');
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void

--- a/src/Symfony/Component/Scheduler/Command/DebugCommand.php
+++ b/src/Symfony/Component/Scheduler/Command/DebugCommand.php
@@ -75,7 +75,7 @@ final class DebugCommand extends Command
         if (!$names = $input->getArgument('schedule') ?: $this->scheduleNames) {
             $io->error('No schedules found.');
 
-            return 2;
+            return Command::INVALID;
         }
 
         $date = new \DateTimeImmutable($input->getOption('date'));
@@ -99,7 +99,7 @@ final class DebugCommand extends Command
             );
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     /**

--- a/src/Symfony/Component/Translation/Command/TranslationPullCommand.php
+++ b/src/Symfony/Component/Translation/Command/TranslationPullCommand.php
@@ -157,7 +157,7 @@ EOF
 
             $io->success(\sprintf('Local translations has been updated from "%s" (for "%s" locale(s), and "%s" domain(s)).', parse_url($provider, \PHP_URL_SCHEME), implode(', ', $locales), implode(', ', $domains)));
 
-            return 0;
+            return Command::SUCCESS;
         }
 
         $localTranslations = $this->readLocalTranslations($locales, $domains, $this->transPaths);
@@ -171,6 +171,6 @@ EOF
 
         $io->success(\sprintf('New translations from "%s" has been written locally (for "%s" locale(s), and "%s" domain(s)).', parse_url($provider, \PHP_URL_SCHEME), implode(', ', $locales), implode(', ', $domains)));
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Symfony/Component/Translation/Command/TranslationPushCommand.php
+++ b/src/Symfony/Component/Translation/Command/TranslationPushCommand.php
@@ -135,7 +135,7 @@ EOF
 
             $io->success(\sprintf('All local translations has been sent to "%s" (for "%s" locale(s), and "%s" domain(s)).', parse_url($provider, \PHP_URL_SCHEME), implode(', ', $locales), implode(', ', $domains)));
 
-            return 0;
+            return Command::SUCCESS;
         }
 
         $providerTranslations = $provider->read($domains, $locales);
@@ -160,7 +160,7 @@ EOF
 
         $io->success(\sprintf('%s local translations has been sent to "%s" (for "%s" locale(s), and "%s" domain(s)).', $force ? 'All' : 'New', parse_url($provider, \PHP_URL_SCHEME), implode(', ', $locales), implode(', ', $domains)));
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function getDomainsFromTranslatorBag(TranslatorBag $translatorBag): array

--- a/src/Symfony/Component/Translation/Command/XliffLintCommand.php
+++ b/src/Symfony/Component/Translation/Command/XliffLintCommand.php
@@ -191,11 +191,13 @@ EOF
 
         if (0 === $erroredFiles) {
             $io->success(\sprintf('All %d XLIFF files contain valid syntax.', $countFiles));
-        } else {
-            $io->warning(\sprintf('%d XLIFF files have valid syntax and %d contain errors.', $countFiles - $erroredFiles, $erroredFiles));
+
+            return Command::SUCCESS;
         }
 
-        return min($erroredFiles, 1);
+        $io->warning(\sprintf('%d XLIFF files have valid syntax and %d contain errors.', $countFiles - $erroredFiles, $erroredFiles));
+
+        return Command::FAILURE;
     }
 
     private function displayJson(SymfonyStyle $io, array $filesInfo): int
@@ -211,7 +213,7 @@ EOF
 
         $io->writeln(json_encode($filesInfo, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
 
-        return min($errors, 1);
+        return 0 === $errors ? Command::SUCCESS : Command::FAILURE;
     }
 
     /**

--- a/src/Symfony/Component/Uid/Command/GenerateUlidCommand.php
+++ b/src/Symfony/Component/Uid/Command/GenerateUlidCommand.php
@@ -70,7 +70,7 @@ EOF
             } catch (\Exception $e) {
                 $io->error(\sprintf('Invalid timestamp "%s": %s', $time, str_replace('DateTimeImmutable::__construct(): ', '', $e->getMessage())));
 
-                return 1;
+                return Command::FAILURE;
             }
         }
 
@@ -81,7 +81,7 @@ EOF
         } else {
             $io->error(\sprintf('Invalid format "%s", supported formats are "%s".', $formatOption, implode('", "', $this->getAvailableFormatOptions())));
 
-            return 1;
+            return Command::FAILURE;
         }
 
         $count = (int) $input->getOption('count');
@@ -92,10 +92,10 @@ EOF
         } catch (\Exception $e) {
             $io->error($e->getMessage());
 
-            return 1;
+            return Command::FAILURE;
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void

--- a/src/Symfony/Component/Uid/Command/GenerateUuidCommand.php
+++ b/src/Symfony/Component/Uid/Command/GenerateUuidCommand.php
@@ -95,19 +95,19 @@ EOF
         if (false !== ($time ?? $name ?? $random) && 1 < ((null !== $time) + (null !== $name) + $random)) {
             $io->error('Only one of "--time-based", "--name-based" or "--random-based" can be provided at a time.');
 
-            return 1;
+            return Command::FAILURE;
         }
 
         if (null === $time && null !== $node) {
             $io->error('Option "--node" can only be used with "--time-based".');
 
-            return 1;
+            return Command::FAILURE;
         }
 
         if (null === $name && null !== $namespace) {
             $io->error('Option "--namespace" can only be used with "--name-based".');
 
-            return 1;
+            return Command::FAILURE;
         }
 
         switch (true) {
@@ -118,7 +118,7 @@ EOF
                     } catch (\InvalidArgumentException $e) {
                         $io->error(\sprintf('Invalid node "%s": %s', $node, $e->getMessage()));
 
-                        return 1;
+                        return Command::FAILURE;
                     }
                 }
 
@@ -127,7 +127,7 @@ EOF
                 } catch (\Exception $e) {
                     $io->error(\sprintf('Invalid timestamp "%s": %s', $time, str_replace('DateTimeImmutable::__construct(): ', '', $e->getMessage())));
 
-                    return 1;
+                    return Command::FAILURE;
                 }
 
                 $create = fn (): Uuid => $this->factory->timeBased($node)->create(new \DateTimeImmutable($time));
@@ -140,7 +140,7 @@ EOF
                     } catch (\InvalidArgumentException $e) {
                         $io->error(\sprintf('Invalid namespace "%s": %s', $namespace, $e->getMessage()));
 
-                        return 1;
+                        return Command::FAILURE;
                     }
                 }
 
@@ -171,7 +171,7 @@ EOF
         } else {
             $io->error(\sprintf('Invalid format "%s", supported formats are "%s".', $formatOption, implode('", "', $this->getAvailableFormatOptions())));
 
-            return 1;
+            return Command::FAILURE;
         }
 
         $count = (int) $input->getOption('count');
@@ -182,10 +182,10 @@ EOF
         } catch (\Exception $e) {
             $io->error($e->getMessage());
 
-            return 1;
+            return Command::FAILURE;
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void

--- a/src/Symfony/Component/Uid/Command/InspectUlidCommand.php
+++ b/src/Symfony/Component/Uid/Command/InspectUlidCommand.php
@@ -50,7 +50,7 @@ EOF
         } catch (\InvalidArgumentException $e) {
             $io->error($e->getMessage());
 
-            return 1;
+            return Command::FAILURE;
         }
 
         $io->table(['Label', 'Value'], [
@@ -62,6 +62,6 @@ EOF
             ['Time', $ulid->getDateTime()->format('Y-m-d H:i:s.v \U\T\C')],
         ]);
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Symfony/Component/Uid/Command/InspectUuidCommand.php
+++ b/src/Symfony/Component/Uid/Command/InspectUuidCommand.php
@@ -53,7 +53,7 @@ EOF
         } catch (\InvalidArgumentException $e) {
             $io->error($e->getMessage());
 
-            return 1;
+            return Command::FAILURE;
         }
 
         if (new NilUuid() == $uuid) {
@@ -79,6 +79,6 @@ EOF
 
         $io->table(['Label', 'Value'], $rows);
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Symfony/Component/Validator/Command/DebugCommand.php
+++ b/src/Symfony/Component/Validator/Command/DebugCommand.php
@@ -65,7 +65,7 @@ EOF
         if (class_exists($class)) {
             $this->dumpValidatorsForClass($input, $output, $class);
 
-            return 0;
+            return Command::SUCCESS;
         }
 
         try {
@@ -76,10 +76,10 @@ EOF
             $io = new SymfonyStyle($input, $output);
             $io->error(\sprintf('Neither class nor path were found with "%s" argument.', $input->getArgument('class')));
 
-            return 1;
+            return Command::FAILURE;
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function dumpValidatorsForClass(InputInterface $input, OutputInterface $output, string $class): void

--- a/src/Symfony/Component/VarDumper/Command/ServerDumpCommand.php
+++ b/src/Symfony/Component/VarDumper/Command/ServerDumpCommand.php
@@ -94,7 +94,7 @@ EOF
             $descriptor->describe($io, $data, $context, $clientId);
         });
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void

--- a/src/Symfony/Component/Yaml/Command/LintCommand.php
+++ b/src/Symfony/Component/Yaml/Command/LintCommand.php
@@ -188,11 +188,13 @@ EOF
 
         if (0 === $erroredFiles) {
             $io->success(\sprintf('All %d YAML files contain valid syntax.', $countFiles));
-        } else {
-            $io->warning(\sprintf('%d YAML files have valid syntax and %d contain errors.%s', $countFiles - $erroredFiles, $erroredFiles, $suggestTagOption ? ' Use the --parse-tags option if you want parse custom tags.' : ''));
+
+            return Command::SUCCESS;
         }
 
-        return min($erroredFiles, 1);
+        $io->warning(\sprintf('%d YAML files have valid syntax and %d contain errors.%s', $countFiles - $erroredFiles, $erroredFiles, $suggestTagOption ? ' Use the --parse-tags option if you want parse custom tags.' : ''));
+
+        return Command::FAILURE;
     }
 
     private function displayJson(SymfonyStyle $io, array $filesInfo): int
@@ -212,7 +214,7 @@ EOF
 
         $io->writeln(json_encode($filesInfo, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
 
-        return min($errors, 1);
+        return 0 === $errors ? Command::SUCCESS : Command::FAILURE;
     }
 
     private function getFiles(string $fileOrDirectory): iterable


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | no
| License       | MIT

This PR refactors the return statements in Symfony console commands to use the predefined constants from the `Symfony\Component\Console\Command\Command` class (`Command::SUCCESS`, `Command::FAILURE`, etc.) instead of raw integers (`0`, `1`, `2`, etc.).

This change improves code readability, makes the return values more self-explanatory, and aligns better with current [Symfony documentation](https://symfony.com/doc/current/console.html#creating-a-command)