### PR TITLE
[Validator] Deprecate implementing `__sleep/wakeup()` on GenericMetadata implementations

### DIFF
--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -84,6 +84,7 @@ Translation
 Validator
 ---------
 
+ * Deprecate implementing `__sleep/wakeup()` on `GenericMetadata` implementations; use `__(un)serialize()` instead
  * Deprecate passing a list of choices to the first argument of the `Choice` constraint. Use the `choices` option instead
  * Deprecate `getRequiredOptions()` and `getDefaultOption()` methods of the `All`, `AtLeastOneOf`, `CardScheme`, `Collection`,
    `CssColor`, `Expression`, `Regex`, `Sequentially`, `Type`, and `When` constraints

--- a/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
@@ -136,9 +136,7 @@ abstract class DataCollector implements DataCollectorInterface
     }
 
     /**
-     * @internal since Symfony 7.4, will be removed in 8.0
-     *
-     * @final since Symfony 7.4, will be removed in 8.0
+     * @deprecated since Symfony 7.4, will be replaced by `__serialize()` in 8.0
      */
     public function __sleep(): array
     {
@@ -148,9 +146,7 @@ abstract class DataCollector implements DataCollectorInterface
     }
 
     /**
-     * @internal since Symfony 7.4, will be removed in 8.0
-     *
-     * @final since Symfony 7.4, will be removed in 8.0
+     * @deprecated since Symfony 7.4, will be replaced by `__unserialize()` in 8.0
      */
     public function __wakeup(): void
     {

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -846,9 +846,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
     }
 
     /**
-     * @internal since Symfony 7.4, will be removed in 8.0
-     *
-     * @final since Symfony 7.4, will be removed in 8.0
+     * @deprecated since Symfony 7.4, will be replaced by `__serialize()` in 8.0
      */
     public function __sleep(): array
     {
@@ -858,9 +856,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
     }
 
     /**
-     * @internal since Symfony 7.4, will be removed in 8.0
-     *
-     * @final since Symfony 7.4, will be removed in 8.0
+     * @deprecated since Symfony 7.4, will be replaced by `__unserialize()` in 8.0
      */
     public function __wakeup(): void
     {

--- a/src/Symfony/Component/String/AbstractString.php
+++ b/src/Symfony/Component/String/AbstractString.php
@@ -729,9 +729,7 @@ abstract class AbstractString implements \Stringable, \JsonSerializable
     }
 
     /**
-     * @internal since Symfony 7.4, will be removed in 8.0
-     *
-     * @final since Symfony 7.4, will be removed in 8.0
+     * @deprecated since Symfony 7.4, will be replaced by `__unserialize()` in 8.0
      */
     public function __sleep(): array
     {

--- a/src/Symfony/Component/String/LazyString.php
+++ b/src/Symfony/Component/String/LazyString.php
@@ -126,12 +126,12 @@ class LazyString implements \Stringable, \JsonSerializable
     }
 
     /**
-     * @internal since Symfony 7.4, will be removed in 8.0
-     *
-     * @final since Symfony 7.4, will be removed in 8.0
+     * @deprecated since Symfony 7.4, will be replaced by `__serialize()` in 8.0
      */
     public function __sleep(): array
     {
+        trigger_deprecation('symfony/string', '7.4', 'Calling "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
+
         $this->__toString();
 
         return ['value'];

--- a/src/Symfony/Component/String/UnicodeString.php
+++ b/src/Symfony/Component/String/UnicodeString.php
@@ -406,9 +406,7 @@ class UnicodeString extends AbstractUnicodeString
     }
 
     /**
-     * @internal since Symfony 7.4, will be removed in 8.0
-     *
-     * @final since Symfony 7.4, will be removed in 8.0
+     * @deprecated since Symfony 7.4, will be replaced by `__unserialize()` in 8.0
      */
     public function __wakeup(): void
     {

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 7.4
 ---
 
+ * Deprecate implementing `__sleep/wakeup()` on `GenericMetadata` implementations; use `__(un)serialize()` instead
  * Deprecate passing a list of choices to the first argument of the `Choice` constraint. Use the `choices` option instead
  * Add the `min` and `max` parameter to the `Length` constraint violation
  * Deprecate `getRequiredOptions()` and `getDefaultOption()` methods of the `All`, `AtLeastOneOf`, `CardScheme`, `Collection`,

--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -119,14 +119,53 @@ class ClassMetadata extends GenericMetadata implements ClassMetadataInterface
         }
     }
 
