### PR TITLE
[Config] Fix incorrect serialized data mangling

### DIFF
--- a/src/Symfony/Component/Config/ResourceCheckerConfigCache.php
+++ b/src/Symfony/Component/Config/ResourceCheckerConfigCache.php
@@ -126,7 +126,7 @@ class ResourceCheckerConfigCache implements ConfigCacheInterface
             }
 
             $ser = preg_replace_callback('/;O:(\d+):"/', static fn ($m) => ';O:'.(9 + $m[1]).':"Tracking\\', $ser);
-            $ser = preg_replace_callback('/s:(\d+):"\0[^\0]++\0/', static fn ($m) => 's:'.($m[1] - \strlen($m[0]) + 6).':"', $ser);
+            $ser = preg_replace_callback('/s:(\d+):"(\0[^\0]++\0)/', static fn ($m) => 's:'.($m[1] - \strlen($m[2])).':"', $ser);
             $ser = unserialize($ser, ['allowed_classes' => false]);
             $ser = @json_encode($ser, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE) ?: [];
             $ser = str_replace('"__PHP_Incomplete_Class_Name":"Tracking\\\\', '"@type":"', $ser);

--- a/src/Symfony/Component/Config/Tests/Fixtures/ResourceWithVeryVeryVeryVeryVeryVeryVeryVeryLongName.php
+++ b/src/Symfony/Component/Config/Tests/Fixtures/ResourceWithVeryVeryVeryVeryVeryVeryVeryVeryLongName.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Symfony\Component\Config\Tests\Fixtures;
+
+use Symfony\Component\Config\Resource\ResourceInterface;
+
+class ResourceWithVeryVeryVeryVeryVeryVeryVeryVeryLongName implements ResourceInterface
+{
+    public function __construct(private string $resource)
+    {
+    }
+
+    public function __toString(): string
+    {
+        return __CLASS__;
+    }
+}

--- a/src/Symfony/Component/Config/Tests/ResourceCheckerConfigCacheTest.php
+++ b/src/Symfony/Component/Config/Tests/ResourceCheckerConfigCacheTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Config\ResourceCheckerConfigCache;
 use Symfony\Component\Config\ResourceCheckerInterface;
+use Symfony\Component\Config\Tests\Fixtures\ResourceWithVeryVeryVeryVeryVeryVeryVeryVeryLongName;
 use Symfony\Component\Config\Tests\Resource\ResourceStub;
 
 class ResourceCheckerConfigCacheTest extends TestCase
@@ -165,6 +166,23 @@ class ResourceCheckerConfigCacheTest extends TestCase
             'resources' => [
                 [
                     '@type' => FileResource::class,
+                    'resource' => __FILE__,
+                ],
+            ],
+        ], \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE));
+    }
+
+    public function testCacheWithResourceWithLongPropertyId()
+    {
+        $cache = new ResourceCheckerConfigCache($this->cacheFile);
+        $cache->write('foo', [new ResourceWithVeryVeryVeryVeryVeryVeryVeryVeryLongName(__FILE__)]);
+
+        $this->assertStringNotEqualsFile($this->cacheFile.'.meta', '');
+
+        $this->assertStringEqualsFile($this->cacheFile.'.meta.json', json_encode([
+            'resources' => [
+                [
+                    '@type' => ResourceWithVeryVeryVeryVeryVeryVeryVeryVeryLongName::class,
                     'resource' => __FILE__,
                 ],
             ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61806 
| License       | MIT

This takes into account the fact that the property id string consisting of the fully-qualified class name and property name may be more than 100 characters long and its length may thus take up more than 2 characters in the serialized format.