### PR TITLE
[MonologBridge] Simplify ConsoleFormatterTest

### DIFF
--- a/src/Symfony/Bridge/Monolog/Tests/Formatter/ConsoleFormatterTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Formatter/ConsoleFormatterTest.php
@@ -11,52 +11,17 @@
 
 namespace Symfony\Bridge\Monolog\Tests\Formatter;
 
-use Monolog\Logger;
-use Monolog\LogRecord;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Monolog\Formatter\ConsoleFormatter;
 use Symfony\Bridge\Monolog\Tests\RecordFactory;
 
 class ConsoleFormatterTest extends TestCase
 {
-    /**
-     * @dataProvider providerFormatTests
-     */
-    public function testFormat(array|LogRecord $record, $expectedMessage)
+    public function testFormat()
     {
+        $record = RecordFactory::create(datetime: new \DateTimeImmutable('2013-01-13 12:34:56 Europe/Berlin'));
         $formatter = new ConsoleFormatter();
-        self::assertSame($expectedMessage, $formatter->format($record));
-    }
 
-    public static function providerFormatTests(): array
-    {
-        $currentDateTime = new \DateTimeImmutable();
-
-        $tests = [
-            'record with DateTime object in datetime field' => [
-                'record' => RecordFactory::create(datetime: $currentDateTime),
-                'expectedMessage' => \sprintf(
-                    "%s <fg=cyan>WARNING  </> <comment>[test]</> test\n",
-                    $currentDateTime->format(ConsoleFormatter::SIMPLE_DATE)
-                ),
-            ],
-        ];
-
-        if (Logger::API < 3) {
-            $tests['record with string in datetime field'] = [
-                'record' => [
-                    'message' => 'test',
-                    'context' => [],
-                    'level' => Level::Warning,
-                    'level_name' => Logger::getLevelName(Level::Warning),
-                    'channel' => 'test',
-                    'datetime' => '2019-01-01T00:42:00+00:00',
-                    'extra' => [],
-                ],
-                'expectedMessage' => "2019-01-01T00:42:00+00:00 <fg=cyan>WARNING  </> <comment>[test]</> test\n",
-            ];
-        }
-
-        return $tests;
+        self::assertSame("12:34:56 <fg=cyan>WARNING  </> <comment>[test]</> test\n", $formatter->format($record));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

`ConsoleFormatterTest` contains test logic for Monolog 2. Given that we only support Monolog 3 on the 7.3 branch, that logic is obsolete.