### PR TITLE
[Console] Fix name/alias/usages when an invokable command has an alias

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -89,31 +89,19 @@ class Command implements SignalableCommandInterface
      */
     public function __construct(?string $name = null, ?callable $code = null)
     {
-        $this->definition = new InputDefinition();
-
         if (null !== $code) {
             if (!\is_object($code) || $code instanceof \Closure) {
                 throw new InvalidArgumentException(\sprintf('The command must be an instance of "%s" or an invokable object.', self::class));
             }
-
             /** @var AsCommand $attribute */
             $attribute = ((new \ReflectionObject($code))->getAttributes(AsCommand::class)[0] ?? null)?->newInstance()
                 ?? throw new LogicException(\sprintf('The command must use the "%s" attribute.', AsCommand::class));
-
-            $this->setName($name ?? $attribute->name)
-                ->setDescription($attribute->description ?? '')
-                ->setHelp($attribute->help ?? '')
-                ->setCode($code);
-
-            foreach ($attribute->usages as $usage) {
-                $this->addUsage($usage);
-            }
-
-            return;
+            $this->setCode($code);
+        } else {
+            $attribute = ((new \ReflectionClass(static::class))->getAttributes(AsCommand::class)[0] ?? null)?->newInstance();
         }
 
-        $attribute = ((new \ReflectionClass(static::class))->getAttributes(AsCommand::class)[0] ?? null)?->newInstance();
-
+        $this->definition = new InputDefinition();
         if (null === $name) {
             if (self::class !== (new \ReflectionMethod($this, 'getDefaultName'))->class) {
                 trigger_deprecation('symfony/console', '7.3', 'Overriding "Command::getDefaultName()" in "%s" is deprecated and will be removed in Symfony 8.0, use the #[AsCommand] attribute instead.', static::class);
@@ -159,7 +147,7 @@ class Command implements SignalableCommandInterface
             $this->addUsage($usage);
         }
 
-        if (\is_callable($this) && self::class === (new \ReflectionMethod($this, 'execute'))->getDeclaringClass()->name) {
+        if (!$code && \is_callable($this) && self::class === (new \ReflectionMethod($this, 'execute'))->getDeclaringClass()->name) {
             $this->code = new InvokableCommand($this, $this(...));
         }
 

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -304,7 +304,15 @@ class CommandTest extends TestCase
 
     public function testInvokableCommand()
     {
-        $tester = new CommandTester(new InvokableTestCommand());
+        $invokable = new InvokableTestCommand();
+        $command = new Command(null, $invokable);
+        $this->assertSame('invokable:test', $command->getName());
+        $this->assertSame(['inv-test'], $command->getAliases());
+        $this->assertSame(['invokable:test usage1', 'invokable:test usage2'], $command->getUsages());
+        $this->assertSame('desc', $command->getDescription());
+        $this->assertSame('help me', $command->getHelp());
+
+        $tester = new CommandTester($invokable);
 
         $this->assertSame(Command::SUCCESS, $tester->execute([]));
     }

--- a/src/Symfony/Component/Console/Tests/Fixtures/InvokableTestCommand.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/InvokableTestCommand.php
@@ -5,7 +5,7 @@ namespace Symfony\Component\Console\Tests\Fixtures;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 
-#[AsCommand('invokable:test')]
+#[AsCommand('invokable:test', aliases: ['inv-test'], usages: ['usage1', 'usage2'], description: 'desc', help: 'help me')]
 class InvokableTestCommand
 {
     public function __invoke(): int


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | 
| License       | MIT

Invokable commands don't construct their command name properly when an alias is present. This makes the command uncallable. The name has a pipe and alias appended such as `example:name | my-alias`. This appending is done by `#[AsCommand]`. You can see the effect by looking [the test failure in the first commit](https://github.com/symfony/symfony/actions/runs/16842451165/job/47716168358) to this PR.

The PR fixes the issue by removing a `return` when handling of invokables in Command::__construct(). We can mostly use same logic as non-invokables.

I discovered this while moving Drush (Drupal's CLI) to invokable commands.