### PR TITLE
[Validator] deprecate implicit constraint option names in YAML/XML mapping files

### DIFF
--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -117,6 +117,52 @@ Uid
 Validator
 ---------
 
+ * Deprecate configuring constraint options implicitly with the XML format
+
+   *Before*
+
+   ```xml
+   <class name="Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\Entity">
+     <constraint name="Callback">
+       <value>Symfony\Component\Validator\Tests\Fixtures\CallbackClass</value>
+       <value>callback</value>
+     </constraint>
+   </class>
+   ```
+
+   *After*
+
+   ```xml
+   <class name="Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\Entity">
+     <constraint name="Callback">
+       <option name="callback">
+         <value>Symfony\Component\Validator\Tests\Fixtures\CallbackClass</value>
+         <value>callback</value>
+       </option>
+     </constraint>
+   </class>
+   ```
+ * Deprecate configuring constraint options implicitly with the YAML format
+
+   *Before*
+
+   ```yaml
+   Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\Entity:
+     constraints:
+       - Callback: validateMeStatic
+       - Callback: [Symfony\Component\Validator\Tests\Fixtures\CallbackClass, callback]
+   ```
+
+   *After*
+
+   ```yaml
+   Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\Entity:
+     constraints:
+       - Callback:
+           callback: validateMeStatic
+       - Callback:
+           callback: [Symfony\Component\Validator\Tests\Fixtures\CallbackClass, callback]
+   ```
  * Deprecate implementing `__sleep/wakeup()` on `GenericMetadata` implementations; use `__(un)serialize()` instead
  * Deprecate passing a list of choices to the first argument of the `Choice` constraint. Use the `choices` option instead
  * Deprecate `getRequiredOptions()` and `getDefaultOption()` methods of the `All`, `AtLeastOneOf`, `CardScheme`, `Collection`,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Validation/Resources/categories.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Validation/Resources/categories.yml
@@ -1,9 +1,11 @@
 Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Validation\Category:
     properties:
         id:
-            - Type: int
+            - Type:
+                type: int
 
 Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Validation\SubCategory:
     properties:
         id:
-            - Type: int
+            - Type:
+                type: int

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -4,6 +4,52 @@ CHANGELOG
 7.4
 ---
 
+ * Deprecate configuring constraint options implicitly with the XML format
+
+   Before:
+
+   ```xml
+   <class name="Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\Entity">
+    <constraint name="Callback">
+      <value>Symfony\Component\Validator\Tests\Fixtures\CallbackClass</value>
+      <value>callback</value>
+    </constraint>
+   </class>
+   ```
+
+   After:
+
+   ```xml
+   <class name="Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\Entity">
+     <constraint name="Callback">
+       <option name="callback">
+         <value>Symfony\Component\Validator\Tests\Fixtures\CallbackClass</value>
+         <value>callback</value>
+       </option>
+     </constraint>
+   </class>
+   ```
+ * Deprecate configuring constraint options implicitly with the YAML format
+
+   Before:
+
+   ```yaml
+   Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\Entity:
+     constraints:
+       - Callback: validateMeStatic
+       - Callback: [Symfony\Component\Validator\Tests\Fixtures\CallbackClass, callback]
+   ```
+
+   After:
+
+   ```yaml
+   Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\Entity:
+     constraints:
+       - Callback:
+           callback: validateMeStatic
+       - Callback:
+           callback: [Symfony\Component\Validator\Tests\Fixtures\CallbackClass, callback]
+   ```
  * Add `#[ExtendsValidationFor]` to declare new constraints for a class
  * Add `ValidatorBuilder::addAttributeMappings()` and `AttributeMetadataPass` to declare compile-time constraint metadata using attributes
  * Add the `Video` constraint for validating video files
