### PR TITLE
[SecurityBundle] add role hierarchy graph to profiler security panel

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG
  * Deprecate configuring an access control rule with many `roles`, use `allow_if` or role hierarchy instead
  * Deprecate configuring both an access control rule `allow_if` and `roles`, update `allow_if` instead
  * Add support for decorating custom authentication failure and success handlers
+ * Add role hierarchy graph to the profiler security panel
 
 8.1
 ---

--- a/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
+++ b/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
@@ -23,6 +23,7 @@ use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 use Symfony\Component\Security\Core\Authorization\TraceableAccessDecisionManager;
 use Symfony\Component\Security\Core\Authorization\Voter\TraceableVoter;
+use Symfony\Component\Security\Core\Dumper\MermaidDumper;
 use Symfony\Component\Security\Core\Role\RoleHierarchyInterface;
 use Symfony\Component\Security\Http\Event\TokenDeauthenticatedEvent;
 use Symfony\Component\Security\Http\FirewallMapInterface;
@@ -49,6 +50,7 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
         private ?FirewallMapInterface $firewallMap = null,
         private ?TraceableFirewallListener $firewall = null,
         private ?ImpersonateUrlGenerator $impersonateUrlGenerator = null,
+        private MermaidDumper $mermaidDumper = new MermaidDumper(),
     ) {
         $this->hasVarDumper = class_exists(ClassStub::class);
     }
@@ -104,7 +106,7 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
                 $impersonatorUser = $originalToken->getUserIdentifier();
             }
 
