### PR TITLE
[HtmlSanitizer] Use the native HTML5 parser when using PHP 8.4+

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     env:
-      php-version: '8.2'
+      php-version: '8.4'
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -16,7 +16,7 @@ Cache
 Console
 -------
 
- * Deprecate `Symfony\Component\Console\Application::add()` in favor of `Symfony\Component\Console\Application::addCommand()`
+ * Deprecate `Symfony\Component\Console\Application::add()` in favor of `addCommand()`
 
 DependencyInjection
 -------------------
@@ -32,7 +32,15 @@ DoctrineBridge
 FrameworkBundle
 ---------------
 
- * Deprecate `Symfony\Bundle\FrameworkBundle\Console\Application::add()` in favor of `Symfony\Bundle\FrameworkBundle\Console\Application::addCommand()`
+ * Deprecate `Symfony\Bundle\FrameworkBundle\Console\Application::add()` in favor of `addCommand()`
+
+HtmlSanitizer
+-------------
+
+ * Use the native HTML5 parser when using PHP 8.4+
+ * Deprecate `MastermindsParser`; use `NativeParser` instead
+ * [BC BREAK] `ParserInterface::parse()` can now return `\Dom\Node|\DOMNode|null` instead of just `\DOMNode|null`
+ * Add argument `$context` to `ParserInterface::parse()`
 
 HttpClient
 ----------

--- a/src/Symfony/Component/HtmlSanitizer/CHANGELOG.md
+++ b/src/Symfony/Component/HtmlSanitizer/CHANGELOG.md
@@ -1,6 +1,14 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+ * Use the native HTML5 parser when using PHP 8.4+
+ * Deprecate `MastermindsParser`; use `NativeParser` instead
+ * [BC BREAK] `ParserInterface::parse()` can now return `\Dom\Node|\DOMNode|null` instead of just `\DOMNode|null`
+ * Add argument `$context` to `ParserInterface::parse()`
+
 7.2
 ---
 

--- a/src/Symfony/Component/HtmlSanitizer/Parser/MastermindsParser.php
+++ b/src/Symfony/Component/HtmlSanitizer/Parser/MastermindsParser.php
@@ -14,15 +14,20 @@ namespace Symfony\Component\HtmlSanitizer\Parser;
 use Masterminds\HTML5;
 
 /**
+ * @deprecated since Symfony 7.4, use `NativeParser` instead
+ *
  * @author Titouan Galopin <galopintitouan@gmail.com>
  */
 final class MastermindsParser implements ParserInterface
 {
     public function __construct(private array $defaultOptions = [])
     {
+        if (\PHP_VERSION_ID >= 80400) {
+            trigger_deprecation('symfony/html-sanitizer', '7.4', '"%s" is deprecated since Symfony 7.4 and will be removed in 8.0. Use the "NativeParser" instead.', self::class);
+        }
     }
 
-    public function parse(string $html): ?\DOMNode
+    public function parse(string $html, string $context = 'body'): ?\DOMNode
     {
         return (new HTML5($this->defaultOptions))->loadHTMLFragment($html);
     }

--- a/src/Symfony/Component/HtmlSanitizer/Parser/NativeParser.php
+++ b/src/Symfony/Component/HtmlSanitizer/Parser/NativeParser.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HtmlSanitizer\Parser;
+
+/**
+ * Parser using PHP 8.4's new Dom API.
+ */
+final class NativeParser implements ParserInterface
+{
+    public function __construct()
+    {
+        if (\PHP_VERSION_ID < 80400) {
+            throw new \LogicException(self::class.' requires PHP 8.4 or higher.');
+        }
+    }
+
+    public function parse(string $html, string $context = 'body'): ?\Dom\Node
+    {
+        $document = @\Dom\HTMLDocument::createFromString(\sprintf('<!DOCTYPE html><%s>%s</%1$s>', $context, $html));
+        $element = $document->getElementsByTagName($context)->item(0);
+
+        return $element->hasChildNodes() ? $element : null;
+    }
+}

--- a/src/Symfony/Component/HtmlSanitizer/Parser/ParserInterface.php
+++ b/src/Symfony/Component/HtmlSanitizer/Parser/ParserInterface.php
@@ -22,6 +22,8 @@ interface ParserInterface
      * Parse a given string and returns a DOMNode tree.
      *
      * This method must return null if the string cannot be parsed as HTML.
+     *
+     * @param string $context The name of the context element in which the HTML is parsed
      */
-    public function parse(string $html): ?\DOMNode;
+    public function parse(string $html/* , string $context = 'body' */): \Dom\Node|\DOMNode|null;
 }

