### PR TITLE
[Validator] Allow using attributes to declare compile-time constraint metadata

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ValidatorCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ValidatorCacheWarmer.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\CacheWarmer;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 use Symfony\Component\Validator\Mapping\Factory\LazyLoadingMetadataFactory;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 use Symfony\Component\Validator\Mapping\Loader\LoaderChain;
 use Symfony\Component\Validator\Mapping\Loader\LoaderInterface;
 use Symfony\Component\Validator\Mapping\Loader\XmlFileLoader;
@@ -21,7 +22,7 @@ use Symfony\Component\Validator\Mapping\Loader\YamlFileLoader;
 use Symfony\Component\Validator\ValidatorBuilder;
 
 /**
- * Warms up XML and YAML validator metadata.
+ * Warms up validator metadata.
  *
  * @author Titouan Galopin <galopintitouan@gmail.com>
  *
@@ -77,14 +78,14 @@ class ValidatorCacheWarmer extends AbstractPhpFileCacheWarmer
     /**
      * @param LoaderInterface[] $loaders
      *
-     * @return XmlFileLoader[]|YamlFileLoader[]
+     * @return list<XmlFileLoader|YamlFileLoader|AttributeLoader>
      */
     private function extractSupportedLoaders(array $loaders): array
     {
         $supportedLoaders = [];
 
         foreach ($loaders as $loader) {
-            if ($loader instanceof XmlFileLoader || $loader instanceof YamlFileLoader) {
+            if (method_exists($loader, 'getMappedClasses')) {
                 $supportedLoaders[] = $loader;
             } elseif ($loader instanceof LoaderChain) {
                 $supportedLoaders = array_merge($supportedLoaders, $this->extractSupportedLoaders($loader->getLoaders()));

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
@@ -102,6 +102,7 @@ class UnusedTagsPass implements CompilerPassInterface
         'twig.extension',
         'twig.loader',
         'twig.runtime',
+        'validator.attribute_metadata',
         'validator.auto_mapper',
         'validator.constraint_validator',
         'validator.group_provider',

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -75,6 +75,7 @@ use Symfony\Component\Translation\DependencyInjection\TranslatorPathsPass;
 use Symfony\Component\Validator\DependencyInjection\AddAutoMappingConfigurationPass;
 use Symfony\Component\Validator\DependencyInjection\AddConstraintValidatorsPass;
 use Symfony\Component\Validator\DependencyInjection\AddValidatorInitializersPass;
+use Symfony\Component\Validator\DependencyInjection\AttributeMetadataPass;
 use Symfony\Component\VarExporter\Internal\Hydrator;
 use Symfony\Component\VarExporter\Internal\Registry;
 use Symfony\Component\Workflow\DependencyInjection\WorkflowDebugPass;
@@ -155,6 +156,7 @@ class FrameworkBundle extends Bundle
         $container->addCompilerPass($registerListenersPass, PassConfig::TYPE_BEFORE_REMOVING);
         $this->addCompilerPassIfExists($container, AddConstraintValidatorsPass::class);
         $this->addCompilerPassIfExists($container, AddValidatorInitializersPass::class);
+        $this->addCompilerPassIfExists($container, AttributeMetadataPass::class);
         $this->addCompilerPassIfExists($container, AddConsoleCommandPass::class, PassConfig::TYPE_BEFORE_REMOVING);
         // must be registered before the AddConsoleCommandPass
         $container->addCompilerPass(new TranslationLintCommandPass(), PassConfig::TYPE_BEFORE_REMOVING, 10);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 use Symfony\Bundle\FrameworkBundle\CacheWarmer\ValidatorCacheWarmer;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\Form\Form;
 use Symfony\Component\Validator\Constraints\EmailValidator;
 use Symfony\Component\Validator\Constraints\ExpressionLanguageProvider;
 use Symfony\Component\Validator\Constraints\ExpressionValidator;
@@ -127,5 +128,9 @@ return static function (ContainerConfigurator $container) {
                 service('property_info'),
             ])
             ->tag('validator.auto_mapper')
+
+        ->set('validator.form.attribute_metadata', Form::class)
+            ->tag('container.excluded')
+            ->tag('validator.attribute_metadata')
     ;
 };

--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/Form.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/Form.php
@@ -11,11 +11,13 @@
 
 namespace Symfony\Component\Form\Extension\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
+#[\Attribute(\Attribute::TARGET_CLASS)]
 class Form extends Constraint
 {
     public const NOT_SYNCHRONIZED_ERROR = '1dafa156-89e1-4736-b832-419c2e501fca';
@@ -25,6 +27,12 @@ class Form extends Constraint
         self::NOT_SYNCHRONIZED_ERROR => 'NOT_SYNCHRONIZED_ERROR',
         self::NO_SUCH_FIELD_ERROR => 'NO_SUCH_FIELD_ERROR',
     ];
+
+    #[HasNamedArguments]
+    public function __construct(mixed $options = null, ?array $groups = null, mixed $payload = null)
+    {
+        parent::__construct($options, $groups, $payload);
+    }
 
     public function getTargets(): string|array
     {

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -22,11 +22,13 @@ use Symfony\Component\Form\Exception\OutOfBoundsException;
 use Symfony\Component\Form\Exception\RuntimeException;
 use Symfony\Component\Form\Exception\TransformationFailedException;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Validator\Constraints\Form as AssertForm;
 use Symfony\Component\Form\Util\FormUtil;
 use Symfony\Component\Form\Util\InheritDataAwareIterator;
 use Symfony\Component\Form\Util\OrderedHashMap;
 use Symfony\Component\PropertyAccess\PropertyPath;
 use Symfony\Component\PropertyAccess\PropertyPathInterface;
+use Symfony\Component\Validator\Constraints\Traverse;
 
 /**
  * Form represents a form.
@@ -68,6 +70,8 @@ use Symfony\Component\PropertyAccess\PropertyPathInterface;
  *
  * @implements \IteratorAggregate<string, FormInterface>
  */
+#[AssertForm]
+#[Traverse(false)]
 class Form implements \IteratorAggregate, FormInterface, ClearableErrorsInterface
 {
     private ?FormInterface $parent = null;
@@ -301,7 +305,7 @@ class Form implements \IteratorAggregate, FormInterface, ClearableErrorsInterfac
             if (null !== $dataClass && !$viewData instanceof $dataClass) {
                 $actualType = get_debug_type($viewData);
 
-                throw new LogicException('The form\'s view data is expected to be a "'.$dataClass.'", but it is a "'.$actualType.'". You can avoid this error by setting the "data_class" option to null or by adding a view transformer that transforms "'.$actualType.'" to an instance of "'.$dataClass.'".');
+                throw new LogicException(\sprintf('The form\'s view data is expected to be a "%s", but it is a "%s". You can avoid this error by setting the "data_class" option to null or by adding a view transformer that transforms "%2$s" to an instance of "%1$s".', $dataClass, $actualType));
             }
         }
 

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 7.4
 ---
 
+ * Add `ValidatorBuilder::addAttributeMappings()` and `AttributeMetadataPass` to declare compile-time constraint metadata using attributes
  * Add the `Video` constraint for validating video files
  * Deprecate implementing `__sleep/wakeup()` on `GenericMetadata` implementations; use `__(un)serialize()` instead
  * Deprecate passing a list of choices to the first argument of the `Choice` constraint. Use the `choices` option instead

--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -27,6 +27,7 @@ use Symfony\Component\Validator\Exception\MissingOptionsException;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 abstract class Constraint
 {
     /**

--- a/src/Symfony/Component/Validator/DependencyInjection/AttributeMetadataPass.php
+++ b/src/Symfony/Component/Validator/DependencyInjection/AttributeMetadataPass.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+final class AttributeMetadataPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('validator.builder')) {
+            return;
+        }
+
+        $resolve = $container->getParameterBag()->resolveValue(...);
+        $mappedClasses = [];
+        foreach ($container->getDefinitions() as $id => $definition) {
+            if (!$definition->hasTag('validator.attribute_metadata')) {
+                continue;
+            }
+            if (!$definition->hasTag('container.excluded')) {
+                throw new InvalidArgumentException(\sprintf('The resource "%s" tagged "validator.attribute_metadata" is missing the "container.excluded" tag.', $id));
+            }
+            $mappedClasses[$resolve($definition->getClass())] = true;
+        }
+
+        if (!$mappedClasses) {
+            return;
+        }
+
+        ksort($mappedClasses);
+
+        $container->getDefinition('validator.builder')
+            ->addMethodCall('addAttributeMappings', [array_keys($mappedClasses)]);
+    }
+}

--- a/src/Symfony/Component/Validator/Mapping/Loader/AttributeLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/AttributeLoader.php
@@ -27,8 +27,29 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
  */
 class AttributeLoader implements LoaderInterface
 {
+    /**
+     * @param class-string[] $mappedClasses
+     */
+    public function __construct(
+        private bool $allowAnyClass = true,
+        private array $mappedClasses = [],
+    ) {
+    }
+
+    /**
+     * @return class-string[]
+     */
+    public function getMappedClasses(): array
+    {
+        return $this->mappedClasses;
+    }
+
     public function loadClassMetadata(ClassMetadata $metadata): bool
     {
+        if (!$this->allowAnyClass && !\in_array($metadata->getClassName(), $this->mappedClasses, true)) {
+            return false;
+        }
+
         $reflClass = $metadata->getReflectionClass();
         $className = $reflClass->name;
         $success = false;

--- a/src/Symfony/Component/Validator/Mapping/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/XmlFileLoader.php
@@ -26,7 +26,7 @@ class XmlFileLoader extends FileLoader
     /**
      * The XML nodes of the mapping file.
      *
-     * @var \SimpleXMLElement[]
+     * @var array<class-string, \SimpleXMLElement>
      */
     protected array $classes;
 
@@ -55,7 +55,7 @@ class XmlFileLoader extends FileLoader
     /**
      * Return the names of the classes mapped in this file.
      *
-     * @return string[]
+     * @return class-string[]
      */
     public function getMappedClasses(): array
     {

--- a/src/Symfony/Component/Validator/Mapping/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/YamlFileLoader.php
@@ -56,7 +56,7 @@ class YamlFileLoader extends FileLoader
     /**
      * Return the names of the classes mapped in this file.
      *
-     * @return string[]
+     * @return class-string[]
      */
     public function getMappedClasses(): array
     {

--- a/src/Symfony/Component/Validator/Tests/DependencyInjection/AttributeMetadataPassTest.php
+++ b/src/Symfony/Component/Validator/Tests/DependencyInjection/AttributeMetadataPassTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\DependencyInjection;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Validator\DependencyInjection\AttributeMetadataPass;
+
+class AttributeMetadataPassTest extends TestCase
+{
+    public function testProcessWithNoValidatorBuilder()
+    {
+        $container = new ContainerBuilder();
+
+        // Should not throw any exception
+        (new AttributeMetadataPass())->process($container);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testProcessWithValidatorBuilderButNoTaggedServices()
+    {
+        $container = new ContainerBuilder();
+        $container->register('validator.builder');
+
+        $pass = new AttributeMetadataPass();
+        $pass->process($container);
+
+        $methodCalls = $container->getDefinition('validator.builder')->getMethodCalls();
+        $this->assertCount(0, $methodCalls);
+    }
+
+    public function testProcessWithTaggedServices()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('user_entity.class', 'App\Entity\User');
+        $container->register('validator.builder')
+            ->addMethodCall('addAttributeMappings', [[]]);
+
+        $container->register('service1', '%user_entity.class%')
+            ->addTag('validator.attribute_metadata')
+            ->addTag('container.excluded');
+        $container->register('service2', 'App\Entity\Product')
+            ->addTag('validator.attribute_metadata')
+            ->addTag('container.excluded');
+        $container->register('service3', 'App\Entity\Order')
+            ->addTag('validator.attribute_metadata')
+            ->addTag('container.excluded');
+        // Classes should be deduplicated
+        $container->register('service4', 'App\Entity\Order')
+            ->addTag('validator.attribute_metadata')
+            ->addTag('container.excluded');
+
+        (new AttributeMetadataPass())->process($container);
+
+        $methodCalls = $container->getDefinition('validator.builder')->getMethodCalls();
+        $this->assertCount(2, $methodCalls);
+        $this->assertEquals('addAttributeMappings', $methodCalls[1][0]);
+
+        // Classes should be sorted alphabetically
+        $expectedClasses = ['App\Entity\Order', 'App\Entity\Product', 'App\Entity\User'];
+        $this->assertEquals([$expectedClasses], $methodCalls[1][1]);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Prerequisite for #61288

At the moment, validation attributes are read at runtime when `framework.validation.enable_attributes` is true.

This means they don't fit for bundles nor can't they be warmed up.

This PR fixes both issues by using a new `validator.attribute_metadata` resource tag, that's turned into a list of classes to parse for attributes at compile-time.

For apps, the tag is added by autoconfiguration: any `Constraint`-derived attributes found on a class in the `src/` folder will trigger the rule to add the tag.

For bundles (and for apps if they want to), the tag is added by explicit service configuration. In an "eat your own dog-food" spirit, this capability is used to declare the constraints of the `Form` class: instead of loading the `validation.xml` file, we now declare this service resource:
```php
        ->set('validator.form.attribute_metadata', Form::class)
            ->resourceTag('validator.attribute_metadata')
```

This reads the attributes added to the `Form` class:
```php
#[AssertForm()]
#[Traverse(false)]
class Form implements \IteratorAggregate, FormInterface, ClearableErrorsInterface
```

Bundles can do the same and replace their XML files by attributes.

As a next step, we could also deprecate runtime-discovery of attributes. This could be worth it if this discovery has a measurable performance impact. To be measured if one wants to dig this idea.

Side note: I'm hoping this could allow removing the yaml and xml config formats one day. For serialization metadata also (PR coming). BUT, this doesn't (yet) cover the use case of overriding metadata defined by bundles. For that, apps still have to use xml or yaml in config/validation/. I have an idea to cover this, coming to a next PR if it works.

(failures unrelated)
