### PR TITLE
[SecurityBundle] Remove legacy parameter in SecurityDataCollectorTest

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
@@ -40,7 +40,7 @@ class SecurityDataCollectorTest extends TestCase
 {
     public function testCollectWhenSecurityIsDisabled()
     {
-        $collector = new SecurityDataCollector(null, null, null, null, null, null, true);
+        $collector = new SecurityDataCollector(null, null, null, null, null, null);
         $collector->collect(new Request(), new Response());
 
         $this->assertSame('security', $collector->getName());
@@ -60,7 +60,7 @@ class SecurityDataCollectorTest extends TestCase
     public function testCollectWhenAuthenticationTokenIsNull()
     {
         $tokenStorage = new TokenStorage();
-        $collector = new SecurityDataCollector($tokenStorage, $this->getRoleHierarchy(), null, null, null, null, true);
+        $collector = new SecurityDataCollector($tokenStorage, $this->getRoleHierarchy(), null, null, null, null);
         $collector->collect(new Request(), new Response());
 
         $this->assertTrue($collector->isEnabled());
@@ -82,7 +82,7 @@ class SecurityDataCollectorTest extends TestCase
         $tokenStorage = new TokenStorage();
         $tokenStorage->setToken(new UsernamePasswordToken(new InMemoryUser('hhamon', 'P4$$w0rD', $roles), 'provider', $roles));
 
-        $collector = new SecurityDataCollector($tokenStorage, $this->getRoleHierarchy(), null, null, null, null, true);
+        $collector = new SecurityDataCollector($tokenStorage, $this->getRoleHierarchy(), null, null, null, null);
         $collector->collect(new Request(), new Response());
         $collector->lateCollect();
 
@@ -105,7 +105,7 @@ class SecurityDataCollectorTest extends TestCase
         $tokenStorage = new TokenStorage();
         $tokenStorage->setToken(new SwitchUserToken(new InMemoryUser('hhamon', 'P4$$w0rD', ['ROLE_USER', 'ROLE_PREVIOUS_ADMIN']), 'provider', ['ROLE_USER', 'ROLE_PREVIOUS_ADMIN'], $adminToken));
 
-        $collector = new SecurityDataCollector($tokenStorage, $this->getRoleHierarchy(), null, null, null, null, true);
+        $collector = new SecurityDataCollector($tokenStorage, $this->getRoleHierarchy(), null, null, null, null);
         $collector->collect(new Request(), new Response());
         $collector->lateCollect();
 
@@ -135,7 +135,7 @@ class SecurityDataCollectorTest extends TestCase
             ->with($request)
             ->willReturn($firewallConfig);
 
-        $collector = new SecurityDataCollector(null, null, null, null, $firewallMap, new TraceableFirewallListener($firewallMap, new EventDispatcher(), new LogoutUrlGenerator()), true);
+        $collector = new SecurityDataCollector(null, null, null, null, $firewallMap, new TraceableFirewallListener($firewallMap, new EventDispatcher(), new LogoutUrlGenerator()));
         $collector->collect($request, new Response());
         $collector->lateCollect();
         $collected = $collector->getFirewall();
@@ -159,7 +159,7 @@ class SecurityDataCollectorTest extends TestCase
         $response = new Response();
 
         // Don't inject any firewall map
-        $collector = new SecurityDataCollector(null, null, null, null, null, null, true);
+        $collector = new SecurityDataCollector(null, null, null, null, null, null);
         $collector->collect($request, $response);
         $this->assertNull($collector->getFirewall());
 
@@ -169,7 +169,7 @@ class SecurityDataCollectorTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $collector = new SecurityDataCollector(null, null, null, null, $firewallMap, new TraceableFirewallListener($firewallMap, new EventDispatcher(), new LogoutUrlGenerator()), true);
+        $collector = new SecurityDataCollector(null, null, null, null, $firewallMap, new TraceableFirewallListener($firewallMap, new EventDispatcher(), new LogoutUrlGenerator()));
         $collector->collect($request, $response);
         $this->assertNull($collector->getFirewall());
 
@@ -179,7 +179,7 @@ class SecurityDataCollectorTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $collector = new SecurityDataCollector(null, null, null, null, $firewallMap, new TraceableFirewallListener($firewallMap, new EventDispatcher(), new LogoutUrlGenerator()), true);
+        $collector = new SecurityDataCollector(null, null, null, null, $firewallMap, new TraceableFirewallListener($firewallMap, new EventDispatcher(), new LogoutUrlGenerator()));
         $collector->collect($request, $response);
         $this->assertNull($collector->getFirewall());
     }
@@ -213,7 +213,7 @@ class SecurityDataCollectorTest extends TestCase
         $firewall = new TraceableFirewallListener($firewallMap, new EventDispatcher(), new LogoutUrlGenerator());
         $firewall->onKernelRequest($event);
 
-        $collector = new SecurityDataCollector(null, null, null, null, $firewallMap, $firewall, true);
+        $collector = new SecurityDataCollector(null, null, null, null, $firewallMap, $firewall);
         $collector->collect($request, $response);
 
         $this->assertNotEmpty($collected = $collector->getListeners()[0]);
@@ -260,7 +260,7 @@ class SecurityDataCollectorTest extends TestCase
                 ],
             ]]);
 
-        $dataCollector = new SecurityDataCollector(null, null, null, $accessDecisionManager, null, null, true);
+        $dataCollector = new SecurityDataCollector(null, null, null, $accessDecisionManager, null, null);
 
         $dataCollector->collect(new Request(), new Response());
 
@@ -348,7 +348,7 @@ class SecurityDataCollectorTest extends TestCase
                 ],
             ]);
 
-        $dataCollector = new SecurityDataCollector(null, null, null, $accessDecisionManager, null, null, true);
+        $dataCollector = new SecurityDataCollector(null, null, null, $accessDecisionManager, null, null);
 
         $dataCollector->collect(new Request(), new Response());
 
@@ -420,7 +420,7 @@ class SecurityDataCollectorTest extends TestCase
                 'voterDetails' => [],
             ]]);
 
-        $dataCollector = new SecurityDataCollector(null, null, null, $accessDecisionManager, null, null, true);
+        $dataCollector = new SecurityDataCollector(null, null, null, $accessDecisionManager, null, null);
 
         $dataCollector->collect(new Request(), new Response());
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| License       | MIT


From https://github.com/symfony/symfony/pull/61786/files#r2367017362
