### PR TITLE
[Lock] fix DynamoDB integration test

### DIFF
--- a/src/Symfony/Component/Lock/Bridge/DynamoDb/Tests/Functional/Store/DynamoDbStoreTest.php
+++ b/src/Symfony/Component/Lock/Bridge/DynamoDb/Tests/Functional/Store/DynamoDbStoreTest.php
@@ -27,7 +27,7 @@ class DynamoDbStoreTest extends AbstractStoreTestCase
         }
 
         $store = new DynamoDbStore(getenv('LOCK_DYNAMODB_DSN'));
-        $store->createTable();
+        (new \ReflectionMethod(DynamoDbStore::class, 'createTable'))->invoke($store);
     }
 
     protected function getStore(): PersistingStoreInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

I accidentally broke the integration test in #61737 when changing the visibility of the `createTable()` method to `private`.