### PR TITLE
[WebProfilerBundle] Hide WDT clearer when it is hidden

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -113,6 +113,9 @@
     background: var(--sf-toolbar-gray-700);
 }
 
+.sf-toolbar.sf-toolbar-closed .sf-toolbar-clearer {
+    display: none;
+}
 .sf-toolbar.sf-toolbar-closed .sf-toolbarreset .sf-toolbar-block {
     display: none;
 }

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
@@ -32,8 +32,8 @@
         </div>
     {% endif %}
 
-    <button class="sf-toolbar-toggle-button" type="button" id="sfToolbarToggleButton-{{ token }}" title="Close Toolbar" accesskey="D" aria-expanded="true" aria-controls="sfToolbarMainContent-{{ token }}">
-        <i class="sf-toolbar-icon-opened">{{ source('@WebProfiler/Icon/close.svg') }}</i>
-        <i class="sf-toolbar-icon-closed">{{ source('@WebProfiler/Icon/symfony.svg') }}</i>
+    <button class="sf-toolbar-toggle-button" type="button" id="sfToolbarToggleButton-{{ token }}" accesskey="D" aria-expanded="true" aria-controls="sfToolbarMainContent-{{ token }}">
+        <i class="sf-toolbar-icon-opened" title="Close Toolbar">{{ source('@WebProfiler/Icon/close.svg') }}</i>
+        <i class="sf-toolbar-icon-closed" title="Open Toolbar">{{ source('@WebProfiler/Icon/symfony.svg') }}</i>
     </button>
 </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61416
| License       | MIT

The `sf-toolbar-clearer` allows for the WDT not to hide content by reserving a space for it, so it should be hidden when the toolbar is closed.

Given a page with a black footer when you scroll to the bottom,

Before: 
<img width="450" height="70" alt="Screenshot 2025-08-14 at 16-05-35 SensioLabs Jobs" src="https://github.com/user-attachments/assets/2c372015-543a-44bb-83d4-8abc8a97dd54" />

After: 
<img width="450" height="70" alt="Screenshot 2025-08-14 at 16-06-04 SensioLabs Jobs" src="https://github.com/user-attachments/assets/8017ceb4-e112-48b9-a578-e7a7db616e44" />

The toggler’s `title` attribute has also been moved to its icons so that it depends on the WDT’s state.