### PR TITLE
[Validator] Reviewed and corrected Ukrainian translations for the Val…

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.uk.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.uk.xlf
@@ -472,87 +472,87 @@
             </trans-unit>
             <trans-unit id="122">
                 <source>This file is not a valid video.</source>
-                <target state="needs-review-translation">Цей файл не є дійсним відео.</target>
+                <target>Цей файл не є допустимим відеофайлом.</target>
             </trans-unit>
             <trans-unit id="123">
                 <source>The size of the video could not be detected.</source>
-                <target state="needs-review-translation">Не вдалося визначити розмір відео.</target>
+                <target>Не вдалося визначити розмір відеофайлу.</target>
             </trans-unit>
             <trans-unit id="124">
                 <source>The video width is too big ({{ width }}px). Allowed maximum width is {{ max_width }}px.</source>
-                <target state="needs-review-translation">Ширина відео занадто велика ({{ width }}px). Допустима максимальна ширина — {{ max_width }}px.</target>
+                <target>Ширина відеофайлу занадто велика ({{ width }}px). Максимально допустима ширина {{ max_width }}px.</target>
             </trans-unit>
             <trans-unit id="125">
                 <source>The video width is too small ({{ width }}px). Minimum width expected is {{ min_width }}px.</source>
-                <target state="needs-review-translation">Ширина відео занадто мала ({{ width }}px). Очікувана мінімальна ширина — {{ min_width }}px.</target>
+                <target>Ширина відеофайлу занадто мала ({{ width }}px). Мінімально допустима ширина {{ min_width }}px.</target>
             </trans-unit>
             <trans-unit id="126">
                 <source>The video height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px.</source>
-                <target state="needs-review-translation">Висота відео занадто велика ({{ height }}px). Дозволена максимальна висота — {{ max_height }}px.</target>
+                <target>Висота відеофайлу занадто велика ({{ height }}px). Максимально допустима висота {{ max_height }}px.</target>
             </trans-unit>
             <trans-unit id="127">
                 <source>The video height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px.</source>
-                <target state="needs-review-translation">Висота відео занадто мала ({{ height }}px). Очікувана мінімальна висота — {{ min_height }}px.</target>
+                <target>Висота відеофайлу занадто мала ({{ height }}px). Мінімально допустима висота {{ min_height }}px.</target>
             </trans-unit>
             <trans-unit id="128">
                 <source>The video has too few pixels ({{ pixels }} pixels). Minimum amount expected is {{ min_pixels }} pixels.</source>
-                <target state="needs-review-translation">У відео занадто мало пікселів ({{ pixels }}). Очікувана мінімальна кількість — {{ min_pixels }}.</target>
+                <target>Кількість пікселів у відеофайлі занадто мала ({{ pixels }} пікселів). Мінімально допустима кількість {{ min_pixels }} пікселів.</target>
             </trans-unit>
             <trans-unit id="129">
                 <source>The video has too many pixels ({{ pixels }} pixels). Maximum amount expected is {{ max_pixels }} pixels.</source>
-                <target state="needs-review-translation">У відео забагато пікселів ({{ pixels }}). Очікувана максимальна кількість — {{ max_pixels }}.</target>
+                <target>Кількість пікселів у відеофайлі занадто велика ({{ pixels }} пікселів). Максимально допустима кількість {{ max_pixels }} пікселів.</target>
             </trans-unit>
             <trans-unit id="130">
                 <source>The video ratio is too big ({{ ratio }}). Allowed maximum ratio is {{ max_ratio }}.</source>
-                <target state="needs-review-translation">Співвідношення сторін відео занадто велике ({{ ratio }}). Допустиме максимальне співвідношення — {{ max_ratio }}.</target>
+                <target>Співвідношення сторін відеофайлу занадто велике ({{ ratio }}). Максимально допустиме співвідношення сторін {{ max_ratio }}.</target>
             </trans-unit>
             <trans-unit id="131">
                 <source>The video ratio is too small ({{ ratio }}). Minimum ratio expected is {{ min_ratio }}.</source>
-                <target state="needs-review-translation">Співвідношення сторін відео надто мале ({{ ratio }}). Очікуване мінімальне співвідношення — {{ min_ratio }}.</target>
+                <target>Співвідношення сторін відеофайлу занадто мале ({{ ratio }}). Мінімально допустиме співвідношення сторін {{ min_ratio }}.</target>
             </trans-unit>
             <trans-unit id="132">
                 <source>The video is square ({{ width }}x{{ height }}px). Square videos are not allowed.</source>
