### PR TITLE
[JsonStreamer] Fix encoding iterable lists

### DIFF
--- a/src/Symfony/Component/JsonStreamer/Tests/JsonStreamWriterTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/JsonStreamWriterTest.php
@@ -105,7 +105,7 @@ class JsonStreamWriterTest extends TestCase
         );
 
         $this->assertWritten(
-            '{"0":{"id":1,"name":"dummy"},"1":{"id":1,"name":"dummy"}}',
+            '[{"id":1,"name":"dummy"},{"id":1,"name":"dummy"}]',
             new \ArrayObject([new ClassicDummy(), new ClassicDummy()]),
             Type::iterable(Type::object(ClassicDummy::class), Type::int()),
         );

--- a/src/Symfony/Component/JsonStreamer/Write/PhpAstBuilder.php
+++ b/src/Symfony/Component/JsonStreamer/Write/PhpAstBuilder.php
@@ -294,7 +294,9 @@ final class PhpAstBuilder
         if ($dataModelNode instanceof CollectionNode) {
             ++$context['depth'];
 
-            if ($dataModelNode->getType()->isList()) {
+            $collectionKeyType = $dataModelNode->getType()->getCollectionKeyType();
+
+            if ($collectionKeyType instanceof BuiltinType && TypeIdentifier::INT === $collectionKeyType->getTypeIdentifier()) {
                 return [
                     new Expression(new Yield_($this->builder->val('['))),
                     new Expression(new Assign($this->builder->var('prefix'), $this->builder->val(''))),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Sibling of https://github.com/symfony/symfony/pull/61561.

Handle any iterable with `int` as key as a list during encoding (which mean being encoded with brackets).