### PR TITLE
[DependencyInjection] Allow disabling instanceof config inheritance

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/WithoutInheritedConfiguration.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/WithoutInheritedConfiguration.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class WithoutInheritedConfiguration
+{
+}

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Allow `#[AsAlias]` to be extended
  * Add argument `$target` to `ContainerBuilder::registerAliasForArgument()`
  * Deprecate registering a service without a class when its id is a non-existing FQCN
+ * Allow disabling instanceof configuration inheritance
 
 7.3
 ---

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection\Compiler;
 
+use Symfony\Component\DependencyInjection\Attribute\WithoutInheritedConfiguration;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -59,6 +60,14 @@ class ResolveInstanceofConditionalsPass implements CompilerPassInterface
             return $definition;
         }
 
+        if (
+            ($reflectionClass = $container->getReflectionClass($class, false) ?: false)
+            && $definition->isAutoconfigured()
+            && $reflectionClass->getAttributes(WithoutInheritedConfiguration::class)
+        ) {
+            $definition->setInheritConfiguration(false);
+        }
+
         $conditionals = $this->mergeConditionals($autoconfiguredInstanceof, $instanceofConditionals, $container);
 
         $definition->setInstanceofConditionals([]);
@@ -66,15 +75,20 @@ class ResolveInstanceofConditionalsPass implements CompilerPassInterface
         $instanceofTags = [];
         $instanceofCalls = [];
         $instanceofBindings = [];
