### PR TITLE
 Use <info> for options in command description

### DIFF
--- a/src/Symfony/Bridge/Monolog/Command/ServerLogCommand.php
+++ b/src/Symfony/Bridge/Monolog/Command/ServerLogCommand.php
@@ -68,7 +68,7 @@ class ServerLogCommand extends Command
 
                   <info>php %command.full_name%</info>
 
-                To filter the log messages using any ExpressionLanguage compatible expression, use the <comment>--filter</> option:
+                To filter the log messages using any ExpressionLanguage compatible expression, use the <info>--filter</> option:
 
                 <info>php %command.full_name% --filter="level > 200 or channel in ['app', 'doctrine']"</info>
                 EOF

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationExtractCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationExtractCommand.php
@@ -88,7 +88,7 @@ class TranslationExtractCommand extends Command
                 the new ones into the translation files.
 
                 When new translation strings are found it can automatically add a prefix to the translation
-                message. However, if the <comment>--no-fill</comment> option is used, the <comment>--prefix</comment>
+                message. However, if the <info>--no-fill</info> option is used, the <info>--prefix</info>
                 option has no effect, since the translation values are left empty.
 
                 Example running against a Bundle (AcmeBundle)
@@ -101,12 +101,12 @@ class TranslationExtractCommand extends Command
                   <info>php %command.full_name% --dump-messages en</info>
                   <info>php %command.full_name% --force --prefix="new_" fr</info>
 
-                You can sort the output with the <comment>--sort</> flag:
+                You can sort the output with the <info>--sort</> flag:
 
                     <info>php %command.full_name% --dump-messages --sort=asc en AcmeBundle</info>
                     <info>php %command.full_name% --force --sort=desc fr</info>
 
-                You can dump a tree-like structure using the yaml format with <comment>--as-tree</> flag:
+                You can dump a tree-like structure using the yaml format with <info>--as-tree</> flag:
 
                     <info>php %command.full_name% --force --format=yaml --as-tree=3 en AcmeBundle</info>
 

--- a/src/Symfony/Component/Console/Command/HelpCommand.php
+++ b/src/Symfony/Component/Console/Command/HelpCommand.php
@@ -44,7 +44,7 @@ class HelpCommand extends Command
 
                   <info>%command.full_name% list</info>
 
-                You can also output the help in other formats by using the <comment>--format</comment> option:
+                You can also output the help in other formats by using the <info>--format</info> option:
 
                   <info>%command.full_name% --format=xml list</info>
 

--- a/src/Symfony/Component/Console/Command/ListCommand.php
+++ b/src/Symfony/Component/Console/Command/ListCommand.php
@@ -45,7 +45,7 @@ class ListCommand extends Command
 
                   <info>%command.full_name% test</info>
 
-                You can also output the information in other formats by using the <comment>--format</comment> option:
+                You can also output the information in other formats by using the <info>--format</info> option:
 
                   <info>%command.full_name% --format=xml</info>
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.json
@@ -241,7 +241,7 @@
                 "help [--format FORMAT] [--raw] [--] [<command_name>]"
             ],
             "description": "Display help for a command",
