### PR TITLE
[TypeInfo] Add space after glue comma

### DIFF
--- a/src/Symfony/Component/TypeInfo/Tests/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/CollectionTypeTest.php
@@ -89,7 +89,7 @@ class CollectionTypeTest extends TestCase
         $this->assertEquals('array<bool>', (string) $type);
 
         $type = new CollectionType(new GenericType(Type::builtin(TypeIdentifier::ARRAY), Type::string(), Type::bool()));
-        $this->assertEquals('array<string,bool>', (string) $type);
+        $this->assertEquals('array<string, bool>', (string) $type);
 
         $type = new CollectionType(Type::generic(Type::builtin(TypeIdentifier::ARRAY), Type::bool()), isList: true);
         $this->assertEquals('list<bool>', (string) $type);

--- a/src/Symfony/Component/TypeInfo/Tests/Type/GenericTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/GenericTypeTest.php
@@ -31,10 +31,10 @@ class GenericTypeTest extends TestCase
         $this->assertEquals('array<bool>', (string) $type);
 
         $type = new GenericType(Type::builtin(TypeIdentifier::ARRAY), Type::string(), Type::bool());
-        $this->assertEquals('array<string,bool>', (string) $type);
+        $this->assertEquals('array<string, bool>', (string) $type);
 
         $type = new GenericType(Type::object(self::class), Type::union(Type::bool(), Type::string()), Type::int(), Type::float());
-        $this->assertEquals(\sprintf('%s<bool|string,int,float>', self::class), (string) $type);
+        $this->assertEquals(\sprintf('%s<bool|string, int, float>', self::class), (string) $type);
     }
 
     public function testWrappedTypeIsSatisfiedBy()

--- a/src/Symfony/Component/TypeInfo/Type/GenericType.php
+++ b/src/Symfony/Component/TypeInfo/Type/GenericType.php
@@ -72,7 +72,7 @@ final class GenericType extends Type implements WrappingTypeInterface
         $glue = '';
         foreach ($this->variableTypes as $t) {
             $variableTypesString .= $glue.$t;
-            $glue = ',';
+            $glue = ', ';
         }
 
         return $typeString.'<'.$variableTypesString.'>';

--- a/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
+++ b/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
@@ -240,7 +240,7 @@ trait TypeFactoryTrait
      * @param T      $className
      * @param U|null $backingType
      *
-     * @return ($className is class-string<\BackedEnum> ? ($backingType is U ? BackedEnumType<T,U> : BackedEnumType<T,BuiltinType<TypeIdentifier::INT>|BuiltinType<TypeIdentifier::STRING>>) : EnumType<T>))
+     * @return ($className is class-string<\BackedEnum> ? ($backingType is U ? BackedEnumType<T, U> : BackedEnumType<T, BuiltinType<TypeIdentifier::INT>|BuiltinType<TypeIdentifier::STRING>>) : EnumType<T>))
      */
     public static function enum(string $className, ?BuiltinType $backingType = null): EnumType
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

With this change, it will print a collection type as `array<key, value>` instead of `array<key,value>`.

I believe it is more standard than without the space. It's also what Symfony itself does everywhere.

Or should this target 8.0?