### PR TITLE
[Validator] allow the asterisk to be passed as a string

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Url.php
+++ b/src/Symfony/Component/Validator/Constraints/Url.php
@@ -40,16 +40,16 @@ class Url extends Constraint
     public $normalizer;
 
     /**
-     * @param string[]|null $protocols        The protocols considered to be valid for the URL (e.g. http, https, ftp, etc.) (defaults to ['http', 'https']; use ['*'] to allow any protocol or regex patterns like ['.*'] for custom matching)
-     * @param bool|null     $relativeProtocol Whether to accept URL without the protocol (i.e. //example.com) (defaults to false)
-     * @param string[]|null $groups
-     * @param bool|null     $requireTld       Whether to require the URL to include a top-level domain (defaults to false)
+     * @param string[]|string|null $protocols        The protocols considered to be valid for the URL (e.g. http, https, ftp, etc.) (defaults to ['http', 'https']; use '*' to allow any protocol)
+     * @param bool|null            $relativeProtocol Whether to accept URL without the protocol (i.e. //example.com) (defaults to false)
+     * @param string[]|null        $groups
+     * @param bool|null            $requireTld       Whether to require the URL to include a top-level domain (defaults to false)
      */
     #[HasNamedArguments]
     public function __construct(
         ?array $options = null,
         ?string $message = null,
-        ?array $protocols = null,
+        array|string|null $protocols = null,
         ?bool $relativeProtocol = null,
         ?callable $normalizer = null,
         ?array $groups = null,
@@ -65,6 +65,10 @@ class Url extends Constraint
 
         if (null === ($options['requireTld'] ?? $requireTld)) {
             trigger_deprecation('symfony/validator', '7.1', 'Not passing a value for the "requireTld" option to the Url constraint is deprecated. Its default value will change to "true".');
+        }
+
+        if (\is_string($protocols)) {
+            $protocols = (array) $protocols;
         }
 
         $this->message = $message ?? $this->message;

--- a/src/Symfony/Component/Validator/Tests/Constraints/UrlTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UrlTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Url;
 use Symfony\Component\Validator\Exception\InvalidArgumentException;
@@ -87,6 +88,15 @@ class UrlTest extends TestCase
         $constraint = new Url();
 
         $this->assertFalse($constraint->requireTld);
+    }
+
+    #[TestWith(['*'])]
+    #[TestWith(['http'])]
+    public function testProtocolsAsString(string $protocol)
+    {
+        $constraint = new Url(protocols: $protocol, requireTld: true);
+
+        $this->assertSame([$protocol], $constraint->protocols);
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

making #60561 easier to use
