### PR TITLE
 chore: PHP CS Fixer - update heredoc handling

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -45,6 +45,9 @@ return (new PhpCsFixer\Config())
             ]),
         ],
         'php_unit_attributes' => true,
+        'method_argument_space' => ['after_heredoc' => true, 'on_multiline' => 'ignore'],
+        'no_trailing_whitespace_in_string' => false,
+        'no_whitespace_before_comma_in_array' => ['after_heredoc' => true],
     ])
     ->setRiskyAllowed(true)
     ->setFinder(

--- a/src/Symfony/Bridge/Twig/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Command/DebugCommandTest.php
@@ -112,8 +112,7 @@ class DebugCommandTest extends TestCase
                  ----------- -------------------------------------%A
 
 
-                TXT
-            ,
+                TXT,
             'paths' => ['vendors/twig-bundle/Resources/views/' => 'Twig'],
         ];
 
@@ -141,8 +140,7 @@ class DebugCommandTest extends TestCase
                  ----------- -------------------------------------%A
 
 
-                TXT
-            ,
+                TXT,
             'paths' => $defaultPaths,
         ];
 
@@ -165,8 +163,7 @@ class DebugCommandTest extends TestCase
                  ----------- ------------%A
 
 
-                TXT
-            ,
+                TXT,
             'paths' => $defaultPaths,
         ];
 
@@ -195,8 +192,7 @@ class DebugCommandTest extends TestCase
                  ----------- -------------------------------------- 
 
 
-                TXT
-            ,
+                TXT,
             'paths' => $defaultPaths,
         ];
 
@@ -218,8 +214,7 @@ class DebugCommandTest extends TestCase
                 %w@Twig%A
 
 
-                TXT
-            ,
+                TXT,
             'paths' => $defaultPaths,
         ];
 
@@ -247,8 +242,7 @@ class DebugCommandTest extends TestCase
                  ----------- -------------------------------------- 
 
 
-                TXT
-            ,
+                TXT,
             'paths' => $defaultPaths,
         ];
     }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap3LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap3LayoutTest.php
@@ -72,8 +72,9 @@ class FormExtensionBootstrap3LayoutTest extends AbstractBootstrap3LayoutTestCase
             <div class="input-group">
                                         <span class="input-group-addon">&euro; </span>
                         <input type="text" id="name" name="name" required="required" class="form-control" />        </div>
-            HTML
-            , trim($this->renderWidget($view)));
+            HTML,
+            trim($this->renderWidget($view))
+        );
     }
 
     protected function getTemplatePaths(): array

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap4LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap4LayoutTest.php
@@ -77,8 +77,9 @@ class FormExtensionBootstrap4LayoutTest extends AbstractBootstrap4LayoutTestCase
             <div class="input-group "><div class="input-group-prepend">
                                 <span class="input-group-text">&euro; </span>
                             </div><input type="text" id="name" name="name" required="required" class="form-control" /></div>
-            HTML
-            , trim($this->renderWidget($view)));
+            HTML,
+            trim($this->renderWidget($view))
+        );
     }
 
     protected function getTemplatePaths(): array

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap5LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap5LayoutTest.php
@@ -76,8 +76,9 @@ class FormExtensionBootstrap5LayoutTest extends AbstractBootstrap5LayoutTestCase
 
         self::assertSame(<<<'HTML'
             <div class="input-group "><span class="input-group-text">&euro; </span><input type="text" id="name" name="name" required="required" class="form-control" /></div>
-            HTML
-            , trim($this->renderWidget($view)));
+            HTML,
+            trim($this->renderWidget($view))
+        );
     }
 
     protected function getTemplatePaths(): array

--- a/src/Symfony/Bridge/Twig/Tests/Extension/HttpKernelExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/HttpKernelExtensionTest.php
@@ -70,8 +70,10 @@ class HttpKernelExtensionTest extends TestCase
         $loader = new ArrayLoader([
             'index' => \sprintf(<<<TWIG
                 {{ fragment_uri(controller("%s::templateAction", {template: "foo.html.twig"})) }}
-                TWIG
-                , str_replace('\\', '\\\\', TemplateController::class)), ]);
+                TWIG,
+                str_replace('\\', '\\\\', TemplateController::class)
+            ),
+        ]);
         $twig = new Environment($loader, ['debug' => true, 'cache' => false]);
         $twig->addExtension(new HttpKernelExtension());
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDumpReferenceCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDumpReferenceCommandTest.php
@@ -95,8 +95,9 @@ class ConfigDumpReferenceCommandTest extends AbstractWebTestCase
                 child2:               ~
 
 
-            EOL
-            , $tester->getDisplay(true));
+            EOL,
+            $tester->getDisplay(true)
+        );
     }
 
     #[TestWith([true])]

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
@@ -183,8 +183,9 @@ class ContainerDebugCommandTest extends AbstractWebTestCase
 
              * UNKNOWN
 
-            TXT
-            , $tester->getDisplay(true));
+            TXT,
+            $tester->getDisplay(true)
+        );
 
         putenv('REAL');
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/FragmentTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/FragmentTest.php
@@ -33,8 +33,9 @@ class FragmentTest extends AbstractWebTestCase
             es
             --
             fr
-            TXT
-            , $client->getResponse()->getContent());
+            TXT,
+            $client->getResponse()->getContent()
+        );
     }
 
     public static function getConfigs()

--- a/src/Symfony/Component/AssetMapper/Tests/AssetMapperDevServerSubscriberFunctionalTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/AssetMapperDevServerSubscriberFunctionalTest.php
@@ -29,7 +29,9 @@ class AssetMapperDevServerSubscriberFunctionalTest extends WebTestCase
             /* file1.css */
             body {}
 
-            EOF, $response->getFile()->getContent());
+            EOF,
+            $response->getFile()->getContent()
+        );
         $this->assertSame('"b3445cb7a86a0795a7af7f2004498aef"', $response->headers->get('ETag'));
         $this->assertSame('immutable, max-age=604800, public', $response->headers->get('Cache-Control'));
         $this->assertTrue($response->headers->has('X-Assets-Dev'));
@@ -46,7 +48,9 @@ class AssetMapperDevServerSubscriberFunctionalTest extends WebTestCase
             /* voilà.css */
             body {}
 
-            EOF, $client->getInternalResponse()->getContent());
+            EOF,
+            $client->getInternalResponse()->getContent()
+        );
     }
 
     public function test404OnUnknownAsset()
@@ -80,7 +84,9 @@ class AssetMapperDevServerSubscriberFunctionalTest extends WebTestCase
             /* already-abcdefVWXYZ0123456789.digested.css */
             body {}
 
-            EOF, $response->getFile()->getContent());
+            EOF,
+            $response->getFile()->getContent()
+        );
     }
 
     protected static function getKernelClass(): string

--- a/src/Symfony/Component/AssetMapper/Tests/Command/AssetMapperCompileCommandTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Command/AssetMapperCompileCommandTest.php
@@ -64,7 +64,9 @@ class AssetMapperCompileCommandTest extends TestCase
             import '../file4.js';
             console.log('file5.js');
 
-            EOF, $this->filesystem->readFile($targetBuildDir.'/subdir/file5-9P3Dc3X.js'));
+            EOF,
+            $this->filesystem->readFile($targetBuildDir.'/subdir/file5-9P3Dc3X.js')
+        );
 
         $finder = new Finder();
         $finder->in($targetBuildDir)->files();

--- a/src/Symfony/Component/AssetMapper/Tests/Compiler/CssAssetUrlCompilerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Compiler/CssAssetUrlCompilerTest.php
@@ -61,14 +61,12 @@ class CssAssetUrlCompilerTest extends TestCase
                 body {
                     background: url("images/foo.png");
                 }
-                EOF
-            ,
+                EOF,
             'expectedOutput' => <<<EOF
                 body {
                     background: url("images/foo.123456.png");
                 }
-                EOF
-            ,
+                EOF,
             'expectedDependencies' => ['images/foo.png'],
         ];
 

--- a/src/Symfony/Component/AssetMapper/Tests/Compiler/JavaScriptImportPathCompilerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Compiler/JavaScriptImportPathCompilerTest.php
@@ -121,8 +121,7 @@ class JavaScriptImportPathCompilerTest extends TestCase
             'input' => <<<EOF
                 const fun;
                 import("./other.js");
-                EOF
-            ,
+                EOF,
             'expectedJavaScriptImports' => ['/assets/other.js' => ['lazy' => true, 'asset' => 'other.js', 'add' => true]],
         ];
 
@@ -182,8 +181,7 @@ class JavaScriptImportPathCompilerTest extends TestCase
                     myFunction,
                     helperFunction
                 } from "./other.js";
-                EOF
-            ,
+                EOF,
             'expectedJavaScriptImports' => ['/assets/other.js' => ['lazy' => false, 'asset' => 'other.js', 'add' => true]],
         ];
 
@@ -239,8 +237,7 @@ class JavaScriptImportPathCompilerTest extends TestCase
             'input' => <<<EOF
                 const fun;
                 // import("./other.js");
-                EOF
-            ,
+                EOF,
             'expectedJavaScriptImports' => [],
         ];
 
@@ -248,8 +245,7 @@ class JavaScriptImportPathCompilerTest extends TestCase
             'input' => <<<EOF
                 const fun;
                  // import("./other.js");
-                EOF
-            ,
+                EOF,
             'expectedJavaScriptImports' => [],
         ];
 
@@ -257,8 +253,7 @@ class JavaScriptImportPathCompilerTest extends TestCase
             'input' => <<<EOF
                 const fun;
                 // this is not going to be parsed import("./other.js");
-                EOF
-            ,
+                EOF,
             'expectedJavaScriptImports' => [],
         ];
 
@@ -266,8 +261,7 @@ class JavaScriptImportPathCompilerTest extends TestCase
             'input' => <<<EOF
                 const fun;
                 console.log('// I am not really a comment'); import("./other.js");
-                EOF
-            ,
+                EOF,
             'expectedJavaScriptImports' => ['/assets/other.js' => ['lazy' => true, 'asset' => 'other.js', 'add' => true]],
         ];
 
@@ -275,8 +269,7 @@ class JavaScriptImportPathCompilerTest extends TestCase
             'input' => <<<EOF
                 const fun;
                 /* comment */ import("./other.js");
-                EOF
-            ,
+                EOF,
             'expectedJavaScriptImports' => ['/assets/other.js' => ['lazy' => true, 'asset' => 'other.js', 'add' => true]],
         ];
 
@@ -284,8 +277,7 @@ class JavaScriptImportPathCompilerTest extends TestCase
             'input' => <<<EOF
                 const fun;
                     /* comment import("./other.js"); */
-                EOF
-            ,
+                EOF,
             'expectedJavaScriptImports' => [],
         ];
 
@@ -295,8 +287,7 @@ class JavaScriptImportPathCompilerTest extends TestCase
                     /* comment import("./other.js");
                     and more
                     */
-                EOF
-            ,
+                EOF,
             'expectedJavaScriptImports' => [],
         ];
 
@@ -304,8 +295,7 @@ class JavaScriptImportPathCompilerTest extends TestCase
             'input' => <<<EOF
                 const fun;
                     console.log('/* not a comment'); import("./other.js");
-                EOF
-            ,
+                EOF,
             'expectedJavaScriptImports' => ['/assets/other.js' => ['lazy' => true, 'asset' => 'other.js', 'add' => true]],
         ];
 
@@ -313,8 +303,7 @@ class JavaScriptImportPathCompilerTest extends TestCase
             'input' => <<<EOF
                 const fun;
                 console.log("import('./foo.js')");
-                EOF
-            ,
+                EOF,
             'expectedJavaScriptImports' => [],
         ];
 
@@ -322,8 +311,7 @@ class JavaScriptImportPathCompilerTest extends TestCase
             'input' => <<<EOF
                 const fun;
                 console.log(" foo \" import('./foo.js')");
-                EOF
-            ,
+                EOF,
             'expectedJavaScriptImports' => [],
         ];
 
@@ -331,8 +319,7 @@ class JavaScriptImportPathCompilerTest extends TestCase
             'input' => <<<EOF
                 const fun;
                 console.log('import("./foo.js")');
-                EOF
-            ,
+                EOF,
             'expectedJavaScriptImports' => [],
         ];
 
@@ -340,8 +327,7 @@ class JavaScriptImportPathCompilerTest extends TestCase
             'input' => <<<EOF
                 const fun;
                 console.log("import('./other.js')"); import("./foo.js");
-                EOF
-            ,
+                EOF,
             'expectedJavaScriptImports' => ['/assets/foo.js' => ['lazy' => true, 'asset' => 'foo.js', 'add' => true]],
         ];
 
@@ -349,8 +335,7 @@ class JavaScriptImportPathCompilerTest extends TestCase
             'input' => <<<EOF
                 const fun;
                 import("./other.js"); console.log("import('./foo.js')");
-                EOF
-            ,
+                EOF,
             'expectedJavaScriptImports' => ['/assets/other.js' => ['lazy' => true, 'asset' => 'other.js', 'add' => true]],
         ];
 
@@ -358,8 +343,7 @@ class JavaScriptImportPathCompilerTest extends TestCase
             'input' => <<<EOF
                 const fun;
                 import("./other.js"); console.log("import('./foo.js')"); import("./subdir/foo.js");
-                EOF
-            ,
+                EOF,
             'expectedJavaScriptImports' => [
                 '/assets/other.js' => ['lazy' => true, 'asset' => 'other.js', 'add' => true],
                 '/assets/subdir/foo.js' => ['lazy' => true, 'asset' => 'subdir/foo.js', 'add' => true],

--- a/src/Symfony/Component/AssetMapper/Tests/Compiler/SourceMappingUrlsCompilerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Compiler/SourceMappingUrlsCompilerTest.php
@@ -60,13 +60,11 @@ class SourceMappingUrlsCompilerTest extends TestCase
             'input' => <<<EOF
                 var fun;
                 //# sourceMappingURL=foo.js.map
-                EOF
-            ,
+                EOF,
             'expectedOutput' => <<<EOF
                 var fun;
                 //# sourceMappingURL=foo.123456.js.map
-                EOF
-            ,
+                EOF,
             'expectedDependencies' => ['foo.js.map'],
         ];
 
@@ -75,13 +73,11 @@ class SourceMappingUrlsCompilerTest extends TestCase
             'input' => <<<EOF
                 .class { color: green; }
                 /*# sourceMappingURL=bar.css.map */
-                EOF
-            ,
+                EOF,
             'expectedOutput' => <<<EOF
                 .class { color: green; }
                 /*# sourceMappingURL=bar.abcd123.css.map */
-                EOF
-            ,
+                EOF,
             'expectedDependencies' => ['styles/bar.css.map'],
         ];
 
@@ -90,13 +86,11 @@ class SourceMappingUrlsCompilerTest extends TestCase
             'input' => <<<EOF
                 .class { color: green; }
                 /*# sourceMappingURL=../sourcemaps/baz.css.map */
-                EOF
-            ,
+                EOF,
             'expectedOutput' => <<<EOF
                 .class { color: green; }
                 /*# sourceMappingURL=../sourcemaps/baz.987fedc.css.map */
-                EOF
-            ,
+                EOF,
             'expectedDependencies' => ['sourcemaps/baz.css.map'],
         ];
 
@@ -104,12 +98,10 @@ class SourceMappingUrlsCompilerTest extends TestCase
             'sourceLogicalName' => 'styles/bar.css',
             'input' => <<<EOF
                 .class { color: green; }
-                EOF
-            ,
+                EOF,
             'expectedOutput' => <<<EOF
                 .class { color: green; }
