### PR TITLE
[Security] keep an empty class segment in remember me cookie to ease upgrades

### DIFF
--- a/src/Symfony/Component/Security/Http/RememberMe/RememberMeDetails.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/RememberMeDetails.php
@@ -78,30 +78,22 @@ class RememberMeDetails
         if (!str_contains($rawCookie, self::COOKIE_DELIMITER)) {
             $rawCookie = base64_decode($rawCookie);
         }
-        $cookieParts = explode(self::COOKIE_DELIMITER, $rawCookie, 3);
 
-        if (isset($cookieParts[1]) && !preg_match('/^\d+$/', $cookieParts[1])) {
-            // legacy (Symfony < 8.0) cookie format
-            $cookieParts = explode(self::COOKIE_DELIMITER, $rawCookie, 4);
+        $cookieParts = explode(self::COOKIE_DELIMITER, $rawCookie, 4);
 
-            if (4 !== \count($cookieParts)) {
-                throw new AuthenticationException('The cookie contains invalid data.');
-            }
+        if (4 !== \count($cookieParts)) {
+            throw new AuthenticationException('The cookie contains invalid data.');
+        }
 
-            if (false === $cookieParts[1] = base64_decode(strtr($cookieParts[1], '-_~', '+/='), true)) {
-                throw new AuthenticationException('The user identifier contains a character from outside the base64 alphabet.');
-            }
+        if (false === $cookieParts[1] = base64_decode(strtr($cookieParts[1], '-_~', '+/='), true)) {
+            throw new AuthenticationException('The user identifier contains a character from outside the base64 alphabet.');
+        }
 
+        if ('' === $cookieParts[0]) {
+            unset($cookieParts[0]);
+        } else {
             $cookieParts[0] = strtr($cookieParts[0], '.', '\\');
             $cookieParts[4] = false;
-        } else {
-            if (3 !== \count($cookieParts)) {
-                throw new AuthenticationException('The cookie contains invalid data.');
-            }
-
-            if (false === $cookieParts[0] = base64_decode(strtr($cookieParts[0], '-_~', '+/='), true)) {
-                throw new AuthenticationException('The user identifier contains a character from outside the base64 alphabet.');
-            }
         }
 
         return new static(...$cookieParts);

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/RememberMeAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/RememberMeAuthenticatorTest.php
@@ -69,7 +69,9 @@ class RememberMeAuthenticatorTest extends TestCase
     public function testAuthenticate()
     {
         $rememberMeDetails = new RememberMeDetails('wouter', 1, 'secret');
-        $request = Request::create('/', 'GET', [], ['_remember_me_cookie' => implode(RememberMeDetails::COOKIE_DELIMITER, \array_slice(explode(RememberMeDetails::COOKIE_DELIMITER, $rememberMeDetails->toString()), 1))]);
+        $cookieData = explode(RememberMeDetails::COOKIE_DELIMITER, $rememberMeDetails->toString());
+        $cookieData[0] = '';
+        $request = Request::create('/', 'GET', [], ['_remember_me_cookie' => implode(RememberMeDetails::COOKIE_DELIMITER, $cookieData)]);
         $passport = $this->authenticator->authenticate($request);
 
         $this->rememberMeHandler->expects($this->once())->method('consumeRememberMeCookie')->with($this->callback(fn ($arg) => $rememberMeDetails == $arg));

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentRememberMeHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentRememberMeHandlerTest.php
@@ -251,7 +251,9 @@ class PersistentRememberMeHandlerTest extends TestCase
         $this->tokenProvider->expects($this->once())->method('updateToken')->with('series1');
 
         $rememberMeDetails = new RememberMeDetails(InMemoryUser::class, 'wouter', 360, 'series1:tokenvalue', false);
-        $rememberMeDetails = RememberMeDetails::fromRawCookie(base64_encode(implode(RememberMeDetails::COOKIE_DELIMITER, \array_slice(explode(RememberMeDetails::COOKIE_DELIMITER, $rememberMeDetails->toString()), 1))));
+        $cookieData = explode(RememberMeDetails::COOKIE_DELIMITER, $rememberMeDetails->toString());
+        $cookieData[0] = '';
+        $rememberMeDetails = RememberMeDetails::fromRawCookie(base64_encode(implode(RememberMeDetails::COOKIE_DELIMITER, $cookieData)));
         $this->handler->consumeRememberMeCookie($rememberMeDetails);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | see https://github.com/symfony/symfony/pull/61760#discussion_r2351263181
| License       | MIT
