### PR TITLE
[TwigBridge] Call `form_label_content` block inside `button_widget` block

### DIFF
--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `access_decision()` and `access_decision_for_user()` Twig functions
+ * Call `form_label_content` inside `button_widget` block to render button label
 
 7.3
 ---

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -226,30 +226,8 @@
 {%- endblock range_widget %}
 
 {%- block button_widget -%}
-    {%- if not label -%}
-        {%- if label_format is not empty -%}
-            {% set label = label_format|replace({
-                '%name%': name,
-                '%id%': id,
-            }) %}
-        {%- elseif label is not same as(false) -%}
-            {% set label = name|humanize %}
-        {%- endif -%}
-    {%- endif -%}
     <button type="{{ type|default('button') }}" {{ block('button_attributes') }}>
-        {%- if translation_domain is same as(false) -%}
-            {%- if label_html is same as(false) -%}
-                {{- label -}}
-            {%- else -%}
-                {{- label|raw -}}
-            {%- endif -%}
-        {%- else -%}
-            {%- if label_html is same as(false) -%}
-                {{- label|trans(label_translation_parameters, translation_domain) -}}
-            {%- else -%}
-                {{- label|trans(label_translation_parameters, translation_domain)|raw -}}
-            {%- endif -%}
-        {%- endif -%}
+        {{- block('form_label_content') -}}
     </button>
 {%- endblock button_widget -%}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Refactor of block `button_widget` to call  block `form_label_content`, introduce in Symfony `6.2`, to render the label of the button.
