### PR TITLE
[Serializer] Add `#[ExtendsSerializationFor]` to declare new serialization attributes for a class

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -188,6 +188,7 @@ use Symfony\Component\Semaphore\Semaphore;
 use Symfony\Component\Semaphore\SemaphoreFactory;
 use Symfony\Component\Semaphore\Store\StoreFactory as SemaphoreStoreFactory;
 use Symfony\Component\Serializer\Attribute as SerializerMapping;
+use Symfony\Component\Serializer\Attribute\ExtendsSerializationFor;
 use Symfony\Component\Serializer\DependencyInjection\AttributeMetadataPass as SerializerAttributeMetadataPass;
 use Symfony\Component\Serializer\Encoder\DecoderInterface;
 use Symfony\Component\Serializer\Encoder\EncoderInterface;
@@ -2164,6 +2165,11 @@ class FrameworkExtension extends Extension
         $container->getDefinition('serializer.normalizer.property')->setArgument(5, $defaultContext);
 
         $container->setParameter('.serializer.named_serializers', $config['named_serializers'] ?? []);
+
+        $container->registerAttributeForAutoconfiguration(ExtendsSerializationFor::class, function (ChildDefinition $definition, ExtendsSerializationFor $attribute) {
+            $definition->addTag('serializer.attribute_metadata', ['for' => $attribute->class])
+                ->addTag('container.excluded', ['source' => 'because it\'s a serializer metadata extension']);
+        });
     }
 
     private function registerJsonStreamerConfiguration(array $config, ContainerBuilder $container, PhpFileLoader $loader): void

--- a/src/Symfony/Component/Serializer/Attribute/ExtendsSerializationFor.php
+++ b/src/Symfony/Component/Serializer/Attribute/ExtendsSerializationFor.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Attribute;
+
+/**
+ * Declares that serialization attributes listed on the current class should be added to the given class.
+ *
+ * Classes that use this attribute should contain only properties and methods that
+ * exist on the target class (not necessarily all of them).
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class ExtendsSerializationFor
+{
+    /**
+     * @param class-string $class
+     */
+    public function __construct(
+        public string $class,
+    ) {
+    }
+}

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 7.4
 ---
 
+ * Add `#[ExtendsSerializationFor]` to declare new serialization attributes for a class
  * Add `AttributeMetadataPass` to declare compile-time constraint metadata using attributes
  * Add `CDATA_WRAPPING_NAME_PATTERN` support to `XmlEncoder`
  * Add support for `can*()` methods to `AttributeLoader`

--- a/src/Symfony/Component/Serializer/DependencyInjection/AttributeMetadataPass.php
+++ b/src/Symfony/Component/Serializer/DependencyInjection/AttributeMetadataPass.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Serializer\DependencyInjection;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Exception\MappingException;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
@@ -35,14 +36,41 @@ final class AttributeMetadataPass implements CompilerPassInterface
             if (!$definition->hasTag('container.excluded')) {
                 throw new InvalidArgumentException(\sprintf('The resource "%s" tagged "serializer.attribute_metadata" is missing the "container.excluded" tag.', $id));
             }
-            $taggedClasses[$resolve($definition->getClass())] = true;
+            $class = $resolve($definition->getClass());
+            foreach ($definition->getTag('serializer.attribute_metadata') as $attributes) {
+                if ($class !== $for = $attributes['for'] ?? $class) {
+                    $this->checkSourceMapsToTarget($container, $class, $for);
+                }
+
+                $taggedClasses[$for][$class] = true;
+            }
+        }
+
+        if (!$taggedClasses) {
+            return;
         }
 
         ksort($taggedClasses);
 
-        if ($taggedClasses) {
-            $container->getDefinition('serializer.mapping.attribute_loader')
-                ->replaceArgument(1, array_keys($taggedClasses));
+        $container->getDefinition('serializer.mapping.attribute_loader')
+            ->replaceArgument(1, array_map('array_keys', $taggedClasses));
+    }
+
+    private function checkSourceMapsToTarget(ContainerBuilder $container, string $source, string $target): void
+    {
+        $source = $container->getReflectionClass($source);
+        $target = $container->getReflectionClass($target);
+
+        foreach ($source->getProperties() as $p) {
+            if ($p->class === $source->name && !($target->hasProperty($p->name) && $target->getProperty($p->name)->class === $target->name)) {
+                throw new MappingException(\sprintf('The property "%s" on "%s" is not present on "%s".', $p->name, $source->name, $target->name));
+            }
+        }
+
+        foreach ($source->getMethods() as $m) {
+            if ($m->class === $source->name && !($target->hasMethod($m->name) && $target->getMethod($m->name)->class === $target->name)) {
+                throw new MappingException(\sprintf('The method "%s" on "%s" is not present on "%s".', $m->name, $source->name, $target->name));
+            }
         }
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/DependencyInjection/AttributeMetadataPassTest.php
+++ b/src/Symfony/Component/Serializer/Tests/DependencyInjection/AttributeMetadataPassTest.php
@@ -13,7 +13,9 @@ namespace Symfony\Component\Serializer\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\DependencyInjection\AttributeMetadataPass;
+use Symfony\Component\Serializer\Exception\MappingException;
 use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
 
 class AttributeMetadataPassTest extends TestCase
@@ -68,7 +70,82 @@ class AttributeMetadataPassTest extends TestCase
         $arguments = $container->getDefinition('serializer.mapping.attribute_loader')->getArguments();
 
         // Classes should be sorted alphabetically
-        $expectedClasses = ['App\Entity\Order', 'App\Entity\Product', 'App\Entity\User'];
+        $expectedClasses = [
+            'App\Entity\Order' => ['App\Entity\Order'],
+            'App\Entity\Product' => ['App\Entity\Product'],
+            'App\Entity\User' => ['App\Entity\User'],
+        ];
         $this->assertSame([false, $expectedClasses], $arguments);
     }