-                EOF
-            ,
+                EOF,
             'expectedDependencies' => [],
         ];
 
@@ -118,13 +110,11 @@ class SourceMappingUrlsCompilerTest extends TestCase
             'input' => <<<EOF
                 .class { color: green; }
                 /*# sourceMappingURL=unknown.css.map */
-                EOF
-            ,
+                EOF,
             'expectedOutput' => <<<EOF
                 .class { color: green; }
                 /*# sourceMappingURL=unknown.css.map */
-                EOF
-            ,
+                EOF,
             'expectedDependencies' => [],
         ];
 
@@ -134,14 +124,12 @@ class SourceMappingUrlsCompilerTest extends TestCase
                 .class::before {
                   content: "# sourceMappingURL=sourceMappingURL-outside-comment.css.map";
                 }
-                EOF
-            ,
+                EOF,
             'expectedOutput' => <<<EOF
                 .class::before {
                   content: "# sourceMappingURL=sourceMappingURL-outside-comment.css.map";
                 }
-                EOF
-            ,
+                EOF,
             'expectedDependencies' => [],
         ];
 
@@ -151,14 +139,12 @@ class SourceMappingUrlsCompilerTest extends TestCase
                 .class {
                   color: green; /*# sourceMappingURL=sourceMappingURL-not-at-start.css.map */
                 }
-                EOF
-            ,
+                EOF,
             'expectedOutput' => <<<EOF
                 .class {
                   color: green; /*# sourceMappingURL=sourceMappingURL-not-at-start.css.map */
                 }
-                EOF
-            ,
+                EOF,
             'expectedDependencies' => [],
         ];
     }

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapRendererTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapRendererTest.php
@@ -137,7 +137,9 @@ class ImportMapRendererTest extends TestCase
                 script.src = 'https://polyfillUrl.example';
                 script.setAttribute('something', 'something');
                 script.setAttribute('data-turbo-track', 'reload');
-            EOTXT, $html);
+            EOTXT,
+            $html
+        );
     }
 
     public function testWithEntrypoint()

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/Resolver/JsDelivrEsmResolverTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/Resolver/JsDelivrEsmResolverTest.php
@@ -487,8 +487,7 @@ class JsDelivrEsmResolverTest extends TestCase
                         url("data:will-be-ignored") format("woff-fake-data-format"),
                         url("data:https://example.com/will-be-ignored") format("woff-fake-absolute-url"),
                         .bi::before,[class*=" bi-"]::before,[class^=bi-]::before{display:inline-block;font-family:bootstrap-icons!important;font-style:normal;font-weight:400!important;font-variant:normal;text-transform:none;
-                    EOF
-                ,
+                    EOF,
             ],
             [
                 'url' => '/npm/bootstrap-icons@1.1.1/font/fonts/bootstrap-icons.woff2',

--- a/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
+++ b/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
@@ -304,48 +304,52 @@ class OutputFormatterTest extends TestCase
         $this->assertEquals(<<<EOF
             \033[32m
             some text\033[39m
-            EOF
-            , $formatter->format(<<<'EOF'
+            EOF,
+            $formatter->format(<<<'EOF'
                 <info>
                 some text</info>
                 EOF
-            ));
+            )
+        );
 
         $this->assertEquals(<<<EOF
             \033[32msome text
             \033[39m
-            EOF
-            , $formatter->format(<<<'EOF'
+            EOF,
+            $formatter->format(<<<'EOF'
                 <info>some text
                 </info>
                 EOF
-            ));
+            )
+        );
 
         $this->assertEquals(<<<EOF
             \033[32m
             some text
             \033[39m
-            EOF
-            , $formatter->format(<<<'EOF'
+            EOF,
+            $formatter->format(<<<'EOF'
                 <info>
                 some text
                 </info>
                 EOF
-            ));
+            )
+        );
 
         $this->assertEquals(<<<EOF
             \033[32m
             some text
             more text
             \033[39m
-            EOF
-            , $formatter->format(<<<'EOF'
+            EOF,
+            $formatter->format(<<<'EOF'
                 <info>
                 some text
                 more text
                 </info>
                 EOF
-            ));
+            )
+        );
     }
 
     public function testFormatAndWrap()

--- a/src/Symfony/Component/Console/Tests/Helper/SymfonyQuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/SymfonyQuestionHelperTest.php
@@ -159,8 +159,10 @@ class SymfonyQuestionHelperTest extends AbstractQuestionHelperTestCase
               [żółw  ] bar
               [łabądź] baz
              >
-            EOT
-            , $output, true);
+            EOT,
+            $output,
+            true
+        );
     }
 
     public function testChoiceQuestionCustomPrompt()
@@ -178,8 +180,10 @@ class SymfonyQuestionHelperTest extends AbstractQuestionHelperTestCase
              qqq:
               [0] foo
              >ccc>
-            EOT
-            , $output, true);
+            EOT,
+            $output,
+            true
+        );
     }
 
     protected function getInputStream($input)

--- a/src/Symfony/Component/Console/Tests/Helper/TableTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableTest.php
@@ -603,8 +603,7 @@ class TableTest extends TestCase
                     | Dante Alighieri | J. R. R. Tolkien | J. R. R |
                     +-----------------+------------------+---------+
 
-                    TABLE
-                ,
+                    TABLE,
                 true,
             ],
             'Row with formatted cells containing a newline' => [
@@ -632,8 +631,7 @@ class TableTest extends TestCase
                     [39;49m| bar   | [39;49m[37;41mhere[39;49m       |
                     +-------+------------+
 
-                    TABLE
-                ,
+                    TABLE,
                 true,
             ],
             'TabeCellStyle with align. Also with rowspan and colspan > 1' => [
@@ -714,8 +712,7 @@ class TableTest extends TestCase
                     |             test              |                                      tttt |
                     +---------------+---------------+-------------------------------------------+
 
-                    TABLE
-                ,
+                    TABLE,
             ],
             'TabeCellStyle with fg,bg. Also with rowspan and colspan > 1' => [
                 [],
@@ -783,8 +780,7 @@ class TableTest extends TestCase
                     |             [37;41mtest[39;49m              |[31;42m                                      tttt [39;49m|
                     +---------------+---------------+-------------------------------------------+
 
-                    TABLE
-                ,
+                    TABLE,
                 true,
             ],
             'TabeCellStyle with cellFormat. Also with rowspan and colspan > 1' => [
@@ -838,8 +834,7 @@ class TableTest extends TestCase
                     |[37;41m test                           [39;49m| tttt                |
                     +----------------+---------------+---------------------+
 
-                    TABLE
-                ,
+                    TABLE,
                 true,
             ],
         ];
@@ -1292,8 +1287,7 @@ class TableTest extends TestCase
                     | 80-902734-1-6 | And Then There Were None | Agatha Christie  |
                     +---------------+--------- Page 1/2 -------+------------------+
 
-                    TABLE
-                ,
+                    TABLE,
             ],
             'header contains multiple lines' => [
                 'Multiline'."\n".'header'."\n".'here',
@@ -1627,8 +1621,7 @@ class TableTest extends TestCase
                 |  Price: 139.25               |
                 +------------------------------+
 
-                EOTXT
-            ,
+                EOTXT,
             ['ISBN', 'Title', 'Author', 'Price'],
             $books,
         ];
@@ -1647,8 +1640,7 @@ class TableTest extends TestCase
                 | 139.25               |
                 +----------------------+
 
-                EOTXT
-            ,
+                EOTXT,
             [],
             $books,
         ];
@@ -1662,8 +1654,7 @@ class TableTest extends TestCase
                 |  Price: 9.95            |
                 +-------------------------+
 
-                EOTXT
-            ,
+                EOTXT,
             ['ISBN', 'Títle', 'Author', 'Price'],
             [
                 [
@@ -1689,8 +1680,7 @@ class TableTest extends TestCase
                 |       : 139.25               |
                 +------------------------------+
 
-                EOTXT
-            ,
+                EOTXT,
             ['ISBN', 'Title', 'Author'],
             $books,
         ];
@@ -1707,8 +1697,7 @@ class TableTest extends TestCase
                 | baz:     |
                 +----------+
 
-                EOTXT
-            ,
+                EOTXT,
             ['foo', 'bar', 'baz'],
             [
                 ['one', 'two'],
@@ -1728,8 +1717,7 @@ class TableTest extends TestCase
                 | baz: 3    |
                 +-----------+
 
-                EOTXT
-            ,
+                EOTXT,
             ['foo', 'bar', 'baz'],
             [
                 ['one', 'two', 'tree'],
@@ -1753,8 +1741,7 @@ class TableTest extends TestCase
                 |  Price: 139.25          |
                 +-------------------------+
 
-                EOTXT
-            ,
+                EOTXT,
             ['ISBN', 'Title', 'Author', 'Price'],
             [
                 ['99921-58-10-7', 'Divine Comedy', 'Dante Alighieri', '9.95'],
@@ -1774,8 +1761,7 @@ class TableTest extends TestCase
                 | Author: Charles Dickens      |
                 +------------------------------+
 
-                EOTXT
-            ,
+                EOTXT,
             ['ISBN', 'Title', 'Author'],
             [
                 ['<info>99921-58-10-7</info>', '<error>Divine Comedy</error>', '<fg=blue;bg=white>Dante Alighieri</fg=blue;bg=white>'],
@@ -1797,8 +1783,7 @@ class TableTest extends TestCase
                 | Author: Charles Dickens                                                               |
                 +---------------------------------------------------------------------------------------+
 
-                EOTXT
-            ,
+                EOTXT,
             ['ISBN', 'Title', 'Author'],
             [
                 ['99921-58-10-7', 'Divine Comedy', 'Dante Alighieri'],
@@ -1829,8 +1814,7 @@ class TableTest extends TestCase
                 | Lorem ipsum dolor sit amet, consectetur                                        |
                 +--------------------------------------------------------------------------------+
 
-                EOTXT
-            ,
+                EOTXT,
             [],
             [
                 [new TableCell('Lorem ipsum dolor sit amet, <fg=white;bg=green>consectetur</> adipiscing elit, <fg=white;bg=red>sed</> do <fg=white;bg=red>eiusmod</> tempor', ['colspan' => 3])],
@@ -1861,8 +1845,7 @@ class TableTest extends TestCase
                    Price: 139.25                
                  ============================== 
 
-                EOTXT
-            ,
+                EOTXT,
             ['ISBN', 'Title', 'Author', 'Price'],
             $books,
             'borderless',
@@ -1880,8 +1863,7 @@ class TableTest extends TestCase
                 Author: Charles Dickens      
                  Price: 139.25               
 
-                EOTXT
-            ,
+                EOTXT,
             ['ISBN', 'Title', 'Author', 'Price'],
             $books,
             'compact',
@@ -1901,8 +1883,7 @@ class TableTest extends TestCase
                    Price: 139.25                
                  ------------------------------ 
 
-                EOTXT
-            ,
+                EOTXT,
             ['ISBN', 'Title', 'Author', 'Price'],
             $books,
             'symfony-style-guide',
@@ -1922,8 +1903,7 @@ class TableTest extends TestCase
                 │  Price: 139.25               │
                 └──────────────────────────────┘
 
-                EOTXT
-            ,
+                EOTXT,
             ['ISBN', 'Title', 'Author', 'Price'],
             $books,
             'box',
@@ -1943,8 +1923,7 @@ class TableTest extends TestCase
                 ║  Price: 139.25               ║
                 ╚══════════════════════════════╝
 
-                EOTXT
-            ,
+                EOTXT,
             ['ISBN', 'Title', 'Author', 'Price'],
             $books,
             'box-double',
@@ -1964,8 +1943,7 @@ class TableTest extends TestCase
                 |  Price: 139.25               |
                 +---------- Page 1/2 ----------+
 
-                EOTXT
-            ,
+                EOTXT,
             ['ISBN', 'Title', 'Author', 'Price'],
             $books,
             'default',
@@ -2045,8 +2023,7 @@ class TableTest extends TestCase
             │ World │ 2 │ 4 │
             └───────┴───┴───┘
 
-            TABLE
-            ,
+            TABLE,
             $this->getOutputContent($output)
         );
     }
@@ -2107,8 +2084,7 @@ class TableTest extends TestCase
             | And a very long line to show difference in previous lines |                    |
             +-----------------------------------------------------------+--------------------+
 
-            TABLE
-            ,
+            TABLE,
             $this->getOutputContent($output)
         );
     }

--- a/src/Symfony/Component/Console/Tests/Helper/TreeHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TreeHelperTest.php
@@ -55,7 +55,9 @@ class TreeHelperTest extends TestCase
             Root
             ├── Child 1
             └── Child 2
-            TREE, self::normalizeLineBreaks(trim($output->fetch())));
+            TREE,
+            self::normalizeLineBreaks(trim($output->fetch()))
+        );
     }
 
     public function testRenderThreeLevelTree()
@@ -78,7 +80,9 @@ class TreeHelperTest extends TestCase
             ├── Child 1
             │   └── SubChild 1
             └── Child 2
-            TREE, self::normalizeLineBreaks(trim($output->fetch())));
+            TREE,
+            self::normalizeLineBreaks(trim($output->fetch()))
+        );
     }
 
     public function testRenderMultiLevelTree()
@@ -107,7 +111,9 @@ class TreeHelperTest extends TestCase
             │   │   └── SubSubChild 1
             │   └── SubChild 2
             └── Child 2
-            TREE, self::normalizeLineBreaks(trim($output->fetch())));
+            TREE,
+            self::normalizeLineBreaks(trim($output->fetch()))
+        );
     }
 
     public function testRenderSingleNodeTree()
@@ -119,7 +125,9 @@ class TreeHelperTest extends TestCase
         $tree->render();
         $this->assertSame(<<<TREE
             Root
-            TREE, self::normalizeLineBreaks(trim($output->fetch())));
+            TREE,
+            self::normalizeLineBreaks(trim($output->fetch()))
+        );
     }
 
     public function testRenderEmptyTree()
@@ -131,7 +139,9 @@ class TreeHelperTest extends TestCase
         $tree->render();
         $this->assertSame(<<<TREE
             Root
-            TREE, self::normalizeLineBreaks(trim($output->fetch())));
+            TREE,
+            self::normalizeLineBreaks(trim($output->fetch()))
+        );
     }
 
     public function testRenderDeeplyNestedTree()
@@ -169,7 +179,9 @@ class TreeHelperTest extends TestCase
                           └── Level 8
                             └── Level 9
                               └── Level 10
-            TREE, self::normalizeLineBreaks(trim($output->fetch())));
+            TREE,
+            self::normalizeLineBreaks(trim($output->fetch()))
+        );
     }
 
     public function testRenderNodeWithMultipleChildren()
@@ -192,7 +204,9 @@ class TreeHelperTest extends TestCase
             ├── Child 1
             ├── Child 2
             └── Child 3
-            TREE, self::normalizeLineBreaks(trim($output->fetch())));
+            TREE,
+            self::normalizeLineBreaks(trim($output->fetch()))
+        );
     }
 
     public function testRenderNodeWithMultipleChildrenWithStringConversion()
@@ -212,7 +226,9 @@ class TreeHelperTest extends TestCase
             ├── Child 1
             ├── Child 2
             └── Child 3
-            TREE, self::normalizeLineBreaks(trim($output->fetch())));
+            TREE,
+            self::normalizeLineBreaks(trim($output->fetch()))
+        );
     }
 
     public function testRenderTreeWithDuplicateNodeNames()
@@ -235,7 +251,9 @@ class TreeHelperTest extends TestCase
             ├── Child
             │   └── Child
             └── Child
