### PR TITLE
[HttpKernel] Handle an array vary header in the http cache store for write

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/Store.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Store.php
@@ -211,13 +211,9 @@ class Store implements StoreInterface
 
         // read existing cache entries, remove non-varying, and add this one to the list
         $entries = [];
-        $vary = $response->headers->get('vary');
+        $vary = implode(', ', $response->headers->all('vary'));
         foreach ($this->getMetadata($key) as $entry) {
-            if (!isset($entry[1]['vary'][0])) {
-                $entry[1]['vary'] = [''];
-            }
-
-            if ($entry[1]['vary'][0] != $vary || !$this->requestsMatch($vary ?? '', $entry[0], $storedEnv)) {
+            if (!$this->requestsMatch($vary ?? '', $entry[0], $storedEnv)) {
                 $entries[] = $entry;
             }
         }
@@ -285,7 +281,7 @@ class Store implements StoreInterface
      */
     private function requestsMatch(?string $vary, array $env1, array $env2): bool
     {
-        if (empty($vary)) {
+        if ('' === ($vary ?? '')) {
             return true;
         }
 

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/StoreTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/StoreTest.php
@@ -349,6 +349,127 @@ class StoreTest extends TestCase
         $this->assertSame($content, $response->getContent());
     }
 
+    /**
+     * Basic case when the second header has a different value.
+     * Both responses should be cached
+     */
+    public function testWriteWithMultipleVaryAndCachedAllResponse()
+    {
+        $req1 = Request::create('/foo', 'get', [], [], [], ['HTTP_FOO' => 'foo', 'HTTP_BAR' => 'bar']);
+        $content = str_repeat('a', 24).'b'.str_repeat('a', 24);
+        $res1 = new Response($content, 200, ['vary' => ['Foo', 'Bar'], 'X-Body-Eval' => 'SSI']);
+        $this->store->write($req1, $res1);
+
+        $responseLook = $this->store->lookup($req1);
+        $this->assertSame($content, $responseLook->getContent());
+
+        $req2 = Request::create('/foo', 'get', [], [], [], ['HTTP_FOO' => 'foo', 'HTTP_BAR' => 'foobar']);
+        $content2 = str_repeat('b', 24).'a'.str_repeat('b', 24);
+        $res2 = new Response($content2, 200, ['vary' => ['Foo', 'Bar'], 'X-Body-Eval' => 'SSI']);
+        $this->store->write($req2, $res2);
+
+        $responseLook = $this->store->lookup($req2);
+        $this->assertSame($content2, $responseLook->getContent());
+
+        $responseLook = $this->store->lookup($req1);
+        $this->assertSame($content, $responseLook->getContent());
+    }
+
+    /**
+     * Basic case when the second header has the same value on both requests.
+     * The last response should be cached
+     */
+    public function testWriteWithMultipleVaryAndCachedLastResponse()
+    {
+        $req1 = Request::create('/foo', 'get', [], [], [], ['HTTP_FOO' => 'foo', 'HTTP_BAR' => 'bar']);
+        $content = str_repeat('a', 24).'b'.str_repeat('a', 24);
+        $res1 = new Response($content, 200, ['vary' => ['Foo', 'Bar'], 'X-Body-Eval' => 'SSI']);
+        $this->store->write($req1, $res1);
+
+        $responseLook = $this->store->lookup($req1);
+        $this->assertSame($content, $responseLook->getContent());
+
+        $req2 = Request::create('/foo', 'get', [], [], [], ['HTTP_FOO' => 'foo', 'HTTP_BAR' => 'bar']);
+        $content2 = str_repeat('b', 24).'a'.str_repeat('b', 24);
+        $res2 = new Response($content2, 200, ['vary' => ['Foo', 'Bar'], 'X-Body-Eval' => 'SSI']);
+        $this->store->write($req2, $res2);
+
+        $responseLook = $this->store->lookup($req2);
+        $this->assertSame($content2, $responseLook->getContent());
+
+        $responseLook = $this->store->lookup($req1);
+        $this->assertSame($content2, $responseLook->getContent());
+    }
+
+    /**
+     * Case when a vary value has been removed.
+     * Both responses should be cached
+     */
+    public function testWriteWithChangingVary()
+    {
+        $req1 = Request::create('/foo', 'get', [], [], [], ['HTTP_FOO' => 'foo', 'HTTP_BAR' => 'bar']);
+        $content = str_repeat('a', 24).'b'.str_repeat('a', 24);
+        $res1 = new Response($content, 200, ['vary' => ['Foo', 'bar', 'foobar'], 'X-Body-Eval' => 'SSI']);
+        $this->store->write($req1, $res1);
+
+        $req2 = Request::create('/foo', 'get', [], [], [], ['HTTP_FOO' => 'foo', 'HTTP_FOOBAR' => 'bar']);
+        $content2 = str_repeat('b', 24).'a'.str_repeat('b', 24);
+        $res2 = new Response($content2, 200, ['vary' => ['Foo', 'foobar'], 'X-Body-Eval' => 'SSI']);
+        $this->store->write($req2, $res2);
+
+        $responseLook = $this->store->lookup($req2);
+        $this->assertSame($content2, $responseLook->getContent());
+
+        $responseLook = $this->store->lookup($req1);
+        $this->assertSame($content, $responseLook->getContent());
+    }
+
+    /**
+     * Case when a vary value has been removed and headers of the new vary list are the same.
+     * The last response should be cached
+     */
+    public function testWriteWithRemoveVaryAndAllHeadersOnTheList()
+    {
+        $req1 = Request::create('/foo', 'get', [], [], [], ['HTTP_FOO' => 'foo', 'HTTP_FOOBAR' => 'bar',]);
+        $content = str_repeat('a', 24).'b'.str_repeat('a', 24);
+        $res1 = new Response($content, 200, ['vary' => ['Foo', 'bar', 'foobar'], 'X-Body-Eval' => 'SSI']);
+        $this->store->write($req1, $res1);
+
+        $req2 = Request::create('/foo', 'get', [], [], [], ['HTTP_FOO' => 'foo', 'HTTP_FOOBAR' => 'bar']);
+        $content2 = str_repeat('b', 24).'a'.str_repeat('b', 24);
+        $res2 = new Response($content2, 200, ['vary' => ['Foo', 'foobar'], 'X-Body-Eval' => 'SSI']);
+        $this->store->write($req2, $res2);
+
+        $responseLook = $this->store->lookup($req2);
+        $this->assertSame($content2, $responseLook->getContent());
+
+        $responseLook = $this->store->lookup($req1);
+        $this->assertSame($content2, $responseLook->getContent());
+    }
+
+    /**
+     * Case when a vary value has been added and headers of the new vary list are the same.
+     * The last response should be cached
+     */
+    public function testWriteWithAddingVaryAndAllHeadersOnTheList()
+    {
+        $req1 = Request::create('/foo', 'get', [], [], [], ['HTTP_FOO' => 'foo', 'HTTP_FOOBAR' => 'bar']);
+        $content = str_repeat('a', 24).'b'.str_repeat('a', 24);
+        $res1 = new Response($content, 200, ['vary' => ['Foo', 'foobar'], 'X-Body-Eval' => 'SSI']);
+        $this->store->write($req1, $res1);
+
+        $req2 = Request::create('/foo', 'get', [], [], [], ['HTTP_FOO' => 'foo', 'HTTP_BAR' => 'foobar', 'HTTP_FOOBAR' => 'bar']);
+        $content2 = str_repeat('b', 24).'a'.str_repeat('b', 24);
+        $res2 = new Response($content2, 200, ['vary' => ['Foo', 'bar', 'foobar'], 'X-Body-Eval' => 'SSI']);
+        $this->store->write($req2, $res2);
+
+        $responseLook = $this->store->lookup($req2);
+        $this->assertSame($content2, $responseLook->getContent());
+
+        $responseLook = $this->store->lookup($req1);
+        $this->assertSame($content, $responseLook->getContent());
+    }
+
     protected function storeSimpleEntry($path = null, $headers = [])
     {
         $path ??= '/test';


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Issues        | -
| License       | MIT

We can have multiple vary on a response : 
```
< HTTP/1.1 200 OK
< Content-Type: application/json
< Vary: Accept-Encoding
< Vary: Foo
< Content-Length: 1234
```

But if we make several calls with different value for the header `Foo`, we don't check them and remove the previous responses.

This fix has the purpose to check all values to keep previous call

Releated to #14635 