### PR TITLE
[TypeInfo] Add missing array key for `arrayShape`

### DIFF
--- a/src/Symfony/Component/TypeInfo/Type/ArrayShapeType.php
+++ b/src/Symfony/Component/TypeInfo/Type/ArrayShapeType.php
@@ -25,12 +25,12 @@ use Symfony\Component\TypeInfo\TypeIdentifier;
 final class ArrayShapeType extends CollectionType
 {
     /**
-     * @var array<array{type: Type, optional: bool}>
+     * @var array<array-key, array{type: Type, optional: bool}>
      */
     private readonly array $shape;
 
     /**
-     * @param array<array{type: Type, optional: bool}> $shape
+     * @param array<array-key, array{type: Type, optional: bool}> $shape
      */
     public function __construct(
         array $shape,
@@ -71,7 +71,7 @@ final class ArrayShapeType extends CollectionType
     }
 
     /**
-     * @return array<array{type: Type, optional: bool}>
+     * @return array<array-key, array{type: Type, optional: bool}>
      */
     public function getShape(): array
     {

--- a/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
+++ b/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
@@ -196,7 +196,7 @@ trait TypeFactoryTrait
     }
 
     /**
-     * @param array<array{type: Type, optional?: bool}|Type> $shape
+     * @param array<array-key, array{type: Type, optional?: bool}|Type> $shape
      */
     public static function arrayShape(array $shape, bool $sealed = true, ?Type $extraKeyType = null, ?Type $extraValueType = null): ArrayShapeType
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

The key is important so it should be defined.

```php
$type = Type::arrayShape([
    'id' => Type::int(),
    'name' => ['type' => Type::string(), 'optional' => true],
]);
```

https://github.com/symfony/symfony/blob/986d4e2e40ef1b59bce71817bc405de5549479de/src/Symfony/Component/TypeInfo/Type/ArrayShapeType.php#L43-L46