### PR TITLE
[Mime] Deprecate implementing `__sleep/wakeup()` on `AbstractPart` implementations

### DIFF
--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -59,6 +59,11 @@ HttpKernel
  * Deprecate implementing `__sleep/wakeup()` on data collectors; use `__(un)serialize()` instead
  * Make `Profile` final and `Profiler::__sleep()` internal
 
+Mime
+----
+
+ * Deprecate implementing `__sleep/wakeup()` on `AbstractPart` implementations; use `__(un)serialize()` instead
+
 Security
 --------
 

--- a/src/Symfony/Bridge/PhpUnit/composer.json
+++ b/src/Symfony/Bridge/PhpUnit/composer.json
@@ -23,7 +23,7 @@
         "php": ">=8.1.0"
     },
     "require-dev": {
-        "symfony/deprecation-contracts": "^2.5|^3.0",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/error-handler": "^6.4.3|^7.0.3|^8.0"
     },
     "autoload": {

--- a/src/Symfony/Component/Cache/composer.json
+++ b/src/Symfony/Component/Cache/composer.json
@@ -25,7 +25,7 @@
         "psr/cache": "^2.0|^3.0",
         "psr/log": "^1.1|^2|^3",
         "symfony/cache-contracts": "^3.6",
-        "symfony/deprecation-contracts": "^2.5|^3.0",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/service-contracts": "^2.5|^3",
         "symfony/var-exporter": "^6.4|^7.0|^8.0"
     },

--- a/src/Symfony/Component/HttpFoundation/composer.json
+++ b/src/Symfony/Component/HttpFoundation/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=8.2",
-        "symfony/deprecation-contracts": "^2.5|^3.0",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/polyfill-mbstring": "~1.1",
         "symfony/polyfill-php83": "^1.27"
     },

