### PR TITLE
[Console] Allow callables for the description and help of `#[AsCommand]`, `#[Argument]` and `#[Option]`

### DIFF
--- a/src/Symfony/Component/Console/Attribute/Argument.php
+++ b/src/Symfony/Component/Console/Attribute/Argument.php
@@ -21,6 +21,7 @@ use Symfony\Component\String\UnicodeString;
 #[\Attribute(\Attribute::TARGET_PARAMETER | \Attribute::TARGET_PROPERTY)]
 class Argument
 {
+    public string $description;
     public mixed $default = null;
     public array|\Closure $suggestedValues;
 
@@ -38,13 +39,15 @@ class Argument
      *
      * If unset, the `name` value will be inferred from the parameter definition.
      *
+     * @param string|(callable():string)                                                 $description     The description of the argument, displayed with the help page
      * @param array<string|Suggestion>|callable(CompletionInput):list<string|Suggestion> $suggestedValues The values used for input completion
      */
     public function __construct(
-        public string $description = '',
+        string|callable $description = '',
         public string $name = '',
         array|callable $suggestedValues = [],
     ) {
+        $this->description = \is_string($description) ? $description : $description();
         $this->suggestedValues = \is_callable($suggestedValues) ? $suggestedValues(...) : $suggestedValues;
     }
 

--- a/src/Symfony/Component/Console/Attribute/AsCommand.php
+++ b/src/Symfony/Component/Console/Attribute/AsCommand.php
@@ -19,24 +19,30 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
 final class AsCommand
 {
+    public ?string $description;
+    public ?string $help;
+
     /**
      * @param string                            $name        The name of the command, used when calling it (i.e. "cache:clear")
-     * @param string|null                       $description The description of the command, displayed with the help page
+     * @param string|(callable():string)|null   $description The description of the command, displayed with the help page
      * @param string[]                          $aliases     The list of aliases of the command. The command will be executed when using one of them (i.e. "cache:clean")
      * @param bool                              $hidden      If true, the command won't be shown when listing all the available commands, but it can still be run as any other command
-     * @param string|null                       $help        The help content of the command, displayed with the help page
+     * @param string|(callable():string)|null   $help        The help content of the command, displayed with the help page
      * @param string[]                          $usages      The list of usage examples, displayed with the help page
      * @param OutputInterface::VERBOSITY_*|null $listedAt    The verbosity from which the command is listed, null to always list it. It can still be run as any other command
      */
     public function __construct(
         public string $name,
-        public ?string $description = null,
+        string|callable|null $description = null,
         array $aliases = [],
         bool $hidden = false,
-        public ?string $help = null,
+        string|callable|null $help = null,
         public array $usages = [],
         public ?int $listedAt = null,
     ) {
+        $this->description = null === $description || \is_string($description) ? $description : $description();
+        $this->help = null === $help || \is_string($help) ? $help : $help();
+
         if (!$hidden && !$aliases) {
             return;
         }

--- a/src/Symfony/Component/Console/Attribute/Option.php
+++ b/src/Symfony/Component/Console/Attribute/Option.php
@@ -22,6 +22,7 @@ use Symfony\Component\String\UnicodeString;
 class Option
 {
     public const ALLOWED_UNION_TYPES = ['bool|string', 'bool|int', 'bool|float'];
+    public string $description;
     public mixed $default = null;
     public array|\Closure $suggestedValues;
 
@@ -42,17 +43,19 @@ class Option
      *
      * If unset, the `name` value will be inferred from the parameter definition.
      *
+     * @param string|(callable():string)                                                 $description     The description of the option, displayed with the help page
      * @param array|string|null                                                          $shortcut        The shortcuts, can be null, a string of shortcuts delimited by | or an array of shortcuts
      * @param array<string|Suggestion>|callable(CompletionInput):list<string|Suggestion> $suggestedValues The values used for input completion
      */
     public function __construct(
-        public string $description = '',
+        string|callable $description = '',
         public string $name = '',
         public array|string|null $shortcut = null,
         array|callable $suggestedValues = [],
         public bool $deprecated = false,
         public bool $hidden = false,
     ) {
+        $this->description = \is_string($description) ? $description : $description();
         $this->suggestedValues = \is_callable($suggestedValues) ? $suggestedValues(...) : $suggestedValues;
     }
 

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add `InputOption::HIDDEN` and `InputOption::DEPRECATED` modes
  * Add the `listedAt` option to `#[AsCommand]` and the `listed_at` attribute to the `console.command` tag, to list a command only from the given verbosity
+ * Allow a callable for the `description` and `help` options of `#[AsCommand]`, and for the `description` option of `#[Argument]` and `#[Option]`
 
 8.1
 ---

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -511,6 +511,23 @@ class CommandTest extends TestCase
         $this->assertNull($command->getCode());
     }
 
+    public function testCommandAttributeWithCallables()
+    {
+        $command = new Php8CommandWithCallables();
+
+        $this->assertSame('Generated description', $command->getDescription());
+        $this->assertSame('Generated help', $command->getHelp());
+    }
+
+    public function testCommandAttributeDescriptionIsNeverResolvedAsCallable()
+    {
+        // "define" is the name of a PHP function, it must still be taken as a plain description
+        $command = new #[AsCommand(name: 'foo', description: 'define', help: 'define')] class extends Command {};
+
+        $this->assertSame('define', $command->getDescription());
+        $this->assertSame('define', $command->getHelp());
+    }
+
     public function testDefaultCommand()
     {
         $apl = new Application();
@@ -558,4 +575,22 @@ class Php8Command extends Command
 #[AsCommand(name: 'foo2', description: 'desc2', hidden: true)]
 class Php8Command2 extends Command
 {
+}
+
+#[AsCommand(
+    name: 'foo3',
+    description: [Php8CommandWithCallables::class, 'generateDescription'],
+    help: [Php8CommandWithCallables::class, 'generateHelp'],
+)]
+class Php8CommandWithCallables extends Command
+{
+    public static function generateDescription(): string
+    {
+        return 'Generated description';
+    }
+
+    public static function generateHelp(): string
+    {
+        return 'Generated help';
+    }
 }

--- a/src/Symfony/Component/Console/Tests/Command/InvokableCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/InvokableCommandTest.php
@@ -92,6 +92,35 @@ class InvokableCommandTest extends TestCase
         self::assertSame(['ROLE_ADMIN', 'ROLE_USER'], array_map(static fn (Suggestion $s) => $s->getValue(), $suggestions->getValueSuggestions()));
     }
 
+    public function testCommandInputDescriptionFromCallable()
+    {
+        $command = new Command('foo');
+        $command->setCode(static function (
+            #[Argument(description: [self::class, 'generateBioDescription'])] string $bio = '',
+            #[Option(description: [self::class, 'generateBioDescription'])] string $summary = '',
+        ): int {
+            return 0;
+        });
+
+        self::assertSame('Generated bio description', $command->getDefinition()->getArgument('bio')->getDescription());
+        self::assertSame('Generated bio description', $command->getDefinition()->getOption('summary')->getDescription());
+    }
+
+    public function testCommandInputDescriptionIsNeverResolvedAsCallable()
+    {
+        $command = new Command('foo');
+        $command->setCode(static function (
+            // "define" is the name of a PHP function, it must still be taken as a plain description
+            #[Argument(description: 'define')] string $bio = '',
+            #[Option(description: 'define')] string $summary = '',
+        ): int {
+            return 0;
+        });
+
+        self::assertSame('define', $command->getDefinition()->getArgument('bio')->getDescription());
+        self::assertSame('define', $command->getDefinition()->getOption('summary')->getDescription());
+    }
+
     public function testCommandInputOptionDefinition()
     {
         $command = new Command('foo');
@@ -598,6 +627,11 @@ class InvokableCommandTest extends TestCase
     public function getSuggestedRoles(CompletionInput $input): array
     {
         return ['ROLE_ADMIN', 'ROLE_USER'];
+    }
+
+    public static function generateBioDescription(): string
+    {
+        return 'Generated bio description';
     }
 
     public function testAskWithInputFileAndConstraints()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT
| Doc PR        | TODO

Attribute arguments are constant expressions, and PHP allows no function calls there. A description that has to be computed, typically one listing the accepted values, is therefore not expressible today:

```php
public function __invoke(
    SymfonyStyle $io,
    // Fatal error: Constant expression contains invalid operations
    #[Argument(description: self::generateDescription())]
    string $status,
): int {
}
```

This PR makes `description` on `#[Argument]` and `#[Option]`, and `description` and `help` on `#[AsCommand]`, accept a callable next to a string:

```php
public function __invoke(
    SymfonyStyle $io,
    #[Argument(description: [self::class, 'generateDescription'])]
    string $status,
): int {
}

public static function generateDescription(): string
{
    return 'One of: '.implode(', ', array_column(Status::cases(), 'value'));
}
```

The callable is called once, when the attribute is instantiated, and the attribute exposes the resolved string, so nothing downstream sees a callable.

A `string` is never resolved as a callable: `description: 'define'` is the description "define", not a call to `define()`.

On PHP 8.5 no separate method is needed, since constant expressions accept static closures and first-class callable syntax:

```php
#[Argument(description: static function (): string {
    return 'One of: '.implode(', ', array_column(Status::cases(), 'value'));
})]
string $status = '',
```

Arrow functions stay rejected there, as they capture by value.

`usages` on `#[AsCommand]` is deliberately left out, since an array of strings and an array callable cannot be told apart.
