### PR TITLE
[HttpKernel] Deprecate `__sleep/wakeup()` on kernels and data collectors and make `Profile` final

### DIFF
--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -52,6 +52,13 @@ HttpFoundation
 
  * Deprecate using `Request::sendHeaders()` after headers have already been sent; use a `StreamedResponse` instead
 
+HttpKernel
+----------
+
+ * Deprecate implementing `__sleep/wakeup()` on kernels; use `__(un)serialize()` instead
+ * Deprecate implementing `__sleep/wakeup()` on data collectors; use `__(un)serialize()` instead
+ * Make `Profile` final and `Profiler::__sleep()` internal
+
 Security
 --------
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Profiler/TemplateManagerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Profiler/TemplateManagerTest.php
@@ -13,6 +13,9 @@ namespace Symfony\Bundle\WebProfilerBundle\Tests\Profiler;
 
 use Symfony\Bundle\WebProfilerBundle\Profiler\TemplateManager;
 use Symfony\Bundle\WebProfilerBundle\Tests\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Profiler\Profile;
 use Symfony\Component\HttpKernel\Profiler\Profiler;
@@ -57,7 +60,10 @@ class TemplateManagerTest extends TestCase
             ->withAnyParameters()
             ->willReturnCallback($this->profilerHasCallback(...));
 
-        $this->assertEquals('@Foo/Collector/foo.html.twig', $this->templateManager->getName(new ProfileDummy(), 'foo'));
+        $profile = new Profile('token');
+        $profile->addCollector(new DummyCollector('foo'));
+        $profile->addCollector(new DummyCollector('bar'));
+        $this->assertEquals('@Foo/Collector/foo.html.twig', $this->templateManager->getName($profile, 'foo'));
     }
 
     public function profilerHasCallback($panel)
@@ -94,19 +100,18 @@ class TemplateManagerTest extends TestCase
     }
 }
 
-class ProfileDummy extends Profile
+class DummyCollector extends DataCollector
 {
-    public function __construct()
+    public function __construct(private string $name)
     {
-        parent::__construct('token');
     }
 
-    public function hasCollector(string $name): bool
+    public function getName(): string
     {
-        return match ($name) {
-            'foo',
-            'bar' => true,
-            default => false,
-        };
+        return $this->name;
+    }
+
+    public function collect(Request $request, Response $response, ?\Throwable $exception = null): void
+    {
     }
 }

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+ * Deprecate implementing `__sleep/wakeup()` on kernels; use `__(un)serialize()` instead
+ * Deprecate implementing `__sleep/wakeup()` on data collectors; use `__(un)serialize()` instead
+ * Make `Profile` final and `Profiler::__sleep()` internal
+
 7.3
 ---
 

--- a/src/Symfony/Component/HttpKernel/Profiler/Profile.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profile.php
@@ -14,9 +14,9 @@ namespace Symfony\Component\HttpKernel\Profiler;
 use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
 
 /**
- * Profile.
- *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @final since Symfony 7.4
  */
 class Profile
 {
@@ -248,6 +248,9 @@ class Profile
         return isset($this->collectors[$name]);
     }
 
+    /**
+     * @internal since Symfony 7.4, will be replaced by `__serialize()` in 8.0
+     */
     public function __sleep(): array
     {
         return ['token', 'parent', 'children', 'collectors', 'ip', 'method', 'url', 'time', 'statusCode', 'virtualType'];

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -246,7 +246,7 @@ class KernelTest extends TestCase
         $env = 'test_env';
         $debug = true;
         $kernel = new KernelForTest($env, $debug);
-        $expected = \sprintf("O:48:\"%s\":2:{s:14:\"\0*\0environment\";s:8:\"test_env\";s:8:\"\0*\0debug\";b:1;}", KernelForTest::class);
+        $expected = \sprintf('O:48:"%s":2:{s:11:"environment";s:8:"test_env";s:5:"debug";b:1;}', KernelForTest::class);
         $this->assertEquals($expected, serialize($kernel));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | -
| License       | MIT

Related to #61407

FTR, I searched for code extending `Profile` on github and found none.