### PR TITLE
[Security] Add `$methods` support to `#[IsGranted]` to restrict access by HTTP method

### DIFF
--- a/src/Symfony/Component/Security/Http/Attribute/IsGranted.php
+++ b/src/Symfony/Component/Security/Http/Attribute/IsGranted.php
@@ -24,12 +24,16 @@ use Symfony\Component\HttpFoundation\Request;
 #[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_FUNCTION)]
 final class IsGranted
 {
+    /** @var string[] */
+    public readonly array $methods;
+
     /**
-     * @param string|Expression|\Closure(IsGrantedContext, mixed $subject):bool $attribute The attribute that will be checked against a given authentication token and optional subject
-     * @param array|string|Expression|\Closure(array<string,mixed>, Request):mixed|null $subject An optional subject - e.g. the current object being voted on
-     * @param string|null $message       A custom message when access is not granted
-     * @param int|null    $statusCode    If set, will throw HttpKernel's HttpException with the given $statusCode; if null, Security\Core's AccessDeniedException will be used
-     * @param int|null    $exceptionCode If set, will add the exception code to thrown exception
+     * @param string|Expression|\Closure(IsGrantedContext, mixed $subject):bool         $attribute     The attribute that will be checked against a given authentication token and optional subject
+     * @param array|string|Expression|\Closure(array<string,mixed>, Request):mixed|null $subject       An optional subject - e.g. the current object being voted on
+     * @param string|null                                                               $message       A custom message when access is not granted
+     * @param int|null                                                                  $statusCode    If set, will throw HttpKernel's HttpException with the given $statusCode; if null, Security\Core's AccessDeniedException will be used
+     * @param int|null                                                                  $exceptionCode If set, will add the exception code to thrown exception
+     * @param string[]|string                                                           $methods       HTTP methods to apply validation to. Empty array means all methods are allowed
      */
     public function __construct(
         public string|Expression|\Closure $attribute,
@@ -37,6 +41,8 @@ final class IsGranted
         public ?string $message = null,
         public ?int $statusCode = null,
         public ?int $exceptionCode = null,
+        array|string $methods = [],
     ) {
+        $this->methods = (array) $methods;
     }
 }

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add support for union types with `#[CurrentUser]`
  * Deprecate callable firewall listeners, extend `AbstractListener` or implement `FirewallListenerInterface` instead
  * Deprecate `AbstractListener::__invoke`
+ * Add `$methods` argument to `#[IsGranted]` to restrict validation to specific HTTP methods
 
 7.3
 ---

--- a/src/Symfony/Component/Security/Http/EventListener/IsGrantedAttributeListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/IsGrantedAttributeListener.php
@@ -47,6 +47,10 @@ class IsGrantedAttributeListener implements EventSubscriberInterface
         $arguments = $event->getNamedArguments();
 
         foreach ($attributes as $attribute) {
+            if ($attribute->methods && !\in_array($request->getMethod(), array_map('strtoupper', $attribute->methods), true)) {
+                continue;
+            }
+
             $subject = null;
 
             if ($subjectRef = $attribute->subject) {

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/IsGrantedAttributeListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/IsGrantedAttributeListenerTest.php
@@ -454,4 +454,74 @@ class IsGrantedAttributeListenerTest extends TestCase
 
         $listener->onKernelControllerArguments($event);
     }
+
+    public function testThrowsAccessDeniedExceptionWhenMethodMatchesStringConstraint()
+    {
+        $authChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authChecker->expects($this->once())->method('isGranted')->willReturn(false);
+
+        $event = new ControllerArgumentsEvent(
+            $this->createMock(HttpKernelInterface::class),
+            [new IsGrantedAttributeMethodsController(), 'adminWithMethodGet'],
+            [],
+            new Request([], [], [], [], [], ['REQUEST_METHOD' => 'GET']),
+            null
+        );
+
+        $listener = new IsGrantedAttributeListener($authChecker);
+        $this->expectException(AccessDeniedException::class);
+        $listener->onKernelControllerArguments($event);
+    }
+
+    public function testThrowsAccessDeniedExceptionWhenMethodMatchesArrayConstraint()
+    {
+        $authChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authChecker->expects($this->once())->method('isGranted')->willReturn(false);
+
+        $event = new ControllerArgumentsEvent(
+            $this->createMock(HttpKernelInterface::class),
+            [new IsGrantedAttributeMethodsController(), 'adminWithMethodGetAndPost'],
+            [],
+            new Request([], [], [], [], [], ['REQUEST_METHOD' => 'POST']),
+            null
+        );
+
+        $listener = new IsGrantedAttributeListener($authChecker);
+        $this->expectException(AccessDeniedException::class);
+        $listener->onKernelControllerArguments($event);
+    }
+
+    public function testSkipsAuthorizationWhenMethodDoesNotMatchArrayConstraint()
+    {
+        $authChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authChecker->expects($this->never())->method('isGranted');
+
+        $event = new ControllerArgumentsEvent(
+            $this->createMock(HttpKernelInterface::class),
+            [new IsGrantedAttributeMethodsController(), 'adminWithMethodGetAndPost'],
+            [],
+            new Request([], [], [], [], [], ['REQUEST_METHOD' => 'PUT']),
+            null
+        );
+
+        $listener = new IsGrantedAttributeListener($authChecker);
+        $listener->onKernelControllerArguments($event);
+    }
+
+    public function testSkipsAuthorizationWhenMethodDoesNotMatchStringConstraint()
+    {
+        $authChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authChecker->expects($this->never())->method('isGranted');
+
+        $event = new ControllerArgumentsEvent(
+            $this->createMock(HttpKernelInterface::class),
+            [new IsGrantedAttributeMethodsController(), 'adminWithMethodGet'],
+            [],
+            new Request([], [], [], [], [], ['REQUEST_METHOD' => 'POST']),
+            null
+        );
+
+        $listener = new IsGrantedAttributeListener($authChecker);
+        $listener->onKernelControllerArguments($event);
+    }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Fixtures/IsGrantedAttributeMethodsController.php
+++ b/src/Symfony/Component/Security/Http/Tests/Fixtures/IsGrantedAttributeMethodsController.php
@@ -77,4 +77,14 @@ class IsGrantedAttributeMethodsController
     public function withRequestAsSubject()
     {
     }
+
+    #[IsGranted(attribute: 'ROLE_ADMIN', methods: 'get')]
+    public function adminWithMethodGet(): void
+    {
+    }
+
+    #[IsGranted(attribute: 'ROLE_ADMIN', methods: ['GET', 'POST'])]
+    public function adminWithMethodGetAndPost(): void
+    {
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | no
| License       | MIT

### Description

This PR adds support for restricting `#[IsGranted]` validation to specific HTTP methods via a new `$methods` argument.

### What's New

You can now define access control per HTTP method directly in the `#[IsGranted]` attribute. This allows greater flexibility when securing controller actions that handle multiple HTTP verbs.

```php
#[IsGranted('ROLE_ADMIN', methods: ['GET', 'POST'])]
public function someAction() {}

#[IsGranted('ROLE_ADMIN', methods: 'POST')]
public function otherAction() {}
```

* If the current request method does not match, the attribute is ignored.
* If the method matches, the usual access check logic runs as expected.


This change aligns `#[IsGranted]` more closely with other HTTP-aware attributes like:
* `#[IsCsrfTokenValid]`
* `#[IsSignatureValid]` (currently under review)