### PR TITLE
[ObjectMapper] Preserve non-promoted constructor parameters

### DIFF
--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InitializedConstructor/C.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InitializedConstructor/C.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\InitializedConstructor;
+
+class C
+{
+    public string $bar;
+
+    public function __construct(string $bar)
+    {
+        $this->bar = $bar;
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InitializedConstructor/D.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InitializedConstructor/D.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\InitializedConstructor;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+class D
+{
+    #[Map(if: false)]
+    public string $barUpperCase;
+
+    public function __construct(string $bar)
+    {
+        $this->barUpperCase = strtoupper($bar);
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -37,6 +37,8 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\Flatten\UserProfile;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\HydrateObject\SourceOnly;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\InitializedConstructor\A as InitializedConstructorA;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\InitializedConstructor\B as InitializedConstructorB;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\InitializedConstructor\C as InitializedConstructorC;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\InitializedConstructor\D as InitializedConstructorD;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\InstanceCallback\A as InstanceCallbackA;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\InstanceCallback\B as InstanceCallbackB;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\InstanceCallbackWithArguments\A as InstanceCallbackWithArgumentsA;
@@ -169,6 +171,36 @@ final class ObjectMapperTest extends TestCase
         $b = $mapper->map($a, InitializedConstructorB::class);
         $this->assertInstanceOf(InitializedConstructorB::class, $b);
         $this->assertEquals($b->tags, ['foo', 'bar']);
+    }
+
+    public function testMapReliesOnConstructorsOwnInitialization()
+    {
+        $expected = 'bar';
+
+        $mapper = new ObjectMapper(propertyAccessor: PropertyAccess::createPropertyAccessor());
+
+        $source = new \stdClass();
+        $source->bar = $expected;
+
+        $c = $mapper->map($source, InitializedConstructorC::class);
+
+        $this->assertInstanceOf(InitializedConstructorC::class, $c);
+        $this->assertEquals($expected, $c->bar);
+    }
+
+    public function testMapConstructorArgumentsDifferFromClassFields()
+    {
+        $expected = 'bar';
+
+        $mapper = new ObjectMapper(propertyAccessor: PropertyAccess::createPropertyAccessor());
+
+        $source = new \stdClass();
+        $source->bar = $expected;
+
+        $actual = $mapper->map($source, InitializedConstructorD::class);
+
+        $this->assertInstanceOf(InitializedConstructorD::class, $actual);
+        $this->assertStringContainsStringIgnoringCase($expected, $actual->barUpperCase);
     }
 
     public function testMapToWithInstanceHook()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #61348 <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

The object mapper does already call the constructor, but its argument values were not determined / collected correctly as non-promoted parameters were skipped. Can not find or think of a valid reason for that. This PR fixes that the non-promoted constructor parameter values will get resolved and thereafter get mapped. 