### PR TITLE
[Security] Ignore target route when exiting impersonation

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -124,7 +124,7 @@ class SwitchUserListener extends AbstractListener
         if (!$this->stateless) {
             $request->query->remove($this->usernameParameter);
             $request->server->set('QUERY_STRING', http_build_query($request->query->all(), '', '&'));
-            $response = new RedirectResponse($this->urlGenerator && $this->targetRoute ? $this->urlGenerator->generate($this->targetRoute) : $request->getUri(), 302);
+            $response = new RedirectResponse($this->urlGenerator && $this->targetRoute && self::EXIT_VALUE !== $username ? $this->urlGenerator->generate($this->targetRoute) : $request->getUri(), 302);
 
             $event->setResponse($response);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53873
| License       | MIT

[The user impersonation documentation](https://symfony.com/doc/current/security/impersonating_user.html#redirecting-to-a-specific-target-route) just mentions

> control the redirection target route via `target_route`

Now, given that Twig’s `impersonation_exit_path` and `impersonation_exit_url` have an `exitTo` parameter but not `impersonation_path` nor `impersonation_url`, it looks like `target_route` should only be used when **starting** an impersonation. However it is currently also used when exiting, which means that if you configured one, an `exitTo` argument wouldn’t have any effect.

Based on this assumption, this PR ignores `target_route` when exiting impersonation.

Since `exitTo` will now work with `target_route` this PR technically breaks BC, but since this behavior was broken I’m not sure it needs to be considered.