### PR TITLE
[Notifier][Telegram] Add TelegramOptions::messageThreadId()

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Telegram/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+ * Add support for `messageThreadId` option in `TelegramOptions`
+
 6.4
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramOptions.php
@@ -51,6 +51,16 @@ final class TelegramOptions implements MessageOptionsInterface
     /**
      * @return $this
      */
+    public function messageThreadId(int $threadId): static
+    {
+        $this->options['message_thread_id'] = $threadId;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
     public function parseMode(string $mode): static
     {
         $this->options['parse_mode'] = $mode;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | #61443
| License       | MIT

---

Telegram has long supported `thread` based messages.
This PR adds an option to enable that support.

Use this method like this:

```php
$options = new TelegramOptions()
	->messageThreadId($_ENV["YOU_THREAD_ID_HERE"]) // <== LIKE THIS
	->parseMode(TelegramOptions::PARSE_MODE_HTML);
```
