### PR TITLE
[DoctrineBridge] Fix exception catch when deleting temporary table in the sameDatabaseChecker

### DIFF
--- a/src/Symfony/Bridge/Doctrine/SchemaListener/AbstractSchemaListener.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/AbstractSchemaListener.php
@@ -12,7 +12,7 @@
 namespace Symfony\Bridge\Doctrine\SchemaListener;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Exception\TableNotFoundException;
+use Doctrine\DBAL\Exception\DatabaseObjectNotFoundException;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
@@ -44,7 +44,7 @@ abstract class AbstractSchemaListener
                 $schemaManager->dropTable($checkTable);
 
                 return false;
-            } catch (TableNotFoundException) {
+            } catch (DatabaseObjectNotFoundException) {
                 return true;
             }
         };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61579
| License       | MIT

When the sameDatabaseChecker tries to delete a table that doesn't exist on MSSQL, it gets a  `DatabaseObjectNotFoundException`, that is a parent error of `TableNotFoundException`.
https://github.com/doctrine/dbal/blob/d5a5a2165676e15a1805dc1b43d57c0bec7493bc/src/Exception/TableNotFoundException.php#L10C38-L10C69

The error code is [15151](https://learn.microsoft.com/en-us/sql/relational-databases/errors-events/database-engine-events-and-errors-15000-to-15999): `Cannot %S_MSG the %S_MSG '%.*ls', because it does not exist or you do not have permission.`. Doctrine DBAL cannot distinguish which object it is: https://github.com/doctrine/dbal/blob/d5a5a2165676e15a1805dc1b43d57c0bec7493bc/src/Driver/API/SQLSrv/ExceptionConverter.php#L43