### PR TITLE
[Console] Allow to test the different streams at the same time with a new result-based testing API for `CommandTester`

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG
  * Add `BackedEnum` and `DateTimeInterface` support to `#[MapInput]`
  * Add `TesterTrait::assertCommandFailed()` to test command
  * Add `TesterTrait::assertCommandIsInvalid()` to test command
+ * Add a result-based testing API with `CommandTester::run()`, `ExecutionResult`, and `ConsoleAssertionsTrait` to assert output and error streams together
 
 8.0
 ---

--- a/src/Symfony/Component/Console/Output/CombinedOutput.php
+++ b/src/Symfony/Component/Console/Output/CombinedOutput.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Output;
+
+use Symfony\Component\Console\Exception\LogicException;
+use Symfony\Component\Console\Formatter\OutputFormatterInterface;
+
+/**
+ * @internal
+ */
+final class CombinedOutput implements OutputInterface
+{
+    /**
+     * @param OutputInterface[] $outputs
+     */
+    public function __construct(
+        private array $outputs,
+    ) {
+        if (!$outputs) {
+            throw new LogicException('Expected at least one output.');
+        }
+    }
+
+    public function write(iterable|string $messages, bool $newline = false, int $options = 0): void
+    {
+        foreach ($this->outputs as $output) {
+            $output->write(...\func_get_args());
+        }
+    }
+
+    public function writeln(iterable|string $messages, int $options = 0): void
+    {
+        foreach ($this->outputs as $output) {
+            $output->writeln(...\func_get_args());
+        }
+    }
+
+    public function setVerbosity(int $level): void
+    {
+        foreach ($this->outputs as $output) {
+            $output->setVerbosity($level);
+        }
+    }
+
+    public function getVerbosity(): int
+    {
+        return array_first($this->outputs)->getVerbosity();
+    }
+
+    public function isSilent(): bool
+    {
+        return array_first($this->outputs)->isSilent();
+    }
+
+    public function isQuiet(): bool
+    {
+        return array_first($this->outputs)->isQuiet();
+    }
+
+    public function isVerbose(): bool
+    {
+        return array_first($this->outputs)->isVerbose();
+    }
+
+    public function isVeryVerbose(): bool
+    {
+        return array_first($this->outputs)->isVeryVerbose();
+    }
+
+    public function isDebug(): bool
+    {
+        return array_first($this->outputs)->isDebug();
+    }
+
+    public function setDecorated(bool $decorated): void
+    {
+        foreach ($this->outputs as $output) {
+            $output->setDecorated($decorated);
+        }
+    }
+
+    public function isDecorated(): bool
+    {
+        return array_first($this->outputs)->isDecorated();
+    }
+
+    public function setFormatter(OutputFormatterInterface $formatter): void
+    {
+        foreach ($this->outputs as $output) {
+            $output->setFormatter($formatter);
+        }
+    }
+
+    public function getFormatter(): OutputFormatterInterface
+    {
+        return array_first($this->outputs)->getFormatter();
+    }
+}