--- a/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
@@ -86,7 +86,7 @@ abstract class DataCollector implements DataCollectorInterface
 
     public function __serialize(): array
     {
-        if (self::class === (new \ReflectionMethod($this, '__sleep'))->class) {
+        if (self::class === (new \ReflectionMethod($this, '__sleep'))->class || self::class !== (new \ReflectionMethod($this, '__serialize'))->class) {
             return ['data' => $this->data];
         }
 
@@ -108,7 +108,7 @@ abstract class DataCollector implements DataCollectorInterface
 
     public function __unserialize(array $data): void
     {
-        if ($wakeup = self::class !== (new \ReflectionMethod($this, '__wakeup'))->class) {
+        if ($wakeup = self::class !== (new \ReflectionMethod($this, '__wakeup'))->class && self::class === (new \ReflectionMethod($this, '__unserialize'))->class) {
             trigger_deprecation('symfony/http-kernel', '7.4', 'Implementing "%s::__wakeup()" is deprecated, use "__unserialize()" instead.', get_debug_type($this));
         }
 

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -777,7 +777,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
 
     public function __serialize(): array
     {
-        if (self::class === (new \ReflectionMethod($this, '__sleep'))->class) {
+        if (self::class === (new \ReflectionMethod($this, '__sleep'))->class || self::class !== (new \ReflectionMethod($this, '__serialize'))->class) {
             return [
                 'environment' => $this->environment,
                 'debug' => $this->debug,
@@ -802,7 +802,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
 
     public function __unserialize(array $data): void
     {
-        if ($wakeup = self::class !== (new \ReflectionMethod($this, '__wakeup'))->class) {
+        if ($wakeup = self::class !== (new \ReflectionMethod($this, '__wakeup'))->class && self::class === (new \ReflectionMethod($this, '__unserialize'))->class) {
             trigger_deprecation('symfony/http-kernel', '7.4', 'Implementing "%s::__wakeup()" is deprecated, use "__unserialize()" instead.', get_debug_type($this));
         }
 

--- a/src/Symfony/Component/Mime/CHANGELOG.md
+++ b/src/Symfony/Component/Mime/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+ * Deprecate implementing `__sleep/wakeup()` on `AbstractPart` implementations; use `__(un)serialize()` instead
+
 7.0
 ---
 

--- a/src/Symfony/Component/Mime/Part/AbstractPart.php
+++ b/src/Symfony/Component/Mime/Part/AbstractPart.php
@@ -62,4 +62,55 @@ abstract class AbstractPart
     abstract public function getMediaType(): string;
 
     abstract public function getMediaSubtype(): string;
+
+    public function __serialize(): array
+    {
+        if (!method_exists($this, '__sleep')) {
+            return ['headers' => $this->headers];
+        }
+
+        trigger_deprecation('symfony/mime', '7.4', 'Implementing "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
+
+        $data = [];
+        foreach ($this->__sleep() as $key) {
+            try {
+                if (($r = new \ReflectionProperty($this, $key))->isInitialized($this)) {
+                    $data[$key] = $r->getValue($this);
+                }
+            } catch (\ReflectionException) {
+                $data[$key] = $this->$key;
+            }
+        }
+
+        return $data;
+    }
+
+    public function __unserialize(array $data): void
+    {
+        if ($wakeup = method_exists($this, '__wakeup') && self::class === (new \ReflectionMethod($this, '__unserialize'))->class) {
+            trigger_deprecation('symfony/mime', '7.4', 'Implementing "%s::__wakeup()" is deprecated, use "__unserialize()" instead.', get_debug_type($this));
+        }
+
+        if (['headers'] === array_keys($data)) {
+            $this->headers = $data['headers'];
+
+            if ($wakeup) {
+                $this->__wakeup();
+            }
+
+            return;
+        }
+
+        trigger_deprecation('symfony/mime', '7.4', 'Passing more than just key "headers" to "%s::__unserialize()" is deprecated, populate properties in "%s::__unserialize()" instead.', self::class, get_debug_type($this));
+
+        \Closure::bind(function ($data) use ($wakeup) {
+            foreach ($data as $key => $value) {
+                $this->{("\0" === $key[0] ?? '') ? substr($key, 1 + strrpos($key, "\0")) : $key} = $value;
+            }
+
+            if ($wakeup) {
+                $this->__wakeup();
+            }
+        }, $this, static::class)($data);
+    }
 }

--- a/src/Symfony/Component/Mime/Part/DataPart.php
+++ b/src/Symfony/Component/Mime/Part/DataPart.php
@@ -19,7 +19,7 @@ use Symfony\Component\Mime\Header\Headers;
  */
 class DataPart extends TextPart
 {
-    /** @internal */
+    /** @internal, to be removed in 8.0 */
     protected array $_parent;
 
     private ?string $filename = null;
@@ -129,8 +129,86 @@ class DataPart extends TextPart
         return bin2hex(random_bytes(16)).'@symfony';
     }
 
+    public function __serialize(): array
+    {
+        if (self::class === (new \ReflectionMethod($this, '__sleep'))->class || self::class !== (new \ReflectionMethod($this, '__serialize'))->class) {
+            $parent = parent::__serialize();
+            $headers = $parent['_headers'];
+            unset($parent['_headers']);
+
+            return [
+                '_headers' => $headers,
+                '_parent' => $parent,
+                'filename' => $this->filename,
+                'mediaType' => $this->mediaType,
+            ];
+        }
+
+        trigger_deprecation('symfony/mime', '7.4', 'Implementing "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
+
+        $data = [];
+        foreach ($this->__sleep() as $key) {
+            try {
+                if (($r = new \ReflectionProperty($this, $key))->isInitialized($this)) {
+                    $data[$key] = $r->getValue($this);
+                }
+            } catch (\ReflectionException) {
+                $data[$key] = $this->$key;
+            }
+        }
+
+        return $data;
+    }
+
+    public function __unserialize(array $data): void
+    {
+        if ($wakeup = self::class !== (new \ReflectionMethod($this, '__wakeup'))->class && self::class === (new \ReflectionMethod($this, '__unserialize'))->class) {
+            trigger_deprecation('symfony/mime', '7.4', 'Implementing "%s::__wakeup()" is deprecated, use "__unserialize()" instead.', get_debug_type($this));
+        }
+
+        if (['_headers', '_parent', 'filename', 'mediaType'] === array_keys($data)) {
+            parent::__unserialize(['_headers' => $data['_headers'], ...$data['_parent']]);
+            $this->filename = $data['filename'];
+            $this->mediaType = $data['mediaType'];
+
+            if ($wakeup) {
+                $this->__wakeup();
+            }
+
+            return;
+        }
+
+        if (["\0*\0_headers", "\0*\0_parent", "\0".self::class."\0filename", "\0".self::class."\0mediaType"] === array_keys($data)) {
+            parent::__unserialize(['_headers' => $data["\0*\0_headers"], ...$data["\0*\0_parent"]]);
+            $this->filename = $data["\0".self::class."\0filename"];
+            $this->mediaType = $data["\0".self::class."\0mediaType"];
+
+            if ($wakeup) {
+                $this->__wakeup();
+            }
+
+            return;
+        }
+
+        trigger_deprecation('symfony/mime', '7.4', 'Passing extra keys to "%s::__unserialize()" is deprecated, populate properties in "%s::__unserialize()" instead.', self::class, get_debug_type($this));
+
+        \Closure::bind(function ($data) use ($wakeup) {
+            foreach ($data as $key => $value) {
+                $this->{("\0" === $key[0] ?? '') ? substr($key, 1 + strrpos($key, "\0")) : $key} = $value;
+            }
+
+            if ($wakeup) {
+                $this->__wakeup();
+            }
+        }, $this, static::class)($data);
+    }
+
+    /**
+     * @deprecated since Symfony 7.4, will be replaced by `__serialize()` in 8.0
+     */
     public function __sleep(): array
     {
+        trigger_deprecation('symfony/mime', '7.4', 'Calling "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
         // converts the body to a string
         parent::__sleep();
 
@@ -144,6 +222,9 @@ class DataPart extends TextPart
         return ['_headers', '_parent', 'filename', 'mediaType'];
     }
 
+    /**
+     * @deprecated since Symfony 7.4, will be replaced by `__unserialize()` in 8.0
+     */
     public function __wakeup(): void
     {
         $r = new \ReflectionProperty(AbstractPart::class, 'headers');

--- a/src/Symfony/Component/Mime/Part/MessagePart.php
+++ b/src/Symfony/Component/Mime/Part/MessagePart.php
@@ -57,13 +57,78 @@ class MessagePart extends DataPart
         return $this->message->toIterable();
     }
 
+    public function __serialize(): array
+    {
+        if (self::class === (new \ReflectionMethod($this, '__sleep'))->class || self::class !== (new \ReflectionMethod($this, '__serialize'))->class) {
+            return ['message' => $this->message];
+        }
+
+        trigger_deprecation('symfony/mime', '7.4', 'Implementing "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
+
+        $data = [];
+        foreach ($this->__sleep() as $key) {
+            try {
+                if (($r = new \ReflectionProperty($this, $key))->isInitialized($this)) {
+                    $data[$key] = $r->getValue($this);
+                }
+            } catch (\ReflectionException) {
+                $data[$key] = $this->$key;
+            }
+        }
+
+        return $data;
+    }
+
+    public function __unserialize(array $data): void
+    {
+        if ($wakeup = self::class !== (new \ReflectionMethod($this, '__wakeup'))->class && self::class === (new \ReflectionMethod($this, '__unserialize'))->class) {
+            trigger_deprecation('symfony/mime', '7.4', 'Implementing "%s::__wakeup()" is deprecated, use "__unserialize()" instead.', get_debug_type($this));
+        }
+
+        if (\in_array(array_keys($data), [['message'], ["\0".self::class."\0message"]], true)) {
+            $this->message = $data['message'] ?? $data["\0".self::class."\0message"];
+
+            if ($wakeup) {
+                $this->__wakeup();
+            } else {
+                $this->__construct($this->message);
+            }
+
+            return;
+        }
+
+        trigger_deprecation('symfony/mime', '7.4', 'Passing more than just key "message" to "%s::__unserialize()" is deprecated, populate properties in "%s::__unserialize()" instead.', self::class, get_debug_type($this));
+
+        \Closure::bind(function ($data) use ($wakeup) {
+            foreach ($data as $key => $value) {
+                $this->{("\0" === $key[0] ?? '') ? substr($key, 1 + strrpos($key, "\0")) : $key} = $value;
+            }
+
+            if ($wakeup) {
+                $this->__wakeup();
+            } else {
+                $this->__construct($this->message);
+            }
+        }, $this, static::class)($data);
+    }
+
+    /**
+     * @deprecated since Symfony 7.4, will be replaced by `__unserialize()` in 8.0
+     */
     public function __sleep(): array
     {
+        trigger_deprecation('symfony/mime', '7.4', 'Calling "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
+
         return ['message'];
     }
 
+    /**
+     * @deprecated since Symfony 7.4, will be replaced by `__unserialize()` in 8.0
+     */
     public function __wakeup(): void
     {
+        trigger_deprecation('symfony/mime', '7.4', 'Calling "%s::__wakeup()" is deprecated, use "__unserialize()" instead.', get_debug_type($this));
+
         $this->__construct($this->message);
     }
 }

--- a/src/Symfony/Component/Mime/Part/SMimePart.php
+++ b/src/Symfony/Component/Mime/Part/SMimePart.php
@@ -18,7 +18,7 @@ use Symfony\Component\Mime\Header\Headers;
  */
 class SMimePart extends AbstractPart
 {
-    /** @internal */
+    /** @internal, to be removed in 8.0 */
     protected Headers $_headers;
 
     public function __construct(
@@ -84,8 +84,97 @@ class SMimePart extends AbstractPart
         return $headers;
     }
 
+    public function __serialize(): array
+    {
+        if (self::class === (new \ReflectionMethod($this, '__sleep'))->class || self::class !== (new \ReflectionMethod($this, '__serialize'))->class) {
+            // convert iterables to strings for serialization
+            if (is_iterable($this->body)) {
+                $this->body = $this->bodyToString();
+            }
+
+            return [
+                '_headers' => $this->getHeaders(),
+                'body' => $this->body,
+                'type' => $this->type,
+                'subtype' => $this->subtype,
+                'parameters' => $this->parameters,
+            ];
+        }
+
+        trigger_deprecation('symfony/mime', '7.4', 'Implementing "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
+
+        $data = [];
+        foreach ($this->__sleep() as $key) {
+            try {
+                if (($r = new \ReflectionProperty($this, $key))->isInitialized($this)) {
+                    $data[$key] = $r->getValue($this);
+                }
+            } catch (\ReflectionException) {
+                $data[$key] = $this->$key;
+            }
+        }
+
+        return $data;
+    }
+
+    public function __unserialize(array $data): void
+    {
+        if ($wakeup = self::class !== (new \ReflectionMethod($this, '__wakeup'))->class && self::class === (new \ReflectionMethod($this, '__unserialize'))->class) {
+            trigger_deprecation('symfony/mime', '7.4', 'Implementing "%s::__wakeup()" is deprecated, use "__unserialize()" instead.', get_debug_type($this));
+        }
+
+        if (['_headers', 'body', 'type', 'subtype', 'parameters'] === array_keys($data)) {
+            parent::__unserialize(['headers' => $data['_headers']]);
+            $this->body = $data['body'];
+            $this->type = $data['type'];
+            $this->subtype = $data['subtype'];
+            $this->parameters = $data['parameters'];
+
+            if ($wakeup) {
+                $this->__wakeup();
+            }
+
+            return;
+        }
+
+        $p = "\0".self::class."\0";
+        if (["\0*\0_headers", $p.'body', $p.'type', $p.'subtype', $p.'parameters'] === array_keys($data)) {
+            $r = new \ReflectionProperty(parent::class, 'headers');
+            $r->setValue($this, $data["\0*\0_headers"]);
+
+            $this->body = $data[$p.'body'];
+            $this->type = $data[$p.'type'];
+            $this->subtype = $data[$p.'subtype'];
+            $this->parameters = $data[$p.'parameters'];
+
+            if ($wakeup) {
+                $this->_headers = $data["\0*\0_headers"];
+                $this->__wakeup();
+            }
+
+            return;
+        }
+
+        trigger_deprecation('symfony/mime', '7.4', 'Passing extra keys to "%s::__unserialize()" is deprecated, populate properties in "%s::__unserialize()" instead.', self::class, get_debug_type($this));
+
+        \Closure::bind(function ($data) use ($wakeup) {
+            foreach ($data as $key => $value) {
+                $this->{("\0" === $key[0] ?? '') ? substr($key, 1 + strrpos($key, "\0")) : $key} = $value;
+            }
+
+            if ($wakeup) {
+                $this->__wakeup();
+            }
+        }, $this, static::class)($data);
+    }
+
+    /**
+     * @deprecated since Symfony 7.4, will be replaced by `__serialize()` in 8.0
+     */
     public function __sleep(): array
     {
+        trigger_deprecation('symfony/mime', '7.4', 'Calling "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
+
         // convert iterables to strings for serialization
         if (is_iterable($this->body)) {
             $this->body = $this->bodyToString();
@@ -96,8 +185,13 @@ class SMimePart extends AbstractPart
         return ['_headers', 'body', 'type', 'subtype', 'parameters'];
     }
 
+    /**
+     * @deprecated since Symfony 7.4, will be replaced by `__unserialize()` in 8.0
+     */
     public function __wakeup(): void
     {
+        trigger_deprecation('symfony/mime', '7.4', 'Calling "%s::__wakeup()" is deprecated, use "__unserialize()" instead.', get_debug_type($this));
+
         $r = new \ReflectionProperty(AbstractPart::class, 'headers');
         $r->setValue($this, $this->_headers);
         unset($this->_headers);

--- a/src/Symfony/Component/Mime/Part/TextPart.php
+++ b/src/Symfony/Component/Mime/Part/TextPart.php
@@ -25,7 +25,7 @@ class TextPart extends AbstractPart
 {
     private const DEFAULT_ENCODERS = ['quoted-printable', 'base64', '8bit'];
 
-    /** @internal */
+    /** @internal, to be removed in 8.0 */
     protected Headers $_headers;
 
     private static array $encoders = [];
@@ -238,8 +238,109 @@ class TextPart extends AbstractPart
         return 'quoted-printable';
     }
 
+    public function __serialize(): array
+    {
+        if (self::class === (new \ReflectionMethod($this, '__sleep'))->class || self::class !== (new \ReflectionMethod($this, '__serialize'))->class) {
+            // convert resources to strings for serialization
+            if (null !== $this->seekable) {
+                $this->body = $this->getBody();
+                $this->seekable = null;
+            }
+
+            return [
+                '_headers' => $this->getHeaders(),
+                'body' => $this->body,
+                'charset' => $this->charset,
+                'subtype' => $this->subtype,
+                'disposition' => $this->disposition,
+                'name' => $this->name,
+                'encoding' => $this->encoding,
+            ];
+        }
+
+        trigger_deprecation('symfony/mime', '7.4', 'Implementing "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
+
+        $data = [];
+        foreach ($this->__sleep() as $key) {
+            try {
+                if (($r = new \ReflectionProperty($this, $key))->isInitialized($this)) {
+                    $data[$key] = $r->getValue($this);
+                }
+            } catch (\ReflectionException) {
+                $data[$key] = $this->$key;
+            }
+        }
+
+        return $data;
+    }
+
+    public function __unserialize(array $data): void
+    {
+        if ($wakeup = self::class !== (new \ReflectionMethod($this, '__wakeup'))->class && self::class === (new \ReflectionMethod($this, '__unserialize'))->class) {
+            trigger_deprecation('symfony/mime', '7.4', 'Implementing "%s::__wakeup()" is deprecated, use "__unserialize()" instead.', get_debug_type($this));
+        }
+
+        if ($headers = $data['_headers'] ?? $data["\0*\0_headers"] ?? null) {
+            unset($data['_headers'], $data["\0*\0_headers"]);
+            parent::__unserialize(['headers' => $headers]);
+        }
+
+        if (['body', 'charset', 'subtype', 'disposition', 'name', 'encoding'] === array_keys($data)) {
+            parent::__unserialize(['headers' => $headers]);
+            $this->body = $data['body'];
+            $this->charset = $data['charset'];
+            $this->subtype = $data['subtype'];
+            $this->disposition = $data['disposition'];
+            $this->name = $data['name'];
+            $this->encoding = $data['encoding'];
+
+            if ($wakeup) {
+                $this->__wakeup();
+            } elseif (!\is_string($this->body) && !$this->body instanceof File) {
+                throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
+            }
+
+            return;
+        }
+
+        if (["\0".self::class."\0body", "\0".self::class."\0charset", "\0".self::class."\0subtype", "\0".self::class."\0disposition", "\0".self::class."\0name", "\0".self::class."\0encoding"] === array_keys($data)) {
+            $this->body = $data["\0".self::class."\0body"];
+            $this->charset = $data["\0".self::class."\0charset"];
+            $this->subtype = $data["\0".self::class."\0subtype"];
+            $this->disposition = $data["\0".self::class."\0disposition"];
+            $this->name = $data["\0".self::class."\0name"];
+            $this->encoding = $data["\0".self::class."\0encoding"];
+
+            if ($wakeup) {
+                $this->_headers = $headers;
+                $this->__wakeup();
+            } elseif (!\is_string($this->body) && !$this->body instanceof File) {
+                throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
+            }
+
+            return;
+        }
+
+        trigger_deprecation('symfony/mime', '7.4', 'Passing extra keys to "%s::__unserialize()" is deprecated, populate properties in "%s::__unserialize()" instead.', self::class, get_debug_type($this));
+
+        \Closure::bind(function ($data) use ($wakeup) {
+            foreach ($data as $key => $value) {
+                $this->{("\0" === $key[0] ?? '') ? substr($key, 1 + strrpos($key, "\0")) : $key} = $value;
+            }
+
+            if ($wakeup) {
+                $this->__wakeup();
+            }
+        }, $this, static::class)($data);
+    }
+
+    /**
+     * @deprecated since Symfony 7.4, will be replaced by `__serialize()` in 8.0
+     */
     public function __sleep(): array
     {
+        trigger_deprecation('symfony/mime', '7.4', 'Calling "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
+
         // convert resources to strings for serialization
         if (null !== $this->seekable) {
             $this->body = $this->getBody();
@@ -251,8 +352,13 @@ class TextPart extends AbstractPart
         return ['_headers', 'body', 'charset', 'subtype', 'disposition', 'name', 'encoding'];
     }
 
+    /**
+     * @deprecated since Symfony 7.4, will be replaced by `__unserialize()` in 8.0
+     */
     public function __wakeup(): void
     {
+        trigger_deprecation('symfony/mime', '7.4', 'Calling "%s::__wakeup()" is deprecated, use "__unserialize()" instead.', get_debug_type($this));
+
         $r = new \ReflectionProperty(AbstractPart::class, 'headers');
         $r->setValue($this, $this->_headers);
         unset($this->_headers);

--- a/src/Symfony/Component/Mime/composer.json
+++ b/src/Symfony/Component/Mime/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=8.2",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/polyfill-intl-idn": "^1.10",
         "symfony/polyfill-mbstring": "^1.0"
     },

--- a/src/Symfony/Component/String/AbstractString.php
+++ b/src/Symfony/Component/String/AbstractString.php
@@ -708,7 +708,7 @@ abstract class AbstractString implements \Stringable, \JsonSerializable
 
     public function __serialize(): array
     {
-        if (self::class === (new \ReflectionMethod($this, '__sleep'))->class) {
+        if (self::class === (new \ReflectionMethod($this, '__sleep'))->class || self::class !== (new \ReflectionMethod($this, '__serialize'))->class) {
             return ['string' => $this->string];
         }
 

--- a/src/Symfony/Component/String/LazyString.php
+++ b/src/Symfony/Component/String/LazyString.php
@@ -103,7 +103,7 @@ class LazyString implements \Stringable, \JsonSerializable
 
     public function __serialize(): array
     {
-        if (self::class === (new \ReflectionMethod($this, '__sleep'))->class) {
+        if (self::class === (new \ReflectionMethod($this, '__sleep'))->class || self::class !== (new \ReflectionMethod($this, '__serialize'))->class) {
             $this->__toString();
 
             return ['value' => $this->value];

--- a/src/Symfony/Component/String/UnicodeString.php
+++ b/src/Symfony/Component/String/UnicodeString.php
@@ -368,7 +368,7 @@ class UnicodeString extends AbstractUnicodeString
 
     public function __unserialize(array $data): void
     {
-        if ($wakeup = self::class !== (new \ReflectionMethod($this, '__wakeup'))->class) {
+        if ($wakeup = self::class !== (new \ReflectionMethod($this, '__wakeup'))->class && self::class === (new \ReflectionMethod($this, '__unserialize'))->class) {
             trigger_deprecation('symfony/string', '7.4', 'Implementing "%s::__wakeup()" is deprecated, use "__unserialize()" instead.', get_debug_type($this));
         }
 

--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -121,7 +121,7 @@ class ClassMetadata extends GenericMetadata implements ClassMetadataInterface
 
     public function __serialize(): array
     {
-        if (self::class === (new \ReflectionMethod($this, '__sleep'))->class) {
+        if (self::class === (new \ReflectionMethod($this, '__sleep'))->class || self::class !== (new \ReflectionMethod($this, '__serialize'))->class) {
             return [
                 'constraints' => $this->constraints,
                 'constraintsByGroup' => $this->constraintsByGroup,

--- a/src/Symfony/Component/Validator/Mapping/GenericMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/GenericMetadata.php
@@ -85,7 +85,7 @@ class GenericMetadata implements MetadataInterface
 
     public function __serialize(): array
     {
-        if (self::class === (new \ReflectionMethod($this, '__sleep'))->class) {
+        if (self::class === (new \ReflectionMethod($this, '__sleep'))->class || self::class !== (new \ReflectionMethod($this, '__serialize'))->class) {
             return [
                 'constraints' => $this->constraints,
                 'constraintsByGroup' => $this->constraintsByGroup,

--- a/src/Symfony/Component/Validator/Mapping/MemberMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/MemberMetadata.php
@@ -78,7 +78,7 @@ abstract class MemberMetadata extends GenericMetadata implements PropertyMetadat
 
     public function __serialize(): array
     {
-        if (self::class === (new \ReflectionMethod($this, '__sleep'))->class) {
+        if (self::class === (new \ReflectionMethod($this, '__sleep'))->class || self::class !== (new \ReflectionMethod($this, '__serialize'))->class) {
             return [
                 'constraints' => $this->constraints,
                 'constraintsByGroup' => $this->constraintsByGroup,

--- a/src/Symfony/Component/Yaml/composer.json
+++ b/src/Symfony/Component/Yaml/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=8.2",
-        "symfony/deprecation-contracts": "^2.5|^3.0",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/polyfill-ctype": "^1.8"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | -
| License       | MIT

The last step to get rid of sleep/wakeup in 8.0
What a mess!