### PR TITLE
[Serializer] Allow using attributes to declare compile-time serialization metadata

### DIFF
--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -95,6 +95,7 @@ Serializer
  * Make `AttributeMetadata` and `ClassMetadata` final
  * Deprecate class aliases in the `Annotation` namespace, use attributes instead
  * Deprecate getters in attribute classes in favor of public properties
+ * Deprecate `ClassMetadataFactoryCompiler`
 
 String
 ------

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/SerializerCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/SerializerCacheWarmer.php
@@ -14,13 +14,14 @@ namespace Symfony\Bundle\FrameworkBundle\CacheWarmer;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Serializer\Mapping\Factory\CacheClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
+use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
 use Symfony\Component\Serializer\Mapping\Loader\LoaderChain;
 use Symfony\Component\Serializer\Mapping\Loader\LoaderInterface;
 use Symfony\Component\Serializer\Mapping\Loader\XmlFileLoader;
 use Symfony\Component\Serializer\Mapping\Loader\YamlFileLoader;
 
 /**
- * Warms up XML and YAML serializer metadata.
+ * Warms up serializer metadata.
  *
  * @author Titouan Galopin <galopintitouan@gmail.com>
  *
@@ -66,14 +67,14 @@ class SerializerCacheWarmer extends AbstractPhpFileCacheWarmer
     /**
      * @param LoaderInterface[] $loaders
      *
-     * @return XmlFileLoader[]|YamlFileLoader[]
+     * @return list<XmlFileLoader|YamlFileLoader|AttributeLoader>
      */
     private function extractSupportedLoaders(array $loaders): array
     {
         $supportedLoaders = [];
 
         foreach ($loaders as $loader) {
-            if ($loader instanceof XmlFileLoader || $loader instanceof YamlFileLoader) {
+            if (method_exists($loader, 'getMappedClasses')) {
                 $supportedLoaders[] = $loader;
             } elseif ($loader instanceof LoaderChain) {
                 $supportedLoaders = array_merge($supportedLoaders, $this->extractSupportedLoaders($loader->getLoaders()));

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -65,6 +65,7 @@ use Symfony\Component\Routing\DependencyInjection\RoutingControllerPass;
 use Symfony\Component\Routing\DependencyInjection\RoutingResolverPass;
 use Symfony\Component\Runtime\SymfonyRuntime;
 use Symfony\Component\Scheduler\DependencyInjection\AddScheduleMessengerPass;
+use Symfony\Component\Serializer\DependencyInjection\AttributeMetadataPass as SerializerAttributeMetadataPass;
 use Symfony\Component\Serializer\DependencyInjection\SerializerPass;
 use Symfony\Component\Translation\DependencyInjection\DataCollectorTranslatorPass;
 use Symfony\Component\Translation\DependencyInjection\LoggingTranslatorPass;
@@ -170,6 +171,7 @@ class FrameworkBundle extends Bundle
         $this->addCompilerPassIfExists($container, TranslationDumperPass::class);
         $container->addCompilerPass(new FragmentRendererPass());
         $this->addCompilerPassIfExists($container, SerializerPass::class);
+        $this->addCompilerPassIfExists($container, SerializerAttributeMetadataPass::class);
         $this->addCompilerPassIfExists($container, PropertyInfoPass::class);
         $this->addCompilerPassIfExists($container, PropertyInfoConstructorPass::class);
         $container->addCompilerPass(new ControllerArgumentValueResolverPass());

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.php
@@ -28,6 +28,7 @@ use Symfony\Component\Serializer\Mapping\ClassDiscriminatorResolverInterface;
 use Symfony\Component\Serializer\Mapping\Factory\CacheClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
+use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
 use Symfony\Component\Serializer\Mapping\Loader\LoaderChain;
 use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
 use Symfony\Component\Serializer\NameConverter\MetadataAwareNameConverter;
@@ -150,6 +151,9 @@ return static function (ContainerConfigurator $container) {
         // Loader
         ->set('serializer.mapping.chain_loader', LoaderChain::class)
             ->args([[]])
+
+        ->set('serializer.mapping.attribute_loader', AttributeLoader::class)
+            ->args([true, []])
 
         // Class Metadata Factory
         ->set('serializer.mapping.class_metadata_factory', ClassMetadataFactory::class)

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/serializer_mapping_without_annotations.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/serializer_mapping_without_annotations.php
@@ -6,7 +6,7 @@ $container->loadFromExtension('framework', [
     'handle_all_throwables' => true,
     'php_errors' => ['log' => true],
     'serializer' => [
-        'enable_attributes' => false,
+        'enable_attributes' => true,
         'mapping' => [
             'paths' => [
                 '%kernel.project_dir%/Fixtures/TestBundle/Resources/config/serializer_mapping/files',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/serializer_mapping_without_annotations.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/serializer_mapping_without_annotations.xml
@@ -7,7 +7,7 @@
     <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
         <framework:php-errors log="true" />
-        <framework:serializer enable-attributes="false">
+        <framework:serializer enable-attributes="true">
             <framework:mapping>
                 <framework:path>%kernel.project_dir%/Fixtures/TestBundle/Resources/config/serializer_mapping/files</framework:path>
                 <framework:path>%kernel.project_dir%/Fixtures/TestBundle/Resources/config/serializer_mapping/serialization.yml</framework:path>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/serializer_mapping_without_annotations.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/serializer_mapping_without_annotations.yml
@@ -5,7 +5,7 @@ framework:
     php_errors:
         log: true
     serializer:
-        enable_attributes: false
+        enable_attributes: true
         mapping:
             paths:
                 - "%kernel.project_dir%/Fixtures/TestBundle/Resources/config/serializer_mapping/files"

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -4,11 +4,13 @@ CHANGELOG
 7.4
 ---
 
+ * Add `AttributeMetadataPass` to declare compile-time constraint metadata using attributes
  * Add `CDATA_WRAPPING_NAME_PATTERN` support to `XmlEncoder`
  * Add support for `can*()` methods to `AttributeLoader`
  * Make `AttributeMetadata` and `ClassMetadata` final
  * Deprecate class aliases in the `Annotation` namespace, use attributes instead
  * Deprecate getters in attribute classes in favor of public properties
+ * Deprecate `ClassMetadataFactoryCompiler`
 
 7.3
 ---

--- a/src/Symfony/Component/Serializer/DependencyInjection/AttributeMetadataPass.php
+++ b/src/Symfony/Component/Serializer/DependencyInjection/AttributeMetadataPass.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+final class AttributeMetadataPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('serializer.mapping.attribute_loader')) {
+            return;
+        }
+
+        $resolve = $container->getParameterBag()->resolveValue(...);
+        $taggedClasses = [];
+        foreach ($container->getDefinitions() as $id => $definition) {
+            if (!$definition->hasTag('serializer.attribute_metadata')) {
+                continue;
+            }
+            if (!$definition->hasTag('container.excluded')) {
+                throw new InvalidArgumentException(\sprintf('The resource "%s" tagged "serializer.attribute_metadata" is missing the "container.excluded" tag.', $id));
+            }
+            $taggedClasses[$resolve($definition->getClass())] = true;
+        }
+
+        ksort($taggedClasses);
+
+        if ($taggedClasses) {
+            $container->getDefinition('serializer.mapping.attribute_loader')
+                ->replaceArgument(1, array_keys($taggedClasses));
+        }
+    }
+}

--- a/src/Symfony/Component/Serializer/Mapping/Factory/ClassMetadataFactoryCompiler.php
+++ b/src/Symfony/Component/Serializer/Mapping/Factory/ClassMetadataFactoryCompiler.php
@@ -14,8 +14,12 @@ namespace Symfony\Component\Serializer\Mapping\Factory;
 use Symfony\Component\Serializer\Mapping\ClassMetadataInterface;
 use Symfony\Component\VarExporter\VarExporter;
 
+trigger_deprecation('symfony/serializer', '7.4', 'The "%s" class is deprecated.', ClassMetadataFactoryCompiler::class);
+
 /**
  * @author Fabien Bourigault <bourigaultfabien@gmail.com>
+ *
+ * @deprecated since Symfony 7.4
  */
 final class ClassMetadataFactoryCompiler
 {

--- a/src/Symfony/Component/Serializer/Mapping/Loader/AttributeLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AttributeLoader.php
@@ -43,12 +43,31 @@ class AttributeLoader implements LoaderInterface
         Context::class,
     ];
 
-    public function __construct()
+    /**
+     * @param bool|null      $allowAnyClass Null is allowed for BC with Symfony <= 6
+     * @param class-string[] $mappedClasses
+     */
+    public function __construct(
+        private ?bool $allowAnyClass = true,
+        private array $mappedClasses = [],
+    ) {
+        $this->allowAnyClass ??= true;
+    }
+
+    /**
+     * @return class-string[]
+     */
+    public function getMappedClasses(): array
     {
+        return $this->mappedClasses;
     }
 
     public function loadClassMetadata(ClassMetadataInterface $classMetadata): bool
     {
+        if (!$this->allowAnyClass && !\in_array($classMetadata->getName(), $this->mappedClasses, true)) {
+            return false;
+        }
+
         $reflectionClass = $classMetadata->getReflectionClass();
         $className = $reflectionClass->name;
         $loaded = false;

--- a/src/Symfony/Component/Serializer/Mapping/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/XmlFileLoader.php
@@ -29,7 +29,7 @@ class XmlFileLoader extends FileLoader
     /**
      * An array of {@class \SimpleXMLElement} instances.
      *
-     * @var \SimpleXMLElement[]|null
+     * @var array<class-string, \SimpleXMLElement>|null
      */
     private ?array $classes = null;
 
@@ -121,7 +121,7 @@ class XmlFileLoader extends FileLoader
     /**
      * Return the names of the classes mapped in this file.
      *
-     * @return string[]
+     * @return class-string[]
      */
     public function getMappedClasses(): array
     {
@@ -144,6 +144,9 @@ class XmlFileLoader extends FileLoader
         return simplexml_import_dom($dom);
     }
 
+    /**
+     * @return array<class-string, \SimpleXMLElement>
+     */
     private function getClassesFromXml(): array
     {
         $xml = $this->parseFile($this->file);

--- a/src/Symfony/Component/Serializer/Mapping/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/YamlFileLoader.php
@@ -30,7 +30,7 @@ class YamlFileLoader extends FileLoader
     private ?Parser $yamlParser = null;
 
     /**
-     * An array of YAML class descriptions.
+     * @var array<class-string, array>
      */
     private ?array $classes = null;
 
@@ -144,13 +144,16 @@ class YamlFileLoader extends FileLoader
     /**
      * Return the names of the classes mapped in this file.
      *
-     * @return string[]
+     * @return class-string[]
      */
     public function getMappedClasses(): array
     {
         return array_keys($this->classes ??= $this->getClassesFromYaml());
     }
 
+    /**
+     * @return array<class-string, array>
+     */
     private function getClassesFromYaml(): array
     {
         if (!stream_is_local($this->file)) {

--- a/src/Symfony/Component/Serializer/Tests/DependencyInjection/AttributeMetadataPassTest.php
+++ b/src/Symfony/Component/Serializer/Tests/DependencyInjection/AttributeMetadataPassTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\DependencyInjection;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Serializer\DependencyInjection\AttributeMetadataPass;
+use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
+
+class AttributeMetadataPassTest extends TestCase
+{
+    public function testProcessWithNoAttributeLoader()
+    {
+        $container = new ContainerBuilder();
+
+        // Should not throw any exception
+        (new AttributeMetadataPass())->process($container);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testProcessWithAttributeLoaderButNoTaggedServices()
+    {
+        $container = new ContainerBuilder();
+        $container->register('serializer.mapping.attribute_loader', AttributeLoader::class)
+            ->setArguments([false, []]);
+
+        // Should not throw any exception
+        (new AttributeMetadataPass())->process($container);
+
+        $arguments = $container->getDefinition('serializer.mapping.attribute_loader')->getArguments();
+        $this->assertSame([false, []], $arguments);
+    }
+
+    public function testProcessWithTaggedServices()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('user_entity.class', 'App\Entity\User');
+
+        $container->register('serializer.mapping.attribute_loader', AttributeLoader::class)
+            ->setArguments([false, []]);
+
+        $container->register('service1', '%user_entity.class%')
+            ->addTag('serializer.attribute_metadata')
+            ->addTag('container.excluded');
+        $container->register('service2', 'App\Entity\Product')
+            ->addTag('serializer.attribute_metadata')
+            ->addTag('container.excluded');
+        $container->register('service3', 'App\Entity\Order')
+            ->addTag('serializer.attribute_metadata')
+            ->addTag('container.excluded');
+        // Classes should be deduplicated
+        $container->register('service4', 'App\Entity\Order')
+            ->addTag('serializer.attribute_metadata')
+            ->addTag('container.excluded');
+
+        (new AttributeMetadataPass())->process($container);
+
+        $arguments = $container->getDefinition('serializer.mapping.attribute_loader')->getArguments();
+
+        // Classes should be sorted alphabetically
+        $expectedClasses = ['App\Entity\Order', 'App\Entity\Product', 'App\Entity\User'];
+        $this->assertSame([false, $expectedClasses], $arguments);
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Factory/ClassMetadataFactoryCompilerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Factory/ClassMetadataFactoryCompilerTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Serializer\Tests\Mapping\Factory;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryCompiler;
@@ -25,6 +27,8 @@ use Symfony\Component\Serializer\Tests\Fixtures\Attributes\SerializedPathDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Attributes\SerializedPathInConstructorDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Dummy;
 
+#[IgnoreDeprecations]
+#[Group('legacy')]
 final class ClassMetadataFactoryCompilerTest extends TestCase
 {
     private string $dumpPath;

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AttributeLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AttributeLoaderTest.php
@@ -247,6 +247,31 @@ class AttributeLoaderTest extends TestCase
         self::assertArrayNotHasKey('h', $attributesMetadata);
     }
 
+    public function testGetMappedClasses()
+    {
+        $mappedClasses = ['App\Entity\User', 'App\Entity\Product'];
+        $loader = new AttributeLoader(false, $mappedClasses);
+
+        $this->assertSame($mappedClasses, $loader->getMappedClasses());
+    }
+
+    public function testLoadClassMetadataReturnsFalseForUnmappedClass()
+    {
+        $loader = new AttributeLoader(false, ['App\Entity\User']);
+        $classMetadata = new ClassMetadata('App\Entity\Product');
+
+        $this->assertFalse($loader->loadClassMetadata($classMetadata));
+    }
+
+    public function testLoadClassMetadataForMappedClassWithAttributes()
+    {
+        $loader = new AttributeLoader(false, [GroupDummy::class]);
+        $classMetadata = new ClassMetadata(GroupDummy::class);
+
+        $this->assertTrue($loader->loadClassMetadata($classMetadata));
+        $this->assertNotEmpty($classMetadata->getAttributesMetadata());
+    }
+
     protected function getLoaderForContextMapping(): AttributeLoader
     {
         return $this->loader;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | -
| License       | MIT

Very close to #61528
Prerequisite for #61287

At the moment, serialization attributes are read at runtime when `framework.serialization.enable_attributes` is true.

This means they don't fit for bundles nor can't they be warmed up.

This PR fixes both issues by using a new `serializer.attribute_metadata` resource tag, that's turned into a list of classes to parse for attributes at compile-time.

For bundles and for apps, the tag is added by explicit service configuration:
```php
        ->set('my_bundle.api_resource.product', Product::class)
            ->resourceTag('serializer.attribute_metadata')
```

Unlike validation where we have constraint attributes to auto-discover service resources, serialization doesn't have any corresponding hooks. We do have a few like `#[DiscriminatorMap]` of `#[Groups]`, but relying on those would miss many more classes that are meant for serialization. Maybe we could introduce an attribute that'd hint that some class is serializable by the component (and require the attribute at some point in the future?)