--- a/src/Symfony/Component/Console/Output/TestOutput.php
+++ b/src/Symfony/Component/Console/Output/TestOutput.php
@@ -1,0 +1,174 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Output;
+
+use Symfony\Component\Console\Exception\LogicException;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Formatter\OutputFormatterInterface;
+
+/**
+ * @internal
+ *
+ * @author Théo FIDRY <theo.fidry@gmail.com>
+ */
+final class TestOutput implements ConsoleOutputInterface
+{
+    private OutputInterface $innerOutput;
+    private OutputInterface $innerErrorOutput;
+    private OutputInterface $displayOutput;
+    private CombinedOutput $output;
+    private CombinedOutput $errorOutput;
+    private OutputFormatterInterface $formatter;
+
+    /**
+     * @param OutputInterface::VERBOSITY_* $verbosity
+     */
+    public function __construct(
+        private bool $decorated,
+        private int $verbosity,
+        ?OutputFormatterInterface $formatter = null,
+    ) {
+        $this->formatter = $formatter ?? new OutputFormatter($decorated);
+        $this->formatter->setDecorated($decorated);
+
+        $this->innerOutput = self::createOutput($this);
+        $this->innerErrorOutput = self::createOutput($this);
+        $this->displayOutput = self::createOutput($this);
+
+        $this->output = new CombinedOutput([
+            $this->innerOutput,
+            $this->displayOutput,
+        ]);
+        $this->errorOutput = new CombinedOutput([
+            $this->innerErrorOutput,
+            $this->displayOutput,
+        ]);
+    }
+
+    public function getOutputContents(): string
+    {
+        return $this->getStreamContents($this->innerOutput);
+    }
+
+    public function getErrorOutputContents(): string
+    {
+        return $this->getStreamContents($this->innerErrorOutput);
+    }
+
+    public function getDisplayContents(): string
+    {
+        return $this->getStreamContents($this->displayOutput);
+    }
+
+    public function getErrorOutput(): OutputInterface
+    {
+        return $this->errorOutput;
+    }
+
+    public function setErrorOutput(OutputInterface $error): void
+    {
+        throw new LogicException('TestOutput does not support modifying the error output.');
+    }
+
+    public function section(): ConsoleSectionOutput
+    {
+        throw new LogicException('ConsoleSectionOutput is not supported by TestOutput.');
+    }
+
+    public function write(iterable|string $messages, bool $newline = false, int $options = 0): void
+    {
+        $this->output->write(...\func_get_args());
+    }
+
+    public function writeln(iterable|string $messages, int $options = 0): void
+    {
+        $this->output->writeln(...\func_get_args());
+    }
+
+    public function setVerbosity(int $level): void
+    {
+        throw new LogicException('TestOutput does not support modifying the verbosity.');
+    }
+
+    public function getVerbosity(): int
+    {
+        return $this->verbosity;
+    }
+
+    public function isSilent(): bool
+    {
+        return self::VERBOSITY_SILENT === $this->verbosity;
+    }
+
+    public function isQuiet(): bool
+    {
+        return self::VERBOSITY_QUIET === $this->verbosity;
+    }
+
+    public function isVerbose(): bool
+    {
+        return self::VERBOSITY_VERBOSE <= $this->verbosity;
+    }
+
+    public function isVeryVerbose(): bool
+    {
+        return self::VERBOSITY_VERY_VERBOSE <= $this->verbosity;
+    }
+
+    public function isDebug(): bool
+    {
+        return self::VERBOSITY_DEBUG <= $this->verbosity;
+    }
+
+    public function setDecorated(bool $decorated): void
+    {
+        throw new LogicException('TestOutput does not support modifying the decorated flag.');
+    }
+
+    public function isDecorated(): bool
+    {
+        return $this->decorated;
+    }
+
+    public function setFormatter(OutputFormatterInterface $formatter): void
+    {
+        throw new LogicException('TestOutput does not support modifying the formatter.');
+    }
+
+    public function getFormatter(): OutputFormatterInterface
+    {
+        return $this->formatter;
+    }
+
+    private static function createOutput(OutputInterface $config): StreamOutput
+    {
+        if (false === $stream = fopen('php://memory', 'w')) {
+            throw new RuntimeException('Failed to open stream.');
+        }
+
+        return new StreamOutput($stream, $config->getVerbosity(), $config->isDecorated(), $config->getFormatter());
+    }
+
+    private function getStreamContents(StreamOutput $output): string
+    {
+        $stream = $output->getStream();
+
+        rewind($stream);
+
+        if (false === $contents = stream_get_contents($stream)) {
+            throw new RuntimeException('Failed to read stream contents.');
+        }
+
+        return $contents;
+    }
+}

