### PR TITLE
[DependencyInjection] Add test case to ensure XML parse exception message includes filename and position

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services31.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services31.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="invalid_service" class="App\Foo">
+            <bogusTag />
+        </service>
+    </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -1286,4 +1286,26 @@ class XmlFileLoaderTest extends TestCase
 
         self::assertInstanceOf(RemoteCallerSocket::class, $container->get(RemoteCaller::class));
     }
+
+    public function testXmlParseExceptionIncludesFilenameAndPosition()
+    {
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader(
+            $container,
+            new FileLocator(__DIR__.'/../Fixtures/xml')
+        );
+
+        $invalidXMLFileName = 'services31.xml';
+
+        try {
+            $loader->load($invalidXMLFileName);
+            $this->fail('Expected an InvalidArgumentException due to invalid XML.');
+        } catch (\InvalidArgumentException $e) {
+            $message = $e->getMessage();
+
+            $this->assertStringContainsString($invalidXMLFileName, $message, 'Exception message should contain the filename.');
+            $this->assertStringContainsString('This element is not expected', $message, 'Exception message should contain XML error details.');
+            $this->assertMatchesRegularExpression('/line \d+, column \d+/', $message, 'Exception message should contain line and column information.');
+        }
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61572
| License       | MIT

This PR adds a dedicated test to `XmlFileLoaderTest` to ensure that XML parse exceptions include the filename, error details, and position (line and column) in their messages.

- Ensures error messages from XML parse exceptions always contain:
  - The XML filename (e.g., `services31.xml`)
  - The error details (e.g., "This element is not expected")
  - The position (line X, column Y)
- Prevents regressions by automatically checking this behavior in tests
- Improves consistency and debuggability of XML parsing errors

## Example

When an invalid XML file (such as `services31.xml`) is loaded, the exception message will now contain:
- The filename: `services31.xml`
- The error detail: "This element is not expected"
- The position: `line X, column Y`