### PR TITLE
[Console] Add support for interactive invokable commands with `#[Interact]` and `#[Ask]` attributes

### DIFF
--- a/src/Symfony/Component/Console/Attribute/Argument.php
+++ b/src/Symfony/Component/Console/Attribute/Argument.php
@@ -32,6 +32,7 @@ class Argument
      * @var string|class-string<\BackedEnum>
      */
     private string $typeName = '';
+    private ?InteractiveAttributeInterface $interactiveAttribute = null;
 
     /**
      * Represents a console command <argument> definition.
@@ -79,7 +80,8 @@ class Argument
 
         $self->default = $reflection->hasDefaultValue() ? $reflection->getDefaultValue() : null;
 
-        $self->mode = ($reflection->hasDefaultValue() || $reflection->isNullable()) ? InputArgument::OPTIONAL : InputArgument::REQUIRED;
+        $isOptional = $reflection->hasDefaultValue() || $reflection->isNullable();
+        $self->mode = $isOptional ? InputArgument::OPTIONAL : InputArgument::REQUIRED;
         if ('array' === $self->typeName) {
             $self->mode |= InputArgument::IS_ARRAY;
         }
@@ -90,6 +92,12 @@ class Argument
 
         if ($isBackedEnum && !$self->suggestedValues) {
             $self->suggestedValues = array_column($self->typeName::cases(), 'value');
+        }
+
+        $self->interactiveAttribute = Ask::tryFrom($member, $self->name);
+
+        if ($self->interactiveAttribute && $isOptional) {
+            throw new LogicException(\sprintf('The %s "$%s" argument of "%s" cannot be both interactive and optional.', $reflection->getMemberName(), $self->name, $reflection->getSourceName()));
         }
 
         return $self;
@@ -117,5 +125,13 @@ class Argument
         }
 
         return $value;
+    }
+
+    /**
+     * @internal
+     */
+    public function getInteractiveAttribute(): ?InteractiveAttributeInterface
+    {
+        return $this->interactiveAttribute;
     }
 }

--- a/src/Symfony/Component/Console/Attribute/Ask.php
+++ b/src/Symfony/Component/Console/Attribute/Ask.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Attribute;
+
+use Symfony\Component\Console\Attribute\Reflection\ReflectionMember;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[\Attribute(\Attribute::TARGET_PARAMETER | \Attribute::TARGET_PROPERTY)]
+class Ask implements InteractiveAttributeInterface
+{
+    public ?\Closure $validator;
+    private \Closure $closure;
+
+    /**
+     * @param string                     $question    The question to ask the user
+     * @param string|bool|int|float|null $default     The default answer to return if the user enters nothing
+     * @param bool                       $hidden      Whether the user response must be hidden or not
+     * @param bool                       $multiline   Whether the user response should accept newline characters
+     * @param bool                       $trimmable   Whether the user response must be trimmed or not
+     * @param int|null                   $timeout     The maximum time the user has to answer the question in seconds
+     * @param callable|null              $validator   The validator for the question
+     * @param int|null                   $maxAttempts The maximum number of attempts allowed to answer the question.
+     *                                                Null means an unlimited number of attempts
+     */
+    public function __construct(
+        public string $question,
+        public string|bool|int|float|null $default = null,
+        public bool $hidden = false,
+        public bool $multiline = false,
+        public bool $trimmable = true,
+        public ?int $timeout = null,
+        ?callable $validator = null,
+        public ?int $maxAttempts = null,
+    ) {
+        $this->validator = $validator ? $validator(...) : null;
+    }
+
+    /**
+     * @internal
+     */
+    public static function tryFrom(\ReflectionParameter|\ReflectionProperty $member, string $name): ?self
+    {
+        $reflection = new ReflectionMember($member);
+
+        if (!$self = $reflection->getAttribute(self::class)) {
+            return null;
+        }
+
+        $self->closure = function (SymfonyStyle $io, InputInterface $input) use ($self, $reflection, $name) {
+            if (($reflection->isProperty() && isset($this->{$reflection->getName()})) || ($reflection->isParameter() && null !== $input->getArgument($name))) {
+                return;
+            }
+
+            $question = new Question($self->question, $self->default);
+            $question->setHidden($self->hidden);
+            $question->setMultiline($self->multiline);
+            $question->setTrimmable($self->trimmable);
+            $question->setTimeout($self->timeout);
+
+            if (!$self->validator && $reflection->isProperty()) {
+                $self->validator = function (mixed $value) use ($reflection): mixed {
+                    return $this->{$reflection->getName()} = $value;
+                };
+            }
+
+            $question->setValidator($self->validator);
+            $question->setMaxAttempts($self->maxAttempts);
+
+            if ($reflection->isBackedEnumType()) {
+                /** @var class-string<\BackedEnum> $backedType */
+                $backedType = $reflection->getType()->getName();
+                $question->setNormalizer(fn (string|int $value) => $backedType::tryFrom($value) ?? throw InvalidArgumentException::fromEnumValue($reflection->getName(), $value, array_map(fn (\BackedEnum $enum): string|int => $enum->value, $backedType::cases())));
+            }
+
+            $value = $io->askQuestion($question);
+
+            if (null === $value && !$reflection->isNullable()) {
+                return;
+            }
+
+            if ($reflection->isProperty()) {
+                $this->{$reflection->getName()} = $value;
+            } else {
+                $input->setArgument($name, $value);
+            }
+        };
+
+        return $self;
+    }
+
+    /**
+     * @internal
+     */
+    public function getFunction(object $instance): \ReflectionFunction
+    {
+        return new \ReflectionFunction($this->closure->bindTo($instance, $instance::class));
+    }
+}

