### PR TITLE
[HttpFoundation] Add route attribute to `Request`

### DIFF
--- a/src/Symfony/Bridge/Monolog/Processor/RouteProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/RouteProcessor.php
@@ -14,6 +14,7 @@ namespace Symfony\Bridge\Monolog\Processor;
 use Monolog\LogRecord;
 use Monolog\ResettableInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -63,7 +64,7 @@ class RouteProcessor implements EventSubscriberInterface, ResetInterface, Resett
 
         $currentRequestData = [
             'controller' => $request->attributes->get('_controller'),
-            'route' => $request->attributes->get('_route'),
+            'route' => $request->attributes->get(Request::ATTRIBUTE_ROUTE),
         ];
 
         if ($this->includeParams) {

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/RouteProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/RouteProcessorTest.php
@@ -144,7 +144,7 @@ class RouteProcessorTest extends TestCase
     {
         return $this->mockRequest([
             '_controller' => $controller,
-            '_route' => self::TEST_ROUTE,
+            Request::ATTRIBUTE_ROUTE => self::TEST_ROUTE,
             '_route_params' => self::TEST_PARAMS,
         ]);
     }

--- a/src/Symfony/Bridge/Twig/AppVariable.php
+++ b/src/Symfony/Bridge/Twig/AppVariable.php
@@ -199,7 +199,7 @@ class AppVariable
             throw new \RuntimeException('The "app.current_route" variable is not available.');
         }
 
