### PR TITLE
[FrameworkBundle][JsonPath] Add support for custom JsonPath functions

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add JsonPath integration to register custom JsonPath functions
+
 8.0
 ---
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
@@ -53,6 +53,7 @@ class UnusedTagsPass implements CompilerPassInterface
         'form.type_guesser',
         'html_sanitizer',
         'http_client.client',
+        'json_path.function',
         'json_streamer.value_transformer',
         'kernel.cache_clearer',
         'kernel.cache_warmer',

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -32,6 +32,7 @@ use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
 use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\IpUtils;
+use Symfony\Component\JsonPath\JsonPath;
 use Symfony\Component\JsonStreamer\StreamWriterInterface;
 use Symfony\Component\Lock\Lock;
 use Symfony\Component\Lock\Store\SemaphoreStore;
@@ -194,6 +195,7 @@ class Configuration implements ConfigurationInterface
         $this->addWebhookSection($rootNode, $enableIfStandalone);
         $this->addRemoteEventSection($rootNode, $enableIfStandalone);
         $this->addJsonStreamerSection($rootNode, $enableIfStandalone);
+        $this->addJsonPathSection($rootNode, $enableIfStandalone);
 
         return $treeBuilder;
     }
@@ -2761,6 +2763,18 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('json_streamer')
                     ->info('JSON streamer configuration')
                     ->{$enableIfStandalone('symfony/json-streamer', StreamWriterInterface::class)}()
+                ->end()
+            ->end()
+        ;
+    }
+
+    private function addJsonPathSection(ArrayNodeDefinition $rootNode, callable $enableIfStandalone): void
+    {
+        $rootNode
+            ->children()
+                ->arrayNode('json_path')
+                    ->info('JsonPath configuration')
+                    ->{$enableIfStandalone('symfony/json-path', JsonPath::class)}()
                 ->end()
             ->end()
         ;

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -102,6 +102,8 @@ use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
 use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\HttpKernel\Log\DebugLoggerConfigurator;
+use Symfony\Component\JsonPath\Functions\AsJsonPathFunction;
+use Symfony\Component\JsonPath\JsonPath;
 use Symfony\Component\JsonStreamer\Attribute\JsonStreamable;
 use Symfony\Component\JsonStreamer\JsonStreamWriter;
 use Symfony\Component\JsonStreamer\StreamReaderInterface;
@@ -465,6 +467,10 @@ class FrameworkExtension extends Extension
             $this->registerJsonStreamerConfiguration($config['json_streamer'], $container, $loader);
         }
 
+        if ($this->readConfigEnabled('json_path', $container, $config['json_path'])) {
+            $this->registerJsonPathConfiguration($loader);
+        }
+
         if ($this->readConfigEnabled('lock', $container, $config['lock'])) {
             $this->registerLockConfiguration($config['lock'], $container, $loader);
         }
@@ -791,6 +797,12 @@ class FrameworkExtension extends Extension
                 'object' => $attribute->asObject,
                 'list' => $attribute->asList,
             ])->addTag('container.excluded', ['source' => 'because it\'s a streamable JSON']);
+        });
+
+        $container->registerAttributeForAutoconfiguration(AsJsonPathFunction::class, static function (ChildDefinition $definition, AsJsonPathFunction $attribute) {
+            $definition->addTag('json_path.function', [
+                'name' => $attribute->name,
+            ]);
         });
 
         if (!$container->getParameter('kernel.debug')) {
@@ -2175,6 +2187,15 @@ class FrameworkExtension extends Extension
 
             $container->getDefinition('type_info.type_context_factory')->replaceArgument(1, $config['aliases']);
         }
+    }
+
+    private function registerJsonPathConfiguration(PhpFileLoader $loader): void
+    {
+        if (!class_exists(JsonPath::class)) {
+            throw new LogicException('JsonPath support cannot be enabled as the JsonPath component is not installed. Try running "composer require symfony/json-path".');
+        }
+
+        $loader->load('json_path.php');
     }
 
     private function registerLockConfiguration(array $config, ContainerBuilder $container, PhpFileLoader $loader): void

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/json_path.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/json_path.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Component\JsonPath\Functions\JsonPathFunctionsProvider;
+use Symfony\Component\JsonPath\Functions\JsonPathFunctionsProviderInterface;
+
+return static function (ContainerConfigurator $container) {
+    $container->services()
+        ->set('json_path.functions_provider', JsonPathFunctionsProvider::class)
+        ->args([
+            tagged_locator('json_path.function', 'name'),
+        ])
+        ->alias(JsonPathFunctionsProviderInterface::class, 'json_path.functions_provider');
+};

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -25,6 +25,7 @@ use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HtmlSanitizer\HtmlSanitizer;
 use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\JsonPath\JsonPath;
 use Symfony\Component\JsonStreamer\JsonStreamWriter;
 use Symfony\Component\Lock\Store\SemaphoreStore;
 use Symfony\Component\Mailer\Mailer;
@@ -988,6 +989,9 @@ class ConfigurationTest extends TestCase
             ],
             'json_streamer' => [
                 'enabled' => !class_exists(FullStack::class) && class_exists(JsonStreamWriter::class),
+            ],
+            'json_path' => [
+                'enabled' => !class_exists(FullStack::class) && class_exists(JsonPath::class),
             ],
         ];
     }

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -75,6 +75,7 @@
         "symfony/validator": "^7.4|^8.0",
         "symfony/workflow": "^7.4|^8.0",
         "symfony/web-link": "^7.4|^8.0",
+        "symfony/json-path": "^7.4|^8.0",
         "symfony/webhook": "^7.4|^8.0",
         "symfony/yaml": "^7.4|^8.0"
     },

--- a/src/Symfony/Component/JsonPath/CHANGELOG.md
+++ b/src/Symfony/Component/JsonPath/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add `JsonPathFunctionsProviderInterface`, `JsonPathFunctionInterface` and `JsonPathFunctionArgumentTrait` to allow registering custom JsonPath functions
+ * Add the `#[AsJsonPathFunction]` attribute to declare custom JsonPath functions
+
 7.4
 ---
 

--- a/src/Symfony/Component/JsonPath/Exception/UnknownJsonPathFunctionException.php
+++ b/src/Symfony/Component/JsonPath/Exception/UnknownJsonPathFunctionException.php
@@ -14,10 +14,10 @@ namespace Symfony\Component\JsonPath\Exception;
 /**
  * @author Alexandre Daubois <alex.daubois@gmail.com>
  */
-class InvalidJsonPathException extends \LogicException implements ExceptionInterface
+class UnknownJsonPathFunctionException extends \RuntimeException implements ExceptionInterface
 {
-    public function __construct(string $message, ?int $position = null, ?\Throwable $previous = null)
+    public function __construct(string $name, ?\Throwable $previous = null)
     {
-        parent::__construct(\sprintf('JSONPath syntax error%s: %s', $position ? ' at position '.$position : '', $message), previous: $previous);
+        parent::__construct(\sprintf('Unknown JSONPath function "%s".', $name), previous: $previous);
     }
 }

--- a/src/Symfony/Component/JsonPath/Functions/AsJsonPathFunction.php
+++ b/src/Symfony/Component/JsonPath/Functions/AsJsonPathFunction.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonPath\Functions;
+
+/**
+ * Declares a service as a JsonPath function, usable in JSONPath expressions.
+ *
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class AsJsonPathFunction
+{
+    public function __construct(
+        public readonly string $name,
+    ) {
+    }
+}

--- a/src/Symfony/Component/JsonPath/Functions/CountFunction.php
+++ b/src/Symfony/Component/JsonPath/Functions/CountFunction.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonPath\Functions;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ *
+ * @internal
+ */
+final class CountFunction implements JsonPathComparableFunctionInterface
+{
+    use JsonPathFunctionArgumentTrait;
+
+    public function __invoke(array $args, mixed $context): int
+    {
+        $results = $args[0] ?? [];
+
+        return \is_array($results) ? \count($results) : 0;
+    }
+
+    public function validate(string $name, array $args): void
+    {
+        $this->assertArgumentsCount($name, $args, 1);
+        $this->assertIsQuery($name, trim($args[0]));
+    }
+}

--- a/src/Symfony/Component/JsonPath/Functions/JsonPathComparableFunctionInterface.php
+++ b/src/Symfony/Component/JsonPath/Functions/JsonPathComparableFunctionInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonPath\Functions;
+
+/**
+ * Interface for functions that return values that must be compared (not used as
+ * standalone boolean expressions). These functions will be validated to ensure they are used in
+ * comparison expressions, such as `==`, `!=`, `<`, `<=`, `>`, or `>=`.
+ *
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ */
+interface JsonPathComparableFunctionInterface extends JsonPathFunctionInterface
+{
+}

--- a/src/Symfony/Component/JsonPath/Functions/JsonPathFunctionArgumentTrait.php
+++ b/src/Symfony/Component/JsonPath/Functions/JsonPathFunctionArgumentTrait.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonPath\Functions;
+
+use Symfony\Component\JsonPath\Exception\InvalidArgumentException;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ */
+trait JsonPathFunctionArgumentTrait
+{
+    /**
+     * @param list<string> $args
+     */
+    public function assertArgumentsCount(string $name, array $args, int $expectedCount): void
+    {
+        if (\count($args) !== $expectedCount) {
+            throw new InvalidArgumentException(\sprintf('the JsonPath function "%s" requires exactly %d argument(s).', $name, $expectedCount));
+        }
+    }
+
+    public function assertIsSingularQuery(string $name, string $arg): void
+    {
+        if (preg_match('/@\.\*/', trim($arg))) {
+            throw new InvalidArgumentException(\sprintf('the JsonPath function "%s" argument must be a singular query.', $name));
+        }
+    }
+
+    public function assertIsQuery(string $name, string $arg): void
+    {
+        if (preg_match('/^(true|false|null|\d+(\.\d+)?([eE][+-]?\d+)?|\'[^\']*\'|"[^"]*")$/', $arg)) {
+            throw new InvalidArgumentException(\sprintf('the JsonPath function "%s" requires a query argument, not a literal.', $name));
+        }
+    }
+}

