### PR TITLE
[Security] Deprecate `PersistentToken::getClass()` and `RememberMeDetails::getUserFqcn()` in order to remove the user FQCN from the remember-me cookie in 8.0

### DIFF
--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -88,6 +88,7 @@ Security
  * Deprecate callable firewall listeners, extend `AbstractListener` or implement `FirewallListenerInterface` instead
  * Deprecate `AbstractListener::__invoke`
  * Deprecate `LazyFirewallContext::__invoke()`
+ * Deprecate `PersistentTokenInterface::getClass()` and `RememberMeDetails::getUserFqcn()`, the user FQCN will be removed from the remember-me cookie in 8.0
 
 Serializer
 ----------

--- a/src/Symfony/Component/Security/Core/Authentication/RememberMe/InMemoryTokenProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/RememberMe/InMemoryTokenProvider.php
@@ -38,7 +38,7 @@ final class InMemoryTokenProvider implements TokenProviderInterface
         }
 
         $token = new PersistentToken(
-            $this->tokens[$series]->getClass(),
+            $this->tokens[$series]->getClass(false),
             $this->tokens[$series]->getUserIdentifier(),
             $series,
             $tokenValue,

--- a/src/Symfony/Component/Security/Core/Authentication/RememberMe/PersistentToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/RememberMe/PersistentToken.php
@@ -43,8 +43,15 @@ final class PersistentToken implements PersistentTokenInterface
         $this->lastUsed = \DateTimeImmutable::createFromInterface($lastUsed);
     }
 
-    public function getClass(): string
+    /**
+     * @deprecated since Symfony 7.4
+     */
+    public function getClass(bool $triggerDeprecation = true): string
     {
+        if ($triggerDeprecation) {
+            trigger_deprecation('symfony/security-core', '7.4', 'The "%s()" method is deprecated: the user class will be removed from the remember-me cookie in 8.0.', __METHOD__);
+        }
+
         return $this->class;
     }
 

--- a/src/Symfony/Component/Security/Core/Authentication/RememberMe/PersistentTokenInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/RememberMe/PersistentTokenInterface.php
@@ -21,6 +21,8 @@ interface PersistentTokenInterface
 {
     /**
      * Returns the class of the user.
+     *
+     * @deprecated since Symfony 7.4, the user class will be removed from the remember-me cookie in 8.0
      */
     public function getClass(): string;
 

--- a/src/Symfony/Component/Security/Core/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Core/CHANGELOG.md
@@ -4,7 +4,8 @@ CHANGELOG
 7.4
 ---
 
-* Add `MermaidDumper` to dump Role Hierarchy graphs in the Mermaid.js flowchart format
+ * Add `MermaidDumper` to dump Role Hierarchy graphs in the Mermaid.js flowchart format
+ * Deprecate `PersistentTokenInterface::getClass()`, the user class will be removed from the remember-me cookie in 8.0
 
 7.3
 ---

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/RememberMe/PersistentTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/RememberMe/PersistentTokenTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Security\Core\Tests\Authentication\RememberMe;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\RememberMe\PersistentToken;
 
@@ -21,7 +23,6 @@ class PersistentTokenTest extends TestCase
         $lastUsed = new \DateTimeImmutable();
         $token = new PersistentToken('fooclass', 'fooname', 'fooseries', 'footokenvalue', $lastUsed);
 
-        $this->assertEquals('fooclass', $token->getClass());
         $this->assertEquals('fooname', $token->getUserIdentifier());
         $this->assertEquals('fooseries', $token->getSeries());
         $this->assertEquals('footokenvalue', $token->getTokenValue());
@@ -34,5 +35,13 @@ class PersistentTokenTest extends TestCase
         $token = new PersistentToken('fooclass', 'fooname', 'fooseries', 'footokenvalue', $lastUsed);
 
         $this->assertEquals($lastUsed, $token->getLastUsed());
+    }
+
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
+    public function testClassDeprecation()
+    {
+        $token = new PersistentToken('fooclass', 'fooname', 'fooseries', 'footokenvalue', new \DateTimeImmutable());
+        $this->assertSame('fooclass', $token->getClass());
     }
 }

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Deprecate `AbstractListener::__invoke`
  * Add `$methods` argument to `#[IsGranted]` to restrict validation to specific HTTP methods
  * Allow subclassing `#[IsGranted]`
+ * Deprecate `RememberMeDetails::getUserFqcn()`, the user FQCN will be removed from the remember-me cookie in 8.0
 
 7.3
 ---

--- a/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php
@@ -65,9 +65,9 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
         }
 
         [$series, $tokenValue] = explode(':', $rememberMeDetails->getValue(), 2);
-        $persistentToken = $this->tokenProvider->loadTokenBySeries($series);
+        $token = $this->tokenProvider->loadTokenBySeries($series);
 
