### PR TITLE
[Validator] Expression constraint docblock incorrectly states default value for negate

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Expression.php
+++ b/src/Symfony/Component/Validator/Constraints/Expression.php
@@ -44,7 +44,7 @@ class Expression extends Constraint
      * @param array<string,mixed>|null                         $values     The values of the custom variables used in the expression (defaults to an empty array)
      * @param string[]|null                                    $groups
      * @param array<string,mixed>|null                         $options
-     * @param bool|null                                        $negate     Whether to fail if the expression evaluates to true (defaults to false)
+     * @param bool|null                                        $negate     When set to true, if the expression returns true, the validation will pass (defaults to true)
      */
     #[HasNamedArguments]
     public function __construct(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT

The docblock incorrectly stated that the default is to false. On line 41, you can see that the default is true. Changing the default to match the docblock would cause a BC break, so fixing the documentation instead.