--- a/src/Symfony/Component/JsonPath/Functions/JsonPathFunctionInterface.php
+++ b/src/Symfony/Component/JsonPath/Functions/JsonPathFunctionInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonPath\Functions;
+
+use Symfony\Component\JsonPath\Exception\InvalidArgumentException;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ */
+interface JsonPathFunctionInterface
+{
+    /**
+     * @param list<string> $args    List of argument strings as they appear in the expression
+     * @param mixed        $context The current node to which the function is applied
+     */
+    public function __invoke(array $args, mixed $context): mixed;
+
+    /**
+     * Validates the arguments during tokenization/parsing phase.
+     *
+     * @param list<string> $args List of argument strings as they appear in the expression
+     *
+     * @throws InvalidArgumentException When arguments are invalid
+     */
+    public function validate(string $name, array $args): void;
+}

--- a/src/Symfony/Component/JsonPath/Functions/JsonPathFunctionsProvider.php
+++ b/src/Symfony/Component/JsonPath/Functions/JsonPathFunctionsProvider.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonPath\Functions;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\JsonPath\Exception\InvalidArgumentException;
+use Symfony\Component\JsonPath\Exception\UnknownJsonPathFunctionException;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ */
+final class JsonPathFunctionsProvider implements JsonPathFunctionsProviderInterface
+{
+    /**
+     * @var array<string, JsonPathFunctionInterface>
+     */
+    private array $functions = [];
+
+    public function __construct(
+        private readonly ?ContainerInterface $locator = null,
+    ) {
+        foreach ([
+            'length' => LengthFunction::class,
+            'count' => CountFunction::class,
+            'match' => MatchFunction::class,
+            'search' => SearchFunction::class,
+            'value' => ValueFunction::class,
+        ] as $name => $function) {
+            if (!$this->locator?->has($name)) {
+                $this->functions[$name] = $function;
+            } else {
+                throw new InvalidArgumentException(\sprintf('Function "%s" is already registered.', $name));
+            }
+        }
+    }
+
+    public function hasFunction(string $name): bool
+    {
+        return isset($this->functions[$name])
+            || $this->locator?->has($name);
+    }
+
+    public function getFunction(string $name): JsonPathFunctionInterface
+    {
+        if ($function = $this->functions[$name] ?? null) {
+            return \is_string($function) ? $this->functions[$name] = new $function() : $function;
+        }
+
+        if ($this->locator?->has($name)) {
+            return $this->locator->get($name);
+        }
+
+        throw new UnknownJsonPathFunctionException($name);
+    }
+}

--- a/src/Symfony/Component/JsonPath/Functions/JsonPathFunctionsProviderInterface.php
+++ b/src/Symfony/Component/JsonPath/Functions/JsonPathFunctionsProviderInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonPath\Functions;
+
+use Symfony\Component\JsonPath\Exception\InvalidArgumentException;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ */
+interface JsonPathFunctionsProviderInterface
+{
+    public function hasFunction(string $name): bool;
+
+    /**
+     * @throws InvalidArgumentException When the function is not available
+     */
+    public function getFunction(string $name): JsonPathFunctionInterface;
+}

--- a/src/Symfony/Component/JsonPath/Functions/LengthFunction.php
+++ b/src/Symfony/Component/JsonPath/Functions/LengthFunction.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonPath\Functions;
+
+use Symfony\Component\JsonPath\Nothing;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ *
+ * @internal
+ */
+final class LengthFunction implements JsonPathComparableFunctionInterface
+{
+    use JsonPathFunctionArgumentTrait;
+
+    public function __invoke(array $args, mixed $context): int|Nothing
+    {
+        $results = $args[0] ?? [];
+        $value = \is_array($results) ? ($results[0] ?? null) : $results;
+
+        return match (true) {
+            \is_string($value) => mb_strlen($value, 'UTF-8'),
+            $value instanceof Nothing, null === $value => Nothing::Nothing,
+            \is_array($value) => \count($value),
+            \is_object($value) => \count((array) $value),
+            default => 0,
+        };
+    }
+
+    public function validate(string $name, array $args): void
+    {
+        $this->assertArgumentsCount($name, $args, 1);
+        $this->assertIsSingularQuery($name, $args[0]);
+    }
+}

--- a/src/Symfony/Component/JsonPath/Functions/MatchFunction.php
+++ b/src/Symfony/Component/JsonPath/Functions/MatchFunction.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonPath\Functions;
+
+use Symfony\Component\JsonPath\JsonPathUtils;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ *
+ * @internal
+ */
+final class MatchFunction implements JsonPathFunctionInterface
+{
+    use JsonPathFunctionArgumentTrait;
+
+    public function __invoke(array $args, mixed $context): bool
+    {
+        $valueResults = $args[0] ?? [];
+        $patternResults = $args[1] ?? [];
+
+        $value = \is_array($valueResults) ? ($valueResults[0] ?? null) : $valueResults;
+        $pattern = \is_array($patternResults) ? ($patternResults[0] ?? null) : $patternResults;
+
+        return \is_string($value) && \is_string($pattern) && @preg_match(\sprintf('/^%s$/u', JsonPathUtils::normalizeRegex($pattern)), $value);
+    }
+
+    public function validate(string $name, array $args): void
+    {
+        $this->assertArgumentsCount($name, $args, 2);
+    }
+}

--- a/src/Symfony/Component/JsonPath/Functions/SearchFunction.php
+++ b/src/Symfony/Component/JsonPath/Functions/SearchFunction.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonPath\Functions;
+
+use Symfony\Component\JsonPath\JsonPathUtils;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ *
+ * @internal
+ */
+final class SearchFunction implements JsonPathFunctionInterface
+{
+    use JsonPathFunctionArgumentTrait;
+
+    public function __invoke(array $args, mixed $context): bool
+    {
+        $valueResults = $args[0] ?? [];
+        $patternResults = $args[1] ?? [];
+
+        $value = \is_array($valueResults) ? ($valueResults[0] ?? null) : $valueResults;
+        $pattern = \is_array($patternResults) ? ($patternResults[0] ?? null) : $patternResults;
+
+        return \is_string($value) && \is_string($pattern) && @preg_match('/'.JsonPathUtils::normalizeRegex($pattern).'/u', $value);
+    }
+
+    public function validate(string $name, array $args): void
+    {
+        $this->assertArgumentsCount($name, $args, 2);
+    }
+}

--- a/src/Symfony/Component/JsonPath/Functions/ValueFunction.php
+++ b/src/Symfony/Component/JsonPath/Functions/ValueFunction.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonPath\Functions;
+
+use Symfony\Component\JsonPath\Nothing;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ *
+ * @internal
+ */
+final class ValueFunction implements JsonPathComparableFunctionInterface
+{
+    use JsonPathFunctionArgumentTrait;
+
+    public function __invoke(array $args, mixed $context): mixed
+    {
+        $results = $args[0] ?? [];
+        if (!\is_array($results)) {
+            return $results;
+        }
+
+        return 1 === \count($results) ? $results[0] : Nothing::Nothing;
+    }
+
+    public function validate(string $name, array $args): void
+    {
+        $this->assertArgumentsCount($name, $args, 1);
+    }
+}

--- a/src/Symfony/Component/JsonPath/JsonCrawler.php
+++ b/src/Symfony/Component/JsonPath/JsonCrawler.php
@@ -15,6 +15,9 @@ use Symfony\Component\JsonPath\Exception\InvalidArgumentException;
 use Symfony\Component\JsonPath\Exception\InvalidJsonPathException;
 use Symfony\Component\JsonPath\Exception\InvalidJsonStringInputException;
 use Symfony\Component\JsonPath\Exception\JsonCrawlerException;
+use Symfony\Component\JsonPath\Functions\JsonPathComparableFunctionInterface;
+use Symfony\Component\JsonPath\Functions\JsonPathFunctionsProvider;
+use Symfony\Component\JsonPath\Functions\JsonPathFunctionsProviderInterface;
 use Symfony\Component\JsonPath\Tokenizer\JsonPathToken;
 use Symfony\Component\JsonPath\Tokenizer\JsonPathTokenizer;
 use Symfony\Component\JsonPath\Tokenizer\TokenType;
@@ -30,14 +33,6 @@ use Symfony\Component\JsonStreamer\Read\Splitter;
  */
 final class JsonCrawler implements JsonCrawlerInterface
 {
-    private const RFC9535_FUNCTIONS = [
-        'length' => true,
-        'count' => true,
-        'match' => true,
-        'search' => true,
-        'value' => true,
-    ];
-
     /**
      * Comparison operators and their corresponding lengths.
      */
@@ -50,15 +45,20 @@ final class JsonCrawler implements JsonCrawlerInterface
         '<' => 1,
     ];
 