--- a/src/Symfony/Component/Console/Tester/CommandTester.php
+++ b/src/Symfony/Component/Console/Tester/CommandTester.php
@@ -12,28 +12,94 @@
 namespace Symfony\Component\Console\Tester;
 
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Formatter\OutputFormatterInterface;
 use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\TestOutput;
 
 /**
  * Eases the testing of console commands.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Robin Chalas <robin.chalas@gmail.com>
+ * @author Théo FIDRY <theo.fidry@gmail.com>
  */
 class CommandTester
 {
     use TesterTrait;
 
     private Command $command;
+    private OutputFormatterInterface $outputFormatter;
 
+    /**
+     * @param OutputInterface::VERBOSITY_* $verbosity
+     */
     public function __construct(
         callable|Command $command,
+        private ?bool $interactive = null,
+        private bool $decorated = false,
+        private int $verbosity = OutputInterface::VERBOSITY_NORMAL,
+        ?OutputFormatterInterface $outputFormatter = null,
     ) {
         $this->command = $command instanceof Command ? $command : new Command(null, $command);
+        $this->outputFormatter = $outputFormatter ?? new OutputFormatter();
+    }
+
+    public function setInteractive(bool $interactive): void
+    {
+        $this->interactive = $interactive;
+    }
+
+    public function setDecorated(bool $decorated): void
+    {
+        $this->decorated = $decorated;
     }
 
     /**
-     * Executes the command.
+     * @param OutputInterface::VERBOSITY_* $level
+     */
+    public function setVerbosity(int $level): void
+    {
+        $this->verbosity = $level;
+    }
+
+    public function setOutputFormatter(OutputFormatterInterface $outputFormatter): void
+    {
+        $this->outputFormatter = $outputFormatter;
+    }
+
+    /**
+     * Runs the command with the result-based testing API.
+     *
+     * This method is intended for new tests and returns an ExecutionResult,
+     * which exposes output, error output and combined display in a single object.
+     *
+     * Unlike execute(), this method does not rely on state read back from TesterTrait.
+     *
+     * @param array                           $input             An array of command arguments and options
+     * @param string[]                        $interactiveInputs An array of strings representing each input passed to the command input stream
+     * @param OutputInterface::VERBOSITY_*    $verbosity
+     * @param array<\Closure(string): string> $normalizers
+     */
+    public function run(array $input = [], array $interactiveInputs = [], ?bool $interactive = null, ?bool $decorated = null, ?int $verbosity = null, array $normalizers = []): ExecutionResult
+    {
+        $input = $this->createInput($input, $interactiveInputs, $interactive);
+        $testOutput = new TestOutput($decorated ?? $this->decorated, $verbosity ?? $this->verbosity, $this->outputFormatter);
+        $statusCode = $this->command->run($input, $testOutput);
+
+        return ExecutionResult::fromExecution($input, $statusCode, $testOutput, $normalizers);
+    }
+
+    /**
+     * Executes the command with the legacy stateful testing API.
+     *
+     * Use this method when interacting with the historical TesterTrait-based API,
+     * e.g. getDisplay(), getErrorOutput(), getStatusCode() and assertCommandIsSuccessful().
+     *
+     * Prefer run() for new tests, as it returns an ExecutionResult object with
+     * explicit output streams and dedicated assertions.
      *
      * Available execution options:
      *
@@ -49,29 +115,31 @@ class CommandTester
      */
     public function execute(array $input, array $options = []): int
     {
-        // set the command name automatically if the application requires
-        // this argument and no command name was passed
-        if (!isset($input['command'])
-            && (null !== $application = $this->command->getApplication())
-            && $application->getDefinition()->hasArgument('command')
-        ) {
-            $input = array_merge(['command' => $this->command->getName()], $input);
-        }
-
-        $this->input = new ArrayInput($input);
-        // Use an in-memory input stream even if no inputs are set so that QuestionHelper::ask() does not rely on the blocking STDIN.
-        $this->input->setStream(self::createStream($this->inputs));
-
-        if (isset($options['interactive'])) {
-            $this->input->setInteractive($options['interactive']);
-        }
+        $this->input = $this->createInput($input, $this->inputs, $options['interactive'] ?? $this->interactive);
 
         if (!isset($options['decorated'])) {
-            $options['decorated'] = false;
+            $options['decorated'] = $this->decorated;
         }
 
         $this->initOutput($options);
 
         return $this->statusCode = $this->command->run($this->input, $this->output);
+    }
+
+    private function createInput(array $input, array $interactiveInputs = [], ?bool $interactive = null): InputInterface
+    {
+        if (!isset($input['command']) && $this->command->getApplication()?->getDefinition()->hasArgument('command')) {
+            $input = array_merge(['command' => $this->command->getName()], $input);
+        }
+
+        $input = new ArrayInput($input);
+        // Use an in-memory input stream even if no inputs are set so that QuestionHelper::ask() does not rely on the blocking STDIN.
+        $input->setStream(self::createStream($interactiveInputs));
+
+        if (null !== $interactive ??= $this->interactive) {
+            $input->setInteractive($interactive);
+        }
+
+        return $input;
     }
 }

