### PR TITLE
[Console] Fix handling of `\E` in Bash completion

### DIFF
--- a/src/Symfony/Component/Console/Resources/completion.bash
+++ b/src/Symfony/Component/Console/Resources/completion.bash
@@ -37,7 +37,7 @@ _sf_{{ COMMAND_NAME }}() {
 
     local completecmd=("$sf_cmd" "_complete" "--no-interaction" "-sbash" "-c$cword" "-a{{ VERSION }}")
     for w in ${words[@]}; do
-        w=$(printf -- '%b' "$w")
+        w="${w//\\\\/\\}"
         # remove quotes from typed values
         quote="${w:0:1}"
         if [ "$quote" == \' ]; then


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Related to #43665

The problem with `$(printf -- '%b' "$w")` is that it also interprets `\E` as an escape sequence.

For example, in

```bash
bin/console debug:form 'Symfony\Component\Form\Extension\Core\Type\EmailType'
```

the `\E` in the class name is replaced with the ASCII escape character:

```
Symfony\Component\Formxtension\Core\TypemailType
```

This PR switches to simply replacing double backslashes with a single one instead of using `printf -- '%b'`.