### PR TITLE
[FrameworkBundle] Don’t collect CLI profiles if the profiler is disabled

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/EventListener/ConsoleProfilerListener.php
+++ b/src/Symfony/Bundle/FrameworkBundle/EventListener/ConsoleProfilerListener.php
@@ -109,6 +109,10 @@ final class ConsoleProfilerListener implements EventSubscriberInterface
             return;
         }
 
+        if (!$this->profiler->isEnabled()) {
+            return;
+        }
+
         if (null !== $sectionId = $request->attributes->get('_stopwatch_token')) {
             // we must close the section before saving the profile to allow late collect
             try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60409
| License       | MIT

#59515 removed the check for the profiler being enabled, but if it isn’t its `collect` method will return `null` and the `ConsoleProfilerListener` will crash when trying to call `saveProfile`.