### PR TITLE
[Console] Don’t automatically append EOT to multiline test inputs

### DIFF
--- a/src/Symfony/Component/Console/Tester/TesterTrait.php
+++ b/src/Symfony/Component/Console/Tester/TesterTrait.php
@@ -169,10 +169,6 @@ trait TesterTrait
 
         foreach ($inputs as $input) {
             fwrite($stream, $input.\PHP_EOL);
-
-            if (str_contains($input, \PHP_EOL)) {
-                fwrite($stream, "\x4");
-            }
         }
 
         rewind($stream);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

#61501 assumed multiline inputs were answers to multiline questions and suffixed them with an EOT character to mark their end.

But if you’re directly reading stdin, you can have line breaks without the need for an EOT: https://github.com/symfony/symfony/pull/61501#issuecomment-3265196006

Since the `TesterTrait` doesn’t know the inputs’ context, this PR reverts this behavior. Multiline questions will still be able to be tested by manually suffixing the answer with an EOT (`x04`) like in the added test.

Documentation PR: https://github.com/symfony/symfony-docs/pull/21357