### PR TITLE
[TypeInfo] Fix converting list to string

### DIFF
--- a/src/Symfony/Component/JsonStreamer/Tests/CacheWarmer/StreamerCacheWarmerTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/CacheWarmer/StreamerCacheWarmerTest.php
@@ -50,17 +50,17 @@ class StreamerCacheWarmerTest extends TestCase
 
         $this->assertSame([
             \sprintf('%s/13791ba3dc4369dc488ec78466326979.json.php', $this->streamWritersDir),
+            \sprintf('%s/30812f0966dfa8321b2976fca874c2c6.json.php', $this->streamWritersDir),
             \sprintf('%s/3d6bea319060b50305c349746ac6cabc.json.php', $this->streamWritersDir),
-            \sprintf('%s/6f7c0ed338bb3b8730cc67686a91941b.json.php', $this->streamWritersDir),
         ], glob($this->streamWritersDir.'/*'));
 
         $this->assertSame([
             \sprintf('%s/13791ba3dc4369dc488ec78466326979.json.php', $this->streamReadersDir),
             \sprintf('%s/13791ba3dc4369dc488ec78466326979.json.stream.php', $this->streamReadersDir),
+            \sprintf('%s/30812f0966dfa8321b2976fca874c2c6.json.php', $this->streamReadersDir),
+            \sprintf('%s/30812f0966dfa8321b2976fca874c2c6.json.stream.php', $this->streamReadersDir),
             \sprintf('%s/3d6bea319060b50305c349746ac6cabc.json.php', $this->streamReadersDir),
             \sprintf('%s/3d6bea319060b50305c349746ac6cabc.json.stream.php', $this->streamReadersDir),
-            \sprintf('%s/6f7c0ed338bb3b8730cc67686a91941b.json.php', $this->streamReadersDir),
-            \sprintf('%s/6f7c0ed338bb3b8730cc67686a91941b.json.stream.php', $this->streamReadersDir),
         ], glob($this->streamReadersDir.'/*'));
     }
 

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/list.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/list.stream.php
@@ -1,7 +1,7 @@
 <?php
 
 return static function (mixed $stream, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
-    $providers['array<int,mixed>'] = static function ($stream, $offset, $length) use ($options, $valueTransformers, $instantiator, &$providers) {
+    $providers['list<mixed>'] = static function ($stream, $offset, $length) use ($options, $valueTransformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitList($stream, $offset, $length);
         $iterable = static function ($stream, $data) use ($options, $valueTransformers, $instantiator, &$providers) {
             foreach ($data as $k => $v) {
@@ -10,5 +10,5 @@ return static function (mixed $stream, \Psr\Container\ContainerInterface $valueT
         };
         return \iterator_to_array($iterable($stream, $data));
     };
-    return $providers['array<int,mixed>']($stream, 0, null);
+    return $providers['list<mixed>']($stream, 0, null);
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object_list.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object_list.php
@@ -1,7 +1,7 @@
 <?php
 
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
-    $providers['array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>'] = static function ($data) use ($options, $valueTransformers, $instantiator, &$providers) {
+    $providers['list<Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>'] = static function ($data) use ($options, $valueTransformers, $instantiator, &$providers) {
         $iterable = static function ($data) use ($options, $valueTransformers, $instantiator, &$providers) {
             foreach ($data as $k => $v) {
                 yield $k => $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy']($v);
@@ -14,14 +14,14 @@ return static function (string|\Stringable $string, \Psr\Container\ContainerInte
             return '_symfony_missing_value' !== $v;
         }));
     };
-    $providers['array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null'] = static function ($data) use ($options, $valueTransformers, $instantiator, &$providers) {
+    $providers['list<Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null'] = static function ($data) use ($options, $valueTransformers, $instantiator, &$providers) {
         if (\is_array($data) && \array_is_list($data)) {
-            return $providers['array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>']($data);
+            return $providers['list<Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>']($data);
         }
         if (null === $data) {
             return null;
         }
-        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null".', \get_debug_type($data)));
+        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "list<Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null".', \get_debug_type($data)));
     };
-    return $providers['array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
+    return $providers['list<Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object_list.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object_list.stream.php
@@ -1,7 +1,7 @@
 <?php
 
 return static function (mixed $stream, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
-    $providers['array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>'] = static function ($stream, $offset, $length) use ($options, $valueTransformers, $instantiator, &$providers) {
+    $providers['list<Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>'] = static function ($stream, $offset, $length) use ($options, $valueTransformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitList($stream, $offset, $length);
         $iterable = static function ($stream, $data) use ($options, $valueTransformers, $instantiator, &$providers) {
             foreach ($data as $k => $v) {
@@ -22,15 +22,15 @@ return static function (mixed $stream, \Psr\Container\ContainerInterface $valueT
             }
         });
     };
-    $providers['array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null'] = static function ($stream, $offset, $length) use ($options, $valueTransformers, $instantiator, &$providers) {
+    $providers['list<Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null'] = static function ($stream, $offset, $length) use ($options, $valueTransformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Decoder::decodeStream($stream, $offset, $length);
         if (\is_array($data) && \array_is_list($data)) {
-            return $providers['array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>']($data);
+            return $providers['list<Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>']($data);
         }
         if (null === $data) {
             return null;
         }
-        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null".', \get_debug_type($data)));
+        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "list<Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null".', \get_debug_type($data)));
     };
-    return $providers['array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null']($stream, 0, null);
+    return $providers['list<Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null']($stream, 0, null);
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_list.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_list.php
@@ -1,7 +1,7 @@
 <?php
 
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
-    $providers['array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>'] = static function ($data) use ($options, $valueTransformers, $instantiator, &$providers) {
+    $providers['list<Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>'] = static function ($data) use ($options, $valueTransformers, $instantiator, &$providers) {
         $iterable = static function ($data) use ($options, $valueTransformers, $instantiator, &$providers) {
             foreach ($data as $k => $v) {
                 yield $k => $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy']($v);
@@ -14,5 +14,5 @@ return static function (string|\Stringable $string, \Psr\Container\ContainerInte
             return '_symfony_missing_value' !== $v;
         }));
     };
-    return $providers['array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
+    return $providers['list<Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_list.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_list.stream.php
@@ -1,7 +1,7 @@
 <?php
 
 return static function (mixed $stream, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
-    $providers['array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>'] = static function ($stream, $offset, $length) use ($options, $valueTransformers, $instantiator, &$providers) {
+    $providers['list<Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>'] = static function ($stream, $offset, $length) use ($options, $valueTransformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitList($stream, $offset, $length);
         $iterable = static function ($stream, $data) use ($options, $valueTransformers, $instantiator, &$providers) {
             foreach ($data as $k => $v) {
@@ -22,5 +22,5 @@ return static function (mixed $stream, \Psr\Container\ContainerInterface $valueT
             }
         });
     };
-    return $providers['array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>']($stream, 0, null);
+    return $providers['list<Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>']($stream, 0, null);
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/union.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/union.php
@@ -1,7 +1,7 @@
 <?php
 
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
-    $providers['array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>'] = static function ($data) use ($options, $valueTransformers, $instantiator, &$providers) {
+    $providers['list<Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>'] = static function ($data) use ($options, $valueTransformers, $instantiator, &$providers) {
         $iterable = static function ($data) use ($options, $valueTransformers, $instantiator, &$providers) {
             foreach ($data as $k => $v) {
                 yield $k => $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum']($v);
@@ -17,9 +17,9 @@ return static function (string|\Stringable $string, \Psr\Container\ContainerInte
             return '_symfony_missing_value' !== $v;
         }));
     };
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes|array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>|int'] = static function ($data) use ($options, $valueTransformers, $instantiator, &$providers) {
+    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes|int|list<Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>'] = static function ($data) use ($options, $valueTransformers, $instantiator, &$providers) {
         if (\is_array($data) && \array_is_list($data)) {
-            return $providers['array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>']($data);
+            return $providers['list<Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>']($data);
         }
         if (\is_array($data)) {
             return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes']($data);
@@ -27,7 +27,7 @@ return static function (string|\Stringable $string, \Psr\Container\ContainerInte
         if (\is_int($data)) {
             return $data;
         }
-        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes|array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>|int".', \get_debug_type($data)));
+        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes|int|list<Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>".', \get_debug_type($data)));
     };
-    return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes|array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>|int'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
+    return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes|int|list<Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/union.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/union.stream.php
@@ -1,7 +1,7 @@
 <?php
 
 return static function (mixed $stream, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
-    $providers['array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>'] = static function ($stream, $offset, $length) use ($options, $valueTransformers, $instantiator, &$providers) {
+    $providers['list<Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>'] = static function ($stream, $offset, $length) use ($options, $valueTransformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitList($stream, $offset, $length);
         $iterable = static function ($stream, $data) use ($options, $valueTransformers, $instantiator, &$providers) {
             foreach ($data as $k => $v) {
@@ -25,10 +25,10 @@ return static function (mixed $stream, \Psr\Container\ContainerInterface $valueT
             }
         });
     };
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes|array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>|int'] = static function ($stream, $offset, $length) use ($options, $valueTransformers, $instantiator, &$providers) {
+    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes|int|list<Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>'] = static function ($stream, $offset, $length) use ($options, $valueTransformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Decoder::decodeStream($stream, $offset, $length);
         if (\is_array($data) && \array_is_list($data)) {
-            return $providers['array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>']($data);
+            return $providers['list<Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>']($data);
         }
         if (\is_array($data)) {
             return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes']($data);
@@ -36,7 +36,7 @@ return static function (mixed $stream, \Psr\Container\ContainerInterface $valueT
         if (\is_int($data)) {
             return $data;
         }
-        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes|array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>|int".', \get_debug_type($data)));
+        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes|int|list<Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>".', \get_debug_type($data)));
     };
-    return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes|array<int,Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>|int']($stream, 0, null);
+    return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes|int|list<Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>']($stream, 0, null);
 };

--- a/src/Symfony/Component/TypeInfo/Tests/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/CollectionTypeTest.php
@@ -90,6 +90,9 @@ class CollectionTypeTest extends TestCase
 
         $type = new CollectionType(new GenericType(Type::builtin(TypeIdentifier::ARRAY), Type::string(), Type::bool()));
         $this->assertEquals('array<string,bool>', (string) $type);
+
+        $type = new CollectionType(Type::generic(Type::builtin(TypeIdentifier::ARRAY), Type::bool()), isList: true);
+        $this->assertEquals('list<bool>', (string) $type);
     }
 
     public function testAccepts()

--- a/src/Symfony/Component/TypeInfo/Type/CollectionType.php
+++ b/src/Symfony/Component/TypeInfo/Type/CollectionType.php
@@ -179,6 +179,10 @@ class CollectionType extends Type implements WrappingTypeInterface
 
     public function __toString(): string
     {
+        if ($this->isList && $this->type->isIdentifiedBy(TypeIdentifier::ARRAY)) {
+            return 'list<'.$this->getCollectionValueType().'>';
+        }
+
         return (string) $this->type;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

It should print `list<type>` instead of `array<type>`