### PR TITLE
[Notifier] Rename LOX24RequestParser to Lox24RequestParser

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Lox24/Tests/Lox24TransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Lox24/Tests/Lox24TransportTest.php
@@ -78,7 +78,7 @@ class Lox24TransportTest extends TransportTestCase
         $this->assertFalse($transport->supports($message));
     }
 
-    public function testSupportWithNotLOX24Options()
+    public function testSupportWithNotLox24Options()
     {
         $transport = new Lox24Transport('user', 'token', 'testFrom');
         $message = new SmsMessage('test', 'test');

--- a/src/Symfony/Component/Notifier/Bridge/Lox24/Tests/Webhook/Lox24RequestParserTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Lox24/Tests/Webhook/Lox24RequestParserTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Notifier\Bridge\Lox24\Tests\Webhook;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Notifier\Bridge\Lox24\Webhook\LOX24RequestParser;
+use Symfony\Component\Notifier\Bridge\Lox24\Webhook\Lox24RequestParser;
 use Symfony\Component\RemoteEvent\Event\Sms\SmsEvent;
 use Symfony\Component\Webhook\Exception\RejectWebhookException;
 
@@ -22,11 +22,11 @@ use Symfony\Component\Webhook\Exception\RejectWebhookException;
  */
 class Lox24RequestParserTest extends TestCase
 {
-    private LOX24RequestParser $parser;
+    private Lox24RequestParser $parser;
 
     protected function setUp(): void
     {
-        $this->parser = new LOX24RequestParser();
+        $this->parser = new Lox24RequestParser();
     }
 
     public function testInvalidNotificationName()

--- a/src/Symfony/Component/Notifier/Bridge/Lox24/Webhook/Lox24RequestParser.php
+++ b/src/Symfony/Component/Notifier/Bridge/Lox24/Webhook/Lox24RequestParser.php
@@ -23,7 +23,7 @@ use Symfony\Component\Webhook\Exception\RejectWebhookException;
  *
  * @see https://doc.lox24.eu/#section/Introduction/Notifications
  */
-final class LOX24RequestParser extends AbstractRequestParser
+final class Lox24RequestParser extends AbstractRequestParser
 {
     protected function getRequestMatcher(): RequestMatcherInterface
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Fixing an inconsistency with our naming policy.
BC break potential, but still, I wouldn't do it differently - a full BC layer is going to be too costly for something introduced quite recently, and for a bridge very few might use ([115 installs](https://packagist.org/packages/symfony/lox24-notifier/stats) on packagist to date).