### PR TITLE
[HttpFoundation] Add `UriSignerInterface`

### DIFF
--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -44,6 +44,7 @@ FrameworkBundle
 ---------------
 
  * Deprecate `Symfony\Bundle\FrameworkBundle\Console\Application::add()` in favor of `addCommand()`
+ * Deprecate the `UriSigner` autowiring aliases, use `UriSignerInterface` instead
 
 HtmlSanitizer
 -------------

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
  * Add `framework.type_info.aliases` option
  * Add `KernelBrowser::getSession()`
  * Add autoconfiguration tag `kernel.uri_signer` to `Symfony\Component\HttpFoundation\UriSigner`
+ * Add `UriSignerInterface` as an alias of the `uri_signer` service
 
 7.3
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -102,6 +102,7 @@ use Symfony\Component\HttpClient\ThrottlingHttpClient;
 use Symfony\Component\HttpClient\UriTemplateHttpClient;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\UriSigner;
+use Symfony\Component\HttpFoundation\UriSignerInterface;
 use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\HttpKernel\Attribute\AsTargetedValueResolver;
 use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
@@ -767,8 +768,16 @@ class FrameworkExtension extends Extension
             ->addTag('mime.mime_type_guesser');
         $container->registerForAutoconfiguration(LoggerAwareInterface::class)
             ->addMethodCall('setLogger', [new Reference('logger')]);
