### PR TITLE
[Finder] Extend `name()` and `notName()` methods to support overwriting name filters; add `resetName()` and `resetNotName()` methods

### DIFF
--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -40,6 +40,13 @@ DomCrawler
 
  * Disabling HTML5 parsing is deprecated; Symfony 8 will unconditionally use the native HTML5 parser
 
+Finder
+----------
+
+* Extend `name()` and `notName()` to allow overwriting existing names/notNames filters.
+* Added `resetName()` and `resetNotName()` to reset names/notNames filters
+
+
 FrameworkBundle
 ---------------
 

--- a/src/Symfony/Component/Finder/CHANGELOG.md
+++ b/src/Symfony/Component/Finder/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+ * Extend `name()` and `notName()` to allow overwriting existing names/notNames filters.
+ * Added `resetName()` and `resetNotName()` to reset names/notNames filters
+
 6.4
 ---
 

--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -169,14 +169,19 @@ class Finder implements \IteratorAggregate, \Countable
      *     $finder->name(['test.py', 'test.php'])
      *
      * @param string|string[] $patterns A pattern (a regexp, a glob, or a string) or an array of patterns
+     * @param bool            $overwriteExistingNames Whether to overwrite existing names or add them
      *
      * @return $this
      *
      * @see FilenameFilterIterator
      */
-    public function name(string|array $patterns): static
+    public function name(string|array $patterns, bool $overwriteExistingNames = false): static
     {
-        $this->names = array_merge($this->names, (array) $patterns);
+        if ($overwriteExistingNames) {
+            $this->names = (array) $patterns;
+        } else {
+            $this->names = array_merge($this->names, (array) $patterns);
+        }
 
         return $this;
     }
@@ -185,15 +190,42 @@ class Finder implements \IteratorAggregate, \Countable
      * Adds rules that files must not match.
      *
      * @param string|string[] $patterns A pattern (a regexp, a glob, or a string) or an array of patterns
+     * @param bool $overwriteExistingNotNames Whether to overwrite existing names or add them
      *
      * @return $this
      *
      * @see FilenameFilterIterator
      */
-    public function notName(string|array $patterns): static
+    public function notName(string|array $patterns, bool $overwriteExistingNotNames = false): static
     {
-        $this->notNames = array_merge($this->notNames, (array) $patterns);
+        if ($overwriteExistingNotNames) {
+            $this->notNames = (array) $patterns;
+        } else {
+            $this->notNames = array_merge($this->notNames, (array) $patterns);
+        }
 
+        return $this;
+    }
+
+    /**
+     * Adds possibility to reset name filter
+     *
+     * @return $this
+     */
+    public function resetNames(): static
+    {
+        $this->names = [];
+        return $this;
+    }
+
+    /**
+     * Adds possibility to reset notName filter
+     *
+     * @return $this
+     */
+    public function resetNotNames(): static
+    {
+        $this->notNames = [];
         return $this;
     }
 

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -237,6 +237,11 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $finder = $this->buildFinder();
         $finder->name('test.p{hp,y}');
         $this->assertIterator($this->toAbsolute(['test.php', 'test.py']), $finder->in(self::$tmpDir)->getIterator());
+
+        $finder = $this->buildFinder();
+        $finder->name('test.ph*');
+        $finder->name('test.py', true);
+        $this->assertIterator($this->toAbsolute(['test.py']), $finder->in(self::$tmpDir)->getIterator());
     }
 
     public function testNameWithArrayParam()
@@ -284,6 +289,13 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $finder->name('test.py');
         $finder->notName('*.p{hp,y}');
         $this->assertIterator([], $finder->in(self::$tmpDir)->getIterator());
+
+        $finder = $this->buildFinder();
+        $finder->name('test.ph*');
+        $finder->name('test.py');
+        $finder->notName('*.php');
+        $finder->notName('*.py', true);
+        $this->assertIterator($this->toAbsolute(['test.php']), $finder->in(self::$tmpDir)->getIterator());
     }
 
     public function testNotNameWithArrayParam()


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #61593
| License       | MIT

Introduced boolean parameter to `name()` and `notName()` to allow overwriting already setup name/notName filter. Default behavior is false, so existing implementation won't break.

This PR also adds `resetName()` and `resetNotName()` methods, which simply clears `$this->names` and `$this->notNames` when called.

Tests have been also added
