### PR TITLE
[PhpUnitBridge] revert patching of PHPUnit about memleak reports

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit.php
+++ b/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit.php
@@ -270,13 +270,6 @@ if (!file_exists("$PHPUNIT_DIR/$PHPUNIT_VERSION_DIR/phpunit") || $configurationH
         exit($exit);
     }
 
-    // Mutate PhptTestCase code
-    $alteredFile = defined('GLOB_BRACE') ? glob('./src/Runner/{Phpt/,PHPT/Phpt,Phpt}TestCase.php', GLOB_BRACE) : false;
-    if ($alteredFile && str_contains($alteredCode = file_get_contents($alteredFile[0]), "            'report_memleaks=0',\n")) {
-        $alteredCode = str_replace("            'report_memleaks=0',\n", '', $alteredCode);
-        file_put_contents($alteredFile[0], $alteredCode);
-    }
-
     // Mutate TestCase code
     if (version_compare($PHPUNIT_VERSION, '11.0', '<')) {
         $alteredCode = file_get_contents($alteredFile = './src/Framework/TestCase.php');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

reverts #61469, sebastianbergmann/phpunit@0eae11435093a25c88b5269de9481f32b26dbe20 is part of PHPUnit 8.5.44, 9.6.25, 10.5.53, 11.5.34 and 12.3.6