### PR TITLE
 Use `>=` operator in `#[RequiresPhp]` attributes to allow compatible versions

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/ManagerRegistryTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ManagerRegistryTest.php
@@ -52,7 +52,7 @@ class ManagerRegistryTest extends TestCase
     }
 
     #[DataProvider('provideResetServiceWithNativeLazyObjectsCases')]
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testResetServiceWithNativeLazyObjects(string $class)
     {
         $container = new $class();

--- a/src/Symfony/Component/DependencyInjection/Tests/LazyProxy/PhpDumper/LazyServiceDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/LazyProxy/PhpDumper/LazyServiceDumperTest.php
@@ -66,7 +66,7 @@ class LazyServiceDumperTest extends TestCase
         $dumper->getProxyCode($definition);
     }
 
-    #[RequiresPhp('8.3')]
+    #[RequiresPhp('>=8.3')]
     public function testReadonlyClass()
     {
         $dumper = new LazyServiceDumper();

--- a/src/Symfony/Component/HtmlSanitizer/Tests/Parser/NativeParserTest.php
+++ b/src/Symfony/Component/HtmlSanitizer/Tests/Parser/NativeParserTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HtmlSanitizer\Parser\NativeParser;
 
-#[RequiresPhp('8.4')]
+#[RequiresPhp('>=8.4')]
 class NativeParserTest extends TestCase
 {
     public function testParseValid()

--- a/src/Symfony/Component/JsonStreamer/Tests/Read/LazyInstantiatorTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Read/LazyInstantiatorTest.php
@@ -59,7 +59,7 @@ class LazyInstantiatorTest extends TestCase
         new LazyInstantiator();
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testCreateLazyGhostUsingPhp()
     {
         $ghost = (new LazyInstantiator())->instantiate(ClassicDummy::class, function (ClassicDummy $object): void {

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -403,7 +403,7 @@ final class ObjectMapperTest extends TestCase
         $this->assertTrue($lazy->isLazyObjectInitialized());
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testMapInitializesNativePhp84LazyObject()
     {
         $initialized = false;

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -1014,7 +1014,7 @@ class PropertyAccessorTest extends TestCase
         return (new \ReflectionClass(UninitializedObjectProperty::class))->newLazyGhost(fn () => null);
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testIsWritableWithAsymmetricVisibility()
     {
         $object = new AsymmetricVisibility();
@@ -1026,7 +1026,7 @@ class PropertyAccessorTest extends TestCase
         $this->assertFalse($this->propertyAccessor->isWritable($object, 'virtualNoSetHook'));
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testIsReadableWithAsymmetricVisibility()
     {
         $object = new AsymmetricVisibility();
@@ -1038,7 +1038,7 @@ class PropertyAccessorTest extends TestCase
         $this->assertTrue($this->propertyAccessor->isReadable($object, 'virtualNoSetHook'));
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     #[DataProvider('setValueWithAsymmetricVisibilityDataProvider')]
     public function testSetValueWithAsymmetricVisibility(string $propertyPath, ?string $expectedException)
     {

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -696,7 +696,7 @@ class ReflectionExtractorTest extends TestCase
         ];
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testAsymmetricVisibility()
     {
         $this->assertTrue($this->extractor->isReadable(AsymmetricVisibility::class, 'publicPrivate'));
@@ -707,7 +707,7 @@ class ReflectionExtractorTest extends TestCase
         $this->assertFalse($this->extractor->isWritable(AsymmetricVisibility::class, 'protectedPrivate'));
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testAsymmetricVisibilityAllowPublicOnly()
     {
         $extractor = new ReflectionExtractor(null, null, null, true, ReflectionExtractor::ALLOW_PUBLIC);
@@ -720,7 +720,7 @@ class ReflectionExtractorTest extends TestCase
         $this->assertFalse($extractor->isWritable(AsymmetricVisibility::class, 'protectedPrivate'));
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testAsymmetricVisibilityAllowProtectedOnly()
     {
         $extractor = new ReflectionExtractor(null, null, null, true, ReflectionExtractor::ALLOW_PROTECTED);
@@ -733,7 +733,7 @@ class ReflectionExtractorTest extends TestCase
         $this->assertFalse($extractor->isWritable(AsymmetricVisibility::class, 'protectedPrivate'));
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testAsymmetricVisibilityAllowPrivateOnly()
     {
         $extractor = new ReflectionExtractor(null, null, null, true, ReflectionExtractor::ALLOW_PRIVATE);
@@ -746,7 +746,7 @@ class ReflectionExtractorTest extends TestCase
         $this->assertTrue($extractor->isWritable(AsymmetricVisibility::class, 'protectedPrivate'));
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testVirtualProperties()
     {
         $this->assertTrue($this->extractor->isReadable(VirtualProperties::class, 'virtualNoSetHook'));
@@ -758,7 +758,7 @@ class ReflectionExtractorTest extends TestCase
     }
 
     #[DataProvider('provideAsymmetricVisibilityMutator')]
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testAsymmetricVisibilityMutator(string $property, string $readVisibility, string $writeVisibility)
     {
         $extractor = new ReflectionExtractor(null, null, null, true, ReflectionExtractor::ALLOW_PUBLIC | ReflectionExtractor::ALLOW_PROTECTED | ReflectionExtractor::ALLOW_PRIVATE);
@@ -781,7 +781,7 @@ class ReflectionExtractorTest extends TestCase
     }
 
     #[DataProvider('provideVirtualPropertiesMutator')]
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testVirtualPropertiesMutator(string $property, string $readVisibility, string $writeVisibility)
     {
         $extractor = new ReflectionExtractor(null, null, null, true, ReflectionExtractor::ALLOW_PUBLIC | ReflectionExtractor::ALLOW_PROTECTED | ReflectionExtractor::ALLOW_PRIVATE);

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/IsGrantedAttributeWithClosureListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/IsGrantedAttributeWithClosureListenerTest.php
@@ -28,7 +28,7 @@ use Symfony\Component\Security\Http\EventListener\IsGrantedAttributeListener;
 use Symfony\Component\Security\Http\Tests\Fixtures\IsGrantedAttributeMethodsWithClosureController;
 use Symfony\Component\Security\Http\Tests\Fixtures\IsGrantedAttributeWithClosureController;
 
-#[RequiresPhp('8.5')]
+#[RequiresPhp('>=8.5')]
 class IsGrantedAttributeWithClosureListenerTest extends TestCase
 {
     public function testAttribute()

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/NumberNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/NumberNormalizerTest.php
@@ -52,7 +52,7 @@ class NumberNormalizerTest extends TestCase
         yield 'null' => [null, false];
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     #[RequiresPhpExtension('bcmath')]
     #[DataProvider('normalizeGoodBcMathNumberValueProvider')]
     public function testNormalizeBcMathNumber(Number $data, string $expected)
@@ -100,7 +100,7 @@ class NumberNormalizerTest extends TestCase
         yield 'null' => [null];
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     #[RequiresPhpExtension('bcmath')]
     public function testSupportsBcMathNumberDenormalization()
     {
@@ -118,7 +118,7 @@ class NumberNormalizerTest extends TestCase
         $this->assertFalse($this->normalizer->supportsDenormalization(null, \stdClass::class));
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     #[RequiresPhpExtension('bcmath')]
     #[DataProvider('denormalizeGoodBcMathNumberValueProvider')]
     public function testDenormalizeBcMathNumber(string|int $data, string $type, Number $expected)
@@ -150,7 +150,7 @@ class NumberNormalizerTest extends TestCase
         }
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     #[RequiresPhpExtension('bcmath')]
     #[DataProvider('denormalizeBadBcMathNumberValueProvider')]
     public function testDenormalizeBadBcMathNumberValueThrows(mixed $data, string $type, string $expectedException, string $expectedExceptionMessage)

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -192,7 +192,7 @@ class PropertyNormalizerTest extends TestCase
         $this->assertSame('childProp', $object->childProp);
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testDenormalizeWithAsymmetricPropertyVisibility()
     {
         /** @var SpecialBookDummy $object */

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -1761,7 +1761,7 @@ class SerializerTest extends TestCase
         }
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testDeserializeObjectWithAsymmetricPropertyVisibility()
     {
         $serializer = new Serializer([new ObjectNormalizer()], ['json' => new JsonEncoder()]);

--- a/src/Symfony/Component/Validator/Tests/Constraints/WhenTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/WhenTest.php
@@ -123,7 +123,7 @@ final class WhenTest extends TestCase
         self::assertSame(['foo'], $quuxConstraint->groups);
     }
 
-    #[RequiresPhp('8.5')]
+    #[RequiresPhp('>=8.5')]
     public function testAttributesWithClosure()
     {
         $loader = new AttributeLoader();

--- a/src/Symfony/Component/VarDumper/Tests/Caster/DOMCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/DOMCasterTest.php
@@ -33,7 +33,7 @@ class DOMCasterTest extends TestCase
         );
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testCastModernImplementation()
     {
         $implementation = new \Dom\Implementation();
@@ -63,7 +63,7 @@ class DOMCasterTest extends TestCase
         );
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testCastModernNode()
     {
         $doc = \Dom\XMLDocument::createFromString('<foo><bar/></foo>');
@@ -97,7 +97,7 @@ class DOMCasterTest extends TestCase
         );
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testCastXMLDocument()
     {
         $doc = \Dom\XMLDocument::createFromString('<foo><bar/></foo>');
@@ -116,7 +116,7 @@ class DOMCasterTest extends TestCase
         );
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testCastHTMLDocument()
     {
         $doc = \Dom\HTMLDocument::createFromString('<!DOCTYPE html><html><body><p>foo</p></body></html>');
@@ -143,7 +143,7 @@ class DOMCasterTest extends TestCase
         );
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testCastModernText()
     {
         $text = \Dom\HTMLDocument::createEmpty()->createTextNode('foo');
@@ -169,7 +169,7 @@ class DOMCasterTest extends TestCase
         );
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testCastModernAttr()
     {
         $attr = \Dom\HTMLDocument::createEmpty()->createAttribute('attr');
@@ -196,7 +196,7 @@ class DOMCasterTest extends TestCase
         );
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testCastModernElement()
     {
         $attr = \Dom\HTMLDocument::createEmpty()->createElement('foo');
@@ -226,7 +226,7 @@ class DOMCasterTest extends TestCase
         );
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testCastModernDocumentType()
     {
         $implementation = new \Dom\Implementation();
@@ -254,7 +254,7 @@ class DOMCasterTest extends TestCase
         );
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testCastModernProcessingInstruction()
     {
         $entity = \Dom\HTMLDocument::createEmpty()->createProcessingInstruction('target', 'data');
@@ -282,7 +282,7 @@ class DOMCasterTest extends TestCase
         );
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testCastModernXPath()
     {
         $entity = new \Dom\XPath(\Dom\HTMLDocument::createEmpty());

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
@@ -531,7 +531,7 @@ class ReflectionCasterTest extends TestCase
         $this->assertDumpMatchesFormat($expectedDump, $generator);
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testGenerator()
     {
         if (\extension_loaded('xdebug')) {

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ResourceCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ResourceCasterTest.php
@@ -66,7 +66,7 @@ class ResourceCasterTest extends TestCase
         );
     }
 
-    #[RequiresPhp('8.4.2')]
+    #[RequiresPhp('>=8.4.2')]
     #[RequiresPhpExtension('dba')]
     public function testCastDba()
     {
@@ -82,7 +82,7 @@ class ResourceCasterTest extends TestCase
         );
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     #[RequiresPhpExtension('dba')]
     public function testCastDbaOnBuggyPhp84()
     {

--- a/src/Symfony/Component/VarDumper/Tests/Caster/SocketCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/SocketCasterTest.php
@@ -21,7 +21,7 @@ class SocketCasterTest extends TestCase
 {
     use VarDumperTestTrait;
 
-    #[RequiresPhp('8.3')]
+    #[RequiresPhp('>=8.3')]
     public function testCastSocket()
     {
         $socket = socket_create(\AF_INET, \SOCK_DGRAM, \SOL_UDP);
@@ -56,7 +56,7 @@ class SocketCasterTest extends TestCase
         );
     }
 
-    #[RequiresPhp('8.3')]
+    #[RequiresPhp('>=8.3')]
     public function testCastSocketIpV6()
     {
         $socket = socket_create(\AF_INET6, \SOCK_STREAM, \SOL_TCP);
@@ -93,7 +93,7 @@ class SocketCasterTest extends TestCase
         );
     }
 
-    #[RequiresPhp('8.3')]
+    #[RequiresPhp('>=8.3')]
     public function testCastUnixSocket()
     {
         $socket = socket_create(\AF_UNIX, \SOCK_STREAM, 0);

--- a/src/Symfony/Component/VarDumper/Tests/Caster/StubCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/StubCasterTest.php
@@ -104,7 +104,7 @@ class StubCasterTest extends TestCase
         $this->assertDumpMatchesFormat($expectedDump, $args);
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testVirtualPropertyStub()
     {
         $class = new \ReflectionClass(VirtualProperty::class);
@@ -119,7 +119,7 @@ class StubCasterTest extends TestCase
         $this->assertDumpMatchesFormat($expectedDump, $args);
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testVirtualPropertyWithoutTypeStub()
     {
         $class = new \ReflectionClass(VirtualProperty::class);

--- a/src/Symfony/Component/VarDumper/Tests/Caster/XmlReaderCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/XmlReaderCasterTest.php
@@ -55,7 +55,7 @@ class XmlReaderCasterTest extends TestCase
         $this->assertDumpMatchesFormat($expectedDump, $this->reader);
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testParserProperty()
     {
         $this->reader->setParserProperty(\XMLReader::SUBST_ENTITIES, true);
@@ -286,7 +286,7 @@ class XmlReaderCasterTest extends TestCase
         $this->assertDumpMatchesFormat($expectedDump, $this->reader);
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testWithUninitializedXMLReader()
     {
         $this->reader = new \XMLReader();

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
@@ -301,7 +301,7 @@ class CliDumperTest extends TestCase
         putenv('DUMP_STRING_LENGTH=');
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testVirtualProperties()
     {
         $this->assertDumpEquals(<<<EODUMP

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/HtmlDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/HtmlDumperTest.php
@@ -119,7 +119,7 @@ class HtmlDumperTest extends TestCase
         );
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testVirtualProperties()
     {
         $dumper = new HtmlDumper('php://output');

--- a/src/Symfony/Component/VarExporter/Tests/LazyProxyTraitTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/LazyProxyTraitTest.php
@@ -32,7 +32,7 @@ use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\TestUnserializeClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\TestWakeupClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\SimpleObject;
 
-#[RequiresPhp('8.4')]
+#[RequiresPhp('>=8.4')]
 class LazyProxyTraitTest extends TestCase
 {
     public function testGetter()
@@ -303,7 +303,7 @@ class LazyProxyTraitTest extends TestCase
         $this->assertSame(234, $object->foo);
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testConcretePropertyHooks()
     {
         $initialized = false;
@@ -330,7 +330,7 @@ class LazyProxyTraitTest extends TestCase
         $this->assertSame(345, $object->backed);
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testAbstractPropertyHooks()
     {
         $initialized = false;
@@ -362,7 +362,7 @@ class LazyProxyTraitTest extends TestCase
         $this->assertTrue($initialized);
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testAsymmetricVisibility()
     {
         $object = $this->createLazyProxy(AsymmetricVisibility::class, function () {

--- a/src/Symfony/Component/VarExporter/Tests/LegacyLazyGhostTraitTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/LegacyLazyGhostTraitTest.php
@@ -242,7 +242,7 @@ class LegacyLazyGhostTraitTest extends TestCase
         $this->assertSame([123], $proxy->foo);
     }
 
-    #[RequiresPhp('8.3')]
+    #[RequiresPhp('>=8.3')]
     public function testReadOnlyClass()
     {
         $proxy = $this->createLazyGhost(ReadOnlyClass::class, fn ($proxy) => $proxy->__construct(123));
@@ -296,7 +296,7 @@ class LegacyLazyGhostTraitTest extends TestCase
         $this->assertSame(3, $object->public);
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testPropertyHooks()
     {
         $initialized = false;
@@ -319,7 +319,7 @@ class LegacyLazyGhostTraitTest extends TestCase
         $this->assertSame(345, $object->backed);
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testPropertyHooksWithDefaultValue()
     {
         $initialized = false;
@@ -345,7 +345,7 @@ class LegacyLazyGhostTraitTest extends TestCase
         $this->assertTrue($object->backedBoolWithDefault);
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testAsymmetricVisibility()
     {
         $object = $this->createLazyGhost(AsymmetricVisibility::class, function ($instance) {

--- a/src/Symfony/Component/VarExporter/Tests/ProxyHelperTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/ProxyHelperTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\VarExporter\ProxyHelper;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\Hooked;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\Php82NullStandaloneReturnType;
 
-#[RequiresPhp('8.4')]
+#[RequiresPhp('>=8.4')]
 class ProxyHelperTest extends TestCase
 {
     #[DataProvider('provideExportSignature')]
@@ -278,7 +278,7 @@ class ProxyHelperTest extends TestCase
         );
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>=8.4')]
     public function testPropertyHooks()
     {
         $proxyCode = ProxyHelper::generateLazyProxy(new \ReflectionClass(Hooked::class));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | no
| License       | MIT

Updated test attributes to use `#[RequiresPhp('>= 8.x')]` instead of just `#[RequiresPhp('8.x')]` to ensure tests run on PHP 8.x and newer versions.