### PR TITLE
[HttpKernel] #[MapUploadedFile] throws http exception on empty files array if argument not nullable nor has default value

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
@@ -232,10 +232,10 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
 
     private function mapUploadedFile(Request $request, ArgumentMetadata $argument, MapUploadedFile $attribute): UploadedFile|array|null
     {
-        if (!($files = $request->files->get($attribute->name ?? $argument->getName(), [])) && ($argument->isNullable() || $argument->hasDefaultValue())) {
+        if (!($files = $request->files->get($attribute->name ?? $argument->getName())) && ($argument->isNullable() || $argument->hasDefaultValue())) {
             return null;
         }
 
-        return $files;
+        return $files ?? ('array' === $argument->getType() ? [] : null);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/UploadedFileValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/UploadedFileValueResolverTest.php
@@ -82,6 +82,35 @@ class UploadedFileValueResolverTest extends TestCase
             $request,
             HttpKernelInterface::MAIN_REQUEST
         );
+
+        $this->expectException(HttpException::class);
+
+        $resolver->onKernelControllerArguments($event);
+    }
+
+    /**
+     * @dataProvider provideContext
+     */
+    public function testEmptyArrayArgument(RequestPayloadValueResolver $resolver, Request $request)
+    {
+        $attribute = new MapUploadedFile();
+        $argument = new ArgumentMetadata(
+            'qux',
+            'array',
+            false,
+            false,
+            null,
+            false,
+            [$attribute::class => $attribute]
+        );
+        $event = new ControllerArgumentsEvent(
+            $this->createMock(HttpKernelInterface::class),
+            static function () {},
+            $resolver->resolve($request, $argument),
+            $request,
+            HttpKernelInterface::MAIN_REQUEST
+        );
+
         $resolver->onKernelControllerArguments($event);
         $data = $event->getArguments()[0];
 
@@ -316,6 +345,36 @@ class UploadedFileValueResolverTest extends TestCase
         $argument = new ArgumentMetadata(
             'qux',
             UploadedFile::class,
+            false,
+            false,
+            null,
+            true,
+            [$attribute::class => $attribute]
+        );
+        /** @var HttpKernelInterface&MockObject $httpKernel */
+        $httpKernel = $this->createMock(HttpKernelInterface::class);
+        $event = new ControllerArgumentsEvent(
+            $httpKernel,
+            static function () {},
+            $resolver->resolve($request, $argument),
+            $request,
+            HttpKernelInterface::MAIN_REQUEST
+        );
+        $resolver->onKernelControllerArguments($event);
+        $data = $event->getArguments()[0];
+
+        $this->assertNull($data);
+    }
+
+    /**
+     * @dataProvider provideContext
+     */
+    public function testShouldAllowEmptyWhenNullableArray(RequestPayloadValueResolver $resolver, Request $request)
+    {
+        $attribute = new MapUploadedFile();
+        $argument = new ArgumentMetadata(
+            'qux',
+            'array',
             false,
             false,
             null,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61376 
| License       | MIT

Fixes #61376 