@@ -48,7 +94,6 @@ CHANGELOG
        }
    }
    ```
-
  * Deprecate the `getRequiredOptions()` method of the base `Constraint` class. Use mandatory constructor arguments instead.
 
    Before:

--- a/src/Symfony/Component/Validator/Mapping/Loader/AbstractLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/AbstractLoader.php
@@ -94,10 +94,16 @@ abstract class AbstractLoader implements LoaderInterface
             }
 
             if (1 === \count($options) && isset($options['value'])) {
+                if (\func_num_args() < 3 || !func_get_arg(2)) {
+                    trigger_deprecation('symfony/validator', '7.4', 'Using the "value" option to configure the "%s" constraint is deprecated.', $className);
+                }
+
                 return new $className($options['value']);
             }
 
             if (array_is_list($options)) {
+                trigger_deprecation('symfony/validator', '7.4', 'Configuring the "%s" without passing its option names is deprecated.', $className);
+
                 return new $className($options);
             }
 
@@ -105,6 +111,8 @@ abstract class AbstractLoader implements LoaderInterface
                 return new $className(...$options);
             } catch (\Error $e) {
                 if (str_starts_with($e->getMessage(), 'Unknown named parameter ')) {
+                    trigger_deprecation('symfony/validator', '7.4', 'Using option names not matching the named arguments of the "%s" constraint is deprecated.', $className);
+
                     return new $className($options);
                 }
 

--- a/src/Symfony/Component/Validator/Mapping/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/XmlFileLoader.php
@@ -80,6 +80,8 @@ class XmlFileLoader extends FileLoader
         foreach ($nodes as $node) {
             if (\count($node) > 0) {
                 if (\count($node->value) > 0) {
+                    trigger_deprecation('symfony/validator', '7.4', 'Using the "value" XML element to configure an option for the "%s" is deprecated. Use the "option" element instead.', (string) $node['name']);
+
                     $options = [
                         'value' => $this->parseValues($node->value),
                     ];
@@ -100,7 +102,7 @@ class XmlFileLoader extends FileLoader
                 $options['groups'] = (array) $options['groups'];
             }
 
-            $constraints[] = $this->newConstraint((string) $node['name'], $options);
+            $constraints[] = $this->newConstraint((string) $node['name'], $options, true);
         }
 
         return $constraints;

--- a/src/Symfony/Component/Validator/Mapping/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/YamlFileLoader.php
@@ -87,12 +87,14 @@ class YamlFileLoader extends FileLoader
                 }
 
                 if (null !== $options && (!\is_array($options) || array_is_list($options))) {
+                    trigger_deprecation('symfony/validator', '7.4', 'Not using a YAML mapping of constraint option names to their values to configure the "%s" constraint is deprecated.', key($childNodes));
+
                     $options = [
                         'value' => $options,
                     ];
                 }
 
-                $values[] = $this->newConstraint(key($childNodes), $options);
+                $values[] = $this->newConstraint(key($childNodes), $options, true);
             } else {
                 if (\is_array($childNodes)) {
                     $childNodes = $this->parseNodes($childNodes);

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/XmlFileLoaderTest.php
@@ -30,6 +30,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Loader\XmlFileLoader;
 use Symfony\Component\Validator\Tests\Dummy\DummyGroupProvider;
 use Symfony\Component\Validator\Tests\Fixtures\Attribute\GroupProviderDto;
+use Symfony\Component\Validator\Tests\Fixtures\CallbackClass;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintA;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintB;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintWithRequiredArgument;
@@ -104,6 +105,7 @@ class XmlFileLoaderTest extends TestCase
         $loader->loadClassMetadata($metadata);
 
         $expected = new ClassMetadata(Entity::class);
+        $expected->addConstraint(new Callback([CallbackClass::class, 'callback']));
         $expected->addPropertyConstraint('firstName', new Type(type: 'string'));
         $expected->addPropertyConstraint('firstName', new Choice(choices: ['A', 'B']));
 

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/YamlFileLoaderTest.php
@@ -27,6 +27,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Loader\YamlFileLoader;
 use Symfony\Component\Validator\Tests\Dummy\DummyGroupProvider;
 use Symfony\Component\Validator\Tests\Fixtures\Attribute\GroupProviderDto;
+use Symfony\Component\Validator\Tests\Fixtures\CallbackClass;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintA;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintB;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintWithRequiredArgument;
@@ -146,6 +147,8 @@ class YamlFileLoaderTest extends TestCase
         $loader->loadClassMetadata($metadata);
 
         $expected = new ClassMetadata(Entity::class);
+        $expected->addConstraint(new Callback('validateMeStatic'));
+        $expected->addConstraint(new Callback([CallbackClass::class, 'callback']));
         $expected->addPropertyConstraint('firstName', new Type(type: 'string'));
         $expected->addPropertyConstraint('firstName', new Choice(choices: ['A', 'B']));
 

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-mapping-value-option.xml
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-mapping-value-option.xml
@@ -7,6 +7,10 @@
   <namespace prefix="custom">Symfony\Component\Validator\Tests\Fixtures\</namespace>
 
   <class name="Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\Entity">
+    <constraint name="Callback">
+      <value>Symfony\Component\Validator\Tests\Fixtures\CallbackClass</value>
+      <value>callback</value>
+    </constraint>
 
     <!-- PROPERTY CONSTRAINTS -->
 

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-mapping-value-option.yml
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-mapping-value-option.yml
@@ -2,6 +2,9 @@ namespaces:
   custom: Symfony\Component\Validator\Tests\Fixtures\
 
 Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\Entity:
+  constraints:
+    - Callback: validateMeStatic
+    - Callback: [Symfony\Component\Validator\Tests\Fixtures\CallbackClass, callback]
   properties:
     firstName:
       # Constraint with single value

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-mapping.xml
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-mapping.xml
@@ -27,8 +27,10 @@
     <constraint name="Callback">validateMeStatic</constraint>
 
     <constraint name="Callback">
-        <value>Symfony\Component\Validator\Tests\Fixtures\CallbackClass</value>
-        <value>callback</value>
+        <option name="callback">
+            <value>Symfony\Component\Validator\Tests\Fixtures\CallbackClass</value>
+            <value>callback</value>
+        </option>
     </constraint>
 
     <!-- Traverse with boolean default option -->
@@ -43,8 +45,10 @@
 
     <!-- Constraint with named arguments support with array value -->
     <constraint name="Symfony\Component\Validator\Tests\Mapping\Loader\Fixtures\ConstraintWithNamedArguments">
-      <value>foo</value>
-      <value>bar</value>
+      <option name="choices">
+        <value>foo</value>
+        <value>bar</value>
+      </option>
     </constraint>
 
     <!-- Constraint with named arguments support with exactly one group -->
@@ -61,11 +65,12 @@
 
       <!-- Constraint with child constraints -->
       <constraint name="All">
-        <constraint name="NotNull" />
-        <constraint name="Range">
-           <option name="min">3</option>
-        </constraint>
-
+        <option name="constraints">
+          <constraint name="NotNull" />
+          <constraint name="Range">
+            <option name="min">3</option>
+          </constraint>
+        </option>
       </constraint>
 
       <!-- Option with child constraints -->

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-mapping.yml
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-mapping.yml
@@ -12,15 +12,20 @@ Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\Entity:
     # Custom constraint with namespaces prefix
     - "custom:ConstraintB": ~
     # Callbacks
-    - Callback: validateMe
-    - Callback: validateMeStatic
-    - Callback: [Symfony\Component\Validator\Tests\Fixtures\CallbackClass, callback]
+    - Callback:
+        callback: validateMe
+    - Callback:
+        callback: validateMeStatic
+    - Callback:
+        callback: [Symfony\Component\Validator\Tests\Fixtures\CallbackClass, callback]
     # Constraint with named arguments support without value
     - Symfony\Component\Validator\Tests\Mapping\Loader\Fixtures\ConstraintWithoutValueWithNamedArguments: ~
     # Constraint with named arguments support with scalar value
-    - Symfony\Component\Validator\Tests\Mapping\Loader\Fixtures\ConstraintWithNamedArguments: foo
+    - Symfony\Component\Validator\Tests\Mapping\Loader\Fixtures\ConstraintWithNamedArguments:
+        choices: foo
     # Constraint with named arguments support with array value
-    - Symfony\Component\Validator\Tests\Mapping\Loader\Fixtures\ConstraintWithNamedArguments: [foo, bar]
+    - Symfony\Component\Validator\Tests\Mapping\Loader\Fixtures\ConstraintWithNamedArguments:
+        choices: [foo, bar]
 
   properties:
     firstName:
@@ -28,9 +33,10 @@ Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\Entity:
       - NotNull: ~
       # Constraint with child constraints
       - All:
-          - NotNull: ~
-          - Range:
-              min: 3
+          constraints:
+            - NotNull: ~
+            - Range:
+                min: 3
       # Option with child constraints
       - All:
           constraints:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | see https://github.com/symfony/symfony/pull/61617#discussion_r2319147759
| License       | MIT