### PR TITLE
[DependencyInjection][Validator] Remove needless code

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AttributeAutoconfigurationPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AttributeAutoconfigurationPass.php
@@ -56,25 +56,10 @@ final class AttributeAutoconfigurationPass extends AbstractRecursivePass
                     throw new LogicException(\sprintf('Argument "$%s" of attribute autoconfigurator should have a type, use one or more of "\ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\Reflector" in "%s" on line "%d".', $reflectorParameter->getName(), $callableReflector->getFileName(), $callableReflector->getStartLine()));
                 }
 
-                try {
-                    $attributeReflector = new \ReflectionClass($attributeName);
-                } catch (\ReflectionException) {
-                    continue;
-                }
-
-                $targets = $attributeReflector->getAttributes(\Attribute::class)[0] ?? 0;
-                $targets = $targets ? $targets->getArguments()[0] ?? -1 : 0;
-
-                foreach (['class', 'method', 'property', 'parameter'] as $symbol) {
-                    if (['Reflector'] !== $types) {
-                        if (!\in_array('Reflection'.ucfirst($symbol), $types, true)) {
-                            continue;
-                        }
-                        if (!($targets & \constant('Attribute::TARGET_'.strtoupper($symbol)))) {
-                            throw new LogicException(\sprintf('Invalid type "Reflection%s" on argument "$%s": attribute "%s" cannot target a '.$symbol.' in "%s" on line "%d".', ucfirst($symbol), $reflectorParameter->getName(), $attributeName, $callableReflector->getFileName(), $callableReflector->getStartLine()));
-                        }
+                foreach (['Class', 'Method', 'Property', 'Parameter'] as $symbol) {
+                    if (['Reflector'] === $types || \in_array('Reflection'.$symbol, $types, true)) {
+                        $this->{lcfirst($symbol).'AttributeConfigurators'}[$attributeName][] = $callable;
                     }
-                    $this->{$symbol.'AttributeConfigurators'}[$attributeName][] = $callable;
                 }
             }
         }

--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -27,7 +27,6 @@ use Symfony\Component\Validator\Exception\MissingOptionsException;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 abstract class Constraint
 {
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

I added the attribute in the validator component in https://github.com/symfony/symfony/commit/0197b5048d3560ad2b56816317b40bbcfe2379ed#diff-eadef5e494fbfb85346e70992f4b18994df0b999b7d336c9cece5ab9e9a4a18aR30

But I didn't realize this was required because of falsy logic in AttributeAutoconfigurationPass, which we can remove. It's the engine's job to validate attribute's targets, not ours.
