### PR TITLE
[EventDispatcher] conflict with symfony/security-http <7.4

### DIFF
--- a/src/Symfony/Component/EventDispatcher/composer.json
+++ b/src/Symfony/Component/EventDispatcher/composer.json
@@ -30,6 +30,7 @@
         "symfony/stopwatch": "^7.4|^8.0"
     },
     "conflict": {
+        "symfony/security-http": "<7.4",
         "symfony/service-contracts": "<2.5"
     },
     "provide": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Because of
src/Symfony/Component/Security/Http/Firewall.php:    public static function getSubscribedEvents()

That's the only occurrence on 6.4