### PR TITLE
[GitHub] Update .github/PULL_REQUEST_TEMPLATE.md to remove SF 7.2 as it's not supported anymore

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 | Q             | A
 | ------------- | ---
-| Branch?       | 7.4 for features / 6.4, 7.2, or 7.3 for bug fixes
+| Branch?       | 7.4 for features / 6.4, or 7.3 for bug fixes
 | Bug fix?      | yes/no
 | New feature?  | yes/no <!-- if yes, also update src/**/CHANGELOG.md -->
 | Deprecations? | yes/no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | no
| License       | MIT

According to https://symfony.com/releases/7.2 version 7.2 is not supported anymore