### PR TITLE
[HttpFoundation] Add option to return default on unexpected value on `ParameterBag::getEnum`

### DIFF
--- a/src/Symfony/Component/HttpFoundation/InputBag.php
+++ b/src/Symfony/Component/HttpFoundation/InputBag.php
@@ -90,10 +90,10 @@ final class InputBag extends ParameterBag
      *
      * @throws BadRequestException if the input cannot be converted to an enum
      */
-    public function getEnum(string $key, string $class, ?\BackedEnum $default = null): ?\BackedEnum
+    public function getEnum(string $key, string $class, ?\BackedEnum $default = null, bool $defaultIfUnexpectedValue = false): ?\BackedEnum
     {
         try {
-            return parent::getEnum($key, $class, $default);
+            return parent::getEnum($key, $class, $default, $defaultIfUnexpectedValue);
         } catch (UnexpectedValueException $e) {
             throw new BadRequestException($e->getMessage(), $e->getCode(), $e);
         }

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -177,7 +177,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
      *
      * @throws UnexpectedValueException if the parameter value cannot be converted to an enum
      */
-    public function getEnum(string $key, string $class, ?\BackedEnum $default = null): ?\BackedEnum
+    public function getEnum(string $key, string $class, ?\BackedEnum $default = null, bool $defaultIfUnexpectedValue = false): ?\BackedEnum
     {
         $value = $this->get($key);
 
@@ -188,6 +188,10 @@ class ParameterBag implements \IteratorAggregate, \Countable
         try {
             return $class::from($value);
         } catch (\ValueError|\TypeError $e) {
+            if ($defaultIfUnexpectedValue) {
+                return $default;
+            }
+
             throw new UnexpectedValueException(\sprintf('Parameter "%s" cannot be converted to enum: %s.', $key, $e->getMessage()), $e->getCode(), $e);
         }
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -357,6 +357,16 @@ class ParameterBagTest extends TestCase
         $this->assertNull($bag->getEnum('invalid-value', FooEnum::class));
     }
 
+    public function testGetEnumWithDefaultIfUnexpectedValue()
+    {
+        $bag = new ParameterBag(['unexpected-value' => 2]);
+
+        $this->assertSame(
+            FooEnum::Bar,
+            $bag->getEnum('unexpected-value', FooEnum::class, FooEnum::Bar, true),
+        );
+    }
+
     public function testGetEnumThrowsExceptionWithInvalidValueType()
     {
         $bag = new ParameterBag(['invalid-value' => ['foo']]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes<!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->

There are cases where I just don't care of somebody did put something unexpected into the query string I just want fallback to the default and not throw a http or other exception:

```php
$order = $request->query->getEnum('sort', SortByEnum::class, SortByEnum::ASC, defaultIfUnexpectedValue: true);
```