-                <target state="needs-review-translation">Відео квадратне ({{ width }}x{{ height }}px). Квадратні відео не дозволені.</target>
+                <target> Відеофайл має квадратні пропорції ({{ width }}x{{ height }}px). Квадратні відеофайли не дозволені.</target>
             </trans-unit>
             <trans-unit id="133">
                 <source>The video is landscape oriented ({{ width }}x{{ height }}px). Landscape oriented videos are not allowed.</source>
-                <target state="needs-review-translation">Відео в альбомній орієнтації ({{ width }}x{{ height }} px). Відео в альбомній орієнтації заборонені.</target>
+                <target>Відеофайл в альбомній орієнтації ({{ width }}x{{ height }}px). Відеофайли в альбомній орієнтації не дозволені.</target>
             </trans-unit>
             <trans-unit id="134">
                 <source>The video is portrait oriented ({{ width }}x{{ height }}px). Portrait oriented videos are not allowed.</source>
-                <target state="needs-review-translation">Відео має портретну орієнтацію ({{ width }}x{{ height }}px). Відео з портретною орієнтацією не дозволені.</target>
+                <target>Відеофайл у портретній орієнтації ({{ width }}x{{ height }}px). Відеофайли у портретній орієнтації не дозволені.</target>
             </trans-unit>
             <trans-unit id="135">
                 <source>The video file is corrupted.</source>
-                <target state="needs-review-translation">Відеофайл пошкоджено.</target>
+                <target>Відеофайл пошкоджено.</target>
             </trans-unit>
             <trans-unit id="136">
                 <source>The video contains multiple streams. Only one stream is allowed.</source>
-                <target state="needs-review-translation">Відео містить кілька потоків. Дозволено лише один потік.</target>
+                <target>Відеофайл містить кілька потоків. Дозволено лише один потік.</target>
             </trans-unit>
             <trans-unit id="137">
                 <source>Unsupported video codec "{{ codec }}".</source>
-                <target state="needs-review-translation">Непідтримуваний відеокодек «{{ codec }}».</target>
+                <target>Непідтримуваний відеокодек «{{ codec }}».</target>
             </trans-unit>
             <trans-unit id="138">
                 <source>Unsupported video container "{{ container }}".</source>
-                <target state="needs-review-translation">Непідтримуваний відеоконтейнер "{{ container }}".</target>
+                <target>Непідтримуваний відеоконтейнер "{{ container }}".</target>
             </trans-unit>
             <trans-unit id="139">
                 <source>The image file is corrupted.</source>
-                <target state="needs-review-translation">Файл зображення пошкоджений.</target>
+                <target>Файл зображення пошкоджено.</target>
             </trans-unit>
             <trans-unit id="140">
                 <source>The image has too few pixels ({{ pixels }} pixels). Minimum amount expected is {{ min_pixels }} pixels.</source>
-                <target state="needs-review-translation">Зображення має надто мало пікселів ({{ pixels }}). Очікувана мінімальна кількість — {{ min_pixels }}.</target>
+                <target>Кількість пікселів у зображенні занадто мала ({{ pixels }} пікселів). Мінімально допустима кількість {{ min_pixels }} пікселів.</target>
             </trans-unit>
             <trans-unit id="141">
                 <source>The image has too many pixels ({{ pixels }} pixels). Maximum amount expected is {{ max_pixels }} pixels.</source>
-                <target state="needs-review-translation">Зображення має надто багато пікселів ({{ pixels }}). Очікувана максимальна кількість — {{ max_pixels }}.</target>
+                <target>Кількість пікселів у зображенні занадто велика ({{ pixels }} пікселів). Максимально допустима кількість {{ max_pixels }} пікселів.</target>
             </trans-unit>
             <trans-unit id="142">
                 <source>This filename does not match the expected charset.</source>
-                <target state="needs-review-translation">Ця назва файлу не відповідає очікуваному набору символів.</target>
+                <target>Назва файлу не відповідає очікуваному набору символів.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no 
| Deprecations? | no
| Issues        | Fix #61643 
| License       | MIT

Reviewed and corrected automatically translated Ukrainian translations so that they match the general tone of the validation messages.

**Examples**

**Before**: `Ширина відео занадто велика ({{ width }}px). Допустима максимальна ширина — {{ max_width }}px.`
**After**: `Ширина відеофайлу занадто велика ({{ width }}px). Максимально допустима ширина {{ max_width }}px.`

**Before**: `У відео занадто мало пікселів ({{ pixels }}). Очікувана мінімальна кількість — {{ min_pixels }}.`
**After**: `Кількість пікселів у відеофайлі занадто мала ({{ pixels }} пікселів). Мінімально допустима кількість {{ min_pixels }} пікселів.`
