### PR TITLE
[HttpFoundation] use PHPUnit's native expectUserDeprecationMessage() method

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
@@ -227,12 +227,10 @@ class NativeSessionStorageTest extends TestCase
     #[Group('legacy')]
     public function testTransSidTagsOption()
     {
-        $unignoredErrors = [];
+        $this->expectUserDeprecationMessage('Since symfony/http-foundation 7.2: NativeSessionStorage\'s "trans_sid_tags" option is deprecated and will be ignored in Symfony 8.0.');
 
-        $previousErrorHandler = set_error_handler(function ($errno, $errstr) use (&$previousErrorHandler, &$unignoredErrors) {
+        $previousErrorHandler = set_error_handler(function ($errno, $errstr) use (&$previousErrorHandler) {
             if ('ini_set(): Usage of session.trans_sid_tags INI setting is deprecated' !== $errstr) {
-                $unignoredErrors[] = $errstr;
-
                 return $previousErrorHandler ? $previousErrorHandler(...\func_get_args()) : false;
             }
         });
@@ -245,8 +243,6 @@ class NativeSessionStorageTest extends TestCase
             restore_error_handler();
         }
 
-        $this->assertCount(1, $unignoredErrors);
-        $this->assertSame('Since symfony/http-foundation 7.2: NativeSessionStorage\'s "trans_sid_tags" option is deprecated and will be ignored in Symfony 8.0.', $unignoredErrors[0]);
         $this->assertSame('a=href', \ini_get('session.trans_sid_tags'));
     }
 
@@ -376,15 +372,13 @@ class NativeSessionStorageTest extends TestCase
     #[Group('legacy')]
     public function testPassingDeprecatedOptions()
     {
-        $unignoredErrors = [];
-
-        $previousErrorHandler = set_error_handler(function ($errno, $errstr) use (&$previousErrorHandler, &$unignoredErrors) {
-            if (!preg_match('/^ini_set\(\):( Disabling| Usage of)? session\..+ is deprecated$/', $errstr)) {
-                $unignoredErrors[] = $errstr;
-
-                return $previousErrorHandler ? $previousErrorHandler(...\func_get_args()) : false;
-            }
-        });
+        $this->expectUserDeprecationMessage('Since symfony/http-foundation 7.2: NativeSessionStorage\'s "sid_length" option is deprecated and will be ignored in Symfony 8.0.');
+        $this->expectUserDeprecationMessage('Since symfony/http-foundation 7.2: NativeSessionStorage\'s "sid_bits_per_character" option is deprecated and will be ignored in Symfony 8.0.');
+        $this->expectUserDeprecationMessage('Since symfony/http-foundation 7.2: NativeSessionStorage\'s "referer_check" option is deprecated and will be ignored in Symfony 8.0.');
+        $this->expectUserDeprecationMessage('Since symfony/http-foundation 7.2: NativeSessionStorage\'s "use_only_cookies" option is deprecated and will be ignored in Symfony 8.0.');
+        $this->expectUserDeprecationMessage('Since symfony/http-foundation 7.2: NativeSessionStorage\'s "use_trans_sid" option is deprecated and will be ignored in Symfony 8.0.');
+        $this->expectUserDeprecationMessage('Since symfony/http-foundation 7.2: NativeSessionStorage\'s "trans_sid_hosts" option is deprecated and will be ignored in Symfony 8.0.');
+        $this->expectUserDeprecationMessage('Since symfony/http-foundation 7.2: NativeSessionStorage\'s "trans_sid_tags" option is deprecated and will be ignored in Symfony 8.0.');
 
         $this->getStorage([
             'sid_length' => 42,
@@ -395,14 +389,5 @@ class NativeSessionStorageTest extends TestCase
             'trans_sid_hosts' => 'foo',
             'trans_sid_tags' => 'foo',
         ]);
-
-        $this->assertCount(7, $unignoredErrors);
-        $this->assertContains('Since symfony/http-foundation 7.2: NativeSessionStorage\'s "sid_length" option is deprecated and will be ignored in Symfony 8.0.', $unignoredErrors);
-        $this->assertContains('Since symfony/http-foundation 7.2: NativeSessionStorage\'s "sid_bits_per_character" option is deprecated and will be ignored in Symfony 8.0.', $unignoredErrors);
-        $this->assertContains('Since symfony/http-foundation 7.2: NativeSessionStorage\'s "referer_check" option is deprecated and will be ignored in Symfony 8.0.', $unignoredErrors);
-        $this->assertContains('Since symfony/http-foundation 7.2: NativeSessionStorage\'s "use_only_cookies" option is deprecated and will be ignored in Symfony 8.0.', $unignoredErrors);
-        $this->assertContains('Since symfony/http-foundation 7.2: NativeSessionStorage\'s "use_trans_sid" option is deprecated and will be ignored in Symfony 8.0.', $unignoredErrors);
-        $this->assertContains('Since symfony/http-foundation 7.2: NativeSessionStorage\'s "trans_sid_hosts" option is deprecated and will be ignored in Symfony 8.0.', $unignoredErrors);
-        $this->assertContains('Since symfony/http-foundation 7.2: NativeSessionStorage\'s "trans_sid_tags" option is deprecated and will be ignored in Symfony 8.0.', $unignoredErrors);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

In #58370 I rewrote the tests in `NativeSessionStorageTest` to work around a bug in PHPUnit that didn't allow to have assertions about deprecations triggered in tests that were run in separate processes. Thanks to sebastianbergmann/phpunit#6283 (available in e.g. PHPUnit 12.3.5+) we don't need this workaround anymore.