### PR TITLE
[Routing] allow setting multiple envs in `#[Route]` attribute

### DIFF
--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -64,6 +64,11 @@ Mime
 
  * Deprecate implementing `__sleep/wakeup()` on `AbstractPart` implementations; use `__(un)serialize()` instead
 
+Routing
+-------
+
+ * Deprecate `getEnv()` and `setEnv()` methods of the `Symfony\Component\Routing\Attribute\Route` class in favor of the plurialized `getEnvs()` and `setEnvs()` methods
+
 Security
 --------
 

--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Allow query-specific parameters in `UrlGenerator` using `_query`
+ * Add support of multiple env names in the  `Symfony\Component\Routing\Attribute\Route` attribute
 
 7.3
 ---

--- a/src/Symfony/Component/Routing/Loader/AttributeClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AttributeClassLoader.php
@@ -105,7 +105,7 @@ abstract class AttributeClassLoader implements LoaderInterface
         $globals = $this->getGlobals($class);
         $collection = new RouteCollection();
         $collection->addResource(new FileResource($class->getFileName()));
-        if ($globals['env'] && $this->env !== $globals['env']) {
+        if ($globals['env'] && !\in_array($this->env, $globals['env'], true)) {
             return $collection;
         }
         $fqcnAlias = false;
@@ -161,7 +161,7 @@ abstract class AttributeClassLoader implements LoaderInterface
      */
     protected function addRoute(RouteCollection $collection, object $attr, array $globals, \ReflectionClass $class, \ReflectionMethod $method): void
     {
-        if ($attr->getEnv() && $attr->getEnv() !== $this->env) {
+        if ($attr->getEnvs() && !\in_array($this->env, $attr->getEnvs(), true)) {
             return;
         }
 
@@ -338,7 +338,7 @@ abstract class AttributeClassLoader implements LoaderInterface
             }
 
             $globals['priority'] = $attr->getPriority() ?? 0;
-            $globals['env'] = $attr->getEnv();
+            $globals['env'] = $attr->getEnvs();
 
             foreach ($globals['requirements'] as $placeholder => $requirement) {
                 if (\is_int($placeholder)) {

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/RouteWithEnv.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/RouteWithEnv.php
@@ -16,4 +16,19 @@ class RouteWithEnv
     public function action2()
     {
     }
+
+    #[Route(path: '/path3', name: 'action3', env: ['some-other-env', 'some-other-env-two'])]
+    public function action3()
+    {
+    }
+
+    #[Route(path: '/path4', name: 'action4', env: null)]
+    public function action4()
+    {
+    }
+
+    #[Route(path: '/path5', name: 'action5', env: ['some-other-env', 'some-env'])]
+    public function action5()
+    {
+    }
 }

--- a/src/Symfony/Component/Routing/Tests/Loader/AttributeClassLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AttributeClassLoaderTest.php
@@ -330,8 +330,10 @@ class AttributeClassLoaderTest extends TestCase
 
         $this->setUp('some-env');
         $routes = $this->loader->load(RouteWithEnv::class);
-        $this->assertCount(1, $routes);
+        $this->assertCount(3, $routes);
         $this->assertSame('/path', $routes->get('action')->getPath());
+        $this->assertSame('/path4', $routes->get('action4')->getPath());
+        $this->assertSame('/path5', $routes->get('action5')->getPath());
     }
 
     public function testMethodsAndSchemes()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | Fix #61344 
| License       | MIT

## Summary

This PR enhances the `Symfony\Component\Routing\Attribute\Route` attribute by allowing the `env` parameter to accept an array of environment names. This change enables defining a single route that is conditionally available in multiple environments without duplicating route definitions.

## Before

To make a route available in both `dev` and `test` environments, two separate route attributes were needed:

```php
#[Route('/test', name: 'test', env: 'dev')]
#[Route('/test', name: 'test-testing', env: 'test')]
```

## After

Now, the same can be achieved with a single attribute by passing an array:

```php
#[Route('/test', name: 'test', env: ['dev', 'test'])]
```