### PR TITLE
[Security] deprecate the FQCN properties of `PersistentToken` and `RememberMeDetails`

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Security/RememberMe/DoctrineTokenProviderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Security/RememberMe/DoctrineTokenProviderTest.php
@@ -27,7 +27,11 @@ class DoctrineTokenProviderTest extends TestCase
     {
         $provider = $this->bootstrapProvider();
 
-        $token = new PersistentToken('someClass', 'someUser', 'someSeries', 'tokenValue', new \DateTimeImmutable('2013-01-26T18:23:51'));
+        if (method_exists(PersistentToken::class, 'getClass')) {
+            $token = new PersistentToken('someClass', 'someUser', 'someSeries', 'tokenValue', new \DateTimeImmutable('2013-01-26T18:23:51'), false);
+        } else {
+            $token = new PersistentToken('someUser', 'someSeries', 'tokenValue', new \DateTimeImmutable('2013-01-26T18:23:51'));
+        }
         $provider->createNewToken($token);
 
         $this->assertEquals($provider->loadTokenBySeries('someSeries'), $token);
@@ -45,7 +49,12 @@ class DoctrineTokenProviderTest extends TestCase
     {
         $provider = $this->bootstrapProvider();
 
-        $token = new PersistentToken('someClass', 'someUser', 'someSeries', 'tokenValue', new \DateTimeImmutable('2013-01-26T18:23:51'));
+        if (method_exists(PersistentToken::class, 'getClass')) {
+            $token = new PersistentToken('someClass', 'someUser', 'someSeries', 'tokenValue', new \DateTimeImmutable('2013-01-26T18:23:51'), false);
+        } else {
+            $token = new PersistentToken('someUser', 'someSeries', 'tokenValue', new \DateTimeImmutable('2013-01-26T18:23:51'));
+        }
+
         $provider->createNewToken($token);
         $provider->updateToken('someSeries', 'newValue', $lastUsed = new \DateTime('2014-06-26T22:03:46'));
         $token = $provider->loadTokenBySeries('someSeries');
@@ -57,7 +66,11 @@ class DoctrineTokenProviderTest extends TestCase
     public function testDeleteToken()
     {
         $provider = $this->bootstrapProvider();
-        $token = new PersistentToken('someClass', 'someUser', 'someSeries', 'tokenValue', new \DateTimeImmutable('2013-01-26T18:23:51'));
+        if (method_exists(PersistentToken::class, 'getClass')) {
+            $token = new PersistentToken('someClass', 'someUser', 'someSeries', 'tokenValue', new \DateTimeImmutable('2013-01-26T18:23:51'), false);
+        } else {
+            $token = new PersistentToken('someUser', 'someSeries', 'tokenValue', new \DateTimeImmutable('2013-01-26T18:23:51'));
+        }
         $provider->createNewToken($token);
         $provider->deleteTokenBySeries('someSeries');
 
@@ -74,7 +87,11 @@ class DoctrineTokenProviderTest extends TestCase
         $newValue = 'newValue';
 
         // setup existing token
-        $token = new PersistentToken('someClass', 'someUser', $series, $oldValue, new \DateTimeImmutable('2013-01-26T18:23:51'));
+        if (method_exists(PersistentToken::class, 'getClass')) {
+            $token = new PersistentToken('someClass', 'someUser', $series, $oldValue, new \DateTimeImmutable('2013-01-26T18:23:51'), false);
+        } else {
+            $token = new PersistentToken('someUser', $series, $oldValue, new \DateTimeImmutable('2013-01-26T18:23:51'));
+        }
         $provider->createNewToken($token);
 
         // new request comes in requiring remember-me auth, which updates the token
@@ -99,7 +116,11 @@ class DoctrineTokenProviderTest extends TestCase
         $newValue = 'newValue';
 
         // setup existing token
-        $token = new PersistentToken('someClass', 'someUser', $series, $oldValue, new \DateTimeImmutable('2013-01-26T18:23:51'));
+        if (method_exists(PersistentToken::class, 'getClass')) {
+            $token = new PersistentToken('someClass', 'someUser', $series, $oldValue, new \DateTimeImmutable('2013-01-26T18:23:51'), false);
+        } else {
+            $token = new PersistentToken('someUser', $series, $oldValue, new \DateTimeImmutable('2013-01-26T18:23:51'));
+        }
         $provider->createNewToken($token);
 
         // new request comes in requiring remember-me auth, which updates the token

--- a/src/Symfony/Component/Security/Core/Authentication/RememberMe/InMemoryTokenProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/RememberMe/InMemoryTokenProvider.php
@@ -42,7 +42,8 @@ final class InMemoryTokenProvider implements TokenProviderInterface
             $this->tokens[$series]->getUserIdentifier(),
             $series,
             $tokenValue,
-            $lastUsed
+            $lastUsed,
+            false
         );
         $this->tokens[$series] = $token;
     }

--- a/src/Symfony/Component/Security/Core/Authentication/RememberMe/PersistentToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/RememberMe/PersistentToken.php
@@ -18,18 +18,61 @@ namespace Symfony\Component\Security\Core\Authentication\RememberMe;
  */
 final class PersistentToken implements PersistentTokenInterface
 {
+    private ?string $class = null;
+    private string $userIdentifier;
+    private string $series;
+    private string $tokenValue;
     private \DateTimeImmutable $lastUsed;
 
+    /**
+     * @param string             $userIdentifier
+     * @param string             $series
+     * @param string             $tokenValue
+     * @param \DateTimeInterface $lastUsed
+     */
     public function __construct(
-        private string $class,
-        private string $userIdentifier,
-        private string $series,
-        #[\SensitiveParameter] private string $tokenValue,
-        \DateTimeInterface $lastUsed,
+        $userIdentifier,
+        $series,
+        #[\SensitiveParameter] $tokenValue,
+        #[\SensitiveParameter] $lastUsed,
     ) {
-        if (!$class) {
-            throw new \InvalidArgumentException('$class must not be empty.');
+        if (\func_num_args() > 4) {
+            if (\func_num_args() < 6 || func_get_arg(5)) {
+                trigger_deprecation('symfony/security-core', '7.4', 'Passing a user FQCN to %s() is deprecated. The user class will be removed from the remember-me cookie in 8.0.', __CLASS__, __NAMESPACE__);
+            }
+
+            if (!\is_string($userIdentifier)) {
+                throw new \TypeError(\sprintf('Argument 1 passed to "%s()" must be a string, "%s" given.', __METHOD__, get_debug_type($userIdentifier)));
+            }
+
+            $this->class = $userIdentifier;
+            $userIdentifier = $series;
+            $series = $tokenValue;
+            $tokenValue = $lastUsed;
+
+            if (\func_num_args() <= 4) {
+                throw new \TypeError(\sprintf('Argument 5 passed to "%s()" must be an instance of "%s", the argument is missing.', __METHOD__, \DateTimeInterface::class));
+            }
+
+            $lastUsed = func_get_arg(4);
         }
+
+        if (!\is_string($userIdentifier)) {
+            throw new \TypeError(\sprintf('The $userIdentifier argument passed to "%s()" must be a string, "%s" given.', __METHOD__, get_debug_type($userIdentifier)));
+        }
+
+        if (!\is_string($series)) {
+            throw new \TypeError(\sprintf('The $series argument  passed to "%s()" must be a string, "%s" given.', __METHOD__, get_debug_type($series)));
+        }
+
+        if (!\is_string($tokenValue)) {
+            throw new \TypeError(\sprintf('The $tokenValue argument  passed to "%s()" must be a string, "%s" given.', __METHOD__, get_debug_type($tokenValue)));
+        }
+
+        if (!$lastUsed instanceof \DateTimeInterface) {
+            throw new \TypeError(\sprintf('The $lastUsed argument  passed to "%s()" must be an instance of "%s", "%s" given.', __METHOD__, \DateTimeInterface::class, get_debug_type($lastUsed)));
+        }
+
         if ('' === $userIdentifier) {
             throw new \InvalidArgumentException('$userIdentifier must not be empty.');
         }
@@ -40,6 +83,9 @@ final class PersistentToken implements PersistentTokenInterface
             throw new \InvalidArgumentException('$tokenValue must not be empty.');
         }
 
+        $this->userIdentifier = $userIdentifier;
+        $this->series = $series;
+        $this->tokenValue = $tokenValue;
         $this->lastUsed = \DateTimeImmutable::createFromInterface($lastUsed);
     }
 
@@ -52,7 +98,7 @@ final class PersistentToken implements PersistentTokenInterface
             trigger_deprecation('symfony/security-core', '7.4', 'The "%s()" method is deprecated: the user class will be removed from the remember-me cookie in 8.0.', __METHOD__);
         }
 
-        return $this->class;
+        return $this->class ?? '';
     }
 
     public function getUserIdentifier(): string

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/RememberMe/CacheTokenVerifierTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/RememberMe/CacheTokenVerifierTest.php
@@ -21,22 +21,22 @@ class CacheTokenVerifierTest extends TestCase
     public function testVerifyCurrentToken()
     {
         $verifier = new CacheTokenVerifier(new ArrayAdapter());
-        $token = new PersistentToken('class', 'user', 'series1@special:chars=/', 'value', new \DateTimeImmutable());
+        $token = new PersistentToken('class', 'user', 'series1@special:chars=/', 'value', new \DateTimeImmutable(), false);
         $this->assertTrue($verifier->verifyToken($token, 'value'));
     }
 
     public function testVerifyFailsInvalidToken()
     {
         $verifier = new CacheTokenVerifier(new ArrayAdapter());
-        $token = new PersistentToken('class', 'user', 'series1@special:chars=/', 'value', new \DateTimeImmutable());
+        $token = new PersistentToken('class', 'user', 'series1@special:chars=/', 'value', new \DateTimeImmutable(), false);
         $this->assertFalse($verifier->verifyToken($token, 'wrong-value'));
     }
 
     public function testVerifyOutdatedToken()
     {
         $verifier = new CacheTokenVerifier(new ArrayAdapter());
-        $outdatedToken = new PersistentToken('class', 'user', 'series1@special:chars=/', 'value', new \DateTimeImmutable());
-        $newToken = new PersistentToken('class', 'user', 'series1@special:chars=/', 'newvalue', new \DateTimeImmutable());
+        $outdatedToken = new PersistentToken('class', 'user', 'series1@special:chars=/', 'value', new \DateTimeImmutable(), false);
+        $newToken = new PersistentToken('class', 'user', 'series1@special:chars=/', 'newvalue', new \DateTimeImmutable(), false);
         $verifier->updateExistingToken($outdatedToken, 'newvalue', new \DateTimeImmutable());
         $this->assertTrue($verifier->verifyToken($newToken, 'value'));
     }

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/RememberMe/InMemoryTokenProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/RememberMe/InMemoryTokenProviderTest.php
@@ -22,7 +22,7 @@ class InMemoryTokenProviderTest extends TestCase
     {
         $provider = new InMemoryTokenProvider();
 
-        $token = new PersistentToken('foo', 'foo', 'foo', 'foo', new \DateTimeImmutable());
+        $token = new PersistentToken('foo', 'foo', 'foo', 'foo', new \DateTimeImmutable(), false);
         $provider->createNewToken($token);
 
         $this->assertSame($provider->loadTokenBySeries('foo'), $token);
@@ -38,7 +38,7 @@ class InMemoryTokenProviderTest extends TestCase
     {
         $provider = new InMemoryTokenProvider();
 
-        $token = new PersistentToken('foo', 'foo', 'foo', 'foo', new \DateTimeImmutable());
+        $token = new PersistentToken('foo', 'foo', 'foo', 'foo', new \DateTimeImmutable(), false);
         $provider->createNewToken($token);
         $provider->updateToken('foo', 'newFoo', $lastUsed = new \DateTime());
         $token = $provider->loadTokenBySeries('foo');
@@ -51,7 +51,7 @@ class InMemoryTokenProviderTest extends TestCase
     {
         $provider = new InMemoryTokenProvider();
 
-        $token = new PersistentToken('foo', 'foo', 'foo', 'foo', new \DateTimeImmutable());
+        $token = new PersistentToken('foo', 'foo', 'foo', 'foo', new \DateTimeImmutable(), false);
         $provider->createNewToken($token);
         $provider->deleteTokenBySeries('foo');
 

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/RememberMe/PersistentTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/RememberMe/PersistentTokenTest.php
@@ -21,7 +21,7 @@ class PersistentTokenTest extends TestCase
     public function testConstructor()
     {
         $lastUsed = new \DateTimeImmutable();
-        $token = new PersistentToken('fooclass', 'fooname', 'fooseries', 'footokenvalue', $lastUsed);
+        $token = new PersistentToken('fooname', 'fooseries', 'footokenvalue', $lastUsed);
 
         $this->assertEquals('fooname', $token->getUserIdentifier());
         $this->assertEquals('fooseries', $token->getSeries());
@@ -32,7 +32,7 @@ class PersistentTokenTest extends TestCase
     public function testDateTime()
     {
         $lastUsed = new \DateTime();
-        $token = new PersistentToken('fooclass', 'fooname', 'fooseries', 'footokenvalue', $lastUsed);
+        $token = new PersistentToken('fooname', 'fooseries', 'footokenvalue', $lastUsed);
 
         $this->assertEquals($lastUsed, $token->getLastUsed());
     }

--- a/src/Symfony/Component/Security/Http/RememberMe/SignatureRememberMeHandler.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/SignatureRememberMeHandler.php
@@ -47,7 +47,7 @@ final class SignatureRememberMeHandler extends AbstractRememberMeHandler
         $expires = time() + $this->options['lifetime'];
         $value = $this->signatureHasher->computeSignatureHash($user, $expires);
 
-        $details = new RememberMeDetails($user::class, $user->getUserIdentifier(), $expires, $value);
+        $details = new RememberMeDetails($user::class, $user->getUserIdentifier(), $expires, $value, false);
         $this->createCookie($details);
     }
 

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/RememberMeAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/RememberMeAuthenticatorTest.php
@@ -68,7 +68,17 @@ class RememberMeAuthenticatorTest extends TestCase
 
     public function testAuthenticate()
     {
-        $rememberMeDetails = new RememberMeDetails(InMemoryUser::class, 'wouter', 1, 'secret');
+        $rememberMeDetails = new RememberMeDetails('wouter', 1, 'secret');
+        $request = Request::create('/', 'GET', [], ['_remember_me_cookie' => implode(RememberMeDetails::COOKIE_DELIMITER, \array_slice(explode(RememberMeDetails::COOKIE_DELIMITER, $rememberMeDetails->toString()), 1))]);
+        $passport = $this->authenticator->authenticate($request);
+
+        $this->rememberMeHandler->expects($this->once())->method('consumeRememberMeCookie')->with($this->callback(fn ($arg) => $rememberMeDetails == $arg));
+        $passport->getUser(); // trigger the user loader
+    }
+
+    public function testAuthenticateLegacyCookieFormat()
+    {
+        $rememberMeDetails = new RememberMeDetails(InMemoryUser::class, 'wouter', 1, 'secret', false);
         $request = Request::create('/', 'GET', [], ['_remember_me_cookie' => $rememberMeDetails->toString()]);
         $passport = $this->authenticator->authenticate($request);
 

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/SignatureRememberMeHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/SignatureRememberMeHandlerTest.php
@@ -76,21 +76,21 @@ class SignatureRememberMeHandlerTest extends TestCase
         $signature = $this->signatureHasher->computeSignatureHash($user, $expire = time() + 3600);
         $this->userProvider->createUser(new InMemoryUser('wouter', null));
 
-        $rememberMeDetails = new RememberMeDetails(InMemoryUser::class, 'wouter', $expire, $signature);
+        $rememberMeDetails = new RememberMeDetails(InMemoryUser::class, 'wouter', $expire, $signature, false);
         $this->handler->consumeRememberMeCookie($rememberMeDetails);
 
         $this->assertTrue($this->request->attributes->has(ResponseListener::COOKIE_ATTR_NAME));
 
         /** @var Cookie $cookie */
         $cookie = $this->request->attributes->get(ResponseListener::COOKIE_ATTR_NAME);
-        $this->assertNotEquals((new RememberMeDetails(InMemoryUser::class, 'wouter', $expire, $signature))->toString(), $cookie->getValue());
+        $this->assertNotEquals((new RememberMeDetails(InMemoryUser::class, 'wouter', $expire, $signature, false))->toString(), $cookie->getValue());
     }
 
     public function testConsumeRememberMeCookieInvalidHash()
     {
         $this->expectException(AuthenticationException::class);
         $this->expectExceptionMessage('The cookie\'s hash is invalid.');
-        $this->handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', time() + 600, 'badsignature'));
+        $this->handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', time() + 600, 'badsignature', false));
     }
 
     public function testConsumeRememberMeCookieExpired()
@@ -100,6 +100,6 @@ class SignatureRememberMeHandlerTest extends TestCase
 
         $this->expectException(AuthenticationException::class);
         $this->expectExceptionMessage('The cookie has expired.');
-        $this->handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, $signature));
+        $this->handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, $signature, false));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | 
| License       | MIT

while cleaning up the `8.0` branch from the deprecations introduced in #61654 I wondered if we shouldn't also deprecate passing the user FQCN to `PersistentToken` and `RememberMeDetails` in the first place
