### PR TITLE
[DependencyInjection] Allow adding resource tags using any config formats

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/Autoconfigure.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/Autoconfigure.php
@@ -20,16 +20,17 @@ namespace Symfony\Component\DependencyInjection\Attribute;
 class Autoconfigure
 {
     /**
-     * @param array<array-key, array<array-key, mixed>>|string[]|null $tags         The tags to add to the service
-     * @param array<array<mixed>>|null                                $calls        The calls to be made when instantiating the service
-     * @param array<string, mixed>|null                               $bind         The bindings to declare for the service
-     * @param bool|string|null                                        $lazy         Whether the service is lazy-loaded
-     * @param bool|null                                               $public       Whether to declare the service as public
-     * @param bool|null                                               $shared       Whether to declare the service as shared
-     * @param bool|null                                               $autowire     Whether to declare the service as autowired
-     * @param array<string, mixed>|null                               $properties   The properties to define when creating the service
-     * @param array{string, string}|string|null                       $configurator A PHP function, reference or an array containing a class/reference and a method to call after the service is fully initialized
-     * @param string|null                                             $constructor  The public static method to use to instantiate the service
+     * @param array<array<mixed>>|string[]|null $tags         The tags to add to the service
+     * @param array<array<mixed>>|null          $calls        The calls to be made when instantiating the service
+     * @param array<string, mixed>|null         $bind         The bindings to declare for the service
+     * @param bool|string|null                  $lazy         Whether the service is lazy-loaded
+     * @param bool|null                         $public       Whether to declare the service as public
+     * @param bool|null                         $shared       Whether to declare the service as shared
+     * @param bool|null                         $autowire     Whether to declare the service as autowired
+     * @param array<string, mixed>|null         $properties   The properties to define when creating the service
+     * @param array{string, string}|string|null $configurator A PHP function, reference or an array containing a class/reference and a method to call after the service is fully initialized
+     * @param string|null                       $constructor  The public static method to use to instantiate the service
+     * @param array<array<mixed>>|string[]|null $resourceTags The resource tags to add to the service
      */
     public function __construct(
         public ?array $tags = null,
@@ -42,6 +43,7 @@ class Autoconfigure
         public ?array $properties = null,
         public array|string|null $configurator = null,
         public ?string $constructor = null,
+        public ?array $resourceTags = null,
     ) {
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Attribute/AutoconfigureResourceTag.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/AutoconfigureResourceTag.php
@@ -12,21 +12,19 @@
 namespace Symfony\Component\DependencyInjection\Attribute;
 
 /**
- * An attribute to tell how a base type should be tagged.
- *
  * @author Nicolas Grekas <p@tchwork.com>
  */
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
-class AutoconfigureTag extends Autoconfigure
+class AutoconfigureResourceTag extends Autoconfigure
 {
     /**
-     * @param string|null  $name       The tag name to add
-     * @param array<mixed> $attributes The attributes to attach to the tag
+     * @param string|null  $name       The resource tag name to add
+     * @param array<mixed> $attributes The attributes to attach to the resource tag
      */
     public function __construct(?string $name = null, array $attributes = [])
     {
         parent::__construct(
-            tags: [
+            resourceTags: [
                 [$name ?? 0 => $attributes],
             ]
         );

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 7.4
 ---
 
+ * Allow adding resource tags using any config format
  * Allow `#[AsAlias]` to be extended
  * Add argument `$target` to `ContainerBuilder::registerAliasForArgument()`
  * Deprecate registering a service without a class when its id is a non-existing FQCN

--- a/src/Symfony/Component/DependencyInjection/Compiler/RegisterAutoconfigureAttributesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RegisterAutoconfigureAttributesPass.php
@@ -72,11 +72,17 @@ final class RegisterAutoconfigureAttributesPass implements CompilerPassInterface
         self::$registerForAutoconfiguration = static function (ContainerBuilder $container, \ReflectionClass $class, \ReflectionAttribute $attribute) use ($parseDefinitions, $yamlLoader) {
             $attribute = (array) $attribute->newInstance();
 
-            foreach ($attribute['tags'] ?? [] as $i => $tag) {
-                if (\is_array($tag) && [0] === array_keys($tag)) {
-                    $attribute['tags'][$i] = [$class->name => $tag[0]];
+            foreach (['tags', 'resourceTags'] as $type) {
+                foreach ($attribute[$type] ?? [] as $i => $tag) {
+                    if (\is_array($tag) && [0] === array_keys($tag)) {
+                        $attribute[$type][$i] = [$class->name => $tag[0]];
+                    }
                 }
             }
+            if (isset($attribute['resourceTags'])) {
+                $attribute['resource_tags'] = $attribute['resourceTags'];
+            }
+            unset($attribute['resourceTags']);
 
             $parseDefinitions->invoke(
                 $yamlLoader,

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/DefaultsConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/DefaultsConfigurator.php
@@ -55,6 +55,26 @@ class DefaultsConfigurator extends AbstractServiceConfigurator
     }
 
     /**
+     * Adds a resource tag for this definition.
+     *
+     * @return $this
+     *
+     * @throws InvalidArgumentException when an invalid tag name or attribute is provided
+     */
+    final public function resourceTag(string $name, array $attributes = []): static
+    {
+        if ('' === $name) {
+            throw new InvalidArgumentException('The resource tag name in "_defaults" must be a non-empty string.');
+        }
+
+        $this->validateAttributes($name, $attributes);
+
+        $this->definition->addResourceTag($name, $attributes);
+
+        return $this;
+    }
+
+    /**
      * Defines an instanceof-conditional to be applied to following service definitions.
      */
     final public function instanceof(string $fqcn): InstanceofConfigurator

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/TagTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/TagTrait.php
@@ -33,6 +33,24 @@ trait TagTrait
         return $this;
     }
 
+    /**
+     * Adds a resource tag for this definition.
+     *
+     * @return $this
+     */
+    final public function resourceTag(string $name, array $attributes = []): static
+    {
+        if ('' === $name) {
+            throw new InvalidArgumentException(\sprintf('The resource tag name for service "%s" must be a non-empty string.', $this->id));
+        }
+
+        $this->validateAttributes($name, $attributes);
+
+        $this->definition->addResourceTag($name, $attributes);
+
+        return $this;
+    }
+
     private function validateAttributes(string $tag, array $attributes, array $path = []): void
     {
         foreach ($attributes as $name => $value) {

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -151,6 +151,7 @@
       <xsd:element name="deprecated" type="deprecated" minOccurs="0" maxOccurs="1" />
       <xsd:element name="call" type="call" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="tag" type="tag" minOccurs="0" maxOccurs="unbounded" />
+      <xsd:element name="resource-tag" type="tag" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="property" type="property" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="bind" type="bind" minOccurs="0" maxOccurs="unbounded" />
     </xsd:choice>
@@ -197,6 +198,7 @@
       <xsd:element name="deprecated" type="deprecated" minOccurs="0" maxOccurs="1" />
       <xsd:element name="call" type="call" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="tag" type="tag" minOccurs="0" maxOccurs="unbounded" />
+      <xsd:element name="resource-tag" type="tag" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="property" type="property" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="bind" type="bind" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="exclude" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/services.schema.json
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/services.schema.json
@@ -249,6 +249,7 @@
         "properties": { "type": "object", "additionalProperties": { "$ref": "#/$defs/parameterValue" } },
         "calls": { "$ref": "#/$defs/calls" },
         "tags": { "$ref": "#/$defs/tags" },
+        "resource_tags": { "$ref": "#/$defs/tags" },
         "decorates": { "type": "string" },
         "decoration_inner_name": { "type": "string" },
         "decoration_priority": { "type": "integer" },
@@ -285,6 +286,7 @@
         "configurator": { "$ref": "#/$defs/callable" },
         "calls": { "$ref": "#/$defs/calls" },
         "tags": { "$ref": "#/$defs/tags" },
+        "resource_tags": { "$ref": "#/$defs/tags" },
         "autowire": { "type": "boolean" },
         "autoconfigure": { "type": "boolean" },
         "bind": { "type": "object", "additionalProperties": { "$ref": "#/$defs/parameterValue" } },
@@ -322,6 +324,7 @@
       "properties": {
         "public": { "type": "boolean" },
         "tags": { "$ref": "#/$defs/tags" },
+        "resource_tags": { "$ref": "#/$defs/tags" },
         "autowire": { "type": "boolean" },
         "autoconfigure": { "type": "boolean" },
         "bind": {
@@ -342,6 +345,7 @@
         "configurator": { "$ref": "#/$defs/callable" },
         "calls": { "$ref": "#/$defs/calls" },
         "tags": { "$ref": "#/$defs/tags" },
+        "resource_tags": { "$ref": "#/$defs/tags" },
         "autowire": { "type": "boolean" },
         "bind": { "type": "object", "additionalProperties": { "$ref": "#/$defs/parameterValue" } },
         "constructor": { "type": "string" }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterAutoconfigureAttributesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterAutoconfigureAttributesPassTest.php
@@ -26,6 +26,7 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\AutoconfigureRepeatedCa
 use Symfony\Component\DependencyInjection\Tests\Fixtures\AutoconfigureRepeatedOverwrite;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\AutoconfigureRepeatedProperties;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\AutoconfigureRepeatedTag;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\AutoconfigureResourceTagsAttributed;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\LazyAutoconfigured;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\LazyLoaded;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\MultipleAutoconfigureAttributed;
@@ -248,5 +249,21 @@ class RegisterAutoconfigureAttributesPassTest extends TestCase
             ->addTag('bar')
         ;
         $this->assertEquals([MultipleAutoconfigureAttributed::class => $expected], $container->getAutoconfiguredInstanceof());
+    }
+
+    public function testAutoconfiguredResourceTags()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', AutoconfigureResourceTagsAttributed::class)
+            ->setAutoconfigured(true);
+
+        (new RegisterAutoconfigureAttributesPass())->process($container);
+
+        $expected = (new ChildDefinition(''))
+            ->addResourceTag('my.tag', ['foo' => 'bar'])
+            ->addResourceTag('another.tag')
+        ;
+
+        $this->assertEquals([AutoconfigureResourceTagsAttributed::class => $expected], $container->getAutoconfiguredInstanceof());
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AutoconfigureResourceTagsAttributed.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AutoconfigureResourceTagsAttributed.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureResourceTag;
+
+#[AutoconfigureResourceTag('my.tag', ['foo' => 'bar'])]
+#[AutoconfigureResourceTag('another.tag')]
+class AutoconfigureResourceTagsAttributed
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/resource_tags.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/resource_tags.php
@@ -1,0 +1,12 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $configurator) {
+    $services = $configurator->services();
+
+    $services->set('foo', stdClass::class)
+        ->resourceTag('my.tag', ['foo' => 'bar'])
+        ->resourceTag('another.tag')
+    ;
+};

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_resource_tags.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_resource_tags.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="foo" class="stdClass">
+            <resource-tag name="my.tag" foo="bar" />
+            <resource-tag>another.tag</resource-tag>
+        </service>
+    </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_resource_tags.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_resource_tags.yml
@@ -1,0 +1,6 @@
+services:
+    foo:
+        class: stdClass
+        resource_tags:
+            - { name: 'my.tag', foo: 'bar' }
+            - 'another.tag'

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
@@ -144,6 +144,21 @@ class PhpFileLoaderTest extends TestCase
         yield ['env_param'];
     }
 
+    public function testResourceTags()
+    {
+        $fixtures = realpath(__DIR__.'/../Fixtures');
+        $loader = new PhpFileLoader($container = new ContainerBuilder(), new FileLocator());
+        $loader->load($fixtures.'/config/resource_tags.php');
+
+        $def = $container->getDefinition('foo');
+        $this->assertTrue($def->hasTag('container.excluded'));
+        $this->assertTrue($def->hasTag('my.tag'));
+        $this->assertTrue($def->hasTag('another.tag'));
+        $this->assertSame([['foo' => 'bar']], $def->getTag('my.tag'));
+        $this->assertSame([[]], $def->getTag('another.tag'));
+        $this->assertTrue($def->isAbstract());
+    }
+
     public function testAutoConfigureAndChildDefinition()
     {
         $fixtures = realpath(__DIR__.'/../Fixtures');

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -369,6 +369,21 @@ class XmlFileLoaderTest extends TestCase
         $this->assertEquals(['decorated', 'decorated.pif-pouf', 5, ContainerInterface::IGNORE_ON_INVALID_REFERENCE], $services['decorator_service_with_name_and_priority_and_on_invalid']->getDecoratedService());
     }
 
+    public function testResourceTags()
+    {
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
+        $loader->load('services_resource_tags.xml');
+
+        $def = $container->getDefinition('foo');
+        $this->assertTrue($def->hasTag('container.excluded'));
+        $this->assertTrue($def->hasTag('my.tag'));
+        $this->assertTrue($def->hasTag('another.tag'));
+        $this->assertSame([['foo' => 'bar']], $def->getTag('my.tag'));
+        $this->assertSame([[]], $def->getTag('another.tag'));
+        $this->assertTrue($def->isAbstract());
+    }
+
     public function testParsesIteratorArgument()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -247,6 +247,21 @@ class YamlFileLoaderTest extends TestCase
         $this->assertEquals(['decorated', 'decorated.pif-pouf', 5, ContainerInterface::IGNORE_ON_INVALID_REFERENCE], $services['decorator_service_with_name_and_priority_and_on_invalid']->getDecoratedService());
     }
 
+    public function testResourceTags()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('services_resource_tags.yml');
+
+        $def = $container->getDefinition('foo');
+        $this->assertTrue($def->hasTag('container.excluded'));
+        $this->assertTrue($def->hasTag('my.tag'));
+        $this->assertTrue($def->hasTag('another.tag'));
+        $this->assertSame([['foo' => 'bar']], $def->getTag('my.tag'));
+        $this->assertSame([[]], $def->getTag('another.tag'));
+        $this->assertTrue($def->isAbstract());
+    }
+
     public function testLoadShortSyntax()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/Scheduler/Attribute/AsCronTask.php
+++ b/src/Symfony/Component/Scheduler/Attribute/AsCronTask.php
@@ -20,16 +20,16 @@ namespace Symfony\Component\Scheduler\Attribute;
 class AsCronTask
 {
     /**
-     * @param string                              $expression The cron expression to define the task schedule (i.e. "5 * * * *")
-     * @param string|null                         $timezone   The timezone used with the cron expression
-     * @param int|null                            $jitter     The cron jitter, in seconds; for example, if set to 60, the cron
-     *                                                        will randomly wait for a number of seconds between 0 and 60 before
-     *                                                        executing which allows to avoid load spikes that can happen when many tasks
-     *                                                        run at the same time
-     * @param array<array-key, mixed>|string|null $arguments  The arguments to pass to the cron task
-     * @param string                              $schedule   The name of the schedule responsible for triggering the task
-     * @param string|null                         $method     The method to run as the task when the attribute target is a class
-     * @param string[]|string|null                $transports One or many transports through which the message scheduling the task will go
+     * @param string                   $expression The cron expression to define the task schedule (i.e. "5 * * * *")
+     * @param string|null              $timezone   The timezone used with the cron expression
+     * @param int|null                 $jitter     The cron jitter, in seconds; for example, if set to 60, the cron
+     *                                             will randomly wait for a number of seconds between 0 and 60 before
+     *                                             executing which allows to avoid load spikes that can happen when many tasks
+     *                                             run at the same time
+     * @param array<mixed>|string|null $arguments  The arguments to pass to the cron task
+     * @param string                   $schedule   The name of the schedule responsible for triggering the task
+     * @param string|null              $method     The method to run as the task when the attribute target is a class
+     * @param string[]|string|null     $transports One or many transports through which the message scheduling the task will go
      */
     public function __construct(
         public readonly string $expression,

--- a/src/Symfony/Component/Scheduler/Attribute/AsPeriodicTask.php
+++ b/src/Symfony/Component/Scheduler/Attribute/AsPeriodicTask.php
@@ -20,17 +20,17 @@ namespace Symfony\Component\Scheduler\Attribute;
 class AsPeriodicTask
 {
     /**
-     * @param string|int                          $frequency  A string (i.e. "every hour") or an integer (the number of seconds) representing the frequency of the task
-     * @param string|null                         $from       A string representing the start time of the periodic task (i.e. "08:00:00")
-     * @param string|null                         $until      A string representing the end time of the periodic task (i.e. "20:00:00")
-     * @param int|null                            $jitter     The cron jitter, in seconds; for example, if set to 60, the cron
-     *                                                        will randomly wait for a number of seconds between 0 and 60 before
-     *                                                        executing which allows to avoid load spikes that can happen when many tasks
-     *                                                        run at the same time
-     * @param array<array-key, mixed>|string|null $arguments  The arguments to pass to the cron task
-     * @param string                              $schedule   The name of the schedule responsible for triggering the task
-     * @param string|null                         $method     The method to run as the task when the attribute target is a class
-     * @param string[]|string|null                $transports One or many transports through which the message scheduling the task will go
+     * @param string|int               $frequency  A string (i.e. "every hour") or an integer (the number of seconds) representing the frequency of the task
+     * @param string|null              $from       A string representing the start time of the periodic task (i.e. "08:00:00")
+     * @param string|null              $until      A string representing the end time of the periodic task (i.e. "20:00:00")
+     * @param int|null                 $jitter     The cron jitter, in seconds; for example, if set to 60, the cron
+     *                                             will randomly wait for a number of seconds between 0 and 60 before
+     *                                             executing which allows to avoid load spikes that can happen when many tasks
+     *                                             run at the same time
+     * @param array<mixed>|string|null $arguments  The arguments to pass to the cron task
+     * @param string                   $schedule   The name of the schedule responsible for triggering the task
+     * @param string|null              $method     The method to run as the task when the attribute target is a class
+     * @param string[]|string|null     $transports One or many transports through which the message scheduling the task will go
      */
     public function __construct(
         public readonly string|int $frequency,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Everywhere we allow defining a tag, this allows defining a resource-tag, to make it easier to register resource services.

Best review [ignoring whitespaces](https://github.com/symfony/symfony/pull/61536/files?w=1).