-        return $this->getRequest()?->attributes->get('_route');
+        return $this->getRequest()?->attributes->get(Request::ATTRIBUTE_ROUTE);
     }
 
     /**

--- a/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
@@ -253,7 +253,7 @@ class AppVariableTest extends TestCase
 
     public function testGetCurrentRoute()
     {
-        $this->setRequestStack(new Request(attributes: ['_route' => 'some_route']));
+        $this->setRequestStack(new Request(attributes: [Request::ATTRIBUTE_ROUTE => 'some_route']));
 
         $this->assertSame('some_route', $this->appVariable->getCurrent_route());
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
@@ -172,7 +172,7 @@ class RedirectController
 
         if (\array_key_exists('route', $p)) {
             if (\array_key_exists('path', $p)) {
-                throw new \RuntimeException(\sprintf('Ambiguous redirection settings, use the "path" or "route" parameter, not both: "%s" and "%s" found respectively in "%s" routing configuration.', $p['path'], $p['route'], $request->attributes->get('_route')));
+                throw new \RuntimeException(\sprintf('Ambiguous redirection settings, use the "path" or "route" parameter, not both: "%s" and "%s" found respectively in "%s" routing configuration.', $p['path'], $p['route'], $request->attributes->get(Request::ATTRIBUTE_ROUTE)));
             }
 
             return $this->redirectAction($request, $p['route'], $p['permanent'] ?? false, $p['ignoreAttributes'] ?? false, $p['keepRequestMethod'] ?? false, $p['keepQueryParams'] ?? false);
@@ -182,6 +182,6 @@ class RedirectController
             return $this->urlRedirectAction($request, $p['path'], $p['permanent'] ?? false, $p['scheme'] ?? null, $p['httpPort'] ?? null, $p['httpsPort'] ?? null, $p['keepRequestMethod'] ?? false);
         }
 
-        throw new \RuntimeException(\sprintf('The parameter "path" or "route" is required to configure the redirect action in "%s" routing configuration.', $request->attributes->get('_route')));
+        throw new \RuntimeException(\sprintf('The parameter "path" or "route" is required to configure the redirect action in "%s" routing configuration.', $request->attributes->get(Request::ATTRIBUTE_ROUTE)));
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/DataCollector/RouterDataCollector.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DataCollector/RouterDataCollector.php
@@ -28,8 +28,8 @@ class RouterDataCollector extends BaseRouterDataCollector
             $controller = $controller[0];
         }
 
-        if ($controller instanceof RedirectController && $request->attributes->has('_route')) {
-            return $request->attributes->get('_route');
+        if ($controller instanceof RedirectController && $request->attributes->has(Request::ATTRIBUTE_ROUTE)) {
+            return $request->attributes->get(Request::ATTRIBUTE_ROUTE);
         }
 
         return parent::guessRoute($request, $controller);

--- a/src/Symfony/Bundle/FrameworkBundle/Routing/RedirectableCompiledUrlMatcher.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/RedirectableCompiledUrlMatcher.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Routing;
 
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Matcher\CompiledUrlMatcher;
 use Symfony\Component\Routing\Matcher\RedirectableUrlMatcherInterface;
 
@@ -30,7 +31,7 @@ class RedirectableCompiledUrlMatcher extends CompiledUrlMatcher implements Redir
             'scheme' => $scheme,
             'httpPort' => $this->context->getHttpPort(),
             'httpsPort' => $this->context->getHttpsPort(),
-            '_route' => $route,
+            Request::ATTRIBUTE_ROUTE => $route,
         ];
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Test/BrowserKitAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/BrowserKitAssertionsTrait.php
@@ -170,7 +170,7 @@ trait BrowserKitAssertionsTrait
 
     public static function assertRouteSame(string $expectedRoute, array $parameters = [], string $message = ''): void
     {
-        $constraint = new ResponseConstraint\RequestAttributeValueSame('_route', $expectedRoute);
+        $constraint = new ResponseConstraint\RequestAttributeValueSame(Request::ATTRIBUTE_ROUTE, $expectedRoute);
         $constraints = [];
         foreach ($parameters as $key => $value) {
             $constraints[] = new ResponseConstraint\RequestAttributeValueSame($key, $value);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/RedirectControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/RedirectControllerTest.php
@@ -71,7 +71,7 @@ class RedirectControllerTest extends TestCase
         $attributes = [
             'route' => $route,
             'permanent' => $permanent,
-            '_route' => 'current-route',
+            Request::ATTRIBUTE_ROUTE => 'current-route',
             '_route_params' => [
                 'route' => $route,
                 'permanent' => $permanent,
@@ -350,7 +350,7 @@ class RedirectControllerTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('The parameter "path" or "route" is required to configure the redirect action in "_redirect" routing configuration.');
 
-        (new RedirectController())(new Request([], [], ['_route' => '_redirect']));
+        (new RedirectController())(new Request([], [], [Request::ATTRIBUTE_ROUTE => '_redirect']));
     }
 
     public function testAmbiguousPathAndRouteParameter()
@@ -358,7 +358,7 @@ class RedirectControllerTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Ambiguous redirection settings, use the "path" or "route" parameter, not both: "/foo" and "bar" found respectively in "_redirect" routing configuration.');
 
-        (new RedirectController())(new Request([], [], ['_route' => '_redirect', '_route_params' => ['path' => '/foo', 'route' => 'bar']]));
+        (new RedirectController())(new Request([], [], [Request::ATTRIBUTE_ROUTE => '_redirect', '_route_params' => ['path' => '/foo', 'route' => 'bar']]));
     }
 
     private function createRequestObject($scheme, $host, $port, $baseUrl, $queryString = '')

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DataCollector/RouterDataCollectorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DataCollector/RouterDataCollectorTest.php
@@ -43,7 +43,7 @@ class RouterDataCollectorTest extends TestCase
         $collector = new RouterDataCollector();
 
         $request = Request::create('http://test.com/foo?bar=baz');
-        $request->attributes->set('_route', 'current-route');
+        $request->attributes->set(Request::ATTRIBUTE_ROUTE, 'current-route');
 
         $response = new RedirectResponse('http://test.com/redirect');
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RedirectableCompiledUrlMatcherTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RedirectableCompiledUrlMatcherTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Routing;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\Routing\RedirectableCompiledUrlMatcher;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Matcher\Dumper\CompiledUrlMatcherDumper;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\Route;
@@ -35,7 +36,7 @@ class RedirectableCompiledUrlMatcherTest extends TestCase
                 'scheme' => null,
                 'httpPort' => $context->getHttpPort(),
                 'httpsPort' => $context->getHttpsPort(),
-                '_route' => 'foo',
+                Request::ATTRIBUTE_ROUTE => 'foo',
             ],
             $matcher->match('/foo')
         );
@@ -56,7 +57,7 @@ class RedirectableCompiledUrlMatcherTest extends TestCase
                 'scheme' => 'https',
                 'httpPort' => $context->getHttpPort(),
                 'httpsPort' => $context->getHttpsPort(),
-                '_route' => 'foo',
+                Request::ATTRIBUTE_ROUTE => 'foo',
             ],
             $matcher->match('/foo')
         );

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Test/WebTestCaseTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Test/WebTestCaseTest.php
@@ -419,7 +419,7 @@ class WebTestCaseTest extends TestCase
         $client = $this->createMock(KernelBrowser::class);
         $request = new Request();
         $request->attributes->set('foo', 'bar');
-        $request->attributes->set('_route', 'homepage');
+        $request->attributes->set(Request::ATTRIBUTE_ROUTE, 'homepage');
         $client->expects($this->any())->method('getRequest')->willReturn($request);
 
         return $this->getTester($client);

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -37,6 +37,7 @@ use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Form\Extension\PasswordHasher\PasswordHasherExtension;
 use Symfony\Component\HttpFoundation\ChainRequestMatcher;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestMatcher\AttributesRequestMatcher;
 use Symfony\Component\HttpFoundation\RequestMatcher\HostRequestMatcher;
 use Symfony\Component\HttpFoundation\RequestMatcher\IpsRequestMatcher;
@@ -225,10 +226,10 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
                 $attributes = $access['attributes'];
 
                 if ($access['route']) {
-                    if (\array_key_exists('_route', $attributes)) {
+                    if (\array_key_exists(Request::ATTRIBUTE_ROUTE, $attributes)) {
                         throw new InvalidConfigurationException('The "route" option should not be specified alongside "attributes._route" option. Use just one of the options.');
                     }
-                    $attributes['_route'] = $access['route'];
+                    $attributes[Request::ATTRIBUTE_ROUTE] = $access['route'];
                 }
 
                 $matcher = $this->createRequestMatcher(

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTestCase.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTestCase.php
@@ -20,6 +20,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestMatcher\AttributesRequestMatcher;
 use Symfony\Component\HttpFoundation\RequestMatcher\HostRequestMatcher;
 use Symfony\Component\HttpFoundation\RequestMatcher\MethodRequestMatcher;
@@ -334,7 +335,7 @@ abstract class CompleteConfigurationTestCase extends TestCase
                 $this->assertEquals(['ROLE_ADMIN'], $attributes);
                 $def = $container->getDefinition((string) $requestMatcher->getArgument(0)[0]);
                 $this->assertSame(AttributesRequestMatcher::class, $def->getClass());
-                $this->assertSame(['_controller' => 'AdminController::index', '_route' => 'admin'], $def->getArgument(0));
+                $this->assertSame(['_controller' => 'AdminController::index', Request::ATTRIBUTE_ROUTE => 'admin'], $def->getArgument(0));
             }
         }
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -316,7 +316,7 @@ class SecurityExtensionTest extends TestCase
         yield 'Invalid configuration with port' => [['port' => 80]];
         yield 'Invalid configuration with methods' => [['methods' => ['POST']]];
         yield 'Invalid configuration with ips' => [['ips' => ['0.0.0.0']]];
-        yield 'Invalid configuration with attributes' => [['attributes' => ['_route' => 'foo_route']]];
+        yield 'Invalid configuration with attributes' => [['attributes' => [Request::ATTRIBUTE_ROUTE => 'foo_route']]];
         yield 'Invalid configuration with route' => [['route' => 'foo_route']];
     }
 
@@ -334,7 +334,7 @@ class SecurityExtensionTest extends TestCase
                 ],
             ],
             'access_control' => [
-                ['attributes' => ['_route' => 'foo_route']],
+                ['attributes' => [Request::ATTRIBUTE_ROUTE => 'foo_route']],
             ],
         ]);
 
@@ -351,8 +351,8 @@ class SecurityExtensionTest extends TestCase
         $attributesRequestMatcher = $container->getDefinition((string) $chainRequestMatcherConstructorArguments[0][0]);
 
         $this->assertCount(1, $attributesRequestMatcher->getArguments());
-        $this->assertArrayHasKey('_route', $attributesRequestMatcher->getArgument(0));
-        $this->assertSame('foo_route', $attributesRequestMatcher->getArgument(0)['_route']);
+        $this->assertArrayHasKey(Request::ATTRIBUTE_ROUTE, $attributesRequestMatcher->getArgument(0));
+        $this->assertSame('foo_route', $attributesRequestMatcher->getArgument(0)[Request::ATTRIBUTE_ROUTE]);
     }
 
     public function testRegisterAccessControlWithSpecifiedRoute()
@@ -386,8 +386,8 @@ class SecurityExtensionTest extends TestCase
         $attributesRequestMatcher = $container->getDefinition((string) $chainRequestMatcherConstructorArguments[0][0]);
 
         $this->assertCount(1, $attributesRequestMatcher->getArguments());
-        $this->assertArrayHasKey('_route', $attributesRequestMatcher->getArgument(0));
-        $this->assertSame('foo_route', $attributesRequestMatcher->getArgument(0)['_route']);
+        $this->assertArrayHasKey(Request::ATTRIBUTE_ROUTE, $attributesRequestMatcher->getArgument(0));
+        $this->assertSame('foo_route', $attributesRequestMatcher->getArgument(0)[Request::ATTRIBUTE_ROUTE]);
     }
 
     public function testRegisterAccessControlWithSpecifiedAttributesThrowsException()
@@ -404,7 +404,7 @@ class SecurityExtensionTest extends TestCase
                 ],
             ],
             'access_control' => [
-                ['route' => 'anything', 'attributes' => ['_route' => 'foo_route']],
+                ['route' => 'anything', 'attributes' => [Request::ATTRIBUTE_ROUTE => 'foo_route']],
             ],
         ]);
 

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -42,6 +42,8 @@ class_exists(ServerBag::class);
  */
 class Request
 {
+    public const ATTRIBUTE_ROUTE = '_route';
+
     public const HEADER_FORWARDED = 0b000001; // When using RFC 7239
     public const HEADER_X_FORWARDED_FOR = 0b000010;
     public const HEADER_X_FORWARDED_HOST = 0b000100;

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -49,7 +49,7 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
         $attributes = [];
         $route = '';
         foreach ($request->attributes->all() as $key => $value) {
-            if ('_route' === $key) {
+            if (Request::ATTRIBUTE_ROUTE === $key) {
                 $route = \is_object($value) ? $value->getPath() : $value;
                 $attributes[$key] = $route;
             } else {
@@ -155,7 +155,7 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
                 'sf_redirect',
                 json_encode([
                     'token' => $response->headers->get('x-debug-token'),
-                    'route' => $request->attributes->get('_route', 'n/a'),
+                    'route' => $request->attributes->get(Request::ATTRIBUTE_ROUTE, 'n/a'),
                     'method' => $request->getMethod(),
                     'controller' => $this->parseController($request->attributes->get('_controller')),
                     'status_code' => $statusCode,

--- a/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
@@ -104,7 +104,7 @@ class RouterListener implements EventSubscriberInterface
             }
 
             $this->logger?->info('Matched route "{route}".', [
-                'route' => $parameters['_route'] ?? 'n/a',
+                'route' => $parameters[Request::ATTRIBUTE_ROUTE] ?? 'n/a',
                 'route_parameters' => $parameters,
                 'request_uri' => $request->getUri(),
                 'method' => $request->getMethod(),
@@ -144,7 +144,7 @@ class RouterListener implements EventSubscriberInterface
             }
 
             $request->attributes->add($attributes);
-            unset($parameters['_route'], $parameters['_controller']);
+            unset($parameters[Request::ATTRIBUTE_ROUTE], $parameters['_controller']);
             $request->attributes->set('_route_params', $parameters);
         } catch (ResourceNotFoundException $e) {
             $message = \sprintf('No route found for "%s %s"', $request->getMethod(), $request->getUriForPath($request->getPathInfo()));

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
@@ -360,7 +360,7 @@ class RequestDataCollectorTest extends TestCase
     {
         $request = Request::create('http://test.com/foo?bar=baz');
         $request->attributes->set('foo', 'bar');
-        $request->attributes->set('_route', 'foobar');
+        $request->attributes->set(Request::ATTRIBUTE_ROUTE, 'foobar');
         $request->attributes->set('_route_params', $routeParams);
         $request->attributes->set('resource', fopen(__FILE__, 'r'));
         $request->attributes->set('object', new \stdClass());

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
@@ -144,7 +144,7 @@ class RouterListenerTest extends TestCase
     public static function getLoggingParameterData()
     {
         return [
-            [['_route' => 'foo'], 'Matched route "{route}".', ['route' => 'foo', 'route_parameters' => ['_route' => 'foo'], 'request_uri' => 'http://localhost/', 'method' => 'GET']],
+            [[Request::ATTRIBUTE_ROUTE => 'foo'], 'Matched route "{route}".', ['route' => 'foo', 'route_parameters' => [Request::ATTRIBUTE_ROUTE => 'foo'], 'request_uri' => 'http://localhost/', 'method' => 'GET']],
             [[], 'Matched route "{route}".', ['route' => 'n/a', 'route_parameters' => [], 'request_uri' => 'http://localhost/', 'method' => 'GET']],
         ];
     }

--- a/src/Symfony/Component/Routing/Matcher/Dumper/CompiledUrlMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/CompiledUrlMatcherDumper.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Routing\Matcher\Dumper;
 
 use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
@@ -261,7 +262,7 @@ class CompiledUrlMatcherDumper extends MatcherDumper
             'vars' => [],
         ];
         $state->getVars = static function ($m) use ($state) {
-            if ('_route' === $m[1]) {
+            if (Request::ATTRIBUTE_ROUTE === $m[1]) {
                 return '?:';
             }
 
@@ -430,7 +431,7 @@ class CompiledUrlMatcherDumper extends MatcherDumper
         }
 
         return [
-            ['_route' => $name] + $defaults,
+            [Request::ATTRIBUTE_ROUTE => $name] + $defaults,
             $vars,
             array_flip($route->getMethods()) ?: null,
             array_flip($route->getSchemes()) ?: null,

--- a/src/Symfony/Component/Routing/Matcher/Dumper/CompiledUrlMatcherTrait.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/CompiledUrlMatcherTrait.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Routing\Matcher\Dumper;
 
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Routing\Exception\NoConfigurationException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
@@ -52,7 +53,7 @@ trait CompiledUrlMatcherTrait
             $this->context->setScheme(key($allowSchemes));
             try {
                 if ($ret = $this->doMatch($pathinfo)) {
-                    return $this->redirect($pathinfo, $ret['_route'], $this->context->getScheme()) + $ret;
+                    return $this->redirect($pathinfo, $ret[Request::ATTRIBUTE_ROUTE], $this->context->getScheme()) + $ret;
                 }
             } finally {
                 $this->context->setScheme($scheme);
@@ -60,7 +61,7 @@ trait CompiledUrlMatcherTrait
         } elseif ('/' !== $trimmedPathinfo = rtrim($pathinfo, '/') ?: '/') {
             $pathinfo = $trimmedPathinfo === $pathinfo ? $pathinfo.'/' : $trimmedPathinfo;
             if ($ret = $this->doMatch($pathinfo, $allow, $allowSchemes)) {
-                return $this->redirect($pathinfo, $ret['_route']) + $ret;
+                return $this->redirect($pathinfo, $ret[Request::ATTRIBUTE_ROUTE]) + $ret;
             }
             if ($allowSchemes) {
                 goto redirect_scheme;
@@ -93,7 +94,7 @@ trait CompiledUrlMatcherTrait
                     continue;
                 }
                 if ('{' === $requiredHost[0] && $hostMatches) {
-                    $hostMatches['_route'] = $ret['_route'];
+                    $hostMatches[Request::ATTRIBUTE_ROUTE] = $ret[Request::ATTRIBUTE_ROUTE];
                     $ret = $this->mergeDefaults($hostMatches, $ret);
                 }
             }

--- a/src/Symfony/Component/Routing/Matcher/RedirectableUrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/RedirectableUrlMatcher.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Routing\Matcher;
 
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Exception\ExceptionInterface;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 
@@ -35,7 +36,7 @@ abstract class RedirectableUrlMatcher extends UrlMatcher implements Redirectable
                 try {
                     $ret = parent::match($pathinfo);
 
-                    return $this->redirect($pathinfo, $ret['_route'] ?? null, $this->context->getScheme()) + $ret;
+                    return $this->redirect($pathinfo, $ret[Request::ATTRIBUTE_ROUTE] ?? null, $this->context->getScheme()) + $ret;
                 } catch (ExceptionInterface) {
                     throw $e;
                 } finally {
@@ -48,7 +49,7 @@ abstract class RedirectableUrlMatcher extends UrlMatcher implements Redirectable
                     $pathinfo = $trimmedPathinfo === $pathinfo ? $pathinfo.'/' : $trimmedPathinfo;
                     $ret = parent::match($pathinfo);
 
-                    return $this->redirect($pathinfo, $ret['_route'] ?? null) + $ret;
+                    return $this->redirect($pathinfo, $ret[Request::ATTRIBUTE_ROUTE] ?? null) + $ret;
                 } catch (ExceptionInterface) {
                     if ($this->allowSchemes) {
                         goto redirect_scheme;

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -195,7 +195,7 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
             $name = $defaults['_canonical_route'];
             unset($defaults['_canonical_route']);
         }
-        $attributes['_route'] = $name;
+        $attributes[Request::ATTRIBUTE_ROUTE] = $name;
 
         if ($mapping = $route->getOption('mapping')) {
             $attributes['_route_mapping'] = $mapping;

--- a/src/Symfony/Component/Routing/README.md
+++ b/src/Symfony/Component/Routing/README.md
@@ -17,6 +17,7 @@ use Symfony\Component\Routing\Matcher\UrlMatcher;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\HttpFoundation\Request;
 
 $route = new Route('/blog/{slug}', ['_controller' => BlogController::class]);
 $routes = new RouteCollection();
@@ -30,7 +31,7 @@ $parameters = $matcher->match('/blog/lorem-ipsum');
 // $parameters = [
 //     '_controller' => 'App\Controller\BlogController',
 //     'slug' => 'lorem-ipsum',
-//     '_route' => 'blog_show'
+//     Request::ATTRIBUTE_ROUTE => 'blog_show'
 // ]
 
 // Routing can also generate URLs for a given route

--- a/src/Symfony/Component/Routing/Tests/Matcher/RedirectableUrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/RedirectableUrlMatcherTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Routing\Tests\Matcher;
 
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\Matcher\RedirectableUrlMatcher;
 use Symfony\Component\Routing\RequestContext;
@@ -63,7 +64,7 @@ class RedirectableUrlMatcherTest extends UrlMatcherTest
             ->expects($this->once())
             ->method('redirect')
             ->with('/foo', 'foo', 'ftp')
-            ->willReturn(['_route' => 'foo'])
+            ->willReturn([Request::ATTRIBUTE_ROUTE => 'foo'])
         ;
         $matcher->match('/foo');
     }
@@ -92,7 +93,7 @@ class RedirectableUrlMatcherTest extends UrlMatcherTest
             ->with('/foo/baz', 'foo', 'https')
             ->willReturn(['redirect' => 'value'])
         ;
-        $this->assertEquals(['_route' => 'foo', 'bar' => 'baz', 'redirect' => 'value'], $matcher->match('/foo/baz'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'foo', 'bar' => 'baz', 'redirect' => 'value'], $matcher->match('/foo/baz'));
     }
 
     public function testSchemeRedirectForRoot()
@@ -106,7 +107,7 @@ class RedirectableUrlMatcherTest extends UrlMatcherTest
             ->method('redirect')
             ->with('/', 'foo', 'https')
             ->willReturn(['redirect' => 'value']);
-        $this->assertEquals(['_route' => 'foo', 'redirect' => 'value'], $matcher->match('/'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'foo', 'redirect' => 'value'], $matcher->match('/'));
     }
 
     public function testSlashRedirectWithParams()
@@ -121,7 +122,7 @@ class RedirectableUrlMatcherTest extends UrlMatcherTest
             ->with('/foo/baz/', 'foo', null)
             ->willReturn(['redirect' => 'value'])
         ;
-        $this->assertEquals(['_route' => 'foo', 'bar' => 'baz', 'redirect' => 'value'], $matcher->match('/foo/baz'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'foo', 'bar' => 'baz', 'redirect' => 'value'], $matcher->match('/foo/baz'));
     }
 
     public function testRedirectPreservesUrlEncoding()
@@ -140,7 +141,7 @@ class RedirectableUrlMatcherTest extends UrlMatcherTest
         $coll->add('foo', new Route('/foo', [], [], [], '', ['https']));
         $matcher = $this->getUrlMatcher($coll, new RequestContext());
         $matcher->expects($this->once())->method('redirect')->with('/foo', 'foo', 'https')->willReturn([]);
-        $this->assertSame(['_route' => 'foo'], $matcher->match('/foo'));
+        $this->assertSame([Request::ATTRIBUTE_ROUTE => 'foo'], $matcher->match('/foo'));
     }
 
     public function testFallbackPage()
@@ -150,16 +151,16 @@ class RedirectableUrlMatcherTest extends UrlMatcherTest
         $coll->add('bar', new Route('/{name}'));
 
         $matcher = $this->getUrlMatcher($coll);
-        $matcher->expects($this->once())->method('redirect')->with('/foo/', 'foo')->willReturn(['_route' => 'foo']);
-        $this->assertSame(['_route' => 'foo'], $matcher->match('/foo'));
+        $matcher->expects($this->once())->method('redirect')->with('/foo/', 'foo')->willReturn([Request::ATTRIBUTE_ROUTE => 'foo']);
+        $this->assertSame([Request::ATTRIBUTE_ROUTE => 'foo'], $matcher->match('/foo'));
 
         $coll = new RouteCollection();
         $coll->add('foo', new Route('/foo'));
         $coll->add('bar', new Route('/{name}/'));
 
         $matcher = $this->getUrlMatcher($coll);
-        $matcher->expects($this->once())->method('redirect')->with('/foo', 'foo')->willReturn(['_route' => 'foo']);
-        $this->assertSame(['_route' => 'foo'], $matcher->match('/foo/'));
+        $matcher->expects($this->once())->method('redirect')->with('/foo', 'foo')->willReturn([Request::ATTRIBUTE_ROUTE => 'foo']);
+        $this->assertSame([Request::ATTRIBUTE_ROUTE => 'foo'], $matcher->match('/foo/'));
     }
 
     public function testMissingTrailingSlashAndScheme()
@@ -180,7 +181,7 @@ class RedirectableUrlMatcherTest extends UrlMatcherTest
 
         $matcher = $this->getUrlMatcher($coll);
         $expected = [
-            '_route' => 'b',
+            Request::ATTRIBUTE_ROUTE => 'b',
             'customerId' => '123',
         ];
         $this->assertEquals($expected, $matcher->match('/api/customers/123/contactpersons/'));
@@ -197,7 +198,7 @@ class RedirectableUrlMatcherTest extends UrlMatcherTest
         $matcher = $this->getUrlMatcher($coll);
         $matcher->expects($this->once())->method('redirect')->with('/123')->willReturn([]);
 
-        $this->assertEquals(['_route' => 'a', 'a' => '123'], $matcher->match('/123/'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'a', 'a' => '123'], $matcher->match('/123/'));
     }
 
     public function testTrailingRequirementWithDefaultA()
@@ -208,7 +209,7 @@ class RedirectableUrlMatcherTest extends UrlMatcherTest
         $matcher = $this->getUrlMatcher($coll);
         $matcher->expects($this->once())->method('redirect')->with('/fr-fr')->willReturn([]);
 
-        $this->assertEquals(['_route' => 'a', 'a' => 'aaa'], $matcher->match('/fr-fr/'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'a', 'a' => 'aaa'], $matcher->match('/fr-fr/'));
     }
 
     protected function getUrlMatcher(RouteCollection $routes, ?RequestContext $context = null)

--- a/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Routing\Tests\Matcher;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Routing\Exception\NoConfigurationException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
@@ -97,7 +98,7 @@ class UrlMatcherTest extends TestCase
         } catch (ResourceNotFoundException $e) {
         }
 
-        $this->assertEquals(['_route' => 'foo', 'bar' => 'baz'], $matcher->match('/foo/baz'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'foo', 'bar' => 'baz'], $matcher->match('/foo/baz'));
     }
 
     public function testDefaultsAreMerged()
