### PR TITLE
[Config] Config builders should accept booleans for array nodes that can be enabled or disabled

### DIFF
--- a/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
@@ -354,7 +354,7 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
             ->treatNullLike(['enabled' => true])
             ->beforeNormalization()
                 ->ifArray()
-                ->then(function (array $v) {
+                ->then(static function ($v) {
                     $v['enabled'] ??= true;
 
                     return $v;
@@ -527,8 +527,14 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
         }
 
         if (isset($this->normalization)) {
+            $allowedTypes = $this->allowedTypes ?? $this->normalization->declaredTypes;
+            foreach ([$this->trueEquivalent, $this->falseEquivalent] as $equivalent) {
+                if (\is_array($equivalent) && $equivalent) {
+                    $allowedTypes[] = ExprBuilder::TYPE_BOOL;
+                }
+            }
             $node->setNormalizationClosures($this->normalization->before);
-            $node->setNormalizedTypes($this->allowedTypes ?? $this->normalization->declaredTypes);
+            $node->setNormalizedTypes($allowedTypes ?: [ExprBuilder::TYPE_ARRAY]);
             $node->setXmlRemappings($this->normalization->remappings);
         }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayValues/Symfony/Config/ArrayValuesConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayValues/Symfony/Config/ArrayValuesConfig.php
@@ -42,11 +42,22 @@ class ArrayValuesConfig implements \Symfony\Component\Config\Builder\ConfigBuild
     }
 
     /**
+     * @template TValue of array|bool
+     * @param TValue $value
      * @default {"enabled":false}
-    */
-    public function errorPages(array $value = []): \Symfony\Config\ArrayValues\ErrorPagesConfig
+     * @return \Symfony\Config\ArrayValues\ErrorPagesConfig|$this
+     * @psalm-return (TValue is array ? \Symfony\Config\ArrayValues\ErrorPagesConfig : static)
+     */
+    public function errorPages(array|bool $value = []): \Symfony\Config\ArrayValues\ErrorPagesConfig|static
     {
-        if (null === $this->errorPages) {
+        if (!\is_array($value)) {
+            $this->_usedProperties['errorPages'] = true;
+            $this->errorPages = $value;
+
+            return $this;
+        }
+
+        if (!$this->errorPages instanceof \Symfony\Config\ArrayValues\ErrorPagesConfig) {
             $this->_usedProperties['errorPages'] = true;
             $this->errorPages = new \Symfony\Config\ArrayValues\ErrorPagesConfig($value);
         } elseif (0 < \func_num_args()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Continuing my journey on the config component, after #51273

That could be considered as a bugfix, but it's not worth fixing on lower branches because nobody is using this missing capability - by definition.

So: this allows doing eg `->lock(false)` to disable locks, as expected when the node definition has `->treatFalseLike(['enabled' => false])`

Note that I didn't turn `->treatNullLike(['enabled' => true])` into accepting `null` as I don't see the point of allowing  `->lock(null)` when one can use  `->lock(true)`.