### PR TITLE
[Form] Add new `active_at`, `not_active_at` and `legal_tender` options to `CurrencyType`

### DIFF
--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -40,6 +40,11 @@ DomCrawler
 
  * Disabling HTML5 parsing is deprecated; Symfony 8 will unconditionally use the native HTML5 parser
 
+Form
+----
+
+ * [BC BREAK] The `CurrencyType` returns only the currencies that are active and recognized as [legal tender](https://en.wikipedia.org/wiki/Legal_tender) for the current date; set the `active_at`, and `legal_tender` options to `null` to list all currencies no matter their current state
+
 FrameworkBundle
 ---------------
 

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add `input=date_point` to `DateTimeType`, `DateType` and `TimeType`
  * Add support for guessing form type of enum properties
+ * Add `active_at`, `not_active_at` and `legal_tender` options to `CurrencyType`
 
 7.3
 ---

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CurrencyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CurrencyTypeTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 use Symfony\Component\Form\Extension\Core\Type\CurrencyType;
 use Symfony\Component\Intl\Util\IntlTestHelper;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 
 class CurrencyTypeTest extends BaseTypeTestCase
 {
@@ -34,7 +35,6 @@ class CurrencyTypeTest extends BaseTypeTestCase
 
         $this->assertContainsEquals(new ChoiceView('EUR', 'EUR', 'Euro'), $choices);
         $this->assertContainsEquals(new ChoiceView('USD', 'USD', 'US Dollar'), $choices);
-        $this->assertContainsEquals(new ChoiceView('SIT', 'SIT', 'Slovenian Tolar'), $choices);
     }
 
     #[RequiresPhpExtension('intl')]
@@ -49,7 +49,6 @@ class CurrencyTypeTest extends BaseTypeTestCase
         // Don't check objects for identity
         $this->assertContainsEquals(new ChoiceView('EUR', 'EUR', 'євро'), $choices);
         $this->assertContainsEquals(new ChoiceView('USD', 'USD', 'долар США'), $choices);
-        $this->assertContainsEquals(new ChoiceView('SIT', 'SIT', 'словенський толар'), $choices);
     }
 
     public function testSubmitNull($expected = null, $norm = null, $view = null)
@@ -60,5 +59,64 @@ class CurrencyTypeTest extends BaseTypeTestCase
     public function testSubmitNullUsesDefaultEmptyData($emptyData = 'EUR', $expectedData = 'EUR')
     {
         parent::testSubmitNullUsesDefaultEmptyData($emptyData, $expectedData);
+    }
+
+    #[RequiresPhpExtension('intl')]
+    public function testAnActiveAndLegalTenderCurrencyIn2006()
+    {
+        $choices = $this->factory
+            ->create(static::TESTED_TYPE, null, [
+                'choice_translation_locale' => 'fr',
+                'active_at' => new \DateTimeImmutable('2006-01-01', new \DateTimeZone('Etc/UTC')),
+                'legal_tender' => true,
+            ])
+            ->createView()->vars['choices'];
+
+        $this->assertContainsEquals(new ChoiceView('SIT', 'SIT', 'tolar slovène'), $choices);
+    }
+
+    #[RequiresPhpExtension('intl')]
+    public function testAnExpiredCurrencyIn2007()
+    {
+        $choices = $this->factory
+            ->create(static::TESTED_TYPE, null, [
+                'choice_translation_locale' => 'fr',
+                'legal_tender' => true,
+                // The SIT currency expired on 2007-01-14.
+                'active_at' => new \DateTimeImmutable('2007-01-15', new \DateTimeZone('Etc/UTC')),
+            ])
+            ->createView()->vars['choices'];
+
+        $this->assertNotContainsEquals(new ChoiceView('SIT', 'SIT', 'tolar slovène'), $choices);
+    }
+
+    #[RequiresPhpExtension('intl')]
+    public function testRetrieveExpiredCurrenciesIn2007()
+    {
+        $choices = $this->factory
+            ->create(static::TESTED_TYPE, null, [
+                'choice_translation_locale' => 'fr',
+                'legal_tender' => true,
+                'active_at' => null,
+                // The SIT currency expired on 2007-01-14.
+                'not_active_at' => new \DateTimeImmutable('2007-01-15', new \DateTimeZone('Etc/UTC')),
+            ])
+            ->createView()->vars['choices'];
+
+        $this->assertContainsEquals(new ChoiceView('SIT', 'SIT', 'tolar slovène'), $choices);
+    }
+
+    public function testAnExceptionShouldBeThrownWhenTheActiveAtAndNotActiveAtOptionsAreBothSet()
+    {
+        $this->expectException(InvalidOptionsException::class);
+
+        $this->expectExceptionMessage('The "active_at" and "not_active_at" options cannot be used together.');
+
+        $this->factory
+            ->create(static::TESTED_TYPE, null, [
+                'active_at' => new \DateTimeImmutable(),
+                'not_active_at' => new \DateTimeImmutable(),
+            ])
+            ->createView();
     }
 }

--- a/src/Symfony/Component/Intl/Currencies.php
+++ b/src/Symfony/Component/Intl/Currencies.php
@@ -225,10 +225,10 @@ final class Currencies extends ResourceBundle
             throw new \RuntimeException("Cannot check whether the currency $currency is active or not in $country because they are no validity dates available.");
         }
 
-        $from = \DateTimeImmutable::createFromFormat('Y-m-d', $currencyMetadata['from']);
+        $from = \DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s', $currencyMetadata['from'], new \DateTimeZone('Etc/UTC'));
 
         if (\array_key_exists('to', $currencyMetadata)) {
-            $to = \DateTimeImmutable::createFromFormat('Y-m-d', $currencyMetadata['to']);
+            $to = \DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s', $currencyMetadata['to'], new \DateTimeZone('Etc/UTC'));
         } else {
             $to = null;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Add the options `active_at`, `not_active_at` and `legal_tender` from #61431 that give the possibility to filter the currencies more precisely. For instance:
- Keep only the current ones for the given `active_at` (`today` by default)
- Keep only the currencies that are [legal tender](https://en.wikipedia.org/wiki/Legal_tender)

Regarding BC compatibility, if people want to have the same results as prior 7.4, they should set the `active_at` and `legal_tender` options to null explicitely.
