### PR TITLE
 [AssetMapper] Prevent duplicate entries in module preloads

### DIFF
--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapRenderer.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapRenderer.php
@@ -73,7 +73,7 @@ class ImportMapRenderer
             if ('css' !== $data['type']) {
                 $importMap[$importName] = $path;
                 if ($preload) {
-                    $modulePreloads[] = $path;
+                    $modulePreloads[$path] = $path;
                 }
             } elseif ($preload) {
                 $cssLinks[] = $path;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

When a library in `assets/controllers.json` is configured with `"eager` (ex. **live-component** when eager),  
it may result in duplicate `modulepreload` entries being generated.

This change ensures that each preload path is only added once, even if the same import
appears multiple times. It also prevents accidental duplication in `importmap.php` if
a library is mistakenly listed more than once.