### PR TITLE
[HttpFoundation] Don’t check suffix on empty MIME type

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1259,8 +1259,8 @@ class Request
             }
         }
 
-        if (!$canonicalMimeType) {
-            $canonicalMimeType = $mimeType;
+        if (!$canonicalMimeType ??= $mimeType) {
+            return null;
         }
 
         if (str_starts_with($canonicalMimeType, 'application/') && str_contains($canonicalMimeType, '+')) {
@@ -1964,8 +1964,6 @@ class Request
     }
 
     /**
-     * Structured MIME suffix fallback formats
-     *
      * This mapping is used when no exact MIME match is found in $formats.
      * It enables handling of types like application/soap+xml → 'xml'.
      *

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -538,9 +538,7 @@ b'])]
         ];
     }
 
-    /**
-     * @dataProvider getFormatWithSubtypeFallbackProvider
-     */
+    #[DataProvider('getFormatWithSubtypeFallbackProvider')]
     public function testGetFormatFromMimeTypeWithSubtypeFallback($expectedFormat, $mimeTypes)
     {
         $request = new Request();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Fix tests from #61267 (remaining failures unrelated).