### PR TITLE
[ExpressionLanguage] add Stringable contract to Expression class

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Expression.php
+++ b/src/Symfony/Component/ExpressionLanguage/Expression.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\ExpressionLanguage;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class Expression
+class Expression implements \Stringable
 {
     public function __construct(
         protected string $expression,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

Added `Stringable` interface to Expression.php to clearly use it, for example:
<img width="761" height="183" alt="image" src="https://github.com/user-attachments/assets/04d0cb0e-af7d-4ead-891b-986b72f069fc" />
