### PR TITLE
[SecurityBundle] Add missing `fixXmlConfig()` call for `issuer`

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/OidcTokenHandlerFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/OidcTokenHandlerFactory.php
@@ -91,6 +91,7 @@ class OidcTokenHandlerFactory implements TokenHandlerFactoryInterface
         $node
             ->arrayNode($this->getKey())
                 ->fixXmlConfig($this->getKey())
+                ->fixXmlConfig('issuer')
                 ->validate()
                     ->ifTrue(static fn ($v) => !isset($v['algorithm']) && !isset($v['algorithms']))
                     ->thenInvalid('You must set either "algorithm" or "algorithms".')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Follows https://github.com/symfony/symfony/pull/60996/files#r2296715420
| License       | MIT

as requested by @fabpot 