-        $reflectionClass = null;
         $parent = $definition instanceof ChildDefinition ? $definition->getParent() : null;
 
         foreach ($conditionals as $interface => $instanceofDefs) {
-            if ($interface !== $class && !($reflectionClass ??= $container->getReflectionClass($class, false) ?: false)) {
+            if ($interface !== $class && !$reflectionClass) {
                 continue;
             }
 
-            if ($interface !== $class && !is_subclass_of($class, $interface)) {
+            if (
+                $interface !== $class
+                && (
+                    !$definition->shouldInheritConfiguration()
+                    || !is_subclass_of($class, $interface)
+                )
+            ) {
                 continue;
             }
 

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -33,6 +33,7 @@ class Definition
     private array $calls = [];
     private array $instanceof = [];
     private bool $autoconfigured = false;
+    private bool $inheritConfiguration = true;
     private string|array|null $configurator = null;
     private array $tags = [];
     private bool $public = false;
@@ -413,6 +414,25 @@ class Definition
     public function isAutoconfigured(): bool
     {
         return $this->autoconfigured;
+    }
+
+    /**
+     * Sets whether instanceof conditionals should be applied to the current definition.
+     *
+     * @return $this
+     */
+    public function setInheritConfiguration(bool $inheritConfiguration): static
+    {
+        $this->changes['inheritConfiguration'] = true;
+
+        $this->inheritConfiguration = $inheritConfiguration;
+
+        return $this;
+    }
+
+    public function shouldInheritConfiguration(): bool
+    {
+        return $this->inheritConfiguration;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
@@ -212,6 +212,10 @@ class XmlDumper extends Dumper
             $xmlAttr .= ' autoconfigure="true"';
         }
 
+        if (!$definition->shouldInheritConfiguration()) {
+            $xmlAttr .= ' inherit-configuration="false"';
+        }
+
         if ($definition->isAbstract()) {
             $xmlAttr .= ' abstract="true"';
         }

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -111,6 +111,10 @@ class YamlDumper extends Dumper
             $code .= "        autoconfigure: true\n";
         }
 
+        if (!$definition->shouldInheritConfiguration()) {
+            $code .= "        inherit_configuration: false\n";
+        }
+
         if ($definition->isAbstract()) {
             $code .= "        abstract: true\n";
         }

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/DefaultsConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/DefaultsConfigurator.php
@@ -22,6 +22,7 @@ class DefaultsConfigurator extends AbstractServiceConfigurator
     use Traits\AutoconfigureTrait;
     use Traits\AutowireTrait;
     use Traits\BindTrait;
+    use Traits\InheritConfigurationTrait;
     use Traits\PublicTrait;
 
     public const FACTORY = 'defaults';

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/FromCallableConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/FromCallableConfigurator.php
@@ -24,6 +24,7 @@ class FromCallableConfigurator extends AbstractServiceConfigurator
     use Traits\BindTrait;
     use Traits\DecorateTrait;
     use Traits\DeprecateTrait;
+    use Traits\InheritConfigurationTrait;
     use Traits\LazyTrait;
     use Traits\PublicTrait;
     use Traits\ShareTrait;

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/PrototypeConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/PrototypeConfigurator.php
@@ -29,6 +29,7 @@ class PrototypeConfigurator extends AbstractServiceConfigurator
     use Traits\ConstructorTrait;
     use Traits\DeprecateTrait;
     use Traits\FactoryTrait;
+    use Traits\InheritConfigurationTrait;
     use Traits\LazyTrait;
     use Traits\ParentTrait;
     use Traits\PropertyTrait;

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ServiceConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ServiceConfigurator.php
@@ -33,6 +33,7 @@ class ServiceConfigurator extends AbstractServiceConfigurator
     use Traits\FactoryTrait;
     use Traits\FileTrait;
     use Traits\FromCallableTrait;
+    use Traits\InheritConfigurationTrait;
     use Traits\LazyTrait;
     use Traits\ParentTrait;
     use Traits\PropertyTrait;

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ServicesConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ServicesConfigurator.php
@@ -86,6 +86,7 @@ class ServicesConfigurator extends AbstractConfigurator
 
         $definition->setAutowired($defaults->isAutowired());
         $definition->setAutoconfigured($defaults->isAutoconfigured());
+        $definition->setInheritConfiguration($defaults->shouldInheritConfiguration());
         // deep clone, to avoid multiple process of the same instance in the passes
         $definition->setBindings(unserialize(serialize($defaults->getBindings())));
         $definition->setChanges([]);

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/InheritConfigurationTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/InheritConfigurationTrait.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator\Traits;
+
+trait InheritConfigurationTrait
+{
+    /**
+     * Sets whether instanceof conditionals should be applied to the current definition.
+     *
+     * @return $this
+     */
+    final public function inheritConfiguration(bool $inheritConfiguration = true): static
+    {
+        $this->definition->setInheritConfiguration($inheritConfiguration);
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -248,6 +248,7 @@ class XmlFileLoader extends FileLoader
         }
         $definition->setAutowired($defaults->isAutowired());
         $definition->setAutoconfigured($defaults->isAutoconfigured());
+        $definition->setInheritConfiguration($defaults->shouldInheritConfiguration());
         $definition->setChanges([]);
 
         foreach (['class', 'public', 'shared', 'synthetic', 'abstract'] as $key) {
@@ -270,6 +271,10 @@ class XmlFileLoader extends FileLoader
 
         if ($value = $service->getAttribute('autoconfigure')) {
             $definition->setAutoconfigured(XmlUtils::phpize($value));
+        }
+
+        if ($value = $service->getAttribute('inherit-configuration')) {
+            $definition->setInheritConfiguration(XmlUtils::phpize($value));
         }
 
         if ($files = $this->getChildren($service, 'file')) {

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -63,6 +63,7 @@ class YamlFileLoader extends FileLoader
         'decoration_on_invalid' => 'decoration_on_invalid',
         'autowire' => 'autowire',
         'autoconfigure' => 'autoconfigure',
+        'inherit_configuration' => 'inherit_configuration',
         'bind' => 'bind',
         'constructor' => 'constructor',
     ];
@@ -85,6 +86,7 @@ class YamlFileLoader extends FileLoader
         'tags' => 'tags',
         'autowire' => 'autowire',
         'autoconfigure' => 'autoconfigure',
+        'inherit_configuration' => 'inherit_configuration',
         'bind' => 'bind',
         'constructor' => 'constructor',
     ];
@@ -98,6 +100,7 @@ class YamlFileLoader extends FileLoader
         'calls' => 'calls',
         'tags' => 'tags',
         'autowire' => 'autowire',
+        'inherit_configuration' => 'inherit_configuration',
         'bind' => 'bind',
         'constructor' => 'constructor',
     ];
@@ -107,6 +110,7 @@ class YamlFileLoader extends FileLoader
         'tags' => 'tags',
         'autowire' => 'autowire',
         'autoconfigure' => 'autoconfigure',
+        'inherit_configuration' => 'inherit_configuration',
         'bind' => 'bind',
     ];
 
@@ -479,6 +483,9 @@ class YamlFileLoader extends FileLoader
         if (isset($defaults['autoconfigure'])) {
             $definition->setAutoconfigured($defaults['autoconfigure']);
         }
+        if (isset($defaults['inherit_configuration'])) {
+            $definition->setInheritConfiguration($defaults['inherit_configuration']);
+        }
 
         $definition->setChanges($changes);
 
@@ -688,6 +695,10 @@ class YamlFileLoader extends FileLoader
 
         if (isset($service['autoconfigure'])) {
             $definition->setAutoconfigured($service['autoconfigure']);
+        }
+
+        if (isset($service['inherit_configuration'])) {
+            $definition->setInheritConfiguration($service['inherit_configuration']);
         }
 
         if (\array_key_exists('namespace', $service) && !\array_key_exists('resource', $service)) {

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -139,6 +139,7 @@
     <xsd:attribute name="public" type="boolean" />
     <xsd:attribute name="autowire" type="boolean" />
     <xsd:attribute name="autoconfigure" type="boolean" />
+    <xsd:attribute name="inherit-configuration" type="boolean" />
   </xsd:complexType>
 
   <xsd:complexType name="service">
@@ -169,6 +170,7 @@
     <xsd:attribute name="decoration-priority" type="xsd:integer" />
     <xsd:attribute name="autowire" type="boolean" />
     <xsd:attribute name="autoconfigure" type="boolean" />
+    <xsd:attribute name="inherit-configuration" type="boolean" />
     <xsd:attribute name="constructor" type="xsd:string" />
   </xsd:complexType>
 
@@ -186,6 +188,7 @@
     <xsd:attribute name="lazy" type="xsd:string" />
     <xsd:attribute name="autowire" type="boolean" />
     <xsd:attribute name="autoconfigure" type="boolean" />
+    <xsd:attribute name="inherit-configuration" type="boolean" />
     <xsd:attribute name="constructor" type="xsd:string" />
   </xsd:complexType>
 
@@ -211,6 +214,7 @@
     <xsd:attribute name="parent" type="xsd:string" />
     <xsd:attribute name="autowire" type="boolean" />
     <xsd:attribute name="autoconfigure" type="boolean" />
+    <xsd:attribute name="inherit-configuration" type="boolean" />
     <xsd:attribute name="constructor" type="xsd:string" />
   </xsd:complexType>
 

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/services.schema.json
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/services.schema.json
@@ -255,6 +255,7 @@
         "decoration_on_invalid": { "oneOf": [ { "enum": ["exception", "ignore"] }, { "type": "null" } ], "$comment": "Use null (without quotes) for NULL_ON_INVALID_REFERENCE." },
         "autowire": { "type": "boolean" },
         "autoconfigure": { "type": "boolean" },
+        "inherit_configuration": { "type": "boolean" },
         "bind": { "type": "object", "additionalProperties": { "$ref": "#/$defs/parameterValue" } },
         "constructor": { "type": "string" },
         "from_callable": { "$ref": "#/$defs/parameterValue", "$comment": "Will be wrapped by factory ['Closure','fromCallable'] and sets lazy=true unless class is 'Closure'." }
@@ -287,6 +288,7 @@
         "tags": { "$ref": "#/$defs/tags" },
         "autowire": { "type": "boolean" },
         "autoconfigure": { "type": "boolean" },
+        "inherit_configuration": { "type": "boolean" },
         "bind": { "type": "object", "additionalProperties": { "$ref": "#/$defs/parameterValue" } },
         "constructor": { "type": "string" }
       },
@@ -324,6 +326,7 @@
         "tags": { "$ref": "#/$defs/tags" },
         "autowire": { "type": "boolean" },
         "autoconfigure": { "type": "boolean" },
+        "inherit_configuration": { "type": "boolean" },
         "bind": {
           "type": "object",
           "additionalProperties": { "$ref": "#/$defs/parameterValue" }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterServiceSubscribersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterServiceSubscribersPassTest.php
@@ -454,7 +454,7 @@ class RegisterServiceSubscribersPassTest extends TestCase
             'autowired' => new ServiceClosureArgument(new TypedReference('service.id', 'stdClass', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, 'autowired', [new Autowire(service: 'service.id')])),
             'autowired.nullable' => new ServiceClosureArgument(new TypedReference('service.id', 'stdClass', ContainerInterface::IGNORE_ON_INVALID_REFERENCE, 'autowired.nullable', [new Autowire(service: 'service.id')])),
             'autowired.parameter' => new ServiceClosureArgument('foobar'),
-            'autowire.decorated' => new ServiceClosureArgument(new Reference('.service_locator.Di.wrC8.inner', ContainerInterface::NULL_ON_INVALID_REFERENCE)),
+            'autowire.decorated' => new ServiceClosureArgument(new Reference('.service_locator.rPR11u5.inner', ContainerInterface::NULL_ON_INVALID_REFERENCE)),
             'target' => new ServiceClosureArgument(new TypedReference('stdClass', 'stdClass', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, 'target', [new Target('someTarget')])),
         ];
         $this->assertEquals($expected, $container->getDefinition((string) $locator->getFactory()[0])->getArgument(0));

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInstanceofConditionalsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInstanceofConditionalsPassTest.php
@@ -11,10 +11,12 @@
 
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Resource\ResourceInterface;
 use Symfony\Component\Config\ResourceCheckerInterface;
 use Symfony\Component\DependencyInjection\Argument\BoundArgument;
+use Symfony\Component\DependencyInjection\Attribute\WithoutInheritedConfiguration;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\ResolveChildDefinitionsPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveInstanceofConditionalsPass;
@@ -177,6 +179,62 @@ class ResolveInstanceofConditionalsPassTest extends TestCase
 
         $def = $container->getDefinition('normal_service');
         $this->assertFalse($def->isAutowired());
+    }
+
+    #[TestWith([true, ['local_instanceof_tag_on_parent' => [[]], 'autoconfigured_tag_on_parent' => [[]]]], 'with inheritConfiguration true')]
+    #[TestWith([false, []], 'with inheritConfiguration false')]
+    public function testInheritConfiguration(bool $inheritConfiguration, array $expectedTags)
+    {
+        $container = new ContainerBuilder();
+        $def = $container->register('normal_service', self::class);
+        $def->setAutoconfigured(true);
+        $def->setInheritConfiguration($inheritConfiguration);
+        $def->setInstanceofConditionals([
+            parent::class => (new ChildDefinition(''))
+                ->addTag('local_instanceof_tag_on_parent'),
+            self::class => (new ChildDefinition(''))
+                ->addTag('local_instanceof_tag_on_self'),
+        ]);
+        $container->registerForAutoconfiguration(parent::class)
+            ->addTag('autoconfigured_tag_on_parent')
+        ;
+        $container->registerForAutoconfiguration(self::class)
+            ->addTag('autoconfigured_tag_on_self')
+        ;
+
+        (new ResolveInstanceofConditionalsPass())->process($container);
+
+        $def = $container->getDefinition('normal_service');
+
+        $this->assertSame(['local_instanceof_tag_on_self' => [[]], 'autoconfigured_tag_on_self' => [[]]] + $expectedTags, $def->getTags());
+    }
+
+    #[TestWith([true, ['autoconfigured_tag_on_self' => [[]]]], 'with autoconfigure true')]
+    #[TestWith([false, ['local_instanceof_tag_on_parent' => [[]]]], 'with autoconfigure false')]
+    public function testWithoutInheritedConfigurationAttribute(bool $autoconfigure, array $expectedTags)
+    {
+        $container = new ContainerBuilder();
+        $def = $container->register('normal_service', WithNoInheritedConfig::class);
+        $def->setAutoconfigured($autoconfigure);
+        $def->setInheritConfiguration(true);
+        $def->setInstanceofConditionals([
+            WithConfigInterface::class => (new ChildDefinition(''))
+                ->addTag('local_instanceof_tag_on_parent'),
+            WithNoInheritedConfig::class => (new ChildDefinition(''))
+                ->addTag('local_instanceof_tag_on_self'),
+        ]);
+        $container->registerForAutoconfiguration(WithConfigInterface::class)
+            ->addTag('autoconfigured_tag_on_parent')
+        ;
+        $container->registerForAutoconfiguration(WithNoInheritedConfig::class)
+            ->addTag('autoconfigured_tag_on_self')
+        ;
+
+        (new ResolveInstanceofConditionalsPass())->process($container);
+
+        $def = $container->getDefinition('normal_service');
+
+        $this->assertSame(['local_instanceof_tag_on_self' => [[]]] + $expectedTags, $def->getTags());
     }
 
     public function testBadInterfaceThrowsException()
