### PR TITLE
[Security] Fix `HttpUtils::createRequest()` when the base request is forwarded

### DIFF
--- a/src/Symfony/Component/Security/Http/HttpUtils.php
+++ b/src/Symfony/Component/Security/Http/HttpUtils.php
@@ -70,7 +70,13 @@ class HttpUtils
      */
     public function createRequest(Request $request, string $path): Request
     {
+        if ($trustedProxies = Request::getTrustedProxies()) {
+            Request::setTrustedProxies([], Request::getTrustedHeaderSet());
+        }
         $newRequest = Request::create($this->generateUri($request, $path), 'get', [], $request->cookies->all(), [], $request->server->all());
+        if ($trustedProxies) {
+            Request::setTrustedProxies($trustedProxies, Request::getTrustedHeaderSet());
+        }
 
         static $setSession;
 

--- a/src/Symfony/Component/Security/Http/Tests/HttpUtilsTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/HttpUtilsTest.php
@@ -233,6 +233,16 @@ class HttpUtilsTest extends TestCase
         ];
     }
 
+    public function testCreateRequestHandlesTrustedHeaders()
+    {
+        Request::setTrustedProxies(['127.0.0.1'], Request::HEADER_X_FORWARDED_PREFIX);
+
+        $this->assertSame(
+            'http://localhost/foo/',
+            (new HttpUtils())->createRequest(Request::create('/', server: ['HTTP_X_FORWARDED_PREFIX' => '/foo']), '/')->getUri(),
+        );
+    }
+
     public function testCheckRequestPath()
     {
         $utils = new HttpUtils($this->getUrlGenerator());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61560
| License       | MIT

Currently trusted headers are both copied from the original request **and** used to generate the URI. That means if we have a trusted `/foo` prefix the URI generated for `/bar` would be `/foo/bar`, and the new request URI would be `/foo/foo/bar`.

This PR temporarily distrusts proxies so that the generated URI would be `/bar`, and the new request URI `/foo/bar`.