### PR TITLE
[Serializer] Don't fallback to default serializer if tags specify a named one

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,7 @@
         "symfony/polyfill-intl-normalizer": "~1.0",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/polyfill-php83": "^1.28",
+        "symfony/polyfill-php84": "^1.30",
         "symfony/polyfill-uuid": "^1.15"
     },
     "replace": {

--- a/src/Symfony/Component/Serializer/DependencyInjection/SerializerPass.php
+++ b/src/Symfony/Component/Serializer/DependencyInjection/SerializerPass.php
@@ -89,6 +89,10 @@ class SerializerPass implements CompilerPassInterface
         foreach ($container->findTaggedServiceIds($tagName) as $serviceId => $tags) {
             $definition = $container->getDefinition($serviceId);
 
+            if (array_any($tags, $closure = fn (array $tag) => (bool) $tag)) {
+                $tags = array_filter($tags, $closure);
+            }
+
             foreach ($tags as $tag) {
                 $names = (array) ($tag['serializer'] ?? []);
 

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -18,7 +18,8 @@
     "require": {
         "php": ">=8.2",
         "symfony/deprecation-contracts": "^2.5|^3",
-        "symfony/polyfill-ctype": "~1.8"
+        "symfony/polyfill-ctype": "~1.8",
+        "symfony/polyfill-php84": "^1.30"
     },
     "require-dev": {
         "phpdocumentor/reflection-docblock": "^3.2|^4.0|^5.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

An alternative to #61511.