### PR TITLE
[DependencyInjection][Routing] Define array-shapes to help writing PHP configs using yaml-like arrays

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -197,6 +197,10 @@
             "Symfony\\Bridge\\Twig\\": "src/Symfony/Bridge/Twig/",
             "Symfony\\Bundle\\": "src/Symfony/Bundle/",
             "Symfony\\Component\\": "src/Symfony/Component/",
+            "Symfony\\Config\\": [
+                "src/Symfony/Component/DependencyInjection/Loader/Config/",
+                "src/Symfony/Component/Routing/Loader/Config/"
+            ],
             "Symfony\\Runtime\\Symfony\\Component\\": "src/Symfony/Component/Runtime/Internal/"
         },
         "files": [

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
  * Allow multiple `#[AsDecorator]` attributes
  * Handle returning arrays and config-builders from config files
  * Handle declaring services using PHP arrays that follow the same shape as corresponding yaml files
+ * Add `ServicesConfig` to help writing PHP configs using yaml-like array-shapes
  * Deprecate using `$this` or its internal scope from PHP config files; use the `$loader` variable instead
  * Deprecate XML configuration format, use YAML or PHP instead
  * Deprecate `ExtensionInterface::getXsdValidationBasePath()` and `getNamespace()`

--- a/src/Symfony/Component/DependencyInjection/Loader/Config/ServicesConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Config/ServicesConfig.php
@@ -1,0 +1,142 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Config;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ReferenceConfigurator;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\ExpressionLanguage\Expression;
+
+require_once __DIR__.\DIRECTORY_SEPARATOR.'functions.php';
+
+/**
+ * @psalm-type Arguments = list<mixed>|array<string, mixed>
+ * @psalm-type Callback = string|array{0:string|Reference|ReferenceConfigurator,1:string}|\Closure|Reference|ReferenceConfigurator|Expression
+ * @psalm-type Tags = list<string|array<string, array<string, mixed>>>
+ * @psalm-type Deprecation = array{package: string, version: string, message?: string}
+ * @psalm-type Call = array<string, Arguments>|array{0:string, 1?:Arguments, 2?:bool}|array{method:string, arguments?:Arguments, returns_clone?:bool}
+ * @psalm-type Imports = list<string|array{
+ *   resource: string,
+ *   type?: string|null,
+ *   ignore_errors?: bool,
+ * }>
+ * @psalm-type Parameters = array<string, scalar|\UnitEnum|array<scalar|\UnitEnum|array|null>|null>
+ * @psalm-type Defaults = array{
+ *   public?: bool,
+ *   tags?: Tags,
+ *   resource_tags?: Tags,
+ *   autowire?: bool,
+ *   autoconfigure?: bool,
+ *   bind?: array<string, mixed>,
+ * }
+ * @psalm-type Instanceof = array{
+ *   shared?: bool,
+ *   lazy?: bool|string,
+ *   public?: bool,
+ *   properties?: array<string, mixed>,
+ *   configurator?: Callback,
+ *   calls?: list<Call>,
+ *   tags?: Tags,
+ *   resource_tags?: Tags,
+ *   autowire?: bool,
+ *   bind?: array<string, mixed>,
+ *   constructor?: string,
+ * }
+ * @psalm-type Definition = array{
+ *   class?: string,
+ *   file?: string,
+ *   parent?: string,
+ *   shared?: bool,
+ *   synthetic?: bool,
+ *   lazy?: bool|string,
+ *   public?: bool,
+ *   abstract?: bool,
+ *   deprecated?: Deprecation,
+ *   factory?: Callback,
+ *   configurator?: Callback,
+ *   arguments?: Arguments,
+ *   properties?: array<string, mixed>,
+ *   calls?: list<Call>,
+ *   tags?: Tags,
+ *   resource_tags?: Tags,
+ *   decorates?: string,
+ *   decoration_inner_name?: string,
+ *   decoration_priority?: int,
+ *   decoration_on_invalid?: 'exception'|'ignore'|null|ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE|ContainerInterface::IGNORE_ON_INVALID_REFERENCE|ContainerInterface::NULL_ON_INVALID_REFERENCE,
+ *   autowire?: bool,
+ *   autoconfigure?: bool,
+ *   bind?: array<string, mixed>,
+ *   constructor?: string,
+ *   from_callable?: mixed,
+ * }
+ * @psalm-type Alias = string|array{
+ *   alias: string,
+ *   public?: bool,
+ *   deprecated?: Deprecation,
+ * }
+ * @psalm-type Prototype = array{
+ *   resource: string,
+ *   namespace?: string,
+ *   exclude?: string|list<string>,
+ *   parent?: string,
+ *   shared?: bool,
+ *   lazy?: bool|string,
+ *   public?: bool,
+ *   abstract?: bool,
+ *   deprecated?: Deprecation,
+ *   factory?: Callback,
+ *   arguments?: Arguments,
+ *   properties?: array<string, mixed>,
+ *   configurator?: Callback,
+ *   calls?: list<Call>,
+ *   tags?: Tags,
+ *   resource_tags?: Tags,
+ *   autowire?: bool,
+ *   autoconfigure?: bool,
+ *   bind?: array<string, mixed>,
+ *   constructor?: string,
+ * }
+ * @psalm-type Stack = array{
+ *   stack: list<Definition|Alias|Prototype|array<class-string, Arguments|null>>,
+ *   public?: bool,
+ *   deprecated?: Deprecation,
+ * }
+ * @psalm-type Services = array<string, Definition|Alias|Prototype|Stack>|array<class-string, Arguments|null>
+ */
+class ServicesConfig
+{
+    public readonly array $services;
+
+    /**
+     * @param Services   $services
+     * @param Imports    $imports
+     * @param Parameters $parameters
+     * @param Defaults   $defaults
+     * @param Instanceof $instanceof
+     */
+    public function __construct(
+        array $services = [],
+        public readonly array $imports = [],
+        public readonly array $parameters = [],
+        array $defaults = [],
+        array $instanceof = [],
+    ) {
+        if (isset($services['_defaults']) || isset($services['_instanceof'])) {
+            throw new InvalidArgumentException('The $services argument should not contain "_defaults" or "_instanceof" keys, use the $defaults and $instanceof parameters instead.');
+        }
+
+        $services['_defaults'] = $defaults;
+        $services['_instanceof'] = $instanceof;
+        $this->services = $services;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Loader/Config/functions.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Config/functions.php
@@ -1,0 +1,129 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Config;
+
+use Symfony\Component\Config\Loader\ParamConfigurator;
+use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
+use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
+use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Loader\Configurator\AbstractConfigurator;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ClosureReferenceConfigurator;
+use Symfony\Component\DependencyInjection\Loader\Configurator\EnvConfigurator;
+use Symfony\Component\DependencyInjection\Loader\Configurator\InlineServiceConfigurator;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ReferenceConfigurator;
+use Symfony\Component\ExpressionLanguage\Expression;
+
+/**
+ * Creates a parameter.
+ */
+function param(string $name): ParamConfigurator
+{
+    return new ParamConfigurator($name);
+}
+
+/**
+ * Creates a reference to a service.
+ */
+function service(string $serviceId): ReferenceConfigurator
+{
+    return new ReferenceConfigurator($serviceId);
+}
+
+/**
+ * Creates an inline service.
+ */
+function inline_service(?string $class = null): InlineServiceConfigurator
+{
+    return new InlineServiceConfigurator(new Definition($class));
+}
+
+/**
+ * Creates a service locator.
+ *
+ * @param array<ReferenceConfigurator|InlineServiceConfigurator> $values
+ */
+function service_locator(array $values): ServiceLocatorArgument
+{
+    $values = AbstractConfigurator::processValue($values, true);
+
+    return new ServiceLocatorArgument($values);
+}
+
+/**
+ * Creates a lazy iterator.
+ *
+ * @param ReferenceConfigurator[] $values
+ */
+function iterator(array $values): IteratorArgument
+{
+    return new IteratorArgument(AbstractConfigurator::processValue($values, true));
+}
+
+/**
+ * Creates a lazy iterator by tag name.
+ */
+function tagged_iterator(string $tag, ?string $indexAttribute = null, ?string $defaultIndexMethod = null, ?string $defaultPriorityMethod = null, string|array $exclude = [], bool $excludeSelf = true): TaggedIteratorArgument
+{
+    return new TaggedIteratorArgument($tag, $indexAttribute, $defaultIndexMethod, false, $defaultPriorityMethod, (array) $exclude, $excludeSelf);
+}
+
+/**
+ * Creates a service locator by tag name.
+ */
+function tagged_locator(string $tag, ?string $indexAttribute = null, ?string $defaultIndexMethod = null, ?string $defaultPriorityMethod = null, string|array $exclude = [], bool $excludeSelf = true): ServiceLocatorArgument
+{
+    return new ServiceLocatorArgument(new TaggedIteratorArgument($tag, $indexAttribute, $defaultIndexMethod, true, $defaultPriorityMethod, (array) $exclude, $excludeSelf));
+}
+
+/**
+ * Creates an expression.
+ */
+function expr(string $expression): Expression
+{
+    return new Expression($expression);
+}
+
+/**
+ * Creates an abstract argument.
+ */
+function abstract_arg(string $description): AbstractArgument
+{
+    return new AbstractArgument($description);
+}
+
+/**
+ * Creates an environment variable reference.
+ */
+function env(string $name): EnvConfigurator
+{
+    return new EnvConfigurator($name);
+}
+
+/**
+ * Creates a closure service reference.
+ */
+function service_closure(string $serviceId): ClosureReferenceConfigurator
+{
+    return new ClosureReferenceConfigurator($serviceId);
+}
+
+/**
+ * Creates a closure.
+ */
+function closure(string|array|\Closure|ReferenceConfigurator|Expression $callable): InlineServiceConfigurator
+{
+    return (new InlineServiceConfigurator(new Definition('Closure')))
+        ->factory(['Closure', 'fromCallable'])
+        ->args([$callable]);
+}

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/AbstractConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/AbstractConfigurator.php
@@ -101,6 +101,9 @@ abstract class AbstractConfigurator
             case $value instanceof \UnitEnum:
                 return $value;
 
+            case $value instanceof \Closure:
+                return self::processClosure($value);
+
             case $value instanceof ArgumentInterface:
             case $value instanceof Definition:
             case $value instanceof Expression:
@@ -120,7 +123,7 @@ abstract class AbstractConfigurator
      *
      * @throws InvalidArgumentException if the closure is anonymous or references a non-static method
      */
-    final public static function processClosure(\Closure $closure): callable
+    private static function processClosure(\Closure $closure): callable
     {
         $function = new \ReflectionFunction($closure);
         if ($function->isAnonymous()) {

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
@@ -11,18 +11,13 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-use Symfony\Component\Config\Loader\ParamConfigurator;
-use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
-use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
-use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
-use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Loader\UndefinedExtensionHandler;
-use Symfony\Component\ExpressionLanguage\Expression;
+
+require_once __DIR__.\DIRECTORY_SEPARATOR.'functions.php';
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
@@ -93,112 +88,4 @@ class ContainerConfigurator extends AbstractConfigurator
 
         return $clone;
     }
-}
-
-/**
- * Creates a parameter.
- */
-function param(string $name): ParamConfigurator
-{
-    return new ParamConfigurator($name);
-}
-
-/**
- * Creates a reference to a service.
- */
-function service(string $serviceId): ReferenceConfigurator
-{
-    return new ReferenceConfigurator($serviceId);
-}
-
-/**
- * Creates an inline service.
- */
-function inline_service(?string $class = null): InlineServiceConfigurator
-{
-    return new InlineServiceConfigurator(new Definition($class));
-}
-
-/**
- * Creates a service locator.
- *
- * @param array<ReferenceConfigurator|InlineServiceConfigurator> $values
- */
-function service_locator(array $values): ServiceLocatorArgument
-{
-    $values = AbstractConfigurator::processValue($values, true);
-
-    return new ServiceLocatorArgument($values);
-}
-
-/**
- * Creates a lazy iterator.
- *
- * @param ReferenceConfigurator[] $values
- */
-function iterator(array $values): IteratorArgument
-{
-    return new IteratorArgument(AbstractConfigurator::processValue($values, true));
-}
-
-/**
- * Creates a lazy iterator by tag name.
- */
-function tagged_iterator(string $tag, ?string $indexAttribute = null, ?string $defaultIndexMethod = null, ?string $defaultPriorityMethod = null, string|array $exclude = [], bool $excludeSelf = true): TaggedIteratorArgument
-{
-    return new TaggedIteratorArgument($tag, $indexAttribute, $defaultIndexMethod, false, $defaultPriorityMethod, (array) $exclude, $excludeSelf);
-}
-
-/**
- * Creates a service locator by tag name.
- */
-function tagged_locator(string $tag, ?string $indexAttribute = null, ?string $defaultIndexMethod = null, ?string $defaultPriorityMethod = null, string|array $exclude = [], bool $excludeSelf = true): ServiceLocatorArgument
-{
-    return new ServiceLocatorArgument(new TaggedIteratorArgument($tag, $indexAttribute, $defaultIndexMethod, true, $defaultPriorityMethod, (array) $exclude, $excludeSelf));
-}
-
-/**
- * Creates an expression.
- */
-function expr(string $expression): Expression
-{
-    return new Expression($expression);
-}
-
-/**
- * Creates an abstract argument.
- */
-function abstract_arg(string $description): AbstractArgument
-{
-    return new AbstractArgument($description);
-}
-
-/**
- * Creates an environment variable reference.
- */
-function env(string $name): EnvConfigurator
-{
-    return new EnvConfigurator($name);
-}
-
-/**
- * Creates a closure service reference.
- */
-function service_closure(string $serviceId): ClosureReferenceConfigurator
-{
-    return new ClosureReferenceConfigurator($serviceId);
-}
-
-/**
- * Creates a closure.
- */
-function closure(string|array|\Closure|ReferenceConfigurator|Expression $callable): InlineServiceConfigurator
-{
-    if ($callable instanceof \Closure) {
-        $callable = AbstractConfigurator::processClosure($callable);
-    }
-
-    return (new InlineServiceConfigurator(new Definition('Closure')))
-        ->factory(['Closure', 'fromCallable'])
-        ->args([$callable]);
 }

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/ConfiguratorTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/ConfiguratorTrait.php
@@ -22,12 +22,6 @@ trait ConfiguratorTrait
      */
     final public function configurator(string|array|\Closure|ReferenceConfigurator $configurator): static
     {
-        if ($configurator instanceof \Closure) {
-            $this->definition->setConfigurator(static::processClosure($configurator));
-
-            return $this;
-        }
-
         $this->definition->setConfigurator(static::processValue($configurator, true));
 
         return $this;

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/FactoryTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/FactoryTrait.php
@@ -24,12 +24,6 @@ trait FactoryTrait
      */
     final public function factory(string|array|\Closure|ReferenceConfigurator|Expression $factory): static
     {
-        if ($factory instanceof \Closure) {
-            $this->definition->setFactory(static::processClosure($factory));
-
-            return $this;
-        }
-
         if (\is_string($factory) && 1 === substr_count($factory, ':')) {
             $factoryParts = explode(':', $factory);
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/FromCallableTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/FromCallableTrait.php
@@ -41,10 +41,6 @@ trait FromCallableTrait
 
         $this->definition->setFactory(['Closure', 'fromCallable']);
 
-        if ($callable instanceof \Closure) {
-            $callable = static::processClosure($callable);
-        }
-
         if (\is_string($callable) && 1 === substr_count($callable, ':')) {
             $parts = explode(':', $callable);
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/functions.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/functions.php
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Component\Config\Loader\ParamConfigurator;
+use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
+use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
+use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\ExpressionLanguage\Expression;
+
+/**
+ * Creates a parameter.
+ */
+function param(string $name): ParamConfigurator
+{
+    return new ParamConfigurator($name);
+}
+
+/**
+ * Creates a reference to a service.
+ */
+function service(string $serviceId): ReferenceConfigurator
+{
+    return new ReferenceConfigurator($serviceId);
+}
+
+/**
+ * Creates an inline service.
+ */
+function inline_service(?string $class = null): InlineServiceConfigurator
+{
+    return new InlineServiceConfigurator(new Definition($class));
+}
+
+/**
+ * Creates a service locator.
+ *
+ * @param array<ReferenceConfigurator|InlineServiceConfigurator> $values
+ */
+function service_locator(array $values): ServiceLocatorArgument
+{
+    $values = AbstractConfigurator::processValue($values, true);
+
+    return new ServiceLocatorArgument($values);
+}
+
+/**
+ * Creates a lazy iterator.
+ *
+ * @param ReferenceConfigurator[] $values
+ */
+function iterator(array $values): IteratorArgument
+{
+    return new IteratorArgument(AbstractConfigurator::processValue($values, true));
+}
+
+/**
+ * Creates a lazy iterator by tag name.
+ */
+function tagged_iterator(string $tag, ?string $indexAttribute = null, ?string $defaultIndexMethod = null, ?string $defaultPriorityMethod = null, string|array $exclude = [], bool $excludeSelf = true): TaggedIteratorArgument
+{
+    return new TaggedIteratorArgument($tag, $indexAttribute, $defaultIndexMethod, false, $defaultPriorityMethod, (array) $exclude, $excludeSelf);
+}
+
+/**
+ * Creates a service locator by tag name.
+ */
+function tagged_locator(string $tag, ?string $indexAttribute = null, ?string $defaultIndexMethod = null, ?string $defaultPriorityMethod = null, string|array $exclude = [], bool $excludeSelf = true): ServiceLocatorArgument
+{
+    return new ServiceLocatorArgument(new TaggedIteratorArgument($tag, $indexAttribute, $defaultIndexMethod, true, $defaultPriorityMethod, (array) $exclude, $excludeSelf));
+}
+
+/**
+ * Creates an expression.
+ */
+function expr(string $expression): Expression
+{
+    return new Expression($expression);
+}
+
+/**
+ * Creates an abstract argument.
+ */
+function abstract_arg(string $description): AbstractArgument
+{
+    return new AbstractArgument($description);
+}
+
+/**
+ * Creates an environment variable reference.
+ */
+function env(string $name): EnvConfigurator
+{
+    return new EnvConfigurator($name);
+}
+
+/**
+ * Creates a closure service reference.
+ */
+function service_closure(string $serviceId): ClosureReferenceConfigurator
+{
+    return new ClosureReferenceConfigurator($serviceId);
+}
+
+/**
+ * Creates a closure.
+ */
+function closure(string|array|\Closure|ReferenceConfigurator|Expression $callable): InlineServiceConfigurator
+{
+    return (new InlineServiceConfigurator(new Definition('Closure')))
+        ->factory(['Closure', 'fromCallable'])
+        ->args([$callable]);
+}

--- a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
@@ -261,23 +261,6 @@ abstract class FileLoader extends BaseFileLoader
 
     final protected function loadExtensionConfig(string $namespace, array $config, string $file = '?'): void
     {
-        if (\in_array($namespace, ['imports', 'services', 'parameters'], true)) {
-            $yamlLoader = new YamlFileLoader($this->container, $this->locator, $this->env, $this->prepend);
-            $loadContent = new \ReflectionMethod(YamlFileLoader::class, 'loadContent');
-            $loadContent->invoke($yamlLoader, [$namespace => $config], $file);
-
-            if ($this->env && isset($config['when@'.$this->env])) {
-                if (!\is_array($config['when@'.$this->env])) {
-                    throw new InvalidArgumentException(\sprintf('The "when@%s" key should contain an array in "%s".', $this->env, $file));
-                }
-
-                $yamlLoader->env = null;
-                $loadContent->invoke($yamlLoader, [$namespace => $config['when@'.$this->env]], $file);
-            }
-
-            return;
-        }
-
         if (!$this->prepend) {
             $this->container->loadFromExtension($namespace, $config);
 

--- a/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
@@ -24,6 +24,7 @@ use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Extension\ConfigurationExtensionInterface;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Config\ServicesConfig;
 
 /**
  * PhpFileLoader loads service definitions from a PHP file.
@@ -58,8 +59,9 @@ class PhpFileLoader extends FileLoader
         $this->setCurrentDir(\dirname($path));
         $this->container->fileExists($path);
 
-        // Force load ContainerConfigurator to make env(), param() etc available.
-        class_exists(ContainerConfigurator::class);
+        // Ensure symbols in the \Symfony\Config and Configurator namespaces are available
+        require_once __DIR__.\DIRECTORY_SEPARATOR.'Config'.\DIRECTORY_SEPARATOR.'functions.php';
+        require_once __DIR__.\DIRECTORY_SEPARATOR.'Configurator'.\DIRECTORY_SEPARATOR.'functions.php';
 
         if ($autoloaderRegistered = !$this->configBuilderAutoloader && $this->generator) {
             spl_autoload_register($this->configBuilderAutoloader = function (string $class) {
@@ -94,23 +96,48 @@ class PhpFileLoader extends FileLoader
             if (\is_object($result) && \is_callable($result)) {
                 $result = $this->callConfigurator($result, new ContainerConfigurator($this->container, $this, $this->instanceof, $path, $resource, $this->env), $path);
             }
-            if ($result instanceof ConfigBuilderInterface) {
-                $this->loadExtensionConfig($result->getExtensionAlias(), ContainerConfigurator::processValue($result->toArray()), $path);
-            } elseif (is_iterable($result)) {
-                foreach ($result as $key => $config) {
-                    if ($config instanceof ConfigBuilderInterface) {
+            if ($result instanceof ConfigBuilderInterface || $result instanceof ServicesConfig) {
+                $result = [$result];
+            } elseif (!is_iterable($result ?? [])) {
+                throw new InvalidArgumentException(\sprintf('The return value in config file "%s" is invalid: "%s" given.', $path, get_debug_type($result)));
+            }
+
+            foreach ($result ?? [] as $key => $config) {
+                if (!str_starts_with($key, 'when@')) {
+                    $config = [$key => $config];
+                } elseif (!$this->env || 'when@'.$this->env !== $key) {
+                    continue;
+                } elseif ($config instanceof ServicesConfig || $config instanceof ConfigBuilderInterface) {
+                    $config = [$config];
+                } elseif (!is_iterable($config)) {
+                    throw new InvalidArgumentException(\sprintf('The "%s" key should contain an array in "%s".', $key, $path));
+                }
+
+                foreach ($config as $key => $config) {
+                    if ($config instanceof ServicesConfig || \in_array($key, ['imports', 'parameters', 'services'], true)) {
+                        if (!$config instanceof ServicesConfig) {
+                            $config = [$key => $config];
+                        } elseif (\is_string($key) && 'services' !== $key) {
+                            throw new InvalidArgumentException(\sprintf('Invalid key "%s" returned for the "%s" config builder; none or "services" expected in file "%s".', $key, get_debug_type($config), $path));
+                        }
+                        $yamlLoader = new YamlFileLoader($this->container, $this->locator, $this->env, $this->prepend);
+                        $loadContent = new \ReflectionMethod(YamlFileLoader::class, 'loadContent');
+                        $loadContent->invoke($yamlLoader, ContainerConfigurator::processValue((array) $config), $path);
+                    } elseif ($config instanceof ConfigBuilderInterface) {
                         if (\is_string($key) && $config->getExtensionAlias() !== $key) {
                             throw new InvalidArgumentException(\sprintf('The extension alias "%s" of the "%s" config builder does not match the key "%s" in file "%s".', $config->getExtensionAlias(), get_debug_type($config), $key, $path));
                         }
                         $this->loadExtensionConfig($config->getExtensionAlias(), ContainerConfigurator::processValue($config->toArray()), $path);
                     } elseif (!\is_string($key) || !\is_array($config)) {
-                        throw new InvalidArgumentException(\sprintf('The configuration returned in file "%s" must yield only string-keyed arrays or ConfigBuilderInterface values.', $path));
+                        throw new InvalidArgumentException(\sprintf('The configuration returned in file "%s" must yield only string-keyed arrays or ConfigBuilderInterface objects.', $path));
                     } else {
+                        if (str_starts_with($key, 'when@')) {
+                            throw new InvalidArgumentException(\sprintf('A service name cannot start with "when@" in "%s".', $path));
+                        }
+
                         $this->loadExtensionConfig($key, ContainerConfigurator::processValue($config), $path);
                     }
                 }
-            } elseif (null !== $result) {
-                throw new InvalidArgumentException(\sprintf('The return value in config file "%s" is invalid: "%s" given.', $path, get_debug_type($result)));
             }
 
             $this->loadExtensionConfigs();
@@ -252,6 +279,10 @@ class PhpFileLoader extends FileLoader
         // If it does not start with Symfony\Config\ we don't know how to handle this
         if (!str_starts_with($namespace, 'Symfony\\Config\\')) {
             throw new InvalidArgumentException(\sprintf('Could not find or generate class "%s".', $namespace));
+        }
+
+        if (is_a($namespace, ServicesConfig::class, true)) {
+            throw new \LogicException(\sprintf('You cannot use "%s" as a config builder; create an instance and return it instead.', $namespace));
         }
 
         // Try to get the extension alias

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -655,17 +655,13 @@ class YamlFileLoader extends FileLoader
             }
 
             $decorationOnInvalid = \array_key_exists('decoration_on_invalid', $service) ? $service['decoration_on_invalid'] : 'exception';
-            if ('exception' === $decorationOnInvalid) {
-                $invalidBehavior = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE;
-            } elseif ('ignore' === $decorationOnInvalid) {
-                $invalidBehavior = ContainerInterface::IGNORE_ON_INVALID_REFERENCE;
-            } elseif (null === $decorationOnInvalid) {
-                $invalidBehavior = ContainerInterface::NULL_ON_INVALID_REFERENCE;
-            } elseif ('null' === $decorationOnInvalid) {
-                throw new InvalidArgumentException(\sprintf('Invalid value "%s" for attribute "decoration_on_invalid" on service "%s". Did you mean null (without quotes) in "%s"?', $decorationOnInvalid, $id, $file));
-            } else {
-                throw new InvalidArgumentException(\sprintf('Invalid value "%s" for attribute "decoration_on_invalid" on service "%s". Did you mean "exception", "ignore" or null in "%s"?', $decorationOnInvalid, $id, $file));
-            }
+            $invalidBehavior = match ($decorationOnInvalid) {
+                'exception', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE => ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE,
+                'ignore', ContainerInterface::IGNORE_ON_INVALID_REFERENCE => ContainerInterface::IGNORE_ON_INVALID_REFERENCE,
+                null, ContainerInterface::NULL_ON_INVALID_REFERENCE => ContainerInterface::NULL_ON_INVALID_REFERENCE,
+                'null' => throw new InvalidArgumentException(\sprintf('Invalid value "%s" for attribute "decoration_on_invalid" on service "%s". Did you mean null (without quotes) in "%s"?', $decorationOnInvalid, $id, $file)),
+                default => throw new InvalidArgumentException(\sprintf('Invalid value "%s" for attribute "decoration_on_invalid" on service "%s". Did you mean "exception", "ignore" or "null" in "%s"?', $decorationOnInvalid, $id, $file)),
+            };
 
             $renameId = $service['decoration_inner_name'] ?? null;
             $priority = $service['decoration_priority'] ?? 0;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/object_array_config.expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/object_array_config.expected.yml
@@ -1,0 +1,15 @@
+parameters:
+    foo: bar
+
+services:
+    service_container:
+        class: Symfony\Component\DependencyInjection\ContainerInterface
+        public: true
+        synthetic: true
+    Symfony\Component\DependencyInjection\Tests\Fixtures\Bar:
+        class: Symfony\Component\DependencyInjection\Tests\Fixtures\Bar
+        public: true
+    my_service:
+        class: Symfony\Component\DependencyInjection\Tests\Fixtures\Bar
+        public: true
+        arguments: [bar]

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/object_array_config.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/object_array_config.php
@@ -1,0 +1,19 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Tests\Fixtures\Bar;
+use Symfony\Config\ServicesConfig;
+
+return new ServicesConfig(
+    parameters: [
+        'foo' => 'bar',
+    ],
+    defaults: [
+        'public' => true,
+    ],
+    services: [
+        Bar::class => null,
+        'my_service' => [
+            'class' => Bar::class,
+            'arguments' => ['%foo%'],
+        ],
+]);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/return_when_env.expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/return_when_env.expected.yml
@@ -1,0 +1,15 @@
+parameters:
+    foo_param: bar_value
+
+services:
+    service_container:
+        class: Symfony\Component\DependencyInjection\ContainerInterface
+        public: true
+        synthetic: true
+    Symfony\Component\DependencyInjection\Tests\Fixtures\Bar:
+        class: Symfony\Component\DependencyInjection\Tests\Fixtures\Bar
+        public: true
+    my_service:
+        class: Symfony\Component\DependencyInjection\Tests\Fixtures\Bar
+        public: true
+        arguments: [bar_value]

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/return_when_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/return_when_env.php
@@ -1,0 +1,24 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Tests\Fixtures\Bar;
+use Symfony\Config\ServicesConfig;
+
+return [
+    'when@prod' => [
+        'parameters' => [
+            'foo_param' => 'bar_value',
+        ],
+        new ServicesConfig(
+            defaults: [
+                'public' => true,
+            ],
+            services: [
+                Bar::class => null,
+                'my_service' => [
+                    'class' => Bar::class,
+                    'arguments' => ['%foo_param%'],
+                ],
+            ]
+        ),
+    ],
+];

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/Configurator/AbstractConfiguratorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/Configurator/AbstractConfiguratorTest.php
@@ -21,12 +21,12 @@ class AbstractConfiguratorTest extends TestCase
     {
         $this->assertSame(
             [\DateTime::class, 'createFromFormat'],
-            AbstractConfigurator::processClosure(\DateTime::createFromFormat(...)),
+            AbstractConfigurator::processValue(\DateTime::createFromFormat(...)),
         );
 
         $this->assertSame(
             'date_create',
-            AbstractConfigurator::processClosure(date_create(...)),
+            AbstractConfigurator::processValue(date_create(...)),
         );
     }
 
@@ -35,7 +35,7 @@ class AbstractConfiguratorTest extends TestCase
         self::expectException(InvalidArgumentException::class);
         self::expectExceptionMessage('The method "DateTime::format(...)" is not static');
 
-        AbstractConfigurator::processClosure((new \DateTime())->format(...));
+        AbstractConfigurator::processValue((new \DateTime())->format(...));
     }
 
     public function testProcessAnonymousClosure()
@@ -43,6 +43,6 @@ class AbstractConfiguratorTest extends TestCase
         self::expectException(InvalidArgumentException::class);
         self::expectExceptionMessage('Anonymous closure not supported. The closure must be created from a static method or a global function.');
 
-        AbstractConfigurator::processClosure(static fn () => new \DateTime());
+        AbstractConfigurator::processValue(static fn () => new \DateTime());
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
@@ -31,6 +31,7 @@ use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooClassWithEnumAttribute;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooUnitEnum;
+use Symfony\Config\ServicesConfig;
 
 class PhpFileLoaderTest extends TestCase
 {
@@ -50,6 +51,16 @@ class PhpFileLoaderTest extends TestCase
         $loader->load(__DIR__.'/../Fixtures/php/simple.php');
 
         $this->assertEquals('foo', $container->getParameter('foo'), '->load() loads a PHP file resource');
+
+        $this->assertTrue(class_exists(ServicesConfig::class));
+        $this->assertTrue(\function_exists('Symfony\Config\service'));
+        $this->assertTrue(\function_exists('Symfony\Component\DependencyInjection\Loader\Configurator\service'));
+
+        $configCode = explode("\n/**", file_get_contents(\dirname(__DIR__, 2).'/Loader/Config/functions.php'), 2);
+        $configuratorCode = explode("\n/**", file_get_contents(\dirname(__DIR__, 2).'/Loader/Configurator/functions.php'), 2);
+
+        $this->assertStringEqualsFile(\dirname(__DIR__, 2).'/Loader/Config/functions.php', $configCode[0]."\n/**".$configuratorCode[1]);
+        $this->assertStringEqualsFile(\dirname(__DIR__, 2).'/Loader/Configurator/functions.php', $configuratorCode[0]."\n/**".$configCode[1]);
     }
 
     public function testPrependExtensionConfigWithLoadMethod()
@@ -145,6 +156,8 @@ class PhpFileLoaderTest extends TestCase
         yield ['from_callable'];
         yield ['env_param'];
         yield ['array_config'];
+        yield ['object_array_config'];
+        yield ['return_when_env'];
     }
 
     public function testResourceTags()

--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -38,7 +38,10 @@
         "symfony/service-implementation": "1.1|2.0|3.0"
     },
     "autoload": {
-        "psr-4": { "Symfony\\Component\\DependencyInjection\\": "" },
+        "psr-4": {
+            "Symfony\\Component\\DependencyInjection\\": "",
+            "Symfony\\Config\\": "Loader/Config/"
+        },
         "exclude-from-classmap": [
             "/Tests/"
         ]

--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add support of multiple env names in the  `Symfony\Component\Routing\Attribute\Route` attribute
  * Add argument `$parameters` to `RequestContext`'s constructor
  * Handle declaring routes using PHP arrays that follow the same shape as corresponding yaml files
+ * Add `RoutesConfig` to help writing PHP configs using yaml-like array-shapes
  * Deprecate class aliases in the `Annotation` namespace, use attributes instead
  * Deprecate getters and setters in attribute classes in favor of public properties
  * Deprecate accessing the internal scope of the loader in PHP config files, use only its public API instead

--- a/src/Symfony/Component/Routing/Loader/Config/RoutesConfig.php
+++ b/src/Symfony/Component/Routing/Loader/Config/RoutesConfig.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Config;
+
+/**
+ * @psalm-type Route = array{
+ *     path: string|array<string,string>,
+ *     controller?: string,
+ *     methods?: string|list<string>,
+ *     requirements?: array<string,string>,
+ *     defaults?: array<string,mixed>,
+ *     options?: array<string,mixed>,
+ *     host?: string|array<string,string>,
+ *     schemes?: string|list<string>,
+ *     condition?: string,
+ *     locale?: string,
+ *     format?: string,
+ *     utf8?: bool,
+ *     stateless?: bool,
+ * }
+ * @psalm-type Import = array{
+ *     resource: string,
+ *     type?: string,
+ *     exclude?: string|list<string>,
+ *     prefix?: string|array<string,string>,
+ *     name_prefix?: string,
+ *     trailing_slash_on_root?: bool,
+ *     controller?: string,
+ *     methods?: string|list<string>,
+ *     requirements?: array<string,string>,
+ *     defaults?: array<string,mixed>,
+ *     options?: array<string,mixed>,
+ *     host?: string|array<string,string>,
+ *     schemes?: string|list<string>,
+ *     condition?: string,
+ *     locale?: string,
+ *     format?: string,
+ *     utf8?: bool,
+ *     stateless?: bool,
+ * }
+ * @psalm-type Alias = array{
+ *     alias: string,
+ *     deprecated?: array{package:string, version:string, message?:string},
+ * }
+ * @psalm-type Routes = array<string, Route|Import|Alias>
+ */
+class RoutesConfig
+{
+    /**
+     * @param Routes $routes
+     */
+    public function __construct(
+        public readonly array $routes,
+    ) {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/routes_object.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/routes_object.php
@@ -1,0 +1,13 @@
+<?php
+
+use Symfony\Config\RoutesConfig;
+
+return new RoutesConfig([
+    'a' => [
+        'path' => '/a',
+    ],
+    'b' => [
+        'path' => '/b',
+        'methods' => ['GET'],
+    ],
+]);

--- a/src/Symfony/Component/Routing/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/PhpFileLoaderTest.php
@@ -374,6 +374,15 @@ class PhpFileLoaderTest extends TestCase
         $this->assertSame(['GET'], $routes->get('b')->getMethods());
     }
 
+    public function testLoadsObjectRoutes()
+    {
+        $loader = new PhpFileLoader(new FileLocator([__DIR__.'/../Fixtures']));
+        $routes = $loader->load('routes_object.php');
+        $this->assertSame('/a', $routes->get('a')->getPath());
+        $this->assertSame('/b', $routes->get('b')->getPath());
+        $this->assertSame(['GET'], $routes->get('b')->getMethods());
+    }
+
     public function testWhenEnvWithArray()
     {
         $locator = new FileLocator([__DIR__.'/../Fixtures']);

--- a/src/Symfony/Component/Routing/composer.json
+++ b/src/Symfony/Component/Routing/composer.json
@@ -33,7 +33,10 @@
         "symfony/yaml": "<6.4"
     },
     "autoload": {
-        "psr-4": { "Symfony\\Component\\Routing\\": "" },
+        "psr-4": {
+            "Symfony\\Component\\Routing\\": "",
+            "Symfony\\Config\\": "Loader/Config/"
+        },
         "exclude-from-classmap": [
             "/Tests/"
         ]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Related to #58771.

This PR adds array-shape helpers:

An example for `routes.php`:
```php
use Symfony\Config\RoutesConfig;

return new RoutesConfig([
    'controllers' => [
        'resource' => 'attributes',
        'type' => 'tagged_services',
    ],
]);
```

And one for `services.php`:
```php
use App\Bar;
use Symfony\Config\ServicesConfig;

return new ServicesConfig(
    defaults: [
        'autowire' => true,
        'autoconfigure' => true,
    ],
    services: [
        'App\\' => ['resource' => '../src/']
        Bar::class => null,
        'my_service' => [
            'class' => Bar::class,
            'arguments' => ['%foo%'],
        ],
    ]
);
```

The `ServicesConfig` and `RoutesConfig` wrappers around the arrays are totally optional: the style in #61894 remains possible.
Yet, those wrappers provide array-shapes that can be used by static analyzers and IDEs.

This also works when nesting behind `when@%env%`:
```php
return [
    'when@dev' => new ServicesConfig([...]);
];
```

Note that as far as IDEs are concerned, autocompletion doesn't work yet for the complex shapes used in `ServicesConfig` - neither in vscode nor in phpstorm /cc @pronskiy 🙏

