### PR TITLE
[Console] Add phpdoc for return type of subscribed signals

### DIFF
--- a/src/Symfony/Component/Console/Command/SignalableCommandInterface.php
+++ b/src/Symfony/Component/Console/Command/SignalableCommandInterface.php
@@ -20,6 +20,10 @@ interface SignalableCommandInterface
 {
     /**
      * Returns the list of signals to subscribe.
+     *
+     * @return list<\SIG*>
+     *
+     * @see https://php.net/pcntl.constants for signals
      */
     public function getSubscribedSignals(): array;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        |
| License       | MIT

The signals are integers, but the array return type was missing. This meant we had to add this to every implementation to prevent phpstan from complaining.
