### PR TITLE
[HttpKernel] Refine `ControllerEvent::getAttributes()` and `ControllerArgumentsEvent::getAttributes()` return types

### DIFF
--- a/src/Symfony/Component/HttpKernel/Event/ControllerArgumentsEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/ControllerArgumentsEvent.php
@@ -97,13 +97,11 @@ final class ControllerArgumentsEvent extends KernelEvent
     }
 
     /**
-     * @template T of class-string|null
+     * @template T of object
      *
-     * @param T $className
+     * @param class-string<T>|null $className
      *
-     * @return array<class-string, list<object>>|list<object>
-     *
-     * @psalm-return (T is null ? array<class-string, list<object>> : list<object>)
+     * @return ($className is null ? array<class-string, list<object>> : list<T>)
      */
     public function getAttributes(?string $className = null): array
     {

--- a/src/Symfony/Component/HttpKernel/Event/ControllerEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/ControllerEvent.php
@@ -79,13 +79,11 @@ final class ControllerEvent extends KernelEvent
     }
 
     /**
-     * @template T of class-string|null
+     * @template T of object
      *
-     * @param T $className
+     * @param class-string<T>|null $className
      *
-     * @return array<class-string, list<object>>|list<object>
-     *
-     * @psalm-return (T is null ? array<class-string, list<object>> : list<object>)
+     * @return ($className is null ? array<class-string, list<object>> : list<T>)
      */
     public function getAttributes(?string $className = null): array
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61722
| License       | MIT

The return type for the `Symfony\Component\HttpKernel\Event\ControllerEvent::getAttributes()` method is refined so that when the `$className` argument is passed, the return type matches the passed list of objects of the passed class.