### PR TITLE
 [SecurityHttp] Removes final keyword from IsGranted attribute

### DIFF
--- a/src/Symfony/Component/Security/Http/Attribute/IsGranted.php
+++ b/src/Symfony/Component/Security/Http/Attribute/IsGranted.php
@@ -22,7 +22,7 @@ use Symfony\Component\HttpFoundation\Request;
  * @author Ryan Weaver <ryan@knpuniversity.com>
  */
 #[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_FUNCTION)]
-final class IsGranted
+class IsGranted
 {
     /** @var string[] */
     public readonly array $methods;

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Deprecate callable firewall listeners, extend `AbstractListener` or implement `FirewallListenerInterface` instead
  * Deprecate `AbstractListener::__invoke`
  * Add `$methods` argument to `#[IsGranted]` to restrict validation to specific HTTP methods
+ * Remove `final` keyword from `#[IsGranted]` to allow implementation of custom attributes
 
 7.3
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #60896 
| License       | MIT

Often times the same set of rules is reused many times across a project making it tedious having to manually add the attributes with their specific configuration.
Making `#[IsGranted]` non `final` allows developers to implement custom attributes like `#[IsAdmin]` etc. in their projects.