@@ -106,7 +107,7 @@ class UrlMatcherTest extends TestCase
         $collection = new RouteCollection();
         $collection->add('foo', new Route('/foo/{bar}', ['def' => 'test']));
         $matcher = $this->getUrlMatcher($collection);
-        $this->assertEquals(['_route' => 'foo', 'bar' => 'baz', 'def' => 'test'], $matcher->match('/foo/baz'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'foo', 'bar' => 'baz', 'def' => 'test'], $matcher->match('/foo/baz'));
     }
 
     public function testMethodIsIgnoredIfNoMethodGiven()
@@ -137,14 +138,14 @@ class UrlMatcherTest extends TestCase
         $collection = new RouteCollection();
         $collection->add('bar', new Route('/{bar}/foo', ['bar' => 'bar'], ['bar' => 'foo|bar']));
         $matcher = $this->getUrlMatcher($collection);
-        $this->assertEquals(['_route' => 'bar', 'bar' => 'bar'], $matcher->match('/bar/foo'));
-        $this->assertEquals(['_route' => 'bar', 'bar' => 'foo'], $matcher->match('/foo/foo'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'bar', 'bar' => 'bar'], $matcher->match('/bar/foo'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'bar', 'bar' => 'foo'], $matcher->match('/foo/foo'));
 
         $collection = new RouteCollection();
         $collection->add('bar', new Route('/{bar}', ['bar' => 'bar'], ['bar' => 'foo|bar']));
         $matcher = $this->getUrlMatcher($collection);
