### PR TITLE
[Cache] Make `TagAwareAdapter` registrable as a service

### DIFF
--- a/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
+++ b/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
@@ -16,6 +16,7 @@ use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\ChainAdapter;
 use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\Cache\Adapter\ParameterNormalizer;
+use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 use Symfony\Component\Cache\Messenger\EarlyExpirationDispatcher;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -156,7 +157,7 @@ class CachePoolPass implements CompilerPassInterface
                         ),
                     ]);
                     $pool->addTag('container.reversible');
-                } elseif ('namespace' !== $attr || !\in_array($class, [ArrayAdapter::class, NullAdapter::class], true)) {
+                } elseif ('namespace' !== $attr || !\in_array($class, [ArrayAdapter::class, NullAdapter::class, TagAwareAdapter::class], true)) {
                     $argument = $tags[0][$attr];
 
                     if ('default_lifetime' === $attr && !is_numeric($argument)) {

--- a/src/Symfony/Component/Cache/Tests/DependencyInjection/CachePoolPassTest.php
+++ b/src/Symfony/Component/Cache/Tests/DependencyInjection/CachePoolPassTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\ChainAdapter;
 use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
+use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 use Symfony\Component\Cache\DependencyInjection\CachePoolPass;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -102,15 +103,18 @@ class CachePoolPassTest extends TestCase
         $this->assertSame('xmOJ8gqF-Y', $cachePool->getArgument(0));
     }
 
-    public function testNamespaceArgumentIsNotReplacedIfArrayAdapterIsUsed()
+    /**
+     * @dataProvider providerAdaptersNotNamespace
+     */
+    public function testNamespaceArgumentIsNotReplacedIfAdapterWithoutNamespace(string $adapterClass)
     {
         $container = new ContainerBuilder();
         $container->setParameter('kernel.container_class', 'app');
         $container->setParameter('kernel.project_dir', 'foo');
 
-        $container->register('cache.adapter.array', ArrayAdapter::class)->addArgument(0);
+        $container->register('cache.adapter', $adapterClass)->addArgument(0);
 
-        $cachePool = new ChildDefinition('cache.adapter.array');
+        $cachePool = new ChildDefinition('cache.adapter');
         $cachePool->addTag('cache.pool');
         $container->setDefinition('app.cache_pool', $cachePool);
 
@@ -119,21 +123,11 @@ class CachePoolPassTest extends TestCase
         $this->assertCount(0, $container->getDefinition('app.cache_pool')->getArguments());
     }
 
-    public function testNamespaceArgumentIsNotReplacedIfNullAdapterIsUsed()
+    public static function providerAdaptersNotNamespace(): iterable
     {
-        $container = new ContainerBuilder();
-        $container->setParameter('kernel.container_class', 'app');
-        $container->setParameter('kernel.project_dir', 'foo');
-
-        $container->register('cache.adapter.null', NullAdapter::class);
-
-        $cachePool = new ChildDefinition('cache.adapter.null');
-        $cachePool->addTag('cache.pool');
-        $container->setDefinition('app.cache_pool', $cachePool);
-
-        $this->cachePoolPass->process($container);
-
-        $this->assertCount(0, $container->getDefinition('app.cache_pool')->getArguments());
+        yield [ArrayAdapter::class];
+        yield [NullAdapter::class];
+        yield [TagAwareAdapter::class];
     }
 
     public function testArgsAreReplaced()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #59193 #61114
| License       | MIT

Fixes error while registering TagAwareAdapter as a service:
```yaml
services:
  cache.adapter.array:
    class:  Symfony\Component\Cache\Adapter\ArrayAdapter
  cache.adapter.tag_aware_array:
    class: Symfony\Component\Cache\Adapter\TagAwareAdapter
    arguments:
      - '@cache.adapter.array'

framework:
    cache:
        pools:
            persistent.cache_pool:
                adapter: cache.adapter.tag_aware_array

```
```
TypeError: Symfony\Component\Cache\Adapter\TagAwareAdapter::__construct(): Argument #1 ($itemsPool) must be of type Symfony\Component\Cache\Adapter\AdapterInterface, string given, called in /var/www/var/cache/test/Container7bUFOLq/getPersistent_CachePoolService.php on line 28
```

Psalm failed unrelated