-            if (null !== $this->roleHierarchy) {
+            if ($this->roleHierarchy) {
                 foreach ($this->roleHierarchy->getReachableRoleNames($assignedRoles) as $role) {
                     if (!\in_array($role, $assignedRoles, true)) {
                         $inheritedRoles[] = $role;
@@ -235,6 +237,9 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
                 $this->data['auth_profile_token'] = null;
                 $response->headers->clearCookie($authCookieName);
             }
+        }
+        if ($this->roleHierarchy) {
+            $this->data['roles_diagram'] = $this->mermaidDumper->dump($this->roleHierarchy);
         }
     }
 
@@ -404,5 +409,10 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
     public function getName(): string
     {
         return 'security';
+    }
+
+    public function getRolesDiagram(): ?string
+    {
+        return $this->data['roles_diagram'] ?? null;
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -310,10 +310,47 @@
                                     </td>
                                 </tr>
 
-                                {% if collector.supportsRoleHierarchy %}
+                                {% if collector.supportsRoleHierarchy and collector.rolesDiagram is not empty %}
+                                <script>
+                                    {{ source('@WebProfiler/Script/Mermaid/mermaid-flowchart-v2.min.js') }}
+                                    const isDarkMode = document.querySelector('body').classList.contains('theme-dark');
+                                    mermaid.initialize({
+                                        flowchart: {
+                                            useMaxWidth: true,
+                                        },
+                                        securityLevel: 'loose',
+                                        theme: 'base',
+                                        themeVariables: {
+                                            darkMode: isDarkMode,
+                                            fontFamily: 'var(--font-family-system)',
+                                            fontSize: 'var(--font-size-body)',
+                                            // the properties below don't support CSS variables
+                                            primaryColor: isDarkMode ? 'lightsteelblue' : 'aliceblue',
+                                            primaryTextColor: isDarkMode ? '#000' : '#000',
+                                            primaryBorderColor: isDarkMode ? 'steelblue' : 'lightsteelblue',
+                                            lineColor: isDarkMode ? '#939393' : '#d4d4d4',
+                                            secondaryColor: isDarkMode ? 'lightyellow' : 'lightyellow',
+                                            tertiaryColor: isDarkMode ? 'lightSalmon' : 'lightSalmon',
+                                        }
+                                    });
+                                    document.addEventListener('DOMContentLoaded', () => {
+                                        const mEl = document.querySelector('.sf-mermaid');
+                                        mermaid.run({
+                                            nodes: [mEl],
+                                        });
+                                    });
+                                </script>
                                 <tr>
                                     <th>Inherited Roles</th>
                                     <td>{{ collector.inheritedRoles is empty ? 'none' : profiler_dump(collector.inheritedRoles, maxDepth: 1) }}</td>
+                                </tr>
+                                <tr>
+                                    <th>Available Roles</th>
+                                    <td>
+                                        <pre class="sf-mermaid">
+                                            {{ collector.rolesDiagram|raw }}
+                                        </pre>
+                                    </td>
                                 </tr>
                                 {% endif %}
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
@@ -34,6 +34,7 @@ use Symfony\Component\Security\Core\Authorization\TraceableAccessDecisionManager
 use Symfony\Component\Security\Core\Authorization\Voter\TraceableVoter;
 use Symfony\Component\Security\Core\Authorization\Voter\Vote;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+use Symfony\Component\Security\Core\Dumper\MermaidDumper;
 use Symfony\Component\Security\Core\Role\RoleHierarchy;
 use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\InMemoryUserProvider;
@@ -133,7 +134,15 @@ class SecurityDataCollectorTest extends TestCase
     public function testCollectWhenAuthenticationTokenIsNull()
     {
         $tokenStorage = new TokenStorage();
-        $collector = new SecurityDataCollector($tokenStorage, $this->getRoleHierarchy(), null, null, null, null);
+        $mermaidDumper = $this->createMock(MermaidDumper::class);
+
+        $mermaidDumper
+            ->expects($this->once())
+            ->method('dump')
+            ->with($this->getRoleHierarchy())
+            ->willReturn('graph TD; A-->B;');
+
+        $collector = new SecurityDataCollector($tokenStorage, $this->getRoleHierarchy(), mermaidDumper: $mermaidDumper);
         $collector->collect(new Request(), new Response());
 
         $this->assertTrue($collector->isEnabled());
@@ -154,8 +163,15 @@ class SecurityDataCollectorTest extends TestCase
     {
         $tokenStorage = new TokenStorage();
         $tokenStorage->setToken(new UsernamePasswordToken(new InMemoryUser('hhamon', 'P4$$w0rD', $roles), 'provider', $roles));
+        $mermaidDumper = $this->createMock(MermaidDumper::class);
 
-        $collector = new SecurityDataCollector($tokenStorage, $this->getRoleHierarchy(), null, null, null, null);
+        $mermaidDumper
+            ->expects($this->once())
+            ->method('dump')
+            ->with($this->getRoleHierarchy())
+            ->willReturn('graph TD; A-->B;');
+
+        $collector = new SecurityDataCollector($tokenStorage, $this->getRoleHierarchy(), mermaidDumper: $mermaidDumper);
         $collector->collect(new Request(), new Response());
         $collector->lateCollect();
 
@@ -177,8 +193,15 @@ class SecurityDataCollectorTest extends TestCase
 
         $tokenStorage = new TokenStorage();
         $tokenStorage->setToken(new SwitchUserToken(new InMemoryUser('hhamon', 'P4$$w0rD', ['ROLE_USER']), 'provider', ['ROLE_USER'], $adminToken));
+        $mermaidDumper = $this->createMock(MermaidDumper::class);
 
-        $collector = new SecurityDataCollector($tokenStorage, $this->getRoleHierarchy(), null, null, null, null);
+        $mermaidDumper
+            ->expects($this->once())
+            ->method('dump')
+            ->with($this->getRoleHierarchy())
+            ->willReturn('graph TD; A-->B;');
+
+        $collector = new SecurityDataCollector($tokenStorage, $this->getRoleHierarchy(), mermaidDumper: $mermaidDumper);
         $collector->collect(new Request(), new Response());
         $collector->lateCollect();
 

--- a/src/Symfony/Component/Security/Core/Dumper/MermaidDumper.php
+++ b/src/Symfony/Component/Security/Core/Dumper/MermaidDumper.php
@@ -32,7 +32,7 @@ class MermaidDumper
         $hierarchy = $this->extractHierarchy($roleHierarchy);
 
         if (!$hierarchy) {
-            return "graph {$direction->value}\n    classDef default fill:#e1f5fe;";
+            return '';
         }
 
         $output = ["graph {$direction->value}"];

--- a/src/Symfony/Component/Security/Core/Tests/Dumper/MermaidDumperTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Dumper/MermaidDumperTest.php
@@ -57,8 +57,7 @@ class MermaidDumperTest extends TestCase
         $dumper = new MermaidDumper();
         $output = $dumper->dump($roleHierarchy);
 
-        $this->assertStringContainsString('graph TB', $output);
-        $this->assertStringContainsString('classDef default fill:#e1f5fe;', $output);
+        $this->assertEmpty($output);
     }
 
     public function testDumpComplexHierarchy()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| License       | MIT

As promised [here](https://github.com/symfony/symfony/pull/61034#issuecomment-3045659526), here it is. This PR adds the role hierarchy chart to the security panel of the profiler. 

Here is how it looks (heavily inspired by the workflow graph) :

<img width="979" height="693" alt="image" src="https://github.com/user-attachments/assets/681671de-7744-47d1-af0d-b6375600dcc7" />