@@ -410,4 +468,13 @@ class DecoratorWithBehavior implements ResetInterface, ResourceCheckerInterface,
     public static function getSubscribedServices(): array
     {
     }
+}
+
+interface WithConfigInterface
+{
+}
+
+#[WithoutInheritedConfiguration]
+class WithNoInheritedConfig implements WithConfigInterface
+{
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/inherit_configuration.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/inherit_configuration.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return function (ContainerConfigurator $container) {
+    $services = $container->services();
+
+    $services->defaults()->inheritConfiguration(false);
+
+    $services->set('foo', 'Foo');
+    $services->set('bar', 'Bar')->inheritConfiguration();
+};

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/services9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/services9.php
@@ -146,4 +146,6 @@ return function (ContainerConfigurator $c) {
 
     $s->alias('alias_for_foo', 'foo')->private()->public();
     $s->alias('alias_for_alias', service('alias_for_foo'));
+
+    $s->set('without_inherited_config', FooClass::class)->public()->inheritConfiguration(false);
 };

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container9.php
@@ -4,8 +4,10 @@ require_once __DIR__.'/../includes/classes.php';
 require_once __DIR__.'/../includes/foo.php';
 
 use Bar\FooClass;
+use Bar\FooInterface;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Parameter;
@@ -196,5 +198,13 @@ $container->register('a_service', 'Bar')
 $container->register('b_service', 'Bar')
     ->setFactory([new Reference('a_factory'), 'getBar'])
     ->setPublic(true);
+
+$container
+    ->register('without_inherited_config', FooClass::class)
+    ->setPublic(true)
+    ->setInstanceofConditionals([
+        FooInterface::class => (new ChildDefinition(''))->setShared(false),
+    ])
+    ->setInheritConfiguration(false);
 
 return $container;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/graphviz/services9.dot
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/graphviz/services9.dot
@@ -40,6 +40,7 @@ digraph sc {
   node_a_factory [label="a_factory\nBar\n", shape=record, fillcolor="#eeeeee", style="filled"];
   node_a_service [label="a_service\nBar\n", shape=record, fillcolor="#eeeeee", style="filled"];
   node_b_service [label="b_service\nBar\n", shape=record, fillcolor="#eeeeee", style="filled"];
+  node_without_inherited_config [label="without_inherited_config\nBar\\FooClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
   node_foo2 [label="foo2\n\n", shape=record, fillcolor="#ff9999", style="filled"];
   node_foo3 [label="foo3\n\n", shape=record, fillcolor="#ff9999", style="filled"];
   node_foobaz [label="foobaz\n\n", shape=record, fillcolor="#ff9999", style="filled"];

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/foo.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/foo.php
@@ -2,7 +2,11 @@
 
 namespace Bar;
 
-class FooClass
+interface FooInterface
+{
+}
+
+class FooClass implements FooInterface
 {
     public $qux;
     public $foo;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_as_files.txt
@@ -530,6 +530,21 @@ class getThrowingOneService extends ProjectServiceContainer
     }
 }
 
+    [Container%s/getWithoutInheritedConfigService.php] => <?php
+%A
+class getWithoutInheritedConfigService extends ProjectServiceContainer
+{
+    /**
+     * Gets the public 'without_inherited_config' shared service.
+     *
+     * @return \Bar\FooClass
+     */
+    public static function do($container, $lazyLoad = true)
+    {
+        return $container->services['without_inherited_config'] = new \Bar\FooClass();
+    }
+}
+
     [Container%s/ProjectServiceContainer.php] => <?php
 
 namespace Container%s;
@@ -591,6 +606,7 @@ class ProjectServiceContainer extends Container
             'service_from_static_method' => 'getServiceFromStaticMethodService',
             'tagged_iterator' => 'getTaggedIteratorService',
             'throwing_one' => 'getThrowingOneService',
+            'without_inherited_config' => 'getWithoutInheritedConfigService',
         ];
         $this->aliases = [
             'alias_for_alias' => 'foo',
@@ -727,6 +743,7 @@ if (in_array(PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
 
 require dirname(__DIR__, %d).'%svendor/autoload.php';
 (require __DIR__.'/ProjectServiceContainer.php')->set(\Container%s\ProjectServiceContainer::class, null);
+require __DIR__.'/Container%s/getWithoutInheritedConfigService.php';
 require __DIR__.'/Container%s/getThrowingOneService.php';
 require __DIR__.'/Container%s/getTaggedIteratorService.php';
 require __DIR__.'/Container%s/getServiceFromStaticMethodService.php';

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -51,6 +51,7 @@ class ProjectServiceContainer extends Container
             'runtime_error' => 'getRuntimeErrorService',
             'service_from_static_method' => 'getServiceFromStaticMethodService',
             'tagged_iterator' => 'getTaggedIteratorService',
+            'without_inherited_config' => 'getWithoutInheritedConfigService',
         ];
         $this->aliases = [
             'alias_for_alias' => 'foo',
@@ -422,6 +423,16 @@ class ProjectServiceContainer extends Container
             yield 0 => ($container->services['foo'] ?? self::getFooService($container));
             yield 1 => ($container->privates['tagged_iterator_foo'] ??= new \Bar());
         }, 2));
+    }
+
+    /**
+     * Gets the public 'without_inherited_config' shared service.
+     *
+     * @return \Bar\FooClass
+     */
+    protected static function getWithoutInheritedConfigService($container)
+    {
+        return $container->services['without_inherited_config'] = new \Bar\FooClass();
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_inlined_factories.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_inlined_factories.txt
@@ -77,6 +77,7 @@ class ProjectServiceContainer extends Container
             'service_from_static_method' => 'getServiceFromStaticMethodService',
             'tagged_iterator' => 'getTaggedIteratorService',
             'throwing_one' => 'getThrowingOneService',
+            'without_inherited_config' => 'getWithoutInheritedConfigService',
         ];
         $this->aliases = [
             'alias_for_alias' => 'foo',
@@ -473,6 +474,16 @@ class ProjectServiceContainer extends Container
     protected static function getThrowingOneService($container)
     {
         return $container->services['throwing_one'] = new \Bar\FooClass(throw new RuntimeException('No-no-no-no'));
+    }
+
+    /**
+     * Gets the public 'without_inherited_config' shared service.
+     *
+     * @return \Bar\FooClass
+     */
+    protected static function getWithoutInheritedConfigService($container)
+    {
+        return $container->services['without_inherited_config'] = new \Bar\FooClass();
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_errored_definition.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_errored_definition.php
@@ -51,6 +51,7 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
             'runtime_error' => 'getRuntimeErrorService',
             'service_from_static_method' => 'getServiceFromStaticMethodService',
             'tagged_iterator' => 'getTaggedIteratorService',
+            'without_inherited_config' => 'getWithoutInheritedConfigService',
         ];
         $this->aliases = [
             'alias_for_alias' => 'foo',
@@ -422,6 +423,16 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
             yield 0 => ($container->services['foo'] ?? self::getFooService($container));
             yield 1 => ($container->privates['tagged_iterator_foo'] ??= new \Bar());
         }, 2));
