### PR TITLE
[Console] Fixing expected error messages for missing inputs

### DIFF
--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -129,7 +129,7 @@ class QuestionHelper extends Helper
                 }
 
                 if (false === $ret) {
-                    throw new MissingInputException('Aborted.');
+                    throw new MissingInputException('Aborted. Unable to read input of question: '.$question->getQuestion());
                 }
                 if ($question->isTrimmable()) {
                     $ret = trim($ret);
@@ -271,7 +271,7 @@ class QuestionHelper extends Helper
             // as opposed to fgets(), fread() returns an empty string when the stream content is empty, not false.
             if (false === $c || ('' === $ret && '' === $c && null === $question->getDefault())) {
                 shell_exec('stty '.$sttyMode);
-                throw new MissingInputException('Aborted while asking: '.$question->getQuestion());
+                throw new MissingInputException('Aborted. Trying to autocomplete: '.$question->getQuestion());
             } elseif ("\177" === $c) { // Backspace Character
                 if (0 === $numMatches && 0 !== $i) {
                     --$i;
@@ -443,7 +443,7 @@ class QuestionHelper extends Helper
         }
 
         if (false === $value) {
-            throw new MissingInputException('Aborted.');
+            throw new MissingInputException('Aborted. Unable to read hidden input.');
         }
         if ($trimmable) {
             $value = trim($value);

--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -740,7 +740,7 @@ class QuestionHelperTest extends AbstractQuestionHelperTestCase
     public function testAskThrowsExceptionOnMissingInputForChoiceQuestion()
     {
         $this->expectException(MissingInputException::class);
-        $this->expectExceptionMessage('Aborted while asking: Choice');
+        $this->expectExceptionMessage('Aborted. Trying to autocomplete: Choice');
         (new QuestionHelper())->ask($this->createStreamableInputInterfaceMock($this->getInputStream('')), $this->createOutputInterface(), new ChoiceQuestion('Choice', ['a', 'b']));
     }
 

--- a/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
@@ -220,7 +220,7 @@ class CommandTesterTest extends TestCase
         $tester = new CommandTester($command);
 
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Aborted.');
+        $this->expectExceptionMessage('Aborted while asking: choice');
 
         $tester->execute([]);
     }

--- a/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
@@ -220,7 +220,7 @@ class CommandTesterTest extends TestCase
         $tester = new CommandTester($command);
 
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Aborted while asking: choice');
+        $this->expectExceptionMessage('Aborted. Unable to read input of question: choice');
 
         $tester->execute([]);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no (fixing tests)
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

In the PR #61308 the error message was updated as well as the tests for the question helper. But it looks like there is also the CommandTesterTest that requires updating the error message.