### PR TITLE
[Validator] fall back to legacy options handling if configured named arguments do not match

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/Loader/AbstractLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/AbstractLoader.php
@@ -101,7 +101,15 @@ abstract class AbstractLoader implements LoaderInterface
                 return new $className($options);
             }
 
-            return new $className(...$options);
+            try {
+                return new $className(...$options);
+            } catch (\Error $e) {
+                if (str_starts_with($e->getMessage(), 'Unknown named parameter ')) {
+                    return new $className($options);
+                }
+
+                throw $e;
+            }
         }
 
         if ($options) {

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/XmlFileLoaderTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Validator\Constraints\Callback;
 use Symfony\Component\Validator\Constraints\Choice;
 use Symfony\Component\Validator\Constraints\Collection;
 use Symfony\Component\Validator\Constraints\IsTrue;
+use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\Range;
 use Symfony\Component\Validator\Constraints\Regex;
@@ -187,5 +188,24 @@ class XmlFileLoaderTest extends TestCase
         $this->expectUserDeprecationMessage('Since symfony/validator 7.3: Using constraints not supporting named arguments is deprecated. Try adding the HasNamedArguments attribute to Symfony\Component\Validator\Tests\Mapping\Loader\Fixtures\ConstraintWithoutNamedArguments.');
 
         $loader->loadClassMetadata($metadata);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLengthConstraintValueOptionTriggersDeprecation()
+    {
+        $loader = new XmlFileLoader(__DIR__.'/constraint-mapping-exactly-value.xml');
+        $metadata = new ClassMetadata(Entity_81::class);
+
+        $this->expectUserDeprecationMessage(\sprintf('Since symfony/validator 7.3: Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', Length::class));
+
+        $loader->loadClassMetadata($metadata);
+        $constraints = $metadata->getPropertyMetadata('title')[0]->constraints;
+
+        self::assertCount(1, $constraints);
+        self::assertInstanceOf(Length::class, $constraints[0]);
+        self::assertSame(6, $constraints[0]->min);
+        self::assertSame(6, $constraints[0]->max);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-mapping-exactly-value.xml
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-mapping-exactly-value.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping
+                        https://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
+
+    <class name="Symfony\Component\Validator\Tests\Fixtures\Entity_81">
+        <property name="title">
+            <constraint name="Length">
+                <option name="value">6</option>
+                <option name="groups">
+                    <value>Foo</value>
+                </option>
+            </constraint>
+        </property>
+    </class>
+</constraint-mapping>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61612
| License       | MIT

generalized alternative to #61613
