### PR TITLE
[Config] Add `Node::getDeprecationMessage()` with full message

### DIFF
--- a/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
+++ b/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
@@ -446,7 +446,7 @@ public function NAME($value): static
         }
 
         if ($node->isDeprecated()) {
-            $comment .= '@deprecated '.$node->getDeprecation($node->getName(), $node->getParent()->getName())['message']."\n";
+            $comment .= '@deprecated '.$node->getDeprecationMessage()."\n";
         }
 
         return $comment ? ' * '.str_replace("\n", "\n * ", rtrim($comment, "\n"))."\n" : '';

--- a/src/Symfony/Component/Config/Definition/Dumper/XmlReferenceDumper.php
+++ b/src/Symfony/Component/Config/Definition/Dumper/XmlReferenceDumper.php
@@ -144,8 +144,7 @@ class XmlReferenceDumper
                 }
 
                 if ($child instanceof BaseNode && $child->isDeprecated()) {
-                    $deprecation = $child->getDeprecation($child->getName(), $node->getPath());
-                    $comments[] = \sprintf('Deprecated (%s)', ($deprecation['package'] || $deprecation['version'] ? "Since {$deprecation['package']} {$deprecation['version']}: " : '').$deprecation['message']);
+                    $comments[] = \sprintf('Deprecated (%s)', $child->getDeprecationMessage($node));
                 }
 
                 if ($child instanceof EnumNode) {

--- a/src/Symfony/Component/Config/Definition/Dumper/YamlReferenceDumper.php
+++ b/src/Symfony/Component/Config/Definition/Dumper/YamlReferenceDumper.php
@@ -120,8 +120,7 @@ class YamlReferenceDumper
 
         // deprecated?
         if ($node instanceof BaseNode && $node->isDeprecated()) {
-            $deprecation = $node->getDeprecation($node->getName(), $parentNode ? $parentNode->getPath() : $node->getPath());
-            $comments[] = \sprintf('Deprecated (%s)', ($deprecation['package'] || $deprecation['version'] ? "Since {$deprecation['package']} {$deprecation['version']}: " : '').$deprecation['message']);
+            $comments[] = \sprintf('Deprecated (%s)', $node->getDeprecationMessage($parentNode));
         }
 
         // example

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/TranslatorConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/TranslatorConfig.php
@@ -43,7 +43,7 @@ class TranslatorConfig
 
     /**
      * looks for translation in old fashion way
-     * @deprecated The child node "books" at path "translator" is deprecated.
+     * @deprecated Since symfony/config 6.0: The child node "books" at path "add_to_list.translator" is deprecated.
     */
     public function books(array $value = []): \Symfony\Config\AddToList\Translator\BooksConfig
     {

--- a/src/Symfony/Component/Config/Tests/Definition/ArrayNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/ArrayNodeTest.php
@@ -239,6 +239,7 @@ class ArrayNodeTest extends TestCase
         $this->assertSame('"foo" is deprecated', $deprecation['message']);
         $this->assertSame('vendor/package', $deprecation['package']);
         $this->assertSame('1.1', $deprecation['version']);
+        $this->assertSame('Since vendor/package 1.1: "foo" is deprecated', $childNode->getDeprecationMessage());
 
         $node = new ArrayNode('root');
         $node->addChild($childNode);

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/BooleanNodeDefinitionTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/BooleanNodeDefinitionTest.php
@@ -61,5 +61,6 @@ class BooleanNodeDefinitionTest extends TestCase
         $this->assertSame('The "foo" node is deprecated.', $deprecation['message']);
         $this->assertSame('vendor/package', $deprecation['package']);
         $this->assertSame('1.1', $deprecation['version']);
+        $this->assertSame('Since vendor/package 1.1: The "foo" node is deprecated.', $node->getDeprecationMessage());
     }
 }

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/EnumNodeDefinitionTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/EnumNodeDefinitionTest.php
@@ -81,10 +81,11 @@ class EnumNodeDefinitionTest extends TestCase
         $node = $def->getNode();
 
         $this->assertTrue($node->isDeprecated());
-        $deprecation = $def->getNode()->getDeprecation($node->getName(), $node->getPath());
+        $deprecation = $node->getDeprecation($node->getName(), $node->getPath());
         $this->assertSame('The "foo" node is deprecated.', $deprecation['message']);
         $this->assertSame('vendor/package', $deprecation['package']);
         $this->assertSame('1.1', $deprecation['version']);
+        $this->assertSame('Since vendor/package 1.1: The "foo" node is deprecated.', $node->getDeprecationMessage());
     }
 
     public function testSameStringCoercedValuesAreDifferent()

--- a/src/Symfony/Component/Config/Tests/Definition/ScalarNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/ScalarNodeTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\Config\Definition\ArrayNode;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Definition\Exception\InvalidTypeException;
 use Symfony\Component\Config\Definition\ScalarNode;
+use Symfony\Component\Config\Exception\LogicException;
 
 class ScalarNodeTest extends TestCase
 {
@@ -52,6 +53,7 @@ class ScalarNodeTest extends TestCase
         $this->assertSame('"foo" is deprecated', $deprecation['message']);
         $this->assertSame('vendor/package', $deprecation['package']);
         $this->assertSame('1.1', $deprecation['version']);
+        $this->assertSame('Since vendor/package 1.1: "foo" is deprecated', $childNode->getDeprecationMessage());
 
         $node = new ArrayNode('root');
         $node->addChild($childNode);
@@ -80,6 +82,16 @@ class ScalarNodeTest extends TestCase
             restore_error_handler();
         }
         $this->assertSame(1, $deprecationTriggered, '->finalize() should trigger if the deprecated node is set');
+    }
+
+    public function testNotDeprecatedException()
+    {
+        $childNode = new ScalarNode('foo');
+
+        $this->assertFalse($childNode->isDeprecated());
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The node "foo" is not deprecated.');
+        $childNode->getDeprecation('node', 'path');
     }
 
     #[DataProvider('getInvalidValues')]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

Avoids repetition of identical code in Yaml and XML dumpers, PHP config generator, and the upcoming [JSON schema](https://github.com/symfony/symfony/pull/59620/files#diff-655b0abb4d17a78c3f29f7180730bd0cfa76ff9abf12bd8414d7eb18cfae9f8bR79) generator.