### PR TITLE
[DoctrineBridge] Use a single table in isSameDatabaseChecker

### DIFF
--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Deprecate `UniqueEntity::getRequiredOptions()` and `UniqueEntity::getDefaultOption()`
+ * Use a single table named `_schema_subscriber_check` in schema listeners to detect same database connections
 
 7.3
 ---

--- a/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/AbstractSchemaListenerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/AbstractSchemaListenerTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SchemaListener;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Doctrine\SchemaListener\AbstractSchemaListener;
+
+#[RequiresPhpExtension('pdo_sqlite')]
+class AbstractSchemaListenerTest extends TestCase
+{
+    public function testSameDatabaseChecker()
+    {
+        $connectionParams = [
+            'dbname' => ':memory:',
+            'driver' => 'pdo_sqlite',
+        ];
+        // Create two distinct in-memory SQLite databases
+        $connection1 = DriverManager::getConnection($connectionParams);
+        $connection2 = DriverManager::getConnection($connectionParams);
+
+        self::assertTrue($this->getIsSameDatabaseChecker($connection1)($connection1->executeStatement(...)));
+        self::assertFalse($this->getIsSameDatabaseChecker($connection1)($connection2->executeStatement(...)));
+
+        $remainingTables = $connection1->executeQuery('SELECT name FROM sqlite_schema WHERE name <> "sqlite_sequence"')->fetchFirstColumn();
+        self::assertSame([], $remainingTables, 'Temporary table was dropped');
+    }
+
+    private function getIsSameDatabaseChecker(Connection $connection): \Closure
+    {
+        return (new class extends AbstractSchemaListener {
+            public function postGenerateSchema($event): void
+            {
+            }
+
+            public function getIsSameDatabaseChecker(Connection $connection): \Closure
+            {
+                return parent::getIsSameDatabaseChecker($connection);
+            }
+        })->getIsSameDatabaseChecker($connection);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #54348
| License       | MIT

The `isSameDatabaseChecker` feature of the SchemaListener detect if 2 DBAL connections are connected to the same server and database by creating a temporary table with one connection and checking if the table exists using the other connection.

Creating a temporary table with a random name cause an issue to configure permissions, as an exhaustive list of table names can be required.

I propose to modify the implementation to always use the same table name, but insert a row with a random key with one connection and try to delete it with the other connection.
The table is dropped only if it is empty, to prevent concurrence issues.