### PR TITLE
no longer use 7.4 workaround for `COMPOSER_ROOT_VERSION`

### DIFF
--- a/.github/build-packages.php
+++ b/.github/build-packages.php
@@ -21,10 +21,6 @@ array_shift($dirs);
 $mergeBase = trim(shell_exec(sprintf('git merge-base "%s" HEAD', array_shift($dirs))));
 $version = array_shift($dirs);
 
-if ('8.0' === $version) {
-    $version = '7.4'; // to be removed once deps allow ^8.0
-}
-
 $packages = [];
 $flags = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
 $preferredInstall = json_decode(file_get_contents(__DIR__.'/composer-config.json'), true)['config']['preferred-install'];

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -228,7 +228,6 @@ jobs:
           COMPOSER_HOME="$(composer config home)"
           ([ -d "$COMPOSER_HOME" ] || mkdir "$COMPOSER_HOME") && cp .github/composer-config.json "$COMPOSER_HOME/config.json"
           export COMPOSER_ROOT_VERSION=$(grep ' VERSION = ' src/Symfony/Component/HttpKernel/Kernel.php | grep -P -o '[0-9]+\.[0-9]+').x-dev
-          export COMPOSER_ROOT_VERSION=7.4.x-dev # to be removed once deps allow ^8.0
           echo COMPOSER_ROOT_VERSION=$COMPOSER_ROOT_VERSION >> $GITHUB_ENV
 
           echo "::group::composer update"

--- a/.github/workflows/intl-data-tests.yml
+++ b/.github/workflows/intl-data-tests.yml
@@ -70,7 +70,6 @@ jobs:
           COMPOSER_HOME="$(composer config home)"
           ([ -d "$COMPOSER_HOME" ] || mkdir "$COMPOSER_HOME") && cp .github/composer-config.json "$COMPOSER_HOME/config.json"
           export COMPOSER_ROOT_VERSION=$(grep ' VERSION = ' src/Symfony/Component/HttpKernel/Kernel.php | grep -P -o '[0-9]+\.[0-9]+').x-dev
-          export COMPOSER_ROOT_VERSION=7.4.x-dev # to be removed once deps allow ^8.0
           echo COMPOSER_ROOT_VERSION=$COMPOSER_ROOT_VERSION >> $GITHUB_ENV
 
           echo "::group::composer update"

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -42,7 +42,6 @@ jobs:
           COMPOSER_HOME="$(composer config home)"
           ([ -d "$COMPOSER_HOME" ] || mkdir "$COMPOSER_HOME") && cp .github/composer-config.json "$COMPOSER_HOME/config.json"
           export COMPOSER_ROOT_VERSION=$(grep ' VERSION = ' src/Symfony/Component/HttpKernel/Kernel.php | grep -P -o '[0-9]+\.[0-9]+').x-dev
-          export COMPOSER_ROOT_VERSION=7.4.x-dev # to be removed once deps allow ^8.0
           composer remove --dev --no-update --no-interaction symfony/phpunit-bridge
           composer require --no-progress --ansi --no-plugins psalm/phar:@stable phpunit/phpunit:^11.5 php-http/discovery psr/event-dispatcher mongodb/mongodb jetbrains/phpstorm-stubs
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -133,7 +133,6 @@ jobs:
 
           echo SYMFONY_VERSION=$SYMFONY_VERSION >> $GITHUB_ENV
           echo COMPOSER_ROOT_VERSION=$SYMFONY_VERSION.x-dev >> $GITHUB_ENV
-          echo COMPOSER_ROOT_VERSION=7.4.x-dev >> $GITHUB_ENV # to be removed once all deps allow ^8.0
           echo SYMFONY_REQUIRE=">=$([ '${{ matrix.mode }}' = low-deps ] && echo 6.4 || echo $SYMFONY_VERSION)" >> $GITHUB_ENV
           [[ "${{ matrix.mode }}" = *-deps ]] && mv composer.json.phpunit composer.json || true
 
@@ -203,7 +202,6 @@ jobs:
               SYMFONY_VERSION=$(echo $SYMFONY_VERSION | awk '{print $1 - 1}')
               echo -e "\\n\\e[33;1mChecking out Symfony $SYMFONY_VERSION and running tests with patched components as deps\\e[0m"
               export COMPOSER_ROOT_VERSION=$SYMFONY_VERSION.x-dev
-              export COMPOSER_ROOT_VERSION=7.4.x-dev # to be removed once deps allow ^8.0
               export SYMFONY_REQUIRE=">=$SYMFONY_VERSION"
               git fetch --depth=2 origin $SYMFONY_VERSION
               git checkout -m FETCH_HEAD

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -66,7 +66,6 @@ jobs:
 
           $env:SYMFONY_VERSION=(Select-String -CaseSensitive -Pattern " VERSION =" -SimpleMatch -Path src/Symfony/Component/HttpKernel/Kernel.php | Select Line | Select-String -Pattern "([0-9][0-9]*\.[0-9])").Matches.Value
           $env:COMPOSER_ROOT_VERSION=$env:SYMFONY_VERSION + ".x-dev"
-          $env:COMPOSER_ROOT_VERSION="7.4.x-dev" # to be removed once all deps allow ^8.0
 
           php .github/build-packages.php HEAD^ $env:SYMFONY_VERSION src\Symfony\Bridge\PhpUnit
           php composer.phar update --no-progress --ansi
@@ -163,7 +162,6 @@ jobs:
 
           $env:SYMFONY_VERSION=(Select-String -CaseSensitive -Pattern " VERSION =" -SimpleMatch -Path src/Symfony/Component/HttpKernel/Kernel.php | Select Line | Select-String -Pattern "([0-9][0-9]*\.[0-9])").Matches.Value
           $env:COMPOSER_ROOT_VERSION=$env:SYMFONY_VERSION + ".x-dev"
-          $env:COMPOSER_ROOT_VERSION="7.4.x-dev" # to be removed once all deps allow ^8.0
 
           php .github/build-packages.php HEAD^ $env:SYMFONY_VERSION src\Symfony\Bridge\PhpUnit
           php composer.phar update --no-progress --ansi


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

This PR requires tijsverkoyen/CssToInlineStyles#255 to be merged first, but let's try and see what else we need to fix on our side.
