### PR TITLE
[FrameworkBundle][HttpKernel] Add `SerializeResponse` attribute for automatic (JSON) response serialization

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
@@ -35,6 +35,7 @@ use Symfony\Component\HttpKernel\EventListener\ErrorListener;
 use Symfony\Component\HttpKernel\EventListener\IsSignatureValidAttributeListener;
 use Symfony\Component\HttpKernel\EventListener\LocaleListener;
 use Symfony\Component\HttpKernel\EventListener\ResponseListener;
+use Symfony\Component\HttpKernel\EventListener\SerializeResponseListener;
 use Symfony\Component\HttpKernel\EventListener\ValidateRequestListener;
 
 return static function (ContainerConfigurator $container) {
@@ -152,6 +153,12 @@ return static function (ContainerConfigurator $container) {
         ->set('controller.is_signature_valid_attribute_listener', IsSignatureValidAttributeListener::class)
             ->args([
                 service('uri_signer'),
+            ])
+            ->tag('kernel.event_subscriber')
+
+        ->set('controller.serialize_response_listener', SerializeResponseListener::class)
+            ->args([
+                service('serializer')->nullOnInvalid(),
             ])
             ->tag('kernel.event_subscriber')
 

--- a/src/Symfony/Component/HttpKernel/Attribute/SerializeResponse.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/SerializeResponse.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Attribute;
+
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Automatically serialize the controller return value to JSON.
+ *
+ * When applied to a controller method, this attribute triggers automatic
+ * JSON serialization of the returned object via the kernel.view event.
+ */
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_CLASS)]
+final class SerializeResponse
+{
+    /**
+     * @param int                  $status               The HTTP status code to use for the response
+     * @param array<string, mixed> $serializationContext Serialization context
+     * @param string               $format               The serialization format to use
+     * @param array<string, mixed> $headers              HTTP headers to add to the response
+     */
+    public function __construct(
+        public readonly int $status = Response::HTTP_OK,
+        public readonly array $serializationContext = [],
+        public readonly string $format = 'json',
+        public readonly array $headers = [],
+    ) {
+    }
+}

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -16,6 +16,7 @@ CHANGELOG
 7.4
 ---
 
+ * Add `#[SerializeResponse]` attribute to automatically serialize controller return values to JSON
  * Add support for the `QUERY` HTTP method
  * Deprecate implementing `__sleep/wakeup()` on kernels; use `__(un)serialize()` instead
  * Deprecate implementing `__sleep/wakeup()` on data collectors; use `__(un)serialize()` instead

