### PR TITLE
[JsonStreamer] Fix decoding iterable lists

### DIFF
--- a/src/Symfony/Component/JsonStreamer/Read/PhpAstBuilder.php
+++ b/src/Symfony/Component/JsonStreamer/Read/PhpAstBuilder.php
@@ -379,10 +379,12 @@ final class PhpAstBuilder
             ? $this->builder->funcCall($this->builder->var('iterable'), [$this->builder->var('stream'), $this->builder->var('data')])
             : $this->builder->funcCall($this->builder->var('iterable'), [$this->builder->var('data')]);
 
+        $collectionKeyType = $node->getType()->getCollectionKeyType();
+
         $prepareDataStmts = $decodeFromStream ? [
             new Expression(new Assign($this->builder->var('data'), $this->builder->staticCall(
                 new FullyQualified(Splitter::class),
-                $node->getType()->isList() ? 'splitList' : 'splitDict',
+                ($collectionKeyType instanceof BuiltinType && TypeIdentifier::INT === $collectionKeyType->getTypeIdentifier()) ? 'splitList' : 'splitDict',
                 [$this->builder->var('stream'), $this->builder->var('offset'), $this->builder->var('length')],
             ))),
         ] : [];

--- a/src/Symfony/Component/JsonStreamer/Tests/JsonStreamReaderTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/JsonStreamReaderTest.php
@@ -87,7 +87,7 @@ class JsonStreamReaderTest extends TestCase
         $this->assertRead($reader, function (mixed $read) {
             $this->assertIsIterable($read);
             $this->assertSame([true, false], iterator_to_array($read));
-        }, '{"0": true, "1": false}', Type::iterable(Type::bool(), Type::int()));
+        }, '[true, false]', Type::iterable(Type::bool(), Type::int()));
     }
 
     public function testReadObject()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61559 
| License       | MIT

Because a `list<T>` is a subtype of `array<T>`, an `iterable<T>` cannot be a list.

This means that, as said [here](https://github.com/symfony/symfony/pull/59308#discussion_r1903884508):
> There is no way to be sure that keys of an iterable are successive (even if they are integers).
> And if keys are not successive, the resulting JSON structure is an object and not an array.
> According, to the [JSON specification](https://datatracker.ietf.org/doc/html/rfc8259#section-4), object' keys must be strings, and not integers.

This imply that it is right now impossible to "yield" items from `[{"itemId": 1, "modificationDate": "2025-10-10"}]` - it can only be yielded from `{"0": {"itemId": 1, "modificationDate": "2025-10-10"}}`.

I think that in the real world, a lot of people want to be able to yield items from `[...]`, even though it does not stick with the JSON specification.

This PR is doing the trade-off of considering `iterable<int, Anything>` as an "iterable list" (like `list<Anything>` but not cast to array).