### PR TITLE
[HttpFoundation][SQLSRV] Change column type from `TEXT` to `STRING`

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -216,7 +216,7 @@ class PdoSessionHandler extends AbstractSessionHandler
                 $table->addColumn($this->timeCol, Types::INTEGER)->setNotnull(true);
                 break;
             case 'sqlsrv':
-                $table->addColumn($this->idCol, Types::TEXT)->setLength(128)->setNotnull(true);
+                $table->addColumn($this->idCol, Types::STRING)->setLength(128)->setNotnull(true);
                 $table->addColumn($this->dataCol, Types::BLOB)->setNotnull(true);
                 $table->addColumn($this->lifetimeCol, Types::INTEGER)->setUnsigned(true)->setNotnull(true);
                 $table->addColumn($this->timeCol, Types::INTEGER)->setUnsigned(true)->setNotnull(true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | None
| License       | MIT

Using TEXT for the id column results in Doctrine setting the SQL column to VARCHAR(MAX) for SQL Server, which results in an SQL error since the primary key cannot be VARCHAR(MAX). This change enables Doctrine to recognize the length setting, which would otherwise be ignored for TEXT objects. This was described by the Doctrine Team here (https://github.com/doctrine/dbal/issues/7126) 
