### PR TITLE
[Runtime] Expose the runtime class in `$_SERVER['APP_RUNTIME']`

### DIFF
--- a/src/Symfony/Component/Runtime/CHANGELOG.md
+++ b/src/Symfony/Component/Runtime/CHANGELOG.md
@@ -7,6 +7,8 @@ CHANGELOG
  * Add JSON encoded value support for `APP_RUNTIME_OPTIONS`
  * Add `FrankenPhpWorkerRunner`
  * Add automatic detection of FrankenPHP worker mode in `SymfonyRuntime`
+ * Expose the runtime class in `$_SERVER['APP_RUNTIME']`
+ * Expose the runtime options in `$_SERVER['APP_RUNTIME_OPTIONS']`
 
 6.4
 ---

--- a/src/Symfony/Component/Runtime/Internal/autoload_runtime.template
+++ b/src/Symfony/Component/Runtime/Internal/autoload_runtime.template
@@ -15,8 +15,8 @@ if (!is_object($app)) {
 if (is_string($_SERVER['APP_RUNTIME_OPTIONS'] ??= $_ENV['APP_RUNTIME_OPTIONS'] ?? [])) {
     $_SERVER['APP_RUNTIME_OPTIONS'] = json_decode($_SERVER['APP_RUNTIME_OPTIONS'], true, 512, JSON_THROW_ON_ERROR);
 }
-$runtime = $_SERVER['APP_RUNTIME'] ?? $_ENV['APP_RUNTIME'] ?? %runtime_class%;
-$runtime = new $runtime($_SERVER['APP_RUNTIME_OPTIONS'] += %runtime_options%);
+$_SERVER['APP_RUNTIME'] ??= $_ENV['APP_RUNTIME'] ?? %runtime_class%;
+$runtime = new $_SERVER['APP_RUNTIME']($_SERVER['APP_RUNTIME_OPTIONS'] += %runtime_options%);
 
 [$app, $args] = $runtime
     ->getResolver($app)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Let's make this var consistently contain the runtime class.
Options were already make so in #61522