### PR TITLE
[HttpKernel] Refine Vary header check to skip special handling of 'Accept-Language' when it's the only entry and '_vary_by_language' is `true`  in `CacheAttributeListener`

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/CacheAttributeListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/CacheAttributeListener.php
@@ -123,7 +123,9 @@ class CacheAttributeListener implements EventSubscriberInterface
 
         unset($this->lastModified[$request]);
         unset($this->etags[$request]);
-        $hasVary = $response->headers->has('Vary');
+        // Check if the response has a Vary header that should be considered, ignoring cases where
+        // it's only 'Accept-Language' and the request has the '_vary_by_language' attribute
+        $hasVary = ['Accept-Language'] === $response->getVary() ? !$request->attributes->get('_vary_by_language') : $response->hasVary();
 
         foreach (array_reverse($attributes) as $cache) {
             if (null !== $cache->smaxage && !$response->headers->hasCacheControlDirective('s-maxage')) {

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/CacheAttributeListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/CacheAttributeListenerTest.php
@@ -318,6 +318,70 @@ class CacheAttributeListenerTest extends TestCase
         $this->assertSame(CacheAttributeController::CLASS_SMAXAGE, $response->getMaxAge());
     }
 
+    /**
+     * @dataProvider provideVaryHeaderScenarios
+     */
+    public function testHasRelevantVaryHeaderBehavior(array $responseVary, array $cacheVary, bool $varyByLanguage, array $expectedVary)
+    {
+        $request = $this->createRequest(new Cache(vary: $cacheVary));
+        $request->attributes->set('_vary_by_language', $varyByLanguage);
+
+        $response = new Response();
+        $response->setVary($responseVary);
+
+        $listener = new CacheAttributeListener();
+        $event = new ResponseEvent($this->getKernel(), $request, HttpKernelInterface::MAIN_REQUEST, $response);
+        $listener->onKernelResponse($event);
+
+        $this->assertSame($expectedVary, $response->getVary());
+    }
+
+    public static function provideVaryHeaderScenarios(): \Traversable
+    {
+        yield 'no vary headers at all' => [
+            'responseVary' => [],
+            'cacheVary' => ['X-Foo'],
+            'varyByLanguage' => false,
+            'expectedVary' => ['X-Foo'],
+        ];
+        yield 'response vary accept-language only, vary_by_language true (append new)' => [
+            'responseVary' => ['Accept-Language'],
+            'cacheVary' => ['X-Bar'],
+            'varyByLanguage' => true,
+            'expectedVary' => ['Accept-Language', 'X-Bar'], // X-Bar is added
+        ];
+        yield 'response vary accept-language only, vary_by_language false (no append)' => [
+            'responseVary' => ['Accept-Language'],
+            'cacheVary' => ['X-Bar'],
+            'varyByLanguage' => false,
+            'expectedVary' => ['Accept-Language'], // no append
+        ];
+        yield 'response vary multiple including accept-language, vary_by_language true (no append)' => [
+            'responseVary' => ['Accept-Language', 'User-Agent'],
+            'cacheVary' => ['X-Baz'],
+            'varyByLanguage' => true,
+            'expectedVary' => ['Accept-Language', 'User-Agent'], // no append
+        ];
+        yield 'cache vary is empty' => [
+            'responseVary' => ['X-Existing'],
+            'cacheVary' => [],
+            'varyByLanguage' => true,
+            'expectedVary' => ['X-Existing'], // nothing to add
+        ];
+        yield 'vary * (no append) — vary_by_language=true' => [
+            'responseVary' => ['*'],
+            'cacheVary' => ['X-Foo'],
+            'varyByLanguage' => true,
+            'expectedVary' => ['*'],
+        ];
+        yield 'vary * (no append) — vary_by_language=false' => [
+            'responseVary' => ['*'],
+            'cacheVary' => ['X-Foo'],
+            'varyByLanguage' => false,
+            'expectedVary' => ['*'],
+        ];
+    }
+
     private function createRequest(Cache $cache): Request
     {
         return new Request([], [], ['_cache' => [$cache]]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61229 
| License       | MIT

### Summary
Refine Vary header check to skip special handling of 'Accept-Language' when it's the only entry and '_vary_by_language' is true in CacheAttributeListener

### Reason
Previously, the `CacheAttributeListener` was executed after the `ResponseListener`. When the `set_locale_from_accept_language` option is enabled in `framework.yaml`, the `ResponseListener` sets a Vary header on the response. Because `CacheAttributeListener` checks if a Vary header already exists before modifying it, its logic was being bypassed if it ran after the `ResponseListener`.

### References
* [LocaleListener](https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/HttpKernel/EventListener/LocaleListener.php#L69-L76)
* [ResponseListener](https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/HttpKernel/EventListener/ResponseListener.php#L55-L57)
* [CacheAttributeListener](https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/HttpKernel/EventListener/CacheAttributeListener.php#L126)
