### PR TITLE
[DependencyInjection] Allow multiple `#[AsDecorator]` attributes

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/AsDecorator.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/AsDecorator.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * Declares a decorating service.
  */
-#[\Attribute(\Attribute::TARGET_CLASS)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 class AsDecorator
 {
     /**

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Allow `#[AsAlias]` to be extended
  * Add argument `$target` to `ContainerBuilder::registerAliasForArgument()`
  * Deprecate registering a service without a class when its id is a non-existing FQCN
+ * Allow multiple `#[AsDecorator]` attributes
 
 7.3
 ---

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -1346,6 +1346,28 @@ class AutowirePassTest extends TestCase
         $this->assertSame(2, $container->getDefinition(AsDecoratorBaz::class)->getArgument(0)->getInvalidBehavior());
     }
 
+    public function testMultipleAsDecoratorAttribute()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register(AsDecoratorMultipleFoo::class);
+        $container->register(AsDecoratorMultipleBar::class);
+        $container->register(AsDecoratorMultiple::class)->setAutowired(true)->setArgument(0, 'arg1');
+
+        (new ResolveClassPass())->process($container);
+        (new AutowireAsDecoratorPass())->process($container);
+        (new DecoratorServicePass())->process($container);
+        (new AutowirePass())->process($container);
+
+        $fooDecoratorName = '.decorator.'.AsDecoratorMultipleFoo::class.'.'.AsDecoratorMultiple::class;
+        $this->assertSame($fooDecoratorName, (string) $container->getAlias(AsDecoratorMultipleFoo::class));
+        $this->assertSame($fooDecoratorName.'.inner', (string) $container->getDefinition($fooDecoratorName)->getArgument(1));
+
+        $barDecoratorName = '.decorator.'.AsDecoratorMultipleBar::class.'.'.AsDecoratorMultiple::class;
+        $this->assertSame($barDecoratorName, (string) $container->getAlias(AsDecoratorMultipleBar::class));
+        $this->assertSame($barDecoratorName.'.inner', (string) $container->getDefinition($barDecoratorName)->getArgument(1));
+    }
+
     public function testTypeSymbolExcluded()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
@@ -125,6 +125,23 @@ class AsDecoratorBaz implements AsDecoratorInterface
     }
 }
 
+class AsDecoratorMultipleFoo implements AsDecoratorInterface
+{
+}
+
+class AsDecoratorMultipleBar implements AsDecoratorInterface
+{
+}
+
+#[AsDecorator(decorates: AsDecoratorMultipleFoo::class)]
+#[AsDecorator(decorates: AsDecoratorMultipleBar::class)]
+class AsDecoratorMultiple implements AsDecoratorInterface
+{
+    public function __construct(string $arg1, #[AutowireDecorated] AsDecoratorInterface $inner)
+    {
+    }
+}
+
 #[AsDecorator(decorates: AsDecoratorFoo::class)]
 class AutowireNestedAttributes implements AsDecoratorInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

Make `#[AsDecorator]` attribute repeatable to allow decorating multiple services at once.

Example for a simple HttpClient logger:
```php
#[AsDecorator('api1.client')]
#[AsDecorator('api2.client')]
#[AsDecorator('api3.client')]
class LoggableService implements HttpClientInterface
{
    use DecoratorTrait;

    public function __construct(
        private HttpClientInterface $client,
        private readonly LoggerInterface $logger,
    ) {
    }

    public function request(string $method, string $url, array $options = []): ResponseInterface
    {
        try {
            $response = $this->client->request($method, $url, $options);

            $this->logger->info('API call: {method} {url}.', ['method'= > $method, 'url' => $url]);

            return $response;
        } catch (\Throwable $e) {
            $this->logger->error('API call failed: {method} {url}.', ['method'= > $method, 'url' => $url, 'exception' => $e]);

            throw $exception;
        }
    }
}
```