+
+    public function testThrowsWhenMissingExcludedTag()
+    {
+        $container = new ContainerBuilder();
+        $container->register('serializer.mapping.attribute_loader');
+
+        $container->register('service_without_excluded', 'App\\Entity\\User')
+            ->addTag('serializer.attribute_metadata');
+
+        $this->expectException(InvalidArgumentException::class);
+        (new AttributeMetadataPass())->process($container);
+    }
+
+    public function testProcessWithForOptionAndMatchingMembers()
+    {
+        $sourceClass = _AttrMeta_Source::class;
+        $targetClass = _AttrMeta_Target::class;
+
+        $container = new ContainerBuilder();
+        $container->register('serializer.mapping.attribute_loader', AttributeLoader::class)
+            ->setArguments([false, []]);
+
+        $container->register('service.source', $sourceClass)
+            ->addTag('serializer.attribute_metadata', ['for' => $targetClass])
+            ->addTag('container.excluded');
+
+        (new AttributeMetadataPass())->process($container);
+
+        $arguments = $container->getDefinition('serializer.mapping.attribute_loader')->getArguments();
+        $this->assertSame([false, [$targetClass => [$sourceClass]]], $arguments);
+    }
+
+    public function testProcessWithForOptionAndMissingMemberThrows()
+    {
+        $sourceClass = _AttrMeta_BadSource::class;
+        $targetClass = _AttrMeta_Target::class;
+
+        $container = new ContainerBuilder();
+        $container->register('serializer.mapping.attribute_loader', AttributeLoader::class)
+            ->setArguments([false, []]);
+
+        $container->register('service.source', $sourceClass)
+            ->addTag('serializer.attribute_metadata', ['for' => $targetClass])
+            ->addTag('container.excluded');
+
+        $this->expectException(MappingException::class);
+        (new AttributeMetadataPass())->process($container);
+    }
+}
+
+class _AttrMeta_Source
+{
+    public string $name;
+
+    public function getName()
+    {
+    }
+}
+
+class _AttrMeta_Target
+{
+    public string $name;
+
+    public function getName()
+    {
+    }
+}
+
+class _AttrMeta_BadSource
+{
+    public string $extra;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR builds on #61532
It's a sibling of #61545

I propose to add a `#[ExtendsSerializationFor]` attribute that allows adding serialization attributes to another class.
This is typically needed for third party classes. For context, Sylius has a nice doc about this:
https://docs.sylius.com/the-customization-guide/customizing-serialization-of-api

At the moment, the only way to achieve this is by declaring the new attributes in the (hardcoded) `config/serialization/` folder, using either xml or yaml. No attributes.

With this PR, one will be able to define those extra serialization attributes using PHP attributes, set on classes that'd mirror the properties/getters of the targeted class. The compiler pass will ensure that all properties/getters declared in these source classes also exist in the target class. (source = the app's class that declares the new serialization attributes; target = the existing class to add serialization attributes to.)

```php
#[ExtendsSerializationFor(TargetClass::class)]
abstract class SourceClass
{
    #[Groups(['my_app'])]
    #[SerializedName('fullName')]
    public string $name = '';

    #[Groups(['my_app'])]
    public string $email = '';

    #[Groups(['my_app'])]
    #[MaxDepth(2)]
    public Category $category;
}
```

(I made the class abstract because it's not supposed to be instantiated - but it's not mandatory.)

Here are the basics of how this works:

1. During container compilation, classes marked with `#[ExtendsSerializationFor(Target::class)]` are collected and validated: the container checks that members declared on the source exist on the target. If not, a `MappingException` is thrown.
2. The serializer is configured to map the target to its source classes.
3. At runtime, when loading serialization metadata for the target, attributes (groups, serialized names, max depth, etc.) are read from both the target and its mapped source classes and applied accordingly.