-        if ($persistentToken->getUserIdentifier() !== $rememberMeDetails->getUserIdentifier() || $persistentToken->getClass() !== $rememberMeDetails->getUserFqcn()) {
+        if ($token->getUserIdentifier() !== $rememberMeDetails->getUserIdentifier()) {
             throw new AuthenticationException('The cookie\'s hash is invalid.');
         }
 
@@ -75,41 +75,41 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
         unset($rememberMeDetails);
 
         if ($this->tokenVerifier) {
-            $isTokenValid = $this->tokenVerifier->verifyToken($persistentToken, $tokenValue);
+            $isTokenValid = $this->tokenVerifier->verifyToken($token, $tokenValue);
         } else {
-            $isTokenValid = hash_equals($persistentToken->getTokenValue(), $tokenValue);
+            $isTokenValid = hash_equals($token->getTokenValue(), $tokenValue);
         }
         if (!$isTokenValid) {
             throw new CookieTheftException('This token was already used. The account is possibly compromised.');
         }
 
-        $expires = $persistentToken->getLastUsed()->getTimestamp() + $this->options['lifetime'];
+        $expires = $token->getLastUsed()->getTimestamp() + $this->options['lifetime'];
         if ($expires < time()) {
             throw new AuthenticationException('The cookie has expired.');
         }
 
         return parent::consumeRememberMeCookie(new RememberMeDetails(
-            $persistentToken->getClass(),
-            $persistentToken->getUserIdentifier(),
+            method_exists($token, 'getClass') ? $token->getClass(false) : '',
+            $token->getUserIdentifier(),
             $expires,
-            $persistentToken->getLastUsed()->getTimestamp().':'.$series.':'.$tokenValue.':'.$persistentToken->getClass()
+            $token->getLastUsed()->getTimestamp().':'.$series.':'.$tokenValue.':'.(method_exists($token, 'getClass') ? $token->getClass(false) : '')
         ));
     }
 
     public function processRememberMe(RememberMeDetails $rememberMeDetails, UserInterface $user): void
     {
         [$lastUsed, $series, $tokenValue, $class] = explode(':', $rememberMeDetails->getValue(), 4);
-        $persistentToken = new PersistentToken($class, $rememberMeDetails->getUserIdentifier(), $series, $tokenValue, new \DateTimeImmutable('@'.$lastUsed));
+        $token = new PersistentToken($class, $rememberMeDetails->getUserIdentifier(), $series, $tokenValue, new \DateTimeImmutable('@'.$lastUsed));
 
         // if a token was regenerated less than a minute ago, there is no need to regenerate it
         // if multiple concurrent requests reauthenticate a user we do not want to update the token several times
-        if ($persistentToken->getLastUsed()->getTimestamp() + 60 >= time()) {
+        if ($token->getLastUsed()->getTimestamp() + 60 >= time()) {
             return;
         }
 
         $tokenValue = strtr(base64_encode(random_bytes(33)), '+/=', '-_~');
         $tokenLastUsed = new \DateTime();
-        $this->tokenVerifier?->updateExistingToken($persistentToken, $tokenValue, $tokenLastUsed);
+        $this->tokenVerifier?->updateExistingToken($token, $tokenValue, $tokenLastUsed);
         $this->tokenProvider->updateToken($series, $tokenValue, $tokenLastUsed);
 
         $this->createCookie($rememberMeDetails->withValue($series.':'.$tokenValue));

--- a/src/Symfony/Component/Security/Http/RememberMe/RememberMeDetails.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/RememberMeDetails.php
@@ -46,9 +46,9 @@ class RememberMeDetails
         return new static(...$cookieParts);
     }
 
-    public static function fromPersistentToken(PersistentToken $persistentToken, int $expires): self
+    public static function fromPersistentToken(PersistentToken $token, int $expires): self
     {
-        return new static($persistentToken->getClass(), $persistentToken->getUserIdentifier(), $expires, $persistentToken->getSeries().':'.$persistentToken->getTokenValue());
+        return new static(method_exists($token, 'getClass') ? $token->getClass(false) : '', $token->getUserIdentifier(), $expires, $token->getSeries().':'.$token->getTokenValue());
     }
 
     public function withValue(string $value): self
@@ -59,8 +59,13 @@ class RememberMeDetails
         return $details;
     }
 
+    /**
+     * @deprecated since Symfony 7.4, the user FQCN will be removed from the remember-me cookie in 8.0
+     */
     public function getUserFqcn(): string
     {
+        trigger_deprecation('symfony/security-http', '7.4', 'The "%s()" method is deprecated: the user FQCN will be removed from the remember-me cookie in 8.0.', __METHOD__);
+
         return $this->userFqcn;
     }
 

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentRememberMeHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentRememberMeHandlerTest.php
@@ -50,9 +50,7 @@ class PersistentRememberMeHandlerTest extends TestCase
     {
         $this->tokenProvider->expects($this->once())
             ->method('createNewToken')
-            ->with($this->callback(fn ($persistentToken) => $persistentToken instanceof PersistentToken
-                && 'wouter' === $persistentToken->getUserIdentifier()
-                && InMemoryUser::class === $persistentToken->getClass()));
+            ->with($this->callback(fn ($token) => $token instanceof PersistentToken && 'wouter' === $token->getUserIdentifier()));
 
         $this->handler->createRememberMeCookie(new InMemoryUser('wouter', null));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | https://github.com/symfony/symfony/issues/42349
| License       | MIT

Instead of #59232

Having the user FQCN in the remember-me cookie leaks internal details that are not needed.

In the end `userProvider->loadUserByIdentifier()` is called, so that there's not need to early-exclude a cookie that's otherwise valid - and that's the only practical use case.