### PR TITLE
[Finder] Add `Finder::clone()` to duplicate a base Finder instance

### DIFF
--- a/src/Symfony/Component/Finder/CHANGELOG.md
+++ b/src/Symfony/Component/Finder/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+ * Add `Finder::clone()` to duplicate a Finder instance with the same configuration
+
 6.4
 ---
 

--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -82,6 +82,16 @@ class Finder implements \IteratorAggregate, \Countable
     }
 
     /**
+     * Clones the current Finder to get a new instance with the same configuration
+     * that can be modified independently.
+     */
+    #[\NoDiscard]
+    public function clone(): static
+    {
+        return clone $this;
+    }
+
+    /**
      * Restricts the matching to directories only.
      *
      * @return $this

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -1656,6 +1656,16 @@ class FinderTest extends Iterator\RealIteratorTestCase
         }
     }
 
+    public function testClone()
+    {
+        $finder = $this->buildFinder();
+        $finder->files()->name('*.php')->in(self::$tmpDir);
+        $clone = $finder->clone();
+
+        self::assertNotSame($finder, $clone);
+        self::assertEquals($finder, $clone);
+    }
+
     protected function buildFinder()
     {
         return Finder::create()->exclude('gitignore');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #61593
| License       | MIT

Replace #61610
Alternative to #61604

It's useful to reuse a base Finder configuration, then add more configuration without altering the base.

This `$finder->clone()` is the same as `(clone $finder)`, but prettier.
