### PR TITLE
[DoctrineBridge] remove deprecated nullable option from primary key columns

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/CompositeObjectNoToStringIdEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/CompositeObjectNoToStringIdEntity.php
@@ -22,12 +22,12 @@ class CompositeObjectNoToStringIdEntity
     public function __construct(
         #[ORM\Id]
         #[ORM\ManyToOne(cascade: ['persist'])]
-        #[ORM\JoinColumn(name: 'object_one_id', nullable: false)]
+        #[ORM\JoinColumn(name: 'object_one_id')]
         protected SingleIntIdNoToStringEntity $objectOne,
 
         #[ORM\Id]
         #[ORM\ManyToOne(cascade: ['persist'])]
-        #[ORM\JoinColumn(name: 'object_two_id', nullable: false)]
+        #[ORM\JoinColumn(name: 'object_two_id')]
         protected SingleIntIdNoToStringEntity $objectTwo,
     ) {
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/SingleAssociationToIntIdEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/SingleAssociationToIntIdEntity.php
@@ -22,7 +22,7 @@ class SingleAssociationToIntIdEntity
 {
     public function __construct(
         #[Id, OneToOne(cascade: ['ALL'])]
-        #[JoinColumn(nullable: false)]
+        #[JoinColumn()]
         protected SingleIntIdNoToStringEntity $entity,
 
         #[Column(nullable: true)]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

see doctrine/orm#12126