### PR TITLE
[Security] Add `$tokenSource` argument to `#[IsCsrfTokenValid]` to support reading tokens from the query string or headers

### DIFF
--- a/src/Symfony/Component/Security/Http/Attribute/IsCsrfTokenValid.php
+++ b/src/Symfony/Component/Security/Http/Attribute/IsCsrfTokenValid.php
@@ -16,6 +16,10 @@ use Symfony\Component\ExpressionLanguage\Expression;
 #[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_FUNCTION)]
 final class IsCsrfTokenValid
 {
+    public const SOURCE_PAYLOAD = 0b0001;
+    public const SOURCE_QUERY = 0b0010;
+    public const SOURCE_HEADER = 0b0100;
+
     public function __construct(
         /**
          * Sets the id, or an Expression evaluated to the id, used when generating the token.
@@ -32,6 +36,13 @@ final class IsCsrfTokenValid
          * If not set, the token will be validated for all methods.
          */
         public array|string $methods = [],
+
+        /**
+         * Sets the source targeted to read the tokenKey.
+         *
+         * @var int-mask-of<self::SOURCE_*>
+         */
+        public int $tokenSource = self::SOURCE_PAYLOAD,
     ) {
     }
 }

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Deprecate `AbstractListener::__invoke`
  * Add `$methods` argument to `#[IsGranted]` to restrict validation to specific HTTP methods
  * Allow subclassing `#[IsGranted]`
+ * Add `$tokenSource` argument to `#[IsCsrfTokenValid]` to support reading tokens from the query string or headers
  * Deprecate `RememberMeDetails::getUserFqcn()`, the user FQCN will be removed from the remember-me cookie in 8.0
 
 7.3

--- a/src/Symfony/Component/Security/Http/Tests/Fixtures/IsCsrfTokenValidAttributeMethodsController.php
+++ b/src/Symfony/Component/Security/Http/Tests/Fixtures/IsCsrfTokenValidAttributeMethodsController.php
@@ -59,4 +59,19 @@ class IsCsrfTokenValidAttributeMethodsController
     public function withPostMethodAndInvalidTokenKey()
     {
     }
+
+    #[IsCsrfTokenValid('foo', tokenSource: IsCsrfTokenValid::SOURCE_QUERY)]
+    public function withCustomTokenSourceQuery()
+    {
+    }
+
+    #[IsCsrfTokenValid('foo', tokenSource: IsCsrfTokenValid::SOURCE_QUERY | IsCsrfTokenValid::SOURCE_PAYLOAD)]
+    public function withCustomTokenSourceQueryPayload()
+    {
+    }
+
+    #[IsCsrfTokenValid('foo', tokenKey: 'my_token_key', tokenSource: IsCsrfTokenValid::SOURCE_HEADER)]
+    public function withCustomTokenSourceHeaderAndCustomSourceToken()
+    {
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

The IsCsrfTokenValid attribute currently only reads the token value from the request payload, which is somewhat restrictive. This PR add the ability to choose more sources.

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
