### PR TITLE
[TypeInfo] Add result cache to `TypeContextFactory`

### DIFF
--- a/src/Symfony/Component/TypeInfo/Tests/TypeContext/TypeContextFactoryTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeContext/TypeContextFactoryTest.php
@@ -60,6 +60,13 @@ class TypeContextFactoryTest extends TestCase
         $this->assertSame('Dummy', $typeContext->declaringClassName);
     }
 
+    public function testCacheResultWhenToStringTypeResolver()
+    {
+        $typeContext = $this->typeContextFactory->createFromClassName(Dummy::class, AbstractDummy::class);
+        $cachedtypeContext = $this->typeContextFactory->createFromClassName(Dummy::class, AbstractDummy::class);
+        $this->assertSame($typeContext, $cachedtypeContext);
+    }
+
     public function testCollectNamespace()
     {
         $namespace = 'Symfony\\Component\\TypeInfo\\Tests\\Fixtures';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61725
| License       | MIT

Add caches to `TypeContextFactory` method to prevent multiple parsing of the same classes by PHPStan property extractor.

1. Add cache to intermediate `TypeContext` creation from `createFromClassName()` and `createFromReflection()` by adding:

   - `intermediateTypeContextCache` proprety.
   - `createIntermediateTypeContext()` create the intermediate `TypeContext` if not found in cache.

2. Add cache to `createFromClassName()` by:

   - `typeContextCache` proprety.
   - extracting `TypeContext` creation to private `createNewInstanceFromClassName()` method.
   - refactoring `createFromClassName()` to get the `TypeContext` from `$this->typeContextCache`, or creating it by calling `createNewInstanceFromClassName()` method.

3. Add a test to check that the results are cached.

This optimize deserialization and form validation.
