### PR TITLE
[HttpFoundation] Fix BC Break introduces in `#61267` and structured suffix formats as constant

### DIFF
--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -61,6 +61,7 @@ HttpFoundation
 --------------
 
  * Deprecate using `Request::sendHeaders()` after headers have already been sent; use a `StreamedResponse` instead
+ * Add argument `$subtypeFallback` to `Request::getFormat()`
 
 HttpKernel
 ----------

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -195,6 +195,28 @@ class Request
         self::HEADER_X_FORWARDED_PREFIX => 'X_FORWARDED_PREFIX',
     ];
 
+    /**
+     * This mapping is used when no exact MIME match is found in $formats.
+     *
+     * It enables mappings like application/soap+xml -> xml.
+     *
+     * @see https://datatracker.ietf.org/doc/html/rfc6839
+     * @see https://datatracker.ietf.org/doc/html/rfc7303
+     * @see https://www.iana.org/assignments/media-types/media-types.xhtml
+     */
+    private const STRUCTURED_SUFFIX_FORMATS = [
+        'json' => 'json',
+        'xml' => 'xml',
+        'xhtml' => 'html',
+        'cbor' => 'cbor',
+        'zip' => 'zip',
+        'ber' => 'asn1',
+        'der' => 'asn1',
+        'tlv' => 'tlv',
+        'wbxml' => 'xml',
+        'yaml' => 'yaml',
+    ];
+
     private bool $isIisRewrite = false;
 
     /**
@@ -1239,8 +1261,9 @@ class Request
      * @param string|null $mimeType        The mime type to check
      * @param bool        $subtypeFallback Whether to fall back to the subtype if no exact match is found
      */
-    public function getFormat(?string $mimeType, bool $subtypeFallback = false): ?string
+    public function getFormat(?string $mimeType/* , bool $subtypeFallback = false */): ?string
     {
+        $subtypeFallback = 2 <= \func_num_args() ? func_get_arg(1) : false;
         $canonicalMimeType = null;
         if ($mimeType && false !== $pos = strpos($mimeType, ';')) {
             $canonicalMimeType = trim(substr($mimeType, 0, $pos));
@@ -1265,8 +1288,8 @@ class Request
 
         if (str_starts_with($canonicalMimeType, 'application/') && str_contains($canonicalMimeType, '+')) {
             $suffix = substr(strrchr($canonicalMimeType, '+'), 1);
-            if (isset(static::getStructuredSuffixFormats()[$suffix])) {
-                return static::getStructuredSuffixFormats()[$suffix];
+            if (isset(self::STRUCTURED_SUFFIX_FORMATS[$suffix])) {
+                return self::STRUCTURED_SUFFIX_FORMATS[$suffix];
             }
         }
 
@@ -1960,32 +1983,6 @@ class Request
             'wbxml' => ['application/vnd.wap.wbxml'],
             'pdf' => ['application/pdf'],
             'csv' => ['text/csv'],
-        ];
-    }
-
-    /**
-     * This mapping is used when no exact MIME match is found in $formats.
-     * It enables handling of types like application/soap+xml → 'xml'.
-     *
-     * @see https://datatracker.ietf.org/doc/html/rfc6839
-     * @see https://datatracker.ietf.org/doc/html/rfc7303
-     * @see https://www.iana.org/assignments/media-types/media-types.xhtml
-     *
-     * @return array<string, string>
-     */
-    private static function getStructuredSuffixFormats(): array
-    {
-        return [
-            'json' => 'json',
-            'xml' => 'xml',
-            'xhtml' => 'html',
-            'cbor' => 'cbor',
-            'zip' => 'zip',
-            'ber' => 'asn1',
-            'der' => 'asn1',
-            'tlv' => 'tlv',
-            'wbxml' => 'xml',
-            'yaml' => 'yaml',
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
