### PR TITLE
[WebProfilerBundle] Update toolbar.css.twig

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -152,7 +152,7 @@
     margin-right: 0;
     position: relative;
     white-space: nowrap;
-    max-width: 15%;
+    max-width: 25%;
 }
 .sf-toolbar-block > a,
 .sf-toolbar-block > a:hover {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no 
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Hi there! Very tiny change to the CSS of the profiler toolbar main part. Some routes are quite often truncated in the toolbar.
Just making sure they can expand, as any monitor of 1440p+ now has more than 50% of the Profiler toolbar width that is empty (which is not really a shame as most of its content is short enough to be fully displayed.

That being said, the HTTP/route part could need a little bump. Didn't expand too much as it might be weird on smaller definitions. :)

4K (2160p) result below (before/after).

<img width="1920" height="32" alt="{34E21161-4171-4ED8-992B-00F7624957E5}" src="https://github.com/user-attachments/assets/1ab33a2d-5387-4b1e-a639-a89a5ff55de1" />

<img width="1915" height="29" alt="{E425D7EB-0259-47A5-8DF3-C344E5BAF1C9}" src="https://github.com/user-attachments/assets/543e3c88-5d19-4273-89ce-0a6ba0caea9a" />


It is now more than common to be work with 1080p/1440p/2160p monitors. And we're talking about mostly working computers (desktop, wider screens), not end-user.