### PR TITLE
[Console] Add `#[Input]` attribute to support DTOs in invokable commands

### DIFF
--- a/src/Symfony/Component/Console/Attribute/Input.php
+++ b/src/Symfony/Component/Console/Attribute/Input.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Attribute;
+
+use Symfony\Component\Console\Attribute\Reflection\ReflectionMember;
+use Symfony\Component\Console\Exception\LogicException;
+use Symfony\Component\Console\Input\InputInterface;
+
+#[\Attribute(\Attribute::TARGET_PARAMETER | \Attribute::TARGET_PROPERTY)]
+final class Input
+{
+    /**
+     * @var array<string, Argument|Option|self>
+     */
+    private array $definition = [];
+
+    private \ReflectionClass $class;
+
+    public static function tryFrom(\ReflectionParameter|\ReflectionProperty $member): ?self
+    {
+        $reflection = new ReflectionMember($member);
+
+        if (!$self = $reflection->getAttribute(self::class)) {
+            return null;
+        }
+
+        $type = $reflection->getType();
+
+        if (!$type instanceof \ReflectionNamedType) {
+            throw new LogicException(\sprintf('The input %s "%s" must have a named type.', $reflection->getMemberName(), $member->name));
+        }
+
+        if (!class_exists($class = $type->getName())) {
+            throw new LogicException(\sprintf('The input class "%s" does not exist.', $type->getName()));
+        }
+
+        $self->class = new \ReflectionClass($class);
+
+        foreach ($self->class->getProperties() as $property) {
+            if (!$property->isPublic() || $property->isStatic()) {
+                continue;
+            }
+
+            if ($argument = Argument::tryFrom($property)) {
+                $self->definition[$property->name] = $argument;
+                continue;
+            }
+
+            if ($option = Option::tryFrom($property)) {
+                $self->definition[$property->name] = $option;
+                continue;
+            }
+
+            if ($input = self::tryFrom($property)) {
+                $self->definition[$property->name] = $input;
+            }
+        }
+
+        if (!$self->definition) {
+            throw new LogicException(\sprintf('The input class "%s" must have at least one argument or option.', $self->class->name));
+        }
+
+        return $self;
+    }
+
+    /**
+     * @internal
+     */
+    public function resolveValue(InputInterface $input): mixed
+    {
+        $instance = $this->class->newInstanceWithoutConstructor();
+
+        foreach ($this->definition as $name => $spec) {
+            $instance->$name = $spec->resolveValue($input);
+        }
+
+        return $instance;
+    }
+
+    /**
+     * @return iterable<Argument>
+     */
+    public function getArguments(): iterable
+    {
+        foreach ($this->definition as $spec) {
+            if ($spec instanceof Argument) {
+                yield $spec;
+            } elseif ($spec instanceof self) {
+                yield from $spec->getArguments();
+            }
+        }
+    }
+
+    /**
+     * @return iterable<Option>
+     */
+    public function getOptions(): iterable
+    {
+        foreach ($this->definition as $spec) {
+            if ($spec instanceof Option) {
+                yield $spec;
+            } elseif ($spec instanceof self) {
+                yield from $spec->getOptions();
+            }
+        }
+    }
+}

--- a/src/Symfony/Component/Console/Attribute/Option.php
+++ b/src/Symfony/Component/Console/Attribute/Option.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Console\Attribute;
 
+use Symfony\Component\Console\Attribute\Reflection\ReflectionMember;
 use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Completion\Suggestion;
 use Symfony\Component\Console\Exception\InvalidOptionException;
@@ -19,7 +20,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\String\UnicodeString;
 
