### PR TITLE
[HttpKernel] Make Kernel::$requestStackSize and Kernel::$resetServices protected

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Deprecate implementing `__sleep/wakeup()` on data collectors; use `__(un)serialize()` instead
  * Add `#[IsSignatureValid]` attribute to validate URI signatures
  * Make `Profile` final and `Profiler::__sleep()` internal
+ * Make `Kernel::$requestStackSize` and `Kernel::$resetServices` protected to allow overriding `handle()` in subclasses
 
 7.3
 ---

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -65,8 +65,8 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
 
     private string $projectDir;
     private ?string $warmupDir = null;
-    private int $requestStackSize = 0;
-    private bool $resetServices = false;
+    protected int $requestStackSize = 0;
+    protected bool $resetServices = false;
 
     /**
      * @var array<string, bool>

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -539,6 +539,46 @@ class KernelTest extends TestCase
         }
     }
 
+    public function testSubclassCanOverrideHandleAndAccessProtectedFields()
+    {
+        $kernel = new OverridableHandleKernel(null, null, 'test');
+
+        $response = $kernel->handle(new Request());
+        $this->assertSame('custom', $response->getContent());
+
+        $ref = new \ReflectionObject($kernel);
+
+        $propStack = $ref->getProperty('requestStackSize');
+        $this->assertSame(0, $propStack->getValue($kernel));
+
+        $propReset = $ref->getProperty('resetServices');
+        $this->assertTrue($propReset->getValue($kernel));
+    }
+
+    public function testServicesResetterWorksWithOverriddenHandle()
+    {
+        $kernel = new OverridableHandleKernel(function (ContainerBuilder $container) {
+            $container->addCompilerPass(new ResettableServicePass());
+            $container->register('one', ResettableService::class)
+                ->setPublic(true)
+                ->addTag('kernel.reset', ['method' => 'reset']);
+            $container->register('services_resetter', ServicesResetter::class)->setPublic(true);
+        }, null, 'resetting');
+
+        ResettableService::$counter = 0;
+        $request = new Request();
+
+        $kernel->handle($request);
+        $kernel->getContainer()->get('one');
+
+        $this->assertEquals(0, ResettableService::$counter);
+        $this->assertFalse($kernel->getContainer()->initialized('services_resetter'));
+
+        $kernel->handle($request);
+
+        $this->assertEquals(1, ResettableService::$counter);
+    }
+
     /**
      * Returns a mock for the BundleInterface.
      */
@@ -723,5 +763,22 @@ class KernelForTestWithLoadClassCache extends KernelForTest
 {
     public function doLoadClassCache(): void
     {
+    }
+}
+
+class OverridableHandleKernel extends CustomProjectDirKernel
+{
+    public function handle(Request $request, int $type = HttpKernelInterface::MAIN_REQUEST, bool $catch = true): Response
+    {
+        $this->boot();
+
+        ++$this->requestStackSize;
+        $this->resetServices = true;
+
+        try {
+            return new Response('custom');
+        } finally {
+            --$this->requestStackSize;
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
|---------------|---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| BC breaks?    | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This PR makes the `Kernel::$requestStackSize` and `Kernel::$resetServices` properties protected instead of private.
This allows extending kernels to override the `handle()` method with custom logic (e.g. to implement alternative HTTP cache layers).

### Use case

Shopware overrides `Kernel::handle()` to integrate its custom HTTP cache.  
Because these fields are private, Shopware cannot reuse Symfony’s lifecycle logic and must duplicate it instead.  

See: shopware/shopware#12501