### PR TITLE
[Validator] Validate translations for Ukrainian (uk)

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.uk.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.uk.xlf
@@ -468,7 +468,7 @@
             </trans-unit>
             <trans-unit id="121">
                 <source>This value is not a valid Twig template.</source>
-                <target state="needs-review-translation">Це значення не є дійсним шаблоном Twig.</target>
+                <target>Це значення не є дійсним шаблоном Twig.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #60474
| License       | MIT



**Description of changes**  
I have reviewed the translation for the key `id="121"` and confirmed that it is accurate. 
The `<target>` text remains unchanged, and the attribute `state="needs-review-translation"` has been removed to mark this translation as fully verified.

These changes address the discussion in issue https://github.com/symfony/symfony/issues/60474.



<img width="1099" height="145" alt="Snip - Administrator symfony-fix local (2)" src="https://github.com/user-attachments/assets/1236f1ff-c8d8-46fa-a3a5-332c06cc50cb" />
