### PR TITLE
[FrameworkBundle] Deprecate container parameters router.request_context.scheme and .host

### DIFF
--- a/UPGRADE-8.1.md
+++ b/UPGRADE-8.1.md
@@ -28,6 +28,8 @@ FrameworkBundle
 ---------------
 
  * Deprecate setting the `framework.profiler.collect_serializer_data` config option
+ * Deprecate parameters `router.request_context.scheme` and `router.request_context.host`;
+   use the `router.request_context.base_url` parameter or the `framework.router.default_uri` config option instead
 
 HttpKernel
 ----------

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -11,6 +11,8 @@ CHANGELOG
  * Enable mocking non-shared services in tests
  * Add `KernelTestCase::executeCommand()` to execute a command in functional tests
  * Add `framework.html_sanitizer.sanitizers.*.default_action` config option
+ * Deprecate parameters `router.request_context.scheme` and `router.request_context.host`;
+   use the `router.request_context.base_url` parameter or the `framework.router.default_uri` config option instead
 
 8.0
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1308,6 +1308,9 @@ class FrameworkExtension extends Extension
 
         $loader->load('routing.php');
 
+        $container->deprecateParameter('router.request_context.scheme', 'symfony/framework-bundle', '8.1', 'Parameter "router.request_context.scheme" is deprecated, use "router.request_context.base_url" parameter or the "framework.router.default_uri" config option instead.');
+        $container->deprecateParameter('router.request_context.host', 'symfony/framework-bundle', '8.1', 'Parameter "router.request_context.host" is deprecated, use "router.request_context.base_url" parameter or the "framework.router.default_uri" config option instead.');
+
         if ($config['utf8']) {
             $container->getDefinition('routing.loader')->replaceArgument(1, ['utf8' => true]);
         }
@@ -1348,8 +1351,7 @@ class FrameworkExtension extends Extension
         $container->setParameter('request_listener.https_port', $config['https_port']);
 
         if (null !== $config['default_uri']) {
-            $container->getDefinition('router.request_context')
-                ->replaceArgument(0, $config['default_uri']);
+            $container->setParameter('router.request_context.base_url', $config['default_uri']);
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.php
@@ -158,8 +158,18 @@ return static function (ContainerConfigurator $container) {
             ->factory([RequestContext::class, 'fromUri'])
             ->args([
                 param('router.request_context.base_url'),
-                param('router.request_context.host'),
-                param('router.request_context.scheme'),
+                inline_service('array')->factory('array_first')->args([
+                    inline_service('array')->factory('array_intersect_key')->args([
+                        inline_service('array')->factory([service('parameter_bag'), 'all']),
+                        array_flip(['router.request_context.host']),
+                    ]),
+                ]),
+                inline_service('array')->factory('array_first')->args([
+                    inline_service('array')->factory('array_intersect_key')->args([
+                        inline_service('array')->factory([service('parameter_bag'), 'all']),
+                        array_flip(['router.request_context.scheme']),
+                    ]),
+                ]),
                 param('request_listener.http_port'),
                 param('request_listener.https_port'),
             ])

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -30,7 +30,7 @@
         "symfony/http-foundation": "^7.4|^8.0",
         "symfony/http-kernel": "^7.4|^8.0",
         "symfony/polyfill-mbstring": "^1.0",
-        "symfony/polyfill-php85": "^1.32",
+        "symfony/polyfill-php85": "^1.33",
         "symfony/routing": "^7.4|^8.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4 
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | Fix #53919
| License       | MIT

The `framework.router.default_uri` config is used to define the request context as fallback for the case that no HTTP request is available. But it does not affect the container params

- `router.request_context.base_url`
- `router.request_context.host`
- `router.request_context.scheme`

They still use the defaults, which are defined in the routing.php config file.

This leads to inconsistency and confusion if a third party bundle relies on the container parameters instead of the request context service.

This PR deprecates those container params like proposed in #53919.