### PR TITLE
[Validator] Optimize serialized metadata and cleanup tests

### DIFF
--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -310,8 +310,6 @@ abstract class Constraint
 
     /**
      * Optimizes the serialized value to minimize storage space.
-     *
-     * @internal
      */
     public function __serialize(): array
     {

--- a/src/Symfony/Component/Validator/Mapping/MemberMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/MemberMetadata.php
@@ -79,7 +79,7 @@ abstract class MemberMetadata extends GenericMetadata implements PropertyMetadat
     public function __serialize(): array
     {
         if (self::class === (new \ReflectionMethod($this, '__sleep'))->class || self::class !== (new \ReflectionMethod($this, '__serialize'))->class) {
-            return [
+            return parent::__serialize() + [
                 'constraints' => $this->constraints,
                 'constraintsByGroup' => $this->constraintsByGroup,
                 'cascadingStrategy' => $this->cascadingStrategy,
@@ -127,7 +127,7 @@ abstract class MemberMetadata extends GenericMetadata implements PropertyMetadat
     }
 
     /**
-     * Returns the name of the member.
+     * Returns the name of the property or its getter.
      */
     public function getName(): string
     {
@@ -144,33 +144,21 @@ abstract class MemberMetadata extends GenericMetadata implements PropertyMetadat
         return $this->property;
     }
 
-    /**
-     * Returns whether this member is public.
-     */
     public function isPublic(object|string $objectOrClassName): bool
     {
         return $this->getReflectionMember($objectOrClassName)->isPublic();
     }
 
-    /**
-     * Returns whether this member is protected.
-     */
     public function isProtected(object|string $objectOrClassName): bool
     {
         return $this->getReflectionMember($objectOrClassName)->isProtected();
     }
 
-    /**
-     * Returns whether this member is private.
-     */
     public function isPrivate(object|string $objectOrClassName): bool
     {
         return $this->getReflectionMember($objectOrClassName)->isPrivate();
     }
 
-    /**
-     * Returns the reflection instance for accessing the member's value.
-     */
     public function getReflectionMember(object|string $objectOrClassName): \ReflectionMethod|\ReflectionProperty
     {
         $className = \is_string($objectOrClassName) ? $objectOrClassName : $objectOrClassName::class;

--- a/src/Symfony/Component/Validator/Tests/Constraints/BicValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/BicValidatorTest.php
@@ -79,7 +79,7 @@ class BicValidatorTest extends ConstraintValidatorTestCase
         $classMetadata = new ClassMetadata(BicDummy::class);
         (new AttributeLoader())->loadClassMetadata($classMetadata);
 
-        [$constraint] = $classMetadata->properties['bic1']->constraints;
+        [$constraint] = $classMetadata->getPropertyMetadata('bic1')[0]->getConstraints();
 
         $this->setObject(new BicDummy());
 
@@ -130,7 +130,7 @@ class BicValidatorTest extends ConstraintValidatorTestCase
         $classMetadata = new ClassMetadata(BicDummy::class);
         (new AttributeLoader())->loadClassMetadata($classMetadata);
 
-        [$constraint] = $classMetadata->properties['bic1']->constraints;
+        [$constraint] = $classMetadata->getPropertyMetadata('bic1')[0]->getConstraints();
 
         $this->validator->validate('UNCRIT2B912', $constraint);
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/CardSchemeTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CardSchemeTest.php
@@ -27,15 +27,15 @@ class CardSchemeTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertSame([CardScheme::MASTERCARD, CardScheme::VISA], $aConstraint->schemes);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame([CardScheme::AMEX], $bConstraint->schemes);
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(['Default', 'CardSchemeDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertSame([CardScheme::DINERS], $cConstraint->schemes);
         self::assertSame(['my_group'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);

--- a/src/Symfony/Component/Validator/Tests/Constraints/CharsetTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CharsetTest.php
@@ -47,10 +47,10 @@ class CharsetTest extends TestCase
         $loader = new AttributeLoader();
         $this->assertTrue($loader->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         $this->assertSame('UTF-8', $aConstraint->encodings);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         $this->assertSame(['ASCII', 'UTF-8'], $bConstraint->encodings);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/ChoiceTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ChoiceTest.php
@@ -37,24 +37,24 @@ class ChoiceTest extends TestCase
         self::assertTrue($loader->loadClassMetadata($metadata));
 
         /** @var Choice $aConstraint */
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertSame([1, 2], $aConstraint->choices);
         self::assertSame(['Default', 'ChoiceDummy'], $aConstraint->groups);
 
         /** @var Choice $bConstraint */
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame(['foo', 'bar'], $bConstraint->choices);
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(['Default', 'ChoiceDummy'], $bConstraint->groups);
 
         /** @var Choice $cConstraint */
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertSame([1, 2], $aConstraint->choices);
         self::assertSame(['my_group'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);
 
         /** @var Choice $stringIndexedConstraint */
-        [$stringIndexedConstraint] = $metadata->properties['stringIndexed']->getConstraints();
+        [$stringIndexedConstraint] = $metadata->getPropertyMetadata('stringIndexed')[0]->getConstraints();
         self::assertSame(['one' => 1, 'two' => 2], $stringIndexedConstraint->choices);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/CidrTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CidrTest.php
@@ -131,19 +131,19 @@ class CidrTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertSame(Ip::ALL, $aConstraint->version);
         self::assertSame(0, $aConstraint->netmaskMin);
         self::assertSame(128, $aConstraint->netmaskMax);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame(Ip::V6, $bConstraint->version);
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(10, $bConstraint->netmaskMin);
         self::assertSame(126, $bConstraint->netmaskMax);
         self::assertSame(['Default', 'CidrDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertSame(['my_group'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/CountTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CountTest.php
@@ -24,12 +24,12 @@ class CountTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertSame(42, $aConstraint->min);
         self::assertSame(42, $aConstraint->max);
         self::assertNull($aConstraint->divisibleBy);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame(1, $bConstraint->min);
         self::assertSame(4711, $bConstraint->max);
         self::assertNull($bConstraint->divisibleBy);
@@ -37,7 +37,7 @@ class CountTest extends TestCase
         self::assertSame('myMaxMessage', $bConstraint->maxMessage);
         self::assertSame(['Default', 'CountDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertNull($cConstraint->min);
         self::assertNull($cConstraint->max);
         self::assertSame(10, $cConstraint->divisibleBy);

--- a/src/Symfony/Component/Validator/Tests/Constraints/CountryTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CountryTest.php
@@ -24,15 +24,15 @@ class CountryTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertFalse($aConstraint->alpha3);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame('myMessage', $bConstraint->message);
         self::assertTrue($bConstraint->alpha3);
         self::assertSame(['Default', 'CountryDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertSame(['my_group'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/CssColorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CssColorTest.php
@@ -27,15 +27,15 @@ final class CssColorTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertSame([CssColor::HEX_LONG, CssColor::HEX_SHORT], $aConstraint->formats);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame([CssColor::HEX_LONG], $bConstraint->formats);
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(['Default', 'CssColorDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertSame([CssColor::HEX_SHORT], $cConstraint->formats);
         self::assertSame(['my_group'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);

--- a/src/Symfony/Component/Validator/Tests/Constraints/CurrencyTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CurrencyTest.php
@@ -24,11 +24,11 @@ class CurrencyTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(['Default', 'CurrencyDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertSame(['my_group'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateTest.php
@@ -24,11 +24,11 @@ class DateTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(['Default', 'DateDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertSame(['my_group'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateTimeTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateTimeTest.php
@@ -24,15 +24,15 @@ class DateTimeTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertSame('Y-m-d H:i:s', $aConstraint->format);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame('d.m.Y', $bConstraint->format);
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(['Default', 'DateTimeDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertSame('m/d/Y', $cConstraint->format);
         self::assertSame(['my_group'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);

--- a/src/Symfony/Component/Validator/Tests/Constraints/DivisibleByTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DivisibleByTest.php
@@ -24,16 +24,16 @@ class DivisibleByTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertSame(2, $aConstraint->value);
         self::assertNull($aConstraint->propertyPath);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame(4711, $bConstraint->value);
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(['Default', 'DivisibleByDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertNull($cConstraint->value);
         self::assertSame('b', $cConstraint->propertyPath);
         self::assertSame('myMessage', $cConstraint->message);

--- a/src/Symfony/Component/Validator/Tests/Constraints/EmailTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EmailTest.php
@@ -79,16 +79,16 @@ class EmailTest extends TestCase
         $metadata = new ClassMetadata(EmailDummy::class);
         (new AttributeLoader())->loadClassMetadata($metadata);
 
-        [$aConstraint] = $metadata->properties['a']->constraints;
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertNull($aConstraint->mode);
         self::assertNull($aConstraint->normalizer);
 
-        [$bConstraint] = $metadata->properties['b']->constraints;
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(Email::VALIDATION_MODE_HTML5, $bConstraint->mode);
         self::assertSame('trim', $bConstraint->normalizer);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertSame(['my_group'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/EqualToTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EqualToTest.php
@@ -24,16 +24,16 @@ class EqualToTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertSame(2, $aConstraint->value);
         self::assertNull($aConstraint->propertyPath);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame(4711, $bConstraint->value);
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(['Default', 'EqualToDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertNull($cConstraint->value);
         self::assertSame('b', $cConstraint->propertyPath);
         self::assertSame('myMessage', $cConstraint->message);

--- a/src/Symfony/Component/Validator/Tests/Constraints/ExpressionSyntaxTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ExpressionSyntaxTest.php
@@ -42,7 +42,7 @@ class ExpressionSyntaxTest extends TestCase
         $metadata = new ClassMetadata(ExpressionSyntaxDummy::class);
         self::assertTrue((new AttributeLoader())->loadClassMetadata($metadata));
 
-        yield 'attribute' => [$metadata->properties['b']->constraints[0]];
+        yield 'attribute' => [$metadata->getPropertyMetadata('b')[0]->getConstraints()[0]];
     }
 
     #[IgnoreDeprecations]
@@ -59,16 +59,16 @@ class ExpressionSyntaxTest extends TestCase
         $metadata = new ClassMetadata(ExpressionSyntaxDummy::class);
         self::assertTrue((new AttributeLoader())->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertNull($aConstraint->service);
         self::assertNull($aConstraint->allowedVariables);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame('my_service', $bConstraint->service);
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(['Default', 'ExpressionSyntaxDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertSame(['foo', 'bar'], $cConstraint->allowedVariables);
         self::assertSame(['my_group'], $cConstraint->groups);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/ExpressionTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ExpressionTest.php
@@ -26,18 +26,18 @@ class ExpressionTest extends TestCase
         $metadata = new ClassMetadata(ExpressionDummy::class);
         self::assertTrue((new AttributeLoader())->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertSame('value == "1"', $aConstraint->expression);
         self::assertSame([], $aConstraint->values);
         self::assertTrue($aConstraint->negate);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame('value == "1"', $bConstraint->expression);
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(['Default', 'ExpressionDummy'], $bConstraint->groups);
         self::assertTrue($bConstraint->negate);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertSame('value == someVariable', $cConstraint->expression);
         self::assertSame(['someVariable' => 42], $cConstraint->values);
         self::assertSame(['foo'], $cConstraint->groups);

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileTest.php
@@ -165,15 +165,15 @@ class FileTest extends TestCase
         $metadata = new ClassMetadata(FileDummy::class);
         self::assertTrue((new AttributeLoader())->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertNull($aConstraint->maxSize);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame(100, $bConstraint->maxSize);
         self::assertSame('myMessage', $bConstraint->notFoundMessage);
         self::assertSame(['Default', 'FileDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertSame(100000, $cConstraint->maxSize);
         self::assertSame(['my_group'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualTest.php
@@ -24,16 +24,16 @@ class GreaterThanOrEqualTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertSame(2, $aConstraint->value);
         self::assertNull($aConstraint->propertyPath);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame(4711, $bConstraint->value);
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(['Default', 'GreaterThanOrEqualDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertNull($cConstraint->value);
         self::assertSame('b', $cConstraint->propertyPath);
         self::assertSame('myMessage', $cConstraint->message);

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanTest.php
@@ -24,16 +24,16 @@ class GreaterThanTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertSame(2, $aConstraint->value);
         self::assertNull($aConstraint->propertyPath);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame(4711, $bConstraint->value);
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(['Default', 'GreaterThanDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertNull($cConstraint->value);
         self::assertSame('b', $cConstraint->propertyPath);
         self::assertSame('myMessage', $cConstraint->message);

--- a/src/Symfony/Component/Validator/Tests/Constraints/HostnameTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/HostnameTest.php
@@ -24,15 +24,15 @@ class HostnameTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertTrue($aConstraint->requireTld);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertFalse($bConstraint->requireTld);
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(['Default', 'HostnameDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertSame(['my_group'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/IbanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IbanValidatorTest.php
@@ -456,7 +456,7 @@ class IbanValidatorTest extends ConstraintValidatorTestCase
         $classMetadata = new ClassMetadata(IbanDummy::class);
         (new AttributeLoader())->loadClassMetadata($classMetadata);
 
-        [$constraint] = $classMetadata->properties['iban']->constraints;
+        [$constraint] = $classMetadata->getPropertyMetadata('iban')[0]->getConstraints();
 
         $this->validator->validate('DE89 3704 0044 0532 0130 01', $constraint);
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/IdenticalToTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IdenticalToTest.php
@@ -24,16 +24,16 @@ class IdenticalToTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertSame(2, $aConstraint->value);
         self::assertNull($aConstraint->propertyPath);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame(4711, $bConstraint->value);
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(['Default', 'IdenticalToDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertNull($cConstraint->value);
         self::assertSame('b', $cConstraint->propertyPath);
         self::assertSame('myMessage', $cConstraint->message);

--- a/src/Symfony/Component/Validator/Tests/Constraints/ImageTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ImageTest.php
@@ -24,20 +24,20 @@ class ImageTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertNull($aConstraint->minWidth);
         self::assertNull($aConstraint->maxWidth);
         self::assertNull($aConstraint->minHeight);
         self::assertNull($aConstraint->maxHeight);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame(50, $bConstraint->minWidth);
         self::assertSame(200, $bConstraint->maxWidth);
         self::assertSame(50, $bConstraint->minHeight);
         self::assertSame(200, $bConstraint->maxHeight);
         self::assertSame(['Default', 'ImageDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertSame(100000, $cConstraint->maxSize);
         self::assertSame(['my_group'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);

--- a/src/Symfony/Component/Validator/Tests/Constraints/IpTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IpTest.php
@@ -55,16 +55,16 @@ class IpTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertSame(Ip::V4, $aConstraint->version);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame(Ip::V6, $bConstraint->version);
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame('trim', $bConstraint->normalizer);
         self::assertSame(['Default', 'IpDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertSame(['my_group'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/IsbnTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IsbnTest.php
@@ -24,15 +24,15 @@ class IsbnTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertNull($aConstraint->type);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame(Isbn::ISBN_13, $bConstraint->type);
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(['Default', 'IsbnDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertSame(['my_group'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/IsinTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IsinTest.php
@@ -24,11 +24,11 @@ class IsinTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(['Default', 'IsinDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertSame(['my_group'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/IssnTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IssnTest.php
@@ -24,17 +24,17 @@ class IssnTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertFalse($aConstraint->caseSensitive);
         self::assertFalse($aConstraint->requireHyphen);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame('myMessage', $bConstraint->message);
         self::assertTrue($bConstraint->caseSensitive);
         self::assertTrue($bConstraint->requireHyphen);
         self::assertSame(['Default', 'IssnDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertSame(['my_group'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/JsonTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/JsonTest.php
@@ -24,11 +24,11 @@ class JsonTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(['Default', 'JsonDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertSame(['my_group'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LanguageTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LanguageTest.php
@@ -24,15 +24,15 @@ class LanguageTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertFalse($aConstraint->alpha3);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame('myMessage', $bConstraint->message);
         self::assertTrue($bConstraint->alpha3);
         self::assertSame(['Default', 'LanguageDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertSame(['my_group'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LengthTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LengthTest.php
@@ -95,11 +95,11 @@ class LengthTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertSame(42, $aConstraint->min);
         self::assertSame(42, $aConstraint->max);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame(1, $bConstraint->min);
         self::assertSame(4711, $bConstraint->max);
         self::assertSame('myMinMessage', $bConstraint->minMessage);
@@ -108,7 +108,7 @@ class LengthTest extends TestCase
         self::assertSame('ISO-8859-15', $bConstraint->charset);
         self::assertSame(['Default', 'LengthDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertSame(['my_group'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualTest.php
@@ -24,16 +24,16 @@ class LessThanOrEqualTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertSame(2, $aConstraint->value);
         self::assertNull($aConstraint->propertyPath);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame(4711, $bConstraint->value);
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(['Default', 'LessThanOrEqualDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertNull($cConstraint->value);
         self::assertSame('b', $cConstraint->propertyPath);
         self::assertSame('myMessage', $cConstraint->message);

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanTest.php
@@ -24,16 +24,16 @@ class LessThanTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertSame(2, $aConstraint->value);
         self::assertNull($aConstraint->propertyPath);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame(4711, $bConstraint->value);
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(['Default', 'LessThanDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertNull($cConstraint->value);
         self::assertSame('b', $cConstraint->propertyPath);
         self::assertSame('myMessage', $cConstraint->message);

--- a/src/Symfony/Component/Validator/Tests/Constraints/LocaleTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LocaleTest.php
@@ -24,15 +24,15 @@ class LocaleTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertTrue($aConstraint->canonicalize);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame('myMessage', $bConstraint->message);
         self::assertFalse($bConstraint->canonicalize);
         self::assertSame(['Default', 'LocaleDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertSame(['my_group'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LuhnTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LuhnTest.php
@@ -24,11 +24,11 @@ class LuhnTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(['Default', 'LuhnDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertSame(['my_group'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/MacAddressTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/MacAddressTest.php
@@ -34,17 +34,17 @@ class MacAddressTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertSame('myMessage', $aConstraint->message);
         self::assertEquals(trim(...), $aConstraint->normalizer);
         self::assertSame(MacAddress::ALL, $aConstraint->type);
         self::assertSame(['Default', 'MacAddressDummy'], $aConstraint->groups);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame(MacAddress::LOCAL_UNICAST, $bConstraint->type);
         self::assertSame(['Default', 'MacAddressDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertSame(['my_group'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/NegativeOrZeroTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NegativeOrZeroTest.php
@@ -24,12 +24,12 @@ class NegativeOrZeroTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertSame(0, $aConstraint->value);
         self::assertNull($aConstraint->propertyPath);
         self::assertSame(['Default', 'NegativeOrZeroDummy'], $aConstraint->groups);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(['foo'], $bConstraint->groups);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/NegativeTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NegativeTest.php
@@ -24,12 +24,12 @@ class NegativeTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertSame(0, $aConstraint->value);
         self::assertNull($aConstraint->propertyPath);
         self::assertSame(['Default', 'NegativeDummy'], $aConstraint->groups);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(['foo'], $bConstraint->groups);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotBlankTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotBlankTest.php
@@ -37,11 +37,11 @@ class NotBlankTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertFalse($aConstraint->allowNull);
         self::assertNull($aConstraint->normalizer);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertTrue($bConstraint->allowNull);
         self::assertSame('trim', $bConstraint->normalizer);
         self::assertSame('myMessage', $bConstraint->message);

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotCompromisedPasswordTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotCompromisedPasswordTest.php
@@ -34,17 +34,17 @@ class NotCompromisedPasswordTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertSame(1, $aConstraint->threshold);
         self::assertFalse($aConstraint->skipOnError);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(42, $bConstraint->threshold);
         self::assertTrue($bConstraint->skipOnError);
         self::assertSame(['Default', 'NotCompromisedPasswordDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertSame(['my_group'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotEqualToTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotEqualToTest.php
@@ -24,16 +24,16 @@ class NotEqualToTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertSame(2, $aConstraint->value);
         self::assertNull($aConstraint->propertyPath);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame(4711, $bConstraint->value);
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(['Default', 'NotEqualToDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertNull($cConstraint->value);
         self::assertSame('b', $cConstraint->propertyPath);
         self::assertSame('myMessage', $cConstraint->message);

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotIdenticalToTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotIdenticalToTest.php
@@ -24,16 +24,16 @@ class NotIdenticalToTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertSame(2, $aConstraint->value);
         self::assertNull($aConstraint->propertyPath);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame(4711, $bConstraint->value);
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(['Default', 'NotIdenticalToDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertNull($cConstraint->value);
         self::assertSame('b', $cConstraint->propertyPath);
         self::assertSame('myMessage', $cConstraint->message);

--- a/src/Symfony/Component/Validator/Tests/Constraints/PositiveOrZeroTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/PositiveOrZeroTest.php
@@ -24,12 +24,12 @@ class PositiveOrZeroTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertSame(0, $aConstraint->value);
         self::assertNull($aConstraint->propertyPath);
         self::assertSame(['Default', 'PositiveOrZeroDummy'], $aConstraint->groups);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(['foo'], $bConstraint->groups);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/PositiveTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/PositiveTest.php
@@ -24,12 +24,12 @@ class PositiveTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertSame(0, $aConstraint->value);
         self::assertNull($aConstraint->propertyPath);
         self::assertSame(['Default', 'PositiveDummy'], $aConstraint->groups);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(['foo'], $bConstraint->groups);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/RegexTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RegexTest.php
@@ -122,19 +122,19 @@ class RegexTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertSame('/^[0-9]+$/', $aConstraint->pattern);
         self::assertTrue($aConstraint->match);
         self::assertNull($aConstraint->normalizer);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame('/^[0-9]+$/', $bConstraint->pattern);
         self::assertSame('[0-9]+', $bConstraint->htmlPattern);
         self::assertFalse($bConstraint->match);
         self::assertSame(['Default', 'RegexDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertSame(['my_group'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimeTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimeTest.php
@@ -24,11 +24,11 @@ class TimeTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(['Default', 'TimeDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertSame(['my_group'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimezoneTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimezoneTest.php
@@ -70,16 +70,16 @@ class TimezoneTest extends TestCase
         $metadata = new ClassMetadata(TimezoneDummy::class);
         self::assertTrue((new AttributeLoader())->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertSame(\DateTimeZone::ALL, $aConstraint->zone);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame(\DateTimeZone::PER_COUNTRY, $bConstraint->zone);
         self::assertSame('DE', $bConstraint->countryCode);
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(['Default', 'TimezoneDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertSame(['my_group'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/TypeTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TypeTest.php
@@ -26,15 +26,15 @@ class TypeTest extends TestCase
         $metadata = new ClassMetadata(TypeDummy::class);
         self::assertTrue((new AttributeLoader())->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertSame('integer', $aConstraint->type);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame(\DateTimeImmutable::class, $bConstraint->type);
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(['Default', 'TypeDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertSame(['string', 'array'], $cConstraint->type);
         self::assertSame(['my_group'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);

--- a/src/Symfony/Component/Validator/Tests/Constraints/UlidTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UlidTest.php
@@ -25,12 +25,12 @@ class UlidTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(['Default', 'UlidDummy'], $bConstraint->groups);
         self::assertSame(Ulid::FORMAT_BASE_58, $bConstraint->format);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertSame(['my_group'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/UniqueTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UniqueTest.php
@@ -27,15 +27,15 @@ class UniqueTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(['Default', 'UniqueDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertSame(['my_group'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);
 
-        [$dConstraint] = $metadata->properties['d']->getConstraints();
+        [$dConstraint] = $metadata->getPropertyMetadata('d')[0]->getConstraints();
         self::assertSame('intval', $dConstraint->normalizer);
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/UrlTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UrlTest.php
@@ -54,26 +54,26 @@ class UrlTest extends TestCase
         $metadata = new ClassMetadata(UrlDummy::class);
         self::assertTrue((new AttributeLoader())->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertSame(['http', 'https'], $aConstraint->protocols);
         self::assertFalse($aConstraint->relativeProtocol);
         self::assertNull($aConstraint->normalizer);
         self::assertFalse($aConstraint->requireTld);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame(['ftp', 'gopher'], $bConstraint->protocols);
         self::assertSame('trim', $bConstraint->normalizer);
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(['Default', 'UrlDummy'], $bConstraint->groups);
         self::assertFalse($bConstraint->requireTld);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertTrue($cConstraint->relativeProtocol);
         self::assertSame(['my_group'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);
         self::assertFalse($cConstraint->requireTld);
 
-        [$dConstraint] = $metadata->properties['d']->getConstraints();
+        [$dConstraint] = $metadata->getPropertyMetadata('d')[0]->getConstraints();
         self::assertSame(['http', 'https'], $dConstraint->protocols);
         self::assertFalse($dConstraint->relativeProtocol);
         self::assertNull($dConstraint->normalizer);

--- a/src/Symfony/Component/Validator/Tests/Constraints/UuidTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UuidTest.php
@@ -54,19 +54,19 @@ class UuidTest extends TestCase
         $metadata = new ClassMetadata(UuidDummy::class);
         self::assertTrue((new AttributeLoader())->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertSame(Uuid::ALL_VERSIONS, $aConstraint->versions);
         self::assertTrue($aConstraint->strict);
         self::assertNull($aConstraint->normalizer);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame([Uuid::V4_RANDOM, Uuid::V6_SORTABLE], $bConstraint->versions);
         self::assertFalse($bConstraint->strict);
         self::assertSame('trim', $bConstraint->normalizer);
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(['Default', 'UuidDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertSame(['my_group'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/ValidTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ValidTest.php
@@ -41,11 +41,11 @@ class ValidTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertFalse($bConstraint->traverse);
         self::assertSame(['traverse_group'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertSame(['my_group'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/WeekTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/WeekTest.php
@@ -81,11 +81,11 @@ class WeekTest extends TestCase
         $loader = new AttributeLoader();
         $this->assertTrue($loader->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         $this->assertNull($aConstraint->min);
         $this->assertNull($aConstraint->max);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         $this->assertSame('2010-W01', $bConstraint->min);
         $this->assertSame('2010-W02', $bConstraint->max);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/WhenTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/WhenTest.php
@@ -73,7 +73,7 @@ final class WhenTest extends TestCase
         ], $classConstraint->constraints);
         self::assertSame([], $classConstraint->otherwise);
 
-        [$fooConstraint] = $metadata->properties['foo']->getConstraints();
+        [$fooConstraint] = $metadata->getPropertyMetadata('foo')[0]->getConstraints();
 
         self::assertInstanceOf(When::class, $fooConstraint);
         self::assertSame('true', $fooConstraint->expression);
@@ -84,7 +84,7 @@ final class WhenTest extends TestCase
         self::assertSame([], $fooConstraint->otherwise);
         self::assertSame(['Default', 'WhenTestWithAttributes'], $fooConstraint->groups);
 
-        [$barConstraint] = $metadata->properties['bar']->getConstraints();
+        [$barConstraint] = $metadata->getPropertyMetadata('bar')[0]->getConstraints();
 
         self::assertInstanceOf(When::class, $barConstraint);
         self::assertSame('false', $barConstraint->expression);
@@ -95,7 +95,7 @@ final class WhenTest extends TestCase
         self::assertSame([], $barConstraint->otherwise);
         self::assertSame(['foo'], $barConstraint->groups);
 
-        [$quxConstraint] = $metadata->properties['qux']->getConstraints();
+        [$quxConstraint] = $metadata->getPropertyMetadata('qux')[0]->getConstraints();
 
         self::assertInstanceOf(When::class, $quxConstraint);
         self::assertSame('true', $quxConstraint->expression);
@@ -103,7 +103,7 @@ final class WhenTest extends TestCase
         self::assertSame([], $quxConstraint->otherwise);
         self::assertSame(['foo'], $quxConstraint->groups);
 
-        [$bazConstraint] = $metadata->getters['baz']->getConstraints();
+        [$bazConstraint] = $metadata->getPropertyMetadata('baz')[0]->getConstraints();
 
         self::assertInstanceOf(When::class, $bazConstraint);
         self::assertSame('true', $bazConstraint->expression);
@@ -114,7 +114,7 @@ final class WhenTest extends TestCase
         self::assertSame([], $bazConstraint->otherwise);
         self::assertSame(['Default', 'WhenTestWithAttributes'], $bazConstraint->groups);
 
-        [$quuxConstraint] = $metadata->properties['quux']->getConstraints();
+        [$quuxConstraint] = $metadata->getPropertyMetadata('quux')[0]->getConstraints();
 
         self::assertInstanceOf(When::class, $quuxConstraint);
         self::assertSame('true', $quuxConstraint->expression);
@@ -143,7 +143,7 @@ final class WhenTest extends TestCase
         ], $classConstraint->constraints);
         self::assertSame([], $classConstraint->otherwise);
 
-        [$fooConstraint] = $metadata->properties['foo']->getConstraints();
+        [$fooConstraint] = $metadata->getPropertyMetadata('foo')[0]->getConstraints();
 
         self::assertInstanceOf(When::class, $fooConstraint);
         self::assertInstanceOf(\Closure::class, $fooConstraint->expression);

--- a/src/Symfony/Component/Validator/Tests/Constraints/WordCountTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/WordCountTest.php
@@ -110,17 +110,17 @@ class WordCountTest extends TestCase
         $loader = new AttributeLoader();
         $this->assertTrue($loader->loadClassMetadata($metadata));
 
-        [$aConstraint] = $metadata->properties['a']->getConstraints();
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         $this->assertSame(1, $aConstraint->min);
         $this->assertNull($aConstraint->max);
         $this->assertNull($aConstraint->locale);
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         $this->assertSame(2, $bConstraint->min);
         $this->assertSame(5, $bConstraint->max);
         $this->assertNull($bConstraint->locale);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         $this->assertSame(3, $cConstraint->min);
         $this->assertNull($cConstraint->max);
         $this->assertSame('en', $cConstraint->locale);

--- a/src/Symfony/Component/Validator/Tests/Constraints/YamlTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/YamlTest.php
@@ -28,15 +28,15 @@ class YamlTest extends TestCase
         $loader = new AttributeLoader();
         self::assertTrue($loader->loadClassMetadata($metadata));
 
-        [$bConstraint] = $metadata->properties['b']->getConstraints();
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         self::assertSame('myMessage', $bConstraint->message);
         self::assertSame(['Default', 'YamlDummy'], $bConstraint->groups);
 
-        [$cConstraint] = $metadata->properties['c']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertSame(['my_group'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);
 
-        [$cConstraint] = $metadata->properties['d']->getConstraints();
+        [$cConstraint] = $metadata->getPropertyMetadata('d')[0]->getConstraints();
         self::assertSame(YamlParser::PARSE_CONSTANT | YamlParser::PARSE_CUSTOM_TAGS, $cConstraint->flags);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
@@ -180,24 +180,15 @@ class ClassMetadataTest extends TestCase
         $this->assertCount(2, $members);
         $this->assertEquals(self::CLASSNAME, $members[0]->getClassName());
         $this->assertEquals([$constraintA2], $members[0]->getConstraints());
-        $this->assertEquals(
-            [
-                'Default' => [$constraintA2],
-                'Entity' => [$constraintA2],
-            ],
-            $members[0]->constraintsByGroup
-        );
+        $this->assertEquals([$constraintA2], $members[0]->findConstraints('Default'));
+        $this->assertEquals([$constraintA2], $members[0]->findConstraints('Entity'));
+
         $this->assertEquals(self::PARENTCLASS, $members[1]->getClassName());
         $this->assertEquals([$constraintA1, $constraintB], $members[1]->getConstraints());
-        $this->assertEquals(
-            [
-                'Default' => [$constraintA1],
-                'Entity' => [$constraintA1],
-                'EntityParent' => [$constraintA1],
-                'foo' => [$constraintB],
-            ],
-            $members[1]->constraintsByGroup
-        );
+        $this->assertEquals([$constraintA1], $members[1]->findConstraints('Default'));
+        $this->assertEquals([$constraintA1], $members[1]->findConstraints('Entity'));
+        $this->assertEquals([$constraintA1], $members[1]->findConstraints('EntityParent'));
+        $this->assertEquals([$constraintB], $members[1]->findConstraints('foo'));
     }
 
     public function testMemberMetadatas()
@@ -337,7 +328,6 @@ class ClassMetadataTest extends TestCase
         $metadata->addConstraint(new Cascade());
 
         $this->assertSame(CascadingStrategy::CASCADE, $metadata->getCascadingStrategy());
-        $this->assertCount(4, $metadata->properties);
         $this->assertSame([
             'requiredChild',
             'optionalChild',
@@ -352,7 +342,6 @@ class ClassMetadataTest extends TestCase
         $metadata->addConstraint(new Cascade());
 
         $this->assertSame(CascadingStrategy::CASCADE, $metadata->getCascadingStrategy());
-        $this->assertCount(5, $metadata->properties);
         $this->assertSame([
             'classes',
             'classAndArray',
@@ -368,7 +357,6 @@ class ClassMetadataTest extends TestCase
         $metadata->addConstraint(new Cascade());
 
         $this->assertSame(CascadingStrategy::CASCADE, $metadata->getCascadingStrategy());
-        $this->assertCount(1, $metadata->properties);
         $this->assertSame([
             'classes',
         ], $metadata->getConstrainedProperties());
@@ -381,7 +369,6 @@ class ClassMetadataTest extends TestCase
         $metadata->addConstraint(new Cascade(exclude: ['requiredChild', 'optionalChild']));
 
         $this->assertSame(CascadingStrategy::CASCADE, $metadata->getCascadingStrategy());
-        $this->assertCount(2, $metadata->properties);
         $this->assertSame([
             'staticChild',
             'children',

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/PropertyInfoLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/PropertyInfoLoaderTest.php
@@ -298,7 +298,7 @@ class PropertyInfoLoaderTest extends TestCase
         /** @var ClassMetadata $classMetadata */
         $classMetadata = $validator->getMetadataFor(new PropertyInfoLoaderNoAutoMappingEntity());
         $this->assertSame([], $classMetadata->getPropertyMetadata('string'));
-        $this->assertCount(2, $classMetadata->getPropertyMetadata('autoMappingExplicitlyEnabled')[0]->constraints);
+        $this->assertCount(2, $classMetadata->getPropertyMetadata('autoMappingExplicitlyEnabled')[0]->getConstraints());
         $this->assertSame(AutoMappingStrategy::ENABLED, $classMetadata->getPropertyMetadata('autoMappingExplicitlyEnabled')[0]->getAutoMappingStrategy());
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Mapping/PropertyMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/PropertyMetadataTest.php
@@ -53,8 +53,10 @@ class PropertyMetadataTest extends TestCase
     public function testGetPropertyValueFromRemovedProperty()
     {
         $entity = new Entity('foobar');
-        $metadata = new PropertyMetadata(self::CLASSNAME, 'internal');
-        $metadata->name = 'test';
+
+        // simulate out-of-sync metadata
+        $metadata = 'O:52:"Symfony\Component\Validator\Mapping\PropertyMetadata":3:{s:5:"class";s:65:"Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\Entity";s:4:"name";s:7:"missing";s:8:"property";s:7:"missing";}';
+        $metadata = unserialize($metadata);
 
         $this->expectException(ValidatorException::class);
         $metadata->getPropertyValue($entity);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Our tests rely on direct access to `@internal` properties that come with notices like:

> This property is public in order to reduce the size of the class' serialized representation. Do not access it. Use [...] instead

This should also apply to test cases.

Also, now that we use `__serialize`, we can also make these properties private. I'll propose it in a follow up PR.

(failures unrelated)