### PR TITLE
[Messenger] Allow to use custom http client for sqs messenger transport

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsTransportFactoryTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsTransportFactoryTest.php
@@ -12,7 +12,10 @@
 namespace Symfony\Component\Messenger\Bridge\AmazonSqs\Tests\Transport;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsTransportFactory;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Transport\Serialization\Serializer;
 
 class AmazonSqsTransportFactoryTest extends TestCase
 {
@@ -24,5 +27,19 @@ class AmazonSqsTransportFactoryTest extends TestCase
         $this->assertTrue($factory->supports('https://sqs.us-east-2.amazonaws.com/123456789012/ab1-MyQueue-A2BCDEF3GHI4', []));
         $this->assertFalse($factory->supports('redis://localhost', []));
         $this->assertFalse($factory->supports('invalid-dsn', []));
+    }
+
+    public function testCustomHttpClient()
+    {
+        $httpClient = new MockHttpClient();
+        $factory = new AmazonSqsTransportFactory(null, $httpClient);
+
+        $transport = $factory->createTransport('https://sqs.us-east-2.amazonaws.com/1111/messages?access_key=KEY&secret_key=SECRET', [], Serializer::create());
+
+        self::assertSame(0, $httpClient->getRequestsCount());
+        $transport->send(new Envelope(new \stdClass(), []));
+
+        // 1 query to check queueExists, 1 query to sendMessage
+        self::assertSame(2, $httpClient->getRequestsCount());
     }
 }

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsTransportFactory.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsTransportFactory.php
@@ -15,6 +15,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\TransportFactoryInterface;
 use Symfony\Component\Messenger\Transport\TransportInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>
@@ -25,6 +26,7 @@ class AmazonSqsTransportFactory implements TransportFactoryInterface
 {
     public function __construct(
         private ?LoggerInterface $logger = null,
+        private ?HttpClientInterface $httpClient = null,
     ) {
     }
 
@@ -32,7 +34,7 @@ class AmazonSqsTransportFactory implements TransportFactoryInterface
     {
         unset($options['transport_name']);
 
-        return new AmazonSqsTransport(Connection::fromDsn($dsn, $options, null, $this->logger), $serializer, null, null, !($options['delete_on_rejection'] ?? false));
+        return new AmazonSqsTransport(Connection::fromDsn($dsn, $options, $this->httpClient, $this->logger), $serializer, null, null, !($options['delete_on_rejection'] ?? false));
     }
 
     public function supports(#[\SensitiveParameter] string $dsn, array $options): bool


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

In some scenarios (test cases) we need to pass specific HTTP client to messenger transport.

