### PR TITLE
[Validator] Update Romanian translations

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.ro.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ro.xlf
@@ -4,11 +4,11 @@
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
-                <target>Această valoare ar trebui să fie falsă (false).</target>
+                <target>Această valoare ar trebui să fie falsă.</target>
             </trans-unit>
             <trans-unit id="2">
                 <source>This value should be true.</source>
-                <target>Această valoare ar trebui să fie adevărată (true).</target>
+                <target>Această valoare ar trebui să fie adevărată.</target>
             </trans-unit>
             <trans-unit id="3">
                 <source>This value should be of type {{ type }}.</source>
@@ -16,7 +16,7 @@
             </trans-unit>
             <trans-unit id="4">
                 <source>This value should be blank.</source>
-                <target>Această valoare ar trebui sa fie goală.</target>
+                <target>Această valoare ar trebui să fie necompletată.</target>
             </trans-unit>
             <trans-unit id="5">
                 <source>The value you selected is not a valid choice.</source>
@@ -24,11 +24,11 @@
             </trans-unit>
             <trans-unit id="6">
                 <source>You must select at least {{ limit }} choice.|You must select at least {{ limit }} choices.</source>
-                <target>Trebuie să selectați cel puțin {{ limit }} opțiune.|Trebuie să selectați cel puțin {{ limit }} opțiuni.|Trebuie să selectați cel puțin {{ limit }} de opțiuni</target>
+                <target>Trebuie să selectați cel puțin {{ limit }} opțiune.|Trebuie să selectați cel puțin {{ limit }} opțiuni.</target>
             </trans-unit>
             <trans-unit id="7">
                 <source>You must select at most {{ limit }} choice.|You must select at most {{ limit }} choices.</source>
-                <target>Trebuie să selectați cel mult {{ limit }} opțiune.|Trebuie să selectați cel mult {{ limit }} opțiuni.|Trebuie să selectați cel mult {{ limit }} de opțiuni.</target>
+                <target>Trebuie să selectați cel mult {{ limit }} opțiune.|Trebuie să selectați cel mult {{ limit }} opțiuni.</target>
             </trans-unit>
             <trans-unit id="8">
                 <source>One or more of the given values is invalid.</source>
@@ -36,11 +36,11 @@
             </trans-unit>
             <trans-unit id="9">
                 <source>This field was not expected.</source>
-                <target>Acest câmp nu era de aşteptat.</target>
+                <target>Acest câmp nu era prevăzut.</target>
             </trans-unit>
             <trans-unit id="10">
                 <source>This field is missing.</source>
-                <target>Acest câmp este lipsă.</target>
+                <target>Acest câmp lipsește.</target>
             </trans-unit>
             <trans-unit id="11">
                 <source>This value is not a valid date.</source>
@@ -68,7 +68,7 @@
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>
-                <target>Tipul fișierului este invalid ({{ type }}). Tipurile permise de fișiere sunt ({{ types }}).</target>
+                <target>Tipul fișierului este invalid ({{ type }}). Tipurile de fișiere permise sunt {{ types }}.</target>
             </trans-unit>
             <trans-unit id="18">
                 <source>This value should be {{ limit }} or less.</source>
@@ -76,7 +76,7 @@
             </trans-unit>
             <trans-unit id="19">
                 <source>This value is too long. It should have {{ limit }} character or less.|This value is too long. It should have {{ limit }} characters or less.</source>
-                <target>Această valoare este prea lungă. Ar trebui să aibă maxim {{ limit }} caracter.|Această valoare este prea lungă. Ar trebui să aibă maxim {{ limit }} caractere.|Această valoare este prea lungă. Ar trebui să aibă maxim {{ limit }} de caractere.</target>
+                <target>Această valoare este prea lungă. Ar trebui să aibă maxim {{ limit }} caracter.|Această valoare este prea lungă. Ar trebui să aibă maxim {{ limit }} caractere.</target>
             </trans-unit>
             <trans-unit id="20">
                 <source>This value should be {{ limit }} or more.</source>
@@ -84,19 +84,19 @@
             </trans-unit>
             <trans-unit id="21">
                 <source>This value is too short. It should have {{ limit }} character or more.|This value is too short. It should have {{ limit }} characters or more.</source>
