### PR TITLE
[FrameworkBundle] Normalize workflow places separately

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -473,27 +473,16 @@ class Configuration implements ConfigurationInterface
                                                     throw new InvalidConfigurationException('The "places" option must be an array in workflow configuration.');
                                                 }
 
-                                                // It's an indexed array of shape  ['place1', 'place2']
-                                                if (isset($places[0]) && \is_string($places[0])) {
-                                                    return array_map(function (string $place) {
-                                                        return ['name' => $place];
-                                                    }, $places);
-                                                }
-
-                                                // It's an indexed array, we let the validation occur
-                                                if (isset($places[0]) && \is_array($places[0])) {
-                                                    return $places;
-                                                }
-
-                                                foreach ($places as $name => $place) {
-                                                    if (\is_array($place) && \array_key_exists('name', $place)) {
-                                                        continue;
+                                                $normalizedPlaces = [];
+                                                foreach ($places as $key => $value) {
+                                                    if (!\is_array($value)) {
+                                                        $value = ['name' => $value];
                                                     }
-                                                    $place['name'] = $name;
-                                                    $places[$name] = $place;
+                                                    $value['name'] ??= $key;
+                                                    $normalizedPlaces[] = $value;
                                                 }
 
-                                                return array_values($places);
+                                                return $normalizedPlaces;
                                             })
                                         ->end()
                                         ->isRequired()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_complex_place_follow_by_simplistic_place_config.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_complex_place_follow_by_simplistic_place_config.php
