### PR TITLE
[Console] Specify types of interactive question choices

### DIFF
--- a/src/Symfony/Component/Console/Question/ChoiceQuestion.php
+++ b/src/Symfony/Component/Console/Question/ChoiceQuestion.php
@@ -26,9 +26,9 @@ class ChoiceQuestion extends Question
     private string $errorMessage = 'Value "%s" is invalid';
 
     /**
-     * @param string                     $question The question to ask to the user
-     * @param array                      $choices  The list of available choices
-     * @param string|bool|int|float|null $default  The default answer to return
+     * @param string                       $question The question to ask to the user
+     * @param array<string|bool|int|float> $choices  The list of available choices
+     * @param string|bool|int|float|null   $default  The default answer to return
      */
     public function __construct(string $question, array $choices, string|bool|int|float|null $default = null)
     {
@@ -44,7 +44,7 @@ class ChoiceQuestion extends Question
     }
 
     /**
-     * Returns available choices.
+     * @return array<string|bool|int|float>
      */
     public function getChoices(): array
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61122
| License       | MIT

Passing a non-string value results in a deprecation message when the value is passed to `str_starts_with`.

Replace #61123