### PR TITLE
[Intl] Remove incorrect condition in `CurrencyDataGenerator::icuPairToDate`

### DIFF
--- a/src/Symfony/Component/Intl/Data/Generator/CurrencyDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/CurrencyDataGenerator.php
@@ -236,11 +236,6 @@ class CurrencyDataGenerator extends AbstractDataGenerator
         // Recompose a 64-bit unsigned integer from two 32-bit chunks.
         $unsigned64 = ((($highBits32 & 0xFFFFFFFF) << 32) | ($lowBits32 & 0xFFFFFFFF));
 
-        // Convert to signed 64-bit (two's complement) if sign bit is set.
-        if ($unsigned64 >= (1 << 63)) {
-            $unsigned64 -= (1 << 64);
-        }
-
         // Split into seconds and milliseconds.
         $seconds = intdiv($unsigned64, 1000);
         $millisecondsRemainder = $unsigned64 - $seconds * 1000;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony/pull/61556#discussion_r2315200758
| License       | MIT

Remove a useless condition that breaks psalm analysis.

- `1 << 63 === PHP_INT_MIN` we cannot have a lower int value
- `1 << 64 === 0` so the removing this value doesn't change anything

Fix psalm crash due to bug https://github.com/vimeo/psalm/issues/11209
When `PHP_INT_MIN - 1`, the value is converted to a float that breaks the type system of psalm https://github.com/vimeo/psalm/blob/279f3eab037923d3f9d3ea3de1a16b425653e30c/src/Psalm/Internal/Type/SimpleAssertionReconciler.php#L2073

Dealing with timestamp `>= (1 << 62)/1000` will be necessary when we reach [year 146140482](https://3v4l.org/AAKNt). 