### PR TITLE
[DomCrawler] [Tests] Adapt testAddHtmlContentWithErrors to be HTML5 compliant

### DIFF
--- a/src/Symfony/Component/DomCrawler/Tests/NativeParserCrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/NativeParserCrawlerTest.php
@@ -29,7 +29,8 @@ class NativeParserCrawlerTest extends AbstractCrawlerTestCase
     <head>
     </head>
     <body>
-        <nav><a href="#"><a href="#"></nav>
+        <div><a href="#"></div>
+    </body>
     </body>
 </html>
 EOF
@@ -37,7 +38,7 @@ EOF
 
         $errors = libxml_get_errors();
         $this->assertCount(1, $errors);
-        $this->assertEquals("Tag nav invalid\n", $errors[0]->message);
+        $this->assertEquals("Unexpected end tag : body\n", $errors[0]->message);
 
         libxml_clear_errors();
         libxml_use_internal_errors($internalErrors);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |6.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Issues        | Fix #61346 
| License       | MIT

- What it does and why it's needed
The new libxml2 uses HTML5 by default, and the current snippet used to test invalid HTML is HTML5-valid. This commit changes the snippet to be invalid both for HTML4 and HTML5, so the test passes.

- A simple example of how it works (include PHP, YAML, etc.)
  - Running the test suite using a `php` build compiled against `libxml2` < `2.14` should keep working
  - Running the test suite using a `php` build compiled against `libxml2` >= `2.14` should now work

- If it modifies existing behavior, include a before/after comparison
It does not.