### PR TITLE
[Security] Pass attributes to nested `ChainUserProvider`s

### DIFF
--- a/src/Symfony/Component/Security/Core/Tests/User/ChainUserProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/ChainUserProviderTest.php
@@ -49,6 +49,14 @@ class ChainUserProviderTest extends TestCase
 
     public function testLoadUserByIdentifierWithAttributes()
     {
+        $provider0 = $this->createMock(ChainUserProvider::class);
+        $provider0
+            ->expects($this->once())
+            ->method('loadUserByIdentifier')
+            ->with($this->equalTo('foo'), $this->equalTo(['attr' => 5]))
+            ->willThrowException(new UserNotFoundException('not found'))
+        ;
+
         $provider1 = $this->createMock(UserProviderInterface::class);
         $provider1
             ->expects($this->once())
@@ -65,7 +73,7 @@ class ChainUserProviderTest extends TestCase
             ->willReturn($account = $this->createMock(UserInterface::class))
         ;
 
-        $provider = new ChainUserProvider([$provider1, $provider2]);
+        $provider = new ChainUserProvider([$provider0, $provider1, $provider2]);
         $this->assertSame($account, $provider->loadUserByIdentifier('foo', ['attr' => 5]));
     }
 

--- a/src/Symfony/Component/Security/Core/User/ChainUserProvider.php
+++ b/src/Symfony/Component/Security/Core/User/ChainUserProvider.php
@@ -64,7 +64,7 @@ class ChainUserProvider implements UserProviderInterface, PasswordUpgraderInterf
         $attributes = \func_num_args() > 1 ? func_get_arg(1) : [];
         foreach ($this->providers as $provider) {
             try {
-                if ($provider instanceof AttributesBasedUserProviderInterface) {
+                if ($provider instanceof AttributesBasedUserProviderInterface || $provider instanceof self) {
                     return $provider->loadUserByIdentifier($identifier, $attributes);
                 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Fix a missed corner case of #61548 found by @nicolas-grekas in https://github.com/symfony/symfony/pull/61594#discussion_r2316916377

_(Not needed on 8.0)_