### PR TITLE
 Define DefinitionConfigurator generic type for AbstractBundle

### DIFF
--- a/src/Symfony/Component/Config/Definition/Configurator/DefinitionConfigurator.php
+++ b/src/Symfony/Component/Config/Definition/Configurator/DefinitionConfigurator.php
@@ -17,7 +17,7 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\Loader\DefinitionFileLoader;
 
 /**
- * @template T of 'array'|'variable'|'scalar'|'string'|'boolean'|'integer'|'float'|'enum'
+ * @template T of 'array'|'variable'|'scalar'|'string'|'boolean'|'integer'|'float'|'enum' = 'array'
  *
  * @author Yonel Ceruto <yonelceruto@gmail.com>
  */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | yes<!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? |no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

### Why?

Currently all `AbstractBundle` run into:

```
Method CmsIg\Seal\Integration\Symfony\SealBundle::configure() has parameter $definition with generic class Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator but does not specify its types: T
 ------ -------------------------------------------------------------------------
  Line   src/SealBundle.php
 ------ -------------------------------------------------------------------------
  37     Method CmsIg\Seal\Integration\Symfony\SealBundle::configure() has
         parameter $definition with generic class
         Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator
         but does not specify its types: T
 ------ -------------------------------------------------------------------------
 ```

I not even sure what is the correct generic type here. If it is `'scalar'` or `'array'` so I think lot of people are not able to guess the correct one. So we should define the correct one for the AbstractBundle already.

PHPDoc was added in https://github.com/symfony/symfony/commit/8099cda627b004df1914f6e8bfe1102684774fcb by @nicolas-grekas 
