### PR TITLE
 Remove calls to no-op functions, deprecated in PHP 8.5

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
@@ -36,7 +36,6 @@ class DateTimeToLocalizedStringTransformerTest extends BaseDateTimeTransformerTe
         // Normalize intl. configuration settings.
         if (\extension_loaded('intl')) {
             $this->initialTestCaseUseException = ini_set('intl.use_exceptions', 0);
-            $this->initialTestCaseErrorLevel = ini_set('intl.error_level', 0);
         }
 
         // Since we test against "de_AT", we need the full implementation
@@ -55,7 +54,6 @@ class DateTimeToLocalizedStringTransformerTest extends BaseDateTimeTransformerTe
 
         if (\extension_loaded('intl')) {
             ini_set('intl.use_exceptions', $this->initialTestCaseUseException);
-            ini_set('intl.error_level', $this->initialTestCaseErrorLevel);
         }
     }
 
@@ -346,6 +344,7 @@ class DateTimeToLocalizedStringTransformerTest extends BaseDateTimeTransformerTe
 
     /**
      * @requires extension intl
+     * @requires PHP < 8.5
      */
     public function testReverseTransformWrapsIntlErrorsWithErrorLevel()
     {
@@ -378,6 +377,7 @@ class DateTimeToLocalizedStringTransformerTest extends BaseDateTimeTransformerTe
 
     /**
      * @requires extension intl
+     * @requires PHP < 8.5
      */
     public function testReverseTransformWrapsIntlErrorsWithExceptionsAndErrorLevel()
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
@@ -21,14 +21,12 @@ class NumberToLocalizedStringTransformerTest extends TestCase
     private string $defaultLocale;
 
     private $initialTestCaseUseException;
-    private $initialTestCaseErrorLevel;
 
     protected function setUp(): void
     {
         // Normalize intl. configuration settings.
         if (\extension_loaded('intl')) {
             $this->initialTestCaseUseException = ini_set('intl.use_exceptions', 0);
-            $this->initialTestCaseErrorLevel = ini_set('intl.error_level', 0);
         }
 
         $this->defaultLocale = \Locale::getDefault();
@@ -41,7 +39,6 @@ class NumberToLocalizedStringTransformerTest extends TestCase
 
         if (\extension_loaded('intl')) {
             ini_set('intl.use_exceptions', $this->initialTestCaseUseException);
-            ini_set('intl.error_level', $this->initialTestCaseErrorLevel);
         }
     }
 
@@ -664,6 +661,7 @@ class NumberToLocalizedStringTransformerTest extends TestCase
 
     /**
      * @requires extension intl
+     * @requires PHP < 8.5
      */
     public function testReverseTransformWrapsIntlErrorsWithErrorLevel()
     {
@@ -696,6 +694,7 @@ class NumberToLocalizedStringTransformerTest extends TestCase
 
     /**
      * @requires extension intl
+     * @requires PHP < 8.5
      */
     public function testReverseTransformWrapsIntlErrorsWithExceptionsAndErrorLevel()
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/PercentToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/PercentToLocalizedStringTransformerTest.php
@@ -21,14 +21,12 @@ class PercentToLocalizedStringTransformerTest extends TestCase
     private string $defaultLocale;
 
     private $initialTestCaseUseException;
-    private $initialTestCaseErrorLevel;
 
     protected function setUp(): void
     {
         // Normalize intl. configuration settings.
         if (\extension_loaded('intl')) {
             $this->initialTestCaseUseException = ini_set('intl.use_exceptions', 0);
-            $this->initialTestCaseErrorLevel = ini_set('intl.error_level', 0);
         }
 
         $this->defaultLocale = \Locale::getDefault();
@@ -41,7 +39,6 @@ class PercentToLocalizedStringTransformerTest extends TestCase
 
         if (\extension_loaded('intl')) {
             ini_set('intl.use_exceptions', $this->initialTestCaseUseException);
-            ini_set('intl.error_level', $this->initialTestCaseErrorLevel);
         }
     }
 
@@ -492,6 +489,7 @@ class PercentToLocalizedStringTransformerTest extends TestCase
 
     /**
      * @requires extension intl
+     * @requires PHP < 8.5
      */
     public function testReverseTransformWrapsIntlErrorsWithErrorLevel()
     {
@@ -524,6 +522,7 @@ class PercentToLocalizedStringTransformerTest extends TestCase
 
     /**
      * @requires extension intl
+     * @requires PHP < 8.5
      */
     public function testReverseTransformWrapsIntlErrorsWithExceptionsAndErrorLevel()
     {

--- a/src/Symfony/Component/HttpClient/Internal/CurlClientState.php
+++ b/src/Symfony/Component/HttpClient/Internal/CurlClientState.php
@@ -83,7 +83,6 @@ final class CurlClientState extends ClientState
         foreach ($this->pushedResponses as $url => $response) {
             $this->logger?->debug(\sprintf('Unused pushed response: "%s"', $url));
             curl_multi_remove_handle($this->handle, $response->handle);
-            curl_close($response->handle);
         }
 
         $this->pushedResponses = [];

--- a/src/Symfony/Component/Validator/Constraints/ImageValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ImageValidator.php
@@ -230,8 +230,6 @@ class ImageValidator extends FileValidator
 
                 return;
             }
-
-            imagedestroy($resource);
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

As listed on https://wiki.php.net/rfc/deprecations_php_8_5