### PR TITLE
[String] Deprecate implementing `__sleep/wakeup()` on string implementations

### DIFF
--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -71,6 +71,11 @@ Serializer
 
  * Make `AttributeMetadata` and `ClassMetadata` final
 
+String
+------
+
+ * Deprecate implementing `__sleep/wakeup()` on string implementations
+
 Translation
 -----------
 

--- a/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
@@ -108,24 +108,30 @@ abstract class DataCollector implements DataCollectorInterface
 
     public function __unserialize(array $data): void
     {
-        if (self::class !== (new \ReflectionMethod($this, '__wakeup'))->class) {
+        if ($wakeup = self::class !== (new \ReflectionMethod($this, '__wakeup'))->class) {
             trigger_deprecation('symfony/http-kernel', '7.4', 'Implementing "%s::__wakeup()" is deprecated, use "__unserialize()" instead.', get_debug_type($this));
         }
 
         if (\in_array(array_keys($data), [['data'], ["\0*\0data"]], true)) {
             $this->data = $data['data'] ?? $data["\0*\0data"];
 
+            if ($wakeup) {
+                $this->__wakeup();
+            }
+
             return;
         }
 
         trigger_deprecation('symfony/http-kernel', '7.4', 'Passing more than just key "data" to "%s::__unserialize()" is deprecated, populate properties in "%s::__unserialize()" instead.', self::class, get_debug_type($this));
 
-        \Closure::bind(function ($data) {
+        \Closure::bind(function ($data) use ($wakeup) {
             foreach ($data as $key => $value) {
                 $this->{("\0" === $key[0] ?? '') ? substr($key, 1 + strrpos($key, "\0")) : $key} = $value;
             }
 
-            $this->__wakeup();
+            if ($wakeup) {
+                $this->__wakeup();
+            }
         }, $this, static::class)($data);
     }
 
@@ -136,6 +142,8 @@ abstract class DataCollector implements DataCollectorInterface
      */
     public function __sleep(): array
     {
+        trigger_deprecation('symfony/http-kernel', '7.4', 'Calling "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
+
         return ['data'];
     }
 
@@ -146,6 +154,7 @@ abstract class DataCollector implements DataCollectorInterface
      */
     public function __wakeup(): void
     {
+        trigger_deprecation('symfony/http-kernel', '7.4', 'Calling "%s::__wakeup()" is deprecated, use "__unserialize()" instead.', get_debug_type($this));
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Mapping/AttributeMetadata.php
+++ b/src/Symfony/Component/Serializer/Mapping/AttributeMetadata.php
@@ -219,7 +219,7 @@ class AttributeMetadata implements AttributeMetadataInterface
     /**
      * @internal since Symfony 7.4, will be replaced by `__serialize()` in 8.0
      *
-     * @final since Symfony 7.4
+     * @final since Symfony 7.4, will be replaced by `__serialize()` in 8.0
      */
     public function __sleep(): array
     {

--- a/src/Symfony/Component/Serializer/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Serializer/Mapping/ClassMetadata.php
@@ -96,7 +96,7 @@ class ClassMetadata implements ClassMetadataInterface
     /**
      * @internal since Symfony 7.4, will be replaced by `__serialize()` in 8.0
      *
-     * @final since Symfony 7.4
+     * @final since Symfony 7.4, will be replaced by `__serialize()` in 8.0
      */
     public function __sleep(): array
     {

--- a/src/Symfony/Component/String/AbstractString.php
+++ b/src/Symfony/Component/String/AbstractString.php
@@ -706,8 +706,37 @@ abstract class AbstractString implements \Stringable, \JsonSerializable
         return $str;
     }
 
+    public function __serialize(): array
+    {
+        if (self::class === (new \ReflectionMethod($this, '__sleep'))->class) {
+            return ['string' => $this->string];
+        }
+
+        trigger_deprecation('symfony/string', '7.4', 'Implementing "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
+
+        $data = [];
+        foreach ($this->__sleep() as $key) {
+            try {
+                if (($r = new \ReflectionProperty($this, $key))->isInitialized($this)) {
+                    $data[$key] = $r->getValue($this);
+                }
+            } catch (\ReflectionException) {
+                $data[$key] = $this->$key;
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * @internal since Symfony 7.4, will be removed in 8.0
+     *
+     * @final since Symfony 7.4, will be removed in 8.0
+     */
     public function __sleep(): array
     {
+        trigger_deprecation('symfony/string', '7.4', 'Calling "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
+
         return ['string'];
     }
 

--- a/src/Symfony/Component/String/CHANGELOG.md
+++ b/src/Symfony/Component/String/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+ * Deprecate implementing `__sleep/wakeup()` on string implementations
+
 7.3
 ---
 

--- a/src/Symfony/Component/String/LazyString.php
+++ b/src/Symfony/Component/String/LazyString.php
@@ -101,6 +101,35 @@ class LazyString implements \Stringable, \JsonSerializable
         }
     }
 
+    public function __serialize(): array
+    {
+        if (self::class === (new \ReflectionMethod($this, '__sleep'))->class) {
+            $this->__toString();
+
+            return ['value' => $this->value];
+        }
+
+        trigger_deprecation('symfony/string', '7.4', 'Implementing "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
+
+        $data = [];
+        foreach ($this->__sleep() as $key) {
+            try {
+                if (($r = new \ReflectionProperty($this, $key))->isInitialized($this)) {
+                    $data[$key] = $r->getValue($this);
+                }
+            } catch (\ReflectionException) {
+                $data[$key] = $this->$key;
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * @internal since Symfony 7.4, will be removed in 8.0
+     *
+     * @final since Symfony 7.4, will be removed in 8.0
+     */
     public function __sleep(): array
     {
         $this->__toString();

--- a/src/Symfony/Component/String/composer.json
+++ b/src/Symfony/Component/String/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=8.2",
+        "symfony/deprecation-contracts": "^2.5|^3.0",
         "symfony/polyfill-ctype": "~1.8",
         "symfony/polyfill-intl-grapheme": "~1.33",
         "symfony/polyfill-intl-normalizer": "~1.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | -
| License       | MIT

Similar to #61412