### PR TITLE
[DependencyInjection] Parse attributes found on abstract classes for resource definitions

### DIFF
--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -27,6 +27,7 @@ DependencyInjection
 -------------------
 
  * Add argument `$target` to `ContainerBuilder::registerAliasForArgument()`
+ * Add argument `$throwOnAbstract` to `ContainerBuilder::findTaggedResourceIds()`
  * Deprecate registering a service without a class when its id is a non-existing FQCN
 
 DoctrineBridge

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Allow adding resource tags using any config format
  * Allow `#[AsAlias]` to be extended
+ * Parse attributes found on abstract classes for resource definitions
  * Add argument `$target` to `ContainerBuilder::registerAliasForArgument()`
  * Deprecate registering a service without a class when its id is a non-existing FQCN
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/AttributeAutoconfigurationPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AttributeAutoconfigurationPass.php
@@ -79,14 +79,18 @@ final class AttributeAutoconfigurationPass extends AbstractRecursivePass
             }
         }
 
-        parent::process($container);
+        $this->container = $container;
+        foreach ($container->getDefinitions() as $id => $definition) {
+            $this->currentId = $id;
+            $this->processValue($definition, true);
+        }
     }
 
     protected function processValue(mixed $value, bool $isRoot = false): mixed
     {
         if (!$value instanceof Definition
             || !$value->isAutoconfigured()
-            || $value->isAbstract()
+            || ($value->isAbstract() && !$value->hasTag('container.excluded'))
             || $value->hasTag('container.ignore_attributes')
             || !($classReflector = $this->container->getReflectionClass($value->getClass(), false))
         ) {

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveInvalidReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveInvalidReferencesPass.php
@@ -62,7 +62,7 @@ class ResolveInvalidReferencesPass implements CompilerPassInterface
         } elseif ($value instanceof ArgumentInterface) {
             $value->setValues($this->processValue($value->getValues(), $rootLevel, 1 + $level));
         } elseif ($value instanceof Definition) {
-            if ($value->isSynthetic() || $value->isAbstract()) {
+            if ($value->isSynthetic() || $value->isAbstract() || $value->hasTag('container.excluded')) {
                 return $value;
             }
             $value->setArguments($this->processValue($value->getArguments(), 0));

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -465,8 +465,7 @@ class Definition
     public function addResourceTag(string $name, array $attributes = []): static
     {
         return $this->addTag($name, $attributes)
-            ->addTag('container.excluded', ['source' => \sprintf('by tag "%s"', $name)])
-            ->setAbstract(true);
+            ->addTag('container.excluded', ['source' => \sprintf('by tag "%s"', $name)]);
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
@@ -189,21 +189,25 @@ abstract class FileLoader extends BaseFileLoader
             }
 
             $r = null === $errorMessage ? $this->container->getReflectionClass($class) : null;
-            if ($r?->isAbstract() || $r?->isInterface()) {
-                if ($r->isInterface()) {
-                    $this->interfaces[] = $class;
-                }
-                $autoconfigureAttributes?->processClass($this->container, $r);
-                continue;
-            }
 
-            $this->setDefinition($class, $definition = $getPrototype());
+            $abstract = $r?->isAbstract() || $r?->isInterface() ? '.abstract.' : '';
+            $this->setDefinition($abstract.$class, $definition = $getPrototype());
             if (null !== $errorMessage) {
                 $definition->addError($errorMessage);
 
                 continue;
             }
             $definition->setClass($class);
+
+            if ($abstract) {
+                if ($r->isInterface()) {
+                    $this->interfaces[] = $class;
+                }
+                $autoconfigureAttributes?->processClass($this->container, $r);
+                $definition->setAbstract(true)
+                    ->addTag('container.excluded', ['source' => 'because the class is abstract']);
+                continue;
+            }
 
             $interfaces = [];
             foreach (class_implements($class, false) as $interface) {

--- a/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
@@ -262,7 +262,7 @@ class DefinitionTest extends TestCase
         $def->addResourceTag('foo', ['bar' => true]);
 
         $this->assertSame([['bar' => true]], $def->getTag('foo'));
-        $this->assertTrue($def->isAbstract());
+        $this->assertFalse($def->isAbstract());
         $this->assertSame([['source' => 'by tag "foo"']], $def->getTag('container.excluded'));
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/AbstractClass.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/AbstractClass.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype;
+
+abstract class AbstractClass
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
@@ -156,7 +156,7 @@ class PhpFileLoaderTest extends TestCase
         $this->assertTrue($def->hasTag('another.tag'));
         $this->assertSame([['foo' => 'bar']], $def->getTag('my.tag'));
         $this->assertSame([[]], $def->getTag('another.tag'));
-        $this->assertTrue($def->isAbstract());
+        $this->assertFalse($def->isAbstract());
     }
 
     public function testAutoConfigureAndChildDefinition()

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -381,7 +381,7 @@ class XmlFileLoaderTest extends TestCase
         $this->assertTrue($def->hasTag('another.tag'));
         $this->assertSame([['foo' => 'bar']], $def->getTag('my.tag'));
         $this->assertSame([[]], $def->getTag('another.tag'));
-        $this->assertTrue($def->isAbstract());
+        $this->assertFalse($def->isAbstract());
     }
 
     public function testParsesIteratorArgument()

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -259,7 +259,7 @@ class YamlFileLoaderTest extends TestCase
         $this->assertTrue($def->hasTag('another.tag'));
         $this->assertSame([['foo' => 'bar']], $def->getTag('my.tag'));
         $this->assertSame([[]], $def->getTag('another.tag'));
-        $this->assertTrue($def->isAbstract());
+        $this->assertFalse($def->isAbstract());
     }
 
     public function testLoadShortSyntax()

--- a/src/Symfony/Component/JsonStreamer/Tests/DependencyInjection/StreamablePassTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/DependencyInjection/StreamablePassTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\JsonStreamer\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\JsonStreamer\DependencyInjection\StreamablePass;
 
 class StreamablePassTest extends TestCase
@@ -25,8 +26,7 @@ class StreamablePassTest extends TestCase
         $container->register('.json_streamer.cache_warmer.streamer')->setArguments([null]);
         $container->register('.json_streamer.cache_warmer.lazy_ghost')->setArguments([null]);
 
-        $container->register('streamable')->setClass('Foo')->addTag('json_streamer.streamable', ['object' => true, 'list' => true]);
-        $container->register('abstractStreamable')->setClass('Bar')->addTag('json_streamer.streamable', ['object' => true, 'list' => true])->setAbstract(true);
+        $container->register('streamable')->setClass('Foo')->addTag('json_streamer.streamable', ['object' => true, 'list' => true])->addTag('container.excluded');
         $container->register('notStreamable')->setClass('Baz');
 
         $pass = new StreamablePass();
@@ -37,5 +37,9 @@ class StreamablePassTest extends TestCase
 
         $this->assertSame(['Foo' => ['object' => true, 'list' => true]], $streamerCacheWarmer->getArgument(0));
         $this->assertSame(['Foo'], $lazyGhostCacheWarmer->getArgument(0));
+
+        $container->register('abstractStreamable')->setClass('Bar')->addTag('json_streamer.streamable', ['object' => true, 'list' => true])->addTag('container.excluded')->setAbstract(true);
+        $this->expectException(InvalidArgumentException::class);
+        $pass->process($container);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR improves support for resource definitions by allowing to parse attributes on abstract classes.

This can be useful for PRs like #61563 and #61545, so that the attribute proposed there could be set on abstract classes.