--- a/src/Symfony/Component/Console/Tester/ConsoleAssertionsTrait.php
+++ b/src/Symfony/Component/Console/Tester/ConsoleAssertionsTrait.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tester;
+
+use Symfony\Component\Console\Tester\Constraint\CommandFailed;
+use Symfony\Component\Console\Tester\Constraint\CommandIsInvalid;
+use Symfony\Component\Console\Tester\Constraint\CommandIsSuccessful;
+
+/**
+ * @psalm-require-extends \PHPUnit\Framework\TestCase
+ *
+ * @author Théo FIDRY <theo.fidry@gmail.com>
+ */
+trait ConsoleAssertionsTrait
+{
+    public function assertIsSuccessful(ExecutionResult $result, string $message = ''): void
+    {
+        $this->assertThat($result->statusCode, new CommandIsSuccessful(), $message);
+    }
+
+    public function assertFailed(ExecutionResult $result, string $message = ''): void
+    {
+        $this->assertThat($result->statusCode, new CommandFailed(), $message);
+    }
+
+    public function assertIsInvalid(ExecutionResult $result, string $message = ''): void
+    {
+        $this->assertThat($result->statusCode, new CommandIsInvalid(), $message);
+    }
+
+    public function assertResultEquals(ExecutionResult $result, ?int $expectedStatusCode = null, ?string $expectedOutput = null, ?string $expectedErrorOutput = null, ?string $expectedDisplay = null, string $message = ''): void
+    {
+        $expected = [];
+        $actual = [];
+
+        if (null !== $expectedStatusCode) {
+            $expected['statusCode'] = $expectedStatusCode;
+            $actual['statusCode'] = $result->statusCode;
+        }
+        if (null !== $expectedOutput) {
+            $expected['output'] = $expectedOutput;
+            $actual['output'] = $result->getOutput();
+        }
+        if (null !== $expectedErrorOutput) {
+            $expected['errorOutput'] = $expectedErrorOutput;
+            $actual['errorOutput'] = $result->getErrorOutput();
+        }
+        if (null !== $expectedDisplay) {
+            $expected['display'] = $expectedDisplay;
+            $actual['display'] = $result->getDisplay();
+        }
+
+        $this->assertEquals($expected, $actual, $message);
+    }
+}

