### PR TITLE
[TwigBridge] Remove unused  block `button_label`

### DIFF
--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add `access_decision()` and `access_decision_for_user()` Twig functions
  * Call `form_label_content` inside `button_widget` block to render button label
+ * Remove `button_label` block
 
 7.3
 ---

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -304,8 +304,6 @@
     {%- endif -%}
 {%- endblock form_label_content -%}
 
-{%- block button_label -%}{%- endblock -%}
-
 {# Help #}
 
 {% block form_help -%}

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractLayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractLayoutTestCase.php
@@ -2315,13 +2315,6 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
         );
     }
 
-    public function testButtonLabelIsEmpty()
-    {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ButtonType');
-
-        $this->assertSame('', $this->renderLabel($form->createView()));
-    }
-
     public function testButtonlabelWithoutTranslation()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ButtonType', null, [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch       | 7.4
| Bug fix      | no
| New feature  | no
| Deprecations | no
| Issues        | -
| License       | MIT

It seems that the `button_label` block is no longer used in any form template since at least Symfony `6.0` (I haven't checked previous versions). Its sole purpose was apparently to ensure that `testButtonLabelIsEmpty` tests did not fail!

However, this test is useless because a button always has a label, even if the **label** option is set to `null` or `false`, because the button text then takes the value of the field name, which is already covered by the `testButton` test.
