### PR TITLE
[PropertyInfo] Fix getting type from constructor of parent class in `PhpStanExtractor`

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
@@ -287,11 +287,11 @@ final class PhpStanExtractor implements PropertyDescriptionExtractorInterface, P
     }
 
     /**
-     * A docblock is splitted into a template marker, a short description, an optional long description and a tags section.
+     * A docblock is split into a template marker, a short description, an optional long description and a tags section.
      *
-     * - The template marker is either empty, or #@+ or #@-.
+     * - The template marker is either empty, #@+ or #@-.
      * - The short description is started from a non-tag character, and until one or multiple newlines.
-     * - The long description (optional), is started from a non-tag character, and until a new line is encountered followed by a tag.
+     * - The long description (optional) is started from a non-tag character, and until a new line is encountered followed by a tag.
      * - Tags, and the remaining characters
      *
      * This method returns the short and the long descriptions.
@@ -374,7 +374,7 @@ final class PhpStanExtractor implements PropertyDescriptionExtractorInterface, P
         ];
     }
 
-    private function getDocBlockFromConstructor(string $class, string $property): ?ParamTagValueNode
+    private function getDocBlockFromConstructor(string &$class, string $property): ?ParamTagValueNode
     {
         try {
             $reflectionClass = new \ReflectionClass($class);
@@ -389,6 +389,7 @@ final class PhpStanExtractor implements PropertyDescriptionExtractorInterface, P
         if (!$rawDocNode = $reflectionConstructor->getDocComment()) {
             return null;
         }
+        $class = $reflectionConstructor->class;
 
         $phpDocNode = $this->getPhpDocNode($rawDocNode);
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
@@ -1143,6 +1143,11 @@ class PhpStanExtractorTest extends TestCase
         yield ['bal', 'A short description ignoring template.', "A long description...\n\n...over several lines."];
         yield ['foo2', null, null];
     }
+
+    public function testGetTypeFromConstructorOfParentClass()
+    {
+        $this->assertEquals(Type::nullable(Type::object(RootDummyItem::class)), $this->extractor->getTypeFromConstructor(Dummy::class, 'rootDummyItem'));
+    }
 }
 
 class PhpStanOmittedParamTagTypeDocBlock

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/ParentDummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/ParentDummy.php
@@ -71,6 +71,14 @@ class ParentDummy
     public $rootDummyItem;
 
     /**
+     * @param RootDummyItem|null $rootDummyItem
+     */
+    public function __construct(?RootDummyItem $rootDummyItem = null)
+    {
+        $this->rootDummyItem = $rootDummyItem;
+    }
+
+    /**
      * @return bool|null
      */
     public function isC()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| License       | MIT

The PhpStanExtractor fails when we try to resolve the type of a constructor argument that is declared in parent class.
It is mainly because the TypeContextFactory doesn't get all the `uses` of parent classes.