### PR TITLE
[Validator] deprecate passing an associative array to GroupSequence

### DIFF
--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -122,6 +122,19 @@ Uid
 Validator
 ---------
 
+ * Deprecate handling associative arrays in `GroupSequence`
+
+   *Before*
+
+   ```php
+   $groupSequence = GroupSequence(['value' => ['group 1', 'group 2']]);
+   ```
+
+   *After*
+
+   ```php
+   $groupSequence = GroupSequence(['group 1', 'group 2']);
+   ```
  * Deprecate configuring constraint options implicitly with the XML format
 
    *Before*

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -4,6 +4,19 @@ CHANGELOG
 7.4
 ---
 
+ * Deprecate handling associative arrays in `GroupSequence`
+
+   Before:
+
+   ```php
+   $groupSequence = GroupSequence(['value' => ['group 1', 'group 2']]);
+   ```
+
+   After:
+
+   ```php
+   $groupSequence = GroupSequence(['group 1', 'group 2']);
+   ```
  * Deprecate configuring constraint options implicitly with the XML format
 
    Before:

--- a/src/Symfony/Component/Validator/Constraints/GroupSequence.php
+++ b/src/Symfony/Component/Validator/Constraints/GroupSequence.php
@@ -80,6 +80,10 @@ class GroupSequence
     #[HasNamedArguments]
     public function __construct(array $groups)
     {
+        if (!array_is_list($groups)) {
+            trigger_deprecation('symfony/validator', '7.4', 'Support for passing an array of options to "%s()" is deprecated.', __METHOD__);
+        }
+
         $this->groups = $groups['value'] ?? $groups;
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/GroupSequenceTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GroupSequenceTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\GroupSequence;
 
@@ -26,8 +28,12 @@ class GroupSequenceTest extends TestCase
         $this->assertSame(['Group 1', 'Group 2'], $sequence->groups);
     }
 
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
     public function testCreateDoctrineStyle()
     {
+        $this->expectUserDeprecationMessage('Since symfony/validator 7.4: Support for passing an array of options to "Symfony\Component\Validator\Constraints\GroupSequence::__construct()" is deprecated.');
+
         $sequence = new GroupSequence(['value' => ['Group 1', 'Group 2']]);
 
         $this->assertSame(['Group 1', 'Group 2'], $sequence->groups);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | 
| License       | MIT