+    }
+
+    /**
+     * Gets the public 'without_inherited_config' shared service.
+     *
+     * @return \Bar\FooClass
+     */
+    protected static function getWithoutInheritedConfigService($container)
+    {
+        return $container->services['without_inherited_config'] = new \Bar\FooClass();
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/inherit_configuration.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/inherit_configuration.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <defaults inherit-configuration="false" />
+
+        <service id="foo" class="Foo" />
+        <service id="bar" class="Bar" inherit-configuration="true" />
+    </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services9.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services9.xml
@@ -159,6 +159,7 @@
     <service id="b_service" class="Bar" public="true">
       <factory service="a_factory" method="getBar"/>
     </service>
+    <service id="without_inherited_config" class="Bar\FooClass" public="true" inherit-configuration="false"/>
     <service id="alias_for_foo" alias="foo" public="true"/>
     <service id="alias_for_alias" alias="foo" public="true"/>
   </services>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/inherit_configuration.yaml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/inherit_configuration.yaml
@@ -1,0 +1,9 @@
+services:
+    _defaults:
+        inherit_configuration: false
+
+    foo:
+        class: Foo
+    bar:
+        class: Bar
+        inherit_configuration: true

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services9.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services9.yml
@@ -191,3 +191,7 @@ services:
         class: Bar
         factory: ['@a_factory', 'getBar']
         public: true
+    without_inherited_config:
+        class: Bar\FooClass
+        public: true
+        inherit_configuration: false

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
@@ -294,4 +294,15 @@ class PhpFileLoaderTest extends TestCase
 
         $this->assertIsString($container->getExtensionConfig('acme')[0]['color']);
     }
