### PR TITLE
[Finder] : extend name filters to allow overwriting name() and not…

### DIFF
--- a/src/Symfony/Component/Finder/CHANGELOG.md
+++ b/src/Symfony/Component/Finder/CHANGELOG.md
@@ -5,6 +5,8 @@ CHANGELOG
 ---
 
  * Add early directory pruning to `Finder::filter()`
+ * Extend `name()` and `notName()` to allow overwriting existing names/notNames filters.
+ * Added `resetName()` and `resetNotName()` to reset names/notNames filters
 
 6.2
 ---

--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -169,14 +169,19 @@ class Finder implements \IteratorAggregate, \Countable
      *     $finder->name(['test.py', 'test.php'])
      *
      * @param string|string[] $patterns A pattern (a regexp, a glob, or a string) or an array of patterns
+     * @param bool            $overwriteExistingNames Whether to overwrite existing names or add them
      *
      * @return $this
      *
      * @see FilenameFilterIterator
      */
-    public function name(string|array $patterns): static
+    public function name(string|array $patterns, bool $overwriteExistingNames = false): static
     {
-        $this->names = array_merge($this->names, (array) $patterns);
+        if ($overwriteExistingNames) {
+            $this->names = (array) $patterns;
+        } else {
+            $this->names = array_merge($this->names, (array) $patterns);
+        }
 
         return $this;
     }
@@ -185,15 +190,42 @@ class Finder implements \IteratorAggregate, \Countable
      * Adds rules that files must not match.
      *
      * @param string|string[] $patterns A pattern (a regexp, a glob, or a string) or an array of patterns
+     * @param bool            $overwriteExistingNotNames Whether to overwrite existing names or add them
      *
      * @return $this
      *
      * @see FilenameFilterIterator
      */
-    public function notName(string|array $patterns): static
+    public function notName(string|array $patterns, bool $overwriteExistingNotNames = false): static
     {
-        $this->notNames = array_merge($this->notNames, (array) $patterns);
+        if ($overwriteExistingNotNames) {
+            $this->notNames = (array) $patterns;
+        } else {
+            $this->notNames = array_merge($this->notNames, (array) $patterns);
+        }
 
+        return $this;
+    }
+
+    /**
+     * Adds possibility to reset name filter
+     *
+     * @return $this
+     */
+    public function resetNames(): static
+    {
+        $this->names = [];
+        return $this;
+    }
+
+    /**
+     * Adds possibility to reset notName filter
+     *
+     * @return $this
+     */
+    public function resetNotNames(): static
+    {
+        $this->notNames = [];
         return $this;
     }
 


### PR DESCRIPTION
…Name() and add related reset methods

| Q             | A
| ------------- | ---
| Branch?       | 7.4 for features / 6.4, 7.3 for bug fixes
| Bug fix?      | yes/no
| New feature?  | yes/no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | yes/no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
