### PR TITLE
[Security] Allow subclassing `#[IsGranted]`

### DIFF
--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -8,7 +8,7 @@ CHANGELOG
  * Deprecate callable firewall listeners, extend `AbstractListener` or implement `FirewallListenerInterface` instead
  * Deprecate `AbstractListener::__invoke`
  * Add `$methods` argument to `#[IsGranted]` to restrict validation to specific HTTP methods
- * Remove `final` keyword from `#[IsGranted]` to allow implementation of custom attributes
+ * Allow subclassing `#[IsGranted]`
 
 7.3
 ---

--- a/src/Symfony/Component/Security/Http/EventListener/IsGrantedAttributeListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/IsGrantedAttributeListener.php
@@ -39,7 +39,14 @@ class IsGrantedAttributeListener implements EventSubscriberInterface
 
     public function onKernelControllerArguments(ControllerArgumentsEvent $event): void
     {
-        if (!$attributes = $event->getAttributes(IsGranted::class)) {
+        $attributes = [];
+        foreach ($event->getAttributes() as $class => $attributes[]) {
+            if (!is_a($class, IsGranted::class, true)) {
+                array_pop($attributes);
+            }
+        }
+
+        if (!$attributes = array_merge(...$attributes)) {
             return;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Was missing from #61504