--- a/src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerCustomTest.php
+++ b/src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerCustomTest.php
@@ -25,8 +25,8 @@ class HtmlSanitizerCustomTest extends TestCase
         ;
 
         $this->assertSame(
-            ' world',
-            (new HtmlSanitizer($config))->sanitizeFor('head', '<div style="width: 100px">Hello</div> world')
+            '',
+            (new HtmlSanitizer($config))->sanitizeFor('head', '<div style="width: 100px">Hello world</div>')
         );
     }
 
@@ -65,8 +65,8 @@ class HtmlSanitizerCustomTest extends TestCase
 
     public function testSanitizeNullByte()
     {
-        $this->assertSame('Null byte', $this->sanitize(new HtmlSanitizerConfig(), "Null byte\0"));
-        $this->assertSame('Null byte', $this->sanitize(new HtmlSanitizerConfig(), 'Null byte&#0;'));
+        $this->assertSame('Null byte�', $this->sanitize(new HtmlSanitizerConfig(), "Null byte\0"));
+        $this->assertSame('Null byte�', $this->sanitize(new HtmlSanitizerConfig(), 'Null byte&#0;'));
     }
 
     public function testSanitizeDefaultBody()

--- a/src/Symfony/Component/HtmlSanitizer/Tests/Parser/MastermindsParserTest.php
+++ b/src/Symfony/Component/HtmlSanitizer/Tests/Parser/MastermindsParserTest.php
@@ -11,9 +11,13 @@
 
 namespace Symfony\Component\HtmlSanitizer\Tests\Parser;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HtmlSanitizer\Parser\MastermindsParser;
 
