### PR TITLE
[Messenger] Show package installation hint also for amqps

### DIFF
--- a/src/Symfony/Component/Messenger/Transport/TransportFactory.php
+++ b/src/Symfony/Component/Messenger/Transport/TransportFactory.php
@@ -41,7 +41,7 @@ class TransportFactory implements TransportFactoryInterface
 
         // Help the user to select Symfony packages based on protocol.
         $packageSuggestion = '';
-        if (str_starts_with($dsn, 'amqp://')) {
+        if (str_starts_with($dsn, 'amqp://') || str_starts_with($dsn, 'amqps://')) {
             $packageSuggestion = ' Run "composer require symfony/amqp-messenger" to install AMQP transport.';
         } elseif (str_starts_with($dsn, 'doctrine://')) {
             $packageSuggestion = ' Run "composer require symfony/doctrine-messenger" to install Doctrine transport.';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes?
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

A customer was confused that he could not use `amqps`, but he did forget to install the package. Adjusted the check to show that package also for `amqps` urls