### PR TITLE
[Doctrine] Allow `doctrine/data-fixtures` v2 in the root composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -133,7 +133,7 @@
         "async-aws/sns": "^1.0",
         "cache/integration-tests": "dev-master",
         "doctrine/collections": "^1.8|^2.0",
-        "doctrine/data-fixtures": "^1.1",
+        "doctrine/data-fixtures": "^1.1|^2",
         "doctrine/dbal": "^3.6|^4",
         "doctrine/orm": "^2.15|^3",
         "dragonmantank/cron-expression": "^3.1",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

In https://github.com/symfony/symfony/pull/58865, the version constraint for `doctrine/data-persistence` was updated for the root and doctrine bridge. The change in the root `composer.json` was lost in the merge of 7.1 in 7.2.

- [PR merged in 5.4](https://github.com/symfony/symfony/commit/1812aafe0657e0ebcd22174f19110a0e1411e2e3) ✅
- [5.4 merged in 6.4](https://github.com/symfony/symfony/commit/70f7d05bbfcf4f29bd499047e0e7c21eeb5f128f) ✅
- [6.4 merged in 7.1](https://github.com/symfony/symfony/commit/39b5b8f61d428ed5e0f1b16f2e7e2b7df503cbd2) ✅
- [7.1 merged in 7.2](https://github.com/symfony/symfony/commit/e2f2a967158182109faa233b37f26687f6092a96) ❌

This is a **minor change**, as it does not change the constraints of `symfony/doctrine-bridge`. But it's necessary to run tests with the latest package versions.