### PR TITLE
[HttpFoundation] fix session cookie options assertions on PHP 8.5

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
@@ -192,6 +192,10 @@ class NativeSessionStorageTest extends TestCase
             'cookie_samesite' => 'lax',
         ];
 
+        if (\PHP_VERSION_ID >= 80500) {
+            $options['cookie_partitioned'] = false;
+        }
+
         $this->getStorage($options);
         $temp = session_get_cookie_params();
         $gco = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

see php/php-src#12652