--- a/src/Symfony/Component/HttpKernel/EventListener/SerializeResponseListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/SerializeResponseListener.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\SerializeResponse;
+use Symfony\Component\HttpKernel\Event\ViewEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * Automatically serializes controller return values when decorated with #[SerializeResponse].
+ */
+class SerializeResponseListener implements EventSubscriberInterface
+{
+    public function __construct(
+        private ?SerializerInterface $serializer,
+    ) {
+    }
+
+    public function onKernelView(ViewEvent $event): void
+    {
+        $result = $event->getControllerResult();
+
+        if (!$attribute = $event->controllerArgumentsEvent?->getAttributes(SerializeResponse::class)[0] ?? null) {
+            return;
+        }
+
+        if (null === $this->serializer) {
+            return;
+        }
+
+        $serializedData = $this->serializer->serialize($result, $attribute->format, $attribute->serializationContext);
+
+        $headers = $attribute->headers;
+
+        if (!isset($headers['Content-Type']) && !isset($headers['content-type']) && ($contentType = $this->getContentTypeForFormat($attribute->format))) {
+            $headers['Content-Type'] = $contentType;
+        }
+
+        $response = new Response(
+            $serializedData,
+            $attribute->status,
+            $headers,
+        );
+
+        $event->setResponse($response);
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::VIEW => ['onKernelView', -128],
+        ];
+    }
+
+    private function getContentTypeForFormat(string $format): ?string
+    {
+        return match ($format) {
+            'json' => 'application/json',
+            'xml' => 'application/xml',
+            'yaml', 'yml' => 'application/x-yaml',
+            'csv' => 'text/csv',
+            default => null,
+        };
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/SerializeResponseListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/SerializeResponseListenerTest.php
@@ -1,0 +1,227 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
+use Symfony\Component\HttpKernel\Event\ViewEvent;
+use Symfony\Component\HttpKernel\EventListener\SerializeResponseListener;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\Tests\Fixtures\Controller\SerializeResponseController;
+use Symfony\Component\Serializer\Encoder\CsvEncoder;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Encoder\XmlEncoder;
+use Symfony\Component\Serializer\Encoder\YamlEncoder;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\Serializer;
+
+class SerializeResponseListenerTest extends TestCase
+{
+    private SerializeResponseListener $listener;
+    private Serializer $serializer;
+
+    protected function setUp(): void
+    {
+        $this->serializer = new Serializer(
+            [new ObjectNormalizer()],
+            [new JsonEncoder(), new XmlEncoder(), new YamlEncoder(), new CsvEncoder()]
+        );
+        $this->listener = new SerializeResponseListener($this->serializer);
+    }
+
+    public function testSerializesControllerResultToJson()
+    {
+        $data = ['message' => 'Hello World', 'status' => 'success'];
+
+        $request = new Request();
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $controllerArgumentsEvent = new ControllerArgumentsEvent($kernel, [new SerializeResponseController(), 'createWithCustomSettings'], [], $request, null);
+
+        $event = new ViewEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, $data, $controllerArgumentsEvent);
+
+        $this->listener->onKernelView($event);
+
+        $response = $event->getResponse();
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame(201, $response->getStatusCode());
+        $this->assertSame('value', $response->headers->get('X-Custom'));
+        $this->assertSame('application/json', $response->headers->get('Content-Type'));
+        $this->assertSame('{"message":"Hello World","status":"success"}', $response->getContent());
+    }
+
+    public function testUsesDefaultStatusAndHeaders()
+    {
+        $data = ['test' => true];
+
+        $request = new Request();
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $controllerArgumentsEvent = new ControllerArgumentsEvent($kernel, [new SerializeResponseController(), 'createWithDefaults'], [], $request, null);
+
+        $event = new ViewEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, $data, $controllerArgumentsEvent);
+
+        $this->listener->onKernelView($event);
+
+        $response = $event->getResponse();
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('application/json', $response->headers->get('Content-Type'));
+        $this->assertSame('{"test":true}', $response->getContent());
+    }
+
+    public function testDoesNotProcessWhenNoAttributePresent()
+    {
+        $data = ['test' => true];
+
+        $request = new Request();
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $controllerArgumentsEvent = new ControllerArgumentsEvent($kernel, [new SerializeResponseController(), 'createWithoutAttribute'], [], $request, null);
+
+        $event = new ViewEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, $data, $controllerArgumentsEvent);
+
+        $this->listener->onKernelView($event);
+
+        $this->assertNull($event->getResponse());
+    }
+
+    public function testDoesNotProcessWhenNoControllerArgumentsEvent()
+    {
+        $data = ['test' => true];
+
+        $request = new Request();
+        $kernel = $this->createMock(HttpKernelInterface::class);
+
+        $event = new ViewEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, $data);
+
+        $this->listener->onKernelView($event);
+
+        $this->assertNull($event->getResponse());
+    }
+
+    public function testHandlesNullControllerResult()
+    {
+        $request = new Request();
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $controllerArgumentsEvent = new ControllerArgumentsEvent($kernel, [new SerializeResponseController(), 'createWithDefaults'], [], $request, null);
+
+        $event = new ViewEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, null, $controllerArgumentsEvent);
+
+        $this->listener->onKernelView($event);
+
+        $response = $event->getResponse();
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame('application/json', $response->headers->get('Content-Type'));
+        $this->assertSame('null', $response->getContent());
+    }
+
+    public function testSerializationContextIsUsed()
+    {
+        $data = new class {
+            public string $public = 'visible';
+            private string $private = 'hidden';
+        };
+
+        $request = new Request();
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $controllerArgumentsEvent = new ControllerArgumentsEvent($kernel, [new SerializeResponseController(), 'createWithSerializationContext'], [], $request, null);
+
+        $event = new ViewEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, $data, $controllerArgumentsEvent);
+
+        $this->listener->onKernelView($event);
+
+        $response = $event->getResponse();
+        $content = $response->getContent();
+        $this->assertStringContainsString('visible', $content);
+        $this->assertStringNotContainsString('hidden', $content);
+    }
+
+    public function testSerializesToXmlFormat()
+    {
+        $data = ['message' => 'Hello World', 'status' => 'success'];
+
+        $request = new Request();
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $controllerArgumentsEvent = new ControllerArgumentsEvent($kernel, [new SerializeResponseController(), 'createWithXmlFormat'], [], $request, null);
+
+        $event = new ViewEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, $data, $controllerArgumentsEvent);
+
+        $this->listener->onKernelView($event);
+
+        $response = $event->getResponse();
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('application/xml', $response->headers->get('Content-Type'));
+        $this->assertStringContainsString('<?xml', $response->getContent());
+    }
+
+    public function testSerializesToYamlFormat()
+    {
+        $data = ['message' => 'Hello World', 'status' => 'success'];
+
+        $request = new Request();
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $controllerArgumentsEvent = new ControllerArgumentsEvent($kernel, [new SerializeResponseController(), 'createWithYamlFormat'], [], $request, null);
+
+        $event = new ViewEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, $data, $controllerArgumentsEvent);
+
+        $this->listener->onKernelView($event);
+
+        $response = $event->getResponse();
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame(202, $response->getStatusCode());
+        $this->assertSame('application/x-yaml', $response->headers->get('Content-Type'));
+        $this->assertStringContainsString('message: \'Hello World\'', $response->getContent());
+    }
+
+    public function testSerializesToCsvFormat()
+    {
+        $data = [
+            ['name' => 'John', 'age' => 30],
+            ['name' => 'Jane', 'age' => 25],
+        ];
+
+        $request = new Request();
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $controllerArgumentsEvent = new ControllerArgumentsEvent($kernel, [new SerializeResponseController(), 'createWithCsvFormat'], [], $request, null);
+
+        $event = new ViewEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, $data, $controllerArgumentsEvent);
+
+        $this->listener->onKernelView($event);
+
+        $response = $event->getResponse();
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('text/csv', $response->headers->get('Content-Type'));
+        $this->assertStringContainsString('name,age', $response->getContent());
+    }
+
+    public function testRespectsCustomContentTypeHeader()
+    {
+        $data = ['message' => 'Hello World', 'status' => 'success'];
+
+        $request = new Request();
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $controllerArgumentsEvent = new ControllerArgumentsEvent($kernel, [new SerializeResponseController(), 'createWithCustomContentType'], [], $request, null);
+
+        $event = new ViewEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, $data, $controllerArgumentsEvent);
+
+        $this->listener->onKernelView($event);
+
+        $response = $event->getResponse();
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame(200, $response->getStatusCode());
+        // Should use the custom content type, not override with application/json
+        $this->assertSame('application/vnd.api+json', $response->headers->get('Content-Type'));
+        $this->assertSame('{"message":"Hello World","status":"success"}', $response->getContent());
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/Controller/SerializeResponseController.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/Controller/SerializeResponseController.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures\Controller;
+
+use Symfony\Component\HttpKernel\Attribute\SerializeResponse;
+
+class SerializeResponseController
+{
+    #[SerializeResponse(201, ['groups' => ['api']], 'json', ['X-Custom' => 'value'])]
+    public function createWithCustomSettings()
+    {
+    }
+
+    #[SerializeResponse]
+    public function createWithDefaults()
+    {
+    }
+
+    #[SerializeResponse(serializationContext: ['ignored_attributes' => ['private']])]
+    public function createWithSerializationContext()
+    {
+    }
+
+    #[SerializeResponse(format: 'xml')]
+    public function createWithXmlFormat()
+    {
+    }
+
+    #[SerializeResponse(202, format: 'yaml')]
+    public function createWithYamlFormat()
+    {
+    }
+
+    #[SerializeResponse(format: 'csv')]
+    public function createWithCsvFormat()
+    {
+    }
+
+    #[SerializeResponse(headers: ['Content-Type' => 'application/vnd.api+json'])]
+    public function createWithCustomContentType()
+    {
+    }
+
+    public function createWithoutAttribute()
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | none
| License       | MIT

This PR adds the `#[SerializeResponse]` attribute.

This attribute allows a returned non-response object in a controller to be serialized. It is practically the opposite of `#[MapRequestPayload]`.

It can be set both at a controller class and controller methods.

Additionally, it allows to set a HTTP status code, serialization context, serialization format, and http headers.

Any feedback would be greatly appreciated.