+    private readonly JsonPathFunctionsProviderInterface $functionsProvider;
+
     /**
      * @param resource|string $raw
      */
     public function __construct(
         private readonly mixed $raw,
+        ?JsonPathFunctionsProviderInterface $functionsProvider = null,
     ) {
         if (!\is_string($raw) && !\is_resource($raw)) {
             throw new InvalidArgumentException(\sprintf('Expected string or resource, got "%s".', get_debug_type($raw)));
         }
+
+        $this->functionsProvider = $functionsProvider ?? new JsonPathFunctionsProvider();
     }
 
     public function find(string|JsonPath $query): array
@@ -69,6 +69,8 @@ final class JsonCrawler implements JsonCrawlerInterface
     private function evaluate(JsonPath $query): array
     {
         try {
+            $this->validateFilterExpressions($query);
+
             if ($this->isComplexBracketExpression($query)) {
                 preg_match('/^\$\[([^\[\]]+)]$/', $query, $matches);
 
@@ -91,7 +93,7 @@ final class JsonCrawler implements JsonCrawlerInterface
                 return $this->normalizeStorage($this->evaluateBracket($matches[1], $data));
             }
 
-            $tokens = JsonPathTokenizer::tokenize($query);
+            $tokens = JsonPathTokenizer::tokenize($query, $this->createFunctionValidator());
 
             if (\is_resource($json = $this->raw)) {
                 if (!class_exists(Splitter::class)) {
@@ -116,7 +118,7 @@ final class JsonCrawler implements JsonCrawlerInterface
                         throw new \RuntimeException('Failed to read from resource stream.');
                     }
 
-                    $tokens = JsonPathTokenizer::tokenize($query);
+                    $tokens = JsonPathTokenizer::tokenize($query, $this->createFunctionValidator());
                 }
             }
 
@@ -600,7 +602,7 @@ final class JsonCrawler implements JsonCrawlerInterface
         }
 
         if (str_starts_with($expr, '@.')) {
-            return $this->isArrayOrObject($context) && $this->evaluateTokensOnDecodedData(JsonPathTokenizer::tokenize(new JsonPath('$'.substr($expr, 1))), $context);
+            return $this->isArrayOrObject($context) && $this->evaluateTokensOnDecodedData(JsonPathTokenizer::tokenize(new JsonPath('$'.substr($expr, 1)), $this->createFunctionValidator()), $context);
         }
 
         if (str_starts_with($expr, '@[') && str_ends_with($expr, ']')) {
@@ -610,7 +612,7 @@ final class JsonCrawler implements JsonCrawlerInterface
         // function calls
         if (preg_match('/^(\w++)\s*+\((.*)\)$/', $expr, $matches)) {
             $functionName = trim($matches[1]);
-            if (!isset(self::RFC9535_FUNCTIONS[$functionName])) {
+            if (!$this->functionsProvider->hasFunction($functionName)) {
                 throw new JsonCrawlerException($expr, \sprintf('invalid function "%s"', $functionName));
             }
 
@@ -721,14 +723,15 @@ final class JsonCrawler implements JsonCrawlerInterface
                 return $result ? $result[0] : Nothing::Nothing;
             }
 
-            $results = $this->evaluateTokensOnDecodedData(JsonPathTokenizer::tokenize(new JsonPath('$'.$path)), $context);
+            $results = $this->evaluateTokensOnDecodedData(JsonPathTokenizer::tokenize(new JsonPath('$'.$path), $this->createFunctionValidator()), $context);
 
             return $results ? $results[0] : Nothing::Nothing;
         }
 
         // function calls
         if (preg_match('/^(\w++)\((.*)\)$/', $expr, $matches)) {
-            if (!isset(self::RFC9535_FUNCTIONS[$functionName = trim($matches[1])])) {
+            $functionName = trim($matches[1]);
+            if (!$this->functionsProvider->hasFunction($functionName)) {
                 throw new JsonCrawlerException($expr, \sprintf('invalid function "%s"', $functionName));
             }
 
@@ -741,60 +744,62 @@ final class JsonCrawler implements JsonCrawlerInterface
     private function evaluateFunction(string $name, string $args, mixed $context): mixed
     {
         $argList = [];
-        $nodelistSizes = [];
         if ($args = trim($args)) {
             $args = JsonPathUtils::parseCommaSeparatedValues($args);
             foreach ($args as $arg) {
                 $arg = trim($arg);
                 if (str_starts_with($arg, '$')) { // special handling for absolute paths
-                    $results = $this->evaluate(new JsonPath($arg));
-                    $argList[] = $results[0] ?? null;
-                    $nodelistSizes[] = \count($results);
+                    $argList[] = $this->evaluate(new JsonPath($arg));
                 } elseif (!str_starts_with($arg, '@')) { // special handling for @ to track nodelist size
-                    $argList[] = $this->evaluateScalar($arg, $context);
-                    $nodelistSizes[] = 1;
+                    $argList[] = [$this->evaluateScalar($arg, $context)];
                 } elseif ('@' === $arg) {
-                    $argList[] = $context;
-                    $nodelistSizes[] = 1;
+                    $argList[] = [$context];
                 } elseif (!$this->isArrayOrObject($context)) {
-                    $argList[] = null;
-                    $nodelistSizes[] = 0;
+                    $argList[] = [];
                 } elseif (str_starts_with($pathPart = substr($arg, 1), '[')) {
                     // handle bracket expressions like @['a','d']
                     $results = $this->evaluateBracket(substr($pathPart, 1, -1), $context);
                     $argList[] = $results;
-                    $nodelistSizes[] = \count($results);
                 } else {
                     // handle dot notation like @.a
-                    $results = $this->evaluateTokensOnDecodedData(JsonPathTokenizer::tokenize(new JsonPath('$'.$pathPart)), $context);
-                    $argList[] = $results[0] ?? null;
-                    $nodelistSizes[] = \count($results);
+                    $results = $this->evaluateTokensOnDecodedData(JsonPathTokenizer::tokenize(new JsonPath('$'.$pathPart), $this->createFunctionValidator()), $context);
+                    $argList[] = $results;
                 }
             }
         }
 
-        $value = $argList[0] ?? null;
-        $nodelistSize = $nodelistSizes[0] ?? 0;
+        if ($this->functionsProvider->hasFunction($name)) {
+            return $this->functionsProvider->getFunction($name)($argList, $context);
+        }
 
-        return match ($name) {
-            'length' => match (true) {
-                \is_string($value) => mb_strlen($value),
-                \is_array($value) => \count($value),
-                $value instanceof \stdClass => \count(get_object_vars($value)),
-                default => Nothing::Nothing,
-            },
-            'count' => $nodelistSize,
-            'match' => match (true) {
-                \is_string($value) && \is_string($argList[1] ?? null) => (bool) @preg_match(\sprintf('/^%s$/u', $this->transformJsonPathRegex($argList[1])), $value),
-                default => false,
-            },
-            'search' => match (true) {
-                \is_string($value) && \is_string($argList[1] ?? null) => (bool) @preg_match("/{$this->transformJsonPathRegex($argList[1])}/u", $value),
-                default => false,
-            },
-            'value' => 1 < $nodelistSize ? Nothing::Nothing : (1 === $nodelistSize ? (\is_array($value) ? ($value[0] ?? null) : $value) : $value),
-            default => null,
-        };
+        return null;
+    }
+
+    private function validateFilterExpressions(JsonPath $query): void
+    {
+        $queryString = (string) $query;
+
+        if (preg_match_all('/\[\?([^]]+)]/', $queryString, $matches)) {
+            foreach ($matches[1] as $filterExpr) {
+                $this->validateFunctionUsageInFilter(trim($filterExpr));
+            }
+        }
+    }
+
+    private function validateFunctionUsageInFilter(string $filterExpr): void
+    {
+        if (preg_match_all('/(\w+)\s*\([^)]*\)/', $filterExpr, $matches, \PREG_SET_ORDER)) {
+            foreach ($matches as $match) {
+                $functionName = $match[1];
+
+                if (preg_match('/^'.preg_quote($match[0], '/').'$/', $filterExpr)) {
+                    if ($this->functionsProvider->hasFunction($functionName)
+                        && $this->functionsProvider->getFunction($functionName) instanceof JsonPathComparableFunctionInterface) {
+                        throw new JsonCrawlerException($filterExpr, 'Function result must be compared.');
+                    }
+                }
+            }
+        }
     }
 
     private function evaluateRecursive(mixed $value): array
@@ -913,9 +918,12 @@ final class JsonCrawler implements JsonCrawlerInterface
 
     private function compareOrdering(mixed $left, mixed $right, string $operator): bool
     {
-        if (null === $left || null === $right) {
+        $leftIsNothing = Nothing::Nothing === $left;
+        $rightIsNothing = Nothing::Nothing === $right;
+
+        if (null === $left || null === $right || $leftIsNothing || $rightIsNothing) {
             return match ($operator) {
-                '>=', '<=' => $left === $right,
+                '>=', '<=' => $left === $right || $leftIsNothing && $rightIsNothing,
                 default => false,
             };
         }
@@ -940,7 +948,7 @@ final class JsonCrawler implements JsonCrawlerInterface
     private function isNonSingularQuery(string $expr): bool
     {
         try {
-            $tokens = JsonPathTokenizer::tokenize(new JsonPath($expr));
+            $tokens = JsonPathTokenizer::tokenize(new JsonPath($expr), $this->createFunctionValidator());
 
             foreach ($tokens as $token) {
                 if (TokenType::Bracket === $token->type) {
@@ -1034,35 +1042,6 @@ final class JsonCrawler implements JsonCrawlerInterface
         }
     }
 
-    /**
-     * Transforms JSONPath regex patterns to comply with RFC 9485.
-     *
-     * @see https://www.rfc-editor.org/rfc/rfc9485.html#name-pcre-re2-and-ruby-regexps
-     */
-    private function transformJsonPathRegex(string $pattern): string
-    {
-        $result = '';
-        $inCharClass = false;
-        $i = -1;
-
-        while (null !== $char = $pattern[++$i] ?? null) {
-            switch ($char) {
-                case '\\': $char .= $pattern[++$i] ?? '';
-                    break;
-                case '[': $inCharClass = true;
-                    break;
-                case ']': $inCharClass = false;
-                    break;
-                case '.': $inCharClass || $char = '[^\r\n]';
-                    break;
-            }
-
-            $result .= $char;
-        }
-
-        return $result;
-    }
-
     private function isArrayOrObject(mixed $value): bool
     {
         return \is_array($value) || $value instanceof \stdClass;
@@ -1102,5 +1081,18 @@ final class JsonCrawler implements JsonCrawlerInterface
     private function getValueIfKeyExists(mixed $value, string $key): array
     {
         return $this->isArrayOrObject($value) && \array_key_exists($key, $arrayValue = (array) $value) ? [$arrayValue[$key]] : [];
+    }
+
+    private function createFunctionValidator(): callable
+    {
+        return function (string $functionName, string $args): void {
+            if (!$this->functionsProvider->hasFunction($functionName)) {
+                return; // the crawler will handle unknown functions
+            }
+
+            $this->functionsProvider
+                ->getFunction($functionName)
+                ->validate($functionName, ($args = trim($args)) ? JsonPathUtils::parseCommaSeparatedValues($args) : []);
+        };
     }
 }

--- a/src/Symfony/Component/JsonPath/JsonPathUtils.php
+++ b/src/Symfony/Component/JsonPath/JsonPathUtils.php
@@ -263,4 +263,33 @@ final class JsonPathUtils
 
         return $negative ? $s < '-9007199254740991' : $s > '9007199254740991';
     }
+
+    /**
+     * Transforms JSONPath regex patterns to comply with RFC 9485.
+     *
+     * @see https://www.rfc-editor.org/rfc/rfc9485.html#name-pcre-re2-and-ruby-regexps
+     */
+    public static function normalizeRegex(string $pattern): string
+    {
+        $result = '';
+        $inCharClass = false;
+        $i = -1;
+
+        while (null !== $char = $pattern[++$i] ?? null) {
+            switch ($char) {
+                case '\\': $char .= $pattern[++$i] ?? '';
+                    break;
+                case '[': $inCharClass = true;
+                    break;
+                case ']': $inCharClass = false;
+                    break;
+                case '.': $inCharClass || $char = '[^\r\n]';
+                    break;
+            }
+
+            $result .= $char;
+        }
+
+        return $result;
+    }
 }

--- a/src/Symfony/Component/JsonPath/Tests/CustomFunctionTest.php
+++ b/src/Symfony/Component/JsonPath/Tests/CustomFunctionTest.php
@@ -1,0 +1,183 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonPath\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\JsonPath\Exception\JsonCrawlerException;
+use Symfony\Component\JsonPath\Functions\JsonPathComparableFunctionInterface;
+use Symfony\Component\JsonPath\Functions\JsonPathFunctionInterface;
+use Symfony\Component\JsonPath\Functions\JsonPathFunctionsProvider;
+use Symfony\Component\JsonPath\JsonCrawler;
+
+class CustomFunctionTest extends TestCase
+{
+    public function testCustomFunction()
+    {
+        $customFunction = new class implements JsonPathFunctionInterface {
+            public function getName(): string
+            {
+                return 'upper';
+            }
+
+            public function __invoke(array $args, mixed $context): ?string
+            {
+                $results = $args[0] ?? [];
+                $value = \is_array($results) ? ($results[0] ?? null) : $results;
+
+                return \is_string($value) ? strtoupper($value) : null;
+            }
+
+            public function validate(string $name, array $args): void
+            {
+            }
+        };
+
+        $locator = $this->createMock(ContainerInterface::class);
+        $locator->method('has')->willReturnCallback(fn ($name) => 'upper' === $name);
+        $locator->method('get')->willReturnCallback(fn ($name) => match ($name) {
+            'upper' => $customFunction,
+        });
+
+        $functionsProvider = new JsonPathFunctionsProvider($locator);
+
+        $crawler = new JsonCrawler(<<<JSON
+                {"name": "test", "items": [{"title": "hello"}, {"title": "world"}]}
+            JSON, $functionsProvider);
+
+        $result = $crawler->find('$.items[?upper(@.title) == "HELLO"]');
+        $this->assertCount(1, $result);
+        $this->assertEquals('hello', $result[0]['title']);
+    }
+
+    public function testCustomFunctionWithMultipleArguments()
+    {
+        $customFunction = new class implements JsonPathFunctionInterface {
+            public function getName(): string
+            {
+                return 'concat';
+            }
+
+            public function __invoke(array $args, mixed $context): string
+            {
+                $results1 = $args[0] ?? [];
+                $results2 = $args[1] ?? [];
+
+                $value1 = \is_array($results1) ? ($results1[0] ?? '') : $results1;
+                $value2 = \is_array($results2) ? ($results2[0] ?? '') : $results2;
+
+                return $value1.$value2;
+            }
+
+            public function validate(string $name, array $args): void
+            {
+            }
+        };
+
+        $locator = $this->createMock(ContainerInterface::class);
+        $locator->method('has')->willReturnCallback(fn ($name) => 'concat' === $name);
+        $locator->method('get')->willReturnCallback(fn ($name) => match ($name) {
+            'concat' => $customFunction,
+        });
+
+        $functionsProvider = new JsonPathFunctionsProvider($locator);
+        $crawler = new JsonCrawler(<<<JSON
+                {"items": [{"first": "hello", "second": "world"}, {"first": "foo", "second": "bar"}]}
+            JSON, $functionsProvider);
+
+        $result = $crawler->find('$.items[?concat(@.first, @.second) == "helloworld"]');
+        $this->assertCount(1, $result);
+        $this->assertEquals('hello', $result[0]['first']);
+        $this->assertEquals('world', $result[0]['second']);
+    }
+
+    public function testComparableFunctionRequiresComparison()
+    {
+        $comparableFunction = new class implements JsonPathComparableFunctionInterface {
+            public function getName(): string
+            {
+                return 'double';
+            }
+
+            public function __invoke(array $args, mixed $context): int|float
+            {
+                $results = $args[0] ?? [];
+                $value = \is_array($results) ? ($results[0] ?? 0) : $results;
+
+                return is_numeric($value) ? $value * 2 : 0;
+            }
+
+            public function validate(string $name, array $args): void
+            {
+            }
+        };
+
+        $locator = $this->createMock(ContainerInterface::class);
+        $locator->method('has')->willReturnCallback(fn ($name) => 'double' === $name);
+        $locator->method('get')->willReturnCallback(fn ($name) => match ($name) {
+            'double' => $comparableFunction,
+        });
+
+        $functionsProvider = new JsonPathFunctionsProvider($locator);
+        $crawler = new JsonCrawler(<<<JSON
+                {"items": [{"value": 5}, {"value": 10}]}
+            JSON, $functionsProvider);
+
+        $result = $crawler->find('$.items[?double(@.value) > 15]');
+        $this->assertCount(1, $result);
+        $this->assertEquals(10, $result[0]['value']);
+
+        $this->expectException(JsonCrawlerException::class);
+        $this->expectExceptionMessage('Function result must be compared');
+
+        $crawler->find('$.items[?double(@.value)]');
+    }
+
+    public function testBooleanFunctionWorksStandalone()
+    {
+        $booleanFunction = new class implements JsonPathFunctionInterface {
+            public function getName(): string
+            {
+                return 'is_positive';
+            }
+
+            public function __invoke(array $args, mixed $context): bool
+            {
+                $results = $args[0] ?? [];
+                $value = \is_array($results) ? ($results[0] ?? 0) : $results;
+
+                return is_numeric($value) && $value > 0;
+            }
+
+            public function validate(string $name, array $args): void
+            {
+            }
+        };
+
+        $locator = $this->createMock(ContainerInterface::class);
+        $locator->method('has')->willReturnCallback(fn ($name) => 'is_positive' === $name);
+        $locator->method('get')->willReturnCallback(fn ($name) => match ($name) {
+            'is_positive' => $booleanFunction,
+        });
+
+        $functionsProvider = new JsonPathFunctionsProvider($locator);
+        $crawler = new JsonCrawler(<<<JSON
+                {"items": [{"value": 5}, {"value": -3}, {"value": 10}]}
+            JSON, $functionsProvider);
+
+        $result = $crawler->find('$.items[?is_positive(@.value)]');
+
+        $this->assertCount(2, $result);
+        $this->assertEquals(5, $result[0]['value']);
+        $this->assertEquals(10, $result[1]['value']);
+    }
+}

--- a/src/Symfony/Component/JsonPath/Tests/JsonPath/Functions/CountFunctionTest.php
+++ b/src/Symfony/Component/JsonPath/Tests/JsonPath/Functions/CountFunctionTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonPath\Tests\JsonPath\Functions;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\JsonPath\Functions\CountFunction;
+
+class CountFunctionTest extends TestCase
+{
+    private CountFunction $function;
+
+    protected function setUp(): void
+    {
+        $this->function = new CountFunction();
+    }
+
+    public function testInvokeWithArrayResults()
+    {
+        $this->assertSame(3, ($this->function)([['a', 'b', 'c']], 'context'));
+    }
+
+    public function testInvokeWithEmptyArray()
+    {
+        $this->assertSame(0, ($this->function)([[]], 'context'));
+    }
+
+    public function testInvokeWithNoArgs()
+    {
+        $this->assertSame(0, ($this->function)([], 'context'));
+    }
+
+    public function testInvokeWithNonArrayResults()
+    {
+        $this->assertSame(0, ($this->function)(['string'], 'context'));
+    }
+
+    public function testInvokeWithNullResults()
+    {
+        $this->assertSame(0, ($this->function)([null], 'context'));
+    }
+
+    public function testInvokeWithNumericResults()
+    {
+        $this->assertSame(0, ($this->function)([123], 'context'));
+    }
+
+    public function testValidateWithCorrectArgumentCount()
+    {
+        $this->function->validate('count', ['@.items']);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testValidateThrowsExceptionWithIncorrectArgumentCount()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('the JsonPath function "count" requires exactly 1 argument(s).');
+
+        $this->function->validate('count', []);
+    }
+
+    public function testValidateThrowsExceptionWithTooManyArguments()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('the JsonPath function "count" requires exactly 1 argument(s).');
+
+        $this->function->validate('count', ['@.items', '@.other']);
+    }
+
+    #[DataProvider('invalidLiteralArgumentProvider')]
+    public function testValidateThrowsExceptionWithLiteralArgument(string $literal)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('the JsonPath function "count" requires a query argument, not a literal.');
+
+        $this->function->validate('count', [$literal]);
+    }
+
+    public static function invalidLiteralArgumentProvider(): \Generator
+    {
+        yield 'numeric literal' => ['123'];
+        yield 'string literal' => ['"string"'];
+        yield 'boolean literal' => ['true'];
+        yield 'null literal' => ['null'];
+        yield 'float literal' => ['3.14'];
+        yield 'scientific notation literal' => ['1e10'];
+    }
+
+    public function testValidateWithValidQuery()
+    {
+        $this->function->validate('count', ['@.items[*]']);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testValidateWithRootQuery()
+    {
+        $this->function->validate('count', ['$.items']);
+
+        $this->expectNotToPerformAssertions();
+    }
+}

--- a/src/Symfony/Component/JsonPath/Tests/JsonPath/Functions/JsonPathFunctionArgumentTraitTest.php
+++ b/src/Symfony/Component/JsonPath/Tests/JsonPath/Functions/JsonPathFunctionArgumentTraitTest.php
@@ -1,0 +1,128 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonPath\Tests\JsonPath\Functions;
+
+use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\JsonPath\Functions\JsonPathFunctionArgumentTrait;
+
+#[CoversTrait(JsonPathFunctionArgumentTrait::class)]
+class JsonPathFunctionArgumentTraitTest extends TestCase
+{
+    private object $trait;
+
+    protected function setUp(): void
+    {
+        $this->trait = new class {
+            use JsonPathFunctionArgumentTrait;
+        };
+    }
+
+    public function testAssertArgumentsCountWithCorrectCount()
+    {
+        $this->trait->assertArgumentsCount('test', ['arg1', 'arg2'], 2);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testAssertArgumentsCountWithIncorrectCount()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('the JsonPath function "test" requires exactly 3 argument(s).');
+
+        $this->trait->assertArgumentsCount('test', ['arg1', 'arg2'], 3);
+    }
+
+    public function testAssertArgumentsCountWithZeroExpected()
+    {
+        $this->trait->assertArgumentsCount('test', [], 0);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testAssertArgumentsCountWithZeroActual()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('the JsonPath function "test" requires exactly 1 argument(s).');
+
+        $this->trait->assertArgumentsCount('test', [], 1);
+    }
+
+    #[DataProvider('validSingularQueryProvider')]
+    public function testAssertIsSingularQueryWithValidQuery(string $query)
+    {
+        $this->trait->assertIsSingularQuery('test', $query);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public static function validSingularQueryProvider(): \Generator
+    {
+        yield 'current query' => ['@.name'];
+        yield 'root query' => ['$.name'];
+        yield 'bracket query' => ['@["name"]'];
+        yield 'query with spaces' => ['  @.name  '];
+        yield 'array wildcard query' => ['@.items[*]'];
+        yield 'nested wildcard query' => ['@.items.*.name'];
+    }
+
+    #[DataProvider('nonSingularQueryProvider')]
+    public function testAssertIsSingularQueryWithNonSingularQuery(string $query)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('the JsonPath function "test" argument must be a singular query.');
+
+        $this->trait->assertIsSingularQuery('test', $query);
+    }
+
+    public static function nonSingularQueryProvider(): \Generator
+    {
+        yield 'wildcard query' => ['@.*'];
+    }
+
+    #[DataProvider('validQueryProvider')]
+    public function testAssertIsQueryWithValidQuery(string $query)
+    {
+        $this->trait->assertIsQuery('test', $query);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public static function validQueryProvider(): \Generator
+    {
+        yield 'current query' => ['@.items'];
+        yield 'root query' => ['$.items'];
+        yield 'complex query' => ['@.items[?(@.active == true)]'];
+    }
+
+    #[DataProvider('literalArgumentProvider')]
+    public function testAssertIsQueryWithLiteral(string $literal)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('the JsonPath function "test" requires a query argument, not a literal.');
+
+        $this->trait->assertIsQuery('test', $literal);
+    }
+
+    public static function literalArgumentProvider(): \Generator
+    {
+        yield 'numeric literal' => ['123'];
+        yield 'float literal' => ['3.14'];
+        yield 'string literal' => ['"hello"'];
+        yield 'single quoted string literal' => ["'hello'"];
+        yield 'boolean true literal' => ['true'];
+        yield 'boolean false literal' => ['false'];
+        yield 'null literal' => ['null'];
+        yield 'scientific notation literal' => ['1e10'];
+    }
+}

--- a/src/Symfony/Component/JsonPath/Tests/JsonPath/Functions/JsonPathFunctionsProviderTest.php
+++ b/src/Symfony/Component/JsonPath/Tests/JsonPath/Functions/JsonPathFunctionsProviderTest.php
@@ -1,0 +1,170 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonPath\Tests\JsonPath\Functions;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\JsonPath\Exception\UnknownJsonPathFunctionException;
+use Symfony\Component\JsonPath\Functions\JsonPathFunctionInterface;
+use Symfony\Component\JsonPath\Functions\JsonPathFunctionsProvider;
+
+class JsonPathFunctionsProviderTest extends TestCase
+{
+    public function testConstructorWithEmptyFunctionsStillContainsCoreFunctions()
+    {
+        $provider = new JsonPathFunctionsProvider();
+
+        $this->assertTrue($provider->hasFunction('length'));
+        $this->assertTrue($provider->hasFunction('count'));
+        $this->assertTrue($provider->hasFunction('search'));
+        $this->assertTrue($provider->hasFunction('value'));
+        $this->assertTrue($provider->hasFunction('match'));
+    }
+
+    public function testItThrowsOnGettingAnUnknownFunction()
+    {
+        $provider = new JsonPathFunctionsProvider();
+
+        $this->expectException(UnknownJsonPathFunctionException::class);
+        $this->expectExceptionMessage('Unknown JSONPath function "unknownFunc".');
+
+        $provider->getFunction('unknownFunc');
+    }
+
+    public function testConstructorWithFunctions()
+    {
+        $function1 = $this->createMock(JsonPathFunctionInterface::class);
+
+        $function2 = $this->createMock(JsonPathFunctionInterface::class);
+
+        $locator = $this->createMock(ContainerInterface::class);
+        $locator->method('has')->willReturnCallback(fn ($name) => \in_array($name, ['func1', 'func2'], true));
+        $locator->method('get')->willReturnCallback(fn ($name) => match ($name) {
+            'func1' => $function1,
+            'func2' => $function2,
+        });
+
+        $provider = new JsonPathFunctionsProvider($locator);
+
+        $this->assertTrue($provider->hasFunction('func1'));
+        $this->assertTrue($provider->hasFunction('func2'));
+        $this->assertTrue($provider->hasFunction('length'));
+        $this->assertTrue($provider->hasFunction('count'));
+        $this->assertTrue($provider->hasFunction('search'));
+        $this->assertTrue($provider->hasFunction('value'));
+        $this->assertTrue($provider->hasFunction('match'));
+    }
+
+    public function testAddFunction()
+    {
+        $function = $this->createMock(JsonPathFunctionInterface::class);
+
+        $provider = new JsonPathFunctionsProvider($this->createLocatorWithFunctions(['testFunc' => $function]));
+
+        $this->assertTrue($provider->hasFunction('testFunc'));
+        $this->assertInstanceOf(JsonPathFunctionInterface::class, $provider->getFunction('testFunc'));
+    }
+
+    public function testAddFunctionThrowsExceptionWhenFunctionAlreadyExists()
+    {
+        $function1 = $this->createMock(JsonPathFunctionInterface::class);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Function "value" is already registered.');
+
+        new JsonPathFunctionsProvider($this->createLocatorWithFunctions(['value' => $function1]));
+    }
+
+    public function testHasFunction()
+    {
+        $function = $this->createMock(JsonPathFunctionInterface::class);
+
+        $provider = new JsonPathFunctionsProvider();
+        $this->assertFalse($provider->hasFunction('nonExistingFunc'));
+
+        $provider = new JsonPathFunctionsProvider($this->createLocatorWithFunctions(['existingFunc' => $function]));
+        $this->assertTrue($provider->hasFunction('existingFunc'));
+    }
+
+    public function testGetFunctions()
+    {
+        $function1 = $this->createMock(JsonPathFunctionInterface::class);
+
+        $function2 = $this->createMock(JsonPathFunctionInterface::class);
+
+        $provider = new JsonPathFunctionsProvider($this->createLocatorWithFunctions(['func1' => $function1, 'func2' => $function2]));
+
+        $this->assertInstanceOf(JsonPathFunctionInterface::class, $provider->getFunction('func1'));
+        $this->assertInstanceOf(JsonPathFunctionInterface::class, $provider->getFunction('func2'));
+    }
+
+    public function testExecuteFunction()
+    {
+        $function = $this->createMock(JsonPathFunctionInterface::class);
+        $function->method('__invoke')->with(['arg1', 'arg2'], 'context')->willReturn('result');
+
+        $provider = new JsonPathFunctionsProvider($this->createLocatorWithFunctions(['testFunc' => $function]));
+        $result = $provider->getFunction('testFunc')(['arg1', 'arg2'], 'context');
+
+        $this->assertSame('result', $result);
+    }
+
+    public function testExecuteFunctionThrowsExceptionWhenFunctionNotAvailable()
+    {
+        $provider = new JsonPathFunctionsProvider();
+
+        $this->expectException(UnknownJsonPathFunctionException::class);
+        $this->expectExceptionMessage('Unknown JSONPath function "nonExistingFunc".');
+
+        $provider->getFunction('nonExistingFunc')([], 'context');
+    }
+
+    public function testExecuteFunctionWithNodelistSizes()
+    {
+        $function = $this->createMock(JsonPathFunctionInterface::class);
+        $function->method('__invoke')->with(['arg1', 'arg2'], 'context')->willReturn('result');
+
+        $provider = new JsonPathFunctionsProvider($this->createLocatorWithFunctions(['testFunc' => $function]));
+
+        $result = $provider->getFunction('testFunc')(['arg1', 'arg2'], 'context');
+        $this->assertSame('result', $result);
+    }
+
+    public function testExecuteFunctionWithNodelistSizesForNodelistAwareFunction()
+    {
+        $function = $this->createMock(JsonPathFunctionInterface::class);
+        $function->method('__invoke')->with(['arg1', 'arg2'], 'context')->willReturn('result');
+
+        $provider = new JsonPathFunctionsProvider($this->createLocatorWithFunctions(['testFunc' => $function]));
+
+        $result = $provider->getFunction('testFunc')(['arg1', 'arg2'], 'context');
+        $this->assertSame('result', $result);
+    }
+
+    public function testExecuteFunctionWithNodelistSizesThrowsExceptionWhenFunctionNotAvailable()
+    {
+        $provider = new JsonPathFunctionsProvider();
+
+        $this->expectException(UnknownJsonPathFunctionException::class);
+        $this->expectExceptionMessage('Unknown JSONPath function "nonExistingFunc".');
+        $provider->getFunction('nonExistingFunc');
+    }
+
+    private function createLocatorWithFunctions(array $functions): ContainerInterface
+    {
+        $locator = $this->createMock(ContainerInterface::class);
+        $locator->method('has')->willReturnCallback(fn ($name) => \in_array($name, array_keys($functions), true));
+        $locator->method('get')->willReturnCallback(fn ($name) => $functions[$name]);
+
+        return $locator;
+    }
+}

--- a/src/Symfony/Component/JsonPath/Tests/JsonPath/Functions/LengthFunctionTest.php
+++ b/src/Symfony/Component/JsonPath/Tests/JsonPath/Functions/LengthFunctionTest.php
@@ -1,0 +1,130 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonPath\Tests\JsonPath\Functions;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\JsonPath\Functions\LengthFunction;
+use Symfony\Component\JsonPath\Nothing;
+
+class LengthFunctionTest extends TestCase
+{
+    private LengthFunction $function;
+
+    protected function setUp(): void
+    {
+        $this->function = new LengthFunction();
+    }
+
+    public function testInvokeWithStringValue()
+    {
+        $this->assertSame(5, ($this->function)([['hello']], 'context'));
+    }
+
+    public function testInvokeWithEmptyString()
+    {
+        $this->assertSame(0, ($this->function)([['']], 'context'));
+    }
+
+    public function testInvokeWithUnicodeString()
+    {
+        $this->assertSame(5, ($this->function)([['h🐘llo']], 'context'));
+    }
+
+    public function testInvokeWithArrayValue()
+    {
+        $this->assertSame(3, ($this->function)([[['a', 'b', 'c']]], 'context'));
+    }
+
+    public function testInvokeWithEmptyArray()
+    {
+        $this->assertSame(0, ($this->function)([[[]]], 'context'));
+    }
+
+    public function testInvokeWithNullValue()
+    {
+        $this->assertSame(Nothing::Nothing, ($this->function)([[null]], 'context'));
+    }
+
+    public function testInvokeWithNumericValue()
+    {
+        $this->assertSame(0, ($this->function)([[123]], 'context'));
+    }
+
+    public function testInvokeWithBooleanValue()
+    {
+        $this->assertSame(0, ($this->function)([[true]], 'context'));
+    }
+
+    public function testInvokeWithNonArrayResults()
+    {
+        $this->assertSame(5, ($this->function)(['hello'], 'context'));
+    }
+
+    public function testInvokeWithNoArgs()
+    {
+        $this->assertSame(Nothing::Nothing, ($this->function)([], 'context'));
+    }
+
+    public function testInvokeWithEmptyArrayResults()
+    {
+        $this->assertSame(Nothing::Nothing, ($this->function)([[]], 'context'));
+    }
+
+    public function testValidateWithCorrectArgumentCount()
+    {
+        $this->function->validate('length', ['@.name']);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testValidateThrowsExceptionWithIncorrectArgumentCount()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('the JsonPath function "length" requires exactly 1 argument(s).');
+
+        $this->function->validate('length', []);
+    }
+
+    public function testValidateThrowsExceptionWithTooManyArguments()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('the JsonPath function "length" requires exactly 1 argument(s).');
+
+        $this->function->validate('length', ['@.name', '@.other']);
+    }
+
+    public function testValidateThrowsExceptionWithNonSingularQuery()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('the JsonPath function "length" argument must be a singular query.');
+
+        $this->function->validate('length', ['@.*']);
+    }
+
+    #[DataProvider('validSingularQueryProvider')]
+    public function testValidateWithValidSingularQuery(string $query)
+    {
+        $this->function->validate('length', [$query]);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public static function validSingularQueryProvider(): \Generator
+    {
+        yield 'current query' => ['@.name'];
+        yield 'root query' => ['$.name'];
+        yield 'bracket notation' => ['@["name"]'];
+        yield 'array wildcard query' => ['@.items[*]'];
+        yield 'nested wildcard query' => ['@.items.*.name'];
+    }
+}

--- a/src/Symfony/Component/JsonPath/Tests/JsonPath/Functions/MatchFunctionTest.php
+++ b/src/Symfony/Component/JsonPath/Tests/JsonPath/Functions/MatchFunctionTest.php
@@ -1,0 +1,152 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonPath\Tests\JsonPath\Functions;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\JsonPath\Functions\MatchFunction;
+
+class MatchFunctionTest extends TestCase
+{
+    private MatchFunction $function;
+
+    protected function setUp(): void
+    {
+        $this->function = new MatchFunction();
+    }
+
+    public function testInvokeWithMatchingStrings()
+    {
+        $this->assertTrue(($this->function)([['hello'], ['hello']], 'context'));
+    }
+
+    public function testInvokeWithNonMatchingStrings()
+    {
+        $this->assertFalse(($this->function)([['hello'], ['world']], 'context'));
+    }
+
+    public function testInvokeWithRegexPattern()
+    {
+        $this->assertTrue(($this->function)([['hello123'], ['hello\\d+']], 'context'));
+    }
+
+    public function testInvokeWithNonMatchingRegexPattern()
+    {
+        $this->assertFalse(($this->function)([['hello'], ['\\d+']], 'context'));
+    }
+
+    public function testInvokeWithCaseInsensitivePattern()
+    {
+        $this->assertFalse(($this->function)([['Hello'], ['hello']], 'context'));
+    }
+
+    public function testInvokeWithDotPattern()
+    {
+        $this->assertTrue(($this->function)([['a'], ['.']], 'context'));
+    }
+
+    public function testInvokeWithStartAnchor()
+    {
+        $this->assertFalse(($this->function)([['hello world'], ['hello']], 'context'));
+    }
+
+    public function testInvokeWithEndAnchor()
+    {
+        $this->assertFalse(($this->function)([['hello world'], ['world']], 'context'));
+    }
+
+    public function testInvokeWithFullMatch()
+    {
+        $this->assertTrue(($this->function)([['hello world'], ['hello world']], 'context'));
+    }
+
+    public function testInvokeWithNonStringValue()
+    {
+        $this->assertFalse(($this->function)([[123], ['123']], 'context'));
+    }
+
+    public function testInvokeWithNonStringPattern()
+    {
+        $this->assertFalse(($this->function)([['hello'], [123]], 'context'));
+    }
+
+    public function testInvokeWithNullValue()
+    {
+        $this->assertFalse(($this->function)([[null], ['pattern']], 'context'));
+    }
+
+    public function testInvokeWithNullPattern()
+    {
+        $this->assertFalse(($this->function)([['value'], [null]], 'context'));
+    }
+
+    public function testInvokeWithEmptyArgs()
+    {
+        $this->assertFalse(($this->function)([], 'context'));
+    }
+
+    public function testInvokeWithSingleArg()
+    {
+        $this->assertFalse(($this->function)([['value']], 'context'));
+    }
+
+    public function testInvokeWithNonArrayResults()
+    {
+        $this->assertTrue(($this->function)(['hello', 'hello'], 'context'));
+    }
+
+    public function testInvokeWithUnicodeString()
+    {
+        $this->assertTrue(($this->function)([['héllo'], ['héllo']], 'context'));
+    }
+
+    public function testInvokeWithInvalidRegex()
+    {
+        $this->assertFalse(($this->function)([['hello'], ['[']], 'context'));
+    }
+
+    #[DataProvider('invalidRegexPatternProvider')]
+    public function testInvokeWithInvalidRegexPatterns(string $invalidPattern)
+    {
+        $this->assertFalse(($this->function)([['hello'], [$invalidPattern]], 'context'));
+    }
+
+    public static function invalidRegexPatternProvider(): \Generator
+    {
+        yield 'unclosed bracket' => ['['];
+        yield 'unclosed parenthesis' => ['('];
+        yield 'invalid quantifier' => ['*'];
+    }
+
+    public function testValidateWithCorrectArgumentCount()
+    {
+        $this->function->validate('match', ['@.name', '"pattern"']);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[DataProvider('invalidArgumentCountProvider')]
+    public function testValidateThrowsExceptionWithIncorrectArgumentCount(array $args)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('the JsonPath function "match" requires exactly 2 argument(s).');
+
+        $this->function->validate('match', $args);
+    }
+
+    public static function invalidArgumentCountProvider(): \Generator
+    {
+        yield 'no arguments' => [[]];
+        yield 'one argument' => [['@.name']];
+        yield 'three arguments' => [['@.name', '"pattern"', 'extra']];
+    }
+}

--- a/src/Symfony/Component/JsonPath/Tests/JsonPath/Functions/SearchFunctionTest.php
+++ b/src/Symfony/Component/JsonPath/Tests/JsonPath/Functions/SearchFunctionTest.php
@@ -1,0 +1,164 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonPath\Tests\JsonPath\Functions;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\JsonPath\Functions\SearchFunction;
+
+class SearchFunctionTest extends TestCase
+{
+    private SearchFunction $function;
+
+    protected function setUp(): void
+    {
+        $this->function = new SearchFunction();
+    }
+
+    public function testInvokeWithMatchingSubstring()
+    {
+        $result = ($this->function)([['hello world'], ['world']], 'context');
+        $this->assertTrue($result);
+    }
+
+    public function testInvokeWithNonMatchingSubstring()
+    {
+        $this->assertFalse(($this->function)([['hello world'], ['xyz']], 'context'));
+    }
+
+    public function testInvokeWithRegexPattern()
+    {
+        $this->assertTrue(($this->function)([['hello123'], ['\\d+']], 'context'));
+    }
+
+    public function testInvokeWithNonMatchingRegexPattern()
+    {
+        $this->assertFalse(($this->function)([['hello'], ['\\d+']], 'context'));
+    }
+
+    public function testInvokeWithCaseInsensitivePattern()
+    {
+        $this->assertFalse(($this->function)([['Hello World'], ['hello']], 'context'));
+    }
+
+    public function testInvokeWithDotPattern()
+    {
+        $this->assertTrue(($this->function)([['abc'], ['.']], 'context'));
+    }
+
+    public function testInvokeWithStartOfString()
+    {
+        $this->assertTrue(($this->function)([['hello world'], ['hello']], 'context'));
+    }
+
+    public function testInvokeWithEndOfString()
+    {
+        $this->assertTrue(($this->function)([['hello world'], ['world']], 'context'));
+    }
+
+    public function testInvokeWithMiddleOfString()
+    {
+        $this->assertTrue(($this->function)([['hello world'], ['o w']], 'context'));
+    }
+
+    public function testInvokeWithNonStringValue()
+    {
+        $this->assertFalse(($this->function)([[123], ['123']], 'context'));
+    }
+
+    public function testInvokeWithNonStringPattern()
+    {
+        $this->assertFalse(($this->function)([['hello'], [123]], 'context'));
+    }
+
+    public function testInvokeWithNullValue()
+    {
+        $this->assertFalse(($this->function)([[null], ['pattern']], 'context'));
+    }
+
+    public function testInvokeWithNullPattern()
+    {
+        $this->assertFalse(($this->function)([['value'], [null]], 'context'));
+    }
+
+    public function testInvokeWithEmptyArgs()
+    {
+        $this->assertFalse(($this->function)([], 'context'));
+    }
+
+    public function testInvokeWithSingleArg()
+    {
+        $this->assertFalse(($this->function)([['value']], 'context'));
+    }
+
+    public function testInvokeWithNonArrayResults()
+    {
+        $this->assertTrue(($this->function)(['hello world', 'world'], 'context'));
+    }
+
+    public function testInvokeWithUnicodeString()
+    {
+        $this->assertTrue(($this->function)([['héllo world'], ['héllo']], 'context'));
+    }
+
+    public function testInvokeWithInvalidRegex()
+    {
+        $this->assertFalse(($this->function)([['hello'], ['[']], 'context'));
+    }
+
+    #[DataProvider('invalidRegexPatternProvider')]
+    public function testInvokeWithInvalidRegexPatterns(string $invalidPattern)
+    {
+        $this->assertFalse(($this->function)([['hello'], [$invalidPattern]], 'context'));
+    }
+
+    public static function invalidRegexPatternProvider(): \Generator
+    {
+        yield 'unclosed bracket' => ['['];
+        yield 'unclosed parenthesis' => ['('];
+        yield 'invalid quantifier' => ['*'];
+        yield 'invalid escape sequence' => ['\\'];
+    }
+
+    public function testInvokeWithEmptyString()
+    {
+        $this->assertTrue(($this->function)([[''], ['']], 'context'));
+    }
+
+    public function testInvokeWithEmptyPattern()
+    {
+        $this->assertTrue(($this->function)([['hello'], ['']], 'context'));
+    }
+
+    public function testValidateWithCorrectArgumentCount()
+    {
+        $this->function->validate('search', ['@.name', '"pattern"']);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[DataProvider('invalidArgumentCountProvider')]
+    public function testValidateThrowsExceptionWithIncorrectArgumentCount(array $args)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('the JsonPath function "search" requires exactly 2 argument(s).');
+
+        $this->function->validate('search', $args);
+    }
+
+    public static function invalidArgumentCountProvider(): \Generator
+    {
+        yield 'no arguments' => [[]];
+        yield 'one argument' => [['@.name']];
+        yield 'three arguments' => [['@.name', '"pattern"', 'extra']];
+    }
+}

--- a/src/Symfony/Component/JsonPath/Tests/JsonPath/Functions/ValueFunctionTest.php
+++ b/src/Symfony/Component/JsonPath/Tests/JsonPath/Functions/ValueFunctionTest.php
@@ -1,0 +1,138 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonPath\Tests\JsonPath\Functions;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\JsonPath\Functions\ValueFunction;
+use Symfony\Component\JsonPath\Nothing;
+
+class ValueFunctionTest extends TestCase
+{
+    private ValueFunction $function;
+
+    protected function setUp(): void
+    {
+        $this->function = new ValueFunction();
+    }
+
+    public function testInvokeWithSingleValue()
+    {
+        $this->assertSame('hello', ($this->function)([['hello']], 'context'));
+    }
+
+    public function testInvokeWithMultipleValues()
+    {
+        $this->assertSame(Nothing::Nothing, ($this->function)([['hello', 'world']], 'context'));
+    }
+
+    public function testInvokeWithEmptyArray()
+    {
+        $this->assertSame(Nothing::Nothing, ($this->function)([[]], 'context'));
+    }
+
+    public function testInvokeWithNoArgs()
+    {
+        $this->assertSame(Nothing::Nothing, ($this->function)([], 'context'));
+    }
+
+    public function testInvokeWithNonArrayResults()
+    {
+        $this->assertSame('hello', ($this->function)(['hello'], 'context'));
+    }
+
+    public function testInvokeWithNullValue()
+    {
+        $this->assertNull(($this->function)([[null]], 'context'));
+    }
+
+    public function testInvokeWithNumericValue()
+    {
+        $this->assertSame(123, ($this->function)([[123]], 'context'));
+    }
+
+    public function testInvokeWithBooleanValue()
+    {
+        $this->assertTrue(($this->function)([[true]], 'context'));
+    }
+
+    public function testInvokeWithArrayValue()
+    {
+        $this->assertSame(['a', 'b'], ($this->function)([[['a', 'b']]], 'context'));
+    }
+
+    public function testInvokeWithObjectValue()
+    {
+        $object = ['key' => 'value'];
+        $this->assertSame($object, ($this->function)([[$object]], 'context'));
+    }
+
+    public function testInvokeWithFloatValue()
+    {
+        $this->assertSame(3.14, ($this->function)([[3.14]], 'context'));
+    }
+
+    public function testInvokeWithZeroValue()
+    {
+        $this->assertSame(0, ($this->function)([[0]], 'context'));
+    }
+
+    public function testInvokeWithEmptyStringValue()
+    {
+        $this->assertSame('', ($this->function)([['']], 'context'));
+    }
+
+    public function testInvokeWithFalseValue()
+    {
+        $this->assertFalse(($this->function)([[false]], 'context'));
+    }
+
+    public function testInvokeWithThreeValues()
+    {
+        $this->assertSame(Nothing::Nothing, ($this->function)([['a', 'b', 'c']], 'context'));
+    }
+
+    public function testValidateWithCorrectArgumentCount()
+    {
+        $this->function->validate('value', ['@.name']);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[DataProvider('invalidArgumentCountProvider')]
+    public function testValidateThrowsExceptionWithIncorrectArgumentCount(array $args)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('the JsonPath function "value" requires exactly 1 argument(s).');
+        $this->function->validate('value', $args);
+    }
+
+    public static function invalidArgumentCountProvider(): \Generator
+    {
+        yield 'no arguments' => [[]];
+        yield 'two arguments' => [['@.name', '@.other']];
+    }
+
+    #[DataProvider('validQueryProvider')]
+    public function testValidateWithValidQuery(string $query)
+    {
+        $this->function->validate('value', [$query]);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public static function validQueryProvider(): \Generator
+    {
+        yield 'indexed query' => ['@.items[0]'];
+        yield 'root query' => ['$.name'];
+    }
+}

--- a/src/Symfony/Component/JsonPath/Tokenizer/JsonPathTokenizer.php
+++ b/src/Symfony/Component/JsonPath/Tokenizer/JsonPathTokenizer.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\JsonPath\Tokenizer;
 
 use Symfony\Component\JsonPath\Exception\InvalidJsonPathException;
 use Symfony\Component\JsonPath\JsonPath;
-use Symfony\Component\JsonPath\JsonPathUtils;
 
 /**
  * @author Alexandre Daubois <alex.daubois@gmail.com>
@@ -26,9 +25,11 @@ final class JsonPathTokenizer
     private const BARE_LITERAL_REGEX = '(true|false|null|\d+(\.\d+)?([eE][+-]?\d+)?|\'[^\']*\'|"[^"]*")';
 
     /**
+     * @param callable(string $functionName, list<string> $args): void|null $functionValidator
+     *
      * @return JsonPathToken[]
      */
-    public static function tokenize(JsonPath $query): array
+    public static function tokenize(JsonPath $query, ?callable $functionValidator = null): array
     {
         $tokens = [];
         $current = '';
@@ -166,7 +167,7 @@ final class JsonPathTokenizer
                             throw new InvalidJsonPathException('unclosed bracket.', $position);
                         }
 
-                        self::validateFilterExpression($current, $position);
+                        self::validateFilterExpression($current, $position, $functionValidator);
                     }
 
                     $tokens[] = new JsonPathToken(TokenType::Bracket, $current);
@@ -295,9 +296,12 @@ final class JsonPathTokenizer
         return $index;
     }
 
-    private static function validateFilterExpression(string $expr, int $position): void
+    /**
+     * @param callable(string $functionName, list<string> $args): void $functionValidator
+     */
+    private static function validateFilterExpression(string $expr, int $position, ?callable $functionValidator): void
     {
-        self::validateBareLiterals($expr, $position);
+        self::validateBareLiterals($expr, $position, $functionValidator);
 
         $filterExpr = ltrim($expr, '?');
         $filterExpr = trim($filterExpr);
@@ -350,7 +354,10 @@ final class JsonPathTokenizer
         }
     }
 
-    private static function validateBareLiterals(string $expr, int $position): void
+    /**
+     * @param callable(string $functionName, string $args): void|null $functionValidator
+     */
+    private static function validateBareLiterals(string $expr, int $position, ?callable $functionValidator): void
     {
         $filterExpr = ltrim($expr, '?');
         $filterExpr = trim($filterExpr);
@@ -359,42 +366,16 @@ final class JsonPathTokenizer
             throw new InvalidJsonPathException('Incorrectly capitalized literal in filter expression.', $position);
         }
 
-        if (preg_match('/^(length|count|value)\s*\([^)]*\)$/', $filterExpr)) {
-            throw new InvalidJsonPathException('Function result must be compared.', $position);
-        }
+        if ($functionValidator && preg_match_all('/(\w+)\s*\(([^)]*)\)/', $filterExpr, $matches, \PREG_SET_ORDER)) {
+            foreach ($matches as $match) {
+                $functionName = $match[1];
+                $args = trim($match[2]);
 
-        if (preg_match('/\b(length|count|value)\s*\(([^)]*)\)/', $filterExpr, $matches)) {
-            $functionName = $matches[1];
-            $args = trim($matches[2]);
-            if (!$args) {
-                throw new InvalidJsonPathException('Function requires exactly one argument.', $position);
-            }
-
-            $argParts = JsonPathUtils::parseCommaSeparatedValues($args);
-            if (1 !== \count($argParts)) {
-                throw new InvalidJsonPathException('Function requires exactly one argument.', $position);
-            }
-
-            $arg = trim($argParts[0]);
-
-            if ('count' === $functionName && preg_match('/^'.self::BARE_LITERAL_REGEX.'$/', $arg)) {
-                throw new InvalidJsonPathException('count() function requires a query argument, not a literal.', $position);
-            }
-
-            if ('length' === $functionName && preg_match('/@\.\*/', $arg)) {
-                throw new InvalidJsonPathException('Function argument must be a singular query.', $position);
-            }
-        }
-
-        if (preg_match('/\b(match|search)\s*\(([^)]*)\)/', $filterExpr, $matches)) {
-            $args = trim($matches[2]);
-            if (!$args) {
-                throw new InvalidJsonPathException('Function requires exactly two arguments.', $position);
-            }
-
-            $argParts = JsonPathUtils::parseCommaSeparatedValues($args);
-            if (2 !== \count($argParts)) {
-                throw new InvalidJsonPathException('Function requires exactly two arguments.', $position);
+                try {
+                    $functionValidator($functionName, $args);
+                } catch (\InvalidArgumentException $e) {
+                    throw new InvalidJsonPathException($e->getMessage(), $position, previous: $e);
+                }
             }
         }
 
@@ -406,8 +387,8 @@ final class JsonPathTokenizer
             throw new InvalidJsonPathException('Bare literals in logical expression - literals must be compared.', $position);
         }
 
-        if (preg_match('/\b(match|search|length|count|value)\s*\([^)]*\)\s*[=!]=\s*(true|false)\b/', $filterExpr)
-            || preg_match('/\b(true|false)\s*[=!]=\s*(match|search|length|count|value)\s*\([^)]*\)/', $filterExpr)) {
+        if (preg_match('/\b(\w+)\s*\([^)]*\)\s*[=!]=\s*(true|false)\b/', $filterExpr)
+            || preg_match('/\b(true|false)\s*[=!]=\s*(\w+)\s*\([^)]*\)/', $filterExpr)) {
             throw new InvalidJsonPathException('Function result cannot be compared to boolean literal.', $position);
         }
 

--- a/src/Symfony/Component/JsonPath/composer.json
+++ b/src/Symfony/Component/JsonPath/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=8.4",
+        "psr/container": "^1.1|^2.0",
         "symfony/polyfill-ctype": "^1.8",
         "symfony/polyfill-mbstring": "^1.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

⚠️ May be replaced by #62823

This PR allows to create custom JsonPath functions thanks to the `#[AsJsonPathFunction]` attribute:

```php
<?php

namespace App\JsonPath;

use Symfony\Component\JsonPath\Functions\AbstractJsonPathFunction;
use Symfony\Component\JsonPath\Functions\AsJsonPathFunction;
use Symfony\Component\JsonPath\Functions\JsonPathFunctionArgumentTrait;

#[AsJsonPathFunction(name: 'upper')]
final class UpperFunction extends AbstractJsonPathFunction
{
    use JsonPathFunctionArgumentTrait;

    public function __invoke(array $args, mixed $context): ?string
    {
        $results = $args[0] ?? [];
        $value = \is_array($results) ? ($results[0] ?? null) : $results;

        return \is_string($value) ? strtoupper($value) : null;
    }

    public function validate(array $args): void
    {
        self::assertArgumentsCount($args, 1);
    }
}
```

Then, it's used like this:

```php
<?php

namespace App\Command;

// ...

#[AsCommand(name: 'cmd', description: 'Hello PhpStorm')]
class MyCommand extends Command
{
    public function __construct(
        private JsonPathFunctionsProviderInterface $jsonPathFunctionsProvider,
    ) {
        parent::__construct();
    }

    protected function execute(InputInterface $input, OutputInterface $output): int
    {
        $crawler = new JsonCrawler(<<<JSON
            {"name": "test", "items": [{"title": "hello"}, {"title": "world"}]}
        JSON, $this->jsonPathFunctionsProvider); // <-- provide the functions provider

        $result = $crawler->find('$.items[?upper(@.title) == "HELLO"]');

        dump($result);

        return Command::SUCCESS;
    }
}
```

All RFC built-in functions are converted to use the new `AbstractJsonPathFunction` to avoid special case handling in the crawler code. This uses the approach detailed here: https://github.com/symfony/symfony/pull/60624#issuecomment-2944699883. What's also nice is that built-in functions now have their very own unit tests as well.