### PR TITLE
[Console] Don’t append a new line to test inputs ending with an EOT

### DIFF
--- a/src/Symfony/Component/Console/Tester/TesterTrait.php
+++ b/src/Symfony/Component/Console/Tester/TesterTrait.php
@@ -168,7 +168,11 @@ trait TesterTrait
         $stream = fopen('php://memory', 'r+', false);
 
         foreach ($inputs as $input) {
-            fwrite($stream, $input.\PHP_EOL);
+            fwrite($stream, $input);
+
+            if (!str_ends_with($input, "\x4")) {
+                fwrite($stream, \PHP_EOL);
+            }
         }
 
         rewind($stream);

--- a/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
@@ -136,7 +136,7 @@ class CommandTesterTest extends TestCase
         $command = new Command('foo');
         $command->setHelperSet(new HelperSet([new QuestionHelper()]));
         $command->setCode(function (InputInterface $input, OutputInterface $output) use ($question, $command): int {
-            $output->write($command->getHelper('question')->ask($input, $output, (new Question($question."\n"))->setMultiline(true)));
+            $output->write($command->getHelper('question')->ask($input, $output, (new Question($question))->setMultiline(true)));
             $output->write(stream_get_contents($input->getStream()));
 
             return 0;
@@ -152,7 +152,7 @@ class CommandTesterTest extends TestCase
         $tester->execute([]);
 
         $tester->assertCommandIsSuccessful();
-        $this->assertSame($question."\n".$address."\n".$address."\n", $tester->getDisplay());
+        $this->assertSame($question.$address.$address.\PHP_EOL, $tester->getDisplay());
     }
 
     public function testCommandWithDefaultInputs()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

#61501 wrote a new line before multiline test inputs’ EOT character, and #61690 wrote it after… so the next input would always be empty.

This PR doesn’t write a new line if a test input ends with `\x4` so that the stream matches the inputs.