### PR TITLE
[Routing] Don't rebuild cache when controller action body changes

### DIFF
--- a/src/Symfony/Component/Routing/Loader/AttributeClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AttributeClassLoader.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Routing\Loader;
 
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Loader\LoaderResolverInterface;
-use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\Config\Resource\ReflectionClassResource;
 use Symfony\Component\Routing\Attribute\DeprecatedAlias;
 use Symfony\Component\Routing\Attribute\Route as RouteAttribute;
 use Symfony\Component\Routing\Exception\InvalidArgumentException;
@@ -104,7 +104,7 @@ abstract class AttributeClassLoader implements LoaderInterface
 
         $globals = $this->getGlobals($class);
         $collection = new RouteCollection();
-        $collection->addResource(new FileResource($class->getFileName()));
+        $collection->addResource(new ReflectionClassResource($class));
         if ($globals['env'] && $this->env !== $globals['env']) {
             return $collection;
         }

--- a/src/Symfony/Component/Routing/Loader/AttributeDirectoryLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AttributeDirectoryLoader.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Routing\Loader;
 
-use Symfony\Component\Config\Resource\DirectoryResource;
+use Symfony\Component\Config\Resource\GlobResource;
 use Symfony\Component\Routing\RouteCollection;
 
 /**
@@ -33,7 +33,7 @@ class AttributeDirectoryLoader extends AttributeFileLoader
         }
 
         $collection = new RouteCollection();
-        $collection->addResource(new DirectoryResource($dir, '/\.php$/'));
+        $collection->addResource(new GlobResource($dir, '/*.php', true));
         $files = iterator_to_array(new \RecursiveIteratorIterator(
             new \RecursiveCallbackFilterIterator(
                 new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::FOLLOW_SYMLINKS),

--- a/src/Symfony/Component/Routing/Loader/AttributeFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AttributeFileLoader.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Routing\Loader;
 
 use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Component\Config\Loader\FileLoader;
-use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\Config\Resource\ReflectionClassResource;
 use Symfony\Component\Routing\RouteCollection;
 
 /**
@@ -52,7 +52,7 @@ class AttributeFileLoader extends FileLoader
                 return null;
             }
 
-            $collection->addResource(new FileResource($path));
+            $collection->addResource(new ReflectionClassResource($refl));
             $collection->addCollection($this->loader->load($class, $type));
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Currently, whenever the body of a controller action that uses attributes for routing is changed, the router cache is rebuilt. This can get a little annoying when you have many routes, as the rebuild time becomes noticeable, in my case, over 2 seconds.

This PR switches to using `ReflectionClassResource` and `GlobResource` to prevent the cache from being rebuilt unnecessarily.

I'm not sure how best to test this, or if there's even anything to test. Any suggestions would be appreciated.