### PR TITLE
[TypeInfo] Prevent interfaces extending BackedEnum to be treated as BackedEnums

### DIFF
--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyBackedEnumInterface.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyBackedEnumInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Tests\Fixtures;
+
+interface DummyBackedEnumInterface extends \BackedEnum
+{
+}

--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/ReflectionExtractableDummy.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/ReflectionExtractableDummy.php
@@ -37,6 +37,8 @@ final class ReflectionExtractableDummy extends AbstractDummy
     public DummyBackedEnum $backedEnum;
     public ?DummyBackedEnum $nullableBackedEnum;
 
+    public DummyBackedEnumInterface $backedEnumInterface;
+
     public int|string $union;
     public \Traversable&\Stringable $intersection;
 

--- a/src/Symfony/Component/TypeInfo/Tests/TypeResolver/ReflectionTypeResolverTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeResolver/ReflectionTypeResolverTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\TypeInfo\Exception\UnsupportedException;
 use Symfony\Component\TypeInfo\Tests\Fixtures\AbstractDummy;
 use Symfony\Component\TypeInfo\Tests\Fixtures\Dummy;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyBackedEnum;
+use Symfony\Component\TypeInfo\Tests\Fixtures\DummyBackedEnumInterface;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyEnum;
 use Symfony\Component\TypeInfo\Tests\Fixtures\ReflectionExtractableDummy;
 use Symfony\Component\TypeInfo\Type;
@@ -67,6 +68,7 @@ class ReflectionTypeResolverTest extends TestCase
         yield [Type::nullable(Type::enum(DummyEnum::class)), $reflection->getProperty('nullableEnum')->getType()];
         yield [Type::enum(DummyBackedEnum::class), $reflection->getProperty('backedEnum')->getType()];
         yield [Type::nullable(Type::enum(DummyBackedEnum::class)), $reflection->getProperty('nullableBackedEnum')->getType()];
+        yield [Type::object(DummyBackedEnumInterface::class), $reflection->getProperty('backedEnumInterface')->getType()];
         yield [Type::union(Type::int(), Type::string()), $reflection->getProperty('union')->getType()];
         yield [Type::intersection(Type::object(\Traversable::class), Type::object(\Stringable::class)), $reflection->getProperty('intersection')->getType()];
     }

--- a/src/Symfony/Component/TypeInfo/TypeResolver/ReflectionTypeResolver.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/ReflectionTypeResolver.php
@@ -76,7 +76,7 @@ final class ReflectionTypeResolver implements TypeResolverInterface
             default => $identifier,
         };
 
-        if (is_subclass_of($className, \UnitEnum::class)) {
+        if (is_subclass_of($className, \UnitEnum::class) && !interface_exists($className)) {
             $type = Type::enum($className);
         } else {
             $type = Type::object($className);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT


Given 
```
interface DummyBackedEnumInterface extends \BackedEnum
{
}
```

`TypeFactoryTrait.php::enum():249` throws exception `Class "DummyBackedEnumInterface" is not an enum` trying to get the backing type, which is not defined.

```
    public static function enum(string $className, ?BuiltinType $backingType = null): EnumType
    {
        if (is_subclass_of($className, \BackedEnum::class)) {
            if (null === $backingType) {
                $reflectionBackingType = (new \ReflectionEnum($className))->getBackingType(); // <-- throws 
                $typeIdentifier = TypeIdentifier::INT->value === (string) $reflectionBackingType ? TypeIdentifier::INT : TypeIdentifier::STRING;
                $backingType = new BuiltinType($typeIdentifier);
            }

            return new BackedEnumType($className, $backingType);
        }

        return new EnumType($className);
    }
```

This PR is meant as a fix. Upgrading to 7.3 broke my project because of this issue. 

The open problem is how TypeInfo should handle BackedEnums that have no backing type defined. Besides interfaces, I'm not aware of any other way this can happen.

An alternative would be to extend `BackedEnumType` to support undefined backing type.