### PR TITLE
[HttpClient] Fix PHP 8.5 deprecation using str_increment()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
         "symfony/polyfill-intl-idn": "^1.10",
         "symfony/polyfill-intl-normalizer": "~1.0",
         "symfony/polyfill-mbstring": "~1.0",
-        "symfony/polyfill-php83": "^1.28",
+        "symfony/polyfill-php83": "^1.29",
         "symfony/polyfill-uuid": "^1.15"
     },
     "replace": {

--- a/src/Symfony/Component/HttpClient/Response/AmpResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/AmpResponse.php
@@ -99,7 +99,8 @@ final class AmpResponse implements ResponseInterface, StreamableInterface
 
         $throttleWatcher = null;
 
-        $this->id = $id = self::$nextId++;
+        $this->id = $id = self::$nextId;
+        self::$nextId = str_increment(self::$nextId);
         Loop::defer(static function () use ($request, $multi, $id, &$info, &$headers, $canceller, &$options, $onProgress, &$handle, $logger, &$pause) {
             return new Coroutine(self::generateResponse($request, $multi, $id, $info, $headers, $canceller, $options, $onProgress, $handle, $logger, $pause));
         });

--- a/src/Symfony/Component/HttpClient/composer.json
+++ b/src/Symfony/Component/HttpClient/composer.json
@@ -26,6 +26,7 @@
         "psr/log": "^1|^2|^3",
         "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/http-client-contracts": "~3.4.4|^3.5.2",
+        "symfony/polyfill-php83": "^1.29",
         "symfony/service-contracts": "^2.5|^3"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

> Increment on non-numeric string is deprecated, use str_increment() instead