### PR TITLE
[CI] fixed the Intl data tests actions

### DIFF
--- a/.github/workflows/intl-data-tests.yml
+++ b/.github/workflows/intl-data-tests.yml
@@ -100,7 +100,7 @@ jobs:
           ./phpunit src/Symfony/Component/Intl
 
       - name: Run Emoji tests
-        run: ./phpunit src/Symfony/Component/Emoji -v
+        run: ./phpunit src/Symfony/Component/Emoji
 
       - name: Test Emoji with compressed data
         run: |


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | np
| Deprecations? | no
| Issues        | Github Actions
| License       | MIT

Tests fails due to unknown option -v which is shorthand of the --verbose as per the phpunit its removed without any replacement https://github.com/sebastianbergmann/phpunit/issues/5647#issuecomment-1890483283

