### PR TITLE
[String] specific fix to avoid 'outag' when inflecting 'outages'

### DIFF
--- a/src/Symfony/Component/String/Inflector/EnglishInflector.php
+++ b/src/Symfony/Component/String/Inflector/EnglishInflector.php
@@ -166,6 +166,9 @@ final class EnglishInflector implements InflectorInterface
         // edges (edge)
         ['segd', 4, true, true, 'dge'],
 
+        // outages (outage) - specific fix to avoid 'outag'
+        ['segatuo', 7, true, true, 'outage'],
+
         // roses (rose), garages (garage), cassettes (cassette),
         // waltzes (waltz), heroes (hero), bushes (bush), arches (arch),
         // shoes (shoe)

--- a/src/Symfony/Component/String/Tests/Inflector/EnglishInflectorTest.php
+++ b/src/Symfony/Component/String/Tests/Inflector/EnglishInflectorTest.php
@@ -124,6 +124,7 @@ class EnglishInflectorTest extends TestCase
             ['news', 'news'],
             ['oases', ['oas', 'oase', 'oasis']],
             ['objectives', 'objective'],
+            ['outages', 'outage'],
             ['oxen', 'ox'],
             ['parties', 'party'],
             ['people', 'person'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| License       | MIT

When inflecting `Outages` with EnglishInflector it would change to the incorrect `Outag` instead of the correct `Outage`
