### PR TITLE
[Form] use `false` instead of `null` to hide the currency symbol

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
@@ -76,7 +76,7 @@ class MoneyTypeTest extends BaseTypeTestCase
 
     public function testMoneyPatternWithoutCurrency()
     {
-        $view = $this->factory->create(static::TESTED_TYPE, null, ['currency' => null])
+        $view = $this->factory->create(static::TESTED_TYPE, null, ['currency' => false])
             ->createView();
 
         $this->assertSame('{{ widget }}', $view->vars['money_pattern']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

This slipped in with #61296. Technically, there shouldn't be a difference but since we explicitly mention false in the documentation let's better be safe here.
