### PR TITLE
[Mailer][Sendgrid] Add support for `global` region

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add support for suppression groups via `SuppressionGroupHeader`
+ * Add support for `global` region
 
 7.2
 ---

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridSmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridSmtpTransportTest.php
@@ -37,6 +37,10 @@ class SendgridSmtpTransportTest extends TestCase
                 new SendgridSmtpTransport('KEY', null, null, 'eu'),
                 'smtps://smtp.eu.sendgrid.net',
             ],
+            [
+                new SendgridSmtpTransport('KEY', null, null, 'global'),
+                'smtps://smtp.sendgrid.net',
+            ],
         ];
     }
 

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridSmtpTransport.php
@@ -27,7 +27,13 @@ class SendgridSmtpTransport extends EsmtpTransport
 {
     public function __construct(#[\SensitiveParameter] string $key, ?EventDispatcherInterface $dispatcher = null, ?LoggerInterface $logger = null, private ?string $region = null)
     {
-        parent::__construct(null !== $region ? \sprintf('smtp.%s.sendgrid.net', $region) : 'smtp.sendgrid.net', 465, true, $dispatcher, $logger);
+        $host = 'smtp.sendgrid.net';
+
+        if (null !== $region && 'global' !== $region) {
+            $host = \sprintf('smtp.%s.sendgrid.net', $region);
+        }
+
+        parent::__construct($host, 465, true, $dispatcher, $logger);
 
         $this->setUsername('apikey');
         $this->setPassword($key);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #61706 
| License       | MIT

This PR ensures that when the `global` region is provided to `SendgridSmtpTransport`, 
the correct host `smtp.sendgrid.net` is used.  

Previously, passing `region=global` resulted in the host being built as 
`smtp.global.sendgrid.net`, which does not exist.

### Why
- DSNs like `sendgrid+smtp://KEY@default?region=global` failed to connect.
- SendGrid documentation specifies that the "global" region is just `smtp.sendgrid.net` 
  (same as when no region is provided).

### How
- Updated `SendgridSmtpTransport` to special-case the `global` region.
- Added a unit test to cover this scenario.

