### PR TITLE
[Mailer][Sweego] Add support for new webhook events

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/complaint.json
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/complaint.json
@@ -1,0 +1,22 @@
+{
+  "event_type": "complaint",
+  "timestamp": "2024-09-02T08:45:05+00:00",
+  "swg_uid": "01-47d3e283-1afb-4b9e-bd45-bfbf32ba251f",
+  "event_id": "3e42ea83-f6a5-40cc-a1fa-8745669454",
+  "channel": "email",
+  "transaction_id": "b0e50d6d-118c-459b-84e1-70209e68c1c9",
+  "headers": {
+    "x-mailer": "Sweego",
+    "x-swg-uid": "01-47d3ekdpj-1fdb-4bde-bsd5-bfbf32sdgf54f",
+    "x-campaign-id": "default",
+    "x-client-id": "0c8cc711c85e45b79189456644166sj",
+    "x-originating-ip": "185.255.28.207",
+    "x-campaign-type": "default",
+    "x-transaction-id": "b0e50d6d-118c-459b-84e1-70209e68c1c9"
+  },
+  "campaign_tags": null,
+  "campaign_type": "default",
+  "campaign_id": "default",
+  "recipient": "recipient@example.com",
+  "domain_from": "example.org"
+}

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/complaint.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/complaint.php
@@ -1,0 +1,18 @@
+<?php
+
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerEngagementEvent;
+
+$wh = new MailerEngagementEvent(MailerEngagementEvent::SPAM, 'b0e50d6d-118c-459b-84e1-70209e68c1c9', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true));
+$wh->setRecipientEmail('recipient@example.com');
+$wh->setMetadata([
+    'x-mailer' => 'Sweego',
+    'x-swg-uid' => '01-47d3ekdpj-1fdb-4bde-bsd5-bfbf32sdgf54f',
+    'x-campaign-id' => 'default',
+    'x-client-id' => '0c8cc711c85e45b79189456644166sj',
+    'x-originating-ip' => '185.255.28.207',
+    'x-campaign-type' => 'default',
+    'x-transaction-id' => 'b0e50d6d-118c-459b-84e1-70209e68c1c9',
+]);
+$wh->setDate(\DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-09-02T08:45:05+00:00'));
+
+return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/delivered.json
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/delivered.json
@@ -5,6 +5,13 @@
     "event_id": "9f26b9d0-13d7-410c-ba04-5019cd30e6d0",
     "channel": "email",
     "headers": {
+        "x-campaign-type": "default",
+        "x-swg-uid": "01-f14sqdf65-fgh9b6-4160-bc45-fliolioa277ca9",
+        "x-mailer": "Sweego",
+        "x-campaign-id": "default",
+        "x-client-id": "0c8cc711c85e4595953862",
+        "x-originating-ip": "XXX.XXX.XXX.XX",
+        "x-email-id": "23",
         "x-transaction-id": "d4fbec9d-eed9-44d5-af47-c1126467a5ca"
     },
     "campaign_tags": null,

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/delivered.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/delivered.php
@@ -5,6 +5,13 @@ use Symfony\Component\RemoteEvent\Event\Mailer\MailerDeliveryEvent;
 $wh = new MailerDeliveryEvent(MailerDeliveryEvent::DELIVERED, 'd4fbec9d-eed9-44d5-af47-c1126467a5ca', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true));
 $wh->setRecipientEmail('recipient@example.com');
 $wh->setMetadata([
+    'x-campaign-type' => 'default',
+    'x-swg-uid' => '01-f14sqdf65-fgh9b6-4160-bc45-fliolioa277ca9',
+    'x-mailer' => 'Sweego',
+    'x-campaign-id' => 'default',
+    'x-client-id' => '0c8cc711c85e4595953862',
+    'x-originating-ip' => 'XXX.XXX.XXX.XX',
+    'x-email-id' => '23',
     'x-transaction-id' => 'd4fbec9d-eed9-44d5-af47-c1126467a5ca',
 ]);
 $wh->setDate(\DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-08-15T16:05:59+00:00'));

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/email_clicked.json
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/email_clicked.json
@@ -1,0 +1,30 @@
+{
+  "event_type": "email_clicked",
+  "timestamp": "2024-09-02T08:45:05+00:00",
+  "swg_uid": "02-6e5dbe48-e6f4-4af3-8fb4-bf125e75776b",
+  "event_id": "3e434a94-628c-4cbd-92b5-ed6be715aa2c",
+  "channel": "email",
+  "transaction_id": "568c5678-2d03-40f8-89e0-22ffb5cfe63d",
+  "headers": {
+    "x-mailer": "Sweego",
+    "x-swg-uid": "02-6e5dbe48-e6f4-4af3-8fb4-bf125e75776b",
+    "x-client-id": "f8367456332369298d050cf4bc83e058",
+    "x-client-ip": "XXX.XXX.XXX.XXX",
+    "x-campaign-id": "fake_campaign",
+    "x-campaign-type": "default",
+    "x-originating-ip": "XXX.XXX.XXX.XXX",
+    "x-transaction-id": "568c5678-2d03-40f8-89e0-22ffb5cfe63d"
+  },
+  "campaign_tags": null,
+  "campaign_type": "default",
+  "campaign_id": "fake_campaign",
+  "recipient": "recipient@example.com",
+  "domain_from": "example.org",
+  "subject": "Test webhook 2024-01-01",
+  "click": {
+    "ip_address": "XXX.XXX.XXX.XXX",
+    "url": "https://google.com",
+    "user_agent": "Mozilla/5.0 (Windows NT 5.1; rv:11.0) Gecko Firefox/11.0 (via ggpht.com GoogleImageProxy)",
+    "proxy": false
+  }
+}

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/email_clicked.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/email_clicked.php
@@ -1,0 +1,19 @@
+<?php
+
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerEngagementEvent;
+
+$wh = new MailerEngagementEvent(MailerEngagementEvent::CLICK, '568c5678-2d03-40f8-89e0-22ffb5cfe63d', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true));
+$wh->setRecipientEmail('recipient@example.com');
+$wh->setMetadata([
+    'x-mailer' => 'Sweego',
+    'x-swg-uid' => '02-6e5dbe48-e6f4-4af3-8fb4-bf125e75776b',
+    'x-client-id' => 'f8367456332369298d050cf4bc83e058',
+    'x-client-ip' => 'XXX.XXX.XXX.XXX',
+    'x-campaign-id' => 'fake_campaign',
+    'x-campaign-type' => 'default',
+    'x-originating-ip' => 'XXX.XXX.XXX.XXX',
+    'x-transaction-id' => '568c5678-2d03-40f8-89e0-22ffb5cfe63d',
+]);
+$wh->setDate(\DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-09-02T08:45:05+00:00'));
+
+return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/email_opened.json
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/email_opened.json
@@ -1,0 +1,29 @@
+{
+  "event_type": "email_opened",
+  "timestamp": "2024-09-02T08:45:05+00:00",
+  "swg_uid": "02-6e5dbe48-e6f4-4af3-8fb4-bf125e75776b",
+  "event_id": "3e434a94-628c-4cbd-92b5-ed6be715aa2c",
+  "channel": "email",
+  "transaction_id": "69b90094-872f-4250-97d5-515ac7114b1b",
+  "headers": {
+    "x-mailer": "Sweego",
+    "x-swg-uid": "02-6e5dbe48-e6f4-4af3-8fb4-bf125e75776b",
+    "x-client-id": "f8367456332593298d050cf4bc83e0ab",
+    "x-client-ip": "XXX.XXX.XXX.XXX",
+    "x-campaign-id": "fake_campaign",
+    "x-campaign-type": "default",
+    "x-originating-ip": "XXX.XXX.XXX.XXX",
+    "x-transaction-id": "69b90094-872f-4250-97d5-515ac7114b1b"
+  },
+  "campaign_tags": null,
+  "campaign_type": "default",
+  "campaign_id": "fake_campaign",
+  "recipient": "recipient@example.com",
+  "domain_from": "example.org",
+  "subject": "Test webhook",
+  "open": {
+    "ip_address": "XXX.XXX.XXX.XXX",
+    "user_agent": "Mozilla/5.0 (Windows NT 5.1; rv:11.0) Gecko Firefox/11.0 (via ggpht.com GoogleImageProxy)",
+    "proxy": true
+  }
+}

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/email_opened.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/email_opened.php
@@ -1,0 +1,19 @@
+<?php
+
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerEngagementEvent;
+
+$wh = new MailerEngagementEvent(MailerEngagementEvent::OPEN, '69b90094-872f-4250-97d5-515ac7114b1b', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true));
+$wh->setRecipientEmail('recipient@example.com');
+$wh->setMetadata([
+    'x-mailer' => 'Sweego',
+    'x-swg-uid' => '02-6e5dbe48-e6f4-4af3-8fb4-bf125e75776b',
+    'x-client-id' => 'f8367456332593298d050cf4bc83e0ab',
+    'x-client-ip' => 'XXX.XXX.XXX.XXX',
+    'x-campaign-id' => 'fake_campaign',
+    'x-campaign-type' => 'default',
+    'x-originating-ip' => 'XXX.XXX.XXX.XXX',
+    'x-transaction-id' => '69b90094-872f-4250-97d5-515ac7114b1b',
+]);
+$wh->setDate(\DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-09-02T08:45:05+00:00'));
+
+return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/email_sent.json
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/email_sent.json
@@ -1,0 +1,23 @@
+{
+  "event_type": "email_sent",
+  "timestamp": "2024-09-02T08:45:05+00:00",
+  "swg_uid": "01-47d3e283-1afb-4b9e-bd45-bfbf32ba251f",
+  "event_id": "3e42ea83-f6a5-40cc-a1fa-8745669454",
+  "channel": "email",
+  "transaction_id": "8a3bf3ee-1863-4a02-906d-2e6494914ddb",
+  "headers": {
+    "x-campaign-type": "default",
+    "x-swg-uid": "01-47d3ekdpj-1fdb-4bde-bsd5-bfbf32sdgf54f",
+    "x-mailer": "Sweego",
+    "x-campaign-id": "default",
+    "x-client-id": "0c8cc711c85e45b79189456644166sj",
+    "x-originating-ip": "185.255.28.207",
+    "x-email-id": "23",
+    "x-transaction-id": "8a3bf3ee-1863-4a02-906d-2e6494914ddb"
+  },
+  "campaign_tags": null,
+  "campaign_type": "default",
+  "campaign_id": "default",
+  "recipient": "recipient@example.com",
+  "domain_from": "example.org"
+}

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/email_sent.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/email_sent.php
@@ -1,0 +1,19 @@
+<?php
+
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerDeliveryEvent;
+
+$wh = new MailerDeliveryEvent(MailerDeliveryEvent::RECEIVED, '8a3bf3ee-1863-4a02-906d-2e6494914ddb', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true));
+$wh->setRecipientEmail('recipient@example.com');
+$wh->setMetadata([
+    'x-campaign-type' => 'default',
+    'x-swg-uid' => '01-47d3ekdpj-1fdb-4bde-bsd5-bfbf32sdgf54f',
+    'x-mailer' => 'Sweego',
+    'x-campaign-id' => 'default',
+    'x-client-id' => '0c8cc711c85e45b79189456644166sj',
+    'x-originating-ip' => '185.255.28.207',
+    'x-email-id' => '23',
+    'x-transaction-id' => '8a3bf3ee-1863-4a02-906d-2e6494914ddb',
+]);
+$wh->setDate(\DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-09-02T08:45:05+00:00'));
+
+return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/hard_bounce.json
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/hard_bounce.json
@@ -1,0 +1,27 @@
+{
+  "event_type": "hard_bounce",
+  "timestamp": "2024-08-20T08:48:35+00:00",
+  "swg_uid": "01-68d20f85-253e-4986-b7f0-0e4229df4d61",
+  "event_id": "88eaff9a-5087-47d9-afdd-6eeaddfb11ae",
+  "channel": "email",
+  "transaction_id": "8dea05e7-9e8b-43d7-b000-3f7d15304162",
+  "headers": {
+    "x-swg-uid": "01-68d20f85-253e-4986-b7f0-0e4229df4d61",
+    "x-client-id": "myid",
+    "x-campaign-pool": "default",
+    "x-campaign-canal": "mycanal",
+    "x-campaign-type": "default",
+    "x-mailer": "Sweego",
+    "x-originating-ip": "XXX.XXX.XXX.XXX",
+    "x-campaign-ref": "895000#N",
+    "x-campaign-id": "b205d7b6-9eb5-4ba7-b3b9-5e2b8cade053",
+    "x-transaction-id": "8dea05e7-9e8b-43d7-b000-3f7d15304162"
+  },
+  "campaign_tags": null,
+  "campaign_type": "default",
+  "campaign_id": "default",
+  "recipient": "recipient@example.com",
+  "domain_from": "example.org",
+  "response_code": 550,
+  "status": null
+}

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/hard_bounce.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/hard_bounce.php
@@ -1,0 +1,21 @@
+<?php
+
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerDeliveryEvent;
+
+$wh = new MailerDeliveryEvent(MailerDeliveryEvent::BOUNCE, '8dea05e7-9e8b-43d7-b000-3f7d15304162', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true));
+$wh->setRecipientEmail('recipient@example.com');
+$wh->setMetadata([
+    'x-swg-uid' => '01-68d20f85-253e-4986-b7f0-0e4229df4d61',
+    'x-client-id' => 'myid',
+    'x-campaign-pool' => 'default',
+    'x-campaign-canal' => 'mycanal',
+    'x-campaign-type' => 'default',
+    'x-mailer' => 'Sweego',
+    'x-originating-ip' => 'XXX.XXX.XXX.XXX',
+    'x-campaign-ref' => '895000#N',
+    'x-campaign-id' => 'b205d7b6-9eb5-4ba7-b3b9-5e2b8cade053',
+    'x-transaction-id' => '8dea05e7-9e8b-43d7-b000-3f7d15304162',
+]);
+$wh->setDate(\DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-08-20T08:48:35+00:00'));
+
+return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/list_unsub.json
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/list_unsub.json
@@ -1,0 +1,28 @@
+{
+  "event_type": "list_unsub",
+  "timestamp": "2024-09-02T12:55:09+00:00",
+  "swg_uid": "02-5898484-484f2-841d-84ea-a33351589aabc0",
+  "event_id": "0a190ab5-aad8-4874-9c32-0848484f8fc",
+  "channel": "email",
+  "transaction_id": "861aad97-e4e8-4aaf-9322-1b64835760b9",
+  "headers": {
+    "x-campaign-id": "42",
+    "x-campaign-tags": "billing",
+    "x-campaign-type": "transac",
+    "x-client-id": "d6b1222eb484fb8f4g8d4fg8cd4",
+    "x-client-ip": "XXX.XXX.XXX.XXX",
+    "x-mailer": "Sweeg",
+    "x-originating-ip": "XXX.XXX.XXX.XXX",
+    "x-ref-1": "643524",
+    "x-ref-2": "lervcn",
+    "x-ref-3": "o10icr",
+    "x-swg-uid": "02-589edd0e-b7f2-4a1d-a3ea-a333cb9aabc0",
+    "x-transaction-id": "861aad97-e4e8-4aaf-9322-1b64835760b9"
+  },
+  "campaign_tags": "billing",
+  "campaign_type": "transac",
+  "campaign_id": "transac",
+  "recipient": "recipient@example.com",
+  "domain_from": "example.org",
+  "one_click": false
+}

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/list_unsub.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/list_unsub.php
@@ -1,0 +1,23 @@
+<?php
+
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerEngagementEvent;
+
+$wh = new MailerEngagementEvent(MailerEngagementEvent::UNSUBSCRIBE, '861aad97-e4e8-4aaf-9322-1b64835760b9', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true));
+$wh->setRecipientEmail('recipient@example.com');
+$wh->setMetadata([
+    'x-campaign-id' => '42',
+    'x-campaign-tags' => 'billing',
+    'x-campaign-type' => 'transac',
+    'x-client-id' => 'd6b1222eb484fb8f4g8d4fg8cd4',
+    'x-client-ip' => 'XXX.XXX.XXX.XXX',
+    'x-mailer' => 'Sweeg',
+    'x-originating-ip' => 'XXX.XXX.XXX.XXX',
+    'x-ref-1' => '643524',
+    'x-ref-2' => 'lervcn',
+    'x-ref-3' => 'o10icr',
+    'x-swg-uid' => '02-589edd0e-b7f2-4a1d-a3ea-a333cb9aabc0',
+    'x-transaction-id' => '861aad97-e4e8-4aaf-9322-1b64835760b9',
+]);
+$wh->setDate(\DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-09-02T12:55:09+00:00'));
+
+return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/soft-bounce.json
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/soft-bounce.json
@@ -1,0 +1,27 @@
+{
+  "event_type": "soft-bounce",
+  "timestamp": "2024-08-20T08:38:27+00:00",
+  "swg_uid": "01-4f5qsdqsd3-b5e1-4012-a350-2e3d0d176ef1",
+  "event_id": "82ebfgbfgb-0fgbfg-4190-967c-2e8484212f1c0f",
+  "channel": "email",
+  "transaction_id": "861aad97-e4e8-4aaf-9322-1b64835760b9",
+  "headers": {
+    "x-campaign-type": "default",
+    "x-swg-uid": "01-4f5e28484-b515-4848-1956-2e3d0d176ef1",
+    "x-mailer": "Sweego",
+    "x-client-id": "MypersonnalId",
+    "x-originating-ip": "XXX.XXX.XXX.XXX",
+    "x-campaign-ref": "895000N",
+    "x-campaign-pool": "default",
+    "x-campaign-id": "b20dsfsdfds6-9595b5-9595a7-565b9-5e2b826595053",
+    "x-campaign-canal": "mycanal",
+    "x-transaction-id": "f11f4fe2-fb05-4882-8303-a20956d47931"
+  },
+  "campaign_tags": null,
+  "campaign_type": "default",
+  "campaign_id": "default",
+  "recipient": "recipient@example.com",
+  "domain_from": "example.org",
+  "response_code": 452,
+  "status": null
+}

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/soft-bounce.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/Fixtures/soft-bounce.php
@@ -1,0 +1,21 @@
+<?php
+
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerDeliveryEvent;
+
+$wh = new MailerDeliveryEvent(MailerDeliveryEvent::BOUNCE, 'f11f4fe2-fb05-4882-8303-a20956d47931', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true));
+$wh->setRecipientEmail('recipient@example.com');
+$wh->setMetadata([
+    'x-campaign-type' => 'default',
+    'x-swg-uid' => '01-4f5e28484-b515-4848-1956-2e3d0d176ef1',
+    'x-mailer' => 'Sweego',
+    'x-client-id' => 'MypersonnalId',
+    'x-originating-ip' => 'XXX.XXX.XXX.XXX',
+    'x-campaign-ref' => '895000N',
+    'x-campaign-pool' => 'default',
+    'x-campaign-id' => 'b20dsfsdfds6-9595b5-9595a7-565b9-5e2b826595053',
+    'x-campaign-canal' => 'mycanal',
+    'x-transaction-id' => 'f11f4fe2-fb05-4882-8303-a20956d47931',
+]);
+$wh->setDate(\DateTimeImmutable::createFromFormat(\DATE_ATOM, '2024-08-20T08:38:27+00:00'));
+
+return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/SweegoSignedRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/SweegoSignedRequestParserTest.php
@@ -17,20 +17,36 @@ use Symfony\Component\Mailer\Bridge\Sweego\Webhook\SweegoRequestParser;
 use Symfony\Component\Webhook\Client\RequestParserInterface;
 use Symfony\Component\Webhook\Test\AbstractRequestParserTestCase;
 
