### PR TITLE
[Mailer][Sendgrid] Add suppression groups support

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+ * Add support for suppression groups via `SuppressionGroupHeader`
+
 7.2
 ---
 

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Header/SuppressionGroupHeader.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Header/SuppressionGroupHeader.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\Sendgrid\Header;
+
+use Symfony\Component\Mime\Header\UnstructuredHeader;
+
+/**
+ * @author Kieran Cross
+ */
+final class SuppressionGroupHeader extends UnstructuredHeader
+{
+    /**
+     * @param int[] $groupsToDisplay
+     */
+    public function __construct(
+        private int $groupId,
+        private array $groupsToDisplay = [],
+    ) {
+        $this->groupsToDisplay = array_values(array_map('intval', $groupsToDisplay));
+
+        parent::__construct('X-Sendgrid-SuppressionGroup', json_encode([
+            'group_id' => $groupId,
+            'groups_to_display' => $this->groupsToDisplay,
+        ], \JSON_THROW_ON_ERROR));
+    }
+
+    public function getGroupId(): int
+    {
+        return $this->groupId;
+    }
+
+    public function getGroupsToDisplay(): array
+    {
+        return $this->groupsToDisplay;
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/README.md
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/README.md
@@ -44,6 +44,22 @@ class SendGridConsumer implements ConsumerInterface
 }
 ```
 
+Suppression Groups
+------------------
+
+Create an e-mail and add the `SuppressionGroupHeader`:
+
+```php
+use Symfony\Component\Mailer\Bridge\Sendgrid\Header\SuppressionGroupHeader;
+// [...]
+$email = new Email();
+$email->getHeaders()->add(new SuppressionGroupHeader(GROUP_ID, GROUPS_TO_DISPLAY));
+```
+
+where:
+ - `GROUP_ID` is your Sendgrid suppression group ID
+ - `GROUPS_TO_DISPLAY_ID` is an array of the Sendgrid suppression group IDs presented to the user
+
 Resources
 ---------
 

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridApiTransport.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Mailer\Bridge\Sendgrid\Transport;
 
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Mailer\Bridge\Sendgrid\Header\SuppressionGroupHeader;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
 use Symfony\Component\Mailer\Exception\TransportException;
@@ -132,6 +133,13 @@ class SendgridApiTransport extends AbstractApiTransport
                 $categories[] = mb_substr($header->getValue(), 0, 255);
             } elseif ($header instanceof MetadataHeader) {
                 $customArguments[$header->getKey()] = $header->getValue();
+            } elseif ($header instanceof SuppressionGroupHeader) {
+                $payload['asm'] = [
+                    'group_id' => $header->getGroupId(),
+                ];
+                if ($groupsToDisplay = $header->getGroupsToDisplay()) {
+                    $payload['asm']['groups_to_display'] = $groupsToDisplay;
+                }
             } else {
                 $payload['headers'][$header->getName()] = $header->getBodyAsString();
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix/Implement #53830 
| License       | MIT

This PR implements a new header which supports the SendGrid suppression group/ASM options - allowing recipients of emails to unsubscribe. 