### PR TITLE
[DomCrawler] Add `DomCrawler` to leverage PHP 8.4's HTML5-compliant DOM parser

### DIFF
--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -18,6 +18,11 @@ Console
 
  * Deprecate `Symfony\Component\Console\Application::add()` in favor of `addCommand()`
 
+BrowserKit
+----------
+
+ * Leverage the native HTML5 parser when using PHP 8.4+
+
 DependencyInjection
 -------------------
 
@@ -28,6 +33,16 @@ DoctrineBridge
 --------------
 
  * Deprecate `UniqueEntity::getRequiredOptions()` and `UniqueEntity::getDefaultOption()`
+
+DomCrawler
+----------
+
+ * [BC BREAK] Type widening on public and protected methods/properties to support both
+   `Dom\*` and `DOM*` native classes for:
+   * properties `FormField::$document`, `$xpath`, `$node` and method `getLabel()`
+   * methods `Form::getFormNode()` and `addField()`
+   * property `AbstractUriElement::$node`, and methods `getNode()` and `setNode()`
+   * methods `Crawler::add()`, `addDocument()`, `addNodeList()`, `addNode()`, `getNode()` and `sibling()`
 
 FrameworkBundle
 ---------------

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ApiAttributesTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ApiAttributesTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\DomCrawler\DomCrawler;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -426,7 +427,7 @@ class ApiAttributesTest extends AbstractWebTestCase
                 </request>
                 XML,
             'responseAssertion' => static function (string $response) {
-                $crawler = new Crawler($response);
+                $crawler = \PHP_VERSION_ID >= 80400 && class_exists(DomCrawler::class) ? new DomCrawler($response) : new Crawler($response);
 
                 self::assertSame('https://symfony.com/errors/validation', $crawler->filterXPath('response/type')->text());
                 self::assertSame('Validation Failed', $crawler->filterXPath('response/title')->text());
@@ -642,7 +643,7 @@ class ApiAttributesTest extends AbstractWebTestCase
                 </request>
                 XML,
             'responseAssertion' => static function (string $response) {
-                $crawler = new Crawler($response);
+                $crawler = \PHP_VERSION_ID >= 80400 && class_exists(DomCrawler::class) ? new DomCrawler($response) : new Crawler($response);
 
                 self::assertSame('https://symfony.com/errors/validation', $crawler->filterXPath('response/type')->text());
                 self::assertSame('Validation Failed', $crawler->filterXPath('response/title')->text());
@@ -860,7 +861,7 @@ class ApiAttributesTest extends AbstractWebTestCase
                 </request>
                 XML,
             'responseAssertion' => static function (string $response) {
-                $crawler = new Crawler($response);
+                $crawler = \PHP_VERSION_ID >= 80400 && class_exists(DomCrawler::class) ? new DomCrawler($response) : new Crawler($response);
 
                 self::assertSame('https://symfony.com/errors/validation', $crawler->filterXPath('response/type')->text());
                 self::assertSame('Validation Failed', $crawler->filterXPath('response/title')->text());

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Test/WebTestCaseTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Test/WebTestCaseTest.php
@@ -23,6 +23,7 @@ use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\BrowserKit\CookieJar;
 use Symfony\Component\BrowserKit\History;
 use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\DomCrawler\DomCrawler;
 use Symfony\Component\HttpFoundation\Cookie as HttpFoundationCookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -231,126 +232,156 @@ class WebTestCaseTest extends TestCase
 
     public function testAssertSelectorExists()
     {
-        $this->getCrawlerTester(new Crawler('<html><body><h1>'))->assertSelectorExists('body > h1');
+        $crawler = \PHP_VERSION_ID >= 80400 && class_exists(DomCrawler::class) ? DomCrawler::class : Crawler::class;
+
+        $this->getCrawlerTester(new $crawler('<html><body><h1>'))->assertSelectorExists('body > h1');
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('matches selector "body > h1".');
-        $this->getCrawlerTester(new Crawler('<html><head><title>Foo'))->assertSelectorExists('body > h1');
+        $this->getCrawlerTester(new $crawler('<html><head><title>Foo'))->assertSelectorExists('body > h1');
     }
 
     public function testAssertSelectorNotExists()
     {
-        $this->getCrawlerTester(new Crawler('<html><head><title>Foo'))->assertSelectorNotExists('body > h1');
+        $crawler = \PHP_VERSION_ID >= 80400 && class_exists(DomCrawler::class) ? DomCrawler::class : Crawler::class;
+
+        $this->getCrawlerTester(new $crawler('<html><head><title>Foo'))->assertSelectorNotExists('body > h1');
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('does not match selector "body > h1".');
-        $this->getCrawlerTester(new Crawler('<html><body><h1>'))->assertSelectorNotExists('body > h1');
+        $this->getCrawlerTester(new $crawler('<html><body><h1>'))->assertSelectorNotExists('body > h1');
     }
 
     public function testAssertSelectorCount()
     {
-        $this->getCrawlerTester(new Crawler('<html><body><p>Hello</p></body></html>'))->assertSelectorCount(1, 'p');
-        $this->getCrawlerTester(new Crawler('<html><body><p>Hello</p><p>Foo</p></body></html>'))->assertSelectorCount(2, 'p');
-        $this->getCrawlerTester(new Crawler('<html><body><h1>This is not a paragraph.</h1></body></html>'))->assertSelectorCount(0, 'p');
+        $crawler = \PHP_VERSION_ID >= 80400 && class_exists(DomCrawler::class) ? DomCrawler::class : Crawler::class;
+
+        $this->getCrawlerTester(new $crawler('<html><body><p>Hello</p></body></html>'))->assertSelectorCount(1, 'p');
+        $this->getCrawlerTester(new $crawler('<html><body><p>Hello</p><p>Foo</p></body></html>'))->assertSelectorCount(2, 'p');
+        $this->getCrawlerTester(new $crawler('<html><body><h1>This is not a paragraph.</h1></body></html>'))->assertSelectorCount(0, 'p');
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that the Crawler selector "p" was expected to be found 0 time(s) but was found 1 time(s).');
-        $this->getCrawlerTester(new Crawler('<html><body><p>Hello</p></body></html>'))->assertSelectorCount(0, 'p');
+        $this->getCrawlerTester(new $crawler('<html><body><p>Hello</p></body></html>'))->assertSelectorCount(0, 'p');
     }
 
     public function testAssertSelectorTextNotContains()
     {
-        $this->getCrawlerTester(new Crawler('<html><body><h1>Foo'))->assertSelectorTextNotContains('body > h1', 'Bar');
+        $crawler = \PHP_VERSION_ID >= 80400 && class_exists(DomCrawler::class) ? DomCrawler::class : Crawler::class;
+
+        $this->getCrawlerTester(new $crawler('<html><body><h1>Foo'))->assertSelectorTextNotContains('body > h1', 'Bar');
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('matches selector "body > h1" and the text "Foo" of the node matching selector "body > h1" does not contain "Foo".');
-        $this->getCrawlerTester(new Crawler('<html><body><h1>Foo'))->assertSelectorTextNotContains('body > h1', 'Foo');
+        $this->getCrawlerTester(new $crawler('<html><body><h1>Foo'))->assertSelectorTextNotContains('body > h1', 'Foo');
     }
 
     public function testAssertAnySelectorTextContains()
     {
-        $this->getCrawlerTester(new Crawler('<ul><li>Bar</li><li>Foo Baz'))->assertAnySelectorTextContains('ul li', 'Foo');
+        $crawler = \PHP_VERSION_ID >= 80400 && class_exists(DomCrawler::class) ? DomCrawler::class : Crawler::class;
+
+        $this->getCrawlerTester(new $crawler('<ul><li>Bar</li><li>Foo Baz'))->assertAnySelectorTextContains('ul li', 'Foo');
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('matches selector "ul li" and the text of any node matching selector "ul li" contains "Foo".');
-        $this->getCrawlerTester(new Crawler('<ul><li>Bar</li><li>Baz'))->assertAnySelectorTextContains('ul li', 'Foo');
+        $this->getCrawlerTester(new $crawler('<ul><li>Bar</li><li>Baz'))->assertAnySelectorTextContains('ul li', 'Foo');
     }
 
     public function testAssertAnySelectorTextSame()
     {
-        $this->getCrawlerTester(new Crawler('<ul><li>Bar</li><li>Foo'))->assertAnySelectorTextSame('ul li', 'Foo');
+        $crawler = \PHP_VERSION_ID >= 80400 && class_exists(DomCrawler::class) ? DomCrawler::class : Crawler::class;
+
+        $this->getCrawlerTester(new $crawler('<ul><li>Bar</li><li>Foo'))->assertAnySelectorTextSame('ul li', 'Foo');
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('matches selector "ul li" and has at least a node matching selector "ul li" with content "Foo".');
-        $this->getCrawlerTester(new Crawler('<ul><li>Bar</li><li>Baz'))->assertAnySelectorTextSame('ul li', 'Foo');
+        $this->getCrawlerTester(new $crawler('<ul><li>Bar</li><li>Baz'))->assertAnySelectorTextSame('ul li', 'Foo');
     }
 
     public function testAssertAnySelectorTextNotContains()
     {
-        $this->getCrawlerTester(new Crawler('<ul><li>Bar</li><li>Baz'))->assertAnySelectorTextNotContains('ul li', 'Foo');
+        $crawler = \PHP_VERSION_ID >= 80400 && class_exists(DomCrawler::class) ? DomCrawler::class : Crawler::class;
+
+        $this->getCrawlerTester(new $crawler('<ul><li>Bar</li><li>Baz'))->assertAnySelectorTextNotContains('ul li', 'Foo');
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('matches selector "ul li" and the text of any node matching selector "ul li" does not contain "Foo".');
-        $this->getCrawlerTester(new Crawler('<ul><li>Bar</li><li>Foo'))->assertAnySelectorTextNotContains('ul li', 'Foo');
+        $this->getCrawlerTester(new $crawler('<ul><li>Bar</li><li>Foo'))->assertAnySelectorTextNotContains('ul li', 'Foo');
     }
 
     public function testAssertPageTitleSame()
     {
-        $this->getCrawlerTester(new Crawler('<html><head><title>Foo'))->assertPageTitleSame('Foo');
+        $crawler = \PHP_VERSION_ID >= 80400 && class_exists(DomCrawler::class) ? DomCrawler::class : Crawler::class;
+
+        $this->getCrawlerTester(new $crawler('<html><head><title>Foo'))->assertPageTitleSame('Foo');
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('matches selector "title" and has a node matching selector "title" with content "Bar".');
-        $this->getCrawlerTester(new Crawler('<html><head><title>Foo'))->assertPageTitleSame('Bar');
+        $this->getCrawlerTester(new $crawler('<html><head><title>Foo'))->assertPageTitleSame('Bar');
     }
 
     public function testAssertPageTitleContains()
     {
-        $this->getCrawlerTester(new Crawler('<html><head><title>Foobar'))->assertPageTitleContains('Foo');
+        $crawler = \PHP_VERSION_ID >= 80400 && class_exists(DomCrawler::class) ? DomCrawler::class : Crawler::class;
+
+        $this->getCrawlerTester(new $crawler('<html><head><title>Foobar'))->assertPageTitleContains('Foo');
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('matches selector "title" and the text "Foo" of the node matching selector "title" contains "Bar".');
-        $this->getCrawlerTester(new Crawler('<html><head><title>Foo'))->assertPageTitleContains('Bar');
+        $this->getCrawlerTester(new $crawler('<html><head><title>Foo'))->assertPageTitleContains('Bar');
     }
 
     public function testAssertInputValueSame()
     {
-        $this->getCrawlerTester(new Crawler('<html><body><form><input type="text" name="username" value="Fabien">'))->assertInputValueSame('username', 'Fabien');
+        $crawler = \PHP_VERSION_ID >= 80400 && class_exists(DomCrawler::class) ? DomCrawler::class : Crawler::class;
+
+        $this->getCrawlerTester(new $crawler('<html><body><form><input type="text" name="username" value="Fabien">'))->assertInputValueSame('username', 'Fabien');
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('matches selector "input[name="password"]" and has a node matching selector "input[name="password"]" with attribute "value" of value "pa$$".');
-        $this->getCrawlerTester(new Crawler('<html><head><title>Foo'))->assertInputValueSame('password', 'pa$$');
+        $this->getCrawlerTester(new $crawler('<html><head><title>Foo'))->assertInputValueSame('password', 'pa$$');
     }
 
     public function testAssertInputValueNotSame()
     {
-        $this->getCrawlerTester(new Crawler('<html><body><input type="text" name="username" value="Helene">'))->assertInputValueNotSame('username', 'Fabien');
+        $crawler = \PHP_VERSION_ID >= 80400 && class_exists(DomCrawler::class) ? DomCrawler::class : Crawler::class;
+
+        $this->getCrawlerTester(new $crawler('<html><body><input type="text" name="username" value="Helene">'))->assertInputValueNotSame('username', 'Fabien');
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('matches selector "input[name="password"]" and does not have a node matching selector "input[name="password"]" with attribute "value" of value "pa$$".');
-        $this->getCrawlerTester(new Crawler('<html><body><form><input type="text" name="password" value="pa$$">'))->assertInputValueNotSame('password', 'pa$$');
+        $this->getCrawlerTester(new $crawler('<html><body><form><input type="text" name="password" value="pa$$">'))->assertInputValueNotSame('password', 'pa$$');
     }
 
     public function testAssertCheckboxChecked()
     {
-        $this->getCrawlerTester(new Crawler('<html><body><form><input type="checkbox" name="rememberMe" checked>'))->assertCheckboxChecked('rememberMe');
-        $this->getCrawlerTester(new Crawler('<!DOCTYPE html><body><form><input type="checkbox" name="rememberMe" checked>'))->assertCheckboxChecked('rememberMe');
+        $crawler = \PHP_VERSION_ID >= 80400 && class_exists(DomCrawler::class) ? DomCrawler::class : Crawler::class;
+
+        $this->getCrawlerTester(new $crawler('<html><body><form><input type="checkbox" name="rememberMe" checked>'))->assertCheckboxChecked('rememberMe');
+        $this->getCrawlerTester(new $crawler('<!DOCTYPE html><body><form><input type="checkbox" name="rememberMe" checked>'))->assertCheckboxChecked('rememberMe');
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('matches selector "input[name="rememberMe"]:checked".');
-        $this->getCrawlerTester(new Crawler('<html><body><form><input type="checkbox" name="rememberMe">'))->assertCheckboxChecked('rememberMe');
+        $this->getCrawlerTester(new $crawler('<html><body><form><input type="checkbox" name="rememberMe">'))->assertCheckboxChecked('rememberMe');
     }
 
     public function testAssertCheckboxNotChecked()
     {
-        $this->getCrawlerTester(new Crawler('<html><body><form><input type="checkbox" name="rememberMe">'))->assertCheckboxNotChecked('rememberMe');
-        $this->getCrawlerTester(new Crawler('<!DOCTYPE html><body><form><input type="checkbox" name="rememberMe">'))->assertCheckboxNotChecked('rememberMe');
+        $crawler = \PHP_VERSION_ID >= 80400 && class_exists(DomCrawler::class) ? DomCrawler::class : Crawler::class;
+
+        $this->getCrawlerTester(new $crawler('<html><body><form><input type="checkbox" name="rememberMe">'))->assertCheckboxNotChecked('rememberMe');
+        $this->getCrawlerTester(new $crawler('<!DOCTYPE html><body><form><input type="checkbox" name="rememberMe">'))->assertCheckboxNotChecked('rememberMe');
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('does not match selector "input[name="rememberMe"]:checked".');
-        $this->getCrawlerTester(new Crawler('<html><body><form><input type="checkbox" name="rememberMe" checked>'))->assertCheckboxNotChecked('rememberMe');
+        $this->getCrawlerTester(new $crawler('<html><body><form><input type="checkbox" name="rememberMe" checked>'))->assertCheckboxNotChecked('rememberMe');
     }
 
     public function testAssertFormValue()
     {
-        $this->getCrawlerTester(new Crawler('<html><body><form id="form"><input type="text" name="username" value="Fabien">', 'http://localhost'))->assertFormValue('#form', 'username', 'Fabien');
+        $crawler = \PHP_VERSION_ID >= 80400 && class_exists(DomCrawler::class) ? DomCrawler::class : Crawler::class;
+
+        $this->getCrawlerTester(new $crawler('<html><body><form id="form"><input type="text" name="username" value="Fabien">', 'http://localhost'))->assertFormValue('#form', 'username', 'Fabien');
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that two strings are identical.');
-        $this->getCrawlerTester(new Crawler('<html><body><form id="form"><input type="text" name="username" value="Fabien">', 'http://localhost'))->assertFormValue('#form', 'username', 'Jane');
+        $this->getCrawlerTester(new $crawler('<html><body><form id="form"><input type="text" name="username" value="Fabien">', 'http://localhost'))->assertFormValue('#form', 'username', 'Jane');
     }
 
     public function testAssertNoFormValue()
     {
-        $this->getCrawlerTester(new Crawler('<html><body><form id="form"><input type="checkbox" name="rememberMe">', 'http://localhost'))->assertNoFormValue('#form', 'rememberMe');
+        $crawler = \PHP_VERSION_ID >= 80400 && class_exists(DomCrawler::class) ? DomCrawler::class : Crawler::class;
+
+        $this->getCrawlerTester(new $crawler('<html><body><form id="form"><input type="checkbox" name="rememberMe">', 'http://localhost'))->assertNoFormValue('#form', 'rememberMe');
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Field "rememberMe" has a value in form "#form".');
-        $this->getCrawlerTester(new Crawler('<html><body><form id="form"><input type="checkbox" name="rememberMe" checked>', 'http://localhost'))->assertNoFormValue('#form', 'rememberMe');
+        $this->getCrawlerTester(new $crawler('<html><body><form id="form"><input type="checkbox" name="rememberMe" checked>', 'http://localhost'))->assertNoFormValue('#form', 'rememberMe');
     }
 
     public function testAssertRequestAttributeValueSame()

--- a/src/Symfony/Component/BrowserKit/AbstractBrowser.php
+++ b/src/Symfony/Component/BrowserKit/AbstractBrowser.php
@@ -16,6 +16,7 @@ use Symfony\Component\BrowserKit\Exception\InvalidArgumentException;
 use Symfony\Component\BrowserKit\Exception\LogicException;
 use Symfony\Component\BrowserKit\Exception\RuntimeException;
 use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\DomCrawler\DomCrawler;
 use Symfony\Component\DomCrawler\Form;
 use Symfony\Component\DomCrawler\Link;
 use Symfony\Component\Process\PhpProcess;
@@ -510,7 +511,11 @@ abstract class AbstractBrowser
             return null;
         }
 
-        $crawler = new Crawler(null, $uri, null, $this->useHtml5Parser);
+        if (\PHP_VERSION_ID >= 80400 && $this->useHtml5Parser && class_exists(DomCrawler::class)) {
+            $crawler = new DomCrawler(null, $uri);
+        } else {
+            $crawler = new Crawler(null, $uri, null, $this->useHtml5Parser);
+        }
         $crawler->addContent($content, $type);
 
         return $crawler;

--- a/src/Symfony/Component/BrowserKit/CHANGELOG.md
+++ b/src/Symfony/Component/BrowserKit/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add `isFirstPage()` and `isLastPage()` methods to the History class for checking navigation boundaries
  * Add PHPUnit constraints: `BrowserHistoryIsOnFirstPage` and `BrowserHistoryIsOnLastPage`
+ * Leverage the native HTML5 parser when using PHP 8.4+
 
 6.4
 ---

--- a/src/Symfony/Component/DomCrawler/AbstractUriElement.php
+++ b/src/Symfony/Component/DomCrawler/AbstractUriElement.php
@@ -14,22 +14,27 @@ namespace Symfony\Component\DomCrawler;
 /**
  * Any HTML element that can link to an URI.
  *
+ * @template T of \Dom\Element|\DOMElement
+ *
  * @author Fabien Potencier <fabien@symfony.com>
  */
 abstract class AbstractUriElement
 {
-    protected \DOMElement $node;
+    /**
+     * @var T
+     */
+    protected \Dom\Element|\DOMElement $node;
     protected ?string $method;
 
     /**
-     * @param \DOMElement $node       A \DOMElement instance
+     * @param T           $node
      * @param string|null $currentUri The URI of the page where the link is embedded (or the base href)
      * @param string|null $method     The method to use for the link (GET by default)
      *
      * @throws \InvalidArgumentException if the node is not a link
      */
     public function __construct(
-        \DOMElement $node,
+        \Dom\Element|\DOMElement $node,
         protected ?string $currentUri = null,
         ?string $method = 'GET',
     ) {
@@ -45,8 +50,10 @@ abstract class AbstractUriElement
 
     /**
      * Gets the node associated with this link.
+     *
+     * @return T
      */
-    public function getNode(): \DOMElement
+    public function getNode(): \Dom\Element|\DOMElement
     {
         return $this->node;
     }
@@ -101,11 +108,11 @@ abstract class AbstractUriElement
     }
 
     /**
-     * Sets current \DOMElement instance.
+     * Sets current DOM Element instance.
      *
-     * @param \DOMElement $node A \DOMElement instance
+     * @param T $node
      *
      * @throws \LogicException If given node is not an anchor
      */
-    abstract protected function setNode(\DOMElement $node): void;
+    abstract protected function setNode(\Dom\Element|\DOMElement $node): void;
 }

--- a/src/Symfony/Component/DomCrawler/CHANGELOG.md
+++ b/src/Symfony/Component/DomCrawler/CHANGELOG.md
@@ -1,6 +1,18 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+ * Add `DomCrawler` to leverage PHP 8.4's HTML5-compliant DOM parser
+ * Deprecate using `masterminds/html5`'s parser; use the new `DomCrawler` class instead
+ * [BC BREAK] Type widening on public and protected methods/properties to support both
+   `Dom\*` and `DOM*` native classes for:
+   * properties `FormField::$document`, `$xpath`, `$node` and method `getLabel()`
+   * methods `Form::getFormNode()` and `addField()`
+   * property `AbstractUriElement::$node`, and methods `getNode()` and `setNode()`
+   * methods `Crawler::add()`, `addDocument()`, `addNodeList()`, `addNode()`, `getNode()` and `sibling()`
+
 7.0
 ---
 

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -15,11 +15,19 @@ use Masterminds\HTML5;
 use Symfony\Component\CssSelector\CssSelectorConverter;
 
 /**
- * Crawler eases navigation of a list of \DOMNode objects.
+ * Crawler eases navigation of a list of DOM Node objects.
+ *
+ * Use DomCrawler instead of this class if you want to use the HTML5 parser and run PHP 8.4 or higher.
+ *
+ * @template T of \Dom\Node|\DOMNode
+ *
+ * @implements \IteratorAggregate<int, T>
+ *
+ * @psalm-type L = (T is \Dom\Node ? \Dom\NodeList<T> : \DOMNodeList<T>)
+ *
+ * @phpstan-type L (T is \Dom\Node ? \Dom\NodeList<T> : \DOMNodeList<T>)
  *
  * @author Fabien Potencier <fabien@symfony.com>
- *
- * @implements \IteratorAggregate<int, \DOMNode>
  */
 class Crawler implements \Countable, \IteratorAggregate
 {
@@ -37,14 +45,20 @@ class Crawler implements \Countable, \IteratorAggregate
 
     /**
      * A map of cached namespaces.
+     *
+     * @var \ArrayObject<string, string|null>
      */
     private \ArrayObject $cachedNamespaces;
 
     private ?string $baseHref;
-    private ?\DOMDocument $document = null;
 
     /**
-     * @var list<\DOMNode>
+     * @var (T is \Dom\Node ? \Dom\Document : \DOMDocument)|null
+     */
+    private \Dom\Document|\DOMDocument|null $document = null;
+
+    /**
+     * @var list<T>
      */
     private array $nodes = [];
 
@@ -56,7 +70,7 @@ class Crawler implements \Countable, \IteratorAggregate
     private ?HTML5 $html5Parser = null;
 
     /**
-     * @param \DOMNodeList|\DOMNode|\DOMNode[]|string|null $node A Node to use as the base for the crawling
+     * @param \DOMNodeList<\DOMNode>|\DOMNode|\DOMNode[]|string|null $node A Node to use as the base for the crawling
      */
     public function __construct(
         \DOMNodeList|\DOMNode|array|string|null $node = null,
@@ -65,8 +79,14 @@ class Crawler implements \Countable, \IteratorAggregate
         bool $useHtml5Parser = true,
     ) {
         $this->baseHref = $baseHref ?: $uri;
-        $this->html5Parser = $useHtml5Parser ? new HTML5(['disable_html_ns' => true]) : null;
         $this->cachedNamespaces = new \ArrayObject();
+        if ($useHtml5Parser) {
+            if (\PHP_VERSION_ID >= 80400) {
+                trigger_deprecation('symfony/dom-crawler', '7.4', 'Using the "masterminds/html5" parser is deprecated; use the "DomCrawler" class instead.');
+                // throw new \LogicException('Use the "DomCrawler" class instead of the "Crawler" one to enable HTML5 parsing.');
+            }
+            $this->html5Parser = new HTML5(['disable_html_ns' => true]);
+        }
 
         $this->add($node);
     }
@@ -103,22 +123,18 @@ class Crawler implements \Countable, \IteratorAggregate
      * This method uses the appropriate specialized add*() method based
      * on the type of the argument.
      *
-     * @param \DOMNodeList|\DOMNode|\DOMNode[]|string|null $node A node
-     *
-     * @throws \InvalidArgumentException when node is not the expected type
+     * @param L|T|T[]|string|null $node
      */
-    public function add(\DOMNodeList|\DOMNode|array|string|null $node): void
+    public function add(\Dom\NodeList|\Dom\Node|\DOMNodeList|\DOMNode|array|string|null $node): void
     {
-        if ($node instanceof \DOMNodeList) {
+        if ($node instanceof \Dom\NodeList || $node instanceof \DOMNodeList) {
             $this->addNodeList($node);
-        } elseif ($node instanceof \DOMNode) {
+        } elseif ($node instanceof \Dom\Node || $node instanceof \DOMNode) {
             $this->addNode($node);
         } elseif (\is_array($node)) {
             $this->addNodes($node);
         } elseif (\is_string($node)) {
             $this->addContent($node);
-        } elseif (null !== $node) {
-            throw new \InvalidArgumentException(\sprintf('Expecting a DOMNodeList or DOMNode instance, an array, a string, or null, but got "%s".', get_debug_type($node)));
         }
     }
 
@@ -212,11 +228,15 @@ class Crawler implements \Countable, \IteratorAggregate
 
         $internalErrors = libxml_use_internal_errors(true);
 
-        $dom = new \DOMDocument('1.0', $charset);
-        $dom->validateOnParse = true;
+        if ($this instanceof DomCrawler) {
+            $dom = @\Dom\XMLDocument::createFromString($content, $options);
+        } else {
+            $dom = new \DOMDocument('1.0', $charset);
+            $dom->validateOnParse = true;
 
-        if ('' !== trim($content)) {
-            @$dom->loadXML($content, $options);
+            if ('' !== trim($content)) {
+                @$dom->loadXML($content, $options);
+            }
         }
 
         libxml_use_internal_errors($internalErrors);
@@ -227,11 +247,11 @@ class Crawler implements \Countable, \IteratorAggregate
     }
 
     /**
-     * Adds a \DOMDocument to the list of nodes.
+     * Adds a DOM Document to the list of nodes.
      *
-     * @param \DOMDocument $dom A \DOMDocument instance
+     * @param (T is \Dom\Node ? \Dom\Document : \DOMDocument) $dom
      */
-    public function addDocument(\DOMDocument $dom): void
+    public function addDocument(\Dom\Document|\DOMDocument $dom): void
     {
         if ($dom->documentElement) {
             $this->addNode($dom->documentElement);
@@ -239,23 +259,23 @@ class Crawler implements \Countable, \IteratorAggregate
     }
 
     /**
-     * Adds a \DOMNodeList to the list of nodes.
+     * Adds a DOM NodeList to the list of nodes.
      *
-     * @param \DOMNodeList $nodes A \DOMNodeList instance
+     * @param L $nodes
      */
-    public function addNodeList(\DOMNodeList $nodes): void
+    public function addNodeList(\Dom\NodeList|\DOMNodeList $nodes): void
     {
         foreach ($nodes as $node) {
-            if ($node instanceof \DOMNode) {
+            if ($node instanceof \Dom\Node || $node instanceof \DOMNode) {
                 $this->addNode($node);
             }
         }
     }
 
     /**
-     * Adds an array of \DOMNode instances to the list of nodes.
+     * Adds an array of DOM Node instances to the list of nodes.
      *
-     * @param \DOMNode[] $nodes An array of \DOMNode instances
+     * @param T[] $nodes
      */
     public function addNodes(array $nodes): void
     {
@@ -265,13 +285,13 @@ class Crawler implements \Countable, \IteratorAggregate
     }
 
     /**
-     * Adds a \DOMNode instance to the list of nodes.
+     * Adds a DOM Node instance to the list of nodes.
      *
-     * @param \DOMNode $node A \DOMNode instance
+     * @param T $node
      */
-    public function addNode(\DOMNode $node): void
+    public function addNode(\Dom\Node|\DOMNode $node): void
     {
-        if ($node instanceof \DOMDocument) {
+        if ($node instanceof \Dom\Document || $node instanceof \DOMDocument) {
             $node = $node->documentElement;
         }
 
@@ -309,13 +329,13 @@ class Crawler implements \Countable, \IteratorAggregate
      *
      * Example:
      *
-     *     $crawler->filter('h1')->each(function ($node, $i) {
-     *         return $node->text();
-     *     });
+     *     $crawler->filter('h1')->each(fn ($node, $i) => $node->text());
      *
-     * @param \Closure $closure An anonymous function
+     * @template R of mixed
      *
-     * @return array An array of values returned by the anonymous function
+     * @param \Closure(static, int):R $closure
+     *
+     * @return list<R> An array of values returned by the anonymous function
      */
     public function each(\Closure $closure): array
     {
@@ -340,7 +360,7 @@ class Crawler implements \Countable, \IteratorAggregate
      *
      * To remove a node from the list, the anonymous function must return false.
      *
-     * @param \Closure $closure An anonymous function
+     * @param \Closure(static, int):bool $closure
      */
     public function reduce(\Closure $closure): static
     {
@@ -373,7 +393,7 @@ class Crawler implements \Countable, \IteratorAggregate
     /**
      * Returns the siblings nodes of the current selection.
      *
-     * @throws \InvalidArgumentException When current node is empty
+     * @throws \InvalidArgumentException When the current node is empty
      */
     public function siblings(): static
     {
@@ -403,7 +423,7 @@ class Crawler implements \Countable, \IteratorAggregate
      *
      * @throws \InvalidArgumentException When current node is empty
      */
-    public function closest(string $selector): ?self
+    public function closest(string $selector): ?static
     {
         if (!$this->nodes) {
             throw new \InvalidArgumentException('The current node list is empty.');
@@ -440,7 +460,7 @@ class Crawler implements \Countable, \IteratorAggregate
     /**
      * Returns the previous sibling nodes of the current selection.
      *
-     * @throws \InvalidArgumentException
+     * @throws \InvalidArgumentException When current node is empty
      */
     public function previousAll(): static
     {
@@ -477,7 +497,7 @@ class Crawler implements \Countable, \IteratorAggregate
     /**
      * Returns the children nodes of the current selection.
      *
-     * @throws \InvalidArgumentException When current node is empty
+     * @throws \InvalidArgumentException When the current node is empty
      * @throws \RuntimeException         If the CssSelector Component is not available and $selector is provided
      */
     public function children(?string $selector = null): static
@@ -523,7 +543,7 @@ class Crawler implements \Countable, \IteratorAggregate
     /**
      * Returns the node name of the first node of the list.
      *
-     * @throws \InvalidArgumentException When current node is empty
+     * @throws \InvalidArgumentException When the current node is empty
      */
     public function nodeName(): string
     {
@@ -531,7 +551,7 @@ class Crawler implements \Countable, \IteratorAggregate
             throw new \InvalidArgumentException('The current node list is empty.');
         }
 
-        return $this->getNode(0)->nodeName;
+        return $this->isHtml ? strtolower($this->getNode(0)->nodeName) : $this->getNode(0)->nodeName;
     }
 
     /**
@@ -554,7 +574,8 @@ class Crawler implements \Countable, \IteratorAggregate
             throw new \InvalidArgumentException('The current node list is empty.');
         }
 
-        $text = $this->getNode(0)->nodeValue;
+        $node = $this->getNode(0);
+        $text = $node instanceof \Dom\Node ? ($node->textContent ?? '') : $node->nodeValue;
 
         if ($normalizeWhitespace) {
             return $this->normalizeWhitespace($text);
@@ -574,11 +595,12 @@ class Crawler implements \Countable, \IteratorAggregate
             if (\XML_TEXT_NODE !== $childNode->nodeType && \XML_CDATA_SECTION_NODE !== $childNode->nodeType) {
                 continue;
             }
+            $content = $childNode instanceof \Dom\Node ? ($childNode->textContent ?? '') : $childNode->nodeValue;
             if (!$normalizeWhitespace) {
-                return $childNode->nodeValue;
+                return $content;
             }
-            if ('' !== trim($childNode->nodeValue)) {
-                return $this->normalizeWhitespace($childNode->nodeValue);
+            if ('' !== trim($content)) {
+                return $this->normalizeWhitespace($content);
             }
         }
 
@@ -590,7 +612,7 @@ class Crawler implements \Countable, \IteratorAggregate
      *
      * @param string|null $default When not null: the value to return when the current node is empty
      *
-     * @throws \InvalidArgumentException When current node is empty
+     * @throws \InvalidArgumentException When the current node is empty
      */
     public function html(?string $default = null): string
     {
@@ -614,9 +636,17 @@ class Crawler implements \Countable, \IteratorAggregate
             $html .= $owner->saveHTML($child);
         }
 
+        if ($this->document instanceof \Dom\HTMLDocument) {
+            // remove all void elements as defined by HTML5
+            $html = str_replace(['</area>', '</base>', '</br>', '</col>', '</embed>', '</hr>', '</img>', '</input>', '</link>', '</meta>', '</source>', '</track>', '</wbr>'], '', $html);
+        }
+
         return $html;
     }
 
+    /**
+     * @throws \InvalidArgumentException When the current node is empty
+     */
     public function outerHtml(): string
     {
         if (!\count($this)) {
@@ -636,10 +666,10 @@ class Crawler implements \Countable, \IteratorAggregate
     /**
      * Evaluates an XPath expression.
      *
-     * Since an XPath expression might evaluate to either a simple type or a \DOMNodeList,
+     * Since an XPath expression might evaluate to either a simple type or a DOM NodeList,
      * this method will return either an array of simple types or a new Crawler instance.
      */
-    public function evaluate(string $xpath): array|self
+    public function evaluate(string $xpath): array|static
     {
         if (null === $this->document) {
             throw new \LogicException('Cannot evaluate the expression on an uninitialized crawler.');
@@ -652,7 +682,7 @@ class Crawler implements \Countable, \IteratorAggregate
             $data[] = $domxpath->evaluate($xpath, $node);
         }
 
-        if (isset($data[0]) && $data[0] instanceof \DOMNodeList) {
+        if (isset($data[0]) && ($data[0] instanceof \Dom\NodeList || $data[0] instanceof \DOMNodeList)) {
             return $this->createSubCrawler($data);
         }
 
@@ -677,11 +707,11 @@ class Crawler implements \Countable, \IteratorAggregate
             $elements = [];
             foreach ($attributes as $attribute) {
                 if ('_text' === $attribute) {
-                    $elements[] = $node->nodeValue;
+                    $elements[] = $node instanceof \Dom\Node ? ($node->textContent ?? '') : $node->nodeValue;
                 } elseif ('_name' === $attribute) {
-                    $elements[] = $node->nodeName;
+                    $elements[] = $this->isHtml ? strtolower($node->nodeName) : $node->nodeName;
                 } else {
-                    $elements[] = $node->getAttribute($attribute);
+                    $elements[] = $node->getAttribute($attribute) ?? '';
                 }
             }
 
@@ -759,7 +789,9 @@ class Crawler implements \Countable, \IteratorAggregate
     /**
      * Returns a Link object for the first node in the list.
      *
-     * @throws \InvalidArgumentException If the current node list is empty or the selected node is not instance of DOMElement
+     * @return Link<(T is \Dom\Node ? \Dom\Element : \DOMElement)>
+     *
+     * @throws \InvalidArgumentException If the current node list is empty or the selected node is not a DOM Element
      */
     public function link(string $method = 'get'): Link
     {
@@ -769,8 +801,8 @@ class Crawler implements \Countable, \IteratorAggregate
 
         $node = $this->getNode(0);
 
-        if (!$node instanceof \DOMElement) {
-            throw new \InvalidArgumentException(\sprintf('The selected node should be instance of DOMElement, got "%s".', get_debug_type($node)));
+        if (!$node instanceof \Dom\Element && !$node instanceof \DOMElement) {
+            throw new \InvalidArgumentException(\sprintf('The selected node should be a DOM Element, got "%s".', get_debug_type($node)));
         }
 
         return new Link($node, $this->baseHref, $method);
@@ -779,16 +811,16 @@ class Crawler implements \Countable, \IteratorAggregate
     /**
      * Returns an array of Link objects for the nodes in the list.
      *
-     * @return Link[]
+     * @return Link<(T is \Dom\Node ? \Dom\Element : \DOMElement)>[]
      *
-     * @throws \InvalidArgumentException If the current node list contains non-DOMElement instances
+     * @throws \InvalidArgumentException If the current node list contains non-DOM Element instances
      */
     public function links(): array
     {
         $links = [];
         foreach ($this->nodes as $node) {
-            if (!$node instanceof \DOMElement) {
-                throw new \InvalidArgumentException(\sprintf('The current node list should contain only DOMElement instances, "%s" found.', get_debug_type($node)));
+            if (!$node instanceof \Dom\Element && !$node instanceof \DOMElement) {
+                throw new \InvalidArgumentException(\sprintf('The current node list should contain only DOM Element instances, "%s" found.', get_debug_type($node)));
             }
 
             $links[] = new Link($node, $this->baseHref, 'get');
@@ -800,6 +832,8 @@ class Crawler implements \Countable, \IteratorAggregate
     /**
      * Returns an Image object for the first node in the list.
      *
+     * @return Image<(T is \Dom\Node ? \Dom\Element : \DOMElement)>
+     *
      * @throws \InvalidArgumentException If the current node list is empty
      */
     public function image(): Image
@@ -810,8 +844,8 @@ class Crawler implements \Countable, \IteratorAggregate
 
         $node = $this->getNode(0);
 
-        if (!$node instanceof \DOMElement) {
-            throw new \InvalidArgumentException(\sprintf('The selected node should be instance of DOMElement, got "%s".', get_debug_type($node)));
+        if (!$node instanceof \Dom\Element && !$node instanceof \DOMElement) {
+            throw new \InvalidArgumentException(\sprintf('The selected node should be a DOM Element, got "%s".', get_debug_type($node)));
         }
 
         return new Image($node, $this->baseHref);
@@ -820,14 +854,14 @@ class Crawler implements \Countable, \IteratorAggregate
     /**
      * Returns an array of Image objects for the nodes in the list.
      *
-     * @return Image[]
+     * @return Image<(T is \Dom\Node ? \Dom\Element : \DOMElement)>[]
      */
     public function images(): array
     {
         $images = [];
         foreach ($this as $node) {
-            if (!$node instanceof \DOMElement) {
-                throw new \InvalidArgumentException(\sprintf('The current node list should contain only DOMElement instances, "%s" found.', get_debug_type($node)));
+            if (!$node instanceof \Dom\Element && !$node instanceof \DOMElement) {
+                throw new \InvalidArgumentException(\sprintf('The current node list should contain only DOM Element instances, "%s" found.', get_debug_type($node)));
             }
 
             $images[] = new Image($node, $this->baseHref);
@@ -839,7 +873,9 @@ class Crawler implements \Countable, \IteratorAggregate
     /**
      * Returns a Form object for the first node in the list.
      *
-     * @throws \InvalidArgumentException If the current node list is empty or the selected node is not instance of DOMElement
+     * @return Form<(T is \Dom\Node ? \Dom\Element : \DOMElement)>
+     *
+     * @throws \InvalidArgumentException If the current node list is empty or the selected node is not instance of a DOM Element
      */
     public function form(?array $values = null, ?string $method = null): Form
     {
@@ -849,8 +885,8 @@ class Crawler implements \Countable, \IteratorAggregate
 
         $node = $this->getNode(0);
 
-        if (!$node instanceof \DOMElement) {
-            throw new \InvalidArgumentException(\sprintf('The selected node should be instance of DOMElement, got "%s".', get_debug_type($node)));
+        if (!$node instanceof \Dom\Element && !$node instanceof \DOMElement) {
+            throw new \InvalidArgumentException(\sprintf('The selected node should be a DOM Element, got "%s".', get_debug_type($node)));
         }
 
         $form = new Form($node, $this->uri, $method, $this->baseHref);
@@ -932,7 +968,15 @@ class Crawler implements \Countable, \IteratorAggregate
         $domxpath = $this->createDOMXPath($this->document, $this->findNamespacePrefixes($xpath));
 
         foreach ($this->nodes as $node) {
-            $crawler->add($domxpath->query($xpath, $node));
+            try {
+                $nodes = $domxpath->query($xpath, $node);
+            } catch (\DOMException $e) {
+                if (str_starts_with($e->getMessage(), 'The namespace axis is not well-defined in the living DOM specification.')) {
+                    continue;
+                }
+                throw $e;
+            }
+            $crawler->add($nodes);
         }
 
         return $crawler;
@@ -1028,7 +1072,10 @@ class Crawler implements \Countable, \IteratorAggregate
         return $xpath; // The XPath expression is invalid
     }
 
-    public function getNode(int $position): ?\DOMNode
+    /**
+     * @return T|null
+     */
+    public function getNode(int $position): \Dom\Node|\DOMNode|null
     {
         return $this->nodes[$position] ?? null;
     }
@@ -1039,14 +1086,17 @@ class Crawler implements \Countable, \IteratorAggregate
     }
 
     /**
-     * @return \ArrayIterator<int, \DOMNode>
+     * @return \ArrayIterator<int, T>
      */
     public function getIterator(): \ArrayIterator
     {
         return new \ArrayIterator($this->nodes);
     }
 
-    protected function sibling(\DOMNode $node, string $siblingDir = 'nextSibling'): array
+    /**
+     * @param T $node
+     */
+    protected function sibling(\Dom\Node|\DOMNode $node, string $siblingDir = 'nextSibling'): array
     {
         $nodes = [];
 
@@ -1074,12 +1124,15 @@ class Crawler implements \Countable, \IteratorAggregate
     {
         try {
             return '' === @mb_convert_encoding('', $encoding, 'UTF-8');
-        } catch (\Throwable $e) {
+        } catch (\Throwable) {
             return false;
         }
     }
 
-    private function parseXhtml(string $htmlContent, string $charset = 'UTF-8'): \DOMDocument
+    /**
+     * @return (T is \Dom\Node ? \Dom\XMLDocument : \DOMDocument)
+     */
+    private function parseXhtml(string $htmlContent, string $charset = 'UTF-8'): \Dom\XMLDocument|\DOMDocument
     {
         if ('UTF-8' === $charset && preg_match('//u', $htmlContent)) {
             $htmlContent = '<?xml encoding="UTF-8">'.$htmlContent;
@@ -1089,11 +1142,15 @@ class Crawler implements \Countable, \IteratorAggregate
 
         $internalErrors = libxml_use_internal_errors(true);
 
-        $dom = new \DOMDocument('1.0', $charset);
-        $dom->validateOnParse = true;
+        if ($this instanceof DomCrawler) {
+            $dom = @\Dom\XMLDocument::createFromString($htmlContent);
+        } else {
+            $dom = new \DOMDocument('1.0', $charset);
+            $dom->validateOnParse = true;
 
-        if ('' !== trim($htmlContent)) {
-            @$dom->loadHTML($htmlContent);
+            if ('' !== trim($htmlContent)) {
+                @$dom->loadHTML($htmlContent);
+            }
         }
 
         libxml_use_internal_errors($internalErrors);
@@ -1124,11 +1181,15 @@ class Crawler implements \Countable, \IteratorAggregate
     }
 
     /**
+     * @param (T is \Dom\Node ? \Dom\Document : \DOMDocument) $document
+     *
+     * @return (T is \Dom\Node ? \Dom\XPath : \DOMXPath)
+     *
      * @throws \InvalidArgumentException
      */
-    private function createDOMXPath(\DOMDocument $document, array $prefixes = []): \DOMXPath
+    private function createDOMXPath(\Dom\Document|\DOMDocument $document, array $prefixes = []): \Dom\XPath|\DOMXPath
     {
-        $domxpath = new \DOMXPath($document);
+        $domxpath = $document instanceof \DOMDocument ? new \DOMXPath($document) : new \Dom\XPath($document);
 
         foreach ($prefixes as $prefix) {
             $namespace = $this->discoverNamespace($domxpath, $prefix);
@@ -1137,13 +1198,21 @@ class Crawler implements \Countable, \IteratorAggregate
             }
         }
 
+        if (!$this->document?->documentElement instanceof \Dom\Node) {
+            return $domxpath;
+        }
+
+        foreach ($domxpath->document->documentElement->getInScopeNamespaces() as $namespace) {
+            $domxpath->registerNamespace($namespace->prefix ?? $this->defaultNamespacePrefix, $namespace->namespaceURI);
+        }
+
         return $domxpath;
     }
 
     /**
      * @throws \InvalidArgumentException
      */
-    private function discoverNamespace(\DOMXPath $domxpath, string $prefix): ?string
+    private function discoverNamespace(\Dom\XPath|\DOMXPath $domxpath, string $prefix): ?string
     {
         if (\array_key_exists($prefix, $this->namespaces)) {
             return $this->namespaces[$prefix];
@@ -1156,7 +1225,7 @@ class Crawler implements \Countable, \IteratorAggregate
         // ask for one namespace, otherwise we'd get a collection with an item for each node
         $namespaces = $domxpath->query(\sprintf('(//namespace::*[name()="%s"])[last()]', $this->defaultNamespacePrefix === $prefix ? '' : $prefix));
 
-        return $this->cachedNamespaces[$prefix] = ($node = $namespaces->item(0)) ? $node->nodeValue : null;
+        return $this->cachedNamespaces[$prefix] = $namespaces->item(0)?->nodeValue;
     }
 
     private function findNamespacePrefixes(string $xpath): array
@@ -1171,11 +1240,11 @@ class Crawler implements \Countable, \IteratorAggregate
     /**
      * Creates a crawler for some subnodes.
      *
-     * @param \DOMNodeList|\DOMNode|\DOMNode[]|string|null $nodes
+     * @param L|T|T[]|string|null $nodes
      */
-    private function createSubCrawler(\DOMNodeList|\DOMNode|array|string|null $nodes): static
+    private function createSubCrawler(\Dom\NodeList|\Dom\Node|\DOMNodeList|\DOMNode|array|string|null $nodes): static
     {
-        $crawler = new static($nodes, $this->uri, $this->baseHref);
+        $crawler = new static($nodes, $this->uri, $this->baseHref, false);
         $crawler->isHtml = $this->isHtml;
         $crawler->document = $this->document;
         $crawler->namespaces = $this->namespaces;
@@ -1198,11 +1267,16 @@ class Crawler implements \Countable, \IteratorAggregate
     }
 
     /**
-     * Parse string into DOMDocument object using HTML5 parser if the content is HTML5 and the library is available.
-     * Use libxml parser otherwise.
+     * Parse string into DOM Document object.
+     *
+     * @return (T is \Dom\Node ? \Dom\Document : \DOMDocument)
      */
-    private function parseHtmlString(string $content, string $charset): \DOMDocument
+    private function parseHtmlString(string $content, string $charset): \Dom\Document|\DOMDocument
     {
+        if ($this instanceof DomCrawler) {
+            return @\Dom\HTMLDocument::createFromString($content, \Dom\HTML_NO_DEFAULT_NS, $charset);
+        }
+
         if ($this->canParseHtml5String($content)) {
             return $this->parseHtml5($content, $charset);
         }
@@ -1216,7 +1290,7 @@ class Crawler implements \Countable, \IteratorAggregate
             return false;
         }
 
-        if (false === ($pos = stripos($content, '<!doctype html>'))) {
+        if (false === $pos = stripos($content, '<!doctype html>')) {
             return false;
         }
 

--- a/src/Symfony/Component/DomCrawler/DomCrawler.php
+++ b/src/Symfony/Component/DomCrawler/DomCrawler.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DomCrawler;
+
+/**
+ * DomCrawler eases navigation of a list of DOM Node objects.
+ *
+ * Use this class instead of Crawler if you want to use the HTML5 parser and run PHP 8.4 or higher.
+ *
+ * @extends Crawler<\Dom\Node>
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class DomCrawler extends Crawler
+{
+    /**
+     * @param \Dom\NodeList|\Dom\Node|\Dom\Node[]|string|null $node A Node to use as the base for the crawling
+     */
+    public function __construct(
+        \Dom\NodeList|\Dom\Node|array|string|null $node = null,
+        ?string $uri = null,
+        ?string $baseHref = null,
+    ) {
+        parent::__construct(null, $uri, $baseHref, false);
+
+        $this->add($node);
+    }
+
+    public function getNode(int $position): ?\Dom\Node
+    {
+        return parent::getNode($position);
+    }
+}

--- a/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
@@ -16,6 +16,10 @@ namespace Symfony\Component\DomCrawler\Field;
  *
  * It is constructed from an HTML select tag, or an HTML checkbox, or radio inputs.
  *
+ * @template T of \Dom\Element|\DOMElement
+ *
+ * @extends FormField<T>
+ *
  * @author Fabien Potencier <fabien@symfony.com>
  */
 class ChoiceFormField extends FormField
@@ -141,11 +145,13 @@ class ChoiceFormField extends FormField
     /**
      * Adds a choice to the current ones.
      *
+     * @param T $node
+     *
      * @throws \LogicException When choice provided is not multiple nor radio
      *
      * @internal
      */
-    public function addChoice(\DOMElement $node): void
+    public function addChoice(\Dom\Element|\DOMElement $node): void
     {
         if (!$this->multiple && 'radio' !== $this->type) {
             throw new \LogicException(\sprintf('Unable to add a choice for "%s" as it is not multiple or is not a radio button.', $this->name));
@@ -182,20 +188,23 @@ class ChoiceFormField extends FormField
      */
     protected function initialize(): void
     {
-        if ('input' !== $this->node->nodeName && 'select' !== $this->node->nodeName) {
+        $nodeName = strtolower($this->node->nodeName);
+        if ('input' !== $nodeName && 'select' !== $nodeName) {
             throw new \LogicException(\sprintf('A ChoiceFormField can only be created from an input or select tag (%s given).', $this->node->nodeName));
         }
 
-        if ('input' === $this->node->nodeName && 'checkbox' !== strtolower($this->node->getAttribute('type')) && 'radio' !== strtolower($this->node->getAttribute('type'))) {
-            throw new \LogicException(\sprintf('A ChoiceFormField can only be created from an input tag with a type of checkbox or radio (given type is "%s").', $this->node->getAttribute('type')));
+        $type = strtolower($this->node->getAttribute('type') ?? '');
+
+        if ('input' === $nodeName && 'checkbox' !== $type && 'radio' !== $type) {
+            throw new \LogicException(\sprintf('A ChoiceFormField can only be created from an input tag with a type of checkbox or radio (given type is "%s").', $type));
         }
 
         $this->value = null;
         $this->options = [];
         $this->multiple = false;
 
-        if ('input' == $this->node->nodeName) {
-            $this->type = strtolower($this->node->getAttribute('type'));
+        if ('input' === $nodeName) {
+            $this->type = $type;
             $optionValue = $this->buildOptionValue($this->node);
             $this->options[] = $optionValue;
 
@@ -234,12 +243,14 @@ class ChoiceFormField extends FormField
 
     /**
      * Returns option value with associated disabled flag.
+     *
+     * @param T $node
      */
-    private function buildOptionValue(\DOMElement $node): array
+    private function buildOptionValue(\Dom\Element|\DOMElement $node): array
     {
         $option = [];
 
-        $defaultDefaultValue = 'select' === $this->node->nodeName ? '' : 'on';
+        $defaultDefaultValue = 'select' === strtolower($this->node->nodeName) ? '' : 'on';
         $defaultValue = (isset($node->nodeValue) && $node->nodeValue) ? $node->nodeValue : $defaultDefaultValue;
         $option['value'] = $node->hasAttribute('value') ? $node->getAttribute('value') : $defaultValue;
         $option['disabled'] = $node->hasAttribute('disabled');

--- a/src/Symfony/Component/DomCrawler/Field/FileFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/FileFormField.php
@@ -14,6 +14,10 @@ namespace Symfony\Component\DomCrawler\Field;
 /**
  * FileFormField represents a file form field (an HTML file input tag).
  *
+ * @template T of \Dom\Element|\DOMElement
+ *
+ * @extends FormField<T>
+ *
  * @author Fabien Potencier <fabien@symfony.com>
  */
 class FileFormField extends FormField
@@ -89,12 +93,14 @@ class FileFormField extends FormField
      */
     protected function initialize(): void
     {
-        if ('input' !== $this->node->nodeName) {
+        if ('input' !== strtolower($this->node->nodeName)) {
             throw new \LogicException(\sprintf('A FileFormField can only be created from an input tag (%s given).', $this->node->nodeName));
         }
 
-        if ('file' !== strtolower($this->node->getAttribute('type'))) {
-            throw new \LogicException(\sprintf('A FileFormField can only be created from an input tag with a type of file (given type is "%s").', $this->node->getAttribute('type')));
+        $type = strtolower($this->node->getAttribute('type') ?? '');
+
+        if ('file' !== $type) {
+            throw new \LogicException(\sprintf('A FileFormField can only be created from an input tag with a type of file (given type is "%s").', $type));
         }
 
         $this->setValue(null);

--- a/src/Symfony/Component/DomCrawler/Field/FormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/FormField.php
@@ -14,34 +14,54 @@ namespace Symfony\Component\DomCrawler\Field;
 /**
  * FormField is the abstract class for all form fields.
  *
+ * @template T of \Dom\Element|\DOMElement
+ *
  * @author Fabien Potencier <fabien@symfony.com>
  */
 abstract class FormField
 {
     protected string $name;
+
     protected string|array|null $value = null;
-    protected \DOMDocument $document;
-    protected \DOMXPath $xpath;
+
+    /**
+     * @var (T is \Dom\Element ? \Dom\Document : \DOMDocument)
+     */
+    protected \Dom\Document|\DOMDocument $document;
+
+    /**
+     * @var (T is \Dom\Element ? \Dom\XPath : \DOMXPath)
+     */
+    protected \Dom\XPath|\DOMXPath $xpath;
+
     protected bool $disabled = false;
 
     /**
-     * @param \DOMElement $node The node associated with this field
+     * @param T $node The DOM node representing the form field
      */
     public function __construct(
-        protected \DOMElement $node,
+        protected \Dom\Element|\DOMElement $node,
     ) {
-        $this->name = $node->getAttribute('name');
-        $this->xpath = new \DOMXPath($node->ownerDocument);
+        $this->name = $node->getAttribute('name') ?? '';
+
+        if ($node instanceof \Dom\Element) {
+            $this->xpath = new \Dom\XPath($node->ownerDocument);
+        } else {
+            $this->xpath = new \DOMXPath($node->ownerDocument);
+        }
 
         $this->initialize();
     }
 
     /**
      * Returns the label tag associated to the field or null if none.
+     *
+     * @return T|null
      */
-    public function getLabel(): ?\DOMElement
+    public function getLabel(): \Dom\Element|\DOMElement|null
     {
-        $xpath = new \DOMXPath($this->node->ownerDocument);
+        $xpath = $this->xpath;
+        $xpath = new $xpath($this->node->ownerDocument);
 
         if ($this->node->hasAttribute('id')) {
             $labels = $xpath->query(\sprintf('descendant::label[@for="%s"]', $this->node->getAttribute('id')));

--- a/src/Symfony/Component/DomCrawler/Field/InputFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/InputFormField.php
@@ -17,6 +17,10 @@ namespace Symfony\Component\DomCrawler\Field;
  * For inputs with type of file, checkbox, or radio, there are other more
  * specialized classes (cf. FileFormField and ChoiceFormField).
  *
+ * @template T of \Dom\Element|\DOMElement
+ *
+ * @extends FormField<T>
+ *
  * @author Fabien Potencier <fabien@symfony.com>
  */
 class InputFormField extends FormField
@@ -28,11 +32,12 @@ class InputFormField extends FormField
      */
     protected function initialize(): void
     {
-        if ('input' !== $this->node->nodeName && 'button' !== $this->node->nodeName) {
+        if (!\in_array(strtolower($this->node->nodeName), ['input', 'button'], true)) {
             throw new \LogicException(\sprintf('An InputFormField can only be created from an input or button tag (%s given).', $this->node->nodeName));
         }
 
         $type = strtolower($this->node->getAttribute('type'));
+
         if ('checkbox' === $type) {
             throw new \LogicException('Checkboxes should be instances of ChoiceFormField.');
         }
@@ -41,6 +46,6 @@ class InputFormField extends FormField
             throw new \LogicException('File inputs should be instances of FileFormField.');
         }
 
-        $this->value = $this->node->getAttribute('value');
+        $this->value = $this->node->getAttribute('value') ?? '';
     }
 }

--- a/src/Symfony/Component/DomCrawler/Field/TextareaFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/TextareaFormField.php
@@ -14,6 +14,10 @@ namespace Symfony\Component\DomCrawler\Field;
 /**
  * TextareaFormField represents a textarea form field (an HTML textarea tag).
  *
+ * @template T of \Dom\Element|\DOMElement
+ *
+ * @extends FormField<T>
+ *
  * @author Fabien Potencier <fabien@symfony.com>
  */
 class TextareaFormField extends FormField
@@ -25,7 +29,7 @@ class TextareaFormField extends FormField
      */
     protected function initialize(): void
     {
-        if ('textarea' !== $this->node->nodeName) {
+        if ('textarea' !== strtolower($this->node->nodeName)) {
             throw new \LogicException(\sprintf('A TextareaFormField can only be created from a textarea tag (%s given).', $this->node->nodeName));
         }
 

--- a/src/Symfony/Component/DomCrawler/Form.php
+++ b/src/Symfony/Component/DomCrawler/Form.php
@@ -17,15 +17,28 @@ use Symfony\Component\DomCrawler\Field\FormField;
 /**
  * Form represents an HTML form.
  *
+ * @template T of \Dom\Element|\DOMElement
+ *
+ * @extends Link<T>
+ *
+ * @implements \ArrayAccess<string, FormField<T>|FormField<T>[]|FormField<T>[][]>
+ *
  * @author Fabien Potencier <fabien@symfony.com>
  */
 class Form extends Link implements \ArrayAccess
 {
-    private \DOMElement $button;
+    /**
+     * @var T
+     */
+    private \Dom\Element|\DOMElement $button;
+
+    /**
+     * @var FormFieldRegistry<T>
+     */
     private FormFieldRegistry $fields;
 
     /**
-     * @param \DOMElement $node       A \DOMElement instance
+     * @param T           $node
      * @param string|null $currentUri The URI of the page where the form is embedded
      * @param string|null $method     The method to use for the link (if null, it defaults to the method defined by the form)
      * @param string|null $baseHref   The URI of the <base> used for relative links, but not for empty action
@@ -33,7 +46,7 @@ class Form extends Link implements \ArrayAccess
      * @throws \LogicException if the node is not a button inside a form tag
      */
     public function __construct(
-        \DOMElement $node,
+        \Dom\Element|\DOMElement $node,
         ?string $currentUri = null,
         ?string $method = null,
         private ?string $baseHref = null,
@@ -45,8 +58,10 @@ class Form extends Link implements \ArrayAccess
 
     /**
      * Gets the form node associated with this form.
+     *
+     * @return T
      */
-    public function getFormNode(): \DOMElement
+    public function getFormNode(): \Dom\Element|\DOMElement
     {
         return $this->node;
     }
@@ -204,7 +219,7 @@ class Form extends Link implements \ArrayAccess
             return $this->button->getAttribute('formaction');
         }
 
-        return $this->node->getAttribute('action');
+        return $this->node->getAttribute('action') ?? '';
     }
 
     /**
@@ -223,7 +238,7 @@ class Form extends Link implements \ArrayAccess
             return strtoupper($this->button->getAttribute('formmethod'));
         }
 
-        return $this->node->getAttribute('method') ? strtoupper($this->node->getAttribute('method')) : 'GET';
+        return $this->node->getAttribute('method') ? strtoupper($this->node->getAttribute('method') ?? '') : 'GET';
     }
 
     /**
@@ -233,7 +248,7 @@ class Form extends Link implements \ArrayAccess
      */
     public function getName(): string
     {
-        return $this->node->getAttribute('name');
+        return $this->node->getAttribute('name') ?? '';
     }
 
     /**
@@ -255,7 +270,7 @@ class Form extends Link implements \ArrayAccess
     /**
      * Gets a named field.
      *
-     * @return FormField|FormField[]|FormField[][]
+     * @return FormField<T>|FormField<T>[]|FormField<T>[][]
      *
      * @throws \InvalidArgumentException When field is not present in this form
      */
@@ -266,6 +281,8 @@ class Form extends Link implements \ArrayAccess
 
     /**
      * Sets a named field.
+     *
+     * @param FormField<T> $field
      */
     public function set(FormField $field): void
     {
@@ -275,7 +292,7 @@ class Form extends Link implements \ArrayAccess
     /**
      * Gets all fields.
      *
-     * @return FormField[]
+     * @return FormField<T>[]
      */
     public function all(): array
     {
@@ -297,7 +314,7 @@ class Form extends Link implements \ArrayAccess
      *
      * @param string $name The field name
      *
-     * @return FormField|FormField[]|FormField[][]
+     * @return FormField<T>|FormField<T>[]|FormField<T>[][]
      *
      * @throws \InvalidArgumentException if the field does not exist
      */
@@ -348,14 +365,18 @@ class Form extends Link implements \ArrayAccess
     /**
      * Sets the node for the form.
      *
-     * Expects a 'submit' button \DOMElement and finds the corresponding form element, or the form element itself.
+     * Expects a 'submit' button DOM Element and finds the corresponding form element, or the form element itself.
+     *
+     * @param T $node
      *
      * @throws \LogicException If given node is not a button or input or does not have a form ancestor
      */
-    protected function setNode(\DOMElement $node): void
+    protected function setNode(\Dom\Element|\DOMElement $node): void
     {
         $this->button = $node;
-        if ('button' === $node->nodeName || ('input' === $node->nodeName && \in_array(strtolower($node->getAttribute('type')), ['submit', 'button', 'image'], true))) {
+        $nodeName = strtolower($node->nodeName);
+
+        if ('button' === $nodeName || ('input' === $nodeName && \in_array(strtolower($node->getAttribute('type') ?? ''), ['submit', 'button', 'image'], true))) {
             if ($node->hasAttribute('form')) {
                 // if the node has the HTML5-compliant 'form' attribute, use it
                 $formId = $node->getAttribute('form');
@@ -372,9 +393,9 @@ class Form extends Link implements \ArrayAccess
                 if (null === $node = $node->parentNode) {
                     throw new \LogicException('The selected node does not have a form ancestor.');
                 }
-            } while ('form' !== $node->nodeName);
-        } elseif ('form' !== $node->nodeName) {
-            throw new \LogicException(\sprintf('Unable to submit on a "%s" tag.', $node->nodeName));
+            } while ('form' !== strtolower($node->nodeName));
+        } elseif ('form' !== $nodeName) {
+            throw new \LogicException(\sprintf('Unable to submit on a "%s" tag.', $nodeName));
         }
 
         $this->node = $node;
@@ -391,11 +412,16 @@ class Form extends Link implements \ArrayAccess
     {
         $this->fields = new FormFieldRegistry();
 
-        $xpath = new \DOMXPath($this->node->ownerDocument);
+        if ($this->node instanceof \Dom\Element) {
+            $xpath = new \Dom\XPath($this->node->ownerDocument);
+        } else {
+            $xpath = new \DOMXPath($this->node->ownerDocument);
+        }
 
+        $buttonNodeName = strtolower($this->button->nodeName);
         // add submitted button if it has a valid name
-        if ('form' !== $this->button->nodeName && $this->button->hasAttribute('name') && $this->button->getAttribute('name')) {
-            if ('input' == $this->button->nodeName && 'image' == strtolower($this->button->getAttribute('type'))) {
+        if ('form' !== $buttonNodeName && $this->button->hasAttribute('name') && $this->button->getAttribute('name')) {
+            if ('input' == $buttonNodeName && 'image' == strtolower($this->button->getAttribute('type') ?? '')) {
                 $name = $this->button->getAttribute('name');
                 $this->button->setAttribute('value', '0');
 
@@ -417,7 +443,7 @@ class Form extends Link implements \ArrayAccess
         // find form elements corresponding to the current form
         if ($this->node->hasAttribute('id')) {
             // corresponding elements are either descendants or have a matching HTML5 form attribute
-            $formId = Crawler::xpathLiteral($this->node->getAttribute('id'));
+            $formId = Crawler::xpathLiteral($this->node->getAttribute('id') ?? '');
 
             $fieldNodes = $xpath->query(\sprintf('( descendant::input[@form=%s] | descendant::button[@form=%1$s] | descendant::textarea[@form=%1$s] | descendant::select[@form=%1$s] | //form[@id=%1$s]//input[not(@form)] | //form[@id=%1$s]//button[not(@form)] | //form[@id=%1$s]//textarea[not(@form)] | //form[@id=%1$s]//select[not(@form)] )[( not(ancestor::template) or ancestor::turbo-stream )]', $formId));
         } else {
@@ -430,18 +456,21 @@ class Form extends Link implements \ArrayAccess
             $this->addField($node);
         }
 
-        if ($this->baseHref && '' !== $this->node->getAttribute('action')) {
+        if ($this->baseHref && '' !== ($this->node->getAttribute('action') ?? '')) {
             $this->currentUri = $this->baseHref;
         }
     }
 
-    private function addField(\DOMElement $node): void
+    /**
+     * @param T $node
+     */
+    private function addField(\Dom\Element|\DOMElement $node): void
     {
         if (!$node->hasAttribute('name') || !$node->getAttribute('name')) {
             return;
         }
 
-        $nodeName = $node->nodeName;
+        $nodeName = strtolower($node->nodeName);
         if ('select' == $nodeName || 'input' == $nodeName && 'checkbox' == strtolower($node->getAttribute('type'))) {
             $this->set(new ChoiceFormField($node));
         } elseif ('input' == $nodeName && 'radio' == strtolower($node->getAttribute('type'))) {
@@ -452,9 +481,9 @@ class Form extends Link implements \ArrayAccess
             } else {
                 $this->set(new ChoiceFormField($node));
             }
-        } elseif ('input' == $nodeName && 'file' == strtolower($node->getAttribute('type'))) {
+        } elseif ('input' == $nodeName && 'file' == strtolower($node->getAttribute('type') ?? '')) {
             $this->set(new Field\FileFormField($node));
-        } elseif ('input' == $nodeName && !\in_array(strtolower($node->getAttribute('type')), ['submit', 'button', 'image'], true)) {
+        } elseif ('input' == $nodeName && !\in_array(strtolower($node->getAttribute('type') ?? ''), ['submit', 'button', 'image'], true)) {
             $this->set(new Field\InputFormField($node));
         } elseif ('textarea' == $nodeName) {
             $this->set(new Field\TextareaFormField($node));

--- a/src/Symfony/Component/DomCrawler/FormFieldRegistry.php
+++ b/src/Symfony/Component/DomCrawler/FormFieldRegistry.php
@@ -16,6 +16,8 @@ use Symfony\Component\DomCrawler\Field\FormField;
 /**
  * This is an internal class that must not be used directly.
  *
+ * @template T of \Dom\Element|\DOMElement
+ *
  * @internal
  */
 class FormFieldRegistry
@@ -25,6 +27,8 @@ class FormFieldRegistry
 
     /**
      * Adds a field to the registry.
+     *
+     * @param FormField<T> $field
      */
     public function add(FormField $field): void
     {
@@ -65,7 +69,7 @@ class FormFieldRegistry
     /**
      * Returns the value of the field based on the fully qualified name and its children.
      *
-     * @return FormField|FormField[]|FormField[][]
+     * @return FormField<T>|FormField<T>[]|FormField<T>[][]
      *
      * @throws \InvalidArgumentException if the field does not exist
      */
@@ -123,7 +127,7 @@ class FormFieldRegistry
     /**
      * Returns the list of field with their value.
      *
-     * @return FormField[] The list of fields as [string] Fully qualified name => (mixed) value)
+     * @return FormField<T>[] The list of fields as fully qualified name => value
      */
     public function all(): array
     {

--- a/src/Symfony/Component/DomCrawler/Image.php
+++ b/src/Symfony/Component/DomCrawler/Image.php
@@ -13,22 +13,32 @@ namespace Symfony\Component\DomCrawler;
 
 /**
  * Image represents an HTML image (an HTML img tag).
+ *
+ * @template T of \Dom\Element|\DOMElement
+ *
+ * @extends AbstractUriElement<T>
  */
 class Image extends AbstractUriElement
 {
-    public function __construct(\DOMElement $node, ?string $currentUri = null)
+    /**
+     * @param T $node
+     */
+    public function __construct(\Dom\Element|\DOMElement $node, ?string $currentUri = null)
     {
         parent::__construct($node, $currentUri, 'GET');
     }
 
     protected function getRawUri(): string
     {
-        return $this->node->getAttribute('src');
+        return $this->node->getAttribute('src') ?? '';
     }
 
-    protected function setNode(\DOMElement $node): void
+    /**
+     * @param T $node
+     */
+    protected function setNode(\Dom\Element|\DOMElement $node): void
     {
-        if ('img' !== $node->nodeName) {
+        if ('img' !== strtolower($node->nodeName)) {
             throw new \LogicException(\sprintf('Unable to visualize a "%s" tag.', $node->nodeName));
         }
 

--- a/src/Symfony/Component/DomCrawler/Link.php
+++ b/src/Symfony/Component/DomCrawler/Link.php
@@ -14,18 +14,25 @@ namespace Symfony\Component\DomCrawler;
 /**
  * Link represents an HTML link (an HTML a, area or link tag).
  *
+ * @template T of \Dom\Element|\DOMElement
+ *
+ * @extends AbstractUriElement<T>
+ *
  * @author Fabien Potencier <fabien@symfony.com>
  */
 class Link extends AbstractUriElement
 {
     protected function getRawUri(): string
     {
-        return $this->node->getAttribute('href');
+        return $this->node->getAttribute('href') ?? '';
     }
 
-    protected function setNode(\DOMElement $node): void
+    /**
+     * @param T $node
+     */
+    protected function setNode(\Dom\Element|\DOMElement $node): void
     {
-        if ('a' !== $node->nodeName && 'area' !== $node->nodeName && 'link' !== $node->nodeName) {
+        if (!\in_array(strtolower($node->nodeName), ['a', 'area', 'link'], true)) {
             throw new \LogicException(\sprintf('Unable to navigate from a "%s" tag.', $node->nodeName));
         }
 

--- a/src/Symfony/Component/DomCrawler/Tests/AbstractCrawlerTestCase.php
+++ b/src/Symfony/Component/DomCrawler/Tests/AbstractCrawlerTestCase.php
@@ -24,9 +24,9 @@ abstract class AbstractCrawlerTestCase extends TestCase
 {
     abstract public static function getDoctype(): string;
 
-    protected function createCrawler($node = null, ?string $uri = null, ?string $baseHref = null, bool $useHtml5Parser = true)
+    protected function createCrawler($node = null, ?string $uri = null, ?string $baseHref = null)
     {
-        return new Crawler($node, $uri, $baseHref, $useHtml5Parser);
+        return new Crawler($node, $uri, $baseHref, false);
     }
 
     public function testConstructor()
@@ -34,7 +34,7 @@ abstract class AbstractCrawlerTestCase extends TestCase
         $crawler = $this->createCrawler();
         $this->assertCount(0, $crawler, '__construct() returns an empty crawler');
 
-        $doc = new \DOMDocument();
+        $doc = $this->createDomDocument();
         $node = $doc->createElement('test');
 
         $crawler = $this->createCrawler($node);
@@ -59,11 +59,11 @@ abstract class AbstractCrawlerTestCase extends TestCase
     {
         $crawler = $this->createCrawler();
         $crawler->add($this->createDomDocument());
-        $this->assertEquals('foo', $crawler->filterXPath('//div')->attr('class'), '->add() adds nodes from a \DOMDocument');
+        $this->assertEquals('foo', $crawler->filterXPath('//div')->attr('class'), '->add() adds nodes from a DOM Document');
 
         $crawler = $this->createCrawler();
         $crawler->add($this->createNodeList());
-        $this->assertEquals('foo', $crawler->filterXPath('//div')->attr('class'), '->add() adds nodes from a \DOMNodeList');
+        $this->assertEquals('foo', $crawler->filterXPath('//div')->attr('class'), '->add() adds nodes from a DOM NodeList');
 
         $list = [];
         foreach ($this->createNodeList() as $node) {
@@ -75,7 +75,7 @@ abstract class AbstractCrawlerTestCase extends TestCase
 
         $crawler = $this->createCrawler();
         $crawler->add($this->createNodeList()->item(0));
-        $this->assertEquals('foo', $crawler->filterXPath('//div')->attr('class'), '->add() adds nodes from a \DOMNode');
+        $this->assertEquals('foo', $crawler->filterXPath('//div')->attr('class'), '->add() adds nodes from a DOM Node');
 
         $crawler = $this->createCrawler();
         $crawler->add($this->getDoctype().'<html><body>Foo</body></html>');
@@ -202,7 +202,7 @@ abstract class AbstractCrawlerTestCase extends TestCase
         $crawler = $this->createCrawler();
         $crawler->addDocument($this->createDomDocument());
 
-        $this->assertEquals('foo', $crawler->filterXPath('//div')->attr('class'), '->addDocument() adds nodes from a \DOMDocument');
+        $this->assertEquals('foo', $crawler->filterXPath('//div')->attr('class'), '->addDocument() adds nodes from a DOM Document');
     }
 
     public function testAddNodeList()
@@ -210,7 +210,7 @@ abstract class AbstractCrawlerTestCase extends TestCase
         $crawler = $this->createCrawler();
         $crawler->addNodeList($this->createNodeList());
 
-        $this->assertEquals('foo', $crawler->filterXPath('//div')->attr('class'), '->addNodeList() adds nodes from a \DOMNodeList');
+        $this->assertEquals('foo', $crawler->filterXPath('//div')->attr('class'), '->addNodeList() adds nodes from a DOM NodeList');
     }
 
     public function testAddNodes()
@@ -231,12 +231,12 @@ abstract class AbstractCrawlerTestCase extends TestCase
         $crawler = $this->createCrawler();
         $crawler->addNode($this->createNodeList()->item(0));
 
-        $this->assertEquals('foo', $crawler->filterXPath('//div')->attr('class'), '->addNode() adds nodes from a \DOMNode');
+        $this->assertEquals('foo', $crawler->filterXPath('//div')->attr('class'), '->addNode() adds nodes from a DOM Node');
     }
 
     public function testClear()
     {
-        $doc = new \DOMDocument();
+        $doc = $this->createDomDocument();
         $node = $doc->createElement('test');
 
         $crawler = $this->createCrawler($node);
@@ -421,9 +421,9 @@ abstract class AbstractCrawlerTestCase extends TestCase
 
     public function testEmojis()
     {
-        $crawler = $this->createCrawler('<body><p>Hey 👋</p></body>');
+        $crawler = $this->createCrawler('<head></head><body><p>Hey 👋</p></body>');
 
-        $this->assertSame('<body><p>Hey 👋</p></body>', $crawler->html());
+        $this->assertSame('<head></head><body><p>Hey 👋</p></body>', $crawler->html());
     }
 
     public function testExtract()
@@ -528,6 +528,16 @@ abstract class AbstractCrawlerTestCase extends TestCase
         $crawler = $crawler->filterXPath('//media:category[@scheme="http://gdata.youtube.com/schemas/2007/categories.cat"]');
         $this->assertCount(1, $crawler);
         $this->assertSame('Music', $crawler->text());
+    }
+
+    public function testCaseSentivity()
+    {
+        $crawler = $this->createTestXmlCrawler();
+
+        $crawler = $crawler->filterXPath('//*[local-name() = "CaseSensitiveTag"]');
+        $this->assertCount(1, $crawler);
+        $this->assertSame('Some Content', $crawler->text());
+        $this->assertSame('CaseSensitiveTag', $crawler->nodeName());
     }
 
     public function testFilterXPathWithFakeRoot()
@@ -798,7 +808,7 @@ abstract class AbstractCrawlerTestCase extends TestCase
     public function testInvalidLink()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The selected node should be instance of DOMElement');
+        $this->expectExceptionMessage('The selected node should be a DOM Element');
         $crawler = $this->createTestCrawler('http://example.com/bar/');
         $crawler->filterXPath('//li/text()')->link();
     }
@@ -806,7 +816,7 @@ abstract class AbstractCrawlerTestCase extends TestCase
     public function testInvalidLinks()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The selected node should be instance of DOMElement');
+        $this->expectExceptionMessage('The selected node should be a DOM Element');
         $crawler = $this->createTestCrawler('http://example.com/bar/');
         $crawler->filterXPath('//li/text()')->link();
     }
@@ -910,7 +920,7 @@ abstract class AbstractCrawlerTestCase extends TestCase
     public function testInvalidForm()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The selected node should be instance of DOMElement');
+        $this->expectExceptionMessage('The selected node should be a DOM Element');
         $crawler = $this->createTestCrawler('http://example.com/bar/');
         $crawler->filterXPath('//li/text()')->form();
     }
@@ -1292,8 +1302,7 @@ abstract class AbstractCrawlerTestCase extends TestCase
 
     public function createTestCrawler($uri = null)
     {
-        $dom = new \DOMDocument();
-        $dom->loadHTML($this->getDoctype().'
+        $html = $this->getDoctype().'
             <html>
                 <body>
                     <a href="foo">Foo</a>
@@ -1352,9 +1361,9 @@ abstract class AbstractCrawlerTestCase extends TestCase
                     </div>
                 </body>
             </html>
-        ');
+        ';
 
-        return $this->createCrawler($dom, $uri);
+        return $this->createCrawler($html, $uri);
     }
 
     protected function createTestXmlCrawler($uri = null)
@@ -1369,6 +1378,7 @@ abstract class AbstractCrawlerTestCase extends TestCase
                     <yt:aspectRatio>widescreen</yt:aspectRatio>
                 </media:group>
                 <media:category label="Music" scheme="http://gdata.youtube.com/schemas/2007/categories.cat">Music</media:category>
+                <CaseSensitiveTag>Some Content</CaseSensitiveTag>
             </entry>';
 
         return $this->createCrawler($xml, $uri);

--- a/src/Symfony/Component/DomCrawler/Tests/DomHtml5ParserCrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/DomHtml5ParserCrawlerTest.php
@@ -1,0 +1,136 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DomCrawler\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresPhp;
+use Symfony\Component\DomCrawler\DomCrawler;
+
+#[RequiresPhp('8.4')]
+class DomHtml5ParserCrawlerTest extends AbstractCrawlerTestCase
+{
+    public static function getDoctype(): string
+    {
+        return '<!DOCTYPE html>';
+    }
+
+    public function testIteration()
+    {
+        $crawler = $this->createTestCrawler()->filterXPath('//li');
+
+        $this->assertInstanceOf(\Traversable::class, $crawler);
+        $this->assertContainsOnlyInstancesOf('Dom\Element', iterator_to_array($crawler), 'Iterating a Crawler gives DOMElement instances');
+    }
+
+    public function testHtml()
+    {
+        $this->assertEquals('<img alt="Bar">', $this->createTestCrawler()->filterXPath('//a[5]')->html());
+        $this->assertEquals('<input type="text" value="TextValue" name="TextName"><input type="submit" value="FooValue" name="FooName" id="FooId"><input type="button" value="BarValue" name="BarName" id="BarId"><button value="ButtonValue" name="ButtonName" id="ButtonId"><input type="submit" value="FooBarValue" name="FooBarName" form="FooFormId"><input type="text" value="FooTextValue" name="FooTextName" form="FooFormId"><input type="image" alt="ImageAlt" form="FooFormId"></button>', trim(preg_replace('~>\s+<~', '><', $this->createTestCrawler()->filterXPath('//form[@id="FooFormId"]')->html())));
+
+        try {
+            $this->createTestCrawler()->filterXPath('//ol')->html();
+            $this->fail('->html() throws an \InvalidArgumentException if the node list is empty');
+        } catch (\InvalidArgumentException $e) {
+            $this->assertTrue(true, '->html() throws an \InvalidArgumentException if the node list is empty');
+        }
+
+        $this->assertSame('my value', $this->createTestCrawler(null)->filterXPath('//ol')->html('my value'));
+    }
+
+    public function testFilterXpathComplexQueries()
+    {
+        $crawler = $this->createTestCrawler()->filterXPath('//body');
+
+        $this->assertCount(0, $crawler->filterXPath('/input'));
+        $this->assertCount(0, $crawler->filterXPath('/body'));
+        $this->assertCount(1, $crawler->filterXPath('./body'));
+        $this->assertCount(1, $crawler->filterXPath('.//body'));
+        $this->assertCount(6, $crawler->filterXPath('.//input'));
+        $this->assertCount(7, $crawler->filterXPath('//form')->filterXPath('//button | //input'));
+        $this->assertCount(1, $crawler->filterXPath('body'));
+        $this->assertCount(8, $crawler->filterXPath('//button | //input'));
+        $this->assertCount(1, $crawler->filterXPath('//body'));
+        $this->assertCount(1, $crawler->filterXPath('descendant-or-self::body'));
+        $this->assertCount(1, $crawler->filterXPath('//div[@id="parent"]')->filterXPath('./div'), 'A child selection finds only the current div');
+        $this->assertCount(3, $crawler->filterXPath('//div[@id="parent"]')->filterXPath('descendant::div'), 'A descendant selector matches the current div and its child');
+        $this->assertCount(3, $crawler->filterXPath('//div[@id="parent"]')->filterXPath('//div'), 'A descendant selector matches the current div and its child');
+        $this->assertCount(5, $crawler->filterXPath('(//a | //div)//img'));
+        $this->assertCount(7, $crawler->filterXPath('((//a | //div)//img | //ul)'));
+        $this->assertCount(7, $crawler->filterXPath('( ( //a | //div )//img | //ul )'));
+        $this->assertCount(1, $crawler->filterXPath("//a[./@href][((./@id = 'Klausi|Claudiu' or normalize-space(string(.)) = 'Klausi|Claudiu' or ./@title = 'Klausi|Claudiu' or ./@rel = 'Klausi|Claudiu') or .//img[./@alt = 'Klausi|Claudiu'])]"));
+    }
+
+    public function testAddHtml5()
+    {
+        // Ensure a bug specific to the DOM extension is fixed (see https://github.com/symfony/symfony/issues/28596)
+        $crawler = $this->createCrawler();
+        $crawler->add($this->getDoctype().'<html><body><h1><p>Foo</p></h1></body></html>');
+        $this->assertEquals('Foo', $crawler->filterXPath('//h1')->text(), '->add() adds nodes from a string');
+    }
+
+    #[DataProvider('validHtml5Provider')]
+    public function testHtml5ParserParseContentStartingWithValidHeading(string $content)
+    {
+        $crawler = $this->createCrawler();
+        $crawler->addHtmlContent($content);
+        self::assertEquals(
+            'Foo',
+            $crawler->filterXPath('//h1')->text(),
+            '->addHtmlContent() parses valid HTML with comment before doctype'
+        );
+    }
+
+    public function testHtml5ParserNotSameAsNativeParserForSpecificHtml()
+    {
+        // Html who create a bug specific to the DOM extension (see https://github.com/symfony/symfony/issues/28596)
+        $html = $this->getDoctype().'<html><body><h1><p>Foo</p></h1></body></html>';
+
+        $html5Crawler = $this->createCrawler();
+        $html5Crawler->add($html);
+
+        $nativeCrawler = parent::createCrawler();
+        $nativeCrawler->add($html);
+
+        $this->assertNotEquals($nativeCrawler->filterXPath('//h1')->text(), $html5Crawler->filterXPath('//h1')->text(), 'Native parser and Html5 parser must be different');
+    }
+
+    public static function validHtml5Provider(): iterable
+    {
+        $html = self::getDoctype().'<html><body><h1><p>Foo</p></h1></body></html>';
+        $BOM = \chr(0xEF).\chr(0xBB).\chr(0xBF);
+
+        yield 'BOM first' => [$BOM.$html];
+        yield 'Single comment' => ['<!-- comment -->'.$html];
+        yield 'Multiline comment' => ["<!-- \n multiline comment \n -->".$html];
+        yield 'Several comments' => ['<!--c--> <!--cc-->'.$html];
+        yield 'Whitespaces' => ['    '.$html];
+        yield 'All together' => [$BOM.'  <!--c-->'.$html];
+    }
+
+    protected function createCrawler($node = null, ?string $uri = null, ?string $baseHref = null)
+    {
+        return new DomCrawler($node, $uri, $baseHref);
+    }
+
+    protected function createDomDocument()
+    {
+        return \Dom\HTMLDocument::createFromString(self::getDoctype().'<html><div class="foo"></div></html>', \Dom\HTML_NO_DEFAULT_NS);
+    }
+
+    protected function createNodeList()
+    {
+        $dom = $this->createDomDocument();
+        $domxpath = new \Dom\XPath($dom);
+
+        return $domxpath->query('//div');
+    }
+}

--- a/src/Symfony/Component/DomCrawler/Tests/FormTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/FormTest.php
@@ -71,7 +71,7 @@ class FormTest extends TestCase
      * __construct() should throw a \LogicException if the form attribute is invalid.
      */
     #[DataProvider('constructorThrowsExceptionIfNoRelatedFormProvider')]
-    public function testConstructorThrowsExceptionIfNoRelatedForm(\DOMElement $node)
+    public function testConstructorThrowsExceptionIfNoRelatedForm(\Dom\Element|\DOMElement $node)
     {
         $this->expectException(\LogicException::class);
 

--- a/src/Symfony/Component/DomCrawler/Tests/LegacyHtml5ParserCrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/LegacyHtml5ParserCrawlerTest.php
@@ -12,9 +12,14 @@
 namespace Symfony\Component\DomCrawler\Tests;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\TestWith;
+use Symfony\Component\DomCrawler\Crawler;
 
-class Html5ParserCrawlerTest extends AbstractCrawlerTestCase
+#[IgnoreDeprecations]
+#[Group('legacy')]
+class LegacyHtml5ParserCrawlerTest extends AbstractCrawlerTestCase
 {
     public static function getDoctype(): string
     {
@@ -54,10 +59,10 @@ class Html5ParserCrawlerTest extends AbstractCrawlerTestCase
         // Html who create a bug specific to the DOM extension (see https://github.com/symfony/symfony/issues/28596)
         $html = $this->getDoctype().'<html><body><h1><p>Foo</p></h1></body></html>';
 
-        $html5Crawler = $this->createCrawler(null, null, null, true);
+        $html5Crawler = $this->createCrawler();
         $html5Crawler->add($html);
 
-        $nativeCrawler = $this->createCrawler(null, null, null, false);
+        $nativeCrawler = parent::createCrawler();
         $nativeCrawler->add($html);
 
         $this->assertNotEquals($nativeCrawler->filterXPath('//h1')->text(), $html5Crawler->filterXPath('//h1')->text(), 'Native parser and Html5 parser must be different');
@@ -67,7 +72,7 @@ class Html5ParserCrawlerTest extends AbstractCrawlerTestCase
     #[TestWith([false])]
     public function testHasHtml5Parser(bool $useHtml5Parser)
     {
-        $crawler = $this->createCrawler(null, null, null, $useHtml5Parser);
+        $crawler = $useHtml5Parser ? $this->createCrawler() : parent::createCrawler();
 
         $r = new \ReflectionProperty($crawler::class, 'html5Parser');
         $html5Parser = $r->getValue($crawler);
@@ -98,5 +103,10 @@ class Html5ParserCrawlerTest extends AbstractCrawlerTestCase
 
         yield 'Text' => ['hello world'.$html];
         yield 'Text between comments' => ['<!--c--> test <!--cc-->'.$html];
+    }
+
+    protected function createCrawler($node = null, ?string $uri = null, ?string $baseHref = null)
+    {
+        return new Crawler($node, $uri, $baseHref, true);
     }
 }

--- a/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerAnySelectorTextContainsTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerAnySelectorTextContainsTest.php
@@ -22,10 +22,10 @@ class CrawlerAnySelectorTextContainsTest extends TestCase
     {
         $constraint = new CrawlerAnySelectorTextContains('ul li', 'Foo');
 
-        self::assertTrue($constraint->evaluate(new Crawler('<ul><li>Foo</li>'), '', true));
-        self::assertTrue($constraint->evaluate(new Crawler('<ul><li>Bar</li><li>Foo'), '', true));
-        self::assertTrue($constraint->evaluate(new Crawler('<ul><li>Bar</li><li>Foo Bar Baz'), '', true));
-        self::assertFalse($constraint->evaluate(new Crawler('<ul><li>Bar</li><li>Baz'), '', true));
+        self::assertTrue($constraint->evaluate(new Crawler('<ul><li>Foo</li>', useHtml5Parser: false), '', true));
+        self::assertTrue($constraint->evaluate(new Crawler('<ul><li>Bar</li><li>Foo', useHtml5Parser: false), '', true));
+        self::assertTrue($constraint->evaluate(new Crawler('<ul><li>Bar</li><li>Foo Bar Baz', useHtml5Parser: false), '', true));
+        self::assertFalse($constraint->evaluate(new Crawler('<ul><li>Bar</li><li>Baz', useHtml5Parser: false), '', true));
     }
 
     public function testDoesNotMatchIfNodeDoesContainExpectedText()
@@ -35,7 +35,7 @@ class CrawlerAnySelectorTextContainsTest extends TestCase
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage('Failed asserting that the text of any node matching selector "ul li" contains "Foo".');
 
-        $constraint->evaluate(new Crawler('<ul><li>Bar</li><li>Baz'));
+        $constraint->evaluate(new Crawler('<ul><li>Bar</li><li>Baz', useHtml5Parser: false));
     }
 
     public function testDoesNotMatchIfNodeDoesNotExist()
@@ -45,6 +45,6 @@ class CrawlerAnySelectorTextContainsTest extends TestCase
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage('Failed asserting that the Crawler has a node matching selector "ul li".');
 
-        $constraint->evaluate(new Crawler('<html><head><title>Foobar'));
+        $constraint->evaluate(new Crawler('<html><head><title>Foobar', useHtml5Parser: false));
     }
 }

--- a/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerAnySelectorTextSameTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerAnySelectorTextSameTest.php
@@ -22,14 +22,14 @@ final class CrawlerAnySelectorTextSameTest extends TestCase
     {
         $constraint = new CrawlerAnySelectorTextSame('ul li', 'Foo');
 
-        self::assertTrue($constraint->evaluate(new Crawler('<ul><li>Foo</li>'), '', true));
-        self::assertTrue($constraint->evaluate(new Crawler('<ul><li>Bar</li><li>Foo'), '', true));
-        self::assertFalse($constraint->evaluate(new Crawler('<ul><li>Bar</li><li>Foo Bar Baz'), '', true));
-        self::assertFalse($constraint->evaluate(new Crawler('<ul><li>Bar</li><li>Baz'), '', true));
+        self::assertTrue($constraint->evaluate(new Crawler('<ul><li>Foo</li>', useHtml5Parser: false), '', true));
+        self::assertTrue($constraint->evaluate(new Crawler('<ul><li>Bar</li><li>Foo', useHtml5Parser: false), '', true));
+        self::assertFalse($constraint->evaluate(new Crawler('<ul><li>Bar</li><li>Foo Bar Baz', useHtml5Parser: false), '', true));
+        self::assertFalse($constraint->evaluate(new Crawler('<ul><li>Bar</li><li>Baz', useHtml5Parser: false), '', true));
 
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage('Failed asserting that the Crawler has at least a node matching selector "ul li" with content "Foo".');
 
-        $constraint->evaluate(new Crawler('<ul><li>Bar</li><li>Baz'));
+        $constraint->evaluate(new Crawler('<ul><li>Bar</li><li>Baz', useHtml5Parser: false));
     }
 }

--- a/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorAttributeValueSameTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorAttributeValueSameTest.php
@@ -21,13 +21,13 @@ class CrawlerSelectorAttributeValueSameTest extends TestCase
     public function testConstraint()
     {
         $constraint = new CrawlerSelectorAttributeValueSame('input[name="username"]', 'value', 'Fabien');
-        $this->assertTrue($constraint->evaluate(new Crawler('<html><body><form><input type="text" name="username" value="Fabien">'), '', true));
-        $this->assertFalse($constraint->evaluate(new Crawler('<html><body><form><input type="text" name="username">'), '', true));
-        $this->assertFalse($constraint->evaluate(new Crawler('<html><head><title>Bar'), '', true));
+        $this->assertTrue($constraint->evaluate(new Crawler('<html><body><form><input type="text" name="username" value="Fabien">', useHtml5Parser: false), '', true));
+        $this->assertFalse($constraint->evaluate(new Crawler('<html><body><form><input type="text" name="username">', useHtml5Parser: false), '', true));
+        $this->assertFalse($constraint->evaluate(new Crawler('<html><head><title>Bar', useHtml5Parser: false), '', true));
 
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage('Failed asserting that the Crawler has a node matching selector "input[name="username"]" with attribute "value" of value "Fabien".');
 
-        $constraint->evaluate(new Crawler('<html><head><title>Bar'));
+        $constraint->evaluate(new Crawler('<html><head><title>Bar', useHtml5Parser: false));
     }
 }

--- a/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorExistsTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorExistsTest.php
@@ -21,13 +21,13 @@ class CrawlerSelectorExistsTest extends TestCase
     public function testConstraint()
     {
         $constraint = new CrawlerSelectorExists('title');
-        $this->assertTrue($constraint->evaluate(new Crawler('<html><head><title>'), '', true));
+        $this->assertTrue($constraint->evaluate(new Crawler('<html><head><title>', useHtml5Parser: false), '', true));
         $constraint = new CrawlerSelectorExists('h1');
-        $this->assertFalse($constraint->evaluate(new Crawler('<html><head><title>'), '', true));
+        $this->assertFalse($constraint->evaluate(new Crawler('<html><head><title>', useHtml5Parser: false), '', true));
 
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage('Failed asserting that the Crawler matches selector "h1".');
 
-        $constraint->evaluate(new Crawler('<html><head><title>'));
+        $constraint->evaluate(new Crawler('<html><head><title>', useHtml5Parser: false));
     }
 }

--- a/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorTextContainsTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorTextContainsTest.php
@@ -21,9 +21,9 @@ class CrawlerSelectorTextContainsTest extends TestCase
     public function testConstraint()
     {
         $constraint = new CrawlerSelectorTextContains('title', 'Foo');
-        $this->assertTrue($constraint->evaluate(new Crawler('<html><head><title>Foobar'), '', true));
-        $this->assertFalse($constraint->evaluate(new Crawler('<html><head><title>Bar'), '', true));
-        $this->assertFalse($constraint->evaluate(new Crawler('<html><head></head><body>Bar'), '', true));
+        $this->assertTrue($constraint->evaluate(new Crawler('<html><head><title>Foobar', useHtml5Parser: false), '', true));
+        $this->assertFalse($constraint->evaluate(new Crawler('<html><head><title>Bar', useHtml5Parser: false), '', true));
+        $this->assertFalse($constraint->evaluate(new Crawler('<html><head></head><body>Bar', useHtml5Parser: false), '', true));
     }
 
     public function testDoesNotMatchIfNodeTextIsNotExpectedValue()
@@ -33,7 +33,7 @@ class CrawlerSelectorTextContainsTest extends TestCase
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage('Failed asserting that the text "Bar" of the node matching selector "title" contains "Foo".');
 
-        $constraint->evaluate(new Crawler('<html><head><title>Bar'));
+        $constraint->evaluate(new Crawler('<html><head><title>Bar', useHtml5Parser: false));
     }
 
     public function testDoesNotMatchIfNodeDoesNotExist()
@@ -43,6 +43,6 @@ class CrawlerSelectorTextContainsTest extends TestCase
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage('Failed asserting that the Crawler has a node matching selector "title".');
 
-        $constraint->evaluate(new Crawler('<html><head></head><body>Bar'));
+        $constraint->evaluate(new Crawler('<html><head></head><body>Bar', useHtml5Parser: false));
     }
 }

--- a/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorTextSameTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorTextSameTest.php
@@ -21,12 +21,12 @@ class CrawlerSelectorTextSameTest extends TestCase
     public function testConstraint()
     {
         $constraint = new CrawlerSelectorTextSame('title', 'Foo');
-        $this->assertTrue($constraint->evaluate(new Crawler('<html><head><title>Foo'), '', true));
-        $this->assertFalse($constraint->evaluate(new Crawler('<html><head><title>Bar'), '', true));
+        $this->assertTrue($constraint->evaluate(new Crawler('<html><head><title>Foo', useHtml5Parser: false), '', true));
+        $this->assertFalse($constraint->evaluate(new Crawler('<html><head><title>Bar', useHtml5Parser: false), '', true));
 
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage('Failed asserting that the Crawler has a node matching selector "title" with content "Foo".');
 
-        $constraint->evaluate(new Crawler('<html><head><title>Bar'));
+        $constraint->evaluate(new Crawler('<html><head><title>Bar', useHtml5Parser: false));
     }
 }

--- a/src/Symfony/Component/DomCrawler/composer.json
+++ b/src/Symfony/Component/DomCrawler/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=8.2",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/polyfill-ctype": "~1.8",
         "symfony/polyfill-mbstring": "~1.0",
         "masterminds/html5": "^2.6"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | https://github.com/symfony/symfony/issues/53666
| License       | MIT

This PR replaces #54383

It takes the BC breaking approach by widening some property and method types to accept / return classes from both `Dom\*` and `DOM*` sets.

This widening is a hard BC break for child classes the re-declare the corresponding properties/methods.
I expect this situation to be rather uncommon, so I don't think this will be a big-bang BC break.
Fortunately, this change in signature will be easy to spot since the PHP engine will fail early.

In addition, the `Crawler` class is made generic: once an instance is created, it's going to stick to one set, either `Dom\*` or `DOM*` classes.
To further limit the impact, `Crawler::__construct()` allows building only `Crawler<DOMNode>` instances and a `DomCrawler` class is introduced to create `Crawler<Dom\Node>` ones.

As a reminder, the goal of this work is to be able to remove the dependency on `masterminds/html5` in Symfony 8.
It is NOT to force moving to the new `Dom\*` API.

Still, in order to achieve this goal and because we want HTML5-parsing to be the default, `BrowserKit` will leverage the new `DomCrawler` class when running on PHP 8.4+.

The new `Dom\*` API has some behavioral changes, all legit and documented at https://wiki.php.net/rfc/opt_in_dom_spec_compliance

The `Crawler` implementation ensures some fundamental behaviors remain, such as node names being returned in lowercase, empty values/texts being returned as the empty string instead of null, or void tags to not have closing tags. I don't think we'd gain much by propagating these changes brought by the `Dom\*` API to the `Crawler` one. It'd actually make adopting the new `Dom\*` implementation harder for little to no benefits.

The BC break is a decision we have to make. I think it's the best possible approach because in practice, the impact will be limited. The alternative taken in #54383 is to create two independent type hierarchies. This will create a situation where suddenly, all the existing crawler-related code will need to be updated. Better not when there's a less costly path - even though it'll break some edge-cases.