-        $this->assertEquals(['_route' => 'bar', 'bar' => 'foo'], $matcher->match('/foo'));
-        $this->assertEquals(['_route' => 'bar', 'bar' => 'bar'], $matcher->match('/'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'bar', 'bar' => 'foo'], $matcher->match('/foo'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'bar', 'bar' => 'bar'], $matcher->match('/'));
     }
 
     public function testRouteWithOnlyOptionalVariables()
@@ -152,9 +153,9 @@ class UrlMatcherTest extends TestCase
         $collection = new RouteCollection();
         $collection->add('bar', new Route('/{foo}/{bar}', ['foo' => 'foo', 'bar' => 'bar'], []));
         $matcher = $this->getUrlMatcher($collection);
-        $this->assertEquals(['_route' => 'bar', 'foo' => 'foo', 'bar' => 'bar'], $matcher->match('/'));
-        $this->assertEquals(['_route' => 'bar', 'foo' => 'a', 'bar' => 'bar'], $matcher->match('/a'));
-        $this->assertEquals(['_route' => 'bar', 'foo' => 'a', 'bar' => 'b'], $matcher->match('/a/b'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'bar', 'foo' => 'foo', 'bar' => 'bar'], $matcher->match('/'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'bar', 'foo' => 'a', 'bar' => 'bar'], $matcher->match('/a'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'bar', 'foo' => 'a', 'bar' => 'b'], $matcher->match('/a/b'));
     }
 
     public function testMatchWithPrefixes()
@@ -165,7 +166,7 @@ class UrlMatcherTest extends TestCase
         $collection->addPrefix('/a');
 
         $matcher = $this->getUrlMatcher($collection);
-        $this->assertEquals(['_route' => 'foo', 'foo' => 'foo'], $matcher->match('/a/b/foo'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'foo', 'foo' => 'foo'], $matcher->match('/a/b/foo'));
     }
 
     public function testMatchWithDynamicPrefix()
@@ -176,7 +177,7 @@ class UrlMatcherTest extends TestCase
         $collection->addPrefix('/{_locale}');
 
         $matcher = $this->getUrlMatcher($collection);
-        $this->assertEquals(['_locale' => 'fr', '_route' => 'foo', 'foo' => 'foo'], $matcher->match('/fr/b/foo'));
+        $this->assertEquals(['_locale' => 'fr', Request::ATTRIBUTE_ROUTE => 'foo', 'foo' => 'foo'], $matcher->match('/fr/b/foo'));
     }
 
     public function testMatchSpecialRouteName()
@@ -185,7 +186,7 @@ class UrlMatcherTest extends TestCase
         $collection->add('$péß^a|', new Route('/bar'));
 
         $matcher = $this->getUrlMatcher($collection);
-        $this->assertEquals(['_route' => '$péß^a|'], $matcher->match('/bar'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => '$péß^a|'], $matcher->match('/bar'));
     }
 
     public function testMatchImportantVariable()
@@ -194,7 +195,7 @@ class UrlMatcherTest extends TestCase
         $collection->add('index', new Route('/index.{!_format}', ['_format' => 'xml']));
 
         $matcher = $this->getUrlMatcher($collection);
-        $this->assertEquals(['_route' => 'index', '_format' => 'xml'], $matcher->match('/index.xml'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'index', '_format' => 'xml'], $matcher->match('/index.xml'));
     }
 
     public function testShortPathDoesNotMatchImportantVariable()
@@ -228,8 +229,8 @@ class UrlMatcherTest extends TestCase
         $collection->add('foo', new Route('/{foo}/bar', [], ['foo' => '['.preg_quote($chars).']+'], ['utf8' => true]));
 
         $matcher = $this->getUrlMatcher($collection);
-        $this->assertEquals(['_route' => 'foo', 'foo' => $chars], $matcher->match('/'.rawurlencode($chars).'/bar'));
-        $this->assertEquals(['_route' => 'foo', 'foo' => $chars], $matcher->match('/'.strtr($chars, ['%' => '%25']).'/bar'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'foo', 'foo' => $chars], $matcher->match('/'.rawurlencode($chars).'/bar'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'foo', 'foo' => $chars], $matcher->match('/'.strtr($chars, ['%' => '%25']).'/bar'));
     }
 
     public function testMatchWithDotMetacharacterInRequirements()
@@ -238,7 +239,7 @@ class UrlMatcherTest extends TestCase
         $collection->add('foo', new Route('/{foo}/bar', [], ['foo' => '.+']));
 
         $matcher = $this->getUrlMatcher($collection);
-        $this->assertEquals(['_route' => 'foo', 'foo' => "\n"], $matcher->match('/'.urlencode("\n").'/bar'), 'linefeed character is matched');
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'foo', 'foo' => "\n"], $matcher->match('/'.urlencode("\n").'/bar'), 'linefeed character is matched');
     }
 
     public function testMatchOverriddenRoute()
@@ -253,7 +254,7 @@ class UrlMatcherTest extends TestCase
 
         $matcher = $this->getUrlMatcher($collection);
 
-        $this->assertEquals(['_route' => 'foo'], $matcher->match('/foo1'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'foo'], $matcher->match('/foo1'));
         $this->expectException(ResourceNotFoundException::class);
         $this->assertEquals([], $matcher->match('/foo'));
     }
@@ -265,7 +266,7 @@ class UrlMatcherTest extends TestCase
         $coll->add('bar', new Route('/foo/bar/{foo}'));
 
         $matcher = $this->getUrlMatcher($coll);
