### PR TITLE
[HttpKernel][Mime][Serializer][String][Validator] Replace `__sleep/wakeup()` by `__(un)serialize()`

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -200,6 +200,7 @@ HttpKernel
  * Remove `Kernel::getAnnotatedClassesToCompile()` and `Kernel::setAnnotatedClassCache()`
  * Make `ServicesResetter` class `final`
  * Add argument `$logChannel` to `ErrorListener::logException()`
+ * Replace `__sleep/wakeup()` by `__(un)serialize()` on kernels and data collectors
 
 Intl
 ----
@@ -223,6 +224,11 @@ Messenger
 
  * Remove `text` format when using the `messenger:stats` command
  * Add method `getRetryDelay()` to `RecoverableExceptionInterface`
+
+Mime
+----
+
+ * Replace `__sleep/wakeup()` by `__(un)serialize()` on `AbstractPart` implementations
 
 Notifier
 --------
@@ -464,6 +470,11 @@ Translation
  * Make `DataCollectorTranslator` class `final`
  * Remove `ProviderFactoryTestCase`, extend `AbstractProviderFactoryTestCase` instead
 
+String
+------
+
+ * Replace `__sleep/wakeup()` by `__(un)serialize()` on string implementations
+
 TwigBridge
 ----------
 
@@ -498,6 +509,7 @@ Validator
 ---------
 
  * Add method `getGroupProvider()` to `ClassMetadataInterface`
+ * Replace `__sleep/wakeup()` by `__(un)serialize()`  on `GenericMetadata` implementations
  * Remove the `getRequiredOptions()` and `getDefaultOption()` methods from the `All`, `AtLeastOneOf`, `CardScheme`, `Collection`,
    `CssColor`, `Expression`, `Regex`, `Sequentially`, `Type`, and `When` constraints
  * Remove support for evaluating options in the base `Constraint` class. Initialize properties in the constructor of the concrete constraint

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Remove `Kernel::getAnnotatedClassesToCompile()` and `Kernel::setAnnotatedClassCache()`
  * Make `ServicesResetter` class `final`
  * Add argument `$logChannel` to `ErrorListener::logException()`
+ * Replace `__sleep/wakeup()` by `__(un)serialize()` on kernels and data collectors
 
 7.4
 ---

