### PR TITLE
[Cache] Fix internal representation of non-static values

### DIFF
--- a/src/Symfony/Component/Cache/Traits/CachedValueInterface.php
+++ b/src/Symfony/Component/Cache/Traits/CachedValueInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Traits;
+
+/**
+ * @internal
+ */
+interface CachedValueInterface
+{
+    public function getValue(): mixed;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

I'm working on a PR to allow exporting named closures, and the way we use closures in PhpArrayAdapter and PhpFilesAdapter gets into my way.

Instead of relying on `instanceof \Closure` checks, this PR adds an internal marker interface. This makes the logic specific to the component, enabling having closures as regular cached values.

The new logic is tested since adapters are.