-        $this->assertEquals(['foo' => 'bar', '_route' => 'bar'], $matcher->match('/foo/bar/bar'));
+        $this->assertEquals(['foo' => 'bar', Request::ATTRIBUTE_ROUTE => 'bar'], $matcher->match('/foo/bar/bar'));
 
         $collection = new RouteCollection();
         $collection->add('foo', new Route('/{bar}'));
@@ -284,7 +285,7 @@ class UrlMatcherTest extends TestCase
         $coll->add('foo2', new Route('/foo/{a}/test/test/{b}'));
         $coll->add('foo3', new Route('/foo/{a}/{b}/{c}/{d}'));
 
-        $route = $this->getUrlMatcher($coll)->match('/foo/test/test/test/bar')['_route'];
+        $route = $this->getUrlMatcher($coll)->match('/foo/test/test/test/bar')[Request::ATTRIBUTE_ROUTE];
 
         $this->assertEquals('foo2', $route);
     }
@@ -295,7 +296,7 @@ class UrlMatcherTest extends TestCase
         $coll->add('test', new Route('/{page}.{_format}', ['page' => 'index', '_format' => 'html']));
 
         $matcher = $this->getUrlMatcher($coll);
-        $this->assertEquals(['page' => 'my-page', '_format' => 'xml', '_route' => 'test'], $matcher->match('/my-page.xml'));
+        $this->assertEquals(['page' => 'my-page', '_format' => 'xml', Request::ATTRIBUTE_ROUTE => 'test'], $matcher->match('/my-page.xml'));
     }
 
     public function testMatchingIsEager()
@@ -304,7 +305,7 @@ class UrlMatcherTest extends TestCase
         $coll->add('test', new Route('/{foo}-{bar}-', [], ['foo' => '.+', 'bar' => '.+']));
 
         $matcher = $this->getUrlMatcher($coll);
-        $this->assertEquals(['foo' => 'text1-text2-text3', 'bar' => 'text4', '_route' => 'test'], $matcher->match('/text1-text2-text3-text4-'));
+        $this->assertEquals(['foo' => 'text1-text2-text3', 'bar' => 'text4', Request::ATTRIBUTE_ROUTE => 'test'], $matcher->match('/text1-text2-text3-text4-'));
     }
 
     public function testAdjacentVariables()
@@ -316,12 +317,12 @@ class UrlMatcherTest extends TestCase
         // 'w' eagerly matches as much as possible and the other variables match the remaining chars.
         // This also shows that the variables w-z must all exclude the separating char (the dot '.' in this case) by default requirement.
         // Otherwise they would also consume '.xml' and _format would never match as it's an optional variable.
-        $this->assertEquals(['w' => 'wwwww', 'x' => 'x', 'y' => 'Y', 'z' => 'Z', '_format' => 'xml', '_route' => 'test'], $matcher->match('/wwwwwxYZ.xml'));
+        $this->assertEquals(['w' => 'wwwww', 'x' => 'x', 'y' => 'Y', 'z' => 'Z', '_format' => 'xml', Request::ATTRIBUTE_ROUTE => 'test'], $matcher->match('/wwwwwxYZ.xml'));
         // As 'y' has custom requirement and can only be of value 'y|Y', it will leave  'ZZZ' to variable z.
         // So with carefully chosen requirements adjacent variables, can be useful.
-        $this->assertEquals(['w' => 'wwwww', 'x' => 'x', 'y' => 'y', 'z' => 'ZZZ', '_format' => 'html', '_route' => 'test'], $matcher->match('/wwwwwxyZZZ'));
+        $this->assertEquals(['w' => 'wwwww', 'x' => 'x', 'y' => 'y', 'z' => 'ZZZ', '_format' => 'html', Request::ATTRIBUTE_ROUTE => 'test'], $matcher->match('/wwwwwxyZZZ'));
         // z and _format are optional.
-        $this->assertEquals(['w' => 'wwwww', 'x' => 'x', 'y' => 'y', 'z' => 'default-z', '_format' => 'html', '_route' => 'test'], $matcher->match('/wwwwwxy'));
+        $this->assertEquals(['w' => 'wwwww', 'x' => 'x', 'y' => 'y', 'z' => 'default-z', '_format' => 'html', Request::ATTRIBUTE_ROUTE => 'test'], $matcher->match('/wwwwwxy'));
 
         $this->expectException(ResourceNotFoundException::class);
         $matcher->match('/wxy.html');
@@ -333,8 +334,8 @@ class UrlMatcherTest extends TestCase
         $coll->add('test', new Route('/get{what}', ['what' => 'All']));
         $matcher = $this->getUrlMatcher($coll);
 
-        $this->assertEquals(['what' => 'All', '_route' => 'test'], $matcher->match('/get'));
-        $this->assertEquals(['what' => 'Sites', '_route' => 'test'], $matcher->match('/getSites'));
+        $this->assertEquals(['what' => 'All', Request::ATTRIBUTE_ROUTE => 'test'], $matcher->match('/get'));
+        $this->assertEquals(['what' => 'Sites', Request::ATTRIBUTE_ROUTE => 'test'], $matcher->match('/getSites'));
 
         // Usually the character in front of an optional parameter can be left out, e.g. with pattern '/get/{what}' just '/get' would match.
         // But here the 't' in 'get' is not a separating character, so it makes no sense to match without it.
@@ -348,7 +349,7 @@ class UrlMatcherTest extends TestCase
         $coll->add('test', new Route('/get{what}Suffix'));
         $matcher = $this->getUrlMatcher($coll);
 
-        $this->assertEquals(['what' => 'Sites', '_route' => 'test'], $matcher->match('/getSitesSuffix'));
+        $this->assertEquals(['what' => 'Sites', Request::ATTRIBUTE_ROUTE => 'test'], $matcher->match('/getSitesSuffix'));
     }
 
     public function testDefaultRequirementOfVariable()
@@ -357,7 +358,7 @@ class UrlMatcherTest extends TestCase
         $coll->add('test', new Route('/{page}.{_format}'));
         $matcher = $this->getUrlMatcher($coll);
 
-        $this->assertEquals(['page' => 'index', '_format' => 'mobile.html', '_route' => 'test'], $matcher->match('/index.mobile.html'));
+        $this->assertEquals(['page' => 'index', '_format' => 'mobile.html', Request::ATTRIBUTE_ROUTE => 'test'], $matcher->match('/index.mobile.html'));
     }
 
     public function testDefaultRequirementOfVariableDisallowsSlash()
@@ -455,7 +456,7 @@ class UrlMatcherTest extends TestCase
         $coll->add('https_route', new Route('/', [], [], [], '', ['https']));
         $coll->add('http_route', new Route('/', [], [], [], '', ['http']));
         $matcher = $this->getUrlMatcher($coll);
-        $this->assertEquals(['_route' => 'http_route'], $matcher->match('/'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'http_route'], $matcher->match('/'));
     }
 
     public function testCondition()
@@ -481,18 +482,18 @@ class UrlMatcherTest extends TestCase
         $route->setCondition('request.getBaseUrl() == "/sub/front.php" and request.getPathInfo() == "/foo/bar"');
         $coll->add('foo', $route);
         $matcher = $this->getUrlMatcher($coll, new RequestContext('/sub/front.php'));
-        $this->assertEquals(['bar' => 'bar', '_route' => 'foo'], $matcher->match('/foo/bar'));
+        $this->assertEquals(['bar' => 'bar', Request::ATTRIBUTE_ROUTE => 'foo'], $matcher->match('/foo/bar'));
     }
 
     public function testRouteParametersCondition()
     {
         $coll = new RouteCollection();
         $route = new Route('/foo');
-        $route->setCondition("params['_route'] matches '/^s[a-z]+$/'");
+        $route->setCondition(\sprintf("params[%s] matches '/^s[a-z]+$/'", Request::ATTRIBUTE_ROUTE));
         $coll->add('static', $route);
         $route = new Route('/bar');
         $route->setHost('en.example.com');
-        $route->setCondition("params['_route'] matches '/^s[a-z\-]+$/'");
+        $route->setCondition(\sprintf("params[%s] matches '/^s[a-z\-]+$/'", Request::ATTRIBUTE_ROUTE));
         $coll->add('static-with-host', $route);
         $route = new Route('/foo/{id}');
         $route->setCondition("params['id'] < 100");
@@ -505,11 +506,11 @@ class UrlMatcherTest extends TestCase
         $coll->add('dynamic-with-slash', $route);
         $matcher = $this->getUrlMatcher($coll, new RequestContext('/sub/front.php', 'GET', 'en.example.com'));
 
-        $this->assertEquals(['_route' => 'static'], $matcher->match('/foo'));
-        $this->assertEquals(['_route' => 'static-with-host'], $matcher->match('/bar'));
-        $this->assertEquals(['_route' => 'dynamic1', 'id' => '10'], $matcher->match('/foo/10'));
-        $this->assertEquals(['_route' => 'dynamic2', 'id' => '200'], $matcher->match('/foo/200'));
-        $this->assertEquals(['_route' => 'dynamic-with-slash', 'id' => '10'], $matcher->match('/bar/10/'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'static'], $matcher->match('/foo'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'static-with-host'], $matcher->match('/bar'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'dynamic1', 'id' => '10'], $matcher->match('/foo/10'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'dynamic2', 'id' => '200'], $matcher->match('/foo/200'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'dynamic-with-slash', 'id' => '10'], $matcher->match('/bar/10/'));
 
         $this->expectException(ResourceNotFoundException::class);
         $matcher->match('/foo/3000');
@@ -521,7 +522,7 @@ class UrlMatcherTest extends TestCase
         $coll->add('foo', new Route('/foo/{foo}'));
 
         $matcher = $this->getUrlMatcher($coll);
-        $this->assertEquals(['foo' => 'bar%23', '_route' => 'foo'], $matcher->match('/foo/bar%2523'));
+        $this->assertEquals(['foo' => 'bar%23', Request::ATTRIBUTE_ROUTE => 'foo'], $matcher->match('/foo/bar%2523'));
     }
 
     public function testCannotRelyOnPrefix()
