### PR TITLE
[WebProfilerBundle] Show `APP_RUNTIME`

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add support for the `QUERY` HTTP method in the profiler
+ * Add `APP_RUNTIME` display in the configuration dashboard
 
 7.3
 ---

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
@@ -278,6 +278,16 @@
         <a href="{{ path('_profiler_phpinfo') }}">View full PHP configuration</a>
     </p>
 
+    {% if collector.appRuntime %}
+        <h2>Application Runtime</h2>
+        <div class="metrics">
+            <div class="metric">
+                <span class="value">{{ collector.appRuntime }}</span>
+                <span class="label">Runtime</span>
+            </div>
+        </div>
+    {% endif %}
+
     {% if collector.bundles %}
         <h2>Enabled Bundles <small>({{ collector.bundles|length }})</small></h2>
         <table>

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Deprecate implementing `__sleep/wakeup()` on kernels; use `__(un)serialize()` instead
  * Deprecate implementing `__sleep/wakeup()` on data collectors; use `__(un)serialize()` instead
  * Make `Profile` final and `Profiler::__sleep()` internal
+ * Add `APP_RUNTIME` display in the Symfony Profiler configuration dashboard
 
 7.3
 ---

--- a/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
@@ -64,7 +64,7 @@ class ConfigDataCollector extends DataCollector implements LateDataCollectorInte
             'zend_opcache_status' => \extension_loaded('Zend OPcache') ? (filter_var(\ini_get('opcache.enable'), \FILTER_VALIDATE_BOOLEAN) ? 'Enabled' : 'Not enabled') : 'Not installed',
             'bundles' => [],
             'sapi_name' => \PHP_SAPI,
-            'app_runtime' => $_SERVER['APP_RUNTIME'] ?? null,
+            'app_runtime_resolved' => $this->resolveAppRuntime(),
         ];
 
         if (isset($this->kernel)) {
@@ -250,12 +250,9 @@ class ConfigDataCollector extends DataCollector implements LateDataCollectorInte
         return $this->data['sapi_name'];
     }
 
-    /**
-     * Gets the application runtime.
-     */
     public function getAppRuntime(): ?string
     {
-        return $this->data['app_runtime'];
+        return $this->data['app_runtime_resolved'] ?? null;
     }
 
     public function getName(): string
@@ -280,5 +277,41 @@ class ConfigDataCollector extends DataCollector implements LateDataCollectorInte
         }
 
         return $versionState;
+    }
+
+    private function resolveAppRuntime(): ?string
+    {
+        static $cachedResolvedRuntime;
+
+        if (null !== $cachedResolvedRuntime) {
+            return $cachedResolvedRuntime;
+        }
+
+        $envRuntime = $_SERVER['APP_RUNTIME'] ?? null;
+        if (\is_string($envRuntime) && '' !== $envRuntime) {
+            return $cachedResolvedRuntime = $envRuntime;
+        }
+
+        if (isset($this->kernel)) {
+            $composerJsonPath = $this->kernel->getProjectDir().'/composer.json';
+            if (is_file($composerJsonPath) && is_readable($composerJsonPath)) {
+                $json = @file_get_contents($composerJsonPath);
+                if (false !== $json) {
+                    $decoded = json_decode($json, true);
+                    if (\is_array($decoded)) {
+                        $runtimeClass = $decoded['extra']['runtime']['class'] ?? null;
+                        if (\is_string($runtimeClass) && '' !== $runtimeClass) {
+                            return $cachedResolvedRuntime = $runtimeClass;
+                        }
+                    }
+                }
+            }
+        }
+
+        if (class_exists('Symfony\\Runtime\\SymfonyRuntime')) {
+            return $cachedResolvedRuntime = 'Symfony\\Runtime\\SymfonyRuntime';
+        }
+
+        return $cachedResolvedRuntime = null;
     }
 }

--- a/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
@@ -281,15 +281,9 @@ class ConfigDataCollector extends DataCollector implements LateDataCollectorInte
 
     private function resolveAppRuntime(): ?string
     {
-        static $cachedResolvedRuntime;
-
-        if (null !== $cachedResolvedRuntime) {
-            return $cachedResolvedRuntime;
-        }
-
         $envRuntime = $_SERVER['APP_RUNTIME'] ?? null;
         if (\is_string($envRuntime) && '' !== $envRuntime) {
-            return $cachedResolvedRuntime = $envRuntime;
+            return $envRuntime;
         }
 
         if (isset($this->kernel)) {
@@ -301,7 +295,7 @@ class ConfigDataCollector extends DataCollector implements LateDataCollectorInte
                     if (\is_array($decoded)) {
                         $runtimeClass = $decoded['extra']['runtime']['class'] ?? null;
                         if (\is_string($runtimeClass) && '' !== $runtimeClass) {
-                            return $cachedResolvedRuntime = $runtimeClass;
+                            return $runtimeClass;
                         }
                     }
                 }
@@ -309,9 +303,9 @@ class ConfigDataCollector extends DataCollector implements LateDataCollectorInte
         }
 
         if (class_exists('Symfony\\Runtime\\SymfonyRuntime')) {
-            return $cachedResolvedRuntime = 'Symfony\\Runtime\\SymfonyRuntime';
+            return 'Symfony\\Runtime\\SymfonyRuntime';
         }
 
-        return $cachedResolvedRuntime = null;
+        return null;
     }
 }