--- a/src/Symfony/Component/Console/Tester/ExecutionResult.php
+++ b/src/Symfony/Component/Console/Tester/ExecutionResult.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tester;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\TestOutput;
+
+/**
+ * @author Théo FIDRY <theo.fidry@gmail.com>
+ */
+final class ExecutionResult
+{
+    // This is purely for memoizing purposes
+    private array $results = [];
+
+    /**
+     * @param array<\Closure(string): string> $normalizers
+     */
+    public static function fromExecution(InputInterface $input, int $statusCode, TestOutput $output, array $normalizers = []): self
+    {
+        return new self($input->__toString(), $statusCode, $output, $normalizers);
+    }
+
+    /**
+     * @param array<\Closure(string): string> $normalizers
+     */
+    public function __construct(
+        public readonly string $input,
+        public readonly int $statusCode,
+        private readonly TestOutput $output,
+        private readonly array $normalizers,
+    ) {
+    }
+
+    /**
+     * Gets the display returned by the execution of the command or application. The display combines what was
+     * written on both the output and error output.
+     */
+    public function getDisplay(bool $normalize = true): string
+    {
+        return $this->results['display'][$normalize] ??= $this->normalize($this->output->getDisplayContents(), $normalize);
+    }
+
+    /**
+     * Gets the output written to the output by the command or application.
+     */
+    public function getOutput(bool $normalize = false): string
+    {
+        return $this->results['output'][$normalize] ??= $this->normalize($this->output->getOutputContents(), $normalize);
+    }
+
+    /**
+     * Gets the output written to the error output by the command or application.
+     */
+    public function getErrorOutput(bool $normalize = false): string
+    {
+        return $this->results['errorOutput'][$normalize] ??= $this->normalize($this->output->getErrorOutputContents(), $normalize);
+    }
+
+    /**
+     * @return $this
+     */
+    public function dump(): static
+    {
+        $summary = "CLI: {$this->input}, Status: {$this->statusCode}";
+        $output = [
+            $summary,
+            $this->getOutput(true),
+            $this->getErrorOutput(true),
+            $summary,
+        ];
+
+        \call_user_func(
+            \function_exists('dump') ? 'dump' : 'var_dump',
+            implode("\n\n", array_filter($output)),
+        );
+
+        return $this;
+    }
+
+    public function dd(): never
+    {
+        $this->dump();
+        exit(1);
+    }
+
+    private function normalize(string $value, bool $normalize): string
+    {
+        if (!$normalize) {
+            return $value;
+        }
+
+        foreach ($this->normalizers as $normalizer) {
+            $value = $normalizer($value);
+        }
+
+        return str_replace(\PHP_EOL, "\n", $value);
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
@@ -29,6 +29,7 @@ use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Console\Tester\ConsoleAssertionsTrait;
 use Symfony\Component\Console\Tests\Fixtures\InvokableExtendingCommandTestCommand;
 use Symfony\Component\Console\Tests\Fixtures\InvokableTestCommand;
 use Symfony\Component\Console\Tests\Fixtures\InvokableWithInputTestCommand;
@@ -39,6 +40,8 @@ use Symfony\Component\Console\Tests\Fixtures\MethodBasedTestCommand;
 
 class CommandTesterTest extends TestCase
 {
+    use ConsoleAssertionsTrait;
+
     protected Command $command;
     protected CommandTester $tester;
 
@@ -638,5 +641,107 @@ class CommandTesterTest extends TestCase
         ): int => 0);
 
         $command->getDefinition();
+    }
+
+    public function testItExecutesTheTestedCommandWithTheSameConfigAsThePreviousApiByDefault()
+    {
+        $oldConfig = [];
+        $newConfig = [];
+
+        $oldTesterCommand = self::createDisplayConfigurationCommand($oldConfig);
+        $newTesterCommand = self::createDisplayConfigurationCommand($newConfig);
+
+        $oldTester = new CommandTester($oldTesterCommand);
+        $oldTester->execute([]);
+
+        $newTester = new CommandTester($newTesterCommand);
+        $newTester->run();
+
+        // Sanity check
+        $this->assertNotEquals([], $oldConfig);
+        $this->assertEquals($oldConfig, $newConfig);
+    }
+
+    public function testItCanConfigureTheExecutedCommand()
+    {
+        $config = [];
+
+        $test = new CommandTester(
+            self::createDisplayConfigurationCommand($config),
+        );
+        $test->run(
+            interactive: true,
+            decorated: false,
+            verbosity: OutputInterface::VERBOSITY_VERY_VERBOSE,
+        );
+
+        $expectedConfig = [
+            'interactive' => true,
+            'decorated' => false,
+            'verbosity' => OutputInterface::VERBOSITY_VERY_VERBOSE,
+        ];
+
+        $this->assertEquals($expectedConfig, $config);
+    }
+
+    public function testItCanTestTheExecutionResult()
+    {
+        $command = new Command('foo');
+        $command->setCode(static function (InputInterface $input, OutputInterface $output) {
+            $output->writeln('bar');
+
+            return 0;
+        });
+
+        $result = (new CommandTester($command))->run();
+
+        $this->assertIsSuccessful($result);
+        $this->assertSame(0, $result->statusCode);
+        $this->assertSame("bar\n", $result->getDisplay());
+    }
+
+    public function testItProvidesUserInputs()
+    {
+        $questions = [
+            'What\'s your name?',
+            'How are you?',
+            'Where do you come from?',
+        ];
+
+        $command = new Command('foo');
+        $command->setHelperSet(new HelperSet([new QuestionHelper()]));
+        $command->setCode(static function (InputInterface $input, OutputInterface $output) use ($questions, $command): int {
+            $helper = $command->getHelper('question');
+            $helper->ask($input, $output, new Question($questions[0]));
+            $helper->ask($input, $output, new Question($questions[1]));
+            $helper->ask($input, $output, new Question($questions[2]));
+
+            return 0;
+        });
+
+        $tester = new CommandTester($command);
+        $result = $tester->run(interactiveInputs: ['Bobby', 'Fine', 'France']);
+
+        $this->assertResultEquals(
+            $result,
+            0,
+            '',
+            implode('', $questions),
+            implode('', $questions),
+        );
+    }
+
+    private static function createDisplayConfigurationCommand(array &$config): Command
+    {
+        $command = new Command('foo');
+        $command->setCode(static function (InputInterface $input, OutputInterface $output) use (&$config) {
+            $config['interactive'] = $input->isInteractive();
+            $config['verbosity'] = $output->getVerbosity();
+            $config['decorated'] = $output->isDecorated();
+
+            return 0;
+        });
+
+        return $command;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Currently, testing a command with separate stdout/stderr streams requires the `capture_stderr_separately` option and two separate API calls:

```php
$this->commandTester->execute(
    ['username' => 'Wouter'],
    ['capture_stderr_separately' => true],
);

$stdoutOutput = $commandTester->getDisplay();
$stderrOutput = $commandTester->getErrorOutput();
```

This works, but you lose the combined display order. If output correctness matters to you (e.g., interleaved stdout/stderr), you need multiple tests.

This PR introduces a cleaner result-based API with `CommandTester::run()`, which returns an `ExecutionResult` exposing all three views at once:

```php
$result = $this->commandTester->run(['username' => 'Wouter']);

$combinedOutput = $result->getDisplay();   // stdout + stderr interleaved
$stdoutOutput   = $result->getOutput();    // stdout only
$stderrOutput   = $result->getErrorOutput(); // stderr only
```

A `ConsoleAssertionsTrait` is also provided for PHPUnit test cases:

```php
use Symfony\Component\Console\Tester\ConsoleAssertionsTrait;

class MyCommandTest extends TestCase
{
    use ConsoleAssertionsTrait;

    public function testExecute()
    {
        $result = (new CommandTester($command))->run();

        $this->assertIsSuccessful($result);
        $this->assertResultEquals($result, 0, 'expected stdout', 'expected stderr', 'expected display');
    }
}
```

The `execute()` method remains fully supported and unchanged for backward compatibility.
Same for `TesterTrait`.
Deprecating them now would be too costly, better wait for 9.x.