### PR TITLE
[DoctrineBridge] Make `EntityUserProvider`s pass attributes to their loader

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
@@ -47,7 +47,10 @@ class EntityUserProvider implements UserProviderInterface, PasswordUpgraderInter
     ) {
     }
 
-    public function loadUserByIdentifier(string $identifier): UserInterface
+    /**
+     * @param ?array $attributes
+     */
+    public function loadUserByIdentifier(string $identifier/* , ?array $attributes = null */): UserInterface
     {
         $repository = $this->getRepository();
         if (null !== $this->property) {
@@ -57,7 +60,11 @@ class EntityUserProvider implements UserProviderInterface, PasswordUpgraderInter
                 throw new \InvalidArgumentException(\sprintf('You must either make the "%s" entity Doctrine Repository ("%s") implement "Symfony\Bridge\Doctrine\Security\User\UserLoaderInterface" or set the "property" option in the corresponding entity provider configuration.', $this->classOrAlias, get_debug_type($repository)));
             }
 
-            $user = $repository->loadUserByIdentifier($identifier);
+            if (null === $attributes = \func_num_args() > 1 ? func_get_arg(1) : null) {
+                $user = $repository->loadUserByIdentifier($identifier);
+            } else {
+                $user = $repository->loadUserByIdentifier($identifier, $attributes);
+            }
         }
 
         if (null === $user) {

--- a/src/Symfony/Bridge/Doctrine/Tests/Security/User/EntityUserProviderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Security/User/EntityUserProviderTest.php
@@ -172,6 +172,24 @@ class EntityUserProviderTest extends TestCase
         $provider->loadUserByIdentifier('name');
     }
 
+    public function testLoadUserByIdentifierShouldPassAttributesToTheUserLoader()
+    {
+        $repository = $this->createMock(UserLoaderRepository::class);
+        $repository->expects($this->once())
+            ->method('loadUserByIdentifier')
+            ->with('name', ['foo' => 'bar'])
+            ->willReturn(
+                $this->createMock(UserInterface::class)
+            );
+
+        $provider = new EntityUserProvider(
+            $this->getManager($this->getObjectManager($repository)),
+            'Symfony\Bridge\Doctrine\Tests\Fixtures\User'
+        );
+
+        $provider->loadUserByIdentifier('name', ['foo' => 'bar']);
+    }
+
     public function testLoadUserByIdentifierShouldDeclineInvalidInterface()
     {
         $repository = $this->createMock(ObjectRepository::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61809
| License       | MIT
