### PR TITLE
[TypeInfo] Fix issue with merging union type with a nullable union type

### DIFF
--- a/src/Symfony/Component/TypeInfo/Tests/TypeFactoryTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeFactoryTest.php
@@ -204,6 +204,10 @@ class TypeFactoryTest extends TestCase
             new NullableType(new UnionType(new BuiltinType(TypeIdentifier::INT), new BuiltinType(TypeIdentifier::STRING))),
             Type::union(Type::nullable(Type::int()), Type::string()),
         );
+        $this->assertEquals(
+            new NullableType(new UnionType(new BuiltinType(TypeIdentifier::INT), new BuiltinType(TypeIdentifier::STRING))),
+            Type::union(Type::nullable(Type::union(Type::int(), Type::string())), Type::string()),
+        );
     }
 
     public function testCreateArrayShape()

--- a/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
+++ b/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
@@ -299,9 +299,7 @@ trait TypeFactoryTrait
         foreach ($types as $type) {
             if ($type instanceof NullableType) {
                 $nullableUnion = true;
-                $unionTypes[] = $type->getWrappedType();
-
-                continue;
+                $type = $type->getWrappedType();
             }
 
             if ($type instanceof UnionType) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT

The new TypeInfo component doesn't handle this situation correctly. 
Found this after upgrading to 7.3, where the PropertyInfo now calls TypeInfo, given this docblock:
```php
/**
 * @phpstan-type NullableUnionType = string|int|null
 * @phpstan-type UnionWithNullableUnionType = float|NullableUnionType
 */
```

In 7.3 it will throw `Symfony\Component\TypeInfo\Exception\InvalidArgumentException: Cannot set "Symfony\Component\TypeInfo\Type\UnionType" as a "Symfony\Component\TypeInfo\Type\UnionType" part.` exception.
This PR makes sure that nullable union types are also merged, before being passed to a new UnionType
