### PR TITLE
[Security] Fix `#[IsCsrfTokenValid]` to ensure `$tokenKey` is non-nullable

### DIFF
--- a/src/Symfony/Component/Security/Http/Attribute/IsCsrfTokenValid.php
+++ b/src/Symfony/Component/Security/Http/Attribute/IsCsrfTokenValid.php
@@ -25,7 +25,7 @@ final class IsCsrfTokenValid
         /**
          * Sets the key of the request that contains the actual token value that should be validated.
          */
-        public ?string $tokenKey = '_token',
+        public string $tokenKey = '_token',
 
         /**
          * Sets the available http methods that can be used to validate the token.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

As discussed/requested https://github.com/symfony/symfony/pull/61694/files#r2334104484

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