@@ -537,7 +538,7 @@ class UrlMatcherTest extends TestCase
         $coll->addCollection($subColl);
 
         $matcher = $this->getUrlMatcher($coll);
-        $this->assertEquals(['_route' => 'bar'], $matcher->match('/new'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'bar'], $matcher->match('/new'));
     }
 
     public function testWithHost()
@@ -546,7 +547,7 @@ class UrlMatcherTest extends TestCase
         $coll->add('foo', new Route('/foo/{foo}', [], [], [], '{locale}.example.com'));
 
         $matcher = $this->getUrlMatcher($coll, new RequestContext('', 'GET', 'en.example.com'));
-        $this->assertEquals(['foo' => 'bar', '_route' => 'foo', 'locale' => 'en'], $matcher->match('/foo/bar'));
+        $this->assertEquals(['foo' => 'bar', Request::ATTRIBUTE_ROUTE => 'foo', 'locale' => 'en'], $matcher->match('/foo/bar'));
     }
 
     public function testWithHostOnRouteCollection()
@@ -557,10 +558,10 @@ class UrlMatcherTest extends TestCase
         $coll->setHost('{locale}.example.com');
 
         $matcher = $this->getUrlMatcher($coll, new RequestContext('', 'GET', 'en.example.com'));
-        $this->assertEquals(['foo' => 'bar', '_route' => 'foo', 'locale' => 'en'], $matcher->match('/foo/bar'));
+        $this->assertEquals(['foo' => 'bar', Request::ATTRIBUTE_ROUTE => 'foo', 'locale' => 'en'], $matcher->match('/foo/bar'));
 
         $matcher = $this->getUrlMatcher($coll, new RequestContext('', 'GET', 'en.example.com'));
-        $this->assertEquals(['foo' => 'bar', '_route' => 'bar', 'locale' => 'en'], $matcher->match('/bar/bar'));
+        $this->assertEquals(['foo' => 'bar', Request::ATTRIBUTE_ROUTE => 'bar', 'locale' => 'en'], $matcher->match('/bar/bar'));
     }
 
     public function testVariationInTrailingSlashWithHosts()
@@ -570,10 +571,10 @@ class UrlMatcherTest extends TestCase
         $coll->add('bar', new Route('/foo', [], [], [], 'bar.example.com'));
 
         $matcher = $this->getUrlMatcher($coll, new RequestContext('', 'GET', 'foo.example.com'));
-        $this->assertEquals(['_route' => 'foo'], $matcher->match('/foo/'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'foo'], $matcher->match('/foo/'));
 
         $matcher = $this->getUrlMatcher($coll, new RequestContext('', 'GET', 'bar.example.com'));
-        $this->assertEquals(['_route' => 'bar'], $matcher->match('/foo'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'bar'], $matcher->match('/foo'));
     }
 
     public function testVariationInTrailingSlashWithHostsInReverse()
@@ -584,10 +585,10 @@ class UrlMatcherTest extends TestCase
         $coll->add('foo', new Route('/foo/', [], [], [], 'foo.example.com'));
 
         $matcher = $this->getUrlMatcher($coll, new RequestContext('', 'GET', 'foo.example.com'));
-        $this->assertEquals(['_route' => 'foo'], $matcher->match('/foo/'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'foo'], $matcher->match('/foo/'));
 
         $matcher = $this->getUrlMatcher($coll, new RequestContext('', 'GET', 'bar.example.com'));
-        $this->assertEquals(['_route' => 'bar'], $matcher->match('/foo'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'bar'], $matcher->match('/foo'));
     }
 
     public function testVariationInTrailingSlashWithHostsAndVariable()
@@ -597,10 +598,10 @@ class UrlMatcherTest extends TestCase
         $coll->add('bar', new Route('/{foo}', [], [], [], 'bar.example.com'));
 
         $matcher = $this->getUrlMatcher($coll, new RequestContext('', 'GET', 'foo.example.com'));
-        $this->assertEquals(['foo' => 'bar', '_route' => 'foo'], $matcher->match('/bar/'));
+        $this->assertEquals(['foo' => 'bar', Request::ATTRIBUTE_ROUTE => 'foo'], $matcher->match('/bar/'));
 
         $matcher = $this->getUrlMatcher($coll, new RequestContext('', 'GET', 'bar.example.com'));
-        $this->assertEquals(['foo' => 'bar', '_route' => 'bar'], $matcher->match('/bar'));
+        $this->assertEquals(['foo' => 'bar', Request::ATTRIBUTE_ROUTE => 'bar'], $matcher->match('/bar'));
     }
 
     public function testVariationInTrailingSlashWithHostsAndVariableInReverse()
@@ -611,10 +612,10 @@ class UrlMatcherTest extends TestCase
         $coll->add('foo', new Route('/{foo}/', [], [], [], 'foo.example.com'));
 
         $matcher = $this->getUrlMatcher($coll, new RequestContext('', 'GET', 'foo.example.com'));
-        $this->assertEquals(['foo' => 'bar', '_route' => 'foo'], $matcher->match('/bar/'));
+        $this->assertEquals(['foo' => 'bar', Request::ATTRIBUTE_ROUTE => 'foo'], $matcher->match('/bar/'));
 
         $matcher = $this->getUrlMatcher($coll, new RequestContext('', 'GET', 'bar.example.com'));
-        $this->assertEquals(['foo' => 'bar', '_route' => 'bar'], $matcher->match('/bar'));
+        $this->assertEquals(['foo' => 'bar', Request::ATTRIBUTE_ROUTE => 'bar'], $matcher->match('/bar'));
     }
 
     public function testVariationInTrailingSlashWithMethods()
@@ -624,10 +625,10 @@ class UrlMatcherTest extends TestCase
         $coll->add('bar', new Route('/foo', [], [], [], '', [], ['GET']));
 
         $matcher = $this->getUrlMatcher($coll, new RequestContext('', 'POST'));
-        $this->assertEquals(['_route' => 'foo'], $matcher->match('/foo/'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'foo'], $matcher->match('/foo/'));
 
         $matcher = $this->getUrlMatcher($coll, new RequestContext('', 'GET'));
-        $this->assertEquals(['_route' => 'bar'], $matcher->match('/foo'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'bar'], $matcher->match('/foo'));
     }
 
     public function testVariationInTrailingSlashWithMethodsInReverse()
@@ -638,10 +639,10 @@ class UrlMatcherTest extends TestCase
         $coll->add('foo', new Route('/foo/', [], [], [], '', [], ['POST']));
 
         $matcher = $this->getUrlMatcher($coll, new RequestContext('', 'POST'));
-        $this->assertEquals(['_route' => 'foo'], $matcher->match('/foo/'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'foo'], $matcher->match('/foo/'));
 
         $matcher = $this->getUrlMatcher($coll, new RequestContext('', 'GET'));
-        $this->assertEquals(['_route' => 'bar'], $matcher->match('/foo'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'bar'], $matcher->match('/foo'));
     }
 
     public function testVariableVariationInTrailingSlashWithMethods()
@@ -651,10 +652,10 @@ class UrlMatcherTest extends TestCase
         $coll->add('bar', new Route('/{foo}', [], [], [], '', [], ['GET']));
 
         $matcher = $this->getUrlMatcher($coll, new RequestContext('', 'POST'));
-        $this->assertEquals(['foo' => 'bar', '_route' => 'foo'], $matcher->match('/bar/'));
+        $this->assertEquals(['foo' => 'bar', Request::ATTRIBUTE_ROUTE => 'foo'], $matcher->match('/bar/'));
 
         $matcher = $this->getUrlMatcher($coll, new RequestContext('', 'GET'));
-        $this->assertEquals(['foo' => 'bar', '_route' => 'bar'], $matcher->match('/bar'));
+        $this->assertEquals(['foo' => 'bar', Request::ATTRIBUTE_ROUTE => 'bar'], $matcher->match('/bar'));
     }
 
     public function testVariableVariationInTrailingSlashWithMethodsInReverse()
