### PR TITLE
[Serializer] Fix dealing with asymmetric visilibity for properties

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -179,16 +179,9 @@ class ObjectNormalizer extends AbstractObjectNormalizer
             return self::$isReadableCache[$class.$attribute];
         }
 
-        if (!isset(self::$isWritableCache[$class.$attribute])) {
-            if (str_contains($attribute, '.')) {
-                self::$isWritableCache[$class.$attribute] = true;
-            } else {
-                self::$isWritableCache[$class.$attribute] = $this->propertyInfoExtractor->isWritable($class, $attribute)
-                    || (($writeInfo = $this->writeInfoExtractor->getWriteInfo($class, $attribute)) && PropertyWriteInfo::TYPE_NONE !== $writeInfo->getType());
-            }
-        }
-
-        return self::$isWritableCache[$class.$attribute];
+        return self::$isWritableCache[$class.$attribute] ??= str_contains($attribute, '.')
+            || $this->propertyInfoExtractor->isWritable($class, $attribute)
+            || !\in_array($this->writeInfoExtractor->getWriteInfo($class, $attribute)?->getType(), [null, PropertyWriteInfo::TYPE_NONE, PropertyWriteInfo::TYPE_PROPERTY], true);
     }
 
     private function hasAttributeAccessorMethod(string $class, string $attribute): bool

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/AsymmetricVisibilityDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/AsymmetricVisibilityDummy.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+final class AsymmetricVisibilityDummy
+{
+    private(set) string $type;
+
+    public function __construct(
+        public readonly string $item,
+    ) {
+        $this->type = 'final';
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -48,6 +48,7 @@ use Symfony\Component\Serializer\Normalizer\PropertyNormalizer;
 use Symfony\Component\Serializer\Normalizer\UidNormalizer;
 use Symfony\Component\Serializer\Normalizer\UnwrappingDenormalizer;
 use Symfony\Component\Serializer\Serializer;
+use Symfony\Component\Serializer\Tests\Fixtures\AsymmetricVisibilityDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummyFirstChild;
 use Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummySecondChild;
@@ -1724,6 +1725,19 @@ class SerializerTest extends TestCase
 
             $this->assertSame($expected, $exceptionsAsArray);
         }
+    }
+
+    /**
+     * @requires PHP 8.4
+     */
+    public function testDeserializeObjectWithAsymmetricPropertyVisibility()
+    {
+        $serializer = new Serializer([new ObjectNormalizer()], ['json' => new JsonEncoder()]);
+        /** @var AsymmetricVisibilityDummy $object */
+        $object = $serializer->deserialize(json_encode(['type' => 'This value must not be changed because the property has a private setter', 'item' => 'one']), AsymmetricVisibilityDummy::class, 'json');
+
+        $this->assertSame('one', $object->item);
+        $this->assertSame('final', $object->type); // Value set in the constructor; must not be changed during deserialization
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61552
| License       | MIT

### Description

This PR resolves a crash in the `Serializer` when deserializing an object with a `protected(set)` or `private(set)` property