### PR TITLE
[DependencyInjection] add routing.controller to the list of known DI tags

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
@@ -78,6 +78,7 @@ class UnusedTagsPass implements CompilerPassInterface
         'proxy',
         'remote_event.consumer',
         'routing.condition_service',
+        'routing.controller',
         'routing.expression_language_function',
         'routing.expression_language_provider',
         'routing.loader',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/UnusedTagsPassUtils.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/UnusedTagsPassUtils.php
@@ -19,6 +19,7 @@ class UnusedTagsPassUtils
     {
         $tags = [
             'proxy' => true,
+            'routing.controller' => true,
         ];
 
         // get all tags used in XML configs


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

re-reading #61492 I wonder if we don't have to add the new tag to this list