-            TREE, self::normalizeLineBreaks(trim($output->fetch())));
+            TREE,
+            self::normalizeLineBreaks(trim($output->fetch()))
+        );
     }
 
     public function testRenderTreeWithComplexNodeNames()
@@ -258,7 +276,9 @@ class TreeHelperTest extends TestCase
             ├── Child 1 (special)
             │   └── Node with spaces
             └── Child_2@#$
-            TREE, self::normalizeLineBreaks(trim($output->fetch())));
+            TREE,
+            self::normalizeLineBreaks(trim($output->fetch()))
+        );
     }
 
     public function testRenderTreeWithCycle()
@@ -310,7 +330,9 @@ class TreeHelperTest extends TestCase
             root
             ├── child1
             └── child2
-            TREE, self::normalizeLineBreaks(trim($output->fetch())));
+            TREE,
+            self::normalizeLineBreaks(trim($output->fetch()))
+        );
     }
 
     public function testCreateWithNestedArray()
@@ -329,7 +351,9 @@ class TreeHelperTest extends TestCase
             │   └── child2.2
             │      └── child2.2.1
             └── child3
-            TREE, self::normalizeLineBreaks(trim($output->fetch())));
+            TREE,
+            self::normalizeLineBreaks(trim($output->fetch()))
+        );
     }
 
     public function testCreateWithoutRoot()
@@ -343,7 +367,9 @@ class TreeHelperTest extends TestCase
         $this->assertSame(<<<TREE
             ├── child1
             └── child2
-            TREE, self::normalizeLineBreaks(trim($output->fetch())));
+            TREE,
+            self::normalizeLineBreaks(trim($output->fetch()))
+        );
     }
 
     public function testCreateWithEmptyArray()

--- a/src/Symfony/Component/Console/Tests/Helper/TreeStyleTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TreeStyleTest.php
@@ -41,7 +41,9 @@ class TreeStyleTest extends TestCase
             │   │   └── B12
             │   └── B2
             └── C
-            TREE, self::normalizeLineBreaks(trim($output->fetch())));
+            TREE,
+            self::normalizeLineBreaks(trim($output->fetch()))
+        );
     }
 
     public function testBoxStyle()
@@ -63,7 +65,9 @@ class TreeStyleTest extends TestCase
             ┃  ┃  ┗╸ B12
             ┃  ┗╸ B2
             ┗╸ C
-            TREE, self::normalizeLineBreaks(trim($output->fetch())));
+            TREE,
+            self::normalizeLineBreaks(trim($output->fetch()))
+        );
     }
 
     public function testBoxDoubleStyle()
@@ -85,7 +89,9 @@ class TreeStyleTest extends TestCase
             ║  ║  ╚═ B12
             ║  ╚═ B2
             ╚═ C
-            TREE, self::normalizeLineBreaks(trim($output->fetch())));
+            TREE,
+            self::normalizeLineBreaks(trim($output->fetch()))
+        );
     }
 
     public function testCompactStyle()
@@ -107,7 +113,9 @@ class TreeStyleTest extends TestCase
             │ │ └ B12
             │ └ B2
             └ C
-            TREE, self::normalizeLineBreaks(trim($output->fetch())));
+            TREE,
+            self::normalizeLineBreaks(trim($output->fetch()))
+        );
     }
 
     public function testLightStyle()