-class SweegoRequestParserTest extends AbstractRequestParserTestCase
+class SweegoSignedRequestParserTest extends AbstractRequestParserTestCase
 {
     protected function createRequestParser(): RequestParserInterface
     {
         return new SweegoRequestParser(new SweegoPayloadConverter());
     }
 
+    public static function getPayloads(): iterable
+    {
+        $filename = 'delivered.json';
+        $currentDir = \dirname((new \ReflectionClass(static::class))->getFileName());
+
+        yield $filename => [
+            file_get_contents($currentDir.'/Fixtures/delivered.json'),
+            include ($currentDir.'/Fixtures/delivered.php'),
+        ];
+    }
+
+    protected function getSecret(): string
+    {
+        return 'GvLY88Uyj70jQm3fUwYyWmAaiz98wWim';
+    }
+
     protected function createRequest(string $payload): Request
     {
         return Request::create('/', 'POST', [], [], [], [
             'Content-Type' => 'application/json',
-            'HTTP_webhook-id' => 'id',
-            'HTTP_webhook-timestamp' => 'timestamp',
-            'HTTP_webhook-signature' => 'signature',
+            'HTTP_webhook-id' => '9f26b9d0-13d7-410c-ba04-5019cd30e6d0',
+            'HTTP_webhook-timestamp' => '1723737959',
+            'HTTP_webhook-signature' => 'E1RfmN81xnbXMqDZUD0eJjPQEWmf24ft//gtV29bp18=',
         ], $payload);
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/SweegoWrongSignatureRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/SweegoWrongSignatureRequestParserTest.php
@@ -28,6 +28,22 @@ class SweegoWrongSignatureRequestParserTest extends AbstractRequestParserTestCas
         return new SweegoRequestParser(new SweegoPayloadConverter());
     }
 
+    public static function getPayloads(): iterable
+    {
+        $filename = 'delivered.json';
+        $currentDir = \dirname((new \ReflectionClass(static::class))->getFileName());
+
+        yield $filename => [
+            file_get_contents($currentDir.'/Fixtures/delivered.json'),
+            include ($currentDir.'/Fixtures/delivered.php'),
+        ];
+    }
+
+    protected function getSecret(): string
+    {
+        return 'GvLY88Uyj70jQm3fUwYyWmAaiz98wWim';
+    }
+
     protected function createRequest(string $payload): Request
     {
         return Request::create('/', 'POST', [], [], [], [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

As documented [here](https://learn.sweego.io/docs/webhooks/payload), Sweego now sent more webhook events for their email service.

Added:
- `soft-bounce` (yes, with a dash)
- `hard_bounce` (yes, with an underscore)
- `list_unsub`
- `complaint`
- `email_clicked`
- `email_opened`

/cc @Wasta-Geek @pydubreucq