### PR TITLE
[Config] Fix `GlobResource` pattern with trailing slash

### DIFF
--- a/src/Symfony/Component/Config/Resource/GlobResource.php
+++ b/src/Symfony/Component/Config/Resource/GlobResource.php
@@ -111,7 +111,7 @@ class GlobResource implements \IteratorAggregate, SelfCheckingResourceInterface
         if (class_exists(Finder::class)) {
             $regex = Glob::toRegex($pattern);
             if ($this->recursive) {
-                $regex = substr_replace($regex, '(/|$)', -2, 1);
+                $regex = substr_replace($regex, str_ends_with($pattern, '/') ? '' : '(/|$)', -2, 1);
             }
         } else {
             $regex = null;

--- a/src/Symfony/Component/Config/Tests/Resource/GlobResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/GlobResourceTest.php
@@ -25,24 +25,20 @@ class GlobResourceTest extends TestCase
         touch($dir.'/Resource/.hiddenFile');
     }
 
-    public function testIterator()
+    /**
+     * @testWith ["/Resource"]
+     *           ["/**\/Resource"]
+     *           ["/**\/Resource/"]
+     */
+    public function testIterator(string $pattern)
     {
         $dir = \dirname(__DIR__).\DIRECTORY_SEPARATOR.'Fixtures';
-        $resource = new GlobResource($dir, '/Resource', true);
+        $resource = new GlobResource($dir, $pattern, true);
 
         $paths = iterator_to_array($resource);
 
         $file = $dir.'/Resource'.\DIRECTORY_SEPARATOR.'ConditionalClass.php';
         $this->assertEquals([$file => new \SplFileInfo($file)], $paths);
-        $this->assertInstanceOf(\SplFileInfo::class, current($paths));
-        $this->assertSame($dir, $resource->getPrefix());
-
-        $resource = new GlobResource($dir, '/**/Resource', true);
-
-        $paths = iterator_to_array($resource);
-
-        $file = $dir.'/Resource'.\DIRECTORY_SEPARATOR.'ConditionalClass.php';
-        $this->assertEquals([$file => $file], $paths);
         $this->assertInstanceOf(\SplFileInfo::class, current($paths));
         $this->assertSame($dir, $resource->getPrefix());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

I've noticed that when using exclude patterns in service imports, a trailing slash doesn't always work:

* `../src/Foo/` - works with the trailing slash
* `../src/**/Foo/` - doesn't work with the trailing slash