-                <target>Această valoare este prea scurtă. Ar trebui să aibă minim {{ limit }} caracter.|Această valoare este prea scurtă. Ar trebui să aibă minim {{ limit }} caractere.|Această valoare este prea scurtă. Ar trebui să aibă minim {{ limit }} de caractere.</target>
+                <target>Această valoare este prea scurtă. Ar trebui să aibă minim {{ limit }} caracter.|Această valoare este prea scurtă. Ar trebui să aibă minim {{ limit }} caractere.</target>
             </trans-unit>
             <trans-unit id="22">
                 <source>This value should not be blank.</source>
-                <target>Această valoare nu ar trebui să fie goală.</target>
+                <target>Această valoare nu ar trebui să fie necompletată.</target>
             </trans-unit>
             <trans-unit id="23">
                 <source>This value should not be null.</source>
-                <target>Această valoare nu ar trebui să fie nulă (null).</target>
+                <target>Această valoare nu ar trebui să fie nulă.</target>
             </trans-unit>
             <trans-unit id="24">
                 <source>This value should be null.</source>
-                <target>Această valoare ar trebui să fie nulă (null).</target>
+                <target>Această valoare ar trebui să fie nulă.</target>
             </trans-unit>
             <trans-unit id="25">
                 <source>This value is not valid.</source>
@@ -108,7 +108,7 @@
             </trans-unit>
             <trans-unit id="27">
                 <source>This value is not a valid URL.</source>
-                <target>Această valoare nu reprezintă un URL (link) valid.</target>
+                <target>Această valoare nu reprezintă un URL valid.</target>
             </trans-unit>
             <trans-unit id="31">
                 <source>The two values should be equal.</source>
@@ -116,7 +116,7 @@
             </trans-unit>
             <trans-unit id="32">
                 <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
