### PR TITLE
[DependencyInjection] Optimize `AutowireRequiredMethodsPass`

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowireRequiredMethodsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowireRequiredMethodsPass.php
@@ -57,11 +57,10 @@ class AutowireRequiredMethodsPass extends AbstractRecursivePass
                     }
                     break;
                 }
-                try {
-                    $r = $r->getPrototype();
-                } catch (\ReflectionException) {
-                    break; // method has no prototype
+                if (!$r->hasPrototype()) {
+                    break;
                 }
+                $r = $r->getPrototype();
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

After profiling container compilation, I noticed that `ReflectionMethod::getPrototype()` accounts for a significant percentage of the total time:

<img width="1917" height="902" alt="Screenshot from 2025-09-03 12-51-13" src="https://github.com/user-attachments/assets/3bb72568-1c94-4dc5-b9f5-0eb94d9f91e8" />

Instead of calling `ReflectionMethod::getPrototype()` each time and wrapping it in a try/catch, this PR switches to using `ReflectionMethod::hasPrototype()`.

Here are some stats before and after this change:

**Before**

```bash
$ rm -rf var/cache/dev/*
$ time bin/console

Symfony 7.3.3 (env: dev, debug: true)

real    1m4.682s
user    1m1.326s
sys     0m3.330s


$ rm -rf var/cache/prod/*
$ time bin/console -e prod

Symfony 7.3.3 (env: prod, debug: false)

real    0m59.614s
user    0m57.520s
sys     0m2.033s
```

**After**

```bash
$ rm -rf var/cache/dev/*
$ time bin/console

Symfony 7.3.3 (env: dev, debug: true)

real    0m24.026s
user    0m21.909s
sys     0m2.109s


$ rm -rf var/cache/prod/*
$ time bin/console -e prod

Symfony 7.3.3 (env: prod, debug: false)

real    0m22.439s
user    0m21.256s
sys     0m1.138s
```

As far as I know, optimizations are considered features rather than bug fixes. If I'm wrong, please let me know and I'll retarget to 6.4.