### PR TITLE
[Messenger] Add `MessageSentToTransportsEvent`

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Allow any `ServiceResetterInterface` implementation in `ResetServicesListener`
  * Add `Symfony\Component\Messenger\Middleware\AddDefaultStampsMiddleware` and `Symfony\Component\Messenger\Message\DefaultStampsProviderInterface`
  * Add the possibility to configure exchange to exchange bindings in AMQP transport
+ * Add `MessageSentToTransportsEvent` that is dispatched only after the message was sent to at least one transport
 
 7.3
 ---

--- a/src/Symfony/Component/Messenger/Event/MessageSentToTransportsEvent.php
+++ b/src/Symfony/Component/Messenger/Event/MessageSentToTransportsEvent.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Event;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
+
+/**
+ * Event is dispatched after a message is sent to the transport.
+ *
+ * The event is *only* dispatched if the message was actually
+ * sent to at least one transport. If the message was sent
+ * to multiple transports, the event is dispatched only once.
+ */
+final class MessageSentToTransportsEvent
+{
+    /**
+     * @param array<string, SenderInterface> $senders
+     */
+    public function __construct(
+        private Envelope $envelope,
+        private array $senders,
+    ) {
+    }
+
+    public function getEnvelope(): Envelope
+    {
+        return $this->envelope;
+    }
+
+    /**
+     * @return array<string, SenderInterface>
+     */
+    public function getSenders(): array
+    {
+        return $this->senders;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR adds a `MessageSentToTransportsEvent`, that is dispatched only after a message was sent to at least one transport. This can be useful, for example, for additional monitoring.
