### PR TITLE
[PhpUnitBridge] Patch phpunit to clear php8.5 deprecation

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit.php
+++ b/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit.php
@@ -270,6 +270,12 @@ if (!file_exists("$PHPUNIT_DIR/$PHPUNIT_VERSION_DIR/phpunit") || $configurationH
         exit($exit);
     }
 
+    $alteredCode = file_get_contents($alteredFile = './src/Runner/PhptTestCase.php');
+    if (str_contains($alteredCode, "            'report_memleaks=0',\n")) {
+        $alteredCode = str_replace("            'report_memleaks=0',\n", '', $alteredCode);
+        file_put_contents($alteredFile, $alteredCode);
+    }
+
     // Mutate TestCase code
     if (version_compare($PHPUNIT_VERSION, '11.0', '<')) {
         $alteredCode = file_get_contents($alteredFile = './src/Framework/TestCase.php');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This backports https://github.com/sebastianbergmann/phpunit/commit/0eae11435093a25c88b5269de9481f32b26dbe20 to any phpunit versions - to ease migration for other projects and make our CI green ASAP.