-                <target>Fișierul este prea mare. Mărimea maximă permisă este {{ limit }} {{ suffix }}.</target>
+                <target>Fișierul este prea mare. Mărimea maximă permisă este de {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>
@@ -144,7 +144,7 @@
             </trans-unit>
             <trans-unit id="39">
                 <source>This value is not a valid locale.</source>
-                <target>Această valoare nu reprezintă un dialect (o limbă) corect.</target>
+                <target>Această valoare nu este o localizare validă.</target>
             </trans-unit>
             <trans-unit id="40">
                 <source>This value is not a valid country.</source>
@@ -180,7 +180,7 @@
             </trans-unit>
             <trans-unit id="48">
                 <source>This value should have exactly {{ limit }} character.|This value should have exactly {{ limit }} characters.</source>
-                <target>Această valoare trebuie să conțină exact {{ limit }} caracter.|Această valoare trebuie să conțină exact {{ limit }} caractere.|Această valoare trebuie să conțină exact {{ limit }} de caractere.</target>
+                <target>Această valoare trebuie să conțină exact {{ limit }} caracter.|Această valoare trebuie să conțină exact {{ limit }} caractere.</target>
             </trans-unit>
             <trans-unit id="49">
                 <source>The file was only partially uploaded.</source>
@@ -188,7 +188,7 @@
             </trans-unit>
             <trans-unit id="50">
                 <source>No file was uploaded.</source>
-                <target>Nu a fost încărcat nici un fișier.</target>
+                <target>Nu a fost încărcat niciun fișier.</target>
             </trans-unit>
             <trans-unit id="51" resname="No temporary folder was configured in php.ini.">
                 <source>No temporary folder was configured in php.ini, or the configured folder does not exist.</source>
@@ -200,27 +200,27 @@
             </trans-unit>
             <trans-unit id="53">
                 <source>A PHP extension caused the upload to fail.</source>
-                <target>O extensie PHP a prevenit încărcarea cu succes a fișierului.</target>
+                <target>O extensie PHP a cauzat eșecul încărcării.</target>
             </trans-unit>
             <trans-unit id="54">
                 <source>This collection should contain {{ limit }} element or more.|This collection should contain {{ limit }} elements or more.</source>
-                <target>Această colecție trebuie să conțină cel puțin {{ limit }} element.|Această colecție trebuie să conțină cel puțin {{ limit }} elemente.|Această colecție trebuie să conțină cel puțin {{ limit }} de elemente.</target>
+                <target>Această colecție trebuie să conțină cel puțin {{ limit }} element.|Această colecție trebuie să conțină cel puțin {{ limit }} elemente.</target>
             </trans-unit>
             <trans-unit id="55">
                 <source>This collection should contain {{ limit }} element or less.|This collection should contain {{ limit }} elements or less.</source>
-                <target>Această colecție trebuie să conțină cel mult {{ limit }} element.|Această colecție trebuie să conțină cel mult {{ limit }} elemente.|Această colecție trebuie să conțină cel mult {{ limit }} de elemente.</target>
+                <target>Această colecție trebuie să conțină cel mult {{ limit }} element.|Această colecție trebuie să conțină cel mult {{ limit }} elemente.</target>
             </trans-unit>
             <trans-unit id="56">
                 <source>This collection should contain exactly {{ limit }} element.|This collection should contain exactly {{ limit }} elements.</source>
-                <target>Această colecție trebuie să conțină {{ limit }} element.|Această colecție trebuie să conțină {{ limit }} elemente.|Această colecție trebuie să conțină {{ limit }} de elemente.</target>
+                <target>Această colecție trebuie să conțină exact {{ limit }} element.|Această colecție trebuie să conțină exact {{ limit }} elemente.</target>
             </trans-unit>
             <trans-unit id="57">
                 <source>Invalid card number.</source>
-                <target>Numărul card invalid.</target>
+                <target>Numărul cardului este invalid.</target>
             </trans-unit>
             <trans-unit id="58">
                 <source>Unsupported card type or invalid card number.</source>
-                <target>Tipul sau numărul cardului nu sunt valide.</target>
+                <target>Tipul sau numărul cardului sunt invalide.</target>
             </trans-unit>
             <trans-unit id="59" resname="This is not a valid International Bank Account Number (IBAN).">
                 <source>This value is not a valid International Bank Account Number (IBAN).</source>
@@ -252,7 +252,7 @@
             </trans-unit>
             <trans-unit id="66">
                 <source>This value should be greater than {{ compared_value }}.</source>
-                <target>Această valoare trebuie să fie mai mare de {{ compared_value }}.</target>
+                <target>Această valoare trebuie să fie mai mare decât {{ compared_value }}.</target>
             </trans-unit>
             <trans-unit id="67">
                 <source>This value should be greater than or equal to {{ compared_value }}.</source>
@@ -260,11 +260,11 @@
             </trans-unit>
             <trans-unit id="68">
                 <source>This value should be identical to {{ compared_value_type }} {{ compared_value }}.</source>
-                <target>Această valoare trebuie identică cu {{ compared_value_type }} {{ compared_value }}.</target>
+                <target>Această valoare trebuie să fie identică cu {{ compared_value_type }} {{ compared_value }}.</target>
             </trans-unit>
             <trans-unit id="69">
                 <source>This value should be less than {{ compared_value }}.</source>
-                <target>Această valoare trebuie să fie mai mică de {{ compared_value }}.</target>
+                <target>Această valoare trebuie să fie mai mică decât {{ compared_value }}.</target>
             </trans-unit>
             <trans-unit id="70">
                 <source>This value should be less than or equal to {{ compared_value }}.</source>
@@ -288,11 +288,11 @@
             </trans-unit>
             <trans-unit id="75">
                 <source>The image is square ({{ width }}x{{ height }}px). Square images are not allowed.</source>
-                <target>Imaginea este un pătrat ({{ width }}x{{ height }}px). Imaginile pătrat nu sunt permise.</target>
+                <target>Imaginea este pătrată ({{ width }}x{{ height }}px). Imaginile pătrate nu sunt permise.</target>
             </trans-unit>
             <trans-unit id="76">
                 <source>The image is landscape oriented ({{ width }}x{{ height }}px). Landscape oriented images are not allowed.</source>
-                <target>Imaginea are orientarea peisaj ({{ width }}x{{ height }}px). Imaginile cu orientare peisaj nu sunt permise.</target>
+                <target>Imaginea are orientarea orizontală ({{ width }}x{{ height }}px). Imaginile cu orientare orizontală nu sunt permise.</target>
             </trans-unit>
             <trans-unit id="77">
                 <source>The image is portrait oriented ({{ width }}x{{ height }}px). Portrait oriented images are not allowed.</source>
@@ -304,7 +304,7 @@
             </trans-unit>
             <trans-unit id="79">
                 <source>The host could not be resolved.</source>
-                <target>Numele host nu a putut fi rezolvat către o adresă IP.</target>
+                <target>Host-ul nu a putut fi rezolvat.</target>
             </trans-unit>
             <trans-unit id="80">
                 <source>This value does not match the expected {{ charset }} charset.</source>
@@ -336,7 +336,7 @@
             </trans-unit>
             <trans-unit id="87">
                 <source>This collection should contain only unique elements.</source>
-                <target>Acest set ar trebui să conțină numai elemente unice.</target>
+                <target>Această colecție ar trebui să conțină numai elemente unice.</target>
             </trans-unit>
             <trans-unit id="88">
                 <source>This value should be positive.</source>
@@ -368,19 +368,19 @@
             </trans-unit>
             <trans-unit id="95">
                 <source>This value is not a valid hostname.</source>
-                <target>Această valoare nu este un numele gazdei valid.</target>
+                <target>Această valoare nu este un hostname valid.</target>
             </trans-unit>
             <trans-unit id="96">
                 <source>The number of elements in this collection should be a multiple of {{ compared_value }}.</source>
-                <target>Numărul de elemente din această colecție ar trebui să fie un multiplu al {{ compared_value }}.</target>
+                <target>Numărul de elemente din această colecție ar trebui să fie un multiplu de {{ compared_value }}.</target>
             </trans-unit>
             <trans-unit id="97">
                 <source>This value should satisfy at least one of the following constraints:</source>
-                <target>Această valoare trebuie să îndeplinească cel puțin una dintre următoarele reguli:</target>
+                <target>Această valoare trebuie să îndeplinească cel puțin una dintre următoarele condiții:</target>
             </trans-unit>
             <trans-unit id="98">
                 <source>Each element of this collection should satisfy its own set of constraints.</source>
-                <target>Fiecare element din acest set ar trebui să îndeplinească propriul set de reguli.</target>
+                <target>Fiecare element din acest set ar trebui să îndeplinească propriul set de condiții.</target>
             </trans-unit>
             <trans-unit id="99">
                 <source>This value is not a valid International Securities Identification Number (ISIN).</source>
@@ -400,11 +400,11 @@
             </trans-unit>
             <trans-unit id="103">
                 <source>The value of the netmask should be between {{ min }} and {{ max }}.</source>
-                <target>Valoarea netmask-ului trebuie sa fie intre {{ min }} si {{ max }}.</target>
+                <target>Valoarea măștii de rețea trebuie să fie între {{ min }} și {{ max }}.</target>
             </trans-unit>
             <trans-unit id="104">
                 <source>The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</source>
-                <target>Denumirea fișierului este prea lungă. Ea trebuie să conțină {{ filename_max_length }} caractere sau mai puține.|Denumirea fișierului este prea lungă. Ea trebuie să conțină {{ filename_max_length }} caractere sau mai puține.</target>
+                <target>Denumirea fișierului este prea lungă. Trebuie să conțină {{ filename_max_length }} caracter sau mai puțin.|Denumirea fișierului este prea lungă. Trebuie să conțină {{ filename_max_length }} caractere sau mai puține.</target>
             </trans-unit>
             <trans-unit id="105">
                 <source>The password strength is too low. Please use a stronger password.</source>
@@ -424,7 +424,7 @@
             </trans-unit>
             <trans-unit id="109">
                 <source>Using hidden overlay characters is not allowed.</source>
-                <target>Folosirea caracterelor invizibile suprapuse nu este permisă.</target>
+                <target>Folosirea caracterelor ascunse nu este permisă.</target>
             </trans-unit>
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
@@ -432,7 +432,7 @@
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target>Codificarea caracterelor detectate nu este valabilă ({{ detected }}). Codificările permise sunt {{ encodings }}.</target>
+                <target>Codificarea caracterelor detectate este invalidă ({{ detected }}). Codificările permise sunt {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This value is not a valid MAC address.</source>
@@ -468,7 +468,7 @@
             </trans-unit>
             <trans-unit id="121">
                 <source>This value is not a valid Twig template.</source>
-                <target state="needs-review-translation">Această valoare nu este un șablon Twig valid.</target>
+                <target>Această valoare nu este un șablon Twig valid.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60468 
| License       | MIT

This PR updates Romanian translations in `validators.ro.xlf`.

- Fixed grammar and spelling issues
- Improved clarity and naturalness of phrasing
- Removed extra plural variants that were incorrect
- Removed unnecessary clarifications in parentheses
- Translated technical terminology

Examples:

**Before:**
`Acest câmp este lipsă.`
**After:**
`Acest câmp lipsește.`

**Before:**
`Această valoare nu reprezintă un URL (link) valid.`
**After:**
`Această valoare nu reprezintă un URL valid.`

**Before:**
`Numărul card invalid.`
**After:**
`Numărul cardului este invalid.`

