### PR TITLE
[Serializer][Validator] Make internal properties private

### DIFF
--- a/src/Symfony/Component/Serializer/Mapping/AttributeMetadata.php
+++ b/src/Symfony/Component/Serializer/Mapping/AttributeMetadata.php
@@ -20,65 +20,22 @@ use Symfony\Component\PropertyAccess\PropertyPath;
  */
 class AttributeMetadata implements AttributeMetadataInterface
 {
-    /**
-     * @internal This property is public in order to reduce the size of the
-     *           class' serialized representation. Do not access it. Use
-     *           {@link getName()} instead.
-     */
-    public string $name;
-
-    /**
-     * @internal This property is public in order to reduce the size of the
-     *           class' serialized representation. Do not access it. Use
-     *           {@link getGroups()} instead.
-     */
-    public array $groups = [];
-
-    /**
-     * @internal This property is public in order to reduce the size of the
-     *           class' serialized representation. Do not access it. Use
-     *           {@link getMaxDepth()} instead.
-     */
-    public ?int $maxDepth = null;
-
-    /**
-     * @internal This property is public in order to reduce the size of the
-     *           class' serialized representation. Do not access it. Use
-     *           {@link getSerializedName()} instead.
-     */
-    public ?string $serializedName = null;
-
-    /**
-     * @internal This property is public in order to reduce the size of the
-     *           class' serialized representation. Do not access it. Use
-     *           {@link getSerializedPath()} instead.
-     */
-    public ?PropertyPath $serializedPath = null;
-
-    /**
-     * @internal This property is public in order to reduce the size of the
-     *           class' serialized representation. Do not access it. Use
-     *           {@link isIgnored()} instead.
-     */
-    public bool $ignore = false;
+    private string $name;
+    private array $groups = [];
+    private ?int $maxDepth = null;
+    private ?string $serializedName = null;
+    private ?PropertyPath $serializedPath = null;
+    private bool $ignore = false;
 
     /**
      * @var array[] Normalization contexts per group name ("*" applies to all groups)
-     *
-     * @internal This property is public in order to reduce the size of the
-     *           class' serialized representation. Do not access it. Use
-     *           {@link getNormalizationContexts()} instead.
      */
-    public array $normalizationContexts = [];
+    private array $normalizationContexts = [];
 
     /**
      * @var array[] Denormalization contexts per group name ("*" applies to all groups)
-     *
-     * @internal This property is public in order to reduce the size of the
-     *           class' serialized representation. Do not access it. Use
-     *           {@link getDenormalizationContexts()} instead.
      */
-    public array $denormalizationContexts = [];
+    private array $denormalizationContexts = [];
 
     public function __construct(string $name)
     {

--- a/src/Symfony/Component/Serializer/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Serializer/Mapping/ClassMetadata.php
@@ -18,34 +18,16 @@ namespace Symfony\Component\Serializer\Mapping;
  */
 class ClassMetadata implements ClassMetadataInterface
 {
-    /**
-     * @internal This property is public in order to reduce the size of the
-     *           class' serialized representation. Do not access it. Use
-     *           {@link getName()} instead.
-     */
-    public string $name;
+    private string $name;
 
     /**
      * @var AttributeMetadataInterface[]
-     *
-     * @internal This property is public in order to reduce the size of the
-     *           class' serialized representation. Do not access it. Use
-     *           {@link getAttributesMetadata()} instead.
      */
-    public array $attributesMetadata = [];
+    private array $attributesMetadata = [];
 
     private ?\ReflectionClass $reflClass = null;
+    private ?ClassDiscriminatorMapping $classDiscriminatorMapping = null;
 
-    /**
-     * @internal This property is public in order to reduce the size of the
-     *           class' serialized representation. Do not access it. Use
-     *           {@link getClassDiscriminatorMapping()} instead.
-     */
-    public ?ClassDiscriminatorMapping $classDiscriminatorMapping = null;
-
-    /**
-     * Constructs a metadata for the given class.
-     */
     public function __construct(string $class, ?ClassDiscriminatorMapping $classDiscriminatorMapping = null)
     {
         $this->name = $class;

--- a/src/Symfony/Component/Serializer/Mapping/Factory/CompiledClassMetadataFactory.php
+++ b/src/Symfony/Component/Serializer/Mapping/Factory/CompiledClassMetadataFactory.php
@@ -56,13 +56,17 @@ final class CompiledClassMetadataFactory implements ClassMetadataFactoryInterfac
         if (!isset($this->loadedClasses[$className])) {
             $classMetadata = new ClassMetadata($className);
             foreach ($this->compiledClassMetadata[$className][0] as $name => $compiledAttributesMetadata) {
-                $classMetadata->attributesMetadata[$name] = $attributeMetadata = new AttributeMetadata($name);
-                [$attributeMetadata->groups, $attributeMetadata->maxDepth, $attributeMetadata->serializedName] = $compiledAttributesMetadata;
+                $classMetadata->addAttributeMetadata($attributeMetadata = new AttributeMetadata($name));
+                foreach ($compiledAttributesMetadata[0] as $group) {
+                    $attributeMetadata->addGroup($group);
+                }
+                $attributeMetadata->setMaxDepth($compiledAttributesMetadata[1]);
+                $attributeMetadata->setSerializedName($compiledAttributesMetadata[2]);
             }
-            $classMetadata->classDiscriminatorMapping = $this->compiledClassMetadata[$className][1]
+            $classMetadata->setClassDiscriminatorMapping($this->compiledClassMetadata[$className][1]
                 ? new ClassDiscriminatorMapping(...$this->compiledClassMetadata[$className][1])
                 : null
-            ;
+            );
 
             $this->loadedClasses[$className] = $classMetadata;
         }

--- a/src/Symfony/Component/Validator/Mapping/GenericMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/GenericMetadata.php
@@ -30,21 +30,13 @@ class GenericMetadata implements MetadataInterface
 {
     /**
      * @var Constraint[]
-     *
-     * @internal This property is public in order to reduce the size of the
-     *           class' serialized representation. Do not access it. Use
-     *           {@link getConstraints()} and {@link findConstraints()} instead.
      */
-    public array $constraints = [];
+    private array $constraints = [];
 
     /**
      * @var array<string, Constraint[]>
-     *
-     * @internal This property is public in order to reduce the size of the
-     *           class' serialized representation. Do not access it. Use
-     *           {@link findConstraints()} instead.
      */
-    public array $constraintsByGroup = [];
+    private array $constraintsByGroup = [];
 
     /**
      * The strategy for cascading objects.
@@ -52,12 +44,8 @@ class GenericMetadata implements MetadataInterface
      * By default, objects are not cascaded.
      *
      * @var CascadingStrategy::*
-     *
-     * @internal This property is public in order to reduce the size of the
-     *           class' serialized representation. Do not access it. Use
-     *           {@link getCascadingStrategy()} instead.
      */
-    public int $cascadingStrategy = CascadingStrategy::NONE;
+    private int $cascadingStrategy = CascadingStrategy::NONE;
 
     /**
      * The strategy for traversing traversable objects.
@@ -65,23 +53,15 @@ class GenericMetadata implements MetadataInterface
      * By default, traversable objects are not traversed.
      *
      * @var TraversalStrategy::*
-     *
-     * @internal This property is public in order to reduce the size of the
-     *           class' serialized representation. Do not access it. Use
-     *           {@link getTraversalStrategy()} instead.
      */
-    public int $traversalStrategy = TraversalStrategy::NONE;
+    private int $traversalStrategy = TraversalStrategy::NONE;
 
     /**
      * Is auto-mapping enabled?
      *
      * @var AutoMappingStrategy::*
-     *
-     * @internal This property is public in order to reduce the size of the
-     *           class' serialized representation. Do not access it. Use
-     *           {@link getAutoMappingStrategy()} instead.
      */
-    public int $autoMappingStrategy = AutoMappingStrategy::NONE;
+    private int $autoMappingStrategy = AutoMappingStrategy::NONE;
 
     public function __serialize(): array
     {
@@ -127,9 +107,6 @@ class GenericMetadata implements MetadataInterface
         ];
     }
 
-    /**
-     * Clones this object.
-     */
     public function __clone()
     {
         $constraints = $this->constraints;
@@ -166,13 +143,9 @@ class GenericMetadata implements MetadataInterface
 
         if ($constraint instanceof Valid && null === $constraint->groups) {
             $this->cascadingStrategy = CascadingStrategy::CASCADE;
+            $this->traversalStrategy = $constraint->traverse ? TraversalStrategy::IMPLICIT : TraversalStrategy::NONE;
 
-            if ($constraint->traverse) {
-                $this->traversalStrategy = TraversalStrategy::IMPLICIT;
-            } else {
-                $this->traversalStrategy = TraversalStrategy::NONE;
-            }
-
+            // The constraint is not added
             return $this;
         }
 
@@ -197,9 +170,9 @@ class GenericMetadata implements MetadataInterface
     }
 
     /**
-     * Adds an list of constraints.
+     * Adds a list of constraints.
      *
-     * @param Constraint[] $constraints The constraints to add
+     * @param Constraint[] $constraints
      *
      * @return $this
      */

--- a/src/Symfony/Component/Validator/Mapping/MemberMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/MemberMetadata.php
@@ -29,26 +29,9 @@ use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
  */
 abstract class MemberMetadata extends GenericMetadata implements PropertyMetadataInterface
 {
-    /**
-     * @internal This property is public in order to reduce the size of the
-     *           class' serialized representation. Do not access it. Use
-     *           {@link getClassName()} instead.
-     */
-    public string $class;
-
-    /**
-     * @internal This property is public in order to reduce the size of the
-     *           class' serialized representation. Do not access it. Use
-     *           {@link getName()} instead.
-     */
-    public string $name;
-
-    /**
-     * @internal This property is public in order to reduce the size of the
-     *           class' serialized representation. Do not access it. Use
-     *           {@link getPropertyName()} instead.
-     */
-    public string $property;
+    private string $class;
+    private string $name;
+    private string $property;
 
     /**
      * @var \ReflectionMethod[]|\ReflectionProperty[]
@@ -80,11 +63,6 @@ abstract class MemberMetadata extends GenericMetadata implements PropertyMetadat
     {
         if (self::class === (new \ReflectionMethod($this, '__sleep'))->class || self::class !== (new \ReflectionMethod($this, '__serialize'))->class) {
             return parent::__serialize() + [
-                'constraints' => $this->constraints,
-                'constraintsByGroup' => $this->constraintsByGroup,
-                'cascadingStrategy' => $this->cascadingStrategy,
-                'traversalStrategy' => $this->traversalStrategy,
-                'autoMappingStrategy' => $this->autoMappingStrategy,
                 'class' => $this->class,
                 'name' => $this->name,
                 'property' => $this->property,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

With the new `__serialize` implementations, we can finally replace those `@internal` properties by private ones, without breaking either child classes still implementing `__sleep` nor payloads created before.