### PR TITLE
[Config] Fix `ReflectionClassResource` hash validation

### DIFF
--- a/src/Symfony/Component/Config/Resource/ReflectionClassResource.php
+++ b/src/Symfony/Component/Config/Resource/ReflectionClassResource.php
@@ -69,7 +69,7 @@ class ReflectionClassResource implements SelfCheckingResourceInterface
             $this->loadFiles($this->classReflector);
         }
 
-        return ['files', 'className', 'hash'];
+        return ['files', 'className', 'excludedVendors', 'hash'];
     }
 
     private function loadFiles(\ReflectionClass $class): void

--- a/src/Symfony/Component/Config/Tests/Fixtures/FakeVendor/Base.php
+++ b/src/Symfony/Component/Config/Tests/Fixtures/FakeVendor/Base.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Tests\Fixtures\FakeVendor;
+
+abstract class Base
+{
+    public $baseFoo;
+
+    protected $baseBar;
+
+    public function baseBaz()
+    {
+    }
+
+    public function baseQux()
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

It looks like #57948 broke hash validation.

The problem is that `$excludedVendors` is now used to generate the hash but is not serialized. After unserialization, the property is empty, so the generated hash never matches the dumped one.