@@ -129,7 +137,9 @@ class TreeStyleTest extends TestCase
             |   |   `-- B12
             |   `-- B2
             `-- C
-            TREE, self::normalizeLineBreaks(trim($output->fetch())));
+            TREE,
+            self::normalizeLineBreaks(trim($output->fetch()))
+        );
     }
 
     public function testMinimalStyle()
@@ -151,7 +161,9 @@ class TreeStyleTest extends TestCase
             . . . B12
             . . B2
             . C
-            TREE, self::normalizeLineBreaks(trim($output->fetch())));
+            TREE,
+            self::normalizeLineBreaks(trim($output->fetch()))
+        );
     }
 
     public function testRoundedStyle()
@@ -173,7 +185,9 @@ class TreeStyleTest extends TestCase
             │  │  ╰─ B12
             │  ╰─ B2
             ╰─ C
-            TREE, self::normalizeLineBreaks(trim($output->fetch())));
+            TREE,
+            self::normalizeLineBreaks(trim($output->fetch()))
+        );
     }
 
     public function testCustomPrefix()
@@ -196,7 +210,9 @@ class TreeStyleTest extends TestCase
             C D D B F B12
             C D B F B2
             C B F C
-            TREE, self::normalizeLineBreaks(trim($output->fetch())));
+            TREE,
+            self::normalizeLineBreaks(trim($output->fetch()))
+        );
     }
 
     private static function createTree(OutputInterface $output, ?TreeStyle $style = null): TreeHelper

--- a/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
+++ b/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
@@ -184,7 +184,9 @@ class SymfonyStyleTest extends TestCase
             │   │   └── B12
             │   └── B2
             └── C
-            TREE, self::normalizeLineBreaks(trim($output->fetch())));
+            TREE,
+            self::normalizeLineBreaks(trim($output->fetch()))
+        );
     }
 
     public function testCreateTreeWithArray()
@@ -205,7 +207,9 @@ class SymfonyStyleTest extends TestCase
             │   │   └── B12
             │   └── B2
             └── C
-            TREE, self::normalizeLineBreaks(trim($output->fetch())));
+            TREE,
+            self::normalizeLineBreaks(trim($output->fetch()))
+        );
     }
 
     public function testCreateTreeWithIterable()
@@ -226,7 +230,9 @@ class SymfonyStyleTest extends TestCase
             │   │   └── B12
             │   └── B2
             └── C
-            TREE, self::normalizeLineBreaks(trim($output->fetch())));
+            TREE,
+            self::normalizeLineBreaks(trim($output->fetch()))
+        );
     }
 
     public function testCreateTreeWithConsoleOutput()

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1026,8 +1026,7 @@ class PhpDumper extends Dumper
                         return $container->%1$s[%2$s];
                     }
 
-            EOTXT
-            ,
+            EOTXT,
             $this->container->getDefinition($id)->isPublic() ? 'services' : 'privates',
             $this->doExport($id)
         );

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -1439,8 +1439,8 @@ class PhpDumperTest extends TestCase
                         default => throw new ParameterNotFoundException($name),
                     };
             %A
-            PHP
-            , $dumpedContainer
+            PHP,
+            $dumpedContainer
         );
     }
 
@@ -2139,48 +2139,49 @@ class PhpDumperTest extends TestCase
             ['<?php echo/**/\foo();', '<?php echo \foo();'],
             ['<?php echo/** bar */\foo();', '<?php echo \foo();'],
             ['<?php /**/echo \foo();', '<?php echo \foo();'],
-            [<<<'EOF'
-                <?php
-                include_once \dirname(__DIR__).'/foo.php';
+            [
+                <<<'EOF'
+                    <?php
+                    include_once \dirname(__DIR__).'/foo.php';
 
-                $string = 'string should not be   modified';
+                    $string = 'string should not be   modified';
 
-                $string = 'string should not be
+                    $string = 'string should not be
 
-                modified';
-
-
-                $heredoc = <<<HD
+                    modified';
 
 
-                Heredoc should not be   modified {$a[1+$b]}
+                    $heredoc = <<<HD
 
 
-                HD;
-
-                $nowdoc = <<<'ND'
+                    Heredoc should not be   modified {$a[1+$b]}
 
 
-                Nowdoc should not be   modified
+                    HD;
+
+                    $nowdoc = <<<'ND'
 
 
-                ND;
+                    Nowdoc should not be   modified
 
-                /**
-                 * some class comments to strip
-                 */
-                class TestClass
-                {
+
+                    ND;
+
                     /**
-                     * some method comments to strip
+                     * some class comments to strip
                      */
-                    public function doStuff()
+                    class TestClass
                     {
-                        // inline comment
+                        /**
+                         * some method comments to strip
+                         */
+                        public function doStuff()
+                        {
+                            // inline comment
+                        }
                     }
-                }
-                EOF
-                , <<<'EOF'
+                    EOF,
+                <<<'EOF'
                     <?php
                     include_once \dirname(__DIR__).'/foo.php';
                     $string = 'string should not be   modified';
@@ -2207,7 +2208,7 @@ class PhpDumperTest extends TestCase
                         {
                             }
                     }
-                    EOF
+                    EOF,
             ],
         ];
     }

--- a/src/Symfony/Component/DomCrawler/Tests/NativeParserCrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/NativeParserCrawlerTest.php
@@ -33,8 +33,9 @@ class NativeParserCrawlerTest extends AbstractCrawlerTestCase
                 </body>
                 </body>
             </html>
-            EOF
-            , 'UTF-8');
+            EOF,
+            'UTF-8'
+        );
 
         $errors = libxml_get_errors();
         $this->assertCount(1, $errors);
@@ -58,8 +59,9 @@ class NativeParserCrawlerTest extends AbstractCrawlerTestCase
                     <nav><a href="#"><a href="#"></nav>
                 </body>
             </html>
-            EOF
-            , 'UTF-8');
+            EOF,
+            'UTF-8'
+        );
 
         $this->assertGreaterThan(1, libxml_get_errors());
 

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/NodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/NodeTest.php
@@ -26,8 +26,9 @@ class NodeTest extends TestCase
             Node(
                 ConstantNode(value: 'foo')
             )
-            EOF
-            , (string) $node);
+            EOF,
+            (string) $node
+        );
     }
 
     public function testSerialization()

--- a/src/Symfony/Component/Form/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Form/Tests/Command/DebugCommandTest.php
@@ -52,8 +52,9 @@ class DebugCommandTest extends TestCase
              * Symfony\Component\Form\Tests\Command\FooType
 
 
-            TXT
-            , $tester->getDisplay(true));
+            TXT,
+            $tester->getDisplay(true)
+        );
     }
 
     public function testDebugSingleFormType()
@@ -134,8 +135,9 @@ class DebugCommandTest extends TestCase
             %A
             %A\A\AmbiguousType (Block prefix: "ambiguous")
             %A
-            TXT
-            , $output);
+            TXT,
+            $output
+        );
     }
 
     public function testDebugInvalidFormType()
@@ -183,8 +185,9 @@ class DebugCommandTest extends TestCase
               Nested Options   -         %s
              ---------------- -----------%s
 
-            TXT
-            , $tester->getDisplay(true));
+            TXT,
+            $tester->getDisplay(true)
+        );
     }
 
     #[DataProvider('provideCompletionSuggestions')]

--- a/src/Symfony/Component/JsonPath/Tests/JsonPathUtilsTest.php
+++ b/src/Symfony/Component/JsonPath/Tests/JsonPathUtilsTest.php
@@ -53,7 +53,9 @@ class JsonPathUtilsTest extends TestCase
                 {"category": "reference", "author": "Nigel Rees", "title": "Sayings", "price": 8.95},
                 {"category": "fiction", "author": "Evelyn Waugh", "title": "Sword", "price": 12.99}
             ]}
-            JSON, $reduced['json']);
+            JSON,
+            $reduced['json']
+        );
         $this->assertEquals([new JsonPathToken(TokenType::Name, 'book')], $reduced['tokens']);
     }
 
@@ -74,7 +76,9 @@ class JsonPathUtilsTest extends TestCase
                 {"category": "reference", "author": "Nigel Rees", "title": "Sayings", "price": 8.95},
                 {"category": "fiction", "author": "Evelyn Waugh", "title": "Sword", "price": 12.99}
             ]}
-            JSON, $reduced['json']);
+            JSON,
+            $reduced['json']
+        );
         $this->assertEquals([new JsonPathToken(TokenType::Bracket, '?(@.book.author == "Nigel Rees")')], $reduced['tokens']);
     }
 
@@ -116,7 +120,10 @@ class JsonPathUtilsTest extends TestCase
                 {"category": "reference", "author": "Nigel Rees", "title": "Sayings", "price": 8.95},
                 {"category": "fiction", "author": "Evelyn Waugh", "title": "Sword", "price": 12.99}
             ]
-            JSON, $reduced['json'], 'reduce to "book", but not further');
+            JSON,
+            $reduced['json'],
+            'reduce to "book", but not further'
+        );
         $this->assertEquals([
             new JsonPathToken(TokenType::Bracket, '1:2'),
         ], $reduced['tokens']);
@@ -158,7 +165,10 @@ class JsonPathUtilsTest extends TestCase
                 {"category": "reference", "author": "Nigel Rees", "title": "Sayings", "price": 8.95},
                 {"category": "fiction", "author": "Evelyn Waugh", "title": "Sword", "price": 12.99}
             ]
-            JSON, $reduced['json'], 'reduce to "book", but not further');
+            JSON,
+            $reduced['json'],
+            'reduce to "book", but not further'
+        );
         $this->assertEquals([
             new JsonPathToken(TokenType::Bracket, '123'),
             new JsonPathToken(TokenType::Name, 'title'),

--- a/src/Symfony/Component/JsonStreamer/Tests/Read/LexerTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Read/LexerTest.php
@@ -101,7 +101,9 @@ class LexerTest extends TestCase
             ["a",
             4
             ,1,
-            JSON, false];
+            JSON,
+            false,
+        ];
         yield ['array_number_and_comma', '[1,]', false];
         yield ['array_number_and_several_commas', '[1,,]', false];
         yield ['array_spaces_vertical_tab_formfeed', '["
@@ -113,7 +115,9 @@ a"\f]', false];
             [1,
             1
             ,1
-            JSON, false];
+            JSON,
+            false,
+        ];
         yield ['array_unclosed_with_object_inside', '[{}', false];
         yield ['incomplete_false', '[fals]', false];
         yield ['incomplete_null', '[nul]', false];
@@ -226,7 +230,9 @@ a"\f]', false];
         yield ['string_unescaped_newline', <<<JSON
             ["new
             line"]
-            JSON, false];
+            JSON,
+            false,
+        ];
         yield ['string_unescaped_tab', '["	"]', false];
         yield ['string_unicode_CapitalU', '"\\UA66D"', false];
         yield ['string_with_trailing_garbage', '""x', false];
@@ -286,7 +292,9 @@ a"\f]', false];
         yield ['array_with_1_and_newline', <<<JSON
             [1
             ]
-            JSON, true];
+            JSON,
+            true,
+        ];
         yield ['array_with_leading_space', '[1]', true];
         yield ['array_with_several_null', '[1,null,null,null,2]', true];
         yield ['array_with_trailing_space', '[2] ', true];
@@ -321,7 +329,9 @@ a"\f]', false];
             {
             "a": "b"
             }
-            JSON, true];
+            JSON,
+            true,
+        ];
         yield ['string_1_2_3_bytes_UTF-8_sequences', '["\\u0060\\u012a\\u12AB"]', true];
         yield ['string_accepted_surrogate_pair', '["\\uD801\\udc37"]', true];
         yield ['string_accepted_surrogate_pairs', '["\\ud83d\\ude39\\ud83d\\udc8d"]', true];
@@ -375,7 +385,9 @@ a"\f]', false];
         yield ['structure_trailing_newline', <<<JSON
             ["a"]
 
-            JSON, true];
+            JSON,
+            true,
+        ];
         yield ['structure_true_in_array', '[true]', true];
         yield ['structure_whitespace_array', '[] ', true];
 

--- a/src/Symfony/Component/Mailer/Tests/EventListener/DkimSignedMessageListenerTest.php
+++ b/src/Symfony/Component/Mailer/Tests/EventListener/DkimSignedMessageListenerTest.php
@@ -44,7 +44,10 @@ class DkimSignedMessageListenerTest extends TestCase
             /yRW4PGoZpRVRiT3SB0CQCkSOXB6YoLDagS3X10RInlGkB5pfBd1cG1pQS7YEFjX
             Y4x0EYVpNU9oHyeMlLgyevy07udFZXvHItT6WgbspQQ=
             -----END RSA PRIVATE KEY-----
-            KEY, 'symfony.com', 's1');
+            KEY,
+            'symfony.com',
+            's1'
+        );
         $listener = new DkimSignedMessageListener($signer);
         $message = new Message(
             new Headers(

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpExtIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpExtIntegrationTest.php
@@ -249,8 +249,9 @@ class AmqpExtIntegrationTest extends TestCase
             ]
             Done.
 
-            TXT
-            , $process->getOutput());
+            TXT,
+            $process->getOutput()
+        );
     }
 
     public function testItCountsMessagesInQueue()

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/PostgreSqlConnection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/PostgreSqlConnection.php
@@ -118,8 +118,10 @@ final class PostgreSqlConnection extends Connection
                         RETURN NEW;
                     END;
                 $$ LANGUAGE plpgsql;
-                SQL
-                , $functionName, $this->configuration['table_name']),
+                SQL,
+                $functionName,
+                $this->configuration['table_name']
+            ),
             // register trigger
             \sprintf('DROP TRIGGER IF EXISTS notify_trigger ON %s;', $this->configuration['table_name']),
             \sprintf('CREATE TRIGGER notify_trigger AFTER INSERT OR UPDATE ON %1$s FOR EACH ROW EXECUTE PROCEDURE %2$s();', $this->configuration['table_name'], $functionName),

--- a/src/Symfony/Component/Messenger/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/DebugCommandTest.php
@@ -101,8 +101,8 @@ class DebugCommandTest extends TestCase
              --------------------------------------------------------------------------------------- 
 
 
-            TXT
-            , $tester->getDisplay(true)
+            TXT,
+            $tester->getDisplay(true)
         );
 
         $tester->execute(['bus' => 'query_bus'], ['decorated' => false]);
@@ -127,8 +127,8 @@ class DebugCommandTest extends TestCase
              --------------------------------------------------------------------------------------- 
 
 
-            TXT
-            , $tester->getDisplay(true)
+            TXT,
+            $tester->getDisplay(true)
         );
     }
 
@@ -155,8 +155,8 @@ class DebugCommandTest extends TestCase
              [WARNING] No handled message found in bus "query_bus".                                                                 
 
 
-            TXT
-            , $tester->getDisplay(true)
+            TXT,
+            $tester->getDisplay(true)
         );
     }
 

--- a/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesShowCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesShowCommandTest.php
@@ -69,7 +69,7 @@ class FailedMessagesShowCommandTest extends TestCase
         $tester = new CommandTester($command);
         $tester->execute(['id' => 15]);
 
-        $this->assertStringContainsString(sprintf(<<<EOF
+        $this->assertStringContainsString(\sprintf(<<<EOF
             ------------- --------------------- 
               Class         stdClass             
               Message Id    15                   
@@ -78,8 +78,7 @@ class FailedMessagesShowCommandTest extends TestCase
               Error Code    123                  
               Error Class   Exception            
               Transport     async
-            EOF
-            ,
+            EOF,
             $redeliveryStamp->getRedeliveredAt()->format('Y-m-d H:i:s')),
             $tester->getDisplay(true));
     }
@@ -111,7 +110,7 @@ class FailedMessagesShowCommandTest extends TestCase
         );
         $tester = new CommandTester($command);
         $tester->execute(['id' => 15]);
-        $this->assertStringContainsString(sprintf(<<<EOF
+        $this->assertStringContainsString(\sprintf(<<<EOF
              ------------- --------------------- 
               Class         stdClass             
               Message Id    15                   
@@ -120,8 +119,7 @@ class FailedMessagesShowCommandTest extends TestCase
               Error Code    123                  
               Error Class   Exception            
               Transport     async
-            EOF
-            ,
+            EOF,
             $redeliveryStamp2->getRedeliveredAt()->format('Y-m-d H:i:s')),
             $tester->getDisplay(true));
     }
@@ -178,8 +176,7 @@ class FailedMessagesShowCommandTest extends TestCase
 
         $this->assertStringContainsString(\sprintf(<<<EOF
             15   stdClass   %s   Things are bad!
-            EOF
-            ,
+            EOF,
             $redeliveryStamp->getRedeliveredAt()->format('Y-m-d H:i:s')),
             $tester->getDisplay(true));
 
@@ -352,8 +349,7 @@ class FailedMessagesShowCommandTest extends TestCase
                   ›     $exceptionLine = __LINE__ - 1;
                 }
             %%A
-            EOF
-            ,
+            EOF,
             __FILE__, $exceptionLine, $exceptionLine),
             $tester->getDisplay(true));
     }
@@ -386,8 +382,7 @@ class FailedMessagesShowCommandTest extends TestCase
         $tester->execute(['--transport' => $failureTransportName]);
         $this->assertStringContainsString(\sprintf(<<<EOF
             15   stdClass   %s   Things are bad!
-            EOF
-            ,
+            EOF,
             $redeliveryStamp->getRedeliveredAt()->format('Y-m-d H:i:s')),
             $tester->getDisplay(true));
     }

--- a/src/Symfony/Component/Messenger/Tests/DataCollector/MessengerDataCollectorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DataCollector/MessengerDataCollectorTest.php
@@ -120,8 +120,9 @@ class MessengerDataCollectorTest extends TestCase
                 "value" => RuntimeException %A
               ]
             ]
-            DUMP
-            , $this->getDataAsString($messages[0]));
+            DUMP,
+            $this->getDataAsString($messages[0])
+        );
     }
 
     public function testKeepsOrderedDispatchCalls()

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -1237,7 +1237,9 @@ class OptionsResolver implements Options
 
                     \|                                  # Match the pipe delimiter (only if not inside a skipped group)
                     /x
-            EOF, $type);
+            EOF,
+            $type
+        );
     }
 
     /**

--- a/src/Symfony/Component/PasswordHasher/Tests/Command/UserPasswordHashCommandTest.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Command/UserPasswordHashCommandTest.php
@@ -263,8 +263,9 @@ class UserPasswordHashCommandTest extends TestCase
               [1] Custom\Class\Pbkdf2\User
               [2] Custom\Class\Test\User
               [3] Symfony\Component\Security\Core\User\InMemoryUser
-            EOTXT
-            , $this->passwordHasherCommandTester->getDisplay(true));
+            EOTXT,
+            $this->passwordHasherCommandTester->getDisplay(true)
+        );
     }
 
     public function testNonInteractiveEncodePasswordUsesFirstUserClass()

--- a/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
@@ -46,8 +46,9 @@ class CsvEncoderTest extends TestCase
             string,int,false,true,int_one,string_one
             foo,2,0,1,1,1
 
-            CSV
-            , $this->encoder->encode($data, 'csv'));
+            CSV,
+            $this->encoder->encode($data, 'csv')
+        );
 
         $this->assertSame([
             'string' => 'foo',
@@ -65,8 +66,9 @@ class CsvEncoderTest extends TestCase
             0,1,2,3,4,5
             ,"""","foo""","\""",\,foo\
 
-            CSV
-            , $this->encoder->encode($data = ['', '"', 'foo"', '\\"', '\\', 'foo\\'], 'csv'));
+            CSV,
+            $this->encoder->encode($data = ['', '"', 'foo"', '\\"', '\\', 'foo\\'], 'csv')
+        );
 
         $this->assertSame($data, $this->encoder->decode($csv, 'csv', [CsvEncoder::AS_COLLECTION_KEY => false]));
     }
@@ -92,8 +94,9 @@ class CsvEncoderTest extends TestCase
             foo,bar
             hello,"hey ho"
 
-            CSV
-            , $this->encoder->encode($value, 'csv'));
+            CSV,
+            $this->encoder->encode($value, 'csv')
+        );
     }
 
     public function testEncodeCollection()
@@ -108,8 +111,9 @@ class CsvEncoderTest extends TestCase
             hello,"hey ho"
             hi,"let's go"
 
-            CSV
-            , $this->encoder->encode($value, 'csv'));
+            CSV,
+            $this->encoder->encode($value, 'csv')
+        );
     }
 
     public function testEncodePlainIndexedArray()
@@ -118,8 +122,9 @@ class CsvEncoderTest extends TestCase
             0,1,2
             a,b,c
 
-            CSV
-            , $this->encoder->encode(['a', 'b', 'c'], 'csv'));
+            CSV,
+            $this->encoder->encode(['a', 'b', 'c'], 'csv')
+        );
     }
 
     public function testEncodeNonArray()
@@ -128,8 +133,9 @@ class CsvEncoderTest extends TestCase
             0
             foo
 
-            CSV
-            , $this->encoder->encode('foo', 'csv'));
+            CSV,
+            $this->encoder->encode('foo', 'csv')
+        );
     }
 
     public function testEncodeNestedArrays()
@@ -143,8 +149,9 @@ class CsvEncoderTest extends TestCase
             foo,bar.0.id,bar.0.1,bar.1.baz,bar.1.foo
             hello,yo,wesh,Halo,olá
 
-            CSV
-            , $this->encoder->encode($value, 'csv'));
+            CSV,
+            $this->encoder->encode($value, 'csv')
+        );
     }
 
     public function testEncodeCustomSettings()
@@ -161,8 +168,9 @@ class CsvEncoderTest extends TestCase
             a;c-d
             'he''llo';foo
 
-            CSV
-            , $this->encoder->encode($value, 'csv'));
+            CSV,
+            $this->encoder->encode($value, 'csv')
+        );
     }
 
     public function testEncodeCustomSettingsPassedInContext()
@@ -173,12 +181,13 @@ class CsvEncoderTest extends TestCase
             a;c-d
             'he''llo';foo
 
-            CSV
-            , $this->encoder->encode($value, 'csv', [
+            CSV,
+            $this->encoder->encode($value, 'csv', [
                 CsvEncoder::DELIMITER_KEY => ';',
                 CsvEncoder::ENCLOSURE_KEY => "'",
                 CsvEncoder::KEY_SEPARATOR_KEY => '-',
-            ]));
+            ])
+        );
     }
 
     public function testEncodeCustomSettingsPassedInConstructor()
@@ -194,8 +203,9 @@ class CsvEncoderTest extends TestCase
             a;c-d
             'he''llo';foo
 
-            CSV
-            , $encoder->encode($value, 'csv'));
+            CSV,
+            $encoder->encode($value, 'csv')
+        );
     }
 
     public function testEncodeEmptyArray()
@@ -264,50 +274,57 @@ class CsvEncoderTest extends TestCase
             0
             '=2+3
 
-            CSV
-            , $this->encoder->encode(['=2+3'], 'csv'));
+            CSV,
+            $this->encoder->encode(['=2+3'], 'csv')
+        );
 
         $this->assertSame(<<<'CSV'
             0
             '-2+3
 
-            CSV
-            , $this->encoder->encode(['-2+3'], 'csv'));
+            CSV,
+            $this->encoder->encode(['-2+3'], 'csv')
+        );
 
         $this->assertSame(<<<'CSV'
             0
             '+2+3
 
-            CSV
-            , $this->encoder->encode(['+2+3'], 'csv'));
+            CSV,
+            $this->encoder->encode(['+2+3'], 'csv')
+        );
 
         $this->assertSame(<<<'CSV'
             0
             '@MyDataColumn
 
-            CSV
-            , $this->encoder->encode(['@MyDataColumn'], 'csv'));
+            CSV,
+            $this->encoder->encode(['@MyDataColumn'], 'csv')
+        );
 
         $this->assertSame(<<<'CSV'
             0
             "'	tab"
 
-            CSV
-            , $this->encoder->encode(["\ttab"], 'csv'));
+            CSV,
+            $this->encoder->encode(["\ttab"], 'csv')
+        );
 
         $this->assertSame(<<<'CSV'
             0
             "'=1+2"";=1+2"
 
-            CSV
-            , $this->encoder->encode(['=1+2";=1+2'], 'csv'));
+            CSV,
+            $this->encoder->encode(['=1+2";=1+2'], 'csv')
+        );
 
         $this->assertSame(<<<'CSV'
             0
             "'=1+2'"" ;,=1+2"
 
-            CSV
-            , $this->encoder->encode(['=1+2\'" ;,=1+2'], 'csv'));
+            CSV,
+            $this->encoder->encode(['=1+2\'" ;,=1+2'], 'csv')
+        );
     }
 
     public function testDoNotEncodeFormulas()
@@ -316,50 +333,57 @@ class CsvEncoderTest extends TestCase
             0
             =2+3
 
-            CSV
-            , $this->encoder->encode(['=2+3'], 'csv'));
+            CSV,
+            $this->encoder->encode(['=2+3'], 'csv')
+        );
 
         $this->assertSame(<<<'CSV'
             0
             -2+3
 
-            CSV
-            , $this->encoder->encode(['-2+3'], 'csv'));
+            CSV,
+            $this->encoder->encode(['-2+3'], 'csv')
+        );
 
         $this->assertSame(<<<'CSV'
             0
             +2+3
 
-            CSV
-            , $this->encoder->encode(['+2+3'], 'csv'));
+            CSV,
+            $this->encoder->encode(['+2+3'], 'csv')
+        );
 
         $this->assertSame(<<<'CSV'
             0
             @MyDataColumn
 
-            CSV
-            , $this->encoder->encode(['@MyDataColumn'], 'csv'));
+            CSV,
+            $this->encoder->encode(['@MyDataColumn'], 'csv')
+        );
 
         $this->assertSame(<<<'CSV'
             0
             "	tab"
 
-            CSV
-            , $this->encoder->encode(["\ttab"], 'csv'));
+            CSV,
+            $this->encoder->encode(["\ttab"], 'csv')
+        );
 
         $this->assertSame(<<<'CSV'
             0
             "=1+2"";=1+2"
 
-            CSV
-            , $this->encoder->encode(['=1+2";=1+2'], 'csv'));
+            CSV,
+            $this->encoder->encode(['=1+2";=1+2'], 'csv')
+        );
 
         $this->assertSame(<<<'CSV'
             0
             "=1+2'"" ;,=1+2"
 
-            CSV
-            , $this->encoder->encode(['=1+2\'" ;,=1+2'], 'csv'));
+            CSV,
+            $this->encoder->encode(['=1+2\'" ;,=1+2'], 'csv')
+        );
     }
 
     public function testEncodeFormulasWithSettingsPassedInContext()
@@ -368,64 +392,71 @@ class CsvEncoderTest extends TestCase
             0
             '=2+3
 
-            CSV
-            , $this->encoder->encode(['=2+3'], 'csv', [
+            CSV,
+            $this->encoder->encode(['=2+3'], 'csv', [
                 CsvEncoder::ESCAPE_FORMULAS_KEY => true,
-            ]));
+            ])
+        );
 
         $this->assertSame(<<<'CSV'
             0
             '-2+3
 
-            CSV
-            , $this->encoder->encode(['-2+3'], 'csv', [
+            CSV,
+            $this->encoder->encode(['-2+3'], 'csv', [
                 CsvEncoder::ESCAPE_FORMULAS_KEY => true,
-            ]));
+            ])
+        );
 
         $this->assertSame(<<<'CSV'
             0
             '+2+3
 
-            CSV
-            , $this->encoder->encode(['+2+3'], 'csv', [
+            CSV,
+            $this->encoder->encode(['+2+3'], 'csv', [
                 CsvEncoder::ESCAPE_FORMULAS_KEY => true,
-            ]));
+            ])
+        );
 
         $this->assertSame(<<<'CSV'
             0
             '@MyDataColumn
 
-            CSV
-            , $this->encoder->encode(['@MyDataColumn'], 'csv', [
+            CSV,
+            $this->encoder->encode(['@MyDataColumn'], 'csv', [
                 CsvEncoder::ESCAPE_FORMULAS_KEY => true,
-            ]));
+            ])
+        );
 
         $this->assertSame(<<<'CSV'
             0
             "'	tab"
 
-            CSV
-            , $this->encoder->encode(["\ttab"], 'csv', [
+            CSV,
+            $this->encoder->encode(["\ttab"], 'csv', [
                 CsvEncoder::ESCAPE_FORMULAS_KEY => true,
-            ]));
+            ])
+        );
 
         $this->assertSame(<<<'CSV'
             0
             "'=1+2"";=1+2"
 
-            CSV
-            , $this->encoder->encode(['=1+2";=1+2'], 'csv', [
+            CSV,
+            $this->encoder->encode(['=1+2";=1+2'], 'csv', [
                 CsvEncoder::ESCAPE_FORMULAS_KEY => true,
-            ]));
+            ])
+        );
 
         $this->assertSame(<<<'CSV'
             0
             "'=1+2'"" ;,=1+2"
 
-            CSV
-            , $this->encoder->encode(['=1+2\'" ;,=1+2'], 'csv', [
+            CSV,
+            $this->encoder->encode(['=1+2\'" ;,=1+2'], 'csv', [
                 CsvEncoder::ESCAPE_FORMULAS_KEY => true,
-            ]));
+            ])
+        );
     }
 
     public function testEncodeWithoutHeader()
@@ -434,19 +465,21 @@ class CsvEncoderTest extends TestCase
             a,b
             c,d
 
-            CSV
-            , $this->encoder->encode([['a', 'b'], ['c', 'd']], 'csv', [
+            CSV,
+            $this->encoder->encode([['a', 'b'], ['c', 'd']], 'csv', [
                 CsvEncoder::NO_HEADERS_KEY => true,
-            ]));
+            ])
+        );
         $encoder = new CsvEncoder([CsvEncoder::NO_HEADERS_KEY => true]);
         $this->assertSame(<<<'CSV'
             a,b
             c,d
 
-            CSV
-            , $encoder->encode([['a', 'b'], ['c', 'd']], 'csv', [
+            CSV,
+            $encoder->encode([['a', 'b'], ['c', 'd']], 'csv', [
                 CsvEncoder::NO_HEADERS_KEY => true,
-            ]));
+            ])
+        );
     }
 
     public function testEncodeArrayObject()
@@ -457,8 +490,9 @@ class CsvEncoderTest extends TestCase
             foo,bar
             hello,"hey ho"
 
-            CSV
-            , $this->encoder->encode($value, 'csv'));
+            CSV,
+            $this->encoder->encode($value, 'csv')
+        );
 
         $value = new \ArrayObject();
 
@@ -473,8 +507,9 @@ class CsvEncoderTest extends TestCase
             foo.nested,bar.another
             value,word
 
-            CSV
-            , $this->encoder->encode($value, 'csv'));
+            CSV,
+            $this->encoder->encode($value, 'csv')
+        );
     }
 
     public function testEncodeEmptyArrayObject()
@@ -499,8 +534,10 @@ class CsvEncoderTest extends TestCase
         $this->assertEquals($expected, $this->encoder->decode(<<<'CSV'
             foo,bar
             a,b
-            CSV
-            , 'csv', [CsvEncoder::AS_COLLECTION_KEY => false]));
+            CSV,
+            'csv',
+            [CsvEncoder::AS_COLLECTION_KEY => false]
+        ));
     }
 
     public function testDecodeCollection()
@@ -517,8 +554,9 @@ class CsvEncoderTest extends TestCase
             c,d
             f
 
-            CSV
-            , 'csv'));
+            CSV,
+            'csv'
+        ));
     }
 
     public function testDecode()
@@ -531,8 +569,9 @@ class CsvEncoderTest extends TestCase
             foo
             a
 
-            CSV
-            , 'csv'));
+            CSV,
+            'csv'
+        ));
     }
 
     public function testDecodeToManyRelation()
@@ -550,8 +589,9 @@ class CsvEncoderTest extends TestCase
             bat,b,
             bat,b
             baz,c,c
-            CSV
-            , 'csv'));
+            CSV,
+            'csv'
+        ));
     }
 
     public function testDecodeNestedArrays()
@@ -565,8 +605,9 @@ class CsvEncoderTest extends TestCase
             foo,bar.baz.bat
             a,b
             c,d
-            CSV
-            , 'csv'));
+            CSV,
+            'csv'
+        ));
     }
 
     public function testDecodeCustomSettings()
@@ -581,8 +622,9 @@ class CsvEncoderTest extends TestCase
         $this->assertEquals($expected, $this->encoder->decode(<<<'CSV'
             a;bar-baz
             'hell''o';b;c
-            CSV
-            , 'csv'));
+            CSV,
+            'csv'
+        ));
     }
 
     public function testDecodeCustomSettingsPassedInContext()
@@ -591,12 +633,14 @@ class CsvEncoderTest extends TestCase
         $this->assertEquals($expected, $this->encoder->decode(<<<'CSV'
             a;bar-baz
             'hell''o';b;c
-            CSV
-            , 'csv', [
+            CSV,
+            'csv',
+            [
                 CsvEncoder::DELIMITER_KEY => ';',
                 CsvEncoder::ENCLOSURE_KEY => "'",
                 CsvEncoder::KEY_SEPARATOR_KEY => '-',
-            ]));
+            ]
+        ));
     }
 
     public function testDecodeCustomSettingsPassedInConstructor()
@@ -611,8 +655,9 @@ class CsvEncoderTest extends TestCase
         $this->assertEquals($expected, $encoder->decode(<<<'CSV'
             a;bar-baz
             'hell''o';b;c
-            CSV
-            , 'csv'));
+            CSV,
+            'csv'
+        ));
     }
 
     public function testDecodeMalformedCollection()
@@ -629,8 +674,9 @@ class CsvEncoderTest extends TestCase
             c,d,g,h
             f
 
-            CSV
-            , 'csv'));
+            CSV,
+            'csv'
+        ));
     }
 
     public function testDecodeEmptyArray()
@@ -644,19 +690,23 @@ class CsvEncoderTest extends TestCase
             a,b
             c,d
 
-            CSV
-            , 'csv', [
+            CSV,
+            'csv',
+            [
                 CsvEncoder::NO_HEADERS_KEY => true,
-            ]));
+            ]
+        ));
         $encoder = new CsvEncoder([CsvEncoder::NO_HEADERS_KEY => true]);
         $this->assertEquals([['a', 'b'], ['c', 'd']], $encoder->decode(<<<'CSV'
             a,b
             c,d
 
-            CSV
-            , 'csv', [
+            CSV,
+            'csv',
+            [
                 CsvEncoder::NO_HEADERS_KEY => true,
-            ]));
+            ]
+        ));
     }
 
     public function testBOMIsAddedOnDemand()
@@ -667,8 +717,9 @@ class CsvEncoderTest extends TestCase
             foo,bar
             hello,"hey ho"
 
-            CSV
-            , $this->encoder->encode($value, 'csv', [CsvEncoder::OUTPUT_UTF8_BOM_KEY => true]));
+            CSV,
+            $this->encoder->encode($value, 'csv', [CsvEncoder::OUTPUT_UTF8_BOM_KEY => true])
+        );
     }
 
     public function testBOMCanNotBeAddedToNonUtf8Csv()
@@ -716,7 +767,9 @@ class CsvEncoderTest extends TestCase
             hello,"hey ho"
             hi,"let's go"
 
-            CSV, $this->encoder->encode($data, 'csv'));
+            CSV,
+            $this->encoder->encode($data, 'csv')
+        );
     }
 
     public static function provideIterable()

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/Tests/CrowdinProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/Tests/CrowdinProviderTest.php
@@ -790,8 +790,7 @@ class CrowdinProviderTest extends ProviderTestCase
                 </body>
               </file>
             </xliff>
-            XLIFF
-            ,
+            XLIFF,
             $expectedTranslatorBagFr, 'fr',
         ];
 
@@ -820,8 +819,7 @@ class CrowdinProviderTest extends ProviderTestCase
                 </body>
               </file>
             </xliff>
-            XLIFF
-            ,
+            XLIFF,
             $expectedTranslatorBagEnUs, 'en-GB',
         ];
     }
@@ -915,8 +913,7 @@ class CrowdinProviderTest extends ProviderTestCase
                 </body>
               </file>
             </xliff>
-            XLIFF
-            ,
+            XLIFF,
             $expectedTranslatorBagEn,
         ];
     }

--- a/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderTest.php
@@ -962,8 +962,7 @@ class LocoProviderTest extends ProviderTestCase
                 </body>
               </file>
             </xliff>
-            XLIFF
-            ,
+            XLIFF,
             $expectedTranslatorBagEn,
         ];
 
@@ -992,8 +991,7 @@ class LocoProviderTest extends ProviderTestCase
                 </body>
               </file>
             </xliff>
-            XLIFF
-            ,
+            XLIFF,
             $expectedTranslatorBagFr,
         ];
     }
@@ -1044,8 +1042,7 @@ class LocoProviderTest extends ProviderTestCase
                             </body>
                           </file>
                         </xliff>
-                        XLIFF
-                    ,
+                        XLIFF,
                     'messages+intl-icu' => <<<'XLIFF'
                         <?xml version="1.0" encoding="UTF-8"?>
                         <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
@@ -1061,8 +1058,7 @@ class LocoProviderTest extends ProviderTestCase
                             </body>
                           </file>
                         </xliff>
-                        XLIFF
-                    ,
+                        XLIFF,
                     'validators' => <<<'XLIFF'
                         <?xml version="1.0" encoding="UTF-8"?>
                         <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
@@ -1082,8 +1078,7 @@ class LocoProviderTest extends ProviderTestCase
                             </body>
                           </file>
                         </xliff>
-                        XLIFF
-                    ,
+                        XLIFF,
                 ],
                 'fr' => [
                     'messages' => <<<'XLIFF'
@@ -1101,8 +1096,7 @@ class LocoProviderTest extends ProviderTestCase
                             </body>
                           </file>
                         </xliff>
-                        XLIFF
-                    ,
+                        XLIFF,
                     'messages+intl-icu' => <<<'XLIFF'
                         <?xml version="1.0" encoding="UTF-8"?>
                         <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
@@ -1118,8 +1112,7 @@ class LocoProviderTest extends ProviderTestCase
                             </body>
                           </file>
                         </xliff>
-                        XLIFF
-                    ,
+                        XLIFF,
                     'validators' => <<<'XLIFF'
                         <?xml version="1.0" encoding="UTF-8"?>
                         <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
@@ -1139,8 +1132,7 @@ class LocoProviderTest extends ProviderTestCase
                             </body>
                           </file>
                         </xliff>
-                        XLIFF
-                    ,
+                        XLIFF,
                 ],
             ],
             $expectedTranslatorBag,

--- a/src/Symfony/Component/Translation/Bridge/Lokalise/Tests/LokaliseProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/Tests/LokaliseProviderTest.php
@@ -831,8 +831,7 @@ class LokaliseProviderTest extends ProviderTestCase
                 </body>
               </file>
             </xliff>
-            XLIFF
-            ,
+            XLIFF,
             $expectedTranslatorBagEn,
         ];
 
@@ -861,8 +860,7 @@ class LokaliseProviderTest extends ProviderTestCase
                 </body>
               </file>
             </xliff>
-            XLIFF
-            ,
+            XLIFF,
             $expectedTranslatorBagEnUS,
         ];
 
@@ -891,8 +889,7 @@ class LokaliseProviderTest extends ProviderTestCase
                 </body>
               </file>
             </xliff>
-            XLIFF
-            ,
+            XLIFF,
             $expectedTranslatorBagFr,
         ];
     }
@@ -943,8 +940,7 @@ class LokaliseProviderTest extends ProviderTestCase
                             </body>
                           </file>
                         </xliff>
-                        XLIFF
-                    ,
+                        XLIFF,
                     'validators' => <<<'XLIFF'
                         <?xml version="1.0" encoding="UTF-8"?>
                         <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
@@ -964,8 +960,7 @@ class LokaliseProviderTest extends ProviderTestCase
                             </body>
                           </file>
                         </xliff>
-                        XLIFF
-                    ,
+                        XLIFF,
                 ],
                 'fr' => [
                     'messages' => <<<'XLIFF'
@@ -987,8 +982,7 @@ class LokaliseProviderTest extends ProviderTestCase
                             </body>
                           </file>
                         </xliff>
-                        XLIFF
-                    ,
+                        XLIFF,
                     'validators' => <<<'XLIFF'
                         <?xml version="1.0" encoding="UTF-8"?>
                         <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
@@ -1008,8 +1002,7 @@ class LokaliseProviderTest extends ProviderTestCase
                             </body>
                           </file>
                         </xliff>
-                        XLIFF
-                    ,
+                        XLIFF,
                 ],
             ],
             $expectedTranslatorBag,

--- a/src/Symfony/Component/Translation/Tests/Command/TranslationLintCommandTest.php
+++ b/src/Symfony/Component/Translation/Tests/Command/TranslationLintCommandTest.php
@@ -104,7 +104,9 @@ final class TranslationLintCommandTest extends TestCase
               en       messages   No
               fr       messages   No
              -------- ---------- --------
-            EOF, $display);
+            EOF,
+            $display
+        );
         $this->assertStringContainsString(\sprintf(<<<EOF
             Errors for locale "en" and domain "messages"
             --------------------------------------------
@@ -113,7 +115,9 @@ final class TranslationLintCommandTest extends TestCase
 
              [ERROR] Invalid message format (error #65807): %s: message formatter creation failed:
                      U_DEFAULT_KEYWORD_MISSING
-            EOF, \PHP_VERSION_ID >= 80500 ? 'MessageFormatter::__construct()' : 'msgfmt_create'), $display);
+            EOF,
+            \PHP_VERSION_ID >= 80500 ? 'MessageFormatter::__construct()' : 'msgfmt_create'
+        ), $display);
 
         if (\PHP_VERSION_ID >= 80500) {
             $this->assertStringContainsString(<<<EOF
@@ -129,7 +133,9 @@ final class TranslationLintCommandTest extends TestCase
 
                  [ERROR] Invalid message format (error #65807): MessageFormatter::__construct(): message formatter creation failed:
                          U_DEFAULT_KEYWORD_MISSING
-                EOF, $display);
+                EOF,
+                $display
+            );
         } else {
             $this->assertStringContainsString(<<<EOF
                 Errors for locale "fr" and domain "messages"
@@ -144,7 +150,9 @@ final class TranslationLintCommandTest extends TestCase
 
                  [ERROR] Invalid message format (error #65807): msgfmt_create: message formatter creation failed:
                          U_DEFAULT_KEYWORD_MISSING
-                EOF, $display);
+                EOF,
+                $display
+            );
         }
     }
 

--- a/src/Symfony/Component/Translation/Tests/Command/TranslationPullCommandTest.php
+++ b/src/Symfony/Component/Translation/Tests/Command/TranslationPullCommandTest.php
@@ -106,8 +106,9 @@ class TranslationPullCommandTest extends TranslationProviderTestCase
                     </body>
                 </file>
             </xliff>
-            XLIFF
-            , file_get_contents($filenameEn));
+            XLIFF,
+            file_get_contents($filenameEn)
+        );
         $this->assertXmlStringEqualsXmlString(<<<XLIFF
             <?xml version="1.0"?>
             <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
@@ -123,8 +124,9 @@ class TranslationPullCommandTest extends TranslationProviderTestCase
                     </body>
                 </file>
             </xliff>
-            XLIFF
-            , file_get_contents($filenameEnIcu));
+            XLIFF,
+            file_get_contents($filenameEnIcu)
+        );
         $this->assertXmlStringEqualsXmlString(<<<XLIFF
             <?xml version="1.0"?>
             <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
@@ -144,8 +146,9 @@ class TranslationPullCommandTest extends TranslationProviderTestCase
                     </body>
                 </file>
             </xliff>
-            XLIFF
-            , file_get_contents($filenameFr));
+            XLIFF,
+            file_get_contents($filenameFr)
+        );
         $this->assertXmlStringEqualsXmlString(<<<XLIFF
             <?xml version="1.0"?>
             <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
@@ -161,8 +164,9 @@ class TranslationPullCommandTest extends TranslationProviderTestCase
                     </body>
                 </file>
             </xliff>
-            XLIFF
-            , file_get_contents($filenameFrIcu));
+            XLIFF,
+            file_get_contents($filenameFrIcu)
+        );
     }
 
     public function testPullNewXlf20Messages()
@@ -215,8 +219,9 @@ class TranslationPullCommandTest extends TranslationProviderTestCase
                 </unit>
               </file>
             </xliff>
-            XLIFF
-            , file_get_contents($filenameEn));
+            XLIFF,
+            file_get_contents($filenameEn)
+        );
         $this->assertXmlStringEqualsXmlString(<<<XLIFF
             <?xml version="1.0" encoding="utf-8"?>
             <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="fr">
@@ -235,8 +240,9 @@ class TranslationPullCommandTest extends TranslationProviderTestCase
                 </unit>
               </file>
             </xliff>
-            XLIFF
-            , file_get_contents($filenameFr));
+            XLIFF,
+            file_get_contents($filenameFr)
+        );
     }
 
     public function testPullNewYamlMessagesAsInlined()
@@ -275,12 +281,16 @@ class TranslationPullCommandTest extends TranslationProviderTestCase
             new.foo: newFoo
             note: NOTE
 
-            YAML, file_get_contents($filenameEn));
+            YAML,
+            file_get_contents($filenameEn)
+        );
         $this->assertEquals(<<<YAML
             new.foo: nouveauFoo
             note: NOTE
 
-            YAML, file_get_contents($filenameFr));
+            YAML,
+            file_get_contents($filenameFr)
+        );
     }
 
     public function testPullNewYamlMessagesAsTree()
@@ -320,13 +330,17 @@ class TranslationPullCommandTest extends TranslationProviderTestCase
                 foo: newFoo
             note: NOTE
 
-            YAML, file_get_contents($filenameEn));
+            YAML,
+            file_get_contents($filenameEn)
+        );
         $this->assertEquals(<<<YAML
             new:
                 foo: nouveauFoo
             note: NOTE
 
-            YAML, file_get_contents($filenameFr));
+            YAML,
+            file_get_contents($filenameFr)
+        );
     }
 
     public function testPullForceMessages()
@@ -390,8 +404,9 @@ class TranslationPullCommandTest extends TranslationProviderTestCase
                     </body>
                 </file>
             </xliff>
-            XLIFF
-            , file_get_contents($filenameMessagesEn));
+            XLIFF,
+            file_get_contents($filenameMessagesEn)
+        );
         $this->assertXmlStringEqualsXmlString(<<<XLIFF
             <?xml version="1.0"?>
             <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
@@ -411,8 +426,9 @@ class TranslationPullCommandTest extends TranslationProviderTestCase
                     </body>
                 </file>
             </xliff>
-            XLIFF
-            , file_get_contents($filenameMessagesFr));
+            XLIFF,
+            file_get_contents($filenameMessagesFr)
+        );
 
         $this->assertXmlStringEqualsXmlString(<<<XLIFF
             <?xml version="1.0"?>
@@ -433,8 +449,9 @@ class TranslationPullCommandTest extends TranslationProviderTestCase
                     </body>
                 </file>
             </xliff>
-            XLIFF
-            , file_get_contents($filenameValidatorsEn));
+            XLIFF,
+            file_get_contents($filenameValidatorsEn)
+        );
         $this->assertXmlStringEqualsXmlString(<<<XLIFF
             <?xml version="1.0"?>
             <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
@@ -454,8 +471,9 @@ class TranslationPullCommandTest extends TranslationProviderTestCase
                     </body>
                 </file>
             </xliff>
-            XLIFF
-            , file_get_contents($filenameValidatorsFr));
+            XLIFF,
+            file_get_contents($filenameValidatorsFr)
+        );
     }
 
     #[RequiresPhpExtension('intl')]
@@ -511,8 +529,9 @@ class TranslationPullCommandTest extends TranslationProviderTestCase
                     </body>
                 </file>
             </xliff>
-            XLIFF
-            , file_get_contents($filenameEn));
+            XLIFF,
+            file_get_contents($filenameEn)
+        );
         $this->assertXmlStringEqualsXmlString(<<<XLIFF
             <?xml version="1.0"?>
             <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
@@ -532,8 +551,9 @@ class TranslationPullCommandTest extends TranslationProviderTestCase
                     </body>
                 </file>
             </xliff>
-            XLIFF
-            , file_get_contents($filenameFr));
+            XLIFF,
+            file_get_contents($filenameFr)
+        );
     }
 
     public function testPullMessagesWithDefaultLocale()
@@ -587,8 +607,9 @@ class TranslationPullCommandTest extends TranslationProviderTestCase
                     </body>
                 </file>
             </xliff>
-            XLIFF
-            , file_get_contents($filenameEn));
+            XLIFF,
+            file_get_contents($filenameEn)
+        );
         $this->assertXmlStringEqualsXmlString(<<<XLIFF
             <?xml version="1.0"?>
             <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
@@ -608,8 +629,9 @@ class TranslationPullCommandTest extends TranslationProviderTestCase
                     </body>
                 </file>
             </xliff>
-            XLIFF
-            , file_get_contents($filenameFr));
+            XLIFF,
+            file_get_contents($filenameFr)
+        );
     }
 
     public function testPullMessagesMultipleDomains()
@@ -664,8 +686,9 @@ class TranslationPullCommandTest extends TranslationProviderTestCase
                     </body>
                 </file>
             </xliff>
-            XLIFF
-            , file_get_contents($filenameMessages));
+            XLIFF,
+            file_get_contents($filenameMessages)
+        );
         $this->assertXmlStringEqualsXmlString(<<<XLIFF
             <?xml version="1.0"?>
             <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
@@ -685,8 +708,9 @@ class TranslationPullCommandTest extends TranslationProviderTestCase
                     </body>
                 </file>
             </xliff>
-            XLIFF
-            , file_get_contents($filenameDomain));
+            XLIFF,
+            file_get_contents($filenameDomain)
+        );
     }
 
     #[DataProvider('provideCompletionSuggestions')]

--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -316,8 +316,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
             %s
             return \$catalogue;
 
-            EOF
-            ,
+            EOF,
             $locale,
             var_export($this->getAllMessages($this->catalogues[$locale]), true),
             $fallbackContent
@@ -341,8 +340,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
                 $catalogue%s = new MessageCatalogue('%s', %s);
                 $catalogue%s->addFallbackCatalogue($catalogue%s);
 
-                EOF
-                ,
+                EOF,
                 $fallbackSuffix,
                 $fallback,
                 var_export($this->getAllMessages($fallbackCatalogue), true),

--- a/src/Symfony/Component/Uid/Tests/Command/InspectUlidCommandTest.php
+++ b/src/Symfony/Component/Uid/Tests/Command/InspectUlidCommandTest.php
@@ -43,8 +43,9 @@ final class InspectUlidCommandTest extends TestCase
                  ---------------------- -------------------------------------- 
 
 
-                EOF
-                , $commandTester->getDisplay(true));
+                EOF,
+                $commandTester->getDisplay(true)
+            );
         }
     }
 }

--- a/src/Symfony/Component/Uid/Tests/Command/InspectUuidCommandTest.php
+++ b/src/Symfony/Component/Uid/Tests/Command/InspectUuidCommandTest.php
@@ -42,8 +42,9 @@ final class InspectUuidCommandTest extends TestCase
              ----------------------- -------------------------------------- 
 
 
-            EOF
-            , $commandTester->getDisplay(true));
+            EOF,
+            $commandTester->getDisplay(true)
+        );
     }
 
     public function testUnknown()
@@ -63,8 +64,9 @@ final class InspectUuidCommandTest extends TestCase
              ----------------------- -------------------------------------- 
 
 
-            EOF
-            , $commandTester->getDisplay(true));
+            EOF,
+            $commandTester->getDisplay(true)
+        );
 
         $this->assertSame(0, $commandTester->execute(['uuid' => '461cc9b9-2397-2dba-91e9-33af4c63f7ec']));
         $this->assertSame(<<<EOF
@@ -79,8 +81,9 @@ final class InspectUuidCommandTest extends TestCase
              ----------------------- -------------------------------------- 
 
 
-            EOF
-            , $commandTester->getDisplay(true));
+            EOF,
+            $commandTester->getDisplay(true)
+        );
 
         $this->assertSame(0, $commandTester->execute(['uuid' => '461cc9b9-2397-adba-91e9-33af4c63f7ec']));
         $this->assertSame(<<<EOF
@@ -95,8 +98,9 @@ final class InspectUuidCommandTest extends TestCase
              ----------------------- -------------------------------------- 
 
 
-            EOF
-            , $commandTester->getDisplay(true));
+            EOF,
+            $commandTester->getDisplay(true)
+        );
 
         $this->assertSame(0, $commandTester->execute(['uuid' => '461cc9b9-2397-cdba-91e9-33af4c63f7ec']));
         $this->assertSame(<<<EOF
@@ -111,8 +115,9 @@ final class InspectUuidCommandTest extends TestCase
              ----------------------- -------------------------------------- 
 
 
-            EOF
-            , $commandTester->getDisplay(true));
+            EOF,
+            $commandTester->getDisplay(true)
+        );
     }
 
     public function testV1()
@@ -134,8 +139,9 @@ final class InspectUuidCommandTest extends TestCase
              ----------------------- -------------------------------------- 
 
 
-            EOF
-            , $commandTester->getDisplay(true));
+            EOF,
+            $commandTester->getDisplay(true)
+        );
     }
 
     public function testV3()
@@ -155,8 +161,9 @@ final class InspectUuidCommandTest extends TestCase
              ----------------------- -------------------------------------- 
 
 
-            EOF
-            , $commandTester->getDisplay(true));
+            EOF,
+            $commandTester->getDisplay(true)
+        );
     }
 
     public function testV4()
@@ -176,8 +183,9 @@ final class InspectUuidCommandTest extends TestCase
              ----------------------- -------------------------------------- 
 
 
-            EOF
-            , $commandTester->getDisplay(true));
+            EOF,
+            $commandTester->getDisplay(true)
+        );
     }
 
     public function testV5()
@@ -197,8 +205,9 @@ final class InspectUuidCommandTest extends TestCase
              ----------------------- -------------------------------------- 
 
 
-            EOF
-            , $commandTester->getDisplay(true));
+            EOF,
+            $commandTester->getDisplay(true)
+        );
     }
 
     public function testV6()
@@ -220,8 +229,9 @@ final class InspectUuidCommandTest extends TestCase
              ----------------------- -------------------------------------- 
 
 
-            EOF
-            , $commandTester->getDisplay(true));
+            EOF,
+            $commandTester->getDisplay(true)
+        );
     }
 
     public function testV7()
@@ -243,8 +253,9 @@ final class InspectUuidCommandTest extends TestCase
              ----------------------- -------------------------------------- 
 
 
-            EOF
-            , $commandTester->getDisplay(true));
+            EOF,
+            $commandTester->getDisplay(true)
+        );
     }
 
     public function testV8()
@@ -264,7 +275,8 @@ final class InspectUuidCommandTest extends TestCase
              ----------------------- -------------------------------------- 
 
 
-            EOF
-            , $commandTester->getDisplay(true));
+            EOF,
+            $commandTester->getDisplay(true)
+        );
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Validator/Tests/Command/DebugCommandTest.php
@@ -75,8 +75,8 @@ class DebugCommandTest extends TestCase
             |               |                                                    |                        | ]                                                          |
             +---------------+----------------------------------------------------+------------------------+------------------------------------------------------------+
 
-            TXT
-            , $tester->getDisplay(true)
+            TXT,
+            $tester->getDisplay(true)
         );
     }
 
@@ -173,8 +173,8 @@ class DebugCommandTest extends TestCase
             |               |                                                    |                        | ]                                                          |
             +---------------+----------------------------------------------------+------------------------+------------------------------------------------------------+
 
-            TXT
-            , $tester->getDisplay(true)
+            TXT,
+            $tester->getDisplay(true)
         );
     }
 
@@ -189,8 +189,8 @@ class DebugCommandTest extends TestCase
 
         $this->assertStringContainsString(<<<TXT
             Neither class nor path were found with "App\NotFoundResource" argument.
-            TXT
-            , $tester->getDisplay(true)
+            TXT,
+            $tester->getDisplay(true)
         );
     }
 }

--- a/src/Symfony/Component/VarDumper/Tests/Caster/CasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/CasterTest.php
@@ -159,8 +159,8 @@ class CasterTest extends TestCase
                 stdClass@anonymous {
                   -foo: "foo"
                 }
-                EOTXT
-            , $c
+                EOTXT,
+            $c
         );
 
         $c = eval('return new class implements \Countable { private $foo = "foo"; public function count(): int { return 0; } };');
@@ -170,8 +170,8 @@ class CasterTest extends TestCase
                 Countable@anonymous {
                   -foo: "foo"
                 }
-                EOTXT
-            , $c
+                EOTXT,
+            $c
         );
     }
 
@@ -196,7 +196,9 @@ class CasterTest extends TestCase
               #e: "e"
               -f: "f"
             }
-            DUMP, new B());
+            DUMP,
+            new B()
+        );
     }
 }
 

--- a/src/Symfony/Component/VarDumper/Tests/Caster/CurlCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/CurlCasterTest.php
@@ -34,6 +34,8 @@ class CurlCasterTest extends TestCase
                   http_code: %d
                 %A
                 }
-                EODUMP, $ch);
+                EODUMP,
+            $ch
+        );
     }
 }

--- a/src/Symfony/Component/VarDumper/Tests/Caster/FFICasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/FFICasterTest.php
@@ -46,7 +46,9 @@ class FFICasterTest extends TestCase
             FFI\CData<struct <anonymous>> size 4 align 4 {
               uint32_t x: 0
             }
-            PHP, \FFI::cdef()->new('struct { uint32_t x; }'));
+            PHP,
+            \FFI::cdef()->new('struct { uint32_t x; }')
+        );
     }
 
     public function testCastNamedStruct()
@@ -55,7 +57,9 @@ class FFICasterTest extends TestCase
             FFI\CData<struct Example> size 4 align 4 {
               uint32_t x: 0
             }
-            PHP, \FFI::cdef()->new('struct Example { uint32_t x; }'));
+            PHP,
+            \FFI::cdef()->new('struct Example { uint32_t x; }')
+        );
     }
 
     public function testCastAnonymousUnion()
@@ -65,7 +69,9 @@ class FFICasterTest extends TestCase
               uint32_t x: 0
               uint32_t y: 0
             }
-            PHP, \FFI::cdef()->new('union { uint32_t x; uint32_t y; }'));
+            PHP,
+            \FFI::cdef()->new('union { uint32_t x; uint32_t y; }')
+        );
     }
 
     public function testCastNamedUnion()
@@ -75,7 +81,9 @@ class FFICasterTest extends TestCase
               uint32_t x: 0
               uint32_t y: 0
             }
-            PHP, \FFI::cdef()->new('union Example { uint32_t x; uint32_t y; }'));
+            PHP,
+            \FFI::cdef()->new('union Example { uint32_t x; uint32_t y; }')
+        );
     }
 
     public function testCastAnonymousEnum()
@@ -84,7 +92,9 @@ class FFICasterTest extends TestCase
             FFI\CData<enum <anonymous>> size 4 align 4 {
               cdata: 0
             }
-            PHP, \FFI::cdef()->new('enum { a, b }'));
+            PHP,
+            \FFI::cdef()->new('enum { a, b }')
+        );
     }
 
     public function testCastNamedEnum()
@@ -93,7 +103,9 @@ class FFICasterTest extends TestCase
             FFI\CData<enum Example> size 4 align 4 {
               cdata: 0
             }
-            PHP, \FFI::cdef()->new('enum Example { a, b }'));
+            PHP,
+            \FFI::cdef()->new('enum Example { a, b }')
+        );
     }
 
     public static function scalarsDataProvider(): array
@@ -122,7 +134,9 @@ class FFICasterTest extends TestCase
             FFI\CData<$type> size $size align $align {
               cdata: $value
             }
-            PHP, \FFI::cdef()->new($type));
+            PHP,
+            \FFI::cdef()->new($type)
+        );
     }
 
     public function testCastVoidFunction()
@@ -133,7 +147,9 @@ class FFICasterTest extends TestCase
             $abi callable(): void {
               returnType: FFI\CType<void> size 1 align 1 {}
             }
-            PHP, \FFI::cdef()->new('void (*)(void)'));
+            PHP,
+            \FFI::cdef()->new('void (*)(void)')
+        );
     }
 
     public function testCastIntFunction()
@@ -144,7 +160,9 @@ class FFICasterTest extends TestCase
             $abi callable(): uint64_t {
               returnType: FFI\CType<uint64_t> size 8 align 8 {}
             }
-            PHP, \FFI::cdef()->new('unsigned long long (*)(void)'));
+            PHP,
+            \FFI::cdef()->new('unsigned long long (*)(void)')
+        );
     }
 
     public function testCastFunctionWithArguments()
@@ -155,7 +173,9 @@ class FFICasterTest extends TestCase
             $abi callable(int32_t, char*): void {
               returnType: FFI\CType<void> size 1 align 1 {}
             }
-            PHP, \FFI::cdef()->new('void (*)(int a, const char* b)'));
+            PHP,
+            \FFI::cdef()->new('void (*)(int a, const char* b)')
+        );
     }
 
     public function testCastNonCuttedPointerToChar()
@@ -170,7 +190,9 @@ class FFICasterTest extends TestCase
             FFI\CData<char*> size 8 align 8 {
               cdata: "Hello World!\x00"
             }
-            PHP, $pointer);
+            PHP,
+            $pointer
+        );
     }
 
     public function testCastCuttedPointerToChar()
@@ -188,7 +210,8 @@ class FFICasterTest extends TestCase
         // allowed by pages size of the current system
         $ffi = \FFI::cdef(<<<C
                 size_t zend_get_page_size(void);
-            C);
+            C
+        );
 
         $pageSize = $ffi->zend_get_page_size();
         $start = $ffi->cast('uintptr_t', $ffi->cast('char*', $pointer))->cdata;
@@ -199,7 +222,9 @@ class FFICasterTest extends TestCase
             FFI\CData<char*> size 8 align 8 {
               cdata: "$expectedMessage"…
             }
-            PHP, $pointer);
+            PHP,
+            $pointer
+        );
     }
 
     public function testCastNonTrailingCharPointer()
@@ -218,7 +243,9 @@ class FFICasterTest extends TestCase
             FFI\CData<char*> size 8 align 8 {
               cdata: %A"$actualMessage%s"
             }
-            PHP, $pointer);
+            PHP,
+            $pointer
+        );
     }
 
     public function testCastUnionWithDirectReferencedFields()
@@ -228,14 +255,17 @@ class FFICasterTest extends TestCase
                 int32_t x;
                 float y;
             } Event;
-            CPP);
+            CPP
+        );
 
         $this->assertDumpEquals(<<<'OUTPUT'
             FFI\CData<union Event> size 4 align 4 {
               int32_t x: 0
               float y: 0.0
             }
-            OUTPUT, $ffi->new('Event'));
+            OUTPUT,
+            $ffi->new('Event')
+        );
     }
 
     public function testCastUnionWithPointerReferencedFields()
@@ -245,7 +275,8 @@ class FFICasterTest extends TestCase
                 void* something;
                 char* string;
             } Event;
-            CPP);
+            CPP
+        );
 
         $this->assertDumpEquals(<<<'OUTPUT'
             FFI\CData<union Event> size 8 align 8 {
@@ -256,7 +287,9 @@ class FFICasterTest extends TestCase
                 0: FFI\CType<char> size 1 align 1 {}
               }
             }
-            OUTPUT, $ffi->new('Event'));
+            OUTPUT,
+            $ffi->new('Event')
+        );
     }
 
     public function testCastUnionWithMixedFields()
@@ -268,7 +301,8 @@ class FFICasterTest extends TestCase
                 char* c;
                 ptrdiff_t d;
             } Event;
-            CPP);
+            CPP
+        );
 
         $this->assertDumpEquals(<<<'OUTPUT'
             FFI\CData<union Event> size 8 align 8 {
@@ -281,7 +315,9 @@ class FFICasterTest extends TestCase
               }
               int64_t d: 0
             }
-            OUTPUT, $ffi->new('Event'));
+            OUTPUT,
+            $ffi->new('Event')
+        );
     }
 
     public function testCastPointerToEmptyScalars()
@@ -296,7 +332,8 @@ class FFICasterTest extends TestCase
                 double *f;
                 bool *g;
             } Example;
-            CPP);
+            CPP
+        );
 
         $this->assertDumpEquals(<<<'OUTPUT'
             FFI\CData<struct <anonymous>> size 56 align 8 {
@@ -308,7 +345,9 @@ class FFICasterTest extends TestCase
               double* f: null
               bool* g: null
             }
-            OUTPUT, $ffi->new('Example'));
+            OUTPUT,
+            $ffi->new('Example')
+        );
     }
 
     public function testCastPointerToNonEmptyScalars()
@@ -323,7 +362,8 @@ class FFICasterTest extends TestCase
                 double *f;
                 bool *g;
             } Example;
-            CPP);
+            CPP
+        );
 
         // Create values
         $int = \FFI::cdef()->new('int64_t');
@@ -369,7 +409,9 @@ class FFICasterTest extends TestCase
                 cdata: true
               }
             }
-            OUTPUT, $struct);
+            OUTPUT,
+            $struct
+        );
     }
 
     public function testCastPointerToStruct()
@@ -378,7 +420,8 @@ class FFICasterTest extends TestCase
             typedef struct {
                 int8_t a;
             } Example;
-            CPP);
+            CPP
+        );
 
         $struct = $ffi->new('Example', false);
 
@@ -388,7 +431,9 @@ class FFICasterTest extends TestCase
                 int8_t a: 0
               }
             }
-            OUTPUT, \FFI::addr($struct));
+            OUTPUT,
+            \FFI::addr($struct)
+        );
 
         // Save the pointer as variable so that
         // it is not cleaned up by the GC
@@ -402,7 +447,9 @@ class FFICasterTest extends TestCase
                 }
               }
             }
-            OUTPUT, \FFI::addr($pointer));
+            OUTPUT,
+            \FFI::addr($pointer)
+        );
 
         \FFI::free($struct);
     }
@@ -433,7 +480,8 @@ class FFICasterTest extends TestCase
                     struct __sub *h
                 );
             } Example;
-            CPP);
+            CPP
+        );
 
         $var = $ffi->new('Example');
         $var->func = (static fn (object $p) => 42);
@@ -460,6 +508,8 @@ class FFICasterTest extends TestCase
                 returnType: FFI\CType<int32_t> size 4 align 4 {}
               }
             }
-            OUTPUT, $var);
+            OUTPUT,
+            $var
+        );
     }
 }

--- a/src/Symfony/Component/VarDumper/Tests/Caster/OpenSSLCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/OpenSSLCasterTest.php
@@ -45,7 +45,9 @@ class OpenSSLCasterTest extends TestCase
                     """
                   type: 0
                 }
-                EODUMP, $key);
+                EODUMP,
+            $key
+        );
     }
 
     public function testOpensslCsr()
@@ -77,6 +79,8 @@ class OpenSSLCasterTest extends TestCase
                   commonName: "symfony.com"
                   emailAddress: "test@symfony.com"
                 }
-                EODUMP, $csr);
+                EODUMP,
+            $csr
+        );
     }
 }

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
@@ -79,8 +79,8 @@ class ReflectionCasterTest extends TestCase
                 %A         position: 0
                 %A
                 }
-                EOTXT
-            , $var
+                EOTXT,
+            $var
         );
     }
 
@@ -99,8 +99,8 @@ class ReflectionCasterTest extends TestCase
                   file: "%sReflectionCasterTest.php"
                   line: "%s"
                 }
-                EOTXT
-            , $var
+                EOTXT,
+            $var
         );
     }
 
@@ -125,8 +125,8 @@ class ReflectionCasterTest extends TestCase
                     line: "%d to %d"
                   }
                 ]
-                EOTXT
-            , $var
+                EOTXT,
+            $var
         );
     }
 
@@ -149,8 +149,8 @@ class ReflectionCasterTest extends TestCase
                   allowsNull: true
                   typeHint: "Symfony\Component\VarDumper\Tests\Fixtures\NotLoadableClass"
                 }
-                EOTXT
-            , $var
+                EOTXT,
+            $var
         );
     }
 
@@ -166,8 +166,8 @@ class ReflectionCasterTest extends TestCase
                   position: 0
                   typeHint: "int"
                 }
-                EOTXT
-            , $var
+                EOTXT,
+            $var
         );
     }
 
@@ -184,8 +184,8 @@ class ReflectionCasterTest extends TestCase
                   allowsNull: true
                   typeHint: "mixed"
                 }
-                EOTXT
-            , $var
+                EOTXT,
+            $var
         );
     }
 
@@ -201,8 +201,8 @@ class ReflectionCasterTest extends TestCase
                   position: 0
                   typeHint: "int|float"
                 }
-                EOTXT
-            , $var
+                EOTXT,
+            $var
         );
     }
 
@@ -219,8 +219,8 @@ class ReflectionCasterTest extends TestCase
                   allowsNull: true
                   typeHint: "int|float|null"
                 }
-                EOTXT
-            , $var
+                EOTXT,
+            $var
         );
     }
 
@@ -236,8 +236,8 @@ class ReflectionCasterTest extends TestCase
                   position: 0
                   typeHint: "Traversable&Countable"
                 }
-                EOTXT
-            , $var
+                EOTXT,
+            $var
         );
     }
 
@@ -251,8 +251,8 @@ class ReflectionCasterTest extends TestCase
                   +class: "Symfony\Component\VarDumper\Tests\Fixtures\ReflectionNamedTypeFixture"
                   modifiers: "public"
                 }
-                EOTXT
-            , $var
+                EOTXT,
+            $var
         );
     }
 
@@ -266,8 +266,8 @@ class ReflectionCasterTest extends TestCase
                   allowsNull: false
                   isBuiltin: true
                 }
-                EOTXT
-            , $var
+                EOTXT,
+            $var
         );
     }
 
@@ -291,8 +291,8 @@ class ReflectionCasterTest extends TestCase
                     }
                   ]
                 }
-                EOTXT
-            , $var
+                EOTXT,
+            $var
         );
     }
 
@@ -316,8 +316,8 @@ class ReflectionCasterTest extends TestCase
                     }
                   ]
                 }
-                EOTXT
-            , $var
+                EOTXT,
+            $var
         );
     }
 
@@ -351,8 +351,8 @@ class ReflectionCasterTest extends TestCase
                     }
                   ]
                 }
-                EOTXT
-            , $var
+                EOTXT,
+            $var
         );
     }
 
@@ -364,8 +364,8 @@ class ReflectionCasterTest extends TestCase
                 Symfony\Component\VarDumper\Tests\Fixtures\ExtendsReflectionTypeFixture {
                   allowsNull: false
                 }
-                EOTXT
-            , $var
+                EOTXT,
+            $var
         );
     }
 
@@ -382,8 +382,8 @@ class ReflectionCasterTest extends TestCase
                   file: "%s"
                   line: "%s"
                 }
-                EOTXT
-            , $f
+                EOTXT,
+            $f
         );
     }
 
@@ -400,8 +400,8 @@ class ReflectionCasterTest extends TestCase
                   file: "%s"
                   line: "%s"
                 }
-                EOTXT
-            , $f
+                EOTXT,
+            $f
         );
     }
 
@@ -417,8 +417,8 @@ class ReflectionCasterTest extends TestCase
                   file: "%s"
                   line: "%s"
                 }
-                EOTXT
-            , (new Php82NullStandaloneReturnType())->foo(...)
+                EOTXT,
+            (new Php82NullStandaloneReturnType())->foo(...)
         );
     }
 
@@ -435,8 +435,8 @@ class ReflectionCasterTest extends TestCase
                   file: "%s"
                   line: "%s"
                 }
-                EOTXT
-            , $f
+                EOTXT,
+            $f
         );
     }
 
@@ -453,8 +453,8 @@ class ReflectionCasterTest extends TestCase
                   file: "%s"
                   line: "%s"
                 }
-                EOTXT
-            , $f
+                EOTXT,
+            $f
         );
     }
 
@@ -622,8 +622,8 @@ class ReflectionCasterTest extends TestCase
                   file: "%s"
                   line: "%s"
                 }
-                EOTXT
-            , $f
+                EOTXT,
+            $f
         );
     }
 
@@ -643,8 +643,9 @@ class ReflectionCasterTest extends TestCase
               ]
             %A
             }
-            EOTXT
-            , $var);
+            EOTXT,
+            $var
+        );
     }
 
     public function testReflectionMethodWithAttribute()
@@ -666,8 +667,9 @@ class ReflectionCasterTest extends TestCase
               ]
             %A
             }
-            EOTXT
-            , $var);
+            EOTXT,
+            $var
+        );
     }
 
     public function testReflectionPropertyWithAttribute()
@@ -689,8 +691,9 @@ class ReflectionCasterTest extends TestCase
                 }
               ]
             }
-            EOTXT
-            , $var);
+            EOTXT,
+            $var
+        );
     }
 
     public function testReflectionClassConstantWithAttribute()
@@ -719,8 +722,9 @@ class ReflectionCasterTest extends TestCase
                 }
               ]
             }
-            EOTXT
-            , $var);
+            EOTXT,
+            $var
+        );
     }
 
     public function testReflectionParameterWithAttribute()
@@ -742,8 +746,9 @@ class ReflectionCasterTest extends TestCase
               ]
             %A
             }
-            EOTXT
-            , $var);
+            EOTXT,
+            $var
+        );
     }
 
     public static function stub(): void

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ResourceCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ResourceCasterTest.php
@@ -61,7 +61,9 @@ class ResourceCasterTest extends TestCase
                 dba resource {
                   file: %s
                 }
-                EODUMP, $dba);
+                EODUMP,
+            $dba
+        );
     }
 
     #[RequiresPhp('8.4.2')]
@@ -75,7 +77,9 @@ class ResourceCasterTest extends TestCase
                 Dba\Connection {
                   +file: %s
                 }
-                EODUMP, $dba);
+                EODUMP,
+            $dba
+        );
     }
 
     #[RequiresPhp('8.4')]
@@ -92,6 +96,8 @@ class ResourceCasterTest extends TestCase
             <<<'EODUMP'
                 Dba\Connection {
                 }
-                EODUMP, $dba);
+                EODUMP,
+            $dba
+        );
     }
 }

--- a/src/Symfony/Component/VarDumper/Tests/Caster/SocketCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/SocketCasterTest.php
@@ -34,7 +34,9 @@ class SocketCasterTest extends TestCase
                   timed_out: false
                   blocked: true%A
                 }
-                EODUMP, $socket);
+                EODUMP,
+            $socket
+        );
     }
 
     #[RequiresPhp('<8.3')]
@@ -49,7 +51,9 @@ class SocketCasterTest extends TestCase
                   timed_out: false
                   blocked: true
                 }
-                EODUMP, $socket);
+                EODUMP,
+            $socket
+        );
     }
 
     #[RequiresPhp('8.3')]
@@ -66,7 +70,9 @@ class SocketCasterTest extends TestCase
                   blocked: true
                   last_error: SOCKET_ECONNREFUSED
                 }
-                EODUMP, $socket);
+                EODUMP,
+            $socket
+        );
     }
 
     #[RequiresPhp('<8.3')]
@@ -82,7 +88,9 @@ class SocketCasterTest extends TestCase
                   blocked: true
                   last_error: SOCKET_ECONNREFUSED
                 }
-                EODUMP, $socket);
+                EODUMP,
+            $socket
+        );
     }
 
     #[RequiresPhp('8.3')]
@@ -99,7 +107,9 @@ class SocketCasterTest extends TestCase
                   blocked: true
                   last_error: SOCKET_ENOENT
                 }
-                EODUMP, $socket);
+                EODUMP,
+            $socket
+        );
     }
 
     #[RequiresPhp('<8.3')]
@@ -115,6 +125,8 @@ class SocketCasterTest extends TestCase
                   blocked: true
                   last_error: SOCKET_ENOENT
                 }
-                EODUMP, $socket);
+                EODUMP,
+            $socket
+        );
     }
 }

--- a/src/Symfony/Component/VarDumper/Tests/Caster/SqliteCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/SqliteCasterTest.php
@@ -36,6 +36,8 @@ class SqliteCasterTest extends TestCase
                     1 => "bar"
                   ]
                 }
-                EODUMP, $result);
+                EODUMP,
+            $result
+        );
     }
 }

--- a/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/CliDescriptorTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/CliDescriptorTest.php
@@ -108,8 +108,8 @@ class CliDescriptorTest extends TestCase
                 %A
                   source   \033]8;;phpstorm://open?file=/Users/ogi/symfony/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/CliDescriptorTest.php&line=30\033\CliDescriptorTest.php on line 30\033]8;;\033%A
                 %A
-                TXT
-            , true,
+                TXT,
+            true,
         ];
 
         yield 'cli' => [

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
@@ -114,8 +114,7 @@ class CliDumperTest extends TestCase
                   b"bin-key-é" => ""
                 ]
 
-                EOTXT
-            ,
+                EOTXT,
             $out
         );
     }
@@ -165,8 +164,9 @@ class CliDumperTest extends TestCase
               }
             }
 
-            EOTXT
-            , $dump);
+            EOTXT,
+            $dump
+        );
     }
 
     public static function provideDumpWithCommaFlagTests()
@@ -226,8 +226,7 @@ class CliDumperTest extends TestCase
                   2 => &1 null
                   "" => 2
                 ]
-                EOTXT
-            ,
+                EOTXT,
             $var
         );
     }
@@ -242,8 +241,7 @@ class CliDumperTest extends TestCase
                 {
                   +"1": 2
                 }
-                EOTXT
-            ,
+                EOTXT,
             $var
         );
     }
@@ -267,8 +265,7 @@ class CliDumperTest extends TestCase
             <<<EOTXT
                 Closed resource @{$res}
 
-                EOTXT
-            ,
+                EOTXT,
             $out
         );
     }
@@ -296,8 +293,7 @@ class CliDumperTest extends TestCase
                     2 => (3) "bar"
                   ]
                 ]
-                EOTXT
-            ,
+                EOTXT,
             $var
         );
 
@@ -315,7 +311,9 @@ class CliDumperTest extends TestCase
               +fullName: ~ string
               -noType: ~
             }
-            EODUMP, new VirtualProperty());
+            EODUMP,
+            new VirtualProperty()
+        );
     }
 
     public function testThrowingCaster()
@@ -375,8 +373,7 @@ class CliDumperTest extends TestCase
                 %Aoptions: []
                 }
 
-                EOTXT
-            ,
+                EOTXT,
             $out
         );
     }
@@ -400,8 +397,7 @@ class CliDumperTest extends TestCase
                   +"bar": &1 "foo"
                 }
 
-                EOTXT
-            ,
+                EOTXT,
             $out
         );
     }
@@ -415,8 +411,7 @@ class CliDumperTest extends TestCase
         $this->assertDumpMatchesFormat(
             <<<EOTXT
                 __PHP_Incomplete_Class(Foo\Buzz) {}
-                EOTXT
-            ,
+                EOTXT,
             $var
         );
     }
@@ -506,8 +501,7 @@ class CliDumperTest extends TestCase
                   ]
                 }
 
-                EOTXT
-            ,
+                EOTXT,
             $dump
         );
     }

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/HtmlDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/HtmlDumperTest.php
@@ -113,8 +113,7 @@ class HtmlDumperTest extends TestCase
                 </samp>]
                 </bar>
 
-                EOTXT
-            ,
+                EOTXT,
 
             $out
         );
@@ -139,7 +138,9 @@ class HtmlDumperTest extends TestCase
               -<span class=sf-dump-virtual><span class=sf-dump-private title="Private property defined in class:&#10;`Symfony\Component\VarDumper\Tests\Fixtures\VirtualProperty`">noType</span></span>: <span class=sf-dump-virtual><span class=sf-dump-const title="Virtual property">~</span></span>
             </samp>}
             </bar>
-            EODUMP, $out);
+            EODUMP,
+            $out
+        );
     }
 
     public function testCharset()
@@ -159,8 +160,7 @@ class HtmlDumperTest extends TestCase
                 <foo></foo><bar>b"<span class=sf-dump-str title="7 binary or non-UTF-8 characters">&#1057;&#1083;&#1086;&#1074;&#1072;&#1088;&#1100;</span>"
                 </bar>
 
-                EOTXT
-            ,
+                EOTXT,
             $out
         );
     }
@@ -185,8 +185,7 @@ class HtmlDumperTest extends TestCase
             <bar><span class=sf-dump-num>456</span>
             </bar>
 
-            EOTXT
-            ,
+            EOTXT,
             $out
         );
     }

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/ServerDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/ServerDumperTest.php
@@ -82,8 +82,9 @@ class ServerDumperTest extends TestCase
               ]
             ]
             %d
-            DUMP
-            , $dumped);
+            DUMP,
+            $dumped
+        );
     }
 
     private function getServerProcess(): Process

--- a/src/Symfony/Component/VarDumper/Tests/Server/ConnectionTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Server/ConnectionTest.php
@@ -65,8 +65,9 @@ class ConnectionTest extends TestCase
             ]
             %d
 
-            DUMP
-            , $dumped);
+            DUMP,
+            $dumped
+        );
     }
 
     public function testNoServer()

--- a/src/Symfony/Component/VarDumper/Tests/Test/VarDumperTestTraitTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Test/VarDumperTestTraitTest.php
@@ -67,8 +67,9 @@ class VarDumperTestTraitTest extends TestCase
                 +date: "09/07/2019"
               }
             ]
-            DUMP
-            , [1, 2, new \DateTimeImmutable('2019-07-09T0:00:00+00:00')]);
+            DUMP,
+            [1, 2, new \DateTimeImmutable('2019-07-09T0:00:00+00:00')]
+        );
 
         $this->tearDownVarDumper();
 

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -1342,8 +1342,7 @@ class ParserTest extends TestCase
                             </body>
 
                         footer # comment3
-                        EOT
-                    ,
+                        EOT,
                 ],
             ],
         ];
@@ -1370,8 +1369,7 @@ class ParserTest extends TestCase
                 # bar
                 baz
 
-                EOT
-            ,
+                EOT,
             'collection' => [
                 [
                     'one' => <<<'EOT'
@@ -1379,16 +1377,14 @@ class ParserTest extends TestCase
                         # bar
                         baz
 
-                        EOT
-                    ,
+                        EOT,
                 ],
                 [
                     'two' => <<<'EOT'
                         foo
                         # bar
                         baz
-                        EOT
-                    ,
+                        EOT,
                 ],
             ],
         ];
@@ -1452,8 +1448,7 @@ class ParserTest extends TestCase
                 'test' => <<<'EOT'
                     <h2>A heading</h2>
                     <ul> <li>a list</li> <li>may be a good example</li> </ul>
-                    EOT
-                ,
+                    EOT,
             ],
             $this->parser->parse($yaml)
         );
@@ -1479,8 +1474,7 @@ class ParserTest extends TestCase
                       <li>a list</li>
                       <li>may be a good example</li>
                     </ul>
-                    EOT
-                ,
+                    EOT,
             ],
             $this->parser->parse($yaml)
         );
@@ -1533,32 +1527,28 @@ class ParserTest extends TestCase
                 <<<'EOT'
                     data: !!binary |
                         SGVsbG8d29ybGQ=
-                    EOT
-                ,
+                    EOT,
                 '/The normalized base64 encoded data \(data without whitespace characters\) length must be a multiple of four \(\d+ bytes given\)/',
             ],
             'invalid characters in block scalar' => [
                 <<<'EOT'
                     data: !!binary |
                         SGVsbG8#d29ybGQ=
-                    EOT
-                ,
+                    EOT,
                 '/The base64 encoded data \(.*\) contains invalid characters/',
             ],
             'too many equals characters in block scalar' => [
                 <<<'EOT'
                     data: !!binary |
                         SGVsbG8gd29yb===
-                    EOT
-                ,
+                    EOT,
                 '/The base64 encoded data \(.*\) contains invalid characters/',
             ],
             'misplaced equals character in block scalar' => [
                 <<<'EOT'
                     data: !!binary |
                         SGVsbG8gd29ybG=Q
-                    EOT
-                ,
+                    EOT,
                 '/The base64 encoded data \(.*\) contains invalid characters/',
             ],
         ];
@@ -1846,8 +1836,7 @@ class ParserTest extends TestCase
                      - message: 'No emails received before timeout - Address: ''test@testemail.company.com''
                            Keyword: ''Your Order confirmation'' ttl: 50'
                        outcome: failed
-                    YAML
-                ,
+                    YAML,
                 [
                     'entries' => [
                         [
@@ -1863,8 +1852,7 @@ class ParserTest extends TestCase
                      - message: "No emails received before timeout - Address: \"test@testemail.company.com\"
                            Keyword: \"Your Order confirmation\" ttl: 50"
                        outcome: failed
-                    YAML
-                ,
+                    YAML,
                 [
                     'entries' => [
                         [
@@ -1968,8 +1956,7 @@ class ParserTest extends TestCase
                         'foo': 'bar',
                         'bar': 'baz'
                     }
-                    YAML
-                ,
+                    YAML,
             ],
             'mapping with unquoted strings and values' => [
                 ['foo' => 'bar', 'bar' => 'baz'],
@@ -1978,8 +1965,7 @@ class ParserTest extends TestCase
                         foo: bar,
                         bar: baz
                     }
-                    YAML
-                ,
+                    YAML,
             ],
             'sequence' => [
                 ['foo', 'bar'],
@@ -1988,8 +1974,7 @@ class ParserTest extends TestCase
                         'foo',
                         'bar'
                     ]
-                    YAML
-                ,
+                    YAML,
             ],
             'sequence with unquoted items' => [
                 ['foo', 'bar'],
@@ -1998,8 +1983,7 @@ class ParserTest extends TestCase
                         foo,
                         bar
                     ]
-                    YAML
-                ,
+                    YAML,
             ],
             'nested mapping terminating at end of line' => [
                 [
@@ -2010,8 +1994,7 @@ class ParserTest extends TestCase
                 <<<YAML
                     { foo: { bar: foobar }
                     }
-                    YAML
-                ,
+                    YAML,
             ],
             'nested sequence terminating at end of line' => [
                 [
@@ -2045,8 +2028,7 @@ class ParserTest extends TestCase
                         'foo': ['bar', 'foobar'],
                         'bar': ['baz']
                     }
-                    YAML
-                ,
+                    YAML,
             ],
             'sequence spanning multiple lines nested in mapping' => [
                 [
@@ -2061,8 +2043,7 @@ class ParserTest extends TestCase
                         bar,
                         baz
                     ]
-                    YAML
-                ,
+                    YAML,
             ],
             'sequence spanning multiple lines nested in mapping with a following mapping' => [
                 [
@@ -2095,8 +2076,7 @@ class ParserTest extends TestCase
                         bar,
                         baz
                     ]]
-                    YAML
-                ,
+                    YAML,
             ],
             'nested sequence nested in mapping starting on the following line' => [
                 [
@@ -2114,8 +2094,7 @@ class ParserTest extends TestCase
                             bar,
                             baz
                     ]]
-                    YAML
-                ,
+                    YAML,
             ],
             'mapping nested in sequence' => [
                 ['foo', ['bar' => 'baz']],
@@ -2126,8 +2105,7 @@ class ParserTest extends TestCase
                             'bar': 'baz'
                         }
                     ]
-                    YAML
-                ,
+                    YAML,
             ],
             'mapping spanning multiple lines nested in sequence' => [
                 [
@@ -2141,8 +2119,7 @@ class ParserTest extends TestCase
                         foo: bar,
                         bar: baz
                     }
-                    YAML
-                ,
+                    YAML,
             ],
             'nested mapping nested in sequence starting on the same line' => [
                 [
@@ -2159,8 +2136,7 @@ class ParserTest extends TestCase
                         },
                         bar: baz
                     }
-                    YAML
-                ,
+                    YAML,
             ],
             'nested mapping nested in sequence starting on the following line' => [
                 [
@@ -2178,8 +2154,7 @@ class ParserTest extends TestCase
                         },
                         bar: baz
                     }
-                    YAML
-                ,
+                    YAML,
             ],
             'single quoted multi-line string' => [
                 "foo\nbar",
@@ -2187,8 +2162,7 @@ class ParserTest extends TestCase
                     'foo
 
                     bar'
-                    YAML
-                ,
+                    YAML,
             ],
             'double quoted multi-line string' => [
                 "foo\nbar",
@@ -2196,8 +2170,7 @@ class ParserTest extends TestCase
                     'foo
 
                     bar'
-                    YAML
-                ,
+                    YAML,
             ],
             'single-quoted multi-line mapping value' => [
                 ['foo' => "bar\nbaz"],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix CS <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

Inspired while #61371 , but can be merged separately.

`@PHPxMigration` and `@Symfony` ruleset have different config for those rules. I assume the difference is coming from supporting pre-7.2 PHP version earlier in the codebase, where heredoc closure and trailing comma had to be on separated lines - but it's no longer the case.

Can we benefit from newer PHP syntax and incorporate those changes? (yes, `trailing_comma_in_multiline`, part of `@Symfony`, is already having this enabled!)
if so, i will also merge them into `@Symfony` ruleset itself afterwards.


with love by [PHP Coding Standards Fixer](https://cs.symfony.com/)