+    public function __serialize(): array
+    {
+        if (self::class === (new \ReflectionMethod($this, '__sleep'))->class) {
+            return [
+                'constraints' => $this->constraints,
+                'constraintsByGroup' => $this->constraintsByGroup,
+                'traversalStrategy' => $this->traversalStrategy,
+                'autoMappingStrategy' => $this->autoMappingStrategy,
+                'getters' => $this->getters,
+                'groupSequence' => $this->groupSequence,
+                'groupSequenceProvider' => $this->groupSequenceProvider,
+                'groupProvider' => $this->groupProvider,
+                'members' => $this->members,
+                'name' => $this->name,
+                'properties' => $this->properties,
+                'defaultGroup' => $this->defaultGroup,
+            ];
+        }
+
+        trigger_deprecation('symfony/validator', '7.4', 'Implementing "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
+
+        $data = [];
+        foreach ($this->__sleep() as $key) {
+            try {
+                if (($r = new \ReflectionProperty($this, $key))->isInitialized($this)) {
+                    $data[$key] = $r->getValue($this);
+                }
+            } catch (\ReflectionException) {
+                $data[$key] = $this->$key;
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * @deprecated since Symfony 7.4, will be removed in 8.0
+     */
     public function __sleep(): array
     {
-        $parentProperties = parent::__sleep();
+        trigger_deprecation('symfony/validator', '7.4', 'Calling "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
 
-        // Don't store the cascading strategy. Classes never cascade.
-        unset($parentProperties[array_search('cascadingStrategy', $parentProperties)]);
-
-        return array_merge($parentProperties, [
+        return [
+            'constraints',
+            'constraintsByGroup',
+            'traversalStrategy',
+            'autoMappingStrategy',
             'getters',
             'groupSequence',
             'groupSequenceProvider',
@@ -135,7 +174,7 @@ class ClassMetadata extends GenericMetadata implements ClassMetadataInterface
             'name',
             'properties',
             'defaultGroup',
-        ]);
+        ];
     }
 
     public function getClassName(): string

--- a/src/Symfony/Component/Validator/Mapping/GenericMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/GenericMetadata.php
@@ -83,13 +83,41 @@ class GenericMetadata implements MetadataInterface
      */
     public int $autoMappingStrategy = AutoMappingStrategy::NONE;
 
+    public function __serialize(): array
+    {
+        if (self::class === (new \ReflectionMethod($this, '__sleep'))->class) {
+            return [
+                'constraints' => $this->constraints,
+                'constraintsByGroup' => $this->constraintsByGroup,
+                'cascadingStrategy' => $this->cascadingStrategy,
+                'traversalStrategy' => $this->traversalStrategy,
+                'autoMappingStrategy' => $this->autoMappingStrategy,
+            ];
+        }
+
+        trigger_deprecation('symfony/validator', '7.4', 'Implementing "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
+
+        $data = [];
+        foreach ($this->__sleep() as $key) {
+            try {
+                if (($r = new \ReflectionProperty($this, $key))->isInitialized($this)) {
+                    $data[$key] = $r->getValue($this);
+                }
+            } catch (\ReflectionException) {
+                $data[$key] = $this->$key;
+            }
+        }
+
+        return $data;
+    }
+
     /**
-     * Returns the names of the properties that should be serialized.
-     *
-     * @return string[]
+     * @deprecated since Symfony 7.4, will be replaced by `__serialize()` in 8.0
      */
     public function __sleep(): array
     {
+        trigger_deprecation('symfony/validator', '7.4', 'Calling "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
+
         return [
             'constraints',
             'constraintsByGroup',

--- a/src/Symfony/Component/Validator/Mapping/MemberMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/MemberMetadata.php
@@ -76,13 +76,54 @@ abstract class MemberMetadata extends GenericMetadata implements PropertyMetadat
         return $this;
     }
 
+    public function __serialize(): array
+    {
+        if (self::class === (new \ReflectionMethod($this, '__sleep'))->class) {
+            return [
+                'constraints' => $this->constraints,
+                'constraintsByGroup' => $this->constraintsByGroup,
+                'cascadingStrategy' => $this->cascadingStrategy,
+                'traversalStrategy' => $this->traversalStrategy,
+                'autoMappingStrategy' => $this->autoMappingStrategy,
+                'class' => $this->class,
+                'name' => $this->name,
+                'property' => $this->property,
+            ];
+        }
+
+        trigger_deprecation('symfony/validator', '7.4', 'Implementing "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
+
+        $data = [];
+        foreach ($this->__sleep() as $key) {
+            try {
+                if (($r = new \ReflectionProperty($this, $key))->isInitialized($this)) {
+                    $data[$key] = $r->getValue($this);
+                }
+            } catch (\ReflectionException) {
+                $data[$key] = $this->$key;
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * @deprecated since Symfony 7.4, will be replaced by `__serialize()` in 8.0
+     */
     public function __sleep(): array
     {
-        return array_merge(parent::__sleep(), [
+        trigger_deprecation('symfony/validator', '7.4', 'Calling "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
+
+        return [
+            'constraints',
+            'constraintsByGroup',
+            'cascadingStrategy',
+            'traversalStrategy',
+            'autoMappingStrategy',
             'class',
             'name',
             'property',
-        ]);
+        ];
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | -
| License       | MIT

Similar to https://github.com/symfony/symfony/pull/61412