### PR TITLE
[Mailer][Sendgrid] Add support for `global` region (api transport)

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridApiTransportTest.php
@@ -44,6 +44,10 @@ class SendgridApiTransportTest extends TestCase
                 'sendgrid+api://api.eu.sendgrid.com',
             ],
             [
+                new SendgridApiTransport('KEY', null, null, null, 'global'),
+                'sendgrid+api://api.sendgrid.com',
+            ],
+            [
                 (new SendgridApiTransport('KEY'))->setHost('example.com'),
                 'sendgrid+api://example.com',
             ],

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridApiTransport.php
@@ -199,7 +199,7 @@ class SendgridApiTransport extends AbstractApiTransport
     private function getEndpoint(): ?string
     {
         $host = $this->host ?: str_replace('%region_dot%', '', self::HOST);
-        if (null !== $this->region && null === $this->host) {
+        if (null !== $this->region && 'global' !== $this->region && null === $this->host) {
             $host = str_replace('%region_dot%', $this->region.'.', self::HOST);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #61706
| License       | MIT

Related to #61706 and #61758
Add support for `global` region (`SendgridApiTransport`) 