### PR TITLE
[Mailer] Fix expected exception message to include quotes around "http(s)://"

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Tests/Transport/MicrosoftGraphTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Tests/Transport/MicrosoftGraphTransportFactoryTest.php
@@ -84,7 +84,7 @@ class MicrosoftGraphTransportFactoryTest extends AbstractTransportFactoryTestCas
         $dsn = new Dsn('microsoftgraph+api', $graph, self::USER, self::PASSWORD, null, ['tenantId' => self::TENANT, 'authEndpoint' => $auth]);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage($failingType.' endpoint needs to be provided without http(s)://.');
+        $this->expectExceptionMessage($failingType.' endpoint needs to be provided without "http(s)://".');
         $factory->create($dsn);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | no
| License       | MIT

### What does this PR do?

This PR updates a test assertion to match the actual exception message being thrown in the code.

The test was previously expecting the message:
`<failingType> endpoint needs to be provided without http(s)://.`

But the actual exception thrown is:
`<failingType> endpoint needs to be provided without "http(s)://".`

The discrepancy caused the test to fail. This fix ensures the test correctly reflects the expected output, including the necessary double quotes.

### Changes made

- Updated `$this->expectExceptionMessage(...)` to include the quoted string `"http(s)://"`.

No other logic or behavior has been changed.



### References
* [MicrosoftGraphTransportFactory.php#L47-L53](https://github.com/symfony/symfony/blob/7.4/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphTransportFactory.php#L47-L53)  
  The exception is thrown with `"http(s)://"` in quotes.
* [MicrosoftGraphTransportFactoryTest.php#L87](https://github.com/symfony/symfony/blob/7.4/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Tests/Transport/MicrosoftGraphTransportFactoryTest.php#L87)  
  The test incorrectly expects the message without quotes.
