### PR TITLE
[Console] Harden array type for test-related user inputs

### DIFF
--- a/src/Symfony/Component/Console/Tester/TesterTrait.php
+++ b/src/Symfony/Component/Console/Tester/TesterTrait.php
@@ -24,6 +24,10 @@ use Symfony\Component\Console\Tester\Constraint\CommandIsSuccessful;
 trait TesterTrait
 {
     private StreamOutput $output;
+
+    /**
+     * @var list<string>
+     */
     private array $inputs = [];
     private bool $captureStreamsIndependently = false;
     private InputInterface $input;
@@ -107,8 +111,8 @@ trait TesterTrait
     /**
      * Sets the user inputs.
      *
-     * @param array $inputs An array of strings representing each input
-     *                      passed to the command input stream
+     * @param list<string> $inputs An array of strings representing each input
+     *                             passed to the command input stream
      *
      * @return $this
      */
@@ -161,6 +165,8 @@ trait TesterTrait
     }
 
     /**
+     * @param list<string> $inputs
+     *
      * @return resource
      */
     private static function createStream(array $inputs)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #...
| License       | MIT

User inputs must be strings, otherwise they cannot be properly written to the `php://memory` stream (because of the `str_contains` check here: https://github.com/symfony/symfony/blob/v6.4.25/src/Symfony/Component/Console/Tester/TesterTrait.php#L173). Using the hardened typed annotation, static code analyzers may assist developers in using correct array values.