@@ -1,0 +1,55 @@
+<?php
+
+use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase;
+
+$container->loadFromExtension('framework', [
+    'annotations' => false,
+    'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
+    'workflows' => [
+        'article' => [
+            'type' => 'workflow',
+            'supports' => [
+                FrameworkExtensionTestCase::class,
+            ],
+            'initial_marking' => ['draft'],
+            'metadata' => [
+                'title' => 'article workflow',
+                'description' => 'workflow for articles',
+            ],
+            'places' => [
+                'draft' => [
+                    'metadata' => [
+                        'foo' => 'bar',
+                    ],
+                ],
+                'wait_for_journalist',
+                'approved_by_journalist' => [
+                    'name' => 'approved_by_journalist',
+                ],
+                'wait_for_spellchecker',
+                'approved_by_spellchecker',
+                'published',
+            ],
+            'transitions' => [
+                'request_review' => [
+                    'from' => 'draft',
+                    'to' => ['wait_for_journalist', 'wait_for_spellchecker'],
+                ],
+                'journalist_approval' => [
+                    'from' => 'wait_for_journalist',
+                    'to' => 'approved_by_journalist',
+                ],
+                'spellchecker_approval' => [
+                    'from' => 'wait_for_spellchecker',
+                    'to' => 'approved_by_spellchecker',
+                ],
+                'publish' => [
+                    'from' => ['approved_by_journalist', 'approved_by_spellchecker'],
+                    'to' => 'published',
+                ],
+            ],
+        ],
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_simplistic_place_follow_by_complex_place_config.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_simplistic_place_follow_by_complex_place_config.php
@@ -1,0 +1,55 @@
+<?php
+
+use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase;
+
+$container->loadFromExtension('framework', [
+    'annotations' => false,
+    'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
+    'workflows' => [
+        'article' => [
+            'type' => 'workflow',
+            'supports' => [
+                FrameworkExtensionTestCase::class,
+            ],
+            'initial_marking' => ['draft'],
+            'metadata' => [
+                'title' => 'article workflow',
+                'description' => 'workflow for articles',
+            ],
+            'places' => [
+                'draft',
+                'wait_for_journalist' => [
+                    'metadata' => [
+                        'description' => 'The article is awaiting approval of an authorized journalist.',
+                    ],
+                ],
+                'approved_by_journalist' => [
+                    'name' => 'approved_by_journalist',
+                ],
+                'wait_for_spellchecker',
+                'approved_by_spellchecker',
+                'published',
+            ],
+            'transitions' => [
+                'request_review' => [
+                    'from' => 'draft',
+                    'to' => ['wait_for_journalist', 'wait_for_spellchecker'],
+                ],
+                'journalist_approval' => [
+                    'from' => 'wait_for_journalist',
+                    'to' => 'approved_by_journalist',
+                ],
+                'spellchecker_approval' => [
+                    'from' => 'wait_for_spellchecker',
+                    'to' => 'approved_by_spellchecker',
+                ],
+                'publish' => [
+                    'from' => ['approved_by_journalist', 'approved_by_spellchecker'],
+                    'to' => 'published',
+                ],
+            ],
+        ],
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_complex_place_follow_by_simplistic_place_config.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_complex_place_follow_by_simplistic_place_config.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:framework="http://symfony.com/schema/dic/symfony"
+           xmlns="http://symfony.com/schema/dic/services"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd"
+>
+    <framework:config http-method-override="false" handle-all-throwables="true">
+        <framework:annotations enabled="false"/>
+        <framework:php-errors log="true"/>
+        <framework:workflow name="article" type="workflow">
+            <framework:audit-trail enabled="true"/>
+            <framework:initial-marking>draft</framework:initial-marking>
+            <framework:support>Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase</framework:support>
+            <framework:place name="draft">
+                <framework:metadata>
+                    <framework:foo>bar</framework:foo>
+                </framework:metadata>
+            </framework:place>
+            <framework:place>wait_for_journalist</framework:place>
+            <framework:place name="approved_by_journalist"/>
+            <framework:place>wait_for_spellchecker</framework:place>
+            <framework:place>approved_by_spellchecker</framework:place>
+            <framework:place>published</framework:place>
+            <framework:transition name="request_review">
+                <framework:from>draft</framework:from>
+                <framework:to>wait_for_journalist</framework:to>
+                <framework:to>wait_for_spellchecker</framework:to>
+            </framework:transition>
+            <framework:transition name="journalist_approval">
+                <framework:from>wait_for_journalist</framework:from>
+                <framework:to>approved_by_journalist</framework:to>
+            </framework:transition>
+            <framework:transition name="spellchecker_approval">
+                <framework:from>wait_for_spellchecker</framework:from>
+                <framework:to>approved_by_spellchecker</framework:to>
+            </framework:transition>
+            <framework:transition name="publish">
+                <framework:from>approved_by_journalist</framework:from>
+                <framework:from>approved_by_spellchecker</framework:from>
+                <framework:to>published</framework:to>
+            </framework:transition>
+            <framework:metadata>
+                <framework:title>article workflow</framework:title>
+                <framework:description>workflow for articles</framework:description>
+            </framework:metadata>
+        </framework:workflow>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_simplistic_place_follow_by_complex_place_config.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_simplistic_place_follow_by_complex_place_config.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:framework="http://symfony.com/schema/dic/symfony"
+           xmlns="http://symfony.com/schema/dic/services"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd"
+>
+    <framework:config http-method-override="false" handle-all-throwables="true">
+        <framework:annotations enabled="false"/>
+        <framework:php-errors log="true"/>
+        <framework:workflow name="article" type="workflow">
+            <framework:audit-trail enabled="true"/>
+            <framework:initial-marking>draft</framework:initial-marking>
+            <framework:support>Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase</framework:support>
+            <framework:place>draft</framework:place>
+            <framework:place name="wait_for_journalist">
+                <framework:metadata>
+                    <framework:description>The article is awaiting approval of an authorized journalist.</framework:description>
+                </framework:metadata>
+            </framework:place>
+            <framework:place name="approved_by_journalist"/>
+            <framework:place>wait_for_spellchecker</framework:place>
+            <framework:place>approved_by_spellchecker</framework:place>
+            <framework:place>published</framework:place>
+            <framework:transition name="request_review">
+                <framework:from>draft</framework:from>
+                <framework:to>wait_for_journalist</framework:to>
+                <framework:to>wait_for_spellchecker</framework:to>
+            </framework:transition>
+            <framework:transition name="journalist_approval">
+                <framework:from>wait_for_journalist</framework:from>
+                <framework:to>approved_by_journalist</framework:to>
+            </framework:transition>
+            <framework:transition name="spellchecker_approval">
+                <framework:from>wait_for_spellchecker</framework:from>
+                <framework:to>approved_by_spellchecker</framework:to>
+            </framework:transition>
+            <framework:transition name="publish">
+                <framework:from>approved_by_journalist</framework:from>
+                <framework:from>approved_by_spellchecker</framework:from>
+                <framework:to>published</framework:to>
+            </framework:transition>
+            <framework:metadata>
+                <framework:title>article workflow</framework:title>
+                <framework:description>workflow for articles</framework:description>
+            </framework:metadata>
+        </framework:workflow>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_complex_place_follow_by_simplistic_place_config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_complex_place_follow_by_simplistic_place_config.yml
@@ -1,0 +1,37 @@
+framework:
+    annotations: false
+    http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
+    workflows:
+        article:
+            type: workflow
+            supports:
+                - Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase
+            initial_marking: [ draft ]
+            metadata:
+                title: article workflow
+                description: workflow for articles
+            places:
+                draft:
+                    metadata:
+                        foo: bar
+                wait_for_journalist: ~
+                approved_by_journalist: ~
+                wait_for_spellchecker: ~
+                approved_by_spellchecker: ~
+                published: ~
+            transitions:
+                request_review:
+                    from: [ draft ]
+                    to: [ wait_for_journalist, wait_for_spellchecker ]
+                journalist_approval:
+                    from: [ wait_for_journalist ]
+                    to: [ approved_by_journalist ]
+                spellchecker_approval:
+                    from: [ wait_for_spellchecker ]
+                    to: [ approved_by_spellchecker ]
+                publish:
+                    from: [ approved_by_journalist, approved_by_spellchecker ]
+                    to: [ published ]

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_complex_place_follow_by_simplistic_place_config_with_alternative_syntax.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_complex_place_follow_by_simplistic_place_config_with_alternative_syntax.yml
@@ -1,0 +1,37 @@
+framework:
+    annotations: false
+    http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
+    workflows:
+        article:
+            type: workflow
+            supports:
+                - Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase
+            initial_marking: [ draft ]
+            metadata:
+                title: article workflow
+                description: workflow for articles
+            places:
+                - draft:
+                      metadata:
+                          foo: bar
+                - wait_for_journalist
+                - approved_by_journalist
+                - wait_for_spellchecker
+                - approved_by_spellchecker
+                - published
+            transitions:
+                request_review:
+                    from: [ draft ]
+                    to: [ wait_for_journalist, wait_for_spellchecker ]
+                journalist_approval:
+                    from: [ wait_for_journalist ]
+                    to: [ approved_by_journalist ]
+                spellchecker_approval:
+                    from: [ wait_for_spellchecker ]
+                    to: [ approved_by_spellchecker ]
+                publish:
+                    from: [ approved_by_journalist, approved_by_spellchecker ]
+                    to: [ published ]

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_simplistic_place_follow_by_complex_place_config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_simplistic_place_follow_by_complex_place_config.yml
@@ -1,0 +1,37 @@
+framework:
+    annotations: false
+    http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
+    workflows:
+        article:
+            type: workflow
+            supports:
+                - Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase
+            initial_marking: [ draft ]
+            metadata:
+                title: article workflow
+                description: workflow for articles
+            places:
+                draft: ~
+                wait_for_journalist:
+                    metadata:
+                        description: The article is awaiting approval of an authorized journalist.
+                approved_by_journalist: ~
+                wait_for_spellchecker: ~
+                approved_by_spellchecker: ~
+                published: ~
+            transitions:
+                request_review:
+                    from: [ draft ]
+                    to: [ wait_for_journalist, wait_for_spellchecker ]
+                journalist_approval:
+                    from: [ wait_for_journalist ]
+                    to: [ approved_by_journalist ]
+                spellchecker_approval:
+                    from: [ wait_for_spellchecker ]
+                    to: [ approved_by_spellchecker ]
+                publish:
+                    from: [ approved_by_journalist, approved_by_spellchecker ]
+                    to: [ published ]

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_simplistic_place_follow_by_complex_place_config_with_alternative_syntax.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_simplistic_place_follow_by_complex_place_config_with_alternative_syntax.yml
@@ -1,0 +1,37 @@
+framework:
+    annotations: false
+    http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
+    workflows:
+        article:
+            type: workflow
+            supports:
+                - Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase
+            initial_marking: [ draft ]
+            metadata:
+                title: article workflow
+                description: workflow for articles
+            places:
+                - draft
+                -   wait_for_journalist:
+                        metadata:
+                            description: The article is awaiting approval of an authorized journalist.
+                - approved_by_journalist
+                - wait_for_spellchecker
+                - approved_by_spellchecker
+                - published
+            transitions:
+                request_review:
+                    from: [ draft ]
+                    to: [ wait_for_journalist, wait_for_spellchecker ]
+                journalist_approval:
+                    from: [ wait_for_journalist ]
+                    to: [ approved_by_journalist ]
+                spellchecker_approval:
+                    from: [ wait_for_spellchecker ]
+                    to: [ approved_by_spellchecker ]
+                publish:
+                    from: [ approved_by_journalist, approved_by_spellchecker ]
+                    to: [ published ]

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -414,6 +414,20 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->createContainerFromFile('workflow_without_support_and_support_strategy');
     }
 
+    public function testWorkflowWithSimplisticPlaceFollowedByComplexPlace()
+    {
+        $container = $this->createContainerFromFile('workflow_with_simplistic_place_follow_by_complex_place_config');
+
+        $this->assertTrue($container->hasDefinition('workflow.article'), 'Workflow is parsed and registered as a service');
+    }
+
+    public function testWorkflowWithComplexPlaceFollowedBySimplisticPlace()
+    {
+        $container = $this->createContainerFromFile('workflow_with_complex_place_follow_by_simplistic_place_config');
+
+        $this->assertTrue($container->hasDefinition('workflow.article'), 'Workflow is parsed and registered as a service');
+    }
+
     public function testWorkflowMultipleTransitionsWithSameName()
     {
         $container = $this->createContainerFromFile('workflow_with_multiple_transitions_with_same_name');

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/YamlFrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/YamlFrameworkExtensionTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection;
 
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
@@ -21,5 +22,19 @@ class YamlFrameworkExtensionTest extends FrameworkExtensionTestCase
     {
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/Fixtures/yml'));
         $loader->load($file.'.yml');
+    }
+
+    public function testWorkflowWithSimplisticPlaceFollowedByComplexPlaceWithAlternativeSyntax()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Unrecognized option "wait_for_journalist" under "framework.workflows.workflows.article.places.1". Available options are "metadata", "name".');
+        $this->createContainerFromFile('workflow_with_simplistic_place_follow_by_complex_place_config_with_alternative_syntax');
+    }
+
+    public function testWorkflowWithComplexPlaceFollowedBySimplisticPlaceWithAlternativeSyntax()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Unrecognized option "draft" under "framework.workflows.workflows.article.places.0". Available options are "metadata", "name".');
+        $this->createContainerFromFile('workflow_with_complex_place_follow_by_simplistic_place_config_with_alternative_syntax');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61581
| License       | MIT

Rewritten the places `beforeNormalization` callback, to normalize the defined places one by one. Rather than asserting behavior based on only the first item in the passed array.

This way it is possible to combine places in both the "simplistic" and non simplistic format for 1 workflow.