### PR TITLE
[Serializer] Remove `#[RequiresPhp('8.4')]`

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Serializer\Tests;
 
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyAccess\Exception\InvalidTypeException;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
@@ -1761,7 +1760,6 @@ class SerializerTest extends TestCase
         }
     }
 
-    #[RequiresPhp('8.4')]
     public function testDeserializeObjectWithAsymmetricPropertyVisibility()
     {
         $serializer = new Serializer([new ObjectNormalizer()], ['json' => new JsonEncoder()]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | no
| License       | MIT

Remove `#[RequiresPhp('8.4')]` as it's unnecessary. Symfony 8.0 already requires PHP 8.4 as the minimum version