### PR TITLE
[TypeInfo] improve BuiltinType::isIdentifiedBy() method performance

### DIFF
--- a/src/Symfony/Component/TypeInfo/Type/BuiltinType.php
+++ b/src/Symfony/Component/TypeInfo/Type/BuiltinType.php
@@ -41,15 +41,9 @@ final class BuiltinType extends Type
     public function isIdentifiedBy(TypeIdentifier|string ...$identifiers): bool
     {
         foreach ($identifiers as $identifier) {
-            if (\is_string($identifier)) {
-                try {
-                    $identifier = TypeIdentifier::from($identifier);
-                } catch (\ValueError) {
-                    continue;
-                }
-            }
-
-            if ($identifier === $this->typeIdentifier) {
+            if (
+                $identifier === $this->typeIdentifier || $identifier === $this->typeIdentifier->value
+            ) {
                 return true;
             }
         }


### PR DESCRIPTION
Improve `isIdentifiedBy` method performance by replacing unnecessary `TypeIdentifier` backed enum instantiation by an identity test between a string identifier and its value. 

| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #61720
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
