### PR TITLE
[Console] Command: Add addOptionWithValue()

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `Command::getCode()` to get the code set via `setCode()`
+ * Add `Command::addOptionWithValue()` to add option with allowed values
  * Allow setting aliases and the hidden flag via the command name passed to the constructor
  * Introduce `Symfony\Component\Console\Application::addCommand()` to simplify using invokable commands when the component is used standalone
  * Deprecate `Symfony\Component\Console\Application::add()` in favor of `Symfony\Component\Console\Application::addCommand()`

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -480,8 +480,28 @@ class Command implements SignalableCommandInterface
      */
     public function addOption(string $name, string|array|null $shortcut = null, ?int $mode = null, string $description = '', mixed $default = null, array|\Closure $suggestedValues = []): static
     {
-        $this->definition->addOption(new InputOption($name, $shortcut, $mode, $description, $default, $suggestedValues));
-        $this->fullDefinition?->addOption(new InputOption($name, $shortcut, $mode, $description, $default, $suggestedValues));
+        return $this->addOptionDefinition(new InputOption($name, $shortcut, $mode, $description, $default, $suggestedValues));
+    }
+
+    /**
+     * @param non-empty-list<string> $allowedValues
+     *
+     * @return $this
+     *
+     * @throws InvalidArgumentException If option mode is invalid or incompatible
+     */
+    public function addOptionWithValue(string $name, array $allowedValues, string|array|null $shortcut = null, string $description = '', mixed $default = null): static
+    {
+        $option = new InputOption($name, $shortcut, InputOption::VALUE_REQUIRED, $description, $default);
+        $option->setAllowedValues($allowedValues);
+
+        return $this->addOptionDefinition($option);
+    }
+
+    private function addOptionDefinition(InputOption $inputOption): static
+    {
+        $this->definition->addOption($inputOption);
+        $this->fullDefinition?->addOption($inputOption);
 
         return $this;
     }

--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -265,7 +265,7 @@ class ArgvInput extends Input
         if ($option->isArray()) {
             $this->options[$name][] = $value;
         } else {
-            $this->options[$name] = $value;
+            $this->setOption($name, $value);
         }
     }
 

--- a/src/Symfony/Component/Console/Input/ArrayInput.php
+++ b/src/Symfony/Component/Console/Input/ArrayInput.php
@@ -145,7 +145,7 @@ class ArrayInput extends Input
      * Adds a long option value.
      *
      * @throws InvalidOptionException When option given doesn't exist
-     * @throws InvalidOptionException When a required value is missing
+     * @throws InvalidOptionException When a required value is missing or invalid
      */
     private function addLongOption(string $name, mixed $value): void
     {
@@ -172,7 +172,7 @@ class ArrayInput extends Input
             }
         }
 
-        $this->options[$name] = $value;
+        $this->setOption($name, $value);
     }
 
     /**

--- a/src/Symfony/Component/Console/Input/Input.php
+++ b/src/Symfony/Component/Console/Input/Input.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Console\Input;
 
 use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Console\Exception\RuntimeException;
 
 /**
@@ -138,6 +139,12 @@ abstract class Input implements InputInterface, StreamableInputInterface
             return;
         } elseif (!$this->definition->hasOption($name)) {
             throw new InvalidArgumentException(\sprintf('The "%s" option does not exist.', $name));
+        }
+
+        $option = $this->definition->getOption($name);
+        $allowedValues = $option->getAllowedValues();
+        if (null !== $allowedValues && !\in_array($value, $allowedValues, true)) {
+            throw InvalidOptionException::fromEnumValue($name, $value, $allowedValues);
         }
 
         $this->options[$name] = $value;

--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -55,6 +55,9 @@ class InputOption
     private int $mode;
     private string|int|bool|array|float|null $default;
 
+    /** @var ?non-empty-list<string> */
+    private ?array $allowedValues = null;
+
     /**
      * @param string|array|null                                                             $shortcut        The shortcuts, can be null, a string of shortcuts delimited by | or an array of shortcuts
      * @param int-mask-of<InputOption::*>|null                                              $mode            The option mode: One of the VALUE_* constants
@@ -218,7 +221,7 @@ class InputOption
      */
     public function getDescription(): string
     {
-        return $this->description;
+        return $this->description.(null !== $this->allowedValues ? \sprintf(' ("%s")', implode('", "', $this->allowedValues)) : '');
     }
 
     /**
@@ -227,6 +230,27 @@ class InputOption
     public function hasCompletion(): bool
     {
         return [] !== $this->suggestedValues;
+    }
+
+    /**
+     * @param non-empty-list<string> $allowedValues
+     *
+     * @return $this
+     */
+    public function setAllowedValues(array $allowedValues): static
+    {
+        $this->allowedValues = $allowedValues;
+        $this->suggestedValues = $allowedValues;
+
+        return $this;
+    }
+
+    /**
+     * @return ?non-empty-list<string>
+     */
+    public function getAllowedValues(): ?array
+    {
+        return $this->allowedValues;
     }
 
     /**
@@ -257,6 +281,7 @@ class InputOption
             && $option->isArray() === $this->isArray()
             && $option->isValueRequired() === $this->isValueRequired()
             && $option->isValueOptional() === $this->isValueOptional()
+            && $option->getAllowedValues() === $this->getAllowedValues()
         ;
     }
 }

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -120,6 +120,23 @@ class CommandTest extends TestCase
         $this->assertTrue($option->hasCompletion());
     }
 
+    public function testAddOptionWithValue()
+    {
+        $command = new \TestCommand();
+        $ret = $command->addOptionWithValue('foo', ['a', 'b'], null, 'Foo');
+        $this->assertEquals($command, $ret, '->addOptionWithValue() implements a fluent interface');
+        $this->assertTrue($command->getDefinition()->hasOption('foo'), '->addOptionWithValue() adds an option to the command');
+        $option = $command->getDefinition()->getOption('foo');
+        $this->assertEquals(['a', 'b'], $option->getAllowedValues(), '->addOptionWithValue() sets allowed values');
+
+        $this->assertEquals('Foo ("a", "b")', $option->getDescription());
+
+        $tester = new CommandTester($command);
+        $this->expectException(InvalidOptionException::class);
+        $this->expectExceptionMessage('The value "invalid" is not valid for the "foo" option. Supported values are "a", "b".');
+        $tester->execute(['--foo' => 'invalid']);
+    }
+
     public function testSetHidden()
     {
         $command = new \TestCommand();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

I wanted to add an option with one of allowed values. To do that, I needed to check the argument validity, format help and set suggested values. This PR encapsulates it in a function.
