### PR TITLE
[PhpUnitBridge] Silence deprecation of __sleep/wakeup()

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -171,6 +171,13 @@ class DeprecationErrorHandler
             exit(1);
         }
 
+        if (\PHP_VERSION_ID >= 80500 && \in_array($msg, [
+            'The __sleep() serialization magic method has been deprecated. Implement __serialize() instead (or in addition, if support for old PHP versions is necessary)',
+            'The __wakeup() serialization magic method has been deprecated. Implement __unserialize() instead (or in addition, if support for old PHP versions is necessary)',
+        ], true)) {
+            return null;
+        }
+
         if ('legacy' === $group) {
             $this->deprecationGroups[$group]->addNotice();
         } elseif ($deprecation->originatesFromAnObject()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This change is required to make our CI green on branches that didn't migrate out of the phpunit-bridge, which means 6.4 and 7.3.

By the time PHP 8.5 will be really adopted, ppl will have moved away from Symfony 6.4/7.3 anyway (or will need to deal with the deprecations on their own).

I already wrote a lot about ways to fix this deprecation, and it's not trivial, so that ignoring is the best course of action.

As a reminder, branch 7.4 moved away from those magic methods already.