### PR TITLE
[Uid] Default to `UuidV7` when using `UuidFactory`

### DIFF
--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -108,6 +108,11 @@ Translation
 
  * Deprecate `TranslatableMessage::__toString`
 
+Uid
+---
+
+ * Default to `UuidV7` when using `UuidFactory`
+
 Validator
 ---------
 

--- a/src/Symfony/Bridge/Doctrine/Tests/IdGenerator/UuidGeneratorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/IdGenerator/UuidGeneratorTest.php
@@ -15,9 +15,9 @@ use Doctrine\ORM\EntityManager;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\IdGenerator\UuidGenerator;
 use Symfony\Component\Uid\Factory\UuidFactory;
+use Symfony\Component\Uid\TimeBasedUidInterface;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Uid\UuidV4;
-use Symfony\Component\Uid\UuidV6;
 
 class UuidGeneratorTest extends TestCase
 {
@@ -47,13 +47,13 @@ class UuidGeneratorTest extends TestCase
     {
         $em = (new \ReflectionClass(EntityManager::class))->newInstanceWithoutConstructor();
         $generator = new UuidGenerator();
-        $this->assertInstanceOf(UuidV6::class, $generator->generate($em, new Entity()));
+        $this->assertInstanceOf(TimeBasedUidInterface::class, $generator->generate($em, new Entity()));
 
         $generator = $generator->randomBased();
         $this->assertInstanceOf(UuidV4::class, $generator->generate($em, new Entity()));
 
         $generator = $generator->timeBased();
-        $this->assertInstanceOf(UuidV6::class, $generator->generate($em, new Entity()));
+        $this->assertInstanceOf(TimeBasedUidInterface::class, $generator->generate($em, new Entity()));
 
         $generator = $generator->nameBased('prop1', Uuid::NAMESPACE_OID);
         $this->assertEquals(Uuid::v5(new Uuid(Uuid::NAMESPACE_OID), '3'), $generator->generate($em, new Entity()));

--- a/src/Symfony/Component/Uid/CHANGELOG.md
+++ b/src/Symfony/Component/Uid/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add microsecond precision to UUIDv7
+ * Default to `UuidV7` when using `UuidFactory`
 
 7.3
 ---

--- a/src/Symfony/Component/Uid/Factory/UuidFactory.php
+++ b/src/Symfony/Component/Uid/Factory/UuidFactory.php
@@ -16,7 +16,7 @@ use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Uid\UuidV1;
 use Symfony\Component\Uid\UuidV4;
 use Symfony\Component\Uid\UuidV5;
-use Symfony\Component\Uid\UuidV6;
+use Symfony\Component\Uid\UuidV7;
 
 class UuidFactory
 {
@@ -27,7 +27,7 @@ class UuidFactory
     private ?Uuid $timeBasedNode;
     private ?Uuid $nameBasedNamespace;
 
-    public function __construct(string|int $defaultClass = UuidV6::class, string|int $timeBasedClass = UuidV6::class, string|int $nameBasedClass = UuidV5::class, string|int $randomBasedClass = UuidV4::class, Uuid|string|null $timeBasedNode = null, Uuid|string|null $nameBasedNamespace = null)
+    public function __construct(string|int $defaultClass = UuidV7::class, string|int $timeBasedClass = UuidV7::class, string|int $nameBasedClass = UuidV5::class, string|int $randomBasedClass = UuidV4::class, Uuid|string|null $timeBasedNode = null, Uuid|string|null $nameBasedNamespace = null)
     {
         if (null !== $timeBasedNode && !$timeBasedNode instanceof Uuid) {
             $timeBasedNode = Uuid::fromString($timeBasedNode);

--- a/src/Symfony/Component/Uid/Tests/Command/GenerateUuidCommandTest.php
+++ b/src/Symfony/Component/Uid/Tests/Command/GenerateUuidCommandTest.php
@@ -23,7 +23,7 @@ use Symfony\Component\Uid\UuidV1;
 use Symfony\Component\Uid\UuidV3;
 use Symfony\Component\Uid\UuidV4;
 use Symfony\Component\Uid\UuidV5;
-use Symfony\Component\Uid\UuidV6;
+use Symfony\Component\Uid\UuidV7;
 
 final class GenerateUuidCommandTest extends TestCase
 {
@@ -31,7 +31,7 @@ final class GenerateUuidCommandTest extends TestCase
     {
         $commandTester = new CommandTester(new GenerateUuidCommand());
         $this->assertSame(0, $commandTester->execute([]));
-        $this->assertInstanceOf(UuidV6::class, Uuid::fromRfc4122(trim($commandTester->getDisplay())));
+        $this->assertInstanceOf(UuidV7::class, Uuid::fromRfc4122(trim($commandTester->getDisplay())));
 
         $commandTester = new CommandTester(new GenerateUuidCommand(new UuidFactory(UuidV4::class)));
         $this->assertSame(0, $commandTester->execute([]));
@@ -59,17 +59,17 @@ final class GenerateUuidCommandTest extends TestCase
         $commandTester = new CommandTester(new GenerateUuidCommand());
 
         $this->assertSame(1, $commandTester->execute(['--time-based' => '@-16807797990']));
-        $this->assertStringContainsString('The given UUID date cannot be earlier than 1582-10-15.', $commandTester->getDisplay());
+        $this->assertStringContainsString('The timestamp must be positive.', $commandTester->getDisplay());
     }
 
     public function testTimeBased()
     {
         $commandTester = new CommandTester(new GenerateUuidCommand());
         $this->assertSame(0, $commandTester->execute(['--time-based' => 'now']));
-        $this->assertInstanceOf(UuidV6::class, Uuid::fromRfc4122(trim($commandTester->getDisplay())));
+        $this->assertInstanceOf(UuidV7::class, Uuid::fromRfc4122(trim($commandTester->getDisplay())));
 
         $commandTester = new CommandTester(new GenerateUuidCommand(new UuidFactory(
-            UuidV6::class,
+            UuidV7::class,
             UuidV1::class,
             UuidV5::class,
             UuidV4::class,
@@ -104,7 +104,7 @@ final class GenerateUuidCommandTest extends TestCase
         $this->assertInstanceOf(UuidV5::class, Uuid::fromRfc4122(trim($commandTester->getDisplay())));
 
         $commandTester = new CommandTester(new GenerateUuidCommand(new UuidFactory(
-            UuidV6::class,
+            UuidV7::class,
             UuidV1::class,
             UuidV3::class,
             UuidV4::class,

--- a/src/Symfony/Component/Uid/Tests/Factory/UuidFactoryTest.php
+++ b/src/Symfony/Component/Uid/Tests/Factory/UuidFactoryTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\Uid\UuidV3;
 use Symfony\Component\Uid\UuidV4;
 use Symfony\Component\Uid\UuidV5;
 use Symfony\Component\Uid\UuidV6;
+use Symfony\Component\Uid\UuidV7;
 
 final class UuidFactoryTest extends TestCase
 {
@@ -51,7 +52,7 @@ final class UuidFactoryTest extends TestCase
 
     public function testCreateTimedDefaultVersion()
     {
-        $this->assertInstanceOf(UuidV6::class, (new UuidFactory())->timeBased()->create());
+        $this->assertInstanceOf(UuidV7::class, (new UuidFactory())->timeBased()->create());
         $this->assertInstanceOf(UuidV1::class, (new UuidFactory(6, 1))->timeBased()->create());
     }
 
@@ -83,7 +84,7 @@ final class UuidFactoryTest extends TestCase
     public function testInvalidCreateTimed()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The given UUID date cannot be earlier than 1582-10-15.');
+        $this->expectExceptionMessage('The timestamp must be positive.');
 
         (new UuidFactory())->timeBased()->create(new \DateTimeImmutable('@-12219292800.001000'));
     }

--- a/src/Symfony/Component/Uid/Ulid.php
+++ b/src/Symfony/Component/Uid/Ulid.php
@@ -33,15 +33,15 @@ class Ulid extends AbstractUid implements TimeBasedUidInterface
         if (null === $ulid) {
             $this->uid = static::generate();
         } elseif (self::NIL === $ulid) {
-            $this->uid = $ulid;
-        } elseif (self::MAX === strtr($ulid, 'z', 'Z')) {
-            $this->uid = $ulid;
+            $this->uid = self::NIL;
         } else {
-            if (!self::isValid($ulid)) {
+            $this->uid = strtoupper($ulid);
+
+            if (self::MAX === $this->uid) {
+                $this->uid = self::MAX;
+            } elseif (!self::isValid($ulid)) {
                 throw new InvalidArgumentException(\sprintf('Invalid ULID: "%s".', $ulid));
             }
-
-            $this->uid = strtoupper($ulid);
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

UUIDv7 are how time-based UUIDs should have been from day 1 :)

(+ some minor optims to Ulid while at it.)