### PR TITLE
 Fix various typo

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/MockFileSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/MockFileSessionStorage.php
@@ -103,7 +103,7 @@ class MockFileSessionStorage extends MockArraySessionStorage
             $this->data = $data;
         }
 
-        // this is needed when the session object is re-used across multiple requests
+        // this is needed when the session object is reused across multiple requests
         // in functional tests.
         $this->started = false;
     }

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -459,7 +459,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
 
             // This try-catch should cover all NotNormalizableValueException (and all return branches after the first
             // exception) so we could try denormalizing all types of an union type. If the target type is not an union
-            // type, we will just re-throw the catched exception.
+            // type, we will just re-throw the caught exception.
             // In the case of no denormalization succeeds with an union type, it will fall back to the default exception
             // with the acceptable types list.
             try {

--- a/src/Symfony/Component/Workflow/Tests/Dumper/MermaidDumperTest.php
+++ b/src/Symfony/Component/Workflow/Tests/Dumper/MermaidDumperTest.php
@@ -141,10 +141,10 @@ class MermaidDumperTest extends TestCase
     {
         $builder = new DefinitionBuilder();
 
-        $builder->addPlaces(['start', 'subgraph', 'end', 'finis']);
+        $builder->addPlaces(['start', 'subgraph', 'end', 'finish']);
         $builder->addTransitions([
             new Transition('t0', ['start', 'subgraph'], ['end']),
-            new Transition('t1', ['end'], ['finis']),
+            new Transition('t1', ['end'], ['finish']),
         ]);
 
         $definition = $builder->build();
@@ -155,7 +155,7 @@ class MermaidDumperTest extends TestCase
             ."place0([\"start\"])\n"
             ."place1((\"subgraph\"))\n"
             ."place2((\"end\"))\n"
-            ."place3((\"finis\"))\n"
+            ."place3((\"finish\"))\n"
             ."transition0[\"t0\"]\n"
             ."place0-->transition0\n"
             ."transition0-->place2\n"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Using [codespell](https://github.com/symfony-tools/fabbot/blob/96dfbd317e87d2b8cd15defdb4adbd7b50d81ddb/.github/workflows/fabbot.yml#L70C11-L70C98) to detect typos.
