### PR TITLE
[Runtime] Support runtime options as a string

### DIFF
--- a/src/Symfony/Component/Runtime/CHANGELOG.md
+++ b/src/Symfony/Component/Runtime/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 7.4
 ---
 
+ * Add JSON encoded value support for `APP_RUNTIME_OPTIONS`
  * Add `FrankenPhpWorkerRunner`
  * Add automatic detection of FrankenPHP worker mode in `SymfonyRuntime`
 

--- a/src/Symfony/Component/Runtime/Internal/autoload_runtime.template
+++ b/src/Symfony/Component/Runtime/Internal/autoload_runtime.template
@@ -12,8 +12,11 @@ if (!is_object($app)) {
     throw new TypeError(sprintf('Invalid return value: callable object expected, "%s" returned from "%s".', get_debug_type($app), $_SERVER['SCRIPT_FILENAME']));
 }
 
+if (is_string($_SERVER['APP_RUNTIME_OPTIONS'] ??= $_ENV['APP_RUNTIME_OPTIONS'] ?? [])) {
+    $_SERVER['APP_RUNTIME_OPTIONS'] = json_decode($_SERVER['APP_RUNTIME_OPTIONS'], true, 512, JSON_THROW_ON_ERROR);
+}
 $runtime = $_SERVER['APP_RUNTIME'] ?? $_ENV['APP_RUNTIME'] ?? %runtime_class%;
-$runtime = new $runtime(($_SERVER['APP_RUNTIME_OPTIONS'] ?? $_ENV['APP_RUNTIME_OPTIONS'] ?? []) + %runtime_options%);
+$runtime = new $runtime($_SERVER['APP_RUNTIME_OPTIONS'] += %runtime_options%);
 
 [$app, $args] = $runtime
     ->getResolver($app)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #60755
| License       | MIT

cc @nicolas-grekas since I think you worked a lot on this.

When setting the APP_RUNTIME_OPTIONS with docker or anything else than php, only a string can be used ; so it could be useful to support a string format for such options, I propose the classic json format and then use json_decode on string.

WDYT ?

I'm unsure how this template is tested...