@@ -665,10 +666,10 @@ class UrlMatcherTest extends TestCase
         $coll->add('foo', new Route('/{foo}/', [], [], [], '', [], ['POST']));
 
         $matcher = $this->getUrlMatcher($coll, new RequestContext('', 'POST'));
-        $this->assertEquals(['foo' => 'bar', '_route' => 'foo'], $matcher->match('/bar/'));
+        $this->assertEquals(['foo' => 'bar', Request::ATTRIBUTE_ROUTE => 'foo'], $matcher->match('/bar/'));
 
         $matcher = $this->getUrlMatcher($coll, new RequestContext('', 'GET'));
-        $this->assertEquals(['foo' => 'bar', '_route' => 'bar'], $matcher->match('/bar'));
+        $this->assertEquals(['foo' => 'bar', Request::ATTRIBUTE_ROUTE => 'bar'], $matcher->match('/bar'));
     }
 
     public function testMixOfStaticAndVariableVariationInTrailingSlashWithHosts()
@@ -678,10 +679,10 @@ class UrlMatcherTest extends TestCase
         $coll->add('bar', new Route('/{foo}', [], [], [], 'bar.example.com'));
 
         $matcher = $this->getUrlMatcher($coll, new RequestContext('', 'GET', 'foo.example.com'));
-        $this->assertEquals(['_route' => 'foo'], $matcher->match('/foo/'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'foo'], $matcher->match('/foo/'));
 
         $matcher = $this->getUrlMatcher($coll, new RequestContext('', 'GET', 'bar.example.com'));
-        $this->assertEquals(['foo' => 'bar', '_route' => 'bar'], $matcher->match('/bar'));
+        $this->assertEquals(['foo' => 'bar', Request::ATTRIBUTE_ROUTE => 'bar'], $matcher->match('/bar'));
     }
 
     public function testMixOfStaticAndVariableVariationInTrailingSlashWithMethods()
@@ -691,11 +692,11 @@ class UrlMatcherTest extends TestCase
         $coll->add('bar', new Route('/{foo}', [], [], [], '', [], ['GET']));
 
         $matcher = $this->getUrlMatcher($coll, new RequestContext('', 'POST'));
-        $this->assertEquals(['_route' => 'foo'], $matcher->match('/foo/'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'foo'], $matcher->match('/foo/'));
 
         $matcher = $this->getUrlMatcher($coll, new RequestContext('', 'GET'));
-        $this->assertEquals(['foo' => 'bar', '_route' => 'bar'], $matcher->match('/bar'));
-        $this->assertEquals(['foo' => 'foo', '_route' => 'bar'], $matcher->match('/foo'));
+        $this->assertEquals(['foo' => 'bar', Request::ATTRIBUTE_ROUTE => 'bar'], $matcher->match('/bar'));
+        $this->assertEquals(['foo' => 'foo', Request::ATTRIBUTE_ROUTE => 'bar'], $matcher->match('/foo'));
     }
 
     public function testWithOutHostHostDoesNotMatch()
@@ -728,7 +729,7 @@ class UrlMatcherTest extends TestCase
         $coll->add('foo', new Route('/', [], ['locale' => 'EN|FR|DE'], [], '{locale}.example.com'));
 
         $matcher = $this->getUrlMatcher($coll, new RequestContext('', 'GET', 'en.example.com'));
-        $this->assertEquals(['_route' => 'foo', 'locale' => 'en'], $matcher->match('/'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'foo', 'locale' => 'en'], $matcher->match('/'));
     }
 
     public function testNoConfiguration()
@@ -761,9 +762,9 @@ class UrlMatcherTest extends TestCase
         $coll->addCollection($subColl);
 
         $matcher = $this->getUrlMatcher($coll);
-        $this->assertEquals(['_route' => 'a'], $matcher->match('/p/a'));
-        $this->assertEquals(['_route' => 'baz', 'baz' => 'p'], $matcher->match('/p'));
-        $this->assertEquals(['_route' => 'buz'], $matcher->match('/prefix/buz'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'a'], $matcher->match('/p/a'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'baz', 'baz' => 'p'], $matcher->match('/p'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'buz'], $matcher->match('/prefix/buz'));
     }
 
     public function testSchemeAndMethodMismatch()
@@ -790,8 +791,8 @@ class UrlMatcherTest extends TestCase
         $coll->add('f', (new Route('/{b}{a}'))->setRequirements(['b' => 'b']));
 
         $matcher = $this->getUrlMatcher($coll);
-        $this->assertEquals(['_route' => 'c', 'a' => 'a'], $matcher->match('/aa'));
-        $this->assertEquals(['_route' => 'f', 'b' => 'b', 'a' => 'a'], $matcher->match('/ba'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'c', 'a' => 'a'], $matcher->match('/aa'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'f', 'b' => 'b', 'a' => 'a'], $matcher->match('/ba'));
     }
 
     public function testUnicodeRoute()
@@ -801,7 +802,7 @@ class UrlMatcherTest extends TestCase
         $coll->add('b', new Route('/{a}', [], ['a' => '.'], ['utf8' => true]));
 
         $matcher = $this->getUrlMatcher($coll);
-        $this->assertEquals(['_route' => 'b', 'a' => 'é'], $matcher->match('/é'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'b', 'a' => 'é'], $matcher->match('/é'));
     }
 
     public function testRequirementWithCapturingGroup()
@@ -810,7 +811,7 @@ class UrlMatcherTest extends TestCase
         $coll->add('a', new Route('/{a}/{b}', [], ['a' => '(a|b)']));
 
         $matcher = $this->getUrlMatcher($coll);
-        $this->assertEquals(['_route' => 'a', 'a' => 'a', 'b' => 'b'], $matcher->match('/a/b'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'a', 'a' => 'a', 'b' => 'b'], $matcher->match('/a/b'));
     }
 
     public function testDotAllWithCatchAll()
@@ -820,7 +821,7 @@ class UrlMatcherTest extends TestCase
         $coll->add('b', new Route('/{all}', [], ['all' => '.+']));
 
         $matcher = $this->getUrlMatcher($coll);
-        $this->assertEquals(['_route' => 'a', 'id' => 'foo/bar'], $matcher->match('/foo/bar.html'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'a', 'id' => 'foo/bar'], $matcher->match('/foo/bar.html'));
     }
 
     public function testHostPattern()
@@ -829,7 +830,7 @@ class UrlMatcherTest extends TestCase
         $coll->add('a', new Route('/{app}/{action}/{unused}', [], [], [], '{host}'));
 
         $expected = [
-            '_route' => 'a',
+            Request::ATTRIBUTE_ROUTE => 'a',
             'app' => 'an_app',
             'action' => 'an_action',
             'unused' => 'unused',
@@ -846,7 +847,7 @@ class UrlMatcherTest extends TestCase
         $coll->add('b', new Route('/è{bar}', [], [], ['utf8' => true]));
 
         $matcher = $this->getUrlMatcher($coll);
-        $this->assertEquals('a', $matcher->match('/éo')['_route']);
+        $this->assertEquals('a', $matcher->match('/éo')[Request::ATTRIBUTE_ROUTE]);
     }
 
     public function testUtf8AndMethodMatching()
@@ -857,7 +858,7 @@ class UrlMatcherTest extends TestCase
         $coll->add('c', new Route('/admin/api/package.{_format}', ['_format' => 'json'], [], [], '', [], ['GET']));
 
         $matcher = $this->getUrlMatcher($coll);
-        $this->assertEquals('c', $matcher->match('/admin/api/package.json')['_route']);
+        $this->assertEquals('c', $matcher->match('/admin/api/package.json')[Request::ATTRIBUTE_ROUTE]);
     }
 
     public function testHostWithDot()
@@ -867,7 +868,7 @@ class UrlMatcherTest extends TestCase
         $coll->add('b', new Route('/bar/{baz}'));
 
         $matcher = $this->getUrlMatcher($coll);
-        $this->assertEquals('b', $matcher->match('/bar/abc.123')['_route']);
+        $this->assertEquals('b', $matcher->match('/bar/abc.123')[Request::ATTRIBUTE_ROUTE]);
     }
 
     public function testSlashVariant()
@@ -876,7 +877,7 @@ class UrlMatcherTest extends TestCase
         $coll->add('a', new Route('/foo/{bar}', [], ['bar' => '.*']));
 
         $matcher = $this->getUrlMatcher($coll);
-        $this->assertEquals('a', $matcher->match('/foo/')['_route']);
+        $this->assertEquals('a', $matcher->match('/foo/')[Request::ATTRIBUTE_ROUTE]);
     }
 
     public function testSlashVariant2()
@@ -885,7 +886,7 @@ class UrlMatcherTest extends TestCase
         $coll->add('a', new Route('/foo/{bär}/', [], ['bär' => '.*'], ['utf8' => true]));
 
         $matcher = $this->getUrlMatcher($coll);
-        $this->assertEquals(['_route' => 'a', 'bär' => 'bar'], $matcher->match('/foo/bar/'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'a', 'bär' => 'bar'], $matcher->match('/foo/bar/'));
     }
 
     public function testSlashWithVerb()
