### PR TITLE
[SecurityBundle] Add missing `fixXmlConfig()` call for `algorithm`

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/OidcTokenHandlerFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/OidcTokenHandlerFactory.php
@@ -90,6 +90,7 @@ class OidcTokenHandlerFactory implements TokenHandlerFactoryInterface
         $node
             ->arrayNode($this->getKey())
                 ->fixXmlConfig($this->getKey())
+                ->fixXmlConfig('algorithm')
                 ->validate()
                     ->ifTrue(static fn ($v) => !isset($v['discovery']) && !isset($v['keyset']))
                     ->thenInvalid('You must set either "discovery" or "keyset".')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Follows https://github.com/symfony/symfony/pull/60996/files#r2296715365
| License       | MIT

As requested by @fabpot 