--- a/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
@@ -64,6 +64,7 @@ class ConfigDataCollector extends DataCollector implements LateDataCollectorInte
             'zend_opcache_status' => \extension_loaded('Zend OPcache') ? (filter_var(\ini_get('opcache.enable'), \FILTER_VALIDATE_BOOLEAN) ? 'Enabled' : 'Not enabled') : 'Not installed',
             'bundles' => [],
             'sapi_name' => \PHP_SAPI,
+            'app_runtime' => $_SERVER['APP_RUNTIME'] ?? null,
         ];
 
         if (isset($this->kernel)) {
@@ -247,6 +248,14 @@ class ConfigDataCollector extends DataCollector implements LateDataCollectorInte
     public function getSapiName(): string
     {
         return $this->data['sapi_name'];
+    }
+
+    /**
+     * Gets the application runtime.
+     */
+    public function getAppRuntime(): ?string
+    {
+        return $this->data['app_runtime'];
     }
 
     public function getName(): string

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
@@ -81,18 +81,80 @@ class ConfigDataCollectorTest extends TestCase
     public function testGetAppRuntime()
     {
         $c = new ConfigDataCollector();
-        
-        // Test without APP_RUNTIME set
+
         $c->collect(new Request(), new Response());
         $this->assertNull($c->getAppRuntime());
-        
-        // Test with APP_RUNTIME set
+
         $_SERVER['APP_RUNTIME'] = 'Symfony\\Runtime\\SymfonyRuntime';
         $c->collect(new Request(), new Response());
         $this->assertSame('Symfony\\Runtime\\SymfonyRuntime', $c->getAppRuntime());
-        
-        // Clean up
+
         unset($_SERVER['APP_RUNTIME']);
+    }
+
+    public function testGetAppRuntimeFromComposerJson()
+    {
+        $tempDir = sys_get_temp_dir().'/sf_runtime_'.uniqid();
+        @mkdir($tempDir);
+
+        $composerJson = [
+            'name' => 'example/app',
+            'type' => 'project',
+            'extra' => [
+                'runtime' => [
+                    'class' => 'App\\CustomRuntime',
+                ],
+            ],
+        ];
+        file_put_contents($tempDir.'/composer.json', json_encode($composerJson));
+
+        $kernel = new class('test', true, $tempDir) extends KernelForTest {
+            public function __construct(string $environment, bool $debug, private string $pdir)
+            {
+                parent::__construct($environment, $debug);
+            }
+            public function getProjectDir(): string
+            {
+                return $this->pdir;
+            }
+        };
+
+        $c = new ConfigDataCollector();
+        $c->setKernel($kernel);
+        $c->collect(new Request(), new Response());
+        $this->assertSame('App\\CustomRuntime', $c->getAppRuntime());
+
+        @unlink($tempDir.'/composer.json');
+        @rmdir($tempDir);
+    }
+
+    public function testGetAppRuntimeFallback()
+    {
+        $tempDir = sys_get_temp_dir().'/sf_runtime_'.uniqid();
+        @mkdir($tempDir);
+
+        $kernel = new class('test', true, $tempDir) extends KernelForTest {
+            public function __construct(string $environment, bool $debug, private string $pdir)
+            {
+                parent::__construct($environment, $debug);
+            }
+            public function getProjectDir(): string
+            {
+                return $this->pdir;
+            }
+        };
+
+        $c = new ConfigDataCollector();
+        $c->setKernel($kernel);
+        $c->collect(new Request(), new Response());
+
+        if (class_exists('Symfony\\Runtime\\SymfonyRuntime')) {
+            $this->assertSame('Symfony\\Runtime\\SymfonyRuntime', $c->getAppRuntime());
+        } else {
+            $this->assertNull($c->getAppRuntime());
+        }
+
+        @rmdir($tempDir);
     }
 }
 

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
@@ -77,6 +77,23 @@ class ConfigDataCollectorTest extends TestCase
         $this->assertSame($eom, $c->getSymfonyEom());
         $this->assertSame($eol, $c->getSymfonyEol());
     }
+
+    public function testGetAppRuntime()
+    {
+        $c = new ConfigDataCollector();
+        
+        // Test without APP_RUNTIME set
+        $c->collect(new Request(), new Response());
+        $this->assertNull($c->getAppRuntime());
+        
+        // Test with APP_RUNTIME set
+        $_SERVER['APP_RUNTIME'] = 'Symfony\\Runtime\\SymfonyRuntime';
+        $c->collect(new Request(), new Response());
+        $this->assertSame('Symfony\\Runtime\\SymfonyRuntime', $c->getAppRuntime());
+        
+        // Clean up
+        unset($_SERVER['APP_RUNTIME']);
+    }
 }
 
 class KernelForTest extends Kernel


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #61491
| License       | MIT

This PR adds support for displaying the `APP_RUNTIME` value in the Symfony Profiler configuration dashboard.

**Before**
- The configuration dashboard did not show which application runtime was used.

**After**
- A new section "Application Runtime" is displayed when `$_SERVER['APP_RUNTIME']` is set, making it easier to debug and confirm the active runtime.

```php
$_SERVER['APP_RUNTIME'] = 'Symfony\\Runtime\\SymfonyRuntime';
```

**Profiler UI**
```
Application Runtime
-------------------
Runtime: Symfony\Runtime\SymfonyRuntime
```

