### PR TITLE
[WebProfilerBundle] Fix toolbar not rendering after replacing it

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -538,10 +538,15 @@
                         'sfwdt' + token,
                         '{{ url("_wdt", { "token": "xxxxxx" })|escape('js') }}'.replace(/xxxxxx/, newToken),
                         function(xhr, el) {
+                            var toolbarContent = document.getElementById('sfToolbarMainContent-' + newToken);
+
                             /* Do nothing in the edge case where the toolbar has already been replaced with a new one */
-                            if (!document.getElementById('sfToolbarMainContent-' + newToken)) {
+                            if (!toolbarContent) {
                                 return;
                             }
+
+                            /* Replace the ID, it has to match the new token */
+                            toolbarContent.parentElement.id = 'sfwdt' + newToken;
 
                             /* Evaluate in global scope scripts embedded inside the toolbar */
                             var i, scripts = [].slice.call(el.querySelectorAll('script'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

When the debug toolbar is replaced by newly loaded content, the parent element's ID has to be updated, else all queries for `'sfwdt' + token` cannot return a DOM element.