--- a/src/Symfony/Component/Console/Attribute/Interact.php
+++ b/src/Symfony/Component/Console/Attribute/Interact.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Attribute;
+
+use Symfony\Component\Console\Exception\LogicException;
+
+#[\Attribute(\Attribute::TARGET_METHOD)]
+class Interact implements InteractiveAttributeInterface
+{
+    private \ReflectionMethod $method;
+
+    /**
+     * @internal
+     */
+    public static function tryFrom(\ReflectionMethod $method): ?self
+    {
+        /** @var self|null $self */
+        if (!$self = ($method->getAttributes(self::class)[0] ?? null)?->newInstance()) {
+            return null;
+        }
+
+        if (!$method->isPublic() || $method->isStatic()) {
+            throw new LogicException(\sprintf('The interactive method "%s::%s()" must be public and non-static.', $method->getDeclaringClass()->getName(), $method->getName()));
+        }
+
+        if ('__invoke' === $method->getName()) {
+            throw new LogicException(\sprintf('The "%s::__invoke()" method cannot be used as an interactive method.', $method->getDeclaringClass()->getName()));
+        }
+
+        $self->method = $method;
+
+        return $self;
+    }
+
+    /**
+     * @internal
+     */
+    public function getFunction(object $instance): \ReflectionFunction
+    {
+        return new \ReflectionFunction($this->method->getClosure($instance));
+    }
+}

--- a/src/Symfony/Component/Console/Attribute/InteractiveAttributeInterface.php
+++ b/src/Symfony/Component/Console/Attribute/InteractiveAttributeInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Attribute;
+
+/**
+ * @internal
+ */
+interface InteractiveAttributeInterface
+{
+    public function getFunction(object $instance): \ReflectionFunction;
+}

--- a/src/Symfony/Component/Console/Attribute/Reflection/ReflectionMember.php
+++ b/src/Symfony/Component/Console/Attribute/Reflection/ReflectionMember.php
@@ -96,4 +96,19 @@ class ReflectionMember
     {
         return $this->member instanceof \ReflectionParameter ? 'parameter' : 'property';
     }
+
+    public function isBackedEnumType(): bool
+    {
+        return $this->member->getType() instanceof \ReflectionNamedType && is_subclass_of($this->member->getType()->getName(), \BackedEnum::class);
+    }
+
+    public function isParameter(): bool
+    {
+        return $this->member instanceof \ReflectionParameter;
+    }
+
+    public function isProperty(): bool
+    {
+        return $this->member instanceof \ReflectionProperty;
+    }
 }

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
  * Allow passing invokable commands to `Symfony\Component\Console\Tester\CommandTester`
  * Add `#[MapInput]` attribute to support DTOs in commands
  * Add optional timeout for interaction in `QuestionHelper`
