### PR TITLE
[Notifier][LOX24] Add Lox24 webhook request parser support

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -3287,6 +3287,7 @@ class FrameworkExtension extends Extension
             $loader->load('notifier_webhook.php');
 
             $webhookRequestParsers = [
+                NotifierBridge\Lox24\Webhook\Lox24RequestParser::class => 'notifier.webhook.request_parser.lox24',
                 NotifierBridge\Smsbox\Webhook\SmsboxRequestParser::class => 'notifier.webhook.request_parser.smsbox',
                 NotifierBridge\Sweego\Webhook\SweegoRequestParser::class => 'notifier.webhook.request_parser.sweego',
                 NotifierBridge\Twilio\Webhook\TwilioRequestParser::class => 'notifier.webhook.request_parser.twilio',

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_webhook.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_webhook.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Symfony\Component\Notifier\Bridge\Lox24\Webhook\Lox24RequestParser;
 use Symfony\Component\Notifier\Bridge\Smsbox\Webhook\SmsboxRequestParser;
 use Symfony\Component\Notifier\Bridge\Sweego\Webhook\SweegoRequestParser;
 use Symfony\Component\Notifier\Bridge\Twilio\Webhook\TwilioRequestParser;
@@ -18,6 +19,9 @@ use Symfony\Component\Notifier\Bridge\Vonage\Webhook\VonageRequestParser;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
+        ->set('notifier.webhook.request_parser.lox24', Lox24RequestParser::class)
+        ->alias(Lox24RequestParser::class, 'notifier.webhook.request_parser.lox24')
+
         ->set('notifier.webhook.request_parser.smsbox', SmsboxRequestParser::class)
         ->alias(SmsboxRequestParser::class, 'notifier.webhook.request_parser.smsbox')
 

--- a/src/Symfony/Component/Notifier/Bridge/Lox24/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Lox24/README.md
@@ -64,6 +64,49 @@ $sms->options($options);
 $texter->send($sms);
 ```
 
+Usage in Combination with the Notifier Component
+------------------------------------------------
+
+The usage of the Webhook component when using a third-party transport in
+the Notifier is very similar to the usage with the Mailer.
+
+Currently, the LOX24 SMS transport supports webhooks. Parser service name ``notifier.webhook.request_parser.lox24``.
+
+For SMS webhooks, react to the class:`Symfony\\Component\\RemoteEvent\\Event\\Sms\\SmsEvent` event.
+
+Other LOX24 webhooks are also possible to handle as class:`Symfony\\Component\\RemoteEvent\\RemoteEvent` instances:
+
+```
+    use Symfony\Component\RemoteEvent\Attribute\AsRemoteEventConsumer;
+    use Symfony\Component\RemoteEvent\Consumer\ConsumerInterface;
+    use Symfony\Component\RemoteEvent\Event\Sms\SmsEvent;
+    use Symfony\Component\RemoteEvent\RemoteEvent;
+
+    #[AsRemoteEventConsumer('notifier_lox24')]
+    class WebhookListener implements ConsumerInterface
+    {
+        public function consume(RemoteEvent $event): void
+        {
+            if ($event instanceof SmsEvent) {
+                $this->handleSmsEvent($event);
+            } else {
+                // Handle other LOX24 webhook events
+                $this->handleRemoteEvent($event);
+            }
+        }
+
+        private function handleSmsEvent(SmsEvent $event): void
+        {
+            // Handle the SMS event
+        }
+
+        private function handleRemoteEvent(RemoteEvent $event): void
+        {
+            // Handle other LOX24 webhook events
+        }
+    }
+```
+
 Resources
 ---------
 

--- a/src/Symfony/Component/Notifier/Bridge/Lox24/Webhook/Lox24RequestParser.php
+++ b/src/Symfony/Component/Notifier/Bridge/Lox24/Webhook/Lox24RequestParser.php
@@ -67,7 +67,7 @@ final class Lox24RequestParser extends AbstractRequestParser
     {
         return match ($eventName) {
             'sms.delivery', 'sms.delivery.dryrun' => $this->createDeliveryEvent($data, $payload),
-            default => $this->createRemoteEvent($eventName, $payload),
+            default => new RemoteEvent($eventName, $payload['id'], $payload),
         };
     }
 
@@ -119,10 +119,5 @@ final class Lox24RequestParser extends AbstractRequestParser
         };
 
         return new SmsEvent($eventType, $data['id'], $payload);
-    }
-
-    private function createRemoteEvent(string $eventName, array $payload): RemoteEvent
-    {
-        return new RemoteEvent($eventName, $payload['id'], $payload);
     }
 }


### PR DESCRIPTION
# Add Lox24 webhook request parser support

| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | N/A
| License       | MIT

This PR adds support for Lox24 webhook request parser to the Symfony Notifier component, enabling developers to handle webhook callbacks from the Lox24 SMS service.

## What it does and why it's needed

- Registers the `Lox24RequestParser` service in the DI container
- Adds the parser to the webhook request parsers registry
- Enables automatic webhook parsing for Lox24 SMS delivery notifications


This change maintains consistency with existing webhook parsers (Smsbox, Sweego, Twilio, Vonage) and follows the same registration pattern.