### PR TITLE
[FrameworkBundle] Perform-no-deep-merging on workflow transitions' from/to configs

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -972,16 +972,16 @@ class FrameworkExtension extends Extension
             $transitionCounter = 0;
             foreach ($workflow['transitions'] as $transition) {
                 if ('workflow' === $type) {
-                    $transitionDefinition = new Definition(Workflow\Transition::class, [$transition['name'], $transition['from'], $transition['to']]);
                     $transitionId = \sprintf('.%s.transition.%s', $workflowId, $transitionCounter++);
-                    $container->setDefinition($transitionId, $transitionDefinition);
+                    $container->register($transitionId, Workflow\Transition::class)
+                        ->setArguments([$transition['name'], $transition['from'], $transition['to']]);
                     $transitions[] = new Reference($transitionId);
                     if (isset($transition['guard'])) {
-                        $configuration = new Definition(Workflow\EventListener\GuardExpression::class);
-                        $configuration->addArgument(new Reference($transitionId));
-                        $configuration->addArgument($transition['guard']);
                         $eventName = \sprintf('workflow.%s.guard.%s', $name, $transition['name']);
-                        $guardsConfiguration[$eventName][] = $configuration;
+                        $guardsConfiguration[$eventName][] = new Definition(
+                            Workflow\EventListener\GuardExpression::class,
+                            [new Reference($transitionId), $transition['guard']]
+                        );
                     }
                     if ($transition['metadata']) {
                         $transitionsMetadataDefinition->addMethodCall('offsetSet', [
@@ -992,16 +992,16 @@ class FrameworkExtension extends Extension
                 } elseif ('state_machine' === $type) {
                     foreach ($transition['from'] as $from) {
                         foreach ($transition['to'] as $to) {
-                            $transitionDefinition = new Definition(Workflow\Transition::class, [$transition['name'], $from, $to]);
                             $transitionId = \sprintf('.%s.transition.%s', $workflowId, $transitionCounter++);
-                            $container->setDefinition($transitionId, $transitionDefinition);
+                            $container->register($transitionId, Workflow\Transition::class)
+                                ->setArguments([$transition['name'], $from, $to]);
                             $transitions[] = new Reference($transitionId);
                             if (isset($transition['guard'])) {
-                                $configuration = new Definition(Workflow\EventListener\GuardExpression::class);
-                                $configuration->addArgument(new Reference($transitionId));
-                                $configuration->addArgument($transition['guard']);
                                 $eventName = \sprintf('workflow.%s.guard.%s', $name, $transition['name']);
-                                $guardsConfiguration[$eventName][] = $configuration;
+                                $guardsConfiguration[$eventName][] = new Definition(
+                                    Workflow\EventListener\GuardExpression::class,
+                                    [new Reference($transitionId), $transition['guard']]
+                                );
                             }
                             if ($transition['metadata']) {
                                 $transitionsMetadataDefinition->addMethodCall('offsetSet', [

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -471,7 +471,8 @@
             <xsd:element name="metadata" type="metadata" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="guard" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
         </xsd:sequence>
-        <xsd:attribute name="name" type="xsd:string" use="required" />
+        <xsd:attribute name="name" type="xsd:string" />
+        <xsd:attribute name="key" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:complexType name="place" mixed="true">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_base_config.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_base_config.php
@@ -1,0 +1,36 @@
+<?php
+
+return function (Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator $container) {
+    $container->services()->alias('test_workflow', 'workflow.test_workflow')->public();
+    $container->extension('framework', [
+        'http_method_override' => false,
+        'handle_all_throwables' => true,
+        'annotations' => [
+            'enabled' => false,
+        ],
+        'php_errors' => [
+            'log' => true,
+        ],
+        'workflows' => [
+            'test_workflow' => [
+                'type' => 'workflow',
+                'supports' => [
+                    'Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase',
+                ],
+                'initial_marking' => ['start'],
+                'places' => [
+                    'start',
+                    'middle',
+                    'end',
+                    'alternative',
+                ],
+                'transitions' => [
+                    'base_transition' => [
+                        'from' => ['start'],
+                        'to' => ['end'],
+                    ],
+                ],
+            ],
+        ],
+    ]);
+};

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_override_config.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_override_config.php
@@ -1,0 +1,35 @@
+<?php
+
+return function (Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator $container) {
+    $container->extension('framework', [
+        'http_method_override' => false,
+        'handle_all_throwables' => true,
+        'annotations' => [
+            'enabled' => false,
+        ],
+        'php_errors' => [
+            'log' => true,
+        ],
+        'workflows' => [
+            'test_workflow' => [
+                'type' => 'workflow',
+                'supports' => [
+                    'Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase',
+                ],
+                'initial_marking' => ['start'],
+                'places' => [
+                    'start',
+                    'middle',
+                    'end',
+                    'alternative',
+                ],
+                'transitions' => [
+                    'base_transition' => [
+                        'from' => ['middle'],
+                        'to' => ['alternative'],
+                    ],
+                ],
+            ],
+        ],
+    ]);
+};

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_base_config.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_base_config.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:framework="http://symfony.com/schema/dic/symfony"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <services>
+        <service id="test_workflow" alias="workflow.test_workflow" public="true" />
+    </services>
+    <framework:config http-method-override="false" handle-all-throwables="true">
+        <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
+        <framework:workflow name="test_workflow" type="workflow">
+            <framework:initial-marking>start</framework:initial-marking>
+            <framework:support>Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase</framework:support>
+            <framework:place>start</framework:place>
+            <framework:place>middle</framework:place>
+            <framework:place>end</framework:place>
+            <framework:place>alternative</framework:place>
+            <framework:transition key="base_transition">
+                <framework:from>start</framework:from>
+                <framework:to>end</framework:to>
+            </framework:transition>
+        </framework:workflow>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_override_config.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_override_config.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:framework="http://symfony.com/schema/dic/symfony"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config http-method-override="false" handle-all-throwables="true">
+        <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
+        <framework:workflow name="test_workflow" type="workflow">
+            <framework:transition key="base_transition">
+                <framework:from>middle</framework:from>
+                <framework:to>alternative</framework:to>
+            </framework:transition>
+        </framework:workflow>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_base_config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_base_config.yml
@@ -1,0 +1,26 @@
+services:
+    test_workflow:
+        alias: workflow.test_workflow
+        public: true
+framework:
+    http_method_override: false
+    handle_all_throwables: true
+    annotations:
+        enabled: false
+    php_errors:
+        log: true
+    workflows:
+        test_workflow:
+            type: workflow
+            supports:
+                - Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase
+            initial_marking: [start]
+            places:
+                - start
+                - middle
+                - end
+                - alternative
+            transitions:
+                base_transition:
+                    from: [start]
+                    to: [end]

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_override_config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_override_config.yml
@@ -1,0 +1,13 @@
+framework:
+    http_method_override: false
+    handle_all_throwables: true
+    annotations:
+        enabled: false
+    php_errors:
+        log: true
+    workflows:
+        test_workflow:
+            transitions:
+                base_transition:
+                    from: [middle]
+                    to: [alternative]

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -561,6 +561,27 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->assertSame([WorkflowEvents::LEAVE, WorkflowEvents::COMPLETED], $eventsToDispatch);
     }
 
+    public function testWorkflowTransitionsPerformNoDeepMerging()
+    {
+        $container = $this->createContainer(['kernel.charset' => 'UTF-8', 'kernel.secret' => 'secret', 'kernel.runtime_environment' => 'test']);
+        $container->registerExtension(new FrameworkExtension());
+
+        $this->loadFromFile($container, 'workflow_base_config');
+
+        $this->loadFromFile($container, 'workflow_override_config');
+
+        $container->compile();
+
+        $transitions = [];
+
+        foreach ($container->getDefinition('test_workflow')->getArgument(0)->getArgument(1) as $transitionDefinition) {
+            $transitions[] = $transitionDefinition->getArguments();
+        }
+
+        $this->assertCount(1, $transitions);
+        $this->assertSame(['base_transition', ['middle'], ['alternative']], $transitions[0]);
+    }
+
     public function testEnabledPhpErrorsConfig()
     {
         $container = $this->createContainerFromFile('php_errors_enabled');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Similar to #61596 but for transitions.

Also replaces #57873 per @stof's comment at https://github.com/symfony/symfony/pull/57873#issuecomment-2286945080