### PR TITLE
[MonologBridge] Deprecate `NotFoundActivationStrategy`

### DIFF
--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -76,6 +76,11 @@ Mime
 
  * Deprecate implementing `__sleep/wakeup()` on `AbstractPart` implementations; use `__(un)serialize()` instead
 
+MonologBridge
+-------------
+
+ * Deprecate class `NotFoundActivationStrategy`, use `HttpCodeActivationStrategy` instead
+
 Routing
 -------
 

--- a/src/Symfony/Bridge/Monolog/CHANGELOG.md
+++ b/src/Symfony/Bridge/Monolog/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+ * Deprecate class `NotFoundActivationStrategy`, use `HttpCodeActivationStrategy` instead
+
 7.0
 ---
 

--- a/src/Symfony/Bridge/Monolog/Handler/FingersCrossed/NotFoundActivationStrategy.php
+++ b/src/Symfony/Bridge/Monolog/Handler/FingersCrossed/NotFoundActivationStrategy.php
@@ -22,6 +22,8 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
  * @author Jordi Boggiano <j.boggiano@seld.be>
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Pierrick Vignand <pierrick.vignand@gmail.com>
+ *
+ * @deprecated since Symfony 7.4, use {@see HttpCodeActivationStrategy} instead
  */
 final class NotFoundActivationStrategy implements ActivationStrategyInterface
 {
@@ -32,6 +34,8 @@ final class NotFoundActivationStrategy implements ActivationStrategyInterface
         array $excludedUrls,
         private ActivationStrategyInterface $inner,
     ) {
+        trigger_deprecation('symfony/monolog-bridge', '7.4', 'The "%s" class is deprecated, use "%s" instead.', __CLASS__, HttpCodeActivationStrategy::class);
+
         $this->exclude = '{('.implode('|', $excludedUrls).')}i';
     }
 

--- a/src/Symfony/Bridge/Monolog/Tests/Handler/FingersCrossed/NotFoundActivationStrategyTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/FingersCrossed/NotFoundActivationStrategyTest.php
@@ -15,6 +15,8 @@ use Monolog\Handler\FingersCrossed\ErrorLevelActivationStrategy;
 use Monolog\Level;
 use Monolog\LogRecord;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Monolog\Handler\FingersCrossed\NotFoundActivationStrategy;
 use Symfony\Bridge\Monolog\Tests\RecordFactory;
@@ -24,6 +26,8 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class NotFoundActivationStrategyTest extends TestCase
 {
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     #[DataProvider('isActivatedProvider')]
     public function testIsActivated(string $url, array|LogRecord $record, bool $expected)
     {

--- a/src/Symfony/Bridge/Monolog/composer.json
+++ b/src/Symfony/Bridge/Monolog/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": ">=8.2",
         "monolog/monolog": "^3",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/service-contracts": "^2.5|^3",
         "symfony/http-kernel": "^6.4|^7.0|^8.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | -
| License       | MIT

Deprecating the class was [mentioned in the PR that added `HttpCodeActivationStrategy`](https://github.com/symfony/symfony/pull/23707#issuecomment-333394507), but was never actually done.

Since MonologBundle v4 will drop support for `excluded_404s`, it would make sense to deprecate this now.