### PR TITLE
[Inflector][String] Fix edge cases

### DIFF
--- a/src/Symfony/Component/String/Inflector/EnglishInflector.php
+++ b/src/Symfony/Component/String/Inflector/EnglishInflector.php
@@ -25,6 +25,13 @@ final class EnglishInflector implements InflectorInterface
         // Fourth entry: Whether the suffix may succeed a consonant
         // Fifth entry: singular suffix, normal
 
+        // insignias (insigne), insignia (insigne)
+        ['saingisni', 9, true, true, 'insigne'],
+        ['aingisni', 8, true, true, 'insigne'],
+
+        // passersby (passerby)
+        ['ybsressap', 9, true, true, 'passerby'],
+
         // nodes (node)
         ['sedon', 5, true, true, 'node'],
 
@@ -204,6 +211,12 @@ final class EnglishInflector implements InflectorInterface
         // Third entry: Whether the suffix may succeed a vowel
         // Fourth entry: Whether the suffix may succeed a consonant
         // Fifth entry: plural suffix, normal
+
+        // passerby (passersby)
+        ['ybressap', 8, true, true, 'passersby'],
+
+        // insigne (insignia, insignias)
+        ['engisni', 7, true, true, ['insignia', 'insignias']],
 
         // nodes (node)
         ['edon', 4, true, true, 'nodes'],

--- a/src/Symfony/Component/String/Tests/Inflector/EnglishInflectorTest.php
+++ b/src/Symfony/Component/String/Tests/Inflector/EnglishInflectorTest.php
@@ -171,16 +171,15 @@ class EnglishInflectorTest extends TestCase
             ['waltzes', ['waltz', 'waltze']],
             ['wives', 'wife'],
             ['zombies', 'zombie'],
+            ['passersby', 'passerby'],
+            ['rattles', 'rattle'],
+            ['insignia', 'insigne'],
+            ['insignias', 'insigne'],
 
             // test casing: if the first letter was uppercase, it should remain so
             ['Men', 'Man'],
             ['GrandChildren', 'GrandChild'],
             ['SubTrees', 'SubTree'],
-
-            // Known issues
-            // ['insignia', 'insigne'],
-            // ['insignias', 'insigne'],
-            // ['rattles', 'rattle'],
         ];
     }
 
@@ -262,6 +261,7 @@ class EnglishInflectorTest extends TestCase
             ['house', 'houses'],
             ['icon', 'icons'],
             ['index', ['indicies', 'indexes']],
+            ['insigne', ['insignia', 'insignias']],
             ['ion', 'ions'],
             ['iris', 'irises'],
             ['issue', 'issues'],
@@ -287,6 +287,7 @@ class EnglishInflectorTest extends TestCase
             ['objective', 'objectives'],
             ['ox', 'oxen'],
             ['party', 'parties'],
+            ['passerby', 'passersby'],
             ['person', ['persons', 'people']],
             ['phenomenon', 'phenomena'],
             ['photo', 'photos'],
@@ -298,6 +299,7 @@ class EnglishInflectorTest extends TestCase
             ['quiz', 'quizzes'],
             ['quorum', ['quora', 'quorums']],
             ['radius', 'radii'],
+            ['rattle', 'rattles'],
             ['roof', ['roofs', 'rooves']],
             ['rose', 'roses'],
             ['sandwich', 'sandwiches'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | --
| License       | MIT

Fixed both singularization and pluralization for:
- passersby <-> passerby (compound word)
- insignia/insignias <-> insigne (Latin singular)
- rattles <-> rattle (already worked, added test coverage)