### PR TITLE
[Notifier][Twilio] WhatsApp number validation

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Twilio/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+ * Add support for the WhatsApp integration if phone numbers are prefixed with `whatsapp:`
+
 6.2
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/Tests/TwilioTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/Tests/TwilioTransportTest.php
@@ -146,5 +146,21 @@ final class TwilioTransportTest extends TransportTestCase
         yield ['+1123456789123'];
         yield ['+11234567891234'];
         yield ['+112345678912345'];
+
+        // whatsapp
+        yield ['whatsapp:+11'];
+        yield ['whatsapp:+112'];
+        yield ['whatsapp:+1123'];
+        yield ['whatsapp:+11234'];
+        yield ['whatsapp:+112345'];
+        yield ['whatsapp:+1123456'];
+        yield ['whatsapp:+11234567'];
+        yield ['whatsapp:+112345678'];
+        yield ['whatsapp:+1123456789'];
+        yield ['whatsapp:+11234567891'];
+        yield ['whatsapp:+112345678912'];
+        yield ['whatsapp:+1123456789123'];
+        yield ['whatsapp:+11234567891234'];
+        yield ['whatsapp:+112345678912345'];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/TwilioTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/TwilioTransport.php
@@ -60,7 +60,7 @@ final class TwilioTransport extends AbstractTransport
 
         $from = $message->getFrom() ?: $this->from;
 
-        if (!preg_match('/^[a-zA-Z0-9\s]{2,11}$/', $from) && !preg_match('/^\+[1-9]\d{1,14}$/', $from)) {
+        if (!preg_match('/^[a-zA-Z0-9\s]{2,11}$/', $from) && !preg_match('/^(?:whatsapp:)?\+[1-9]\d{1,14}$/', $from)) {
             throw new InvalidArgumentException(\sprintf('The "From" number "%s" is not a valid phone number, shortcode, or alphanumeric sender ID.', $from));
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #61776 
| License       | MIT

This commit modifies the validation regex to handle 'whatsapp:' prefixes. The regex now correctly validates WhatsApp numbers without breaking existing functionality for standard phone numbers.

See 
- [https://github.com/symfony/symfony/issues/61776](url)
