### PR TITLE
[Mailer][Mandrill] Add `subaccount` to the payload

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+* Add support for specifying a subaccount using the `X-MC-Subaccount` header
+
 7.2
 ---
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Transport/MandrillApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Transport/MandrillApiTransportTest.php
@@ -66,6 +66,21 @@ class MandrillApiTransportTest extends TestCase
         $this->assertEquals('bar', $payload['message']['headers']['foo']);
     }
 
+    public function testSubaccountHeaderIsAddedToPayload()
+    {
+        $email = new Email();
+        $email->getHeaders()->addTextHeader('X-MC-Subaccount', 'foo-bar');
+        $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
+
+        $transport = new MandrillApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(MandrillApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertArrayHasKey('subaccount', $payload['message']);
+        $this->assertEquals('foo-bar', $payload['message']['subaccount']);
+        $this->assertArrayNotHasKey('headers', $payload['message']);
+    }
+
     public function testSend()
     {
         $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillApiTransport.php
@@ -93,6 +93,10 @@ class MandrillApiTransport extends AbstractApiTransport
             ],
         ];
 
+        if ($email->getHeaders()->get('X-MC-Subaccount')) {
+            $payload['message']['subaccount'] = $email->getHeaders()->get('X-MC-Subaccount')->getBodyAsString();
+        }
+
         if ('' !== $envelope->getSender()->getName()) {
             $payload['message']['from_name'] = $envelope->getSender()->getName();
         }
@@ -118,7 +122,7 @@ class MandrillApiTransport extends AbstractApiTransport
         }
 
         foreach ($email->getHeaders()->all() as $name => $header) {
-            if (\in_array($name, ['from', 'to', 'cc', 'bcc', 'subject', 'content-type'], true)) {
+            if (\in_array($name, ['from', 'to', 'cc', 'bcc', 'subject', 'content-type', 'x-mc-subaccount'], true)) {
                 continue;
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | N/A
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- Adds support for MailChimp / Mandrill's subaccount feature - https://mailchimp.com/developer/transactional/docs/subaccounts/
- When emails are sent through the API, there is an option to set the subaccount parameter under [message][subaccount]. The current MandrillApiTransport class does not support this.
- If emails are sent through SMTP the subaccount can be specified by setting the `X-MC-Subaccount` header
- Proposal: If the X-MC-Subaccount header is present the MandrillApiTransport should set the [message][subaccount] field in the JSON it sends to the API  

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