+
+    public function testInheritConfiguration()
+    {
+        $container = new ContainerBuilder();
+
+        $loader = new PhpFileLoader($container, new FileLocator(realpath(__DIR__.'/../Fixtures').'/config'));
+        $loader->load('inherit_configuration.php');
+
+        self::assertFalse($container->getDefinition('foo')->shouldInheritConfiguration());
+        self::assertTrue($container->getDefinition('bar')->shouldInheritConfiguration());
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -1356,4 +1356,15 @@ class XmlFileLoaderTest extends TestCase
 
         self::assertInstanceOf(RemoteCallerSocket::class, $container->get(RemoteCaller::class));
     }
+
+    public function testInheritConfiguration()
+    {
+        $container = new ContainerBuilder();
+
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
+        $loader->load('inherit_configuration.xml');
+
+        self::assertFalse($container->getDefinition('foo')->shouldInheritConfiguration());
+        self::assertTrue($container->getDefinition('bar')->shouldInheritConfiguration());
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -1219,4 +1219,15 @@ class YamlFileLoaderTest extends TestCase
 
         $loader->load('tagged_deprecated.yml');
     }
+
+    public function testInheritConfiguration()
+    {
+        $container = new ContainerBuilder();
+
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('inherit_configuration.yaml');
+
+        self::assertFalse($container->getDefinition('foo')->shouldInheritConfiguration());
+        self::assertTrue($container->getDefinition('bar')->shouldInheritConfiguration());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

When configuring services like normalizers for a named serializer or Monolog processors for specific channels/handlers, autoconfiguration can get in the way.

For example, the `NormalizerInterface` is [registered for autoconfiguration](https://github.com/symfony/symfony/blob/39e55e3c775faf61805261cb8132189c49136b76/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php#L739-L740).
If I try to register a custom normalizer for a specific named serializer, it also gets registered with the default serializer because of autoconfiguration:

```php
#[AutoconfigureTag(
    name: 'serializer.normalizer',
    attributes: [
        'serializer' => 'my_named_serializer',
    ],
)]
class MyNormalizer implements NormalizerInterface {}
```

Currently, the only way around this is to disable autoconfiguration entirely:

```yaml
services:
    App\MyNormalizer:
        autoconfigure: false
        tags:
            - serializer.normalizer: { serializer: 'my_named_serializer' }
```

This PR introduces a new `inherit_configuration` option for service definitions and a `#[WithoutInheritedConfiguration]` attribute.
Both allow skipping the inheritance of `instanceof` conditionals from parent classes or interfaces:

```php
#[AutoconfigureTag(
    name: 'serializer.normalizer',
    attributes: [
        'serializer' => 'my_named_serializer',
    ],
)]
#[WithoutInheritedConfiguration]
class MyNormalizer implements NormalizerInterface {}
```

It can also be used to exclude specific services from inheriting `_instanceof` configurations:

```yaml
services:
    _defaults:
        autowire: true
        autoconfigure: true

    _instanceof:
        App\SomeInterface:
            tags: ['some.tag']

    App\SomeInterfaceImplementation:
        inherit_configuration: false # This implementation won't inherit instanceof config
```

---

### Why a new attribute?

I initially tried adding a new argument to the existing `#[Autoconfigure]` attribute.
However, this attribute itself is [resolved via instanceof conditionals](https://github.com/symfony/symfony/blob/39e55e3c775faf61805261cb8132189c49136b76/src/Symfony/Component/DependencyInjection/Compiler/RegisterAutoconfigureAttributesPass.php#L81-L92).
I could try something like [`$conditionals[$class]`](https://github.com/symfony/symfony/blob/39e55e3c775faf61805261cb8132189c49136b76/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php#L62), but since the attribute is repeatable, it’s unclear how to handle cases like:

```php
#[Autoconfigure(inheritConfiguration: false)]
#[Autoconfigure(inheritConfiguration: true)]
class MyClass {}
```