### PR TITLE
[HttpKernel] Remove unnecessary check in `RegisterControllerArgumentLocatorsPass`

### DIFF
--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
@@ -46,7 +46,7 @@ class RegisterControllerArgumentLocatorsPass implements CompilerPassInterface
 
         $publicAliases = [];
         foreach ($container->getAliases() as $id => $alias) {
-            if ($alias->isPublic() && !$alias->isPrivate()) {
+            if ($alias->isPublic()) {
                 $publicAliases[(string) $alias][] = $id;
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

If the $alias is [public](https://github.com/symfony/symfony/blob/f37691b2d37f1a883c217f519a63c0fc448a4379/src/Symfony/Component/DependencyInjection/Alias.php#L35), then for sure it is not [private](https://github.com/symfony/symfony/blob/7.4/src/Symfony/Component/DependencyInjection/Alias.php#L55).