+ * Add support for interactive invokable commands with `#[Interactive]` and `#[InteractiveQuestion]` attributes
 
 7.3
 ---

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -313,6 +313,10 @@ class Command implements SignalableCommandInterface
 
         if ($input->isInteractive()) {
             $this->interact($input, $output);
+
+            if ($this->code?->isInteractive()) {
+                $this->code->interact($input, $output);
+            }
         }
 
         // The command name argument is often omitted when a command is executed directly with its run() method.

--- a/src/Symfony/Component/Console/Interaction/Interaction.php
+++ b/src/Symfony/Component/Console/Interaction/Interaction.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Interaction;
+
+use Symfony\Component\Console\Attribute\InteractiveAttributeInterface;
+use Symfony\Component\Console\Attribute\MapInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @internal
+ */
+final readonly class Interaction
+{
+    public function __construct(
+        private object $owner,
+        private InteractiveAttributeInterface $attribute,
+    ) {
+    }
+
+    /**
+     * @param \Closure(\ReflectionFunction $function, InputInterface $input, OutputInterface $output): array $parameterResolver
+     */
+    public function interact(InputInterface $input, OutputInterface $output, \Closure $parameterResolver): void
+    {
+        if ($this->owner instanceof MapInput) {
+            $function = $this->attribute->getFunction($this->owner->resolveValue($input));
+            $function->invoke(...$parameterResolver($function, $input, $output));
+            $this->owner->setValue($input, $function->getClosureThis());
+
+            return;
+        }
+
+        $function = $this->attribute->getFunction($this->owner);
+        $function->invoke(...$args = $parameterResolver($function, $input, $output));
+        foreach ($function->getParameters() as $i => $parameter) {
+            if (\is_object($args[$i]) && $spec = MapInput::tryFrom($parameter)) {
+                $spec->setValue($input, $args[$i]);
+            }
+        }
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/InvokableWithInputTestCommand.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/InvokableWithInputTestCommand.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Console\Tests\Fixtures;
 
 use Symfony\Component\Console\Attribute\Argument;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\Interact;
 use Symfony\Component\Console\Attribute\MapInput;
 use Symfony\Component\Console\Attribute\Option;
 use Symfony\Component\Console\Command\Command;
@@ -21,6 +22,12 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 #[AsCommand('invokable:input:test')]
 class InvokableWithInputTestCommand
 {
+    #[Interact]
+    public function interact(SymfonyStyle $io, #[MapInput] UserDto $user): void
+    {
+        $user->email ??= 'user.interactive@command.com';
+    }
+
     public function __invoke(SymfonyStyle $io, #[MapInput] UserDto $user): int
     {
         $io->writeln($user->name);
@@ -58,6 +65,12 @@ final class UserDto
 
     #[Option]
     public UserStatus $status = UserStatus::Unverified;
+
+    #[Interact]
+    public function interact(SymfonyStyle $io): void
+    {
+        $this->password ??= 'user-dto-interactive-password';
+    }
 }
 
 final class UserGroupDto

--- a/src/Symfony/Component/Console/Tests/Fixtures/InvokableWithInteractiveAttributesTestCommand.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/InvokableWithInteractiveAttributesTestCommand.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Fixtures;
+
+use Symfony\Component\Console\Attribute\Argument;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\Ask;
+use Symfony\Component\Console\Attribute\Interact;
+use Symfony\Component\Console\Attribute\MapInput;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand('invokable:interactive:question')]
+class InvokableWithInteractiveAttributesTestCommand
+{
+    #[Interact]
+    public function prompt(SymfonyStyle $io, #[MapInput] DummyDto $dto): void
+    {
+        $dto->arg5 ??= $io->ask('Enter arg5');
+    }
+
+    public function __invoke(
+        SymfonyStyle $io,
+
+        #[Argument, Ask('Enter arg1')]
+        string $arg1,
+
+        #[MapInput]
+        DummyDto $dto,
+    ): int {
+        $io->writeln('Arg1: '.$arg1);
+        $io->writeln('Arg2: '.$dto->arg2->value);
+        $io->writeln('Arg3: '.$dto->arg3);
+        $io->writeln('Arg4: '.$dto->arg4);
+        $io->writeln('Arg5: '.$dto->arg5);
+        $io->writeln('Arg6: '.$dto->dummyDto2->arg6);
+        $io->writeln('Arg7: '.$dto->dummyDto2->arg7);
+
+        return Command::SUCCESS;
+    }
+}
+
+class DummyDto
+{
+    #[Argument]
+    #[Ask('Enter arg2')]
+    public Arg2 $arg2;
+
+    #[Argument]
+    #[Ask('Enter arg3', hidden: true)]
+    public string $arg3;
+
+    #[Argument]
+    public string $arg4;
+
+    #[Argument]
+    public string $arg5;
+
+    #[MapInput]
+    public DummyDto2 $dummyDto2;
+
+    #[Interact]
+    public function prompt(SymfonyStyle $io): void
+    {
+        $this->arg4 ??= $io->ask('Enter arg4');
+    }
+}
+
+class DummyDto2
+{
+    #[Argument]
+    #[Ask('Enter arg6')]
+    public string $arg6;
+
+    #[Argument]
+    #[Ask('Enter arg7')]
+    public string $arg7;
+
+    #[Interact]
+    public function prompt(SymfonyStyle $io): void
+    {
+        $this->arg7 ??= $io->ask('Enter arg7');
+    }
+}
+
+enum Arg2: string {
+    case ARG2_VALUE = 'arg2-value';
+    case ARG22_VALUE = 'arg22-value';
+}

--- a/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
@@ -29,6 +29,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Console\Tests\Fixtures\InvokableExtendingCommandTestCommand;
 use Symfony\Component\Console\Tests\Fixtures\InvokableTestCommand;
 use Symfony\Component\Console\Tests\Fixtures\InvokableWithInputTestCommand;
+use Symfony\Component\Console\Tests\Fixtures\InvokableWithInteractiveAttributesTestCommand;
 
 class CommandTesterTest extends TestCase
 {
@@ -448,5 +449,45 @@ class CommandTesterTest extends TestCase
 
                 TXT,
         ];
+
+        yield 'defaults with interactive' => [
+            'input' => [
+                'username' => 'user',
+            ],
+            'output' => <<<TXT
+                user
+                user.interactive@command.com
+                user-dto-interactive-password
+                no
+                yes
+                unverified
+                users
+                Standard Users
+
+                TXT,
+        ];
+    }
+
+    public function testInvokableWithInteractiveQuestionParameter()
+    {
+        $tester = new CommandTester(new InvokableWithInteractiveAttributesTestCommand());
+        $tester->setInputs(['arg1-value', 'arg2-value', 'arg3-value', 'arg6-value', 'arg7-value', 'arg4-value', 'arg5-value']);
+        $tester->execute([], ['interactive' => true]);
+        $tester->assertCommandIsSuccessful();
+
+        self::assertStringContainsString('Enter arg1', $tester->getDisplay());
+        self::assertStringContainsString('Arg1: arg1-value', $tester->getDisplay());
+        self::assertStringContainsString('Enter arg2', $tester->getDisplay());
+        self::assertStringContainsString('Arg2: arg2-value', $tester->getDisplay());
+        self::assertStringContainsString('Enter arg3', $tester->getDisplay());
+        self::assertStringContainsString('Arg3: arg3-value', $tester->getDisplay());
+        self::assertStringContainsString('Enter arg6', $tester->getDisplay());
+        self::assertStringContainsString('Arg6: arg6-value', $tester->getDisplay());
+        self::assertStringContainsString('Enter arg7', $tester->getDisplay());
+        self::assertStringContainsString('Arg7: arg7-value', $tester->getDisplay());
+        self::assertStringContainsString('Enter arg4', $tester->getDisplay());
+        self::assertStringContainsString('Arg4: arg4-value', $tester->getDisplay());
+        self::assertStringContainsString('Enter arg5', $tester->getDisplay());
+        self::assertStringContainsString('Arg5: arg5-value', $tester->getDisplay());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

The `#[Interact]` attribute lets you hook into the command *interactive phase* without extending `Command`, and unlocks even more flexibility!

**Characteristics**
- The method marked with `#[Interact]` attribute will be called during interactive mode
- The method must be **public, non‑static**, otherwise a `LogicException` is thrown
- As usual, it runs only when the interactive mode is enabled (e.g. not with `--no-interaction`)
- Supports common helpers and DTOs parameters just like `__invoke()`

**Before:**
```php
#[AsCommand('app:create-user')]
class CreateUserCommand extends Command
{
    protected function interact(InputInterface $input, OutputInterface $output): void
    {
        $io = new SymfonyStyle($input, $output);

        if (!$input->getArgument('username')) {
            $input->setArgument('username', $io->ask('Enter the username'));
        }
    }

    public function __invoke(#[Argument] string $username): int
    {
        // ...
    }
}
```

**After (long version):**
```php
#[AsCommand('app:create-user')]
class CreateUserCommand
{
    #[Interact]
    public function prompt(InputInterface $input, SymfonyStyle $io): void
    {
        if (!$input->getArgument('username')) {
            $input->setArgument('username', $io->ask('Enter the username'));
        }
    }

    public function __invoke(#[Argument] string $username): int
    {
        // ...
    }
}
```

This PR also adds the `#[Ask]` attribute for the most basic use cases. It lets you declare interactive prompts directly on parameters. Symfony will automatically ask the user for missing values during the interactive phase, without needing to implement a custom "interact" method yourself:

**After (short version):**
```php
#[AsCommand('app:create-user')]
class CreateUserCommand
{
    public function __invoke(
        #[Argument, Ask('Enter the username')] 
        string $username,
    ): int {
        // ...
    }
}
```

### DTO‑friendly interaction

In more complex commands, the DTO approach (see PR https://github.com/symfony/symfony/pull/61478) lets you work directly with the DTO instance and its properties. You've got three ways to do this, so let's start with the simplest and move toward the most flexible:

#### 1) Attribute-driven interactivity

You can also use the `#[Ask]` attribute on DTO properties that have the `#[Argument]` attribute and no default value; if such a property is unset when running the command (e.g. when the linked argument isn't passed), the component automatically triggers a prompt using your defined question:

```php
class UserDto
{
    #[Argument]
    #[Ask('Enter the username')]
    public string $username;

    #[Argument]
    #[Ask('Enter the password', hidden: true)]
    public string $password;
}

#[AsCommand('app:create-user')]
class CreateUserCommand
{
    public function __invoke(#[MapInput] UserDto $user): int
    {
        // use $user->username and $user->password
    }
}
```
Example run:
```bash
bin/console app:create-user

 Enter the username:
 > yceruto

 Enter the password:
 > 🔑
```
This makes the most common interactive cases completely declarative.

> [RFC] You may also find other declarative prompts useful, such as #[Choice] (with better support for BackedEnum properties) and #[Confirm] (for bool properties).

#### 2) DTO-driven interactivity

For scenarios that go beyond simple prompts, you can handle interactivity inside the DTO itself. As long as it only concerns the DTO's own properties (and doesn't require external services), you can mark a method with `#[Interact]`. Symfony will call it during the interactive phase, giving you access to helpers to implement custom logic:
```php
class UserDto
{
    #[Argument]
    #[Ask('Enter the username')]
    public string $username;

    #[Argument]
    #[Ask('Enter the password (or press Enter for a random one)', hidden: true)]
    public string $password;

    #[Interact]
    public function prompt(SymfonyStyle $io): void  
    {  
        if (!isset($this->password)) {
            $this->password = generate_password(10);
            copy_to_clipboard($this->password);
            $io->writeln('Password generated and copied to your clipboard.');
        }
    }
}
```
Yes! `#[Ask]` and `#[Interact]` complement each other and are executed in sequence during the interactive phase.

#### 3) Service‑aware prompts

For cases where prompts depend on external services or need a broader context, you can declare the `#[Interact]` method on the command class itself, giving you full control over the interactive phase:

```php
#[AsCommand('app:create-user')]
class CreateUserCommand
{
    public function __construct(
        private PasswordStrengthValidatorInterface $validator,
    ) {
    }

    #[Interact]
    public function prompt(SymfonyStyle $io, #[MapInput] UserDto $user): void
    {
        $user->password ??= $io->askHidden('Enter password', $this->validator->isValid(...));
    }

    public function __invoke(#[MapInput] UserDto $user): int
    {
        // ...
    }
}
```
In earlier approaches, you had to set arguments manually with `$input->setArgument()`. With DTOs, you can now work directly on typed properties, which makes the code more expressive and less error-prone.

All three ways can coexist, and the execution order is:
1. `#[Ask]` on `__invoke` parameters
2. `#[Ask]` on DTO properties
3. `#[Interact]` on the DTO class
4. `#[Interact]` on the command class

More related features will be unveiled later.

Cheers!