### PR TITLE
[Validator] remove support for passing associative arrays to GroupSequence

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -531,6 +531,19 @@ Uid
 Validator
 ---------
 
+ * Remove support for passing associative arrays to `GroupSequence`
+
+   *Before*
+
+   ```php
+   $groupSequence = GroupSequence(['value' => ['group 1', 'group 2']]);
+   ```
+
+   *After*
+
+   ```php
+   $groupSequence = GroupSequence(['group 1', 'group 2']);
+   ```
  * Change the default value of the `$requireTld` option of the `Url` constraint to `true`
  * Add method `getGroupProvider()` to `ClassMetadataInterface`
  * Replace `__sleep/wakeup()` by `__(un)serialize()`  on `GenericMetadata` implementations
@@ -539,7 +552,7 @@ Validator
  * Remove support for evaluating options in the base `Constraint` class. Initialize properties in the constructor of the concrete constraint
    class instead.
 
-   Before:
+   *Before*
 
    ```php
    class CustomConstraint extends Constraint
@@ -554,7 +567,7 @@ Validator
    }
    ```
 
-   After:
+   *After*
 
    ```php
    class CustomConstraint extends Constraint
@@ -572,7 +585,7 @@ Validator
 
  * Remove the `getRequiredOptions()` method from the base `Constraint` class. Use mandatory constructor arguments instead.
 
-   Before:
+   *Before*
 
    ```php
    class CustomConstraint extends Constraint
@@ -592,7 +605,7 @@ Validator
    }
    ```
 
-   After:
+   *After*
 
    ```php
    class CustomConstraint extends Constraint
@@ -612,7 +625,7 @@ Validator
  * Remove support for passing an array of options to the `Composite` constraint class. Initialize the properties referenced with `getNestedConstraints()`
    in child classes before calling the constructor of `Composite`.
 
-   Before:
+   *Before*
 
    ```php
    class CustomCompositeConstraint extends Composite
@@ -631,7 +644,7 @@ Validator
    }
    ```
 
-   After:
+   *After*
 
    ```php
    class CustomCompositeConstraint extends Composite

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -4,6 +4,19 @@ CHANGELOG
 8.0
 ---
 
+ * Remove support for passing associative arrays to `GroupSequence`
+
+   Before:
+
+   ```php
+   $groupSequence = GroupSequence(['value' => ['group 1', 'group 2']]);
+   ```
+
+   After:
+
+   ```php
+   $groupSequence = GroupSequence(['group 1', 'group 2']);
+   ```
  * Change the default value of the `$requireTld` option of the `Url` constraint to `true`
  * Add method `getGroupProvider()` to `ClassMetadataInterface`
  * Replace `__sleep/wakeup()` by `__(un)serialize()`  on `GenericMetadata` implementations

--- a/src/Symfony/Component/Validator/Constraints/GroupSequence.php
+++ b/src/Symfony/Component/Validator/Constraints/GroupSequence.php
@@ -77,10 +77,6 @@ class GroupSequence
      */
     public function __construct(array $groups)
     {
-        if (!array_is_list($groups)) {
-            trigger_deprecation('symfony/validator', '7.4', 'Support for passing an array of options to "%s()" is deprecated.', __METHOD__);
-        }
-
-        $this->groups = $groups['value'] ?? $groups;
+        $this->groups = $groups;
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/GroupSequenceTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GroupSequenceTest.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\GroupSequence;
 
@@ -24,17 +22,6 @@ class GroupSequenceTest extends TestCase
     public function testCreate()
     {
         $sequence = new GroupSequence(['Group 1', 'Group 2']);
-
-        $this->assertSame(['Group 1', 'Group 2'], $sequence->groups);
-    }
-
-    #[Group('legacy')]
-    #[IgnoreDeprecations]
-    public function testCreateDoctrineStyle()
-    {
-        $this->expectUserDeprecationMessage('Since symfony/validator 7.4: Support for passing an array of options to "Symfony\Component\Validator\Constraints\GroupSequence::__construct()" is deprecated.');
-
-        $sequence = new GroupSequence(['value' => ['Group 1', 'Group 2']]);
 
         $this->assertSame(['Group 1', 'Group 2'], $sequence->groups);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT
