### PR TITLE
[VarExporter] Add support for exporting named closures

### DIFF
--- a/src/Symfony/Component/VarExporter/CHANGELOG.md
+++ b/src/Symfony/Component/VarExporter/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+ * Add support for exporting named closures
+
 7.3
 ---
 

--- a/src/Symfony/Component/VarExporter/Internal/Exporter.php
+++ b/src/Symfony/Component/VarExporter/Internal/Exporter.php
@@ -73,6 +73,14 @@ class Exporter
                 goto handle_value;
             }
 
+            if ($value instanceof \Closure && !($r = new \ReflectionFunction($value))->isAnonymous()) {
+                $callable = [$r->getClosureThis() ?? $r->getClosureCalledClass()?->name, $r->name];
+                $r = $callable[0] ? new \ReflectionMethod(...$callable) : null;
+                $value = new NamedClosure(self::prepare($callable, $objectsPool, $refsPool, $objectsCount, $valueIsStatic), $r);
+
+                goto handle_value;
+            }
+
             $class = $value::class;
             $reflector = Registry::$reflectors[$class] ??= Registry::getClassReflector($class);
             $properties = [];
@@ -216,6 +224,19 @@ class Exporter
             return '&$r['.$value.']';
         }
         $subIndent = $indent.'    ';
+
+        if ($value instanceof NamedClosure) {
+            if ($value->method?->isPublic() ?? true) {
+                return match (true) {
+                    null === $value->callable[0] => '\\'.$value->callable[1],
+                    \is_string($value->callable[0]) => '\\'.$value->callable[0].'::'.$value->callable[1],
+                    \is_object($value->callable[0]) => self::export($value->callable[0], $subIndent).'->'.$value->callable[1],
+                }.'(...)';
+            }
+
+            return 'new \ReflectionMethod(\\'.$value->method->class.'::class, '.self::export($value->callable[1]).')'
+                .'->getClosure('.(\is_object($value->callable[0]) ? self::export($value->callable[0]) : '').')';
+        }
 
         if (\is_string($value)) {
             $code = \sprintf("'%s'", addcslashes($value, "'\\"));

--- a/src/Symfony/Component/VarExporter/Internal/NamedClosure.php
+++ b/src/Symfony/Component/VarExporter/Internal/NamedClosure.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarExporter\Internal;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @internal
+ */
+class NamedClosure
+{
+    public function __construct(
+        public readonly array $callable,
+        public readonly ?\ReflectionMethod $method = null,
+    ) {
+    }
+}

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/PrivateFCC.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/PrivateFCC.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarExporter\Tests\Fixtures;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+#[PrivateFCC(self::testMethod(...))]
+class PrivateFCC
+{
+    private static function testMethod()
+    {
+    }
+}

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/named-closure-method.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/named-closure-method.php
@@ -1,0 +1,11 @@
+<?php
+
+return \Symfony\Component\VarExporter\Internal\Hydrator::hydrate(
+    $o = [
+        clone (\Symfony\Component\VarExporter\Internal\Registry::$prototypes['Symfony\\Component\\VarExporter\\Tests\\TestClass'] ?? \Symfony\Component\VarExporter\Internal\Registry::p('Symfony\\Component\\VarExporter\\Tests\\TestClass')),
+    ],
+    null,
+    [],
+    $o[0]->testMethod(...),
+    []
+);

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/named-closure-static.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/named-closure-static.php
@@ -1,0 +1,3 @@
+<?php
+
+return \Symfony\Component\VarExporter\Tests\TestClass::testStaticMethod(...);

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/private-fcc.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/private-fcc.php
@@ -1,0 +1,3 @@
+<?php
+
+return new \ReflectionMethod(\Symfony\Component\VarExporter\Tests\Fixtures\PrivateFCC::class, 'testMethod')->getClosure();

--- a/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\VarExporter\Tests\Fixtures\FooReadonly;
 use Symfony\Component\VarExporter\Tests\Fixtures\FooSerializable;
 use Symfony\Component\VarExporter\Tests\Fixtures\FooUnitEnum;
 use Symfony\Component\VarExporter\Tests\Fixtures\MySerializable;
+use Symfony\Component\VarExporter\Tests\Fixtures\PrivateFCC;
 use Symfony\Component\VarExporter\VarExporter;
 
 class VarExporterTest extends TestCase
@@ -80,7 +81,7 @@ class VarExporterTest extends TestCase
     public function testExport(string $testName, $value, bool $staticValueExpected = false)
     {
         $dumpedValue = $this->getDump($value);
-        $isStaticValue = true;
+        $isStaticValue = null;
         $marshalledValue = VarExporter::export($value, $isStaticValue);
 
         $this->assertSame($staticValueExpected, $isStaticValue);
@@ -99,7 +100,7 @@ class VarExporterTest extends TestCase
         }
         $marshalledValue = include $fixtureFile;
 
-        if (!$isStaticValue) {
+        if (!$isStaticValue || 'named-closure-static' === $testName || 'private-fcc' === $testName) {
             if ($value instanceof MyWakeup) {
                 $value->bis = null;
             }
@@ -234,11 +235,20 @@ class VarExporterTest extends TestCase
         yield ['unit-enum', [FooUnitEnum::Bar], true];
         yield ['readonly', new FooReadonly('k', 'v')];
 
+        yield ['named-closure-method', (new TestClass())->testMethod(...)];
+        yield ['named-closure-static', TestClass::testStaticMethod(...), true];
+
         if (\PHP_VERSION_ID < 80400) {
             return;
         }
 
         yield ['backed-property', new BackedProperty('name')];
+
+        if (\PHP_VERSION_ID < 80500) {
+            return;
+        }
+
+        yield ['private-fcc', (new \ReflectionClass(PrivateFCC::class))->getAttributes(PrivateFCC::class)[0]->getArguments()[0], true];
     }
 
     public function testUnicodeDirectionality()
@@ -296,6 +306,19 @@ class PrivateConstructor
     private function __construct($prop)
     {
         $this->prop = $prop;
+    }
+}
+
+class TestClass
+{
+    public function testMethod()
+    {
+        return 'test';
+    }
+
+    public static function testStaticMethod()
+    {
+        return 'test';
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

With first-class callables now allowed in attributes since PHP 8.5, it might become more common to find named closures in exported objects.

