### PR TITLE
[FrameworkBundle] Fix block type from `OK` to `ERROR` when local vault is disabled in `SecretsRemoveCommand`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/SecretsRemoveCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/SecretsRemoveCommand.php
@@ -63,7 +63,7 @@ EOF
         $vault = $input->getOption('local') ? $this->localVault : $this->vault;
 
         if (null === $vault) {
-            $io->success('The local vault is disabled.');
+            $io->error('The local vault is disabled.');
 
             return 1;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | no
| License       | MIT

Minor: fix block type from `OK` to `ERROR` when local vault is disabled in `SecretsRemoveCommand`

[Reference](https://github.com/symfony/symfony/pull/61317)