### PR TITLE
[Routing][Serializer] Deprecate annotation aliases and getters and setters in favor of public properties on attributes

### DIFF
--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -77,7 +77,8 @@ Mime
 Routing
 -------
 
- * Deprecate `getEnv()` and `setEnv()` methods of the `Symfony\Component\Routing\Attribute\Route` class in favor of the plurialized `getEnvs()` and `setEnvs()` methods
+ * Deprecate class aliases in the `Annotation` namespace, use attributes instead
+ * Deprecate getters and setters in attribute classes in favor of public properties
 
 Security
 --------
@@ -90,6 +91,8 @@ Serializer
 ----------
 
  * Make `AttributeMetadata` and `ClassMetadata` final
+ * Deprecate class aliases in the `Annotation` namespace, use attributes instead
+ * Deprecate getters in attribute classes in favor of public properties
 
 String
 ------

--- a/src/Symfony/Component/Routing/Annotation/Route.php
+++ b/src/Symfony/Component/Routing/Annotation/Route.php
@@ -16,6 +16,9 @@ namespace Symfony\Component\Routing\Annotation;
 class_exists(\Symfony\Component\Routing\Attribute\Route::class);
 
 if (false) {
+    /**
+     * @deprecated since Symfony 7.4, use {@see \Symfony\Component\Routing\Attribute\Route} instead
+     */
     #[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
     class Route extends \Symfony\Component\Routing\Attribute\Route
     {

--- a/src/Symfony/Component/Routing/Attribute/DeprecatedAlias.php
+++ b/src/Symfony/Component/Routing/Attribute/DeprecatedAlias.php
@@ -17,28 +17,32 @@ namespace Symfony\Component\Routing\Attribute;
 class DeprecatedAlias
 {
     public function __construct(
-        private string $aliasName,
-        private string $package,
-        private string $version,
-        private string $message = '',
+        public readonly string $aliasName,
+        public readonly string $package,
+        public readonly string $version,
+        public readonly string $message = '',
     ) {
     }
 
+    #[\Deprecated('Use the "message" property instead', 'symfony/routing:7.4')]
     public function getMessage(): string
     {
         return $this->message;
     }
 
+    #[\Deprecated('Use the "aliasName" property instead', 'symfony/routing:7.4')]
     public function getAliasName(): string
     {
         return $this->aliasName;
     }
 
+    #[\Deprecated('Use the "package" property instead', 'symfony/routing:7.4')]
     public function getPackage(): string
     {
         return $this->package;
     }
 
+    #[\Deprecated('Use the "version" property instead', 'symfony/routing:7.4')]
     public function getVersion(): string
     {
         return $this->version;

--- a/src/Symfony/Component/Routing/Attribute/Route.php
+++ b/src/Symfony/Component/Routing/Attribute/Route.php
@@ -20,16 +20,17 @@ use Symfony\Component\Routing\Exception\LogicException;
 #[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
 class Route
 {
-    private ?string $path = null;
-    private array $localizedPaths = [];
-    private array $methods;
     /** @var string[] */
-    private array $env;
-    private array $schemes;
-    /**
-     * @var (string|DeprecatedAlias)[]
-     */
-    private array $aliases = [];
+    public array $methods;
+
+    /** @var string[] */
+    public array $envs;
+
+    /** @var string[] */
+    public array $schemes;
+
+    /** @var (string|DeprecatedAlias)[] */
+    public array $aliases = [];
 
     /**
      * @param string|array<string,string>|null                  $path         The route path (i.e. "/user/login")
@@ -50,16 +51,16 @@ class Route
      * @param string|DeprecatedAlias|(string|DeprecatedAlias)[] $alias        The list of aliases for this route
      */
     public function __construct(
-        string|array|null $path = null,
-        private ?string $name = null,
-        private array $requirements = [],
-        private array $options = [],
-        private array $defaults = [],
-        private ?string $host = null,
+        public string|array|null $path = null,
+        public ?string $name = null,
+        public array $requirements = [],
+        public array $options = [],
+        public array $defaults = [],
+        public ?string $host = null,
         array|string $methods = [],
         array|string $schemes = [],
-        private ?string $condition = null,
-        private ?int $priority = null,
+        public ?string $condition = null,
+        public ?int $priority = null,
         ?string $locale = null,
         ?string $format = null,
         ?bool $utf8 = null,
@@ -67,15 +68,11 @@ class Route
         string|array|null $env = null,
         string|DeprecatedAlias|array $alias = [],
     ) {
-        if (\is_array($path)) {
-            $this->localizedPaths = $path;
-        } else {
-            $this->path = $path;
-        }
-        $this->setMethods($methods);
-        $this->setSchemes($schemes);
-        $this->setAliases($alias);
-        $this->setEnvs((array) $env);
+        $this->path = $path;
+        $this->methods = (array) $methods;
+        $this->schemes = (array) $schemes;
+        $this->envs = (array) $env;
+        $this->aliases = \is_array($alias) ? $alias : [$alias];
 
         if (null !== $locale) {
             $this->defaults['_locale'] = $locale;
@@ -94,154 +91,161 @@ class Route
         }
     }
 
+    #[\Deprecated('Use the "path" property instead', 'symfony/routing:7.4')]
     public function setPath(string $path): void
     {
         $this->path = $path;
     }
 
+    #[\Deprecated('Use the "path" property instead', 'symfony/routing:7.4')]
     public function getPath(): ?string
     {
-        return $this->path;
+        return \is_array($this->path) ? null : $this->path;
     }
 
+    #[\Deprecated('Use the "path" property instead', 'symfony/routing:7.4')]
     public function setLocalizedPaths(array $localizedPaths): void
     {
-        $this->localizedPaths = $localizedPaths;
+        $this->path = $localizedPaths;
     }
 
+    #[\Deprecated('Use the "path" property instead', 'symfony/routing:7.4')]
     public function getLocalizedPaths(): array
     {
-        return $this->localizedPaths;
+        return \is_array($this->path) ? $this->path : [];
     }
 
+    #[\Deprecated('Use the "host" property instead', 'symfony/routing:7.4')]
     public function setHost(string $pattern): void
     {
         $this->host = $pattern;
     }
 
+    #[\Deprecated('Use the "host" property instead', 'symfony/routing:7.4')]
     public function getHost(): ?string
     {
         return $this->host;
     }
 
+    #[\Deprecated('Use the "name" property instead', 'symfony/routing:7.4')]
     public function setName(string $name): void
     {
         $this->name = $name;
     }
 
+    #[\Deprecated('Use the "name" property instead', 'symfony/routing:7.4')]
     public function getName(): ?string
     {
         return $this->name;
     }
 
+    #[\Deprecated('Use the "requirements" property instead', 'symfony/routing:7.4')]
     public function setRequirements(array $requirements): void
     {
         $this->requirements = $requirements;
     }
 
+    #[\Deprecated('Use the "requirements" property instead', 'symfony/routing:7.4')]
     public function getRequirements(): array
     {
         return $this->requirements;
     }
 
+    #[\Deprecated('Use the "options" property instead', 'symfony/routing:7.4')]
     public function setOptions(array $options): void
     {
         $this->options = $options;
     }
 
+    #[\Deprecated('Use the "options" property instead', 'symfony/routing:7.4')]
     public function getOptions(): array
     {
         return $this->options;
     }
 
+    #[\Deprecated('Use the "defaults" property instead', 'symfony/routing:7.4')]
     public function setDefaults(array $defaults): void
     {
         $this->defaults = $defaults;
     }
 
+    #[\Deprecated('Use the "defaults" property instead', 'symfony/routing:7.4')]
     public function getDefaults(): array
     {
         return $this->defaults;
     }
 
+    #[\Deprecated('Use the "schemes" property instead', 'symfony/routing:7.4')]
     public function setSchemes(array|string $schemes): void
     {
         $this->schemes = (array) $schemes;
     }
 
+    #[\Deprecated('Use the "schemes" property instead', 'symfony/routing:7.4')]
     public function getSchemes(): array
     {
         return $this->schemes;
     }
 
+    #[\Deprecated('Use the "methods" property instead', 'symfony/routing:7.4')]
     public function setMethods(array|string $methods): void
     {
         $this->methods = (array) $methods;
     }
 
+    #[\Deprecated('Use the "methods" property instead', 'symfony/routing:7.4')]
     public function getMethods(): array
     {
         return $this->methods;
     }
 
+    #[\Deprecated('Use the "condition" property instead', 'symfony/routing:7.4')]
     public function setCondition(?string $condition): void
     {
         $this->condition = $condition;
     }
 
+    #[\Deprecated('Use the "condition" property instead', 'symfony/routing:7.4')]
     public function getCondition(): ?string
     {
         return $this->condition;
     }
 
+    #[\Deprecated('Use the "priority" property instead', 'symfony/routing:7.4')]
     public function setPriority(int $priority): void
     {
         $this->priority = $priority;
     }
 
+    #[\Deprecated('Use the "priority" property instead', 'symfony/routing:7.4')]
     public function getPriority(): ?int
     {
         return $this->priority;
     }
 
-    /**
-     * @deprecated since Symfony 7.4, use the {@see setEnvs()} method instead
-     */
+    #[\Deprecated('Use the "envs" property instead', 'symfony/routing:7.4')]
     public function setEnv(?string $env): void
     {
-        trigger_deprecation('symfony/routing', '7.4', 'The "%s()" method is deprecated, use "setEnvs()" instead.', __METHOD__);
-        $this->env = (array) $env;
+        $this->envs = (array) $env;
     }
 
-    /**
-     * @deprecated since Symfony 7.4, use {@see getEnvs()} method instead
-     */
+    #[\Deprecated('Use the "envs" property instead', 'symfony/routing:7.4')]
     public function getEnv(): ?string
     {
-        trigger_deprecation('symfony/routing', '7.4', 'The "%s()" method is deprecated, use "getEnvs()" instead.', __METHOD__);
-        if (!$this->env) {
+        if (!$this->envs) {
             return null;
         }
-        if (\count($this->env) > 1) {
-            throw new LogicException(\sprintf('The "env" property has %d environments. Use "getEnvs()" to get all of them.', \count($this->env)));
+        if (\count($this->envs) > 1) {
+            throw new LogicException(\sprintf('The "env" property has %d environments. Use "getEnvs()" to get all of them.', \count($this->envs)));
         }
 
-        return $this->env[0];
-    }
-
-    public function setEnvs(array|string $env): void
-    {
-        $this->env = (array) $env;
-    }
-
-    public function getEnvs(): array
-    {
-        return $this->env;
+        return $this->envs[0];
     }
 
     /**
      * @return (string|DeprecatedAlias)[]
      */
+    #[\Deprecated('Use the "aliases" property instead', 'symfony/routing:7.4')]
     public function getAliases(): array
     {
         return $this->aliases;
@@ -250,6 +254,7 @@ class Route
     /**
      * @param string|DeprecatedAlias|(string|DeprecatedAlias)[] $aliases
      */
+    #[\Deprecated('Use the "aliases" property instead', 'symfony/routing:7.4')]
     public function setAliases(string|DeprecatedAlias|array $aliases): void
     {
         $this->aliases = \is_array($aliases) ? $aliases : [$aliases];

--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -7,6 +7,8 @@ CHANGELOG
  * Allow query-specific parameters in `UrlGenerator` using `_query`
  * Add support of multiple env names in the  `Symfony\Component\Routing\Attribute\Route` attribute
  * Add argument `$parameters` to `RequestContext`'s constructor
+ * Deprecate class aliases in the `Annotation` namespace, use attributes instead
+ * Deprecate getters and setters in attribute classes in favor of public properties
 
 7.3
 ---

--- a/src/Symfony/Component/Routing/Loader/AttributeClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AttributeClassLoader.php
@@ -112,7 +112,7 @@ abstract class AttributeClassLoader implements LoaderInterface
 
         if (!$class->hasMethod('__invoke')) {
             foreach ($this->getAttributes($class) as $attr) {
-                if ($attr->getAliases()) {
+                if ($attr->aliases) {
                     throw new InvalidArgumentException(\sprintf('Route aliases cannot be used on non-invokable class "%s".', $class->getName()));
                 }
             }
@@ -161,14 +161,14 @@ abstract class AttributeClassLoader implements LoaderInterface
      */
     protected function addRoute(RouteCollection $collection, object $attr, array $globals, \ReflectionClass $class, \ReflectionMethod $method): void
     {
-        if ($attr->getEnvs() && !\in_array($this->env, $attr->getEnvs(), true)) {
+        if ($attr->envs && !\in_array($this->env, $attr->envs, true)) {
             return;
         }
 
-        $name = $attr->getName() ?? $this->getDefaultRouteName($class, $method);
+        $name = $attr->name ?? $this->getDefaultRouteName($class, $method);
         $name = $globals['name'].$name;
 
-        $requirements = $attr->getRequirements();
+        $requirements = $attr->requirements;
 
         foreach ($requirements as $placeholder => $requirement) {
             if (\is_int($placeholder)) {
@@ -176,17 +176,17 @@ abstract class AttributeClassLoader implements LoaderInterface
             }
         }
 
-        $defaults = array_replace($globals['defaults'], $attr->getDefaults());
+        $defaults = array_replace($globals['defaults'], $attr->defaults);
         $requirements = array_replace($globals['requirements'], $requirements);
-        $options = array_replace($globals['options'], $attr->getOptions());
-        $schemes = array_unique(array_merge($globals['schemes'], $attr->getSchemes()));
-        $methods = array_unique(array_merge($globals['methods'], $attr->getMethods()));
+        $options = array_replace($globals['options'], $attr->options);
+        $schemes = array_unique(array_merge($globals['schemes'], $attr->schemes));
+        $methods = array_unique(array_merge($globals['methods'], $attr->methods));
 
-        $host = $attr->getHost() ?? $globals['host'];
-        $condition = $attr->getCondition() ?? $globals['condition'];
-        $priority = $attr->getPriority() ?? $globals['priority'];
+        $host = $attr->host ?? $globals['host'];
+        $condition = $attr->condition ?? $globals['condition'];
+        $priority = $attr->priority ?? $globals['priority'];
 
-        $path = $attr->getLocalizedPaths() ?: $attr->getPath();
+        $path = $attr->path;
         $prefix = $globals['localized_paths'] ?: $globals['path'];
         $paths = [];
 
@@ -241,13 +241,13 @@ abstract class AttributeClassLoader implements LoaderInterface
             } else {
                 $collection->add($name, $route, $priority);
             }
-            foreach ($attr->getAliases() as $aliasAttribute) {
+            foreach ($attr->aliases as $aliasAttribute) {
                 if ($aliasAttribute instanceof DeprecatedAlias) {
-                    $alias = $collection->addAlias($aliasAttribute->getAliasName(), $name);
+                    $alias = $collection->addAlias($aliasAttribute->aliasName, $name);
                     $alias->setDeprecated(
-                        $aliasAttribute->getPackage(),
-                        $aliasAttribute->getVersion(),
-                        $aliasAttribute->getMessage()
+                        $aliasAttribute->package,
+                        $aliasAttribute->version,
+                        $aliasAttribute->message
                     );
                     continue;
                 }
@@ -299,46 +299,47 @@ abstract class AttributeClassLoader implements LoaderInterface
         if ($attribute = $class->getAttributes($this->routeAnnotationClass, \ReflectionAttribute::IS_INSTANCEOF)[0] ?? null) {
             $attr = $attribute->newInstance();
 
-            if (null !== $attr->getName()) {
-                $globals['name'] = $attr->getName();
+            if (null !== $attr->name) {
+                $globals['name'] = $attr->name;
             }
 
-            if (null !== $attr->getPath()) {
-                $globals['path'] = $attr->getPath();
+            if (\is_string($attr->path)) {
+                $globals['path'] = $attr->path;
+                $globals['localized_paths'] = [];
+            } else {
+                $globals['localized_paths'] = $attr->path ?? [];
             }
 
-            $globals['localized_paths'] = $attr->getLocalizedPaths();
-
-            if (null !== $attr->getRequirements()) {
-                $globals['requirements'] = $attr->getRequirements();
+            if (null !== $attr->requirements) {
+                $globals['requirements'] = $attr->requirements;
             }
 
-            if (null !== $attr->getOptions()) {
-                $globals['options'] = $attr->getOptions();
+            if (null !== $attr->options) {
+                $globals['options'] = $attr->options;
             }
 
-            if (null !== $attr->getDefaults()) {
-                $globals['defaults'] = $attr->getDefaults();
+            if (null !== $attr->defaults) {
+                $globals['defaults'] = $attr->defaults;
             }
 
-            if (null !== $attr->getSchemes()) {
-                $globals['schemes'] = $attr->getSchemes();
+            if (null !== $attr->schemes) {
+                $globals['schemes'] = $attr->schemes;
             }
 
-            if (null !== $attr->getMethods()) {
-                $globals['methods'] = $attr->getMethods();
+            if (null !== $attr->methods) {
+                $globals['methods'] = $attr->methods;
             }
 
-            if (null !== $attr->getHost()) {
-                $globals['host'] = $attr->getHost();
+            if (null !== $attr->host) {
+                $globals['host'] = $attr->host;
             }
 
-            if (null !== $attr->getCondition()) {
-                $globals['condition'] = $attr->getCondition();
+            if (null !== $attr->condition) {
+                $globals['condition'] = $attr->condition;
             }
 
-            $globals['priority'] = $attr->getPriority() ?? 0;
-            $globals['env'] = $attr->getEnvs();
+            $globals['priority'] = $attr->priority ?? 0;
+            $globals['env'] = $attr->envs;
 
             foreach ($globals['requirements'] as $placeholder => $requirement) {
                 if (\is_int($placeholder)) {

--- a/src/Symfony/Component/Routing/Tests/Attribute/RouteTest.php
+++ b/src/Symfony/Component/Routing/Tests/Attribute/RouteTest.php
@@ -19,27 +19,27 @@ use Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures\FooController;
 class RouteTest extends TestCase
 {
     #[DataProvider('getValidParameters')]
-    public function testLoadFromAttribute(string $methodName, string $getter, mixed $expectedReturn)
+    public function testLoadFromAttribute(string $methodName, string $property, mixed $expectedReturn)
     {
         $route = (new \ReflectionMethod(FooController::class, $methodName))->getAttributes(Route::class)[0]->newInstance();
 
-        $this->assertEquals($route->$getter(), $expectedReturn);
+        $this->assertEquals($route->$property, $expectedReturn);
     }
 
     public static function getValidParameters(): iterable
     {
         return [
-            ['simplePath', 'getPath', '/Blog'],
-            ['localized', 'getLocalizedPaths', ['nl' => '/hier', 'en' => '/here']],
-            ['requirements', 'getRequirements', ['locale' => 'en']],
-            ['options', 'getOptions', ['compiler_class' => 'RouteCompiler']],
-            ['name', 'getName', 'blog_index'],
-            ['defaults', 'getDefaults', ['_controller' => 'MyBlogBundle:Blog:index']],
-            ['schemes', 'getSchemes', ['https']],
-            ['methods', 'getMethods', ['GET', 'POST']],
-            ['host', 'getHost', '{locale}.example.com'],
-            ['condition', 'getCondition', 'context.getMethod() == \'GET\''],
-            ['alias', 'getAliases', ['alias', 'completely_different_name']],
+            ['simplePath', 'path', '/Blog'],
+            ['localized', 'path', ['nl' => '/hier', 'en' => '/here']],
+            ['requirements', 'requirements', ['locale' => 'en']],
+            ['options', 'options', ['compiler_class' => 'RouteCompiler']],
+            ['name', 'name', 'blog_index'],
+            ['defaults', 'defaults', ['_controller' => 'MyBlogBundle:Blog:index']],
+            ['schemes', 'schemes', ['https']],
+            ['methods', 'methods', ['GET', 'POST']],
+            ['host', 'host', '{locale}.example.com'],
+            ['condition', 'condition', 'context.getMethod() == \'GET\''],
+            ['alias', 'aliases', ['alias', 'completely_different_name']],
         ];
     }
 }

--- a/src/Symfony/Component/Serializer/Annotation/Context.php
+++ b/src/Symfony/Component/Serializer/Annotation/Context.php
@@ -16,6 +16,9 @@ namespace Symfony\Component\Serializer\Annotation;
 class_exists(\Symfony\Component\Serializer\Attribute\Context::class);
 
 if (false) {
+    /**
+     * @deprecated since Symfony 7.4, use {@see \Symfony\Component\Serializer\Attribute\Context} instead
+     */
     #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
     class Context extends \Symfony\Component\Serializer\Attribute\Context
     {

--- a/src/Symfony/Component/Serializer/Annotation/DiscriminatorMap.php
+++ b/src/Symfony/Component/Serializer/Annotation/DiscriminatorMap.php
@@ -14,6 +14,9 @@ namespace Symfony\Component\Serializer\Annotation;
 class_exists(\Symfony\Component\Serializer\Attribute\DiscriminatorMap::class);
 
 if (false) {
+    /**
+     * @deprecated since Symfony 7.4, use {@see \Symfony\Component\Serializer\Attribute\DiscriminatorMap} instead
+     */
     #[\Attribute(\Attribute::TARGET_CLASS)]
     class DiscriminatorMap extends \Symfony\Component\Serializer\Attribute\DiscriminatorMap
     {

--- a/src/Symfony/Component/Serializer/Annotation/Groups.php
+++ b/src/Symfony/Component/Serializer/Annotation/Groups.php
@@ -14,6 +14,9 @@ namespace Symfony\Component\Serializer\Annotation;
 class_exists(\Symfony\Component\Serializer\Attribute\Groups::class);
 
 if (false) {
+    /**
+     * @deprecated since Symfony 7.4, use {@see \Symfony\Component\Serializer\Attribute\Groups} instead
+     */
     #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY | \Attribute::TARGET_CLASS)]
     class Groups extends \Symfony\Component\Serializer\Attribute\Groups
     {

--- a/src/Symfony/Component/Serializer/Annotation/Ignore.php
+++ b/src/Symfony/Component/Serializer/Annotation/Ignore.php
@@ -14,6 +14,9 @@ namespace Symfony\Component\Serializer\Annotation;
 class_exists(\Symfony\Component\Serializer\Attribute\Ignore::class);
 
 if (false) {
+    /**
+     * @deprecated since Symfony 7.4, use {@see \Symfony\Component\Serializer\Attribute\Ignore} instead
+     */
     #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
     class Ignore extends \Symfony\Component\Serializer\Attribute\Ignore
     {

--- a/src/Symfony/Component/Serializer/Annotation/MaxDepth.php
+++ b/src/Symfony/Component/Serializer/Annotation/MaxDepth.php
@@ -14,6 +14,9 @@ namespace Symfony\Component\Serializer\Annotation;
 class_exists(\Symfony\Component\Serializer\Attribute\MaxDepth::class);
 
 if (false) {
+    /**
+     * @deprecated since Symfony 7.4, use {@see \Symfony\Component\Serializer\Attribute\MaxDepth} instead
+     */
     #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
     class MaxDepth extends \Symfony\Component\Serializer\Attribute\MaxDepth
     {

--- a/src/Symfony/Component/Serializer/Annotation/SerializedName.php
+++ b/src/Symfony/Component/Serializer/Annotation/SerializedName.php
@@ -14,6 +14,9 @@ namespace Symfony\Component\Serializer\Annotation;
 class_exists(\Symfony\Component\Serializer\Attribute\SerializedName::class);
 
 if (false) {
+    /**
+     * @deprecated since Symfony 7.4, use {@see \Symfony\Component\Serializer\Attribute\SerializedName} instead
+     */
     #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
     class SerializedName extends \Symfony\Component\Serializer\Attribute\SerializedName
     {

--- a/src/Symfony/Component/Serializer/Annotation/SerializedPath.php
+++ b/src/Symfony/Component/Serializer/Annotation/SerializedPath.php
@@ -14,6 +14,9 @@ namespace Symfony\Component\Serializer\Annotation;
 class_exists(\Symfony\Component\Serializer\Attribute\SerializedPath::class);
 
 if (false) {
+    /**
+     * @deprecated since Symfony 7.4, use {@see \Symfony\Component\Serializer\Attribute\SerializedPath} instead
+     */
     #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
     class SerializedPath extends \Symfony\Component\Serializer\Attribute\SerializedPath
     {

--- a/src/Symfony/Component/Serializer/Attribute/Context.php
+++ b/src/Symfony/Component/Serializer/Attribute/Context.php
@@ -19,7 +19,7 @@ use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class Context
 {
-    private array $groups;
+    public readonly array $groups;
 
     /**
      * @param array<string, mixed> $context                The common context to use when serializing or deserializing
@@ -30,9 +30,9 @@ class Context
      * @throws InvalidArgumentException
      */
     public function __construct(
-        private readonly array $context = [],
-        private readonly array $normalizationContext = [],
-        private readonly array $denormalizationContext = [],
+        public readonly array $context = [],
+        public readonly array $normalizationContext = [],
+        public readonly array $denormalizationContext = [],
         string|array $groups = [],
     ) {
         if (!$context && !$normalizationContext && !$denormalizationContext) {
@@ -48,21 +48,25 @@ class Context
         }
     }
 
+    #[\Deprecated('Use the "context" property instead', 'symfony/serializer:7.4')]
     public function getContext(): array
     {
         return $this->context;
     }
 
+    #[\Deprecated('Use the "normalizationContext" property instead', 'symfony/serializer:7.4')]
     public function getNormalizationContext(): array
     {
         return $this->normalizationContext;
     }
 
+    #[\Deprecated('Use the "denormalizationContext" property instead', 'symfony/serializer:7.4')]
     public function getDenormalizationContext(): array
     {
         return $this->denormalizationContext;
     }
 
+    #[\Deprecated('Use the "groups" property instead', 'symfony/serializer:7.4')]
     public function getGroups(): array
     {
         return $this->groups;

--- a/src/Symfony/Component/Serializer/Attribute/DiscriminatorMap.php
+++ b/src/Symfony/Component/Serializer/Attribute/DiscriminatorMap.php
@@ -27,9 +27,9 @@ class DiscriminatorMap
      * @throws InvalidArgumentException
      */
     public function __construct(
-        private readonly string $typeProperty,
-        private readonly array $mapping,
-        private readonly ?string $defaultType = null,
+        public readonly string $typeProperty,
+        public readonly array $mapping,
+        public readonly ?string $defaultType = null,
     ) {
         if (!$typeProperty) {
             throw new InvalidArgumentException(\sprintf('Parameter "typeProperty" given to "%s" cannot be empty.', static::class));
@@ -44,16 +44,19 @@ class DiscriminatorMap
         }
     }
 
+    #[\Deprecated('Use the "typeProperty" property instead', 'symfony/serializer:7.4')]
     public function getTypeProperty(): string
     {
         return $this->typeProperty;
     }
 
+    #[\Deprecated('Use the "mapping" property instead', 'symfony/serializer:7.4')]
     public function getMapping(): array
     {
         return $this->mapping;
     }
 
+    #[\Deprecated('Use the "defaultType" property instead', 'symfony/serializer:7.4')]
     public function getDefaultType(): ?string
     {
         return $this->defaultType;

--- a/src/Symfony/Component/Serializer/Attribute/Groups.php
+++ b/src/Symfony/Component/Serializer/Attribute/Groups.php
@@ -22,7 +22,7 @@ class Groups
     /**
      * @var string[]
      */
-    private readonly array $groups;
+    public readonly array $groups;
 
     /**
      * @param string|string[] $groups The groups to define on the attribute target
@@ -45,6 +45,7 @@ class Groups
     /**
      * @return string[]
      */
+    #[\Deprecated('Use the "groups" property instead', 'symfony/serializer:7.4')]
     public function getGroups(): array
     {
         return $this->groups;

--- a/src/Symfony/Component/Serializer/Attribute/MaxDepth.php
+++ b/src/Symfony/Component/Serializer/Attribute/MaxDepth.php
@@ -22,13 +22,15 @@ class MaxDepth
     /**
      * @param int $maxDepth The maximum serialization depth
      */
-    public function __construct(private readonly int $maxDepth)
-    {
+    public function __construct(
+        public readonly int $maxDepth,
+    ) {
         if ($maxDepth <= 0) {
             throw new InvalidArgumentException(\sprintf('Parameter given to "%s" must be a positive integer.', static::class));
         }
     }
 
+    #[\Deprecated('Use the "maxdepth" property instead', 'symfony/serializer:7.4')]
     public function getMaxDepth(): int
     {
         return $this->maxDepth;

--- a/src/Symfony/Component/Serializer/Attribute/SerializedName.php
+++ b/src/Symfony/Component/Serializer/Attribute/SerializedName.php
@@ -22,13 +22,15 @@ class SerializedName
     /**
      * @param string $serializedName The name of the property as it will be serialized
      */
-    public function __construct(private readonly string $serializedName)
-    {
+    public function __construct(
+        public readonly string $serializedName,
+    ) {
         if ('' === $serializedName) {
             throw new InvalidArgumentException(\sprintf('Parameter given to "%s" must be a non-empty string.', self::class));
         }
     }
 
+    #[\Deprecated('Use the "serializedName" property instead', 'symfony/serializer:7.4')]
     public function getSerializedName(): string
     {
         return $this->serializedName;

--- a/src/Symfony/Component/Serializer/Attribute/SerializedPath.php
+++ b/src/Symfony/Component/Serializer/Attribute/SerializedPath.php
@@ -21,7 +21,7 @@ use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
 class SerializedPath
 {
-    private PropertyPath $serializedPath;
+    public readonly PropertyPath $serializedPath;
 
     /**
      * @param string $serializedPath A path using a valid PropertyAccess syntax where the value is stored in a normalized representation
@@ -30,11 +30,12 @@ class SerializedPath
     {
         try {
             $this->serializedPath = new PropertyPath($serializedPath);
-        } catch (InvalidPropertyPathException $pathException) {
+        } catch (InvalidPropertyPathException) {
             throw new InvalidArgumentException(\sprintf('Parameter given to "%s" must be a valid property path.', self::class));
         }
     }
 
+    #[\Deprecated('Use the "serializedPath" property instead', 'symfony/serializer:7.4')]
     public function getSerializedPath(): PropertyPath
     {
         return $this->serializedPath;

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -7,6 +7,8 @@ CHANGELOG
  * Add `CDATA_WRAPPING_NAME_PATTERN` support to `XmlEncoder`
  * Add support for `can*()` methods to `AttributeLoader`
  * Make `AttributeMetadata` and `ClassMetadata` final
+ * Deprecate class aliases in the `Annotation` namespace, use attributes instead
+ * Deprecate getters in attribute classes in favor of public properties
 
 7.3
 ---

--- a/src/Symfony/Component/Serializer/Mapping/Loader/AttributeLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AttributeLoader.php
@@ -59,8 +59,8 @@ class AttributeLoader implements LoaderInterface
 
         foreach ($this->loadAttributes($reflectionClass) as $attribute) {
             match (true) {
-                $attribute instanceof DiscriminatorMap => $classMetadata->setClassDiscriminatorMapping(new ClassDiscriminatorMapping($attribute->getTypeProperty(), $attribute->getMapping(), $attribute->getDefaultType())),
-                $attribute instanceof Groups => $classGroups = $attribute->getGroups(),
+                $attribute instanceof DiscriminatorMap => $classMetadata->setClassDiscriminatorMapping(new ClassDiscriminatorMapping($attribute->typeProperty, $attribute->mapping, $attribute->defaultType)),
+                $attribute instanceof Groups => $classGroups = $attribute->groups,
                 $attribute instanceof Context => $classContextAttribute = $attribute,
                 default => null,
             };
@@ -86,7 +86,7 @@ class AttributeLoader implements LoaderInterface
                     $loaded = true;
 
                     if ($attribute instanceof Groups) {
-                        foreach ($attribute->getGroups() as $group) {
+                        foreach ($attribute->groups as $group) {
                             $attributeMetadata->addGroup($group);
                         }
 
@@ -94,9 +94,9 @@ class AttributeLoader implements LoaderInterface
                     }
 
                     match (true) {
-                        $attribute instanceof MaxDepth => $attributeMetadata->setMaxDepth($attribute->getMaxDepth()),
-                        $attribute instanceof SerializedName => $attributeMetadata->setSerializedName($attribute->getSerializedName()),
-                        $attribute instanceof SerializedPath => $attributeMetadata->setSerializedPath($attribute->getSerializedPath()),
+                        $attribute instanceof MaxDepth => $attributeMetadata->setMaxDepth($attribute->maxDepth),
+                        $attribute instanceof SerializedName => $attributeMetadata->setSerializedName($attribute->serializedName),
+                        $attribute instanceof SerializedPath => $attributeMetadata->setSerializedPath($attribute->serializedPath),
                         $attribute instanceof Ignore => $attributeMetadata->setIgnore(true),
                         $attribute instanceof Context => $this->setAttributeContextsForGroups($attribute, $attributeMetadata),
                         default => null,
@@ -132,7 +132,7 @@ class AttributeLoader implements LoaderInterface
                         throw new MappingException(\sprintf('Groups on "%s::%s()" cannot be added. Groups can only be added on methods beginning with "get", "is", "has" or "set".', $className, $method->name));
                     }
 
-                    foreach ($attribute->getGroups() as $group) {
+                    foreach ($attribute->groups as $group) {
                         $attributeMetadata->addGroup($group);
                     }
                 } elseif ($attribute instanceof MaxDepth) {
@@ -140,19 +140,19 @@ class AttributeLoader implements LoaderInterface
                         throw new MappingException(\sprintf('MaxDepth on "%s::%s()" cannot be added. MaxDepth can only be added on methods beginning with "get", "is", "has" or "set".', $className, $method->name));
                     }
 
-                    $attributeMetadata->setMaxDepth($attribute->getMaxDepth());
+                    $attributeMetadata->setMaxDepth($attribute->maxDepth);
                 } elseif ($attribute instanceof SerializedName) {
                     if (!$accessorOrMutator) {
                         throw new MappingException(\sprintf('SerializedName on "%s::%s()" cannot be added. SerializedName can only be added on methods beginning with "get", "is", "has" or "set".', $className, $method->name));
                     }
 
-                    $attributeMetadata->setSerializedName($attribute->getSerializedName());
+                    $attributeMetadata->setSerializedName($attribute->serializedName);
                 } elseif ($attribute instanceof SerializedPath) {
                     if (!$accessorOrMutator) {
                         throw new MappingException(\sprintf('SerializedPath on "%s::%s()" cannot be added. SerializedPath can only be added on methods beginning with "get", "is", "has" or "set".', $className, $method->name));
                     }
 
-                    $attributeMetadata->setSerializedPath($attribute->getSerializedPath());
+                    $attributeMetadata->setSerializedPath($attribute->serializedPath);
                 } elseif ($attribute instanceof Ignore) {
                     if ($accessorOrMutator) {
                         $attributeMetadata->setIgnore(true);
@@ -197,10 +197,10 @@ class AttributeLoader implements LoaderInterface
 
     private function setAttributeContextsForGroups(Context $attribute, AttributeMetadataInterface $attributeMetadata): void
     {
-        $context = $attribute->getContext();
-        $groups = $attribute->getGroups();
-        $normalizationContext = $attribute->getNormalizationContext();
-        $denormalizationContext = $attribute->getDenormalizationContext();
+        $context = $attribute->context;
+        $groups = $attribute->groups;
+        $normalizationContext = $attribute->normalizationContext;
+        $denormalizationContext = $attribute->denormalizationContext;
 
         if ($normalizationContext || $context) {
             $attributeMetadata->setNormalizationContextForGroups($normalizationContext ?: $context, $groups);

--- a/src/Symfony/Component/Serializer/Tests/Attribute/ContextTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Attribute/ContextTest.php
@@ -50,20 +50,20 @@ class ContextTest extends TestCase
     {
         $context = new Context(['foo' => 'bar']);
 
-        self::assertSame(['foo' => 'bar'], $context->getContext());
-        self::assertSame([], $context->getNormalizationContext());
-        self::assertSame([], $context->getDenormalizationContext());
-        self::assertSame([], $context->getGroups());
+        self::assertSame(['foo' => 'bar'], $context->context);
+        self::assertSame([], $context->normalizationContext);
+        self::assertSame([], $context->denormalizationContext);
+        self::assertSame([], $context->groups);
     }
 
     public function testAsContextArg()
     {
         $context = new Context(context: ['foo' => 'bar']);
 
-        self::assertSame(['foo' => 'bar'], $context->getContext());
-        self::assertSame([], $context->getNormalizationContext());
-        self::assertSame([], $context->getDenormalizationContext());
-        self::assertSame([], $context->getGroups());
+        self::assertSame(['foo' => 'bar'], $context->context);
+        self::assertSame([], $context->normalizationContext);
+        self::assertSame([], $context->denormalizationContext);
+        self::assertSame([], $context->groups);
     }
 
     #[DataProvider('provideValidInputs')]
@@ -78,12 +78,12 @@ class ContextTest extends TestCase
             fn () => new Context(context: ['foo' => 'bar']),
             <<<DUMP
                 Symfony\Component\Serializer\Attribute\Context {
-                  -groups: []
-                  -context: [
+                  +groups: []
+                  +context: [
                     "foo" => "bar",
                   ]
-                  -normalizationContext: []
-                  -denormalizationContext: []
+                  +normalizationContext: []
+                  +denormalizationContext: []
                 }
                 DUMP,
         ];
@@ -92,12 +92,12 @@ class ContextTest extends TestCase
             fn () => new Context(normalizationContext: ['foo' => 'bar']),
             <<<DUMP
                 Symfony\Component\Serializer\Attribute\Context {
-                  -groups: []
-                  -context: []
-                  -normalizationContext: [
+                  +groups: []
+                  +context: []
+                  +normalizationContext: [
                     "foo" => "bar",
                   ]
-                  -denormalizationContext: []
+                  +denormalizationContext: []
                 }
                 DUMP,
         ];
@@ -106,10 +106,10 @@ class ContextTest extends TestCase
             fn () => new Context(denormalizationContext: ['foo' => 'bar']),
             <<<DUMP
                 Symfony\Component\Serializer\Attribute\Context {
-                  -groups: []
-                  -context: []
-                  -normalizationContext: []
-                  -denormalizationContext: [
+                  +groups: []
+                  +context: []
+                  +normalizationContext: []
+                  +denormalizationContext: [
                     "foo" => "bar",
                   ]
                 }
@@ -120,14 +120,14 @@ class ContextTest extends TestCase
             fn () => new Context(context: ['foo' => 'bar'], groups: 'a'),
             <<<DUMP
                 Symfony\Component\Serializer\Attribute\Context {
-                  -groups: [
+                  +groups: [
                     "a",
                   ]
-                  -context: [
+                  +context: [
                     "foo" => "bar",
                   ]
-                  -normalizationContext: []
-                  -denormalizationContext: []
+                  +normalizationContext: []
+                  +denormalizationContext: []
                 }
                 DUMP,
         ];
@@ -136,15 +136,15 @@ class ContextTest extends TestCase
             fn () => new Context(context: ['foo' => 'bar'], groups: ['a', 'b']),
             <<<DUMP
                 Symfony\Component\Serializer\Attribute\Context {
-                  -groups: [
+                  +groups: [
                     "a",
                     "b",
                   ]
-                  -context: [
+                  +context: [
                     "foo" => "bar",
                   ]
-                  -normalizationContext: []
-                  -denormalizationContext: []
+                  +normalizationContext: []
+                  +denormalizationContext: []
                 }
                 DUMP,
         ];

--- a/src/Symfony/Component/Serializer/Tests/Attribute/DiscriminatorMapTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Attribute/DiscriminatorMapTest.php
@@ -27,11 +27,11 @@ class DiscriminatorMapTest extends TestCase
             'bar' => 'BarClass',
         ]);
 
-        $this->assertEquals('type', $attribute->getTypeProperty());
+        $this->assertEquals('type', $attribute->typeProperty);
         $this->assertEquals([
             'foo' => 'FooClass',
             'bar' => 'BarClass',
-        ], $attribute->getMapping());
+        ], $attribute->mapping);
     }
 
     public function testExceptionWithEmptyTypeProperty()

--- a/src/Symfony/Component/Serializer/Tests/Attribute/GroupsTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Attribute/GroupsTest.php
@@ -37,12 +37,12 @@ class GroupsTest extends TestCase
         $validData = ['a', 'b'];
 
         $groups = new Groups($validData);
-        $this->assertEquals($validData, $groups->getGroups());
+        $this->assertEquals($validData, $groups->groups);
     }
 
     public function testSingleGroup()
     {
         $groups = new Groups('a');
-        $this->assertEquals(['a'], $groups->getGroups());
+        $this->assertEquals(['a'], $groups->groups);
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Attribute/MaxDepthTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Attribute/MaxDepthTest.php
@@ -33,6 +33,6 @@ class MaxDepthTest extends TestCase
     public function testMaxDepthParameters()
     {
         $maxDepth = new MaxDepth(3);
-        $this->assertEquals(3, $maxDepth->getMaxDepth());
+        $this->assertEquals(3, $maxDepth->maxDepth);
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Attribute/SerializedNameTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Attribute/SerializedNameTest.php
@@ -31,6 +31,6 @@ class SerializedNameTest extends TestCase
     public function testSerializedNameParameters()
     {
         $foo = new SerializedName('foo');
-        $this->assertEquals('foo', $foo->getSerializedName());
+        $this->assertEquals('foo', $foo->serializedName);
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Attribute/SerializedPathTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Attribute/SerializedPathTest.php
@@ -34,6 +34,6 @@ class SerializedPathTest extends TestCase
         $path = '[one][two]';
         $serializedPath = new SerializedPath($path);
         $propertyPath = new PropertyPath($path);
-        $this->assertEquals($propertyPath, $serializedPath->getSerializedPath());
+        $this->assertEquals($propertyPath, $serializedPath->serializedPath);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | -
| License       | MIT

Let's remove more needless boilerplate.

These deprecations shouldn't affect anyone since I don't expected other code than ours to read these attributes.

Note that I don't make properties on `Route` readonly because of the existing setters.
(Note also that having readonly on the other attribute properties isn't useful in pragmatic terms, that's mostly pedantic ;) )