### PR TITLE
[Security] Add bool return type to CustomCredentials callable parameter

### DIFF
--- a/src/Symfony/Component/Security/Http/Authenticator/Passport/Credentials/CustomCredentials.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Passport/Credentials/CustomCredentials.php
@@ -27,9 +27,9 @@ class CustomCredentials implements CredentialsInterface
     private bool $resolved = false;
 
     /**
-     * @param callable(mixed, UserInterface) $customCredentialsChecker If the callable does not return `true`, a
-     *                                                                 BadCredentialsException is thrown. You may
-     *                                                                 also throw a more specific exception.
+     * @param callable(mixed, UserInterface): bool $customCredentialsChecker If the callable does not return `true`, a
+     *                                                                       BadCredentialsException is thrown. You may
+     *                                                                       also throw a more specific exception.
      */
     public function __construct(
         callable $customCredentialsChecker,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3 for bug fixes
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fixes comment in [#60245](https://github.com/symfony/symfony/pull/60245#issuecomment-3187293201)
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