-            "help": "The <info>help<\/info> command displays help for a given command:\n\n  <info>%%PHP_SELF%% help list<\/info>\n\nYou can also output the help in other formats by using the <comment>--format<\/comment> option:\n\n  <info>%%PHP_SELF%% help --format=xml list<\/info>\n\nTo display the list of available commands, please use the <info>list<\/info> command.",
+            "help": "The <info>help<\/info> command displays help for a given command:\n\n  <info>%%PHP_SELF%% help list<\/info>\n\nYou can also output the help in other formats by using the <info>--format<\/info> option:\n\n  <info>%%PHP_SELF%% help --format=xml list<\/info>\n\nTo display the list of available commands, please use the <info>list<\/info> command.",
             "definition": {
                 "arguments": {
                     "command_name": {
@@ -353,7 +353,7 @@
                 "list [--raw] [--format FORMAT] [--short] [--] [<namespace>]"
             ],
             "description": "List commands",
-            "help": "The <info>list<\/info> command lists all commands:\n\n  <info>%%PHP_SELF%% list<\/info>\n\nYou can also display the commands for a specific namespace:\n\n  <info>%%PHP_SELF%% list test<\/info>\n\nYou can also output the information in other formats by using the <comment>--format<\/comment> option:\n\n  <info>%%PHP_SELF%% list --format=xml<\/info>\n\nIt's also possible to get raw list of commands (useful for embedding command runner):\n\n  <info>%%PHP_SELF%% list --raw<\/info>",
+            "help": "The <info>list<\/info> command lists all commands:\n\n  <info>%%PHP_SELF%% list<\/info>\n\nYou can also display the commands for a specific namespace:\n\n  <info>%%PHP_SELF%% list test<\/info>\n\nYou can also output the information in other formats by using the <info>--format<\/info> option:\n\n  <info>%%PHP_SELF%% list --format=xml<\/info>\n\nIt's also possible to get raw list of commands (useful for embedding command runner):\n\n  <info>%%PHP_SELF%% list --raw<\/info>",
             "definition": {
                 "arguments": {
                     "namespace": {

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.xml
@@ -106,7 +106,7 @@
  
    &lt;info&gt;%%PHP_SELF%% help list&lt;/info&gt;
  
- You can also output the help in other formats by using the &lt;comment&gt;--format&lt;/comment&gt; option:
+ You can also output the help in other formats by using the &lt;info&gt;--format&lt;/info&gt; option:
  
    &lt;info&gt;%%PHP_SELF%% help --format=xml list&lt;/info&gt;
  
@@ -168,7 +168,7 @@
  
    &lt;info&gt;%%PHP_SELF%% list test&lt;/info&gt;
  
- You can also output the information in other formats by using the &lt;comment&gt;--format&lt;/comment&gt; option:
+ You can also output the information in other formats by using the &lt;info&gt;--format&lt;/info&gt; option:
  
    &lt;info&gt;%%PHP_SELF%% list --format=xml&lt;/info&gt;
  

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.json
@@ -245,7 +245,7 @@
                 "help [--format FORMAT] [--raw] [--] [<command_name>]"
             ],
             "description": "Display help for a command",
-            "help": "The <info>help<\/info> command displays help for a given command:\n\n  <info>%%PHP_SELF%% help list<\/info>\n\nYou can also output the help in other formats by using the <comment>--format<\/comment> option:\n\n  <info>%%PHP_SELF%% help --format=xml list<\/info>\n\nTo display the list of available commands, please use the <info>list<\/info> command.",
+            "help": "The <info>help<\/info> command displays help for a given command:\n\n  <info>%%PHP_SELF%% help list<\/info>\n\nYou can also output the help in other formats by using the <info>--format<\/info> option:\n\n  <info>%%PHP_SELF%% help --format=xml list<\/info>\n\nTo display the list of available commands, please use the <info>list<\/info> command.",
             "definition": {
                 "arguments": {
                     "command_name": {
@@ -357,7 +357,7 @@
                 "list [--raw] [--format FORMAT] [--short] [--] [<namespace>]"
             ],
             "description": "List commands",
-            "help": "The <info>list<\/info> command lists all commands:\n\n  <info>%%PHP_SELF%% list<\/info>\n\nYou can also display the commands for a specific namespace:\n\n  <info>%%PHP_SELF%% list test<\/info>\n\nYou can also output the information in other formats by using the <comment>--format<\/comment> option:\n\n  <info>%%PHP_SELF%% list --format=xml<\/info>\n\nIt's also possible to get raw list of commands (useful for embedding command runner):\n\n  <info>%%PHP_SELF%% list --raw<\/info>",
+            "help": "The <info>list<\/info> command lists all commands:\n\n  <info>%%PHP_SELF%% list<\/info>\n\nYou can also display the commands for a specific namespace:\n\n  <info>%%PHP_SELF%% list test<\/info>\n\nYou can also output the information in other formats by using the <info>--format<\/info> option:\n\n  <info>%%PHP_SELF%% list --format=xml<\/info>\n\nIt's also possible to get raw list of commands (useful for embedding command runner):\n\n  <info>%%PHP_SELF%% list --raw<\/info>",
             "definition": {
                 "arguments": {
                     "namespace": {

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.xml
@@ -106,7 +106,7 @@
  
    &lt;info&gt;%%PHP_SELF%% help list&lt;/info&gt;
  
- You can also output the help in other formats by using the &lt;comment&gt;--format&lt;/comment&gt; option:
+ You can also output the help in other formats by using the &lt;info&gt;--format&lt;/info&gt; option:
  
    &lt;info&gt;%%PHP_SELF%% help --format=xml list&lt;/info&gt;
  
@@ -168,7 +168,7 @@
  
    &lt;info&gt;%%PHP_SELF%% list test&lt;/info&gt;
  
- You can also output the information in other formats by using the &lt;comment&gt;--format&lt;/comment&gt; option:
+ You can also output the information in other formats by using the &lt;info&gt;--format&lt;/info&gt; option:
  
    &lt;info&gt;%%PHP_SELF%% list --format=xml&lt;/info&gt;
  

--- a/src/Symfony/Component/Messenger/Command/AbstractFailedMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/AbstractFailedMessagesCommand.php
@@ -146,9 +146,9 @@ abstract class AbstractFailedMessagesCommand extends Command
     {
         if ($receiver instanceof MessageCountAwareInterface) {
             if (1 === $receiver->getMessageCount()) {
-                $io->writeln('There is <comment>1</comment> message pending in the failure transport.');
+                $io->writeln('There is <info>1</info> message pending in the failure transport.');
             } else {
-                $io->writeln(\sprintf('There are <comment>%d</comment> messages pending in the failure transport.', $receiver->getMessageCount()));
+                $io->writeln(\sprintf('There are <info>%d</info> messages pending in the failure transport.', $receiver->getMessageCount()));
             }
         }
     }
@@ -195,9 +195,9 @@ abstract class AbstractFailedMessagesCommand extends Command
         $failureTransportsCount = \count($failureTransports);
         if ($failureTransportsCount > 1) {
             $io->writeln([
-                \sprintf('> Loading messages from the <comment>global</comment> failure transport <comment>%s</comment>.', $failureTransportName),
-                '> To use a different failure transport, pass <comment>--transport=</comment>.',
-                \sprintf('> Available failure transports are: <comment>%s</comment>', implode(', ', $failureTransports)),
+                \sprintf('> Loading messages from the <info>global</info> failure transport <info>%s</info>.', $failureTransportName),
+                '> To use a different failure transport, pass <info>--transport=</info>.',
+                \sprintf('> Available failure transports are: <info>%s</info>', implode(', ', $failureTransports)),
                 "\n",
             ]);
         }

--- a/src/Symfony/Component/Translation/Command/TranslationPullCommand.php
+++ b/src/Symfony/Component/Translation/Command/TranslationPullCommand.php
@@ -93,7 +93,7 @@ final class TranslationPullCommand extends Command
                 The <info>%command.name%</> command pulls translations from the given provider. Only
                 new translations are pulled, existing ones are not overwritten.
 
-                You can overwrite existing translations (and remove the missing ones on local side) by using the <comment>--force</> flag:
+                You can overwrite existing translations (and remove the missing ones on local side) by using the <info>--force</> flag:
 
                   <info>php %command.full_name% --force provider</>
 
@@ -101,7 +101,7 @@ final class TranslationPullCommand extends Command
 
                   <info>php %command.full_name% provider --force --domains=messages --domains=validators --locales=en</>
 
-                This command pulls all translations associated with the <comment>messages</> and <comment>validators</> domains for the <comment>en</> locale.
+                This command pulls all translations associated with the <info>messages</> and <info>validators</> domains for the <info>en</> locale.
                 Local translations for the specified domains and locale are deleted if they're not present on the provider and overwritten if it's the case.
                 Local translations for others domains and locales are ignored.
                 EOF

--- a/src/Symfony/Component/Translation/Command/TranslationPushCommand.php
+++ b/src/Symfony/Component/Translation/Command/TranslationPushCommand.php
@@ -84,11 +84,11 @@ final class TranslationPushCommand extends Command
                 The <info>%command.name%</> command pushes translations to the given provider. Only new
                 translations are pushed, existing ones are not overwritten.
 
-                You can overwrite existing translations by using the <comment>--force</> flag:
+                You can overwrite existing translations by using the <info>--force</> flag:
 
                   <info>php %command.full_name% --force provider</>
 
-                You can delete provider translations which are not present locally by using the <comment>--delete-missing</> flag:
+                You can delete provider translations which are not present locally by using the <info>--delete-missing</> flag:
 
                   <info>php %command.full_name% --delete-missing provider</>
 
@@ -96,7 +96,7 @@ final class TranslationPushCommand extends Command
 
                   <info>php %command.full_name% provider --force --delete-missing --domains=messages --domains=validators --locales=en</>
 
-                This command pushes all translations associated with the <comment>messages</> and <comment>validators</> domains for the <comment>en</> locale.
+                This command pushes all translations associated with the <info>messages</> and <info>validators</> domains for the <info>en</> locale.
                 Provider translations for the specified domains and locale are deleted if they're not present locally and overwritten if it's the case.
                 Provider translations for others domains and locales are ignored.
                 EOF

--- a/src/Symfony/Component/VarDumper/Command/ServerDumpCommand.php
+++ b/src/Symfony/Component/VarDumper/Command/ServerDumpCommand.php
@@ -63,7 +63,7 @@ class ServerDumpCommand extends Command
 
                   <info>php %command.full_name%</info>
 
-                You can consult dumped data in HTML format in your browser by providing the <comment>--format=html</comment> option
+                You can consult dumped data in HTML format in your browser by providing the <info>--format=html</info> option
                 and redirecting the output to a file:
 
                   <info>php %command.full_name% --format="html" > dump.html</info>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | n/a
| License       | MIT

A small change to always use `<info>` when using a flag in a command description.