### PR TITLE
[Validator] Add `#[ExtendsValidationFor]` to declare new constraints for a class

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -214,6 +214,7 @@ use Symfony\Component\TypeInfo\TypeResolver\StringTypeResolver;
 use Symfony\Component\TypeInfo\TypeResolver\TypeResolverInterface;
 use Symfony\Component\Uid\Factory\UuidFactory;
 use Symfony\Component\Uid\UuidV4;
+use Symfony\Component\Validator\Attribute\ExtendsValidationFor;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\ExpressionLanguageProvider;
 use Symfony\Component\Validator\Constraints\Traverse;
@@ -1819,9 +1820,15 @@ class FrameworkExtension extends Extension
         if (class_exists(ValidatorAttributeMetadataPass::class) && (!($config['enable_attributes'] ?? false) || !$container->getParameter('kernel.debug'))) {
             // The $reflector argument hints at where the attribute could be used
             $container->registerAttributeForAutoconfiguration(Constraint::class, function (ChildDefinition $definition, Constraint $attribute, \ReflectionClass|\ReflectionMethod|\ReflectionProperty $reflector) {
-                $definition->addTag('validator.attribute_metadata');
+                $definition->addTag('validator.attribute_metadata')
+                    ->addTag('container.excluded', ['source' => 'because it\'s a validator constraint extension']);
             });
         }
+
+        $container->registerAttributeForAutoconfiguration(ExtendsValidationFor::class, function (ChildDefinition $definition, ExtendsValidationFor $attribute) {
+            $definition->addTag('validator.attribute_metadata', ['for' => $attribute->class])
+                ->addTag('container.excluded', ['source' => 'because it\'s a validator constraint extension']);
+        });
 
         if ($config['enable_attributes'] ?? false) {
             $validatorBuilder->addMethodCall('enableAttributeMapping');

--- a/src/Symfony/Component/Validator/Attribute/ExtendsValidationFor.php
+++ b/src/Symfony/Component/Validator/Attribute/ExtendsValidationFor.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Attribute;
+
+/**
+ * Declares that constraints listed on the current class should be added to the given class.
+ *
+ * Classes that use this attribute should contain only properties and methods that
+ * exist on the target class (not necessarily all of them).
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class ExtendsValidationFor
+{
+    /**
+     * @param class-string $class
+     */
+    public function __construct(
+        public string $class,
+    ) {
+    }
+}

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 7.4
 ---
 
+ * Add `#[ExtendsValidationFor]` to declare new constraints for a class
  * Add `ValidatorBuilder::addAttributeMappings()` and `AttributeMetadataPass` to declare compile-time constraint metadata using attributes
  * Add the `Video` constraint for validating video files
  * Deprecate implementing `__sleep/wakeup()` on `GenericMetadata` implementations; use `__(un)serialize()` instead

--- a/src/Symfony/Component/Validator/ValidatorBuilder.php
+++ b/src/Symfony/Component/Validator/ValidatorBuilder.php
@@ -150,9 +150,12 @@ class ValidatorBuilder
     }
 
     /**
-     * Adds a list of classes with mapping constraints as attributes.
+     * Adds classes with mapping constraints as attributes.
      *
-     * @param class-string[] $classes The paths to the mapping classes
+     * The keys are the classes on which the constraints should be added.
+     * The values are the classes that contain the constraints to add as attributes.
+     *
+     * @param array<class-string, list<class-string>> $classes
      *
      * @return $this
      */
@@ -162,7 +165,7 @@ class ValidatorBuilder
             throw new ValidatorException('You cannot add custom mappings after setting a custom metadata factory. Configure your metadata factory instead.');
         }
 
-        $this->attributeMappings = array_merge($this->attributeMappings, $classes);
+        $this->attributeMappings = array_merge_recursive($this->attributeMappings, $classes);
 
         return $this;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR builds on #61528

I propose to add a `#[ExtendsValidationFor]` attribute that allows adding validation constraints to another class.
This is typically needed for third party classes. For context, Sylius has a nice doc about this:
 https://docs.sylius.com/the-customization-guide/customizing-validation

At the moment, the only way to achieve this is by declaring the new constraints in the (hardcoded) `config/validation/` folder, using either xml or yaml. No attributes.

With this PR, one will be able to define those extra constraints using PHP attributes, set on classes that'd mirror the properties/getters of the targeted class. The compiler pass will ensure that all properties/getters declared in these source classes also exist in the target class. (source = the app's class that declares the new constraints; target = the existing class to add constraints to.)

```php
#[ExtendsValidationFor(TargetClass::class)]
abstract class SourceClass
{
    #[Assert\NotBlank(groups: ['my_app'])]
    #[Assert\Length(min: 3, groups: ['my_app'])]
    public string $name = '';

    #[Assert\Email(groups: ['my_app'])]
    public string $email = '';

    #[Assert\Range(min: 18, groups: ['my_app'])]
    public int $age = 0;
}
```

(I made the class abstract because it's not supposed to be instantiated - but it's not mandatory.)

Here are the basics of how this works:

1. During container compilation, classes marked with `#[ExtendsValidationFor(Target::class)]` are collected and validated: the container checks that members declared on the source exist on the target. If not, a `MappingException` is thrown.
2. The validator is configured to map the target to its source classes.
3. At runtime, when loading validation metadata for the target, attributes (constraints, callbacks, group providers) are read from both the target and its mapped source classes and applied accordingly.