+#[IgnoreDeprecations]
+#[Group('legacy')]
 class MastermindsParserTest extends TestCase
 {
     public function testParseValid()

--- a/src/Symfony/Component/HtmlSanitizer/Tests/Parser/NativeParserTest.php
+++ b/src/Symfony/Component/HtmlSanitizer/Tests/Parser/NativeParserTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HtmlSanitizer\Tests\Parser;
+
+use PHPUnit\Framework\Attributes\RequiresPhp;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HtmlSanitizer\Parser\NativeParser;
+
+#[RequiresPhp('8.4')]
+class NativeParserTest extends TestCase
+{
+    public function testParseValid()
+    {
+        $node = (new NativeParser())->parse('<div></div>');
+        $this->assertInstanceOf(\Dom\Node::class, $node);
+        $this->assertSame('BODY', $node->nodeName);
+        $this->assertCount(1, $node->childNodes);
+        $this->assertSame('DIV', $node->childNodes->item(0)->nodeName);
+    }
+
+    public function testParseHtml()
+    {
+        $html = '<div><p>Hello <strong>World</strong>!</p></div>';
+        $node = (new NativeParser())->parse($html);
+        $this->assertInstanceOf(\Dom\Node::class, $node);
+        $this->assertSame('BODY', $node->nodeName);
+        $this->assertCount(1, $node->childNodes);
+        $this->assertSame('DIV', $node->childNodes->item(0)->nodeName);
+    }
+}

--- a/src/Symfony/Component/HtmlSanitizer/TextSanitizer/StringSanitizer.php
+++ b/src/Symfony/Component/HtmlSanitizer/TextSanitizer/StringSanitizer.php
@@ -16,46 +16,24 @@ namespace Symfony\Component\HtmlSanitizer\TextSanitizer;
  */
 final class StringSanitizer
 {
-    private const LOWERCASE = [
-        'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
-        'abcdefghijklmnopqrstuvwxyz',
-    ];
-
     private const REPLACEMENTS = [
-        [
-            // "&#34;" is shorter than "&quot;"
-            '&quot;',
+        // "&#34;" is shorter than "&quot;"
+        '&quot;' => '&#34;',
 
-            // Fix several potential issues in how browsers interpret attributes values
-            '+',
-            '=',
-            '@',
-            '`',
+        // Fix several potential issues in how browsers interpret attribute values
+        '+' => '&#43;',
+        '=' => '&#61;',
+        '@' => '&#64;',
+        '`' => '&#96;',
 
-            // Some DB engines will transform UTF8 full-width characters their classical version
-            // if the data is saved in a non-UTF8 field
-            '＜',
-            '＞',
-            '＋',
-            '＝',
-            '＠',
-            '｀',
-        ],
-        [
-            '&#34;',
-
-            '&#43;',
-            '&#61;',
-            '&#64;',
-            '&#96;',
-
-            '&#xFF1C;',
-            '&#xFF1E;',
-            '&#xFF0B;',
-            '&#xFF1D;',
-            '&#xFF20;',
-            '&#xFF40;',
-        ],
+        // Some DB engines will transform UTF8 full-width characters with
+        // their classical version if the data is saved in a non-UTF8 field
+        '＜' => '&#xFF1C;',
+        '＞' => '&#xFF1E;',
+        '＋' => '&#xFF0B;',
+        '＝' => '&#xFF1D;',
+        '＠' => '&#xFF20;',
+        '｀' => '&#xFF40;',
     ];
 
     /**
@@ -65,7 +43,7 @@ final class StringSanitizer
      */
     public static function htmlLower(string $string): string
     {
-        return strtr($string, self::LOWERCASE[0], self::LOWERCASE[1]);
+        return strtolower($string);
     }
 
     /**
@@ -73,10 +51,6 @@ final class StringSanitizer
      */
     public static function encodeHtmlEntities(string $string): string
     {
-        return str_replace(
-            self::REPLACEMENTS[0],
-            self::REPLACEMENTS[1],
-            htmlspecialchars($string, \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8')
-        );
+        return strtr(htmlspecialchars($string, \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8'), self::REPLACEMENTS);
     }
 }

--- a/src/Symfony/Component/HtmlSanitizer/TextSanitizer/UrlSanitizer.php
+++ b/src/Symfony/Component/HtmlSanitizer/TextSanitizer/UrlSanitizer.php
@@ -76,7 +76,7 @@ final class UrlSanitizer
     /**
      * Parses a given URL and returns an array of its components.
      *
-     * @return null|array{
+     * @return array{
      *     scheme:?string,
      *     user:?string,
      *     pass:?string,
@@ -85,7 +85,7 @@ final class UrlSanitizer
      *     path:string,
      *     query:?string,
      *     fragment:?string
-     * }
+     * }|null
      */
     public static function parse(string $url): ?array
     {

--- a/src/Symfony/Component/HtmlSanitizer/Visitor/Node/TextNode.php
+++ b/src/Symfony/Component/HtmlSanitizer/Visitor/Node/TextNode.php
@@ -18,8 +18,10 @@ use Symfony\Component\HtmlSanitizer\TextSanitizer\StringSanitizer;
  */
 final class TextNode implements NodeInterface
 {
-    public function __construct(private NodeInterface $parentNode, private string $text)
-    {
+    public function __construct(
+        private NodeInterface $parentNode,
+        private string $text,
+    ) {
     }
 
     public function addChild(NodeInterface $node): void

--- a/src/Symfony/Component/HtmlSanitizer/composer.json
+++ b/src/Symfony/Component/HtmlSanitizer/composer.json
@@ -19,7 +19,8 @@
         "php": ">=8.2",
         "ext-dom": "*",
         "league/uri": "^6.5|^7.0",
-        "masterminds/html5": "^2.7.2"
+        "masterminds/html5": "^2.7.2",
+        "symfony/deprecation-contracts": "^2.5|^3"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\HtmlSanitizer\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | #53666
| License       | MIT

Together with #61356, this PR allows removing any dependency on masterminds/html5 in favor of the native HTML5 capabilities of PHP 8.4 on Symfony 8

In order to do so, this we:
 * Use the native HTML5 parser when using PHP 8.4+
 * Deprecate `MastermindsParser`; use `NativeParser` instead
 * [BC BREAK] `ParserInterface::parse()` can now return `\Dom\Node|\DOMNode|null` instead of just `\DOMNode|null`
 * Add argument `$context` to `ParserInterface::parse()`

Note that `DomVisitor` is internal so no BC breaks there.
And `StringSanitizer::htmlLower()` can leverage `strtolower()` since PHP 8.2 thanks to https://wiki.php.net/rfc/strtolower-ascii