--- a/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
@@ -86,71 +86,12 @@ abstract class DataCollector implements DataCollectorInterface
 
     public function __serialize(): array
     {
-        if (self::class === (new \ReflectionMethod($this, '__sleep'))->class || self::class !== (new \ReflectionMethod($this, '__serialize'))->class) {
-            return ['data' => $this->data];
-        }
-
-        trigger_deprecation('symfony/http-kernel', '7.4', 'Implementing "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
-
-        $data = [];
-        foreach ($this->__sleep() as $key) {
-            try {
-                if (($r = new \ReflectionProperty($this, $key))->isInitialized($this)) {
-                    $data[$key] = $r->getValue($this);
-                }
-            } catch (\ReflectionException) {
-                $data[$key] = $this->$key;
-            }
-        }
-
-        return $data;
+        return ['data' => $this->data];
     }
 
     public function __unserialize(array $data): void
     {
-        if ($wakeup = self::class !== (new \ReflectionMethod($this, '__wakeup'))->class && self::class === (new \ReflectionMethod($this, '__unserialize'))->class) {
-            trigger_deprecation('symfony/http-kernel', '7.4', 'Implementing "%s::__wakeup()" is deprecated, use "__unserialize()" instead.', get_debug_type($this));
-        }
-
-        if (\in_array(array_keys($data), [['data'], ["\0*\0data"]], true)) {
-            $this->data = $data['data'] ?? $data["\0*\0data"];
-
-            if ($wakeup) {
-                $this->__wakeup();
-            }
-
-            return;
-        }
-
-        trigger_deprecation('symfony/http-kernel', '7.4', 'Passing more than just key "data" to "%s::__unserialize()" is deprecated, populate properties in "%s::__unserialize()" instead.', self::class, get_debug_type($this));
-
-        \Closure::bind(function ($data) use ($wakeup) {
-            foreach ($data as $key => $value) {
-                $this->{("\0" === $key[0] ?? '') ? substr($key, 1 + strrpos($key, "\0")) : $key} = $value;
-            }
-
-            if ($wakeup) {
-                $this->__wakeup();
-            }
-        }, $this, static::class)($data);
-    }
-
-    /**
-     * @deprecated since Symfony 7.4, will be replaced by `__serialize()` in 8.0
-     */
-    public function __sleep(): array
-    {
-        trigger_deprecation('symfony/http-kernel', '7.4', 'Calling "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
-
-        return ['data'];
-    }
-
-    /**
-     * @deprecated since Symfony 7.4, will be replaced by `__unserialize()` in 8.0
-     */
-    public function __wakeup(): void
-    {
-        trigger_deprecation('symfony/http-kernel', '7.4', 'Calling "%s::__wakeup()" is deprecated, use "__unserialize()" instead.', get_debug_type($this));
+        $this->data = $data['data'] ?? $data["\0*\0data"];
     }
 
     public function reset(): void

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -751,95 +751,24 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
 
     public function __serialize(): array
     {
-        if (self::class === (new \ReflectionMethod($this, '__sleep'))->class || self::class !== (new \ReflectionMethod($this, '__serialize'))->class) {
-            return [
-                'environment' => $this->environment,
-                'debug' => $this->debug,
-            ];
-        }
-
-        trigger_deprecation('symfony/http-kernel', '7.4', 'Implementing "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
-
-        $data = [];
-        foreach ($this->__sleep() as $key) {
-            try {
-                if (($r = new \ReflectionProperty($this, $key))->isInitialized($this)) {
-                    $data[$key] = $r->getValue($this);
-                }
-            } catch (\ReflectionException) {
-                $data[$key] = $this->$key;
-            }
-        }
-
-        return $data;
+        return [
+            'environment' => $this->environment,
+            'debug' => $this->debug,
+        ];
     }
 
     public function __unserialize(array $data): void
     {
-        if ($wakeup = self::class !== (new \ReflectionMethod($this, '__wakeup'))->class && self::class === (new \ReflectionMethod($this, '__unserialize'))->class) {
-            trigger_deprecation('symfony/http-kernel', '7.4', 'Implementing "%s::__wakeup()" is deprecated, use "__unserialize()" instead.', get_debug_type($this));
-        }
+        $environment = $data['environment'] ?? $data["\0*\0environment"];
+        $debug = $data['debug'] ?? $data["\0*\0debug"];
 
-        if (\in_array(array_keys($data), [['environment', 'debug'], ["\0*\0environment", "\0*\0debug"]], true)) {
-            $environment = $data['environment'] ?? $data["\0*\0environment"];
-            $debug = $data['debug'] ?? $data["\0*\0debug"];
-
-            if (\is_object($environment) || \is_object($debug)) {
-                throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
-            }
-
-            $this->environment = $environment;
-            $this->debug = $debug;
-
-            if ($wakeup) {
-                $this->__wakeup();
-            } else {
-                $this->__construct($environment, $debug);
-            }
-
-            return;
-        }
-
-        trigger_deprecation('symfony/http-kernel', '7.4', 'Passing more than just key "environment" and "debug" to "%s::__unserialize()" is deprecated, populate properties in "%s::__unserialize()" instead.', self::class, get_debug_type($this));
-
-        \Closure::bind(function ($data) use ($wakeup) {
-            foreach ($data as $key => $value) {
-                $this->{("\0" === $key[0] ?? '') ? substr($key, 1 + strrpos($key, "\0")) : $key} = $value;
-            }
-
-            if ($wakeup) {
-                $this->__wakeup();
-            } else {
-                if (\is_object($this->environment) || \is_object($this->debug)) {
-                    throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
-                }
-
-                $this->__construct($this->environment, $this->debug);
-            }
-        }, $this, static::class)($data);
-    }
-
-    /**
-     * @deprecated since Symfony 7.4, will be replaced by `__serialize()` in 8.0
-     */
-    public function __sleep(): array
-    {
-        trigger_deprecation('symfony/http-kernel', '7.4', 'Calling "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
-
-        return ['environment', 'debug'];
-    }
-
-    /**
-     * @deprecated since Symfony 7.4, will be replaced by `__unserialize()` in 8.0
-     */
-    public function __wakeup(): void
-    {
-        trigger_deprecation('symfony/http-kernel', '7.4', 'Calling "%s::__wakeup()" is deprecated, use "__unserialize()" instead.', get_debug_type($this));
-
-        if (\is_object($this->environment) || \is_object($this->debug)) {
+        if (\is_object($environment) || \is_object($debug)) {
             throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
         }
 
-        $this->__construct($this->environment, $this->debug);
+        $this->environment = $environment;
+        $this->debug = $debug;
+
+        $this->__construct($environment, $debug);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Profiler/Profile.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profile.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  *
- * @final since Symfony 7.4
+ * @final
  */
 class Profile
 {
@@ -248,11 +248,19 @@ class Profile
         return isset($this->collectors[$name]);
     }
 
-    /**
-     * @internal since Symfony 7.4, will be replaced by `__serialize()` in 8.0
-     */
-    public function __sleep(): array
+    public function __serialize(): array
     {
-        return ['token', 'parent', 'children', 'collectors', 'ip', 'method', 'url', 'time', 'statusCode', 'virtualType'];
+        return [
+            'token' => $this->token,
+            'parent' => $this->parent,
+            'children' => $this->children,
+            'collectors' => $this->collectors,
+            'ip' => $this->ip,
+            'method' => $this->method,
+            'url' => $this->url,
+            'time' => $this->time,
+            'statusCode' => $this->statusCode,
+            'virtualType' => $this->virtualType,
+        ];
     }
 }

--- a/src/Symfony/Component/Mime/CHANGELOG.md
+++ b/src/Symfony/Component/Mime/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.0
+---
+
+ * Replace `__sleep/wakeup()` by `__(un)serialize()` on `AbstractPart` implementations
+
 7.4
 ---
 

--- a/src/Symfony/Component/Mime/Part/AbstractPart.php
+++ b/src/Symfony/Component/Mime/Part/AbstractPart.php
@@ -65,52 +65,11 @@ abstract class AbstractPart
 
     public function __serialize(): array
     {
-        if (!method_exists($this, '__sleep')) {
-            return ['headers' => $this->headers];
-        }
-
-        trigger_deprecation('symfony/mime', '7.4', 'Implementing "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
-
-        $data = [];
-        foreach ($this->__sleep() as $key) {
-            try {
-                if (($r = new \ReflectionProperty($this, $key))->isInitialized($this)) {
-                    $data[$key] = $r->getValue($this);
-                }
-            } catch (\ReflectionException) {
-                $data[$key] = $this->$key;
-            }
-        }
-
-        return $data;
+        return ['headers' => $this->headers];
     }
 
     public function __unserialize(array $data): void
     {
-        if ($wakeup = method_exists($this, '__wakeup') && self::class === (new \ReflectionMethod($this, '__unserialize'))->class) {
-            trigger_deprecation('symfony/mime', '7.4', 'Implementing "%s::__wakeup()" is deprecated, use "__unserialize()" instead.', get_debug_type($this));
-        }
-
-        if (['headers'] === array_keys($data)) {
-            $this->headers = $data['headers'];
-
-            if ($wakeup) {
-                $this->__wakeup();
-            }
-
-            return;
-        }
-
-        trigger_deprecation('symfony/mime', '7.4', 'Passing more than just key "headers" to "%s::__unserialize()" is deprecated, populate properties in "%s::__unserialize()" instead.', self::class, get_debug_type($this));
-
-        \Closure::bind(function ($data) use ($wakeup) {
-            foreach ($data as $key => $value) {
-                $this->{("\0" === $key[0] ?? '') ? substr($key, 1 + strrpos($key, "\0")) : $key} = $value;
-            }
-
-            if ($wakeup) {
-                $this->__wakeup();
-            }
-        }, $this, static::class)($data);
+        $this->headers = $data['headers'];
     }
 }

--- a/src/Symfony/Component/Mime/Part/DataPart.php
+++ b/src/Symfony/Component/Mime/Part/DataPart.php
@@ -19,9 +19,6 @@ use Symfony\Component\Mime\Header\Headers;
  */
 class DataPart extends TextPart
 {
-    /** @internal, to be removed in 8.0 */
-    protected array $_parent;
-
     private ?string $filename = null;
     private string $mediaType;
     private ?string $cid = null;
@@ -131,116 +128,22 @@ class DataPart extends TextPart
 
     public function __serialize(): array
     {
-        if (self::class === (new \ReflectionMethod($this, '__sleep'))->class || self::class !== (new \ReflectionMethod($this, '__serialize'))->class) {
-            $parent = parent::__serialize();
-            $headers = $parent['_headers'];
-            unset($parent['_headers']);
+        $parent = parent::__serialize();
+        $headers = $parent['_headers'];
+        unset($parent['_headers']);
 
-            return [
-                '_headers' => $headers,
-                '_parent' => $parent,
-                'filename' => $this->filename,
-                'mediaType' => $this->mediaType,
-            ];
-        }
-
-        trigger_deprecation('symfony/mime', '7.4', 'Implementing "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
-
-        $data = [];
-        foreach ($this->__sleep() as $key) {
-            try {
-                if (($r = new \ReflectionProperty($this, $key))->isInitialized($this)) {
-                    $data[$key] = $r->getValue($this);
-                }
-            } catch (\ReflectionException) {
-                $data[$key] = $this->$key;
-            }
-        }
-
-        return $data;
+        return [
+            '_headers' => $headers,
+            '_parent' => $parent,
+            'filename' => $this->filename,
+            'mediaType' => $this->mediaType,
+        ];
     }
 
     public function __unserialize(array $data): void
     {
-        if ($wakeup = self::class !== (new \ReflectionMethod($this, '__wakeup'))->class && self::class === (new \ReflectionMethod($this, '__unserialize'))->class) {
-            trigger_deprecation('symfony/mime', '7.4', 'Implementing "%s::__wakeup()" is deprecated, use "__unserialize()" instead.', get_debug_type($this));
-        }
-
-        if (['_headers', '_parent', 'filename', 'mediaType'] === array_keys($data)) {
-            parent::__unserialize(['_headers' => $data['_headers'], ...$data['_parent']]);
-            $this->filename = $data['filename'];
-            $this->mediaType = $data['mediaType'];
-
-            if ($wakeup) {
-                $this->__wakeup();
-            }
-
-            return;
-        }
-
-        if (["\0*\0_headers", "\0*\0_parent", "\0".self::class."\0filename", "\0".self::class."\0mediaType"] === array_keys($data)) {
-            parent::__unserialize(['_headers' => $data["\0*\0_headers"], ...$data["\0*\0_parent"]]);
-            $this->filename = $data["\0".self::class."\0filename"];
-            $this->mediaType = $data["\0".self::class."\0mediaType"];
-
-            if ($wakeup) {
-                $this->__wakeup();
-            }
-
-            return;
-        }
-
-        trigger_deprecation('symfony/mime', '7.4', 'Passing extra keys to "%s::__unserialize()" is deprecated, populate properties in "%s::__unserialize()" instead.', self::class, get_debug_type($this));
-
-        \Closure::bind(function ($data) use ($wakeup) {
-            foreach ($data as $key => $value) {
-                $this->{("\0" === $key[0] ?? '') ? substr($key, 1 + strrpos($key, "\0")) : $key} = $value;
-            }
-
-            if ($wakeup) {
-                $this->__wakeup();
-            }
-        }, $this, static::class)($data);
-    }
-
-    /**
-     * @deprecated since Symfony 7.4, will be replaced by `__serialize()` in 8.0
-     */
-    public function __sleep(): array
-    {
-        trigger_deprecation('symfony/mime', '7.4', 'Calling "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
-        // converts the body to a string
-        parent::__sleep();
-
-        $this->_parent = [];
-        foreach (['body', 'charset', 'subtype', 'disposition', 'name', 'encoding'] as $name) {
-            $r = new \ReflectionProperty(TextPart::class, $name);
-            $this->_parent[$name] = $r->getValue($this);
-        }
-        $this->_headers = $this->getHeaders();
-
-        return ['_headers', '_parent', 'filename', 'mediaType'];
-    }
-
-    /**
-     * @deprecated since Symfony 7.4, will be replaced by `__unserialize()` in 8.0
-     */
-    public function __wakeup(): void
-    {
-        $r = new \ReflectionProperty(AbstractPart::class, 'headers');
-        $r->setValue($this, $this->_headers);
-        unset($this->_headers);
-
-        if (!\is_array($this->_parent)) {
-            throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
-        }
-        foreach (['body', 'charset', 'subtype', 'disposition', 'name', 'encoding'] as $name) {
-            if (null !== $this->_parent[$name] && !\is_string($this->_parent[$name]) && !$this->_parent[$name] instanceof File) {
-                throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
-            }
-            $r = new \ReflectionProperty(TextPart::class, $name);
-            $r->setValue($this, $this->_parent[$name]);
-        }
-        unset($this->_parent);
+        parent::__unserialize(['_headers' => $data['_headers'] ?? $data["\0*\0_headers"], ...$data['_parent'] ?? $data["\0*\0_parent"]]);
+        $this->filename = $data['filename'] ?? $data["\0".self::class."\0filename"] ?? null;
+        $this->mediaType = $data['mediaType'] ?? $data["\0".self::class."\0mediaType"];
     }
 }

--- a/src/Symfony/Component/Mime/Part/MessagePart.php
+++ b/src/Symfony/Component/Mime/Part/MessagePart.php
@@ -59,76 +59,12 @@ class MessagePart extends DataPart
 
     public function __serialize(): array
     {
-        if (self::class === (new \ReflectionMethod($this, '__sleep'))->class || self::class !== (new \ReflectionMethod($this, '__serialize'))->class) {
-            return ['message' => $this->message];
-        }
-
-        trigger_deprecation('symfony/mime', '7.4', 'Implementing "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
-
-        $data = [];
-        foreach ($this->__sleep() as $key) {
-            try {
-                if (($r = new \ReflectionProperty($this, $key))->isInitialized($this)) {
-                    $data[$key] = $r->getValue($this);
-                }
-            } catch (\ReflectionException) {
-                $data[$key] = $this->$key;
-            }
-        }
-
-        return $data;
+        return ['message' => $this->message];
     }
 
     public function __unserialize(array $data): void
     {
-        if ($wakeup = self::class !== (new \ReflectionMethod($this, '__wakeup'))->class && self::class === (new \ReflectionMethod($this, '__unserialize'))->class) {
-            trigger_deprecation('symfony/mime', '7.4', 'Implementing "%s::__wakeup()" is deprecated, use "__unserialize()" instead.', get_debug_type($this));
-        }
-
-        if (\in_array(array_keys($data), [['message'], ["\0".self::class."\0message"]], true)) {
-            $this->message = $data['message'] ?? $data["\0".self::class."\0message"];
-
-            if ($wakeup) {
-                $this->__wakeup();
-            } else {
-                $this->__construct($this->message);
-            }
-
-            return;
-        }
-
-        trigger_deprecation('symfony/mime', '7.4', 'Passing more than just key "message" to "%s::__unserialize()" is deprecated, populate properties in "%s::__unserialize()" instead.', self::class, get_debug_type($this));
-
-        \Closure::bind(function ($data) use ($wakeup) {
-            foreach ($data as $key => $value) {
-                $this->{("\0" === $key[0] ?? '') ? substr($key, 1 + strrpos($key, "\0")) : $key} = $value;
-            }
-
-            if ($wakeup) {
-                $this->__wakeup();
-            } else {
-                $this->__construct($this->message);
-            }
-        }, $this, static::class)($data);
-    }
-
-    /**
-     * @deprecated since Symfony 7.4, will be replaced by `__unserialize()` in 8.0
-     */
-    public function __sleep(): array
-    {
-        trigger_deprecation('symfony/mime', '7.4', 'Calling "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
-
-        return ['message'];
-    }
-
-    /**
-     * @deprecated since Symfony 7.4, will be replaced by `__unserialize()` in 8.0
-     */
-    public function __wakeup(): void
-    {
-        trigger_deprecation('symfony/mime', '7.4', 'Calling "%s::__wakeup()" is deprecated, use "__unserialize()" instead.', get_debug_type($this));
-
+        $this->message = $data['message'] ?? $data["\0".self::class."\0message"];
         $this->__construct($this->message);
     }
 }

--- a/src/Symfony/Component/Mime/Part/SMimePart.php
+++ b/src/Symfony/Component/Mime/Part/SMimePart.php
@@ -86,114 +86,26 @@ class SMimePart extends AbstractPart
 
     public function __serialize(): array
     {
-        if (self::class === (new \ReflectionMethod($this, '__sleep'))->class || self::class !== (new \ReflectionMethod($this, '__serialize'))->class) {
-            // convert iterables to strings for serialization
-            if (is_iterable($this->body)) {
-                $this->body = $this->bodyToString();
-            }
-
-            return [
-                '_headers' => $this->getHeaders(),
-                'body' => $this->body,
-                'type' => $this->type,
-                'subtype' => $this->subtype,
-                'parameters' => $this->parameters,
-            ];
-        }
-
-        trigger_deprecation('symfony/mime', '7.4', 'Implementing "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
-
-        $data = [];
-        foreach ($this->__sleep() as $key) {
-            try {
-                if (($r = new \ReflectionProperty($this, $key))->isInitialized($this)) {
-                    $data[$key] = $r->getValue($this);
-                }
-            } catch (\ReflectionException) {
-                $data[$key] = $this->$key;
-            }
-        }
-
-        return $data;
-    }
-
-    public function __unserialize(array $data): void
-    {
-        if ($wakeup = self::class !== (new \ReflectionMethod($this, '__wakeup'))->class && self::class === (new \ReflectionMethod($this, '__unserialize'))->class) {
-            trigger_deprecation('symfony/mime', '7.4', 'Implementing "%s::__wakeup()" is deprecated, use "__unserialize()" instead.', get_debug_type($this));
-        }
-
-        if (['_headers', 'body', 'type', 'subtype', 'parameters'] === array_keys($data)) {
-            parent::__unserialize(['headers' => $data['_headers']]);
-            $this->body = $data['body'];
-            $this->type = $data['type'];
-            $this->subtype = $data['subtype'];
-            $this->parameters = $data['parameters'];
-
-            if ($wakeup) {
-                $this->__wakeup();
-            }
-
-            return;
-        }
-
-        $p = "\0".self::class."\0";
-        if (["\0*\0_headers", $p.'body', $p.'type', $p.'subtype', $p.'parameters'] === array_keys($data)) {
-            $r = new \ReflectionProperty(parent::class, 'headers');
-            $r->setValue($this, $data["\0*\0_headers"]);
-
-            $this->body = $data[$p.'body'];
-            $this->type = $data[$p.'type'];
-            $this->subtype = $data[$p.'subtype'];
-            $this->parameters = $data[$p.'parameters'];
-
-            if ($wakeup) {
-                $this->_headers = $data["\0*\0_headers"];
-                $this->__wakeup();
-            }
-
-            return;
-        }
-
-        trigger_deprecation('symfony/mime', '7.4', 'Passing extra keys to "%s::__unserialize()" is deprecated, populate properties in "%s::__unserialize()" instead.', self::class, get_debug_type($this));
-
-        \Closure::bind(function ($data) use ($wakeup) {
-            foreach ($data as $key => $value) {
-                $this->{("\0" === $key[0] ?? '') ? substr($key, 1 + strrpos($key, "\0")) : $key} = $value;
-            }
-
-            if ($wakeup) {
-                $this->__wakeup();
-            }
-        }, $this, static::class)($data);
-    }
-
-    /**
-     * @deprecated since Symfony 7.4, will be replaced by `__serialize()` in 8.0
-     */
-    public function __sleep(): array
-    {
-        trigger_deprecation('symfony/mime', '7.4', 'Calling "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
-
         // convert iterables to strings for serialization
         if (is_iterable($this->body)) {
             $this->body = $this->bodyToString();
         }
 
-        $this->_headers = $this->getHeaders();
-
-        return ['_headers', 'body', 'type', 'subtype', 'parameters'];
+        return [
+            '_headers' => $this->getHeaders(),
+            'body' => $this->body,
+            'type' => $this->type,
+            'subtype' => $this->subtype,
+            'parameters' => $this->parameters,
+        ];
     }
 
-    /**
-     * @deprecated since Symfony 7.4, will be replaced by `__unserialize()` in 8.0
-     */
-    public function __wakeup(): void
+    public function __unserialize(array $data): void
     {
-        trigger_deprecation('symfony/mime', '7.4', 'Calling "%s::__wakeup()" is deprecated, use "__unserialize()" instead.', get_debug_type($this));
-
-        $r = new \ReflectionProperty(AbstractPart::class, 'headers');
-        $r->setValue($this, $this->_headers);
-        unset($this->_headers);
+        parent::__unserialize(['headers' => $data['_headers'] ?? $data["\0*\0_headers"]]);
+        $this->body = $data['body'] ?? $data["\0".self::class."\0body"];
+        $this->type = $data['type'] ?? $data["\0".self::class."\0type"];
+        $this->subtype = $data['subtype'] ?? $data["\0".self::class."\0subtype"];
+        $this->parameters = $data['parameters'] ?? $data["\0".self::class."\0parameters"];
     }
 }

--- a/src/Symfony/Component/Mime/Part/TextPart.php
+++ b/src/Symfony/Component/Mime/Part/TextPart.php
@@ -25,9 +25,6 @@ class TextPart extends AbstractPart
 {
     private const DEFAULT_ENCODERS = ['quoted-printable', 'base64', '8bit'];
 
-    /** @internal, to be removed in 8.0 */
-    protected Headers $_headers;
-
     private static array $encoders = [];
 
     /** @var resource|string|File */
@@ -240,127 +237,38 @@ class TextPart extends AbstractPart
 
     public function __serialize(): array
     {
-        if (self::class === (new \ReflectionMethod($this, '__sleep'))->class || self::class !== (new \ReflectionMethod($this, '__serialize'))->class) {
-            // convert resources to strings for serialization
-            if (null !== $this->seekable) {
-                $this->body = $this->getBody();
-                $this->seekable = null;
-            }
-
-            return [
-                '_headers' => $this->getHeaders(),
-                'body' => $this->body,
-                'charset' => $this->charset,
-                'subtype' => $this->subtype,
-                'disposition' => $this->disposition,
-                'name' => $this->name,
-                'encoding' => $this->encoding,
-            ];
-        }
-
-        trigger_deprecation('symfony/mime', '7.4', 'Implementing "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
-
-        $data = [];
-        foreach ($this->__sleep() as $key) {
-            try {
-                if (($r = new \ReflectionProperty($this, $key))->isInitialized($this)) {
-                    $data[$key] = $r->getValue($this);
-                }
-            } catch (\ReflectionException) {
-                $data[$key] = $this->$key;
-            }
-        }
-
-        return $data;
-    }
-
-    public function __unserialize(array $data): void
-    {
-        if ($wakeup = self::class !== (new \ReflectionMethod($this, '__wakeup'))->class && self::class === (new \ReflectionMethod($this, '__unserialize'))->class) {
-            trigger_deprecation('symfony/mime', '7.4', 'Implementing "%s::__wakeup()" is deprecated, use "__unserialize()" instead.', get_debug_type($this));
-        }
-
-        if ($headers = $data['_headers'] ?? $data["\0*\0_headers"] ?? null) {
-            unset($data['_headers'], $data["\0*\0_headers"]);
-            parent::__unserialize(['headers' => $headers]);
-        }
-
-        if (['body', 'charset', 'subtype', 'disposition', 'name', 'encoding'] === array_keys($data)) {
-            parent::__unserialize(['headers' => $headers]);
-            $this->body = $data['body'];
-            $this->charset = $data['charset'];
-            $this->subtype = $data['subtype'];
-            $this->disposition = $data['disposition'];
-            $this->name = $data['name'];
-            $this->encoding = $data['encoding'];
-
-            if ($wakeup) {
-                $this->__wakeup();
-            } elseif (!\is_string($this->body) && !$this->body instanceof File) {
-                throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
-            }
-
-            return;
-        }
-
-        if (["\0".self::class."\0body", "\0".self::class."\0charset", "\0".self::class."\0subtype", "\0".self::class."\0disposition", "\0".self::class."\0name", "\0".self::class."\0encoding"] === array_keys($data)) {
-            $this->body = $data["\0".self::class."\0body"];
-            $this->charset = $data["\0".self::class."\0charset"];
-            $this->subtype = $data["\0".self::class."\0subtype"];
-            $this->disposition = $data["\0".self::class."\0disposition"];
-            $this->name = $data["\0".self::class."\0name"];
-            $this->encoding = $data["\0".self::class."\0encoding"];
-
-            if ($wakeup) {
-                $this->_headers = $headers;
-                $this->__wakeup();
-            } elseif (!\is_string($this->body) && !$this->body instanceof File) {
-                throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
-            }
-
-            return;
-        }
-
-        trigger_deprecation('symfony/mime', '7.4', 'Passing extra keys to "%s::__unserialize()" is deprecated, populate properties in "%s::__unserialize()" instead.', self::class, get_debug_type($this));
-
-        \Closure::bind(function ($data) use ($wakeup) {
-            foreach ($data as $key => $value) {
-                $this->{("\0" === $key[0] ?? '') ? substr($key, 1 + strrpos($key, "\0")) : $key} = $value;
-            }
-
-            if ($wakeup) {
-                $this->__wakeup();
-            }
-        }, $this, static::class)($data);
-    }
-
-    /**
-     * @deprecated since Symfony 7.4, will be replaced by `__serialize()` in 8.0
-     */
-    public function __sleep(): array
-    {
-        trigger_deprecation('symfony/mime', '7.4', 'Calling "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
-
         // convert resources to strings for serialization
         if (null !== $this->seekable) {
             $this->body = $this->getBody();
             $this->seekable = null;
         }
 
-        $this->_headers = $this->getHeaders();
-
-        return ['_headers', 'body', 'charset', 'subtype', 'disposition', 'name', 'encoding'];
+        return [
+            '_headers' => $this->getHeaders(),
+            'body' => $this->body,
+            'charset' => $this->charset,
+            'subtype' => $this->subtype,
+            'disposition' => $this->disposition,
+            'name' => $this->name,
+            'encoding' => $this->encoding,
+        ];
     }
 
-    /**
-     * @deprecated since Symfony 7.4, will be replaced by `__unserialize()` in 8.0
-     */
-    public function __wakeup(): void
+    public function __unserialize(array $data): void
     {
-        trigger_deprecation('symfony/mime', '7.4', 'Calling "%s::__wakeup()" is deprecated, use "__unserialize()" instead.', get_debug_type($this));
+        if ($headers = $data['_headers'] ?? $data["\0*\0_headers"] ?? null) {
+            parent::__unserialize(['headers' => $headers]);
+        }
 
-        $r = new \ReflectionProperty(AbstractPart::class, 'headers');
-        $r->setValue($this, $this->_headers);
-        unset($this->_headers);
+        $this->body = $data['body'] ?? $data["\0".self::class."\0body"];
+        $this->charset = $data['charset'] ?? $data["\0".self::class."\0charset"] ?? null;
+        $this->subtype = $data['subtype'] ?? $data["\0".self::class."\0subtype"];
+        $this->disposition = $data['disposition'] ?? $data["\0".self::class."\0disposition"] ?? null;
+        $this->name = $data['name'] ?? $data["\0".self::class."\0name"] ?? null;
+        $this->encoding = $data['encoding'] ?? $data["\0".self::class."\0encoding"];
+
+        if (!\is_string($this->body) && !$this->body instanceof File) {
+            throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
+        }
     }
 }

--- a/src/Symfony/Component/Serializer/Mapping/AttributeMetadata.php
+++ b/src/Symfony/Component/Serializer/Mapping/AttributeMetadata.php
@@ -16,7 +16,7 @@ use Symfony\Component\PropertyAccess\PropertyPath;
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
  *
- * @final since Symfony 7.4
+ * @final
  */
 class AttributeMetadata implements AttributeMetadataInterface
 {
@@ -216,13 +216,17 @@ class AttributeMetadata implements AttributeMetadataInterface
         }
     }
 
-    /**
-     * @internal since Symfony 7.4, will be replaced by `__serialize()` in 8.0
-     *
-     * @final since Symfony 7.4, will be replaced by `__serialize()` in 8.0
-     */
-    public function __sleep(): array
+    public function __serialize(): array
     {
-        return ['name', 'groups', 'maxDepth', 'serializedName', 'serializedPath', 'ignore', 'normalizationContexts', 'denormalizationContexts'];
+        return [
+            'name' => $this->name,
+            'groups' => $this->groups,
+            'maxDepth' => $this->maxDepth,
+            'serializedName' => $this->serializedName,
+            'serializedPath' => $this->serializedPath,
+            'ignore' => $this->ignore,
+            'normalizationContexts' => $this->normalizationContexts,
+            'denormalizationContexts' => $this->denormalizationContexts,
+        ];
     }
 }

--- a/src/Symfony/Component/Serializer/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Serializer/Mapping/ClassMetadata.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Serializer\Mapping;
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
  *
- * @final since Symfony 7.4
+ * @final
  */
 class ClassMetadata implements ClassMetadataInterface
 {
@@ -93,17 +93,12 @@ class ClassMetadata implements ClassMetadataInterface
         $this->classDiscriminatorMapping = $mapping;
     }
 
-    /**
-     * @internal since Symfony 7.4, will be replaced by `__serialize()` in 8.0
-     *
-     * @final since Symfony 7.4, will be replaced by `__serialize()` in 8.0
-     */
-    public function __sleep(): array
+    public function __serialize(): array
     {
         return [
-            'name',
-            'attributesMetadata',
-            'classDiscriminatorMapping',
+            'name' => $this->name,
+            'attributesMetadata' => $this->attributesMetadata,
+            'classDiscriminatorMapping' => $this->classDiscriminatorMapping,
         ];
     }
 }

--- a/src/Symfony/Component/String/AbstractString.php
+++ b/src/Symfony/Component/String/AbstractString.php
@@ -708,34 +708,7 @@ abstract class AbstractString implements \Stringable, \JsonSerializable
 
     public function __serialize(): array
     {
-        if (self::class === (new \ReflectionMethod($this, '__sleep'))->class || self::class !== (new \ReflectionMethod($this, '__serialize'))->class) {
-            return ['string' => $this->string];
-        }
-
-        trigger_deprecation('symfony/string', '7.4', 'Implementing "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
-
-        $data = [];
-        foreach ($this->__sleep() as $key) {
-            try {
-                if (($r = new \ReflectionProperty($this, $key))->isInitialized($this)) {
-                    $data[$key] = $r->getValue($this);
-                }
-            } catch (\ReflectionException) {
-                $data[$key] = $this->$key;
-            }
-        }
-
-        return $data;
-    }
-
-    /**
-     * @deprecated since Symfony 7.4, will be replaced by `__unserialize()` in 8.0
-     */
-    public function __sleep(): array
-    {
-        trigger_deprecation('symfony/string', '7.4', 'Calling "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
-
-        return ['string'];
+        return ['string' => $this->string];
     }
 
     public function __clone()

--- a/src/Symfony/Component/String/CHANGELOG.md
+++ b/src/Symfony/Component/String/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.0
+---
+
+ * Replace `__sleep/wakeup()` by `__(un)serialize()` on string implementations
+
 7.4
 ---
 

--- a/src/Symfony/Component/String/LazyString.php
+++ b/src/Symfony/Component/String/LazyString.php
@@ -103,38 +103,9 @@ class LazyString implements \Stringable, \JsonSerializable
 
     public function __serialize(): array
     {
-        if (self::class === (new \ReflectionMethod($this, '__sleep'))->class || self::class !== (new \ReflectionMethod($this, '__serialize'))->class) {
-            $this->__toString();
-
-            return ['value' => $this->value];
-        }
-
-        trigger_deprecation('symfony/string', '7.4', 'Implementing "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
-
-        $data = [];
-        foreach ($this->__sleep() as $key) {
-            try {
-                if (($r = new \ReflectionProperty($this, $key))->isInitialized($this)) {
-                    $data[$key] = $r->getValue($this);
-                }
-            } catch (\ReflectionException) {
-                $data[$key] = $this->$key;
-            }
-        }
-
-        return $data;
-    }
-
-    /**
-     * @deprecated since Symfony 7.4, will be replaced by `__serialize()` in 8.0
-     */
-    public function __sleep(): array
-    {
-        trigger_deprecation('symfony/string', '7.4', 'Calling "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
-
         $this->__toString();
 
-        return ['value'];
+        return ['value' => $this->value];
     }
 
     public function jsonSerialize(): string

--- a/src/Symfony/Component/String/UnicodeString.php
+++ b/src/Symfony/Component/String/UnicodeString.php
@@ -368,49 +368,7 @@ class UnicodeString extends AbstractUnicodeString
 
     public function __unserialize(array $data): void
     {
-        if ($wakeup = self::class !== (new \ReflectionMethod($this, '__wakeup'))->class && self::class === (new \ReflectionMethod($this, '__unserialize'))->class) {
-            trigger_deprecation('symfony/string', '7.4', 'Implementing "%s::__wakeup()" is deprecated, use "__unserialize()" instead.', get_debug_type($this));
-        }
-
-        try {
-            if (\in_array(array_keys($data), [['string'], ["\0*\0string"]], true)) {
-                $this->string = $data['string'] ?? $data["\0*\0string"];
-
-                if ($wakeup) {
-                    $this->__wakeup();
-                }
-
-                return;
-            }
-
-            trigger_deprecation('symfony/string', '7.4', 'Passing more than just key "string" to "%s::__unserialize()" is deprecated, populate properties in "%s::__unserialize()" instead.', self::class, get_debug_type($this));
-
-            \Closure::bind(function ($data) use ($wakeup) {
-                foreach ($data as $key => $value) {
-                    $this->{("\0" === $key[0] ?? '') ? substr($key, 1 + strrpos($key, "\0")) : $key} = $value;
-                }
-
-                if ($wakeup) {
-                    $this->__wakeup();
-                }
-            }, $this, static::class)($data);
-        } finally {
-            if (!$wakeup) {
-                if (!\is_string($this->string)) {
-                    throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
-                }
-
-                normalizer_is_normalized($this->string) ?: $this->string = normalizer_normalize($this->string);
-            }
-        }
-    }
-
-    /**
-     * @deprecated since Symfony 7.4, will be replaced by `__unserialize()` in 8.0
-     */
-    public function __wakeup(): void
-    {
-        trigger_deprecation('symfony/string', '7.4', 'Calling "%s::__wakeup()" is deprecated, use "__unserialize()" instead.', get_debug_type($this));
+        $this->string = $data['string'] ?? $data["\0*\0string"];
 
         if (!\is_string($this->string)) {
             throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add method `getGroupProvider()` to `ClassMetadataInterface`
+ * Replace `__sleep/wakeup()` by `__(un)serialize()`  on `GenericMetadata` implementations
  * Remove the `getRequiredOptions()` and `getDefaultOption()` methods from the `All`, `AtLeastOneOf`, `CardScheme`, `Collection`,
    `CssColor`, `Expression`, `Regex`, `Sequentially`, `Type`, and `When` constraints
  * Remove support for evaluating options in the base `Constraint` class. Initialize properties in the constructor of the concrete constraint

--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -121,59 +121,19 @@ class ClassMetadata extends GenericMetadata implements ClassMetadataInterface
 
     public function __serialize(): array
     {
-        if (self::class === (new \ReflectionMethod($this, '__sleep'))->class || self::class !== (new \ReflectionMethod($this, '__serialize'))->class) {
-            return [
-                'constraints' => $this->constraints,
-                'constraintsByGroup' => $this->constraintsByGroup,
-                'traversalStrategy' => $this->traversalStrategy,
-                'autoMappingStrategy' => $this->autoMappingStrategy,
-                'getters' => $this->getters,
-                'groupSequence' => $this->groupSequence,
-                'groupSequenceProvider' => $this->groupSequenceProvider,
-                'groupProvider' => $this->groupProvider,
-                'members' => $this->members,
-                'name' => $this->name,
-                'properties' => $this->properties,
-                'defaultGroup' => $this->defaultGroup,
-            ];
-        }
-
-        trigger_deprecation('symfony/validator', '7.4', 'Implementing "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
-
-        $data = [];
-        foreach ($this->__sleep() as $key) {
-            try {
-                if (($r = new \ReflectionProperty($this, $key))->isInitialized($this)) {
-                    $data[$key] = $r->getValue($this);
-                }
-            } catch (\ReflectionException) {
-                $data[$key] = $this->$key;
-            }
-        }
-
-        return $data;
-    }
-
-    /**
-     * @deprecated since Symfony 7.4, will be removed in 8.0
-     */
-    public function __sleep(): array
-    {
-        trigger_deprecation('symfony/validator', '7.4', 'Calling "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
-
         return [
-            'constraints',
-            'constraintsByGroup',
-            'traversalStrategy',
-            'autoMappingStrategy',
-            'getters',
-            'groupSequence',
-            'groupSequenceProvider',
-            'groupProvider',
-            'members',
-            'name',
-            'properties',
-            'defaultGroup',
+            'constraints' => $this->constraints,
+            'constraintsByGroup' => $this->constraintsByGroup,
+            'traversalStrategy' => $this->traversalStrategy,
+            'autoMappingStrategy' => $this->autoMappingStrategy,
+            'getters' => $this->getters,
+            'groupSequence' => $this->groupSequence,
+            'groupSequenceProvider' => $this->groupSequenceProvider,
+            'groupProvider' => $this->groupProvider,
+            'members' => $this->members,
+            'name' => $this->name,
+            'properties' => $this->properties,
+            'defaultGroup' => $this->defaultGroup,
         ];
     }
 

--- a/src/Symfony/Component/Validator/Mapping/GenericMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/GenericMetadata.php
@@ -85,45 +85,12 @@ class GenericMetadata implements MetadataInterface
 
     public function __serialize(): array
     {
-        if (self::class === (new \ReflectionMethod($this, '__sleep'))->class || self::class !== (new \ReflectionMethod($this, '__serialize'))->class) {
-            return [
-                'constraints' => $this->constraints,
-                'constraintsByGroup' => $this->constraintsByGroup,
-                'cascadingStrategy' => $this->cascadingStrategy,
-                'traversalStrategy' => $this->traversalStrategy,
-                'autoMappingStrategy' => $this->autoMappingStrategy,
-            ];
-        }
-
-        trigger_deprecation('symfony/validator', '7.4', 'Implementing "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
-
-        $data = [];
-        foreach ($this->__sleep() as $key) {
-            try {
-                if (($r = new \ReflectionProperty($this, $key))->isInitialized($this)) {
-                    $data[$key] = $r->getValue($this);
-                }
-            } catch (\ReflectionException) {
-                $data[$key] = $this->$key;
-            }
-        }
-
-        return $data;
-    }
-
-    /**
-     * @deprecated since Symfony 7.4, will be replaced by `__serialize()` in 8.0
-     */
-    public function __sleep(): array
-    {
-        trigger_deprecation('symfony/validator', '7.4', 'Calling "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
-
         return [
-            'constraints',
-            'constraintsByGroup',
-            'cascadingStrategy',
-            'traversalStrategy',
-            'autoMappingStrategy',
+            'constraints' => $this->constraints,
+            'constraintsByGroup' => $this->constraintsByGroup,
+            'cascadingStrategy' => $this->cascadingStrategy,
+            'traversalStrategy' => $this->traversalStrategy,
+            'autoMappingStrategy' => $this->autoMappingStrategy,
         ];
     }
 

--- a/src/Symfony/Component/Validator/Mapping/MemberMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/MemberMetadata.php
@@ -78,51 +78,15 @@ abstract class MemberMetadata extends GenericMetadata implements PropertyMetadat
 
     public function __serialize(): array
     {
-        if (self::class === (new \ReflectionMethod($this, '__sleep'))->class || self::class !== (new \ReflectionMethod($this, '__serialize'))->class) {
-            return [
-                'constraints' => $this->constraints,
-                'constraintsByGroup' => $this->constraintsByGroup,
-                'cascadingStrategy' => $this->cascadingStrategy,
-                'traversalStrategy' => $this->traversalStrategy,
-                'autoMappingStrategy' => $this->autoMappingStrategy,
-                'class' => $this->class,
-                'name' => $this->name,
-                'property' => $this->property,
-            ];
-        }
-
-        trigger_deprecation('symfony/validator', '7.4', 'Implementing "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
-
-        $data = [];
-        foreach ($this->__sleep() as $key) {
-            try {
-                if (($r = new \ReflectionProperty($this, $key))->isInitialized($this)) {
-                    $data[$key] = $r->getValue($this);
-                }
-            } catch (\ReflectionException) {
-                $data[$key] = $this->$key;
-            }
-        }
-
-        return $data;
-    }
-
-    /**
-     * @deprecated since Symfony 7.4, will be replaced by `__serialize()` in 8.0
-     */
-    public function __sleep(): array
-    {
-        trigger_deprecation('symfony/validator', '7.4', 'Calling "%s::__sleep()" is deprecated, use "__serialize()" instead.', get_debug_type($this));
-
         return [
-            'constraints',
-            'constraintsByGroup',
-            'cascadingStrategy',
-            'traversalStrategy',
-            'autoMappingStrategy',
-            'class',
-            'name',
-            'property',
+            'constraints' => $this->constraints,
+            'constraintsByGroup' => $this->constraintsByGroup,
+            'cascadingStrategy' => $this->cascadingStrategy,
+            'traversalStrategy' => $this->traversalStrategy,
+            'autoMappingStrategy' => $this->autoMappingStrategy,
+            'class' => $this->class,
+            'name' => $this->name,
+            'property' => $this->property,
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #61407
| License       | MIT

This gets rid of all usages of `__sleep/wakeup()` while preserving FC/BC for payloads.