### PR TITLE
[HttpKernel] Dont try to pop session cookie when headers are sent

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
@@ -103,7 +103,7 @@ abstract class AbstractSessionListener implements EventSubscriberInterface, Rese
      */
     public function onKernelResponse(ResponseEvent $event): void
     {
-        if (!$event->isMainRequest() || (!$this->container->has('initialized_session') && !$event->getRequest()->hasSession())) {
+        if (!$event->isMainRequest() || headers_sent() || (!$this->container->has('initialized_session') && !$event->getRequest()->hasSession())) {
             return;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes/
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

I am handling a request while the headers are sent (on purpose, register shutdown after fast_cgi_finish request). and this crashes because Symfony tries to pop out some cookie, but it's not possible as the headers are sent. 

<img width="1127" height="669" alt="image" src="https://github.com/user-attachments/assets/326963b5-09e9-46e8-9605-0e79f613bb7a" />

So I added an early return if the headers are sent we do nothing anymore there.