-#[\Attribute(\Attribute::TARGET_PARAMETER)]
+#[\Attribute(\Attribute::TARGET_PARAMETER | \Attribute::TARGET_PROPERTY)]
 class Option
 {
     private const ALLOWED_TYPES = ['string', 'bool', 'int', 'float', 'array'];
@@ -28,9 +29,13 @@ class Option
     private string|bool|int|float|array|null $default = null;
     private array|\Closure $suggestedValues;
     private ?int $mode = null;
+    /**
+     * @var string|class-string<\BackedEnum>
+     */
     private string $typeName = '';
     private bool $allowNull = false;
-    private string $function = '';
+    private string $memberName = '';
+    private string $sourceName = '';
 
     /**
      * Represents a console command --option definition.
@@ -52,54 +57,52 @@ class Option
     /**
      * @internal
      */
-    public static function tryFrom(\ReflectionParameter $parameter): ?self
+    public static function tryFrom(\ReflectionParameter|\ReflectionProperty $member): ?self
     {
-        /** @var self $self */
-        if (null === $self = ($parameter->getAttributes(self::class, \ReflectionAttribute::IS_INSTANCEOF)[0] ?? null)?->newInstance()) {
+        $reflection = new ReflectionMember($member);
+
+        if (!$self = $reflection->getAttribute(self::class)) {
             return null;
         }
 
-        if (($function = $parameter->getDeclaringFunction()) instanceof \ReflectionMethod) {
-            $self->function = $function->class.'::'.$function->name;
-        } else {
-            $self->function = $function->name;
-        }
+        $self->memberName = $reflection->getMemberName();
+        $self->sourceName = $reflection->getSourceName();
 
-        $name = $parameter->getName();
-        $type = $parameter->getType();
+        $name = $reflection->getName();
+        $type = $reflection->getType();
 
-        if (!$parameter->isDefaultValueAvailable()) {
-            throw new LogicException(\sprintf('The option parameter "$%s" of "%s()" must declare a default value.', $name, $self->function));
+        if (!$reflection->hasDefaultValue()) {
+            throw new LogicException(\sprintf('The option %s "$%s" of "%s" must declare a default value.', $self->memberName, $name, $self->sourceName));
         }
 
         if (!$self->name) {
             $self->name = (new UnicodeString($name))->kebab();
         }
 
-        $self->default = $parameter->getDefaultValue() instanceof \BackedEnum ? $parameter->getDefaultValue()->value : $parameter->getDefaultValue();
-        $self->allowNull = $parameter->allowsNull();
+        $self->default = $reflection->getDefaultValue();
+        $self->allowNull = $reflection->isNullable();
 
         if ($type instanceof \ReflectionUnionType) {
             return $self->handleUnion($type);
         }
 
         if (!$type instanceof \ReflectionNamedType) {
-            throw new LogicException(\sprintf('The parameter "$%s" of "%s()" must have a named type. Untyped or Intersection types are not supported for command options.', $name, $self->function));
+            throw new LogicException(\sprintf('The %s "$%s" of "%s" must have a named type. Untyped or Intersection types are not supported for command options.', $self->memberName, $name, $self->sourceName));
         }
 
         $self->typeName = $type->getName();
         $isBackedEnum = is_subclass_of($self->typeName, \BackedEnum::class);
 
         if (!\in_array($self->typeName, self::ALLOWED_TYPES, true) && !$isBackedEnum) {
-            throw new LogicException(\sprintf('The type "%s" on parameter "$%s" of "%s()" is not supported as a command option. Only "%s" types and BackedEnum are allowed.', $self->typeName, $name, $self->function, implode('", "', self::ALLOWED_TYPES)));
+            throw new LogicException(\sprintf('The type "%s" on %s "$%s" of "%s" is not supported as a command option. Only "%s" types and BackedEnum are allowed.', $self->typeName, $self->memberName, $name, $self->sourceName, implode('", "', self::ALLOWED_TYPES)));
         }
 
         if ('bool' === $self->typeName && $self->allowNull && \in_array($self->default, [true, false], true)) {
-            throw new LogicException(\sprintf('The option parameter "$%s" of "%s()" must not be nullable when it has a default boolean value.', $name, $self->function));
+            throw new LogicException(\sprintf('The option %s "$%s" of "%s" must not be nullable when it has a default boolean value.', $self->memberName, $name, $self->sourceName));
         }
 
         if ($self->allowNull && null !== $self->default) {
-            throw new LogicException(\sprintf('The option parameter "$%s" of "%s()" must either be not-nullable or have a default of null.', $name, $self->function));
+            throw new LogicException(\sprintf('The option %s "$%s" of "%s" must either be not-nullable or have a default of null.', $self->memberName, $name, $self->sourceName));
         }
 
         if ('bool' === $self->typeName) {
@@ -113,12 +116,12 @@ class Option
             $self->mode = InputOption::VALUE_REQUIRED;
         }
 
-        if (\is_array($self->suggestedValues) && !\is_callable($self->suggestedValues) && 2 === \count($self->suggestedValues) && ($instance = $parameter->getDeclaringFunction()->getClosureThis()) && $instance::class === $self->suggestedValues[0] && \is_callable([$instance, $self->suggestedValues[1]])) {
+        if (\is_array($self->suggestedValues) && !\is_callable($self->suggestedValues) && 2 === \count($self->suggestedValues) && ($instance = $reflection->getSourceThis()) && $instance::class === $self->suggestedValues[0] && \is_callable([$instance, $self->suggestedValues[1]])) {
             $self->suggestedValues = [$instance, $self->suggestedValues[1]];
         }
 
         if ($isBackedEnum && !$self->suggestedValues) {
-            $self->suggestedValues = array_column(($self->typeName)::cases(), 'value');
+            $self->suggestedValues = array_column($self->typeName::cases(), 'value');
         }
 
         return $self;
@@ -147,7 +150,7 @@ class Option
         }
 
         if (is_subclass_of($this->typeName, \BackedEnum::class) && (\is_string($value) || \is_int($value))) {
-            return ($this->typeName)::tryFrom($value) ?? throw InvalidOptionException::fromEnumValue($this->name, $value, $this->suggestedValues);
+            return $this->typeName::tryFrom($value) ?? throw InvalidOptionException::fromEnumValue($this->name, $value, $this->suggestedValues);
         }
 
         if ('array' === $this->typeName && $this->allowNull && [] === $value) {
@@ -177,11 +180,11 @@ class Option
         $this->typeName = implode('|', array_filter($types));
 
         if (!\in_array($this->typeName, self::ALLOWED_UNION_TYPES, true)) {
-            throw new LogicException(\sprintf('The union type for parameter "$%s" of "%s()" is not supported as a command option. Only "%s" types are allowed.', $this->name, $this->function, implode('", "', self::ALLOWED_UNION_TYPES)));
+            throw new LogicException(\sprintf('The union type for %s "$%s" of "%s" is not supported as a command option. Only "%s" types are allowed.', $this->memberName, $this->name, $this->sourceName, implode('", "', self::ALLOWED_UNION_TYPES)));
         }
 
         if (false !== $this->default) {
-            throw new LogicException(\sprintf('The option parameter "$%s" of "%s()" must have a default value of false.', $this->name, $this->function));
+            throw new LogicException(\sprintf('The option %s "$%s" of "%s" must have a default value of false.', $this->memberName, $this->name, $this->sourceName));
         }
 
         $this->mode = InputOption::VALUE_OPTIONAL;

--- a/src/Symfony/Component/Console/Attribute/Reflection/ReflectionMember.php
+++ b/src/Symfony/Component/Console/Attribute/Reflection/ReflectionMember.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Attribute\Reflection;
+
+/**
+ * @internal
+ */
+class ReflectionMember
+{
+    public function __construct(
+        private readonly \ReflectionParameter|\ReflectionProperty $member,
+    ) {
+    }
+
+    /**
+     * @template T of object
+     *
+     * @param class-string<T> $class
+     *
+     * @return T|null
+     */
+    public function getAttribute(string $class): ?object
+    {
+        return ($this->member->getAttributes($class, \ReflectionAttribute::IS_INSTANCEOF)[0] ?? null)?->newInstance();
+    }
+
+    public function getSourceName(): string
+    {
+        if ($this->member instanceof \ReflectionProperty) {
+            return $this->member->getDeclaringClass()->name;
+        }
+
+        $function = $this->member->getDeclaringFunction();
+
+        if ($function instanceof \ReflectionMethod) {
+            return $function->class.'::'.$function->name.'()';
+        }
+
+        return $function->name.'()';
+    }
+
+    public function getSourceThis(): ?object
+    {
+        if ($this->member instanceof \ReflectionParameter) {
+            return $this->member->getDeclaringFunction()->getClosureThis();
+        }
+
+        return null;
+    }
+
+    public function getType(): ?\ReflectionType
+    {
+        return $this->member->getType();
+    }
+
+    public function getName(): string
+    {
+        return $this->member->getName();
+    }
+
+    public function hasDefaultValue(): bool
+    {
+        if ($this->member instanceof \ReflectionParameter) {
+            return $this->member->isDefaultValueAvailable();
+        }
+
+        return $this->member->hasDefaultValue();
+    }
+
+    public function getDefaultValue(): mixed
+    {
+        $defaultValue = $this->member->getDefaultValue();
+
+        if ($defaultValue instanceof \BackedEnum) {
+            return $defaultValue->value;
+        }
+
+        return $defaultValue;
+    }
+
+    public function isNullable(): bool
+    {
+        return (bool) $this->member->getType()?->allowsNull();
+    }
+
+    public function getMemberName(): string
+    {
+        return $this->member instanceof \ReflectionParameter ? 'parameter' : 'property';
+    }
+}

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Add `BackedEnum` support with `#[Argument]` and `#[Option]` inputs in invokable commands
  * Allow Usages to be specified via `#[AsCommand]` attribute.
  * Allow passing invokable commands to `Symfony\Component\Console\Tester\CommandTester`
+ * Add `#[Input]` attribute to support DTOs in commands
 
 7.3
 ---

--- a/src/Symfony/Component/Console/Tests/Fixtures/InvokableWithInputTestCommand.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/InvokableWithInputTestCommand.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Fixtures;
+
+use Symfony\Component\Console\Attribute\Argument;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\Input;
+use Symfony\Component\Console\Attribute\Option;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand('invokable:input:test')]
+class InvokableWithInputTestCommand
+{
+    public function __invoke(SymfonyStyle $io, #[Input] UserDto $user): int
+    {
+        $io->writeln($user->name);
+        $io->writeln($user->email);
+        $io->writeln($user->password);
+        $io->writeln($user->admin ? 'yes' : 'no');
+        $io->writeln($user->active ? 'yes' : 'no');
+        $io->writeln($user->status->value);
+        $io->writeln($user->group->name);
+        $io->writeln($user->group->description);
+
+        return Command::SUCCESS;
+    }
+}
+
+final class UserDto
+{
+    #[Argument(name: 'username')]
+    public string $name;
+
+    #[Argument]
+    public string $email;
+
+    #[Argument]
+    public string $password;
+
+    #[Input]
+    public UserGroupDto $group;
+
+    #[Option]
+    public bool $admin = false;
+
+    #[Option]
+    public bool $active = true;
+
+    #[Option]
+    public UserStatus $status = UserStatus::Unverified;
+}
+
+final class UserGroupDto
+{
+    #[Option(name: 'group')]
+    public string $name = 'users';
+
+    #[Option(name: 'group-description')]
+    public string $description = 'Standard Users';
+}
+
+enum UserStatus: string
+{
+    case Unverified = 'unverified';
+    case Verified = 'verified';
+    case Locked = 'locked';
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Introduce `#[Input]` to let invokable console commands receive a DTO that defines the command's arguments/options on its own public properties via `#[Argument]`/`#[Option]`. This avoids stuffing `__invoke()` with a long parameter list and keeps the command's input model in one place.

## How it works

* You put `#[Input]` on a `__invoke()` parameter, typed as your DTO class (it's not limited to a single parameter)
* Inside that DTO, public non-static properties marked with `#[Argument]` and `#[Option]` become the command's input definition
* At runtime, Symfony instantiates the DTO (without calling its constructor), resolves CLI values, and assigns them to the properties (recursively, if you nest DTOs)

## Example

```php
class UserInput
{
    #[Argument] 
    public string $email {
        set => strtolower($value); // normalize with a property hook
    }

    #[Argument] 
    public string $password;

    #[Option] 
    public bool $admin = false;
}

#[AsCommand('app:create-user')]
class CreateUserCommand
{
    public function __invoke(#[Input] UserInput $user): int
    {
        // use $user->email, $user->password, $user->admin

        return 0;
    }
}
```

This produces the usage:

```
$ bin/console help app:create-user
Usage:
  app:create-user [options] [--] <email> <password>

Arguments:
  email
  password

Options:
      --admin|--no-admin
```

(booleans render as `--foo/--no-foo` as usual)

## Nested DTOs (group inputs)

You can compose inputs by nesting DTOs and giving them a form:

```php
class UserInput
{
    #[Argument] 
    public string $email;

    #[Argument] 
    public string $password;

    #[Option]   
    public bool $active = true;

    #[Input]    
    public ProfileInput $profile;
}

class ProfileInput
{
    #[Argument] 
    public string $name;
    
    #[Option]   
    public ?string $phone = null;
}
```

The resulting signature merges everything:

```
Usage:
  app:create-user [options] [--] <email> <password> <name>

Arguments:
  email                     
  password                  
  name                      

Options:
      --active|--no-active  
      --phone=PHONE
```

The resolver walks nested DTOs and fills them accordingly.

## Rules & constraints (important)

Same rules as parameter-based `#[Argument] `/ `#[Option]` apply, plus:

* Public, non-static properties only. Private/protected/static properties are ignored
* Constructor is not called. The DTO is instantiated without invoking `__construct`, values are assigned directly to properties (property hooks run on assignment if present)
* If an `#[Input]` class has **no** `#[Argument]`, `#[Option]` or nested inputs, that's a logic error

## Why this is better

* One source of truth for command input (definition + mapping live in the DTO)
* Shorter commands: `__invoke(#[Input] Foo $foo)` instead of a dozen parameters
* Composable: group related inputs with nested DTOs
* Built-in normalization: use property hooks on DTO properties (e.g. lowercase emails)

## Future follow-ups (out of scope here)

* Automatic validation (if Validator is installed) with CLI-friendly violations
* Delegated interactivity (`Command::interact()`) to the DTO

Cheers!