### PR TITLE
[Security] Fix attribute-based chained user providers

### DIFF
--- a/src/Symfony/Component/Security/Core/User/ChainUserProvider.php
+++ b/src/Symfony/Component/Security/Core/User/ChainUserProvider.php
@@ -56,10 +56,18 @@ class ChainUserProvider implements UserProviderInterface, PasswordUpgraderInterf
         return $this->loadUserByIdentifier($username);
     }
 
-    public function loadUserByIdentifier(string $identifier): UserInterface
+    /**
+     * @param array $attributes
+     */
+    public function loadUserByIdentifier(string $identifier/* , array $attributes = [] */): UserInterface
     {
+        $attributes = \func_num_args() > 1 ? func_get_arg(1) : [];
         foreach ($this->providers as $provider) {
             try {
+                if ($provider instanceof AttributesBasedUserProviderInterface) {
+                    return $provider->loadUserByIdentifier($identifier, $attributes);
+                }
+
                 return $provider->loadUserByIdentifier($identifier);
             } catch (UserNotFoundException) {
                 // try next one


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

The attributes were not passed to an attribute-based user provider (`AttributesBasedUserProviderInterface`) in a `UserProviderChain`.

On 7.4 we could make `ChainUserProvider` implement `AttributesBasedUserProviderInterface`.