### PR TITLE
[Security][TwigBridge] Add `access_decision()` and `access_decision_for_user()`

### DIFF
--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+ * Add `access_decision()` and `access_decision_for_user()` Twig functions
+
 7.3
 ---
 

--- a/src/Symfony/Bridge/Twig/Extension/SecurityExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/SecurityExtension.php
@@ -55,6 +55,18 @@ final class SecurityExtension extends AbstractExtension
         }
     }
 
+    public function getAccessDecision(mixed $role, mixed $object = null, ?string $field = null): AccessDecision
+    {
+        if (!class_exists(AccessDecision::class)) {
+            throw new \LogicException(\sprintf('Using the "access_decision()" function requires symfony/security-core >= 7.3. Try running "composer %s symfony/security-core".', $this->securityChecker ? 'update' : 'require'));
+        }
+
+        $accessDecision = new AccessDecision();
+        $this->isGranted($role, $object, $field, $accessDecision);
+
+        return $accessDecision;
+    }
+
     public function isGrantedForUser(UserInterface $user, mixed $attribute, mixed $subject = null, ?string $field = null, ?AccessDecision $accessDecision = null): bool
     {
         if (null === $this->securityChecker) {
@@ -78,6 +90,18 @@ final class SecurityExtension extends AbstractExtension
         } catch (AuthenticationCredentialsNotFoundException) {
             return false;
         }
+    }
+
+    public function getAccessDecisionForUser(UserInterface $user, mixed $attribute, mixed $subject = null, ?string $field = null): AccessDecision
+    {
+        if (!class_exists(AccessDecision::class)) {
+            throw new \LogicException(\sprintf('Using the "access_decision_for_user()" function requires symfony/security-core >= 7.3. Try running "composer %s symfony/security-core".', $this->securityChecker ? 'update' : 'require'));
+        }
+
+        $accessDecision = new AccessDecision();
+        $this->isGrantedForUser($user, $attribute, $subject, $field, $accessDecision);
+
+        return $accessDecision;
     }
 
     public function getImpersonateExitUrl(?string $exitTo = null): string
@@ -120,6 +144,7 @@ final class SecurityExtension extends AbstractExtension
     {
         $functions = [
             new TwigFunction('is_granted', $this->isGranted(...)),
+            new TwigFunction('access_decision', $this->getAccessDecision(...)),
             new TwigFunction('impersonation_exit_url', $this->getImpersonateExitUrl(...)),
             new TwigFunction('impersonation_exit_path', $this->getImpersonateExitPath(...)),
             new TwigFunction('impersonation_url', $this->getImpersonateUrl(...)),
@@ -128,6 +153,7 @@ final class SecurityExtension extends AbstractExtension
 
         if ($this->securityChecker instanceof UserAuthorizationCheckerInterface) {
             $functions[] = new TwigFunction('is_granted_for_user', $this->isGrantedForUser(...));
+            $functions[] = new TwigFunction('access_decision_for_user', $this->getAccessDecisionForUser(...));
         }
 
         return $functions;

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 7.4
 ---
 
+ * Add `Security::getAccessDecision()` and `getAccessDecisionForUser()` helpers
  * Add options to configure a cache pool and storage service for login throttling rate limiters
  * Register alias for argument for password hasher when its key is not a class name:
 

--- a/src/Symfony/Bundle/SecurityBundle/Security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security.php
@@ -65,6 +65,14 @@ class Security implements AuthorizationCheckerInterface, UserAuthorizationChecke
             ->isGranted($attributes, $subject, $accessDecision);
     }
 
+    public function getAccessDecision(mixed $attributes, mixed $subject = null): AccessDecision
+    {
+        $accessDecision = new AccessDecision();
+        $this->isGranted($attributes, $subject, $accessDecision);
+
+        return $accessDecision;
+    }
+
     /**
      * Checks if the attribute is granted against the user and optionally supplied subject.
      *
@@ -74,6 +82,14 @@ class Security implements AuthorizationCheckerInterface, UserAuthorizationChecke
     {
         return $this->container->get('security.user_authorization_checker')
             ->isGrantedForUser($user, $attribute, $subject, $accessDecision);
+    }
+
+    public function getAccessDecisionForUser(UserInterface $user, mixed $attributes, mixed $subject = null): AccessDecision
+    {
+        $accessDecision = new AccessDecision();
+        $this->isGrantedForUser($user, $attributes, $subject, $accessDecision);
+
+        return $accessDecision;
     }
 
     public function getToken(): ?TokenInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

This PR adds 2 new methods and the corresponding twig helpers to retrieve the access decision from a Voter rather than simply the result. This way, you can enumerate the AccessDecision::votes and retrieve the votes and their reason, and you can get the reason message.

For instance, in a controller or service:

```php
$accessDecision = $this->security->getAccessDecision('post_edit', $post);
if (!$accessDecision->isGranted) {
    $this->addFlash('danger', $accessDecision->getMessage());
}
```

Same for a user on his behalf, and same in Twig;

```twig
{% set access = access_decision('post_edit', post) %}

<a href="/post/123/edit" 
    {% if not access.isGranted %}
    title="You don't have access to this post : {{ access.message }}"
    disabled
    {% endif %}
>
  Edit this post
</a>    
```