@@ -895,14 +896,14 @@ class UrlMatcherTest extends TestCase
         $coll->add('b', new Route('/bar/'));
 
         $matcher = $this->getUrlMatcher($coll);
-        $this->assertSame(['_route' => 'b'], $matcher->match('/bar/'));
+        $this->assertSame([Request::ATTRIBUTE_ROUTE => 'b'], $matcher->match('/bar/'));
 
         $coll = new RouteCollection();
         $coll->add('a', new Route('/dav/{foo}', [], ['foo' => '.*'], [], '', [], ['GET', 'OPTIONS']));
 
         $matcher = $this->getUrlMatcher($coll, new RequestContext('', 'OPTIONS'));
         $expected = [
-            '_route' => 'a',
+            Request::ATTRIBUTE_ROUTE => 'a',
             'foo' => 'files/bar/',
         ];
         $this->assertEquals($expected, $matcher->match('/dav/files/bar/'));
@@ -916,7 +917,7 @@ class UrlMatcherTest extends TestCase
 
         $matcher = $this->getUrlMatcher($coll);
         $expected = [
-            '_route' => 'b',
+            Request::ATTRIBUTE_ROUTE => 'b',
             'customerId' => '123',
         ];
         $this->assertEquals($expected, $matcher->match('/api/customers/123/contactpersons'));
@@ -927,7 +928,7 @@ class UrlMatcherTest extends TestCase
 
         $matcher = $this->getUrlMatcher($coll, new RequestContext('', 'POST'));
         $expected = [
-            '_route' => 'b',
+            Request::ATTRIBUTE_ROUTE => 'b',
             'customerId' => '123',
         ];
         $this->assertEquals($expected, $matcher->match('/api/customers/123/contactpersons'));
@@ -940,8 +941,8 @@ class UrlMatcherTest extends TestCase
 
         $matcher = $this->getUrlMatcher($coll);
 
-        $this->assertEquals(['_route' => 'a', 'a' => 'foo'], $matcher->match('/foo'));
-        $this->assertEquals(['_route' => 'a', 'a' => 'foo/'], $matcher->match('/foo/'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'a', 'a' => 'foo'], $matcher->match('/foo'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'a', 'a' => 'foo/'], $matcher->match('/foo/'));
     }
 
     public function testTrailingRequirementWithDefault()
@@ -952,10 +953,10 @@ class UrlMatcherTest extends TestCase
 
         $matcher = $this->getUrlMatcher($coll);
 
-        $this->assertEquals(['_route' => 'a', 'a' => 'aaa'], $matcher->match('/fr-fr'));
-        $this->assertEquals(['_route' => 'a', 'a' => 'AAA'], $matcher->match('/fr-fr/AAA'));
-        $this->assertEquals(['_route' => 'b', 'b' => 'bbb'], $matcher->match('/en-en'));
-        $this->assertEquals(['_route' => 'b', 'b' => 'BBB'], $matcher->match('/en-en/BBB'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'a', 'a' => 'aaa'], $matcher->match('/fr-fr'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'a', 'a' => 'AAA'], $matcher->match('/fr-fr/AAA'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'b', 'b' => 'bbb'], $matcher->match('/en-en'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'b', 'b' => 'BBB'], $matcher->match('/en-en/BBB'));
     }
 
     public function testTrailingRequirementWithDefaultA()
@@ -976,7 +977,7 @@ class UrlMatcherTest extends TestCase
 
         $matcher = $this->getUrlMatcher($coll);
 
-        $this->assertEquals(['_route' => 'b', 'b' => ''], $matcher->match('/en-en/'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'b', 'b' => ''], $matcher->match('/en-en/'));
     }
 
     public function testRestrictiveTrailingRequirementWithStaticRouteAfter()
@@ -987,7 +988,7 @@ class UrlMatcherTest extends TestCase
 
         $matcher = $this->getUrlMatcher($coll);
 
-        $this->assertEquals(['_route' => 'a', '_' => '/'], $matcher->match('/hello/'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'a', '_' => '/'], $matcher->match('/hello/'));
     }
 
     public function testUtf8VarName()
@@ -997,7 +998,7 @@ class UrlMatcherTest extends TestCase
 
         $matcher = $this->getUrlMatcher($collection);
 
-        $this->assertEquals(['_route' => 'foo', 'bär' => 'baz', 'bäz' => 'foo'], $matcher->match('/foo/baz'));
+        $this->assertEquals([Request::ATTRIBUTE_ROUTE => 'foo', 'bär' => 'baz', 'bäz' => 'foo'], $matcher->match('/foo/baz'));
     }
 
     public function testParameterWithRequirementWithDefault()
@@ -1010,7 +1011,7 @@ class UrlMatcherTest extends TestCase
         $matcher = $this->getUrlMatcher($collection);
 
         $result = $matcher->match('/test/foo');
-        $this->assertSame('test', $result['_route']);
+        $this->assertSame('test', $result[Request::ATTRIBUTE_ROUTE]);
         $this->assertSame('foo', $result['foo']);
 
         try {
@@ -1020,7 +1021,7 @@ class UrlMatcherTest extends TestCase
         }
 
         $result = $matcher->match('/test');
-        $this->assertSame('test', $result['_route']);
+        $this->assertSame('test', $result[Request::ATTRIBUTE_ROUTE]);
         $this->assertSame('foo-', $result['foo']);
     }
 
@@ -1032,7 +1033,7 @@ class UrlMatcherTest extends TestCase
         $matcher = $this->getUrlMatcher($collection);
 
         $expected = [
-            '_route' => 'a',
+            Request::ATTRIBUTE_ROUTE => 'a',
             'slug' => 'vienna-2024',
             '_route_mapping' => [
                 'slug' => [
@@ -1052,7 +1053,7 @@ class UrlMatcherTest extends TestCase
         $matcher = $this->getUrlMatcher($collection);
 
         $expected = [
-            '_route' => 'a',
+            Request::ATTRIBUTE_ROUTE => 'a',
             'conferenceSlug' => 'vienna-2024',
             '_route_mapping' => [
                 'conferenceSlug' => [

--- a/src/Symfony/Component/Security/Http/HttpUtils.php
+++ b/src/Symfony/Component/Security/Http/HttpUtils.php
@@ -103,8 +103,8 @@ class HttpUtils
     {
         if ('/' !== $path[0]) {
             // Shortcut if request has already been matched before
-            if ($request->attributes->has('_route')) {
-                return $path === $request->attributes->get('_route');
+            if ($request->attributes->has(Request::ATTRIBUTE_ROUTE)) {
+                return $path === $request->attributes->get(Request::ATTRIBUTE_ROUTE);
             }
 
             try {
@@ -115,7 +115,7 @@ class HttpUtils
                     $parameters = $this->urlMatcher->match($request->getPathInfo());
                 }
 
-                return isset($parameters['_route']) && $path === $parameters['_route'];
+                return isset($parameters[Request::ATTRIBUTE_ROUTE]) && $path === $parameters[Request::ATTRIBUTE_ROUTE];
             } catch (MethodNotAllowedException|ResourceNotFoundException) {
                 return false;
             }

--- a/src/Symfony/Component/Security/Http/Tests/HttpUtilsTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/HttpUtilsTest.php
@@ -277,7 +277,7 @@ class HttpUtilsTest extends TestCase
             ->expects($this->any())
             ->method('match')
             ->with('/foo/bar')
-            ->willReturn(['_route' => 'foobar'])
+            ->willReturn([Request::ATTRIBUTE_ROUTE => 'foobar'])
         ;
 
         $utils = new HttpUtils(null, $urlMatcher);
@@ -292,7 +292,7 @@ class HttpUtilsTest extends TestCase
             ->expects($this->any())
             ->method('matchRequest')
             ->with($request)
-            ->willReturn(['_route' => 'foobar'])
+            ->willReturn([Request::ATTRIBUTE_ROUTE => 'foobar'])
         ;
 
         $utils = new HttpUtils(null, $urlMatcher);
@@ -324,7 +324,7 @@ class HttpUtilsTest extends TestCase
         ;
 
         $request = $this->getRequest();
-        $request->attributes->set('_route', 'route_name');
+        $request->attributes->set(Request::ATTRIBUTE_ROUTE, 'route_name');
 
         $utils = new HttpUtils(null, $urlMatcher);
         $this->assertTrue($utils->checkRequestPath($request, 'route_name'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

This PR introduces a new `Request::ATTRIBUTE_ROUTE` constant to replace the repeated use of the "_route" magic string across the codebase.

The motivation comes from other projects, where I noticed that "_route" and other attribute keys were frequently used as plain strings. Using constants improves readability, reduces the chance of typos, and makes it easier for developers to discover available attribute names.

At this stage, I’ve only introduced `ATTRIBUTE_ROUTE`, but the same approach could be extended to other commonly used attributes such as "_controller". Before proceeding further, I’d like to gather feedback on whether this direction aligns with Symfony’s standards and expectations.