-        $container->registerForAutoconfiguration(UriSigner::class)
-            ->addTag('kernel.uri_signer');
+        if (!interface_exists(UriSignerInterface::class)) {
+            $container->removeAlias(UriSignerInterface::class);
+            $container->registerForAutoconfiguration(UriSigner::class)
+                ->addTag('kernel.uri_signer');
+        } else {
+            $container->getAlias(UriSigner::class)
+                ->setDeprecated('symfony/framework-bundle', '7.4', 'The "%alias_id%" autowiring alias is deprecated and will be removed in 8.0, use "UriSignerInterface" instead.');
+            $container->registerForAutoconfiguration(UriSignerInterface::class)
+                ->addTag('kernel.uri_signer');
+        }
 
         $container->registerAttributeForAutoconfiguration(AsEventListener::class, static function (ChildDefinition $definition, AsEventListener $attribute, \ReflectionClass|\ReflectionMethod $reflector) {
             $tagAttributes = get_object_vars($attribute);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
@@ -37,6 +37,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpFoundation\UriSigner;
+use Symfony\Component\HttpFoundation\UriSignerInterface;
 use Symfony\Component\HttpFoundation\UrlHelper;
 use Symfony\Component\HttpKernel\CacheClearer\ChainCacheClearer;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerAggregate;
@@ -164,6 +165,7 @@ return static function (ContainerConfigurator $container) {
             ])
             ->lazy()
         ->alias(UriSigner::class, 'uri_signer')
+        ->alias(UriSignerInterface::class, 'uri_signer')
 
         ->set('config_cache_factory', ResourceCheckerConfigCacheFactory::class)
             ->args([

--- a/src/Symfony/Component/HttpFoundation/UriSigner.php
+++ b/src/Symfony/Component/HttpFoundation/UriSigner.php
@@ -14,14 +14,13 @@ namespace Symfony\Component\HttpFoundation;
 use Psr\Clock\ClockInterface;
 use Symfony\Component\HttpFoundation\Exception\ExpiredSignedUriException;
 use Symfony\Component\HttpFoundation\Exception\LogicException;
-use Symfony\Component\HttpFoundation\Exception\SignedUriException;
 use Symfony\Component\HttpFoundation\Exception\UnsignedUriException;
 use Symfony\Component\HttpFoundation\Exception\UnverifiedSignedUriException;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class UriSigner
+class UriSigner implements UriSignerInterface
 {
     private const STATUS_VALID = 1;
     private const STATUS_INVALID = 2;
@@ -94,10 +93,6 @@ class UriSigner
         return $this->buildUrl($url, $params);
     }
 
-    /**
-     * Checks that a URI contains the correct hash.
-     * Also checks if the URI has not expired (If you used expiration during signing).
-     */
     public function check(string $uri): bool
     {
         return self::STATUS_VALID === $this->doVerify($uri);
@@ -108,14 +103,6 @@ class UriSigner
         return self::STATUS_VALID === $this->doVerify(self::normalize($request));
     }
 
-    /**
-     * Verify a Request or string URI.
-     *
-     * @throws UnsignedUriException         If the URI is not signed
-     * @throws UnverifiedSignedUriException If the signature is invalid
-     * @throws ExpiredSignedUriException    If the URI has expired
-     * @throws SignedUriException
-     */
     public function verify(Request|string $uri): void
     {
         $uri = self::normalize($uri);

--- a/src/Symfony/Component/HttpFoundation/UriSignerInterface.php
+++ b/src/Symfony/Component/HttpFoundation/UriSignerInterface.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation;
+
+use Symfony\Component\HttpFoundation\Exception\ExpiredSignedUriException;
+use Symfony\Component\HttpFoundation\Exception\SignedUriException;
+use Symfony\Component\HttpFoundation\Exception\UnsignedUriException;
+use Symfony\Component\HttpFoundation\Exception\UnverifiedSignedUriException;
+
+/**
+ * @author Santiago San Martin <sanmartindev@gmail.com>
+ */
+interface UriSignerInterface
+{
+    /**
+     * Signs a URI.
+     *
+     * The given URI is signed by adding the query string parameter
+     * which value depends on the URI and the secret.
+     *
+     * @param \DateTimeInterface|\DateInterval|int|null $expiration The expiration for the given URI.
+     *                                                              If $expiration is a \DateTimeInterface, it's expected to be the exact date + time.
+     *                                                              If $expiration is a \DateInterval, the interval is added to "now" to get the date + time.
+     *                                                              If $expiration is an int, it's expected to be a timestamp in seconds of the exact date + time.
+     *                                                              If $expiration is null, no expiration.
+     *
+     * The expiration is added as a query string parameter.
+     */
+    public function sign(string $uri/* , \DateTimeInterface|\DateInterval|int|null $expiration = null */): string;
+
+    /**
+     * Checks that a URI contains the correct hash.
+     * Also checks if the URI has not expired (If you used expiration during signing).
+     */
+    public function check(string $uri): bool;
+
+    /**
+     * Checks that a Request contains the correct hash.
+     * Also checks if the URI has not expired (if you used expiration during signing).
+     */
+    public function checkRequest(Request $request): bool;
+
+    /**
+     * Verify a Request or string URI.
+     *
+     * @throws UnsignedUriException         If the URI is not signed
+     * @throws UnverifiedSignedUriException If the signature is invalid
+     * @throws ExpiredSignedUriException    If the URI has expired
+     * @throws SignedUriException
+     */
+    public function verify(Request|string $uri): void;
+}

--- a/src/Symfony/Component/HttpKernel/EventListener/FragmentListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/FragmentListener.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\HttpKernel\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\UriSigner;
+use Symfony\Component\HttpFoundation\UriSignerInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -37,7 +37,7 @@ class FragmentListener implements EventSubscriberInterface
      * @param string $fragmentPath The path that triggers this listener
      */
     public function __construct(
-        private UriSigner $signer,
+        private UriSignerInterface $signer,
         private string $fragmentPath = '/_fragment',
     ) {
     }

--- a/src/Symfony/Component/HttpKernel/EventListener/IsSignatureValidAttributeListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/IsSignatureValidAttributeListener.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\HttpKernel\EventListener;
 
 use Psr\Container\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpFoundation\UriSigner;
+use Symfony\Component\HttpFoundation\UriSignerInterface;
 use Symfony\Component\HttpKernel\Attribute\IsSignatureValid;
 use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -26,7 +26,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
 class IsSignatureValidAttributeListener implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly UriSigner $uriSigner,
+        private readonly UriSignerInterface $uriSigner,
         private readonly ContainerInterface $container,
     ) {
     }
@@ -50,8 +50,8 @@ class IsSignatureValidAttributeListener implements EventSubscriberInterface
             }
 
             $signer = $this->container->get($attribute->signer);
-            if (!$signer instanceof UriSigner) {
-                throw new \LogicException(\sprintf('The service "%s" is not an instance of "%s".', $attribute->signer, UriSigner::class));
+            if (!$signer instanceof UriSignerInterface) {
+                throw new \LogicException(\sprintf('The service "%s" is not an instance of "%s".', $attribute->signer, UriSignerInterface::class));
             }
 
             $signer->verify($request);

--- a/src/Symfony/Component/HttpKernel/Fragment/AbstractSurrogateFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/AbstractSurrogateFragmentRenderer.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\HttpKernel\Fragment;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\UriSigner;
+use Symfony\Component\HttpFoundation\UriSignerInterface;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
 use Symfony\Component\HttpKernel\HttpCache\SurrogateInterface;
 
@@ -33,7 +33,7 @@ abstract class AbstractSurrogateFragmentRenderer extends RoutableFragmentRendere
     public function __construct(
         private ?SurrogateInterface $surrogate,
         private FragmentRendererInterface $inlineStrategy,
-        private ?UriSigner $signer = null,
+        private ?UriSignerInterface $signer = null,
     ) {
     }
 

--- a/src/Symfony/Component/HttpKernel/Fragment/FragmentUriGenerator.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/FragmentUriGenerator.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\HttpKernel\Fragment;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\HttpFoundation\UriSigner;
+use Symfony\Component\HttpFoundation\UriSignerInterface;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
 
 /**
@@ -26,7 +26,7 @@ final class FragmentUriGenerator implements FragmentUriGeneratorInterface
 {
     public function __construct(
         private string $fragmentPath,
-        private ?UriSigner $signer = null,
+        private ?UriSignerInterface $signer = null,
         private ?RequestStack $requestStack = null,
     ) {
     }

--- a/src/Symfony/Component/HttpKernel/Fragment/HIncludeFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/HIncludeFragmentRenderer.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\HttpKernel\Fragment;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\UriSigner;
+use Symfony\Component\HttpFoundation\UriSignerInterface;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
 use Twig\Environment;
 
@@ -29,7 +29,7 @@ class HIncludeFragmentRenderer extends RoutableFragmentRenderer
      */
     public function __construct(
         private ?Environment $twig = null,
-        private ?UriSigner $signer = null,
+        private ?UriSignerInterface $signer = null,
         private ?string $globalDefaultTemplate = null,
         private string $charset = 'utf-8',
     ) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | no
| License       | MIT

This PR adds a `UriSignerInterface` implemented by the existing `UriSigner` class.

The goal is to allow autoconfiguration based on the interface, enabling developers to provide custom `UriSigner` implementations without extending the core class. This follows feedback from previous [discussions](https://github.com/symfony/symfony/pull/60395#discussion_r2337444746)