### PR TITLE
[Cache] Redis Sentinel - Allow having 2 different auth in config for master & sentinel

### DIFF
--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -217,7 +217,7 @@ trait RedisTrait
                 do {
                     $host = $hosts[$hostIndex]['host'] ?? $hosts[$hostIndex]['path'];
                     $port = $hosts[$hostIndex]['port'] ?? 0;
-                    $passAuth = isset($params['auth']) && (!$isRedisExt || \defined('Redis::OPT_NULL_MULTIBULK_AS_NULL'));
+                    $passAuth = (isset($params['redis_sentinel_auth']) || isset($params['auth'])) && (!$isRedisExt || \defined('Redis::OPT_NULL_MULTIBULK_AS_NULL'));
                     $address = false;
 
                     if (isset($hosts[$hostIndex]['host']) && $tls) {
@@ -240,12 +240,12 @@ trait RedisTrait
                             ];
 
                             if ($passAuth) {
-                                $options['auth'] = $params['auth'];
+                                $options['auth'] = $params['redis_sentinel_auth'] ?? $params['auth'];
                             }
 
                             $sentinel = new \RedisSentinel($options);
                         } else {
-                            $extra = $passAuth ? [$params['auth']] : [];
+                            $extra = $passAuth ? [$params['redis_sentinel_auth'] ?? $params['auth']] : [];
 
                             $sentinel = @new $sentinelClass($host, $port, $params['timeout'], (string) $params['persistent_id'], $params['retry_interval'], $params['read_timeout'], ...$extra);
                         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58727
| License       | MIT

Many time, same auth (like password) is set on both Redis master and Sentinel, but you may want to not use the same auth for both of them.

Currently, using DNS, you can only set one and only one auth for both.

This PR allow to set a different auth for sentinel while keeping backward compatibility for previous DSN config.

**Problematical usage**
```.env
REDIS_DSN=redis:masterPassword@?host[redis_sentinel:26379]&auth=sentinelPassword&redis_sentinel=mymaster
```

Add `auth` option will override the password `masterPassword`.

**Fixed usage**
```.env
REDIS_DSN=redis:masterPassword@?host[redis_sentinel:26379]&redis_sentinel_auth=sentinelPassword&redis_sentinel=mymaster

# With both `auth` and `redis_sentinel_auth`
REDIS_DSN=redis:masterPassword@?host[redis_sentinel:26379]&auth=anyThingHere&redis_sentinel_auth=sentinelPassword&redis_sentinel=mymaster

# Can still be just `auth` -> will work same as before (fix do nothing in this case)
REDIS_DSN=redis:masterPassword@?host[redis_sentinel:26379]&auth=masterPassword&redis_sentinel=mymaster
```

`redis_sentinel_auth` option will be prioritized over `auth` option. That way, after update, an existing DSN will still work as it was before.


