### PR TITLE
[Console] Ensure terminal is usable after termination signal

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -1018,14 +1018,6 @@ class Application implements ResetInterface
                 throw new RuntimeException('Unable to subscribe to signal events. Make sure that the "pcntl" extension is installed and that "pcntl_*" functions are not disabled by your php.ini\'s "disable_functions" directive.');
             }
 
-            if (Terminal::hasSttyAvailable()) {
-                $sttyMode = shell_exec('stty -g');
-
-                foreach ([\SIGINT, \SIGTERM] as $signal) {
-                    $this->signalRegistry->register($signal, static fn () => shell_exec('stty '.$sttyMode));
-                }
-            }
-
             if ($this->dispatcher) {
                 // We register application signals, so that we can dispatch the event
                 foreach ($this->signalsToDispatchEvent as $signal) {

--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -258,11 +258,7 @@ class QuestionHelper extends Helper
         $ofs = -1;
         $matches = $autocomplete($ret);
         $numMatches = \count($matches);
-
-        $sttyMode = shell_exec('stty -g');
-        $isStdin = 'php://stdin' === (stream_get_meta_data($inputStream)['uri'] ?? null);
-        $r = [$inputStream];
-        $w = [];
+        $inputHelper = new TerminalInputHelper($inputStream);
 
         // Disable icanon (so we can fread each keypress) and echo (we'll do echoing here instead)
         shell_exec('stty -icanon -echo');
@@ -272,15 +268,13 @@ class QuestionHelper extends Helper
 
         // Read a keypress
         while (!feof($inputStream)) {
-            while ($isStdin && 0 === @stream_select($r, $w, $w, 0, 100)) {
-                // Give signal handlers a chance to run
-                $r = [$inputStream];
-            }
+            $inputHelper->waitForInput();
             $c = fread($inputStream, 1);
 
             // as opposed to fgets(), fread() returns an empty string when the stream content is empty, not false.
             if (false === $c || ('' === $ret && '' === $c && null === $question->getDefault())) {
-                shell_exec('stty '.$sttyMode);
+                // Restore the terminal so it behaves normally again
+                $inputHelper->finish();
                 throw new MissingInputException('Aborted.');
             } elseif ("\177" === $c) { // Backspace Character
                 if (0 === $numMatches && 0 !== $i) {
@@ -382,8 +376,8 @@ class QuestionHelper extends Helper
             }
         }
 
-        // Reset stty so it behaves normally again
-        shell_exec('stty '.$sttyMode);
+        // Restore the terminal so it behaves normally again
+        $inputHelper->finish();
 
         return $fullChoice;
     }
@@ -434,12 +428,16 @@ class QuestionHelper extends Helper
             return $value;
         }
 
+        $inputHelper = null;
+
         if (self::$stty && Terminal::hasSttyAvailable()) {
-            $sttyMode = shell_exec('stty -g');
+            $inputHelper = new TerminalInputHelper($inputStream);
             shell_exec('stty -echo');
         } elseif ($this->isInteractiveInput($inputStream)) {
             throw new RuntimeException('Unable to hide the response.');
         }
+
+        $inputHelper?->waitForInput();
 
         $value = fgets($inputStream, 4096);
 
@@ -448,9 +446,8 @@ class QuestionHelper extends Helper
             $errOutput->warning('The value was possibly truncated by your shell or terminal emulator');
         }
 
-        if (self::$stty && Terminal::hasSttyAvailable()) {
-            shell_exec('stty '.$sttyMode);
-        }
+        // Restore the terminal so it behaves normally again
+        $inputHelper?->finish();
 
         if (false === $value) {
             throw new MissingInputException('Aborted.');

--- a/src/Symfony/Component/Console/Helper/TerminalInputHelper.php
+++ b/src/Symfony/Component/Console/Helper/TerminalInputHelper.php
@@ -1,0 +1,144 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Helper;
+
+/**
+ * TerminalInputHelper stops Ctrl-C and similar signals from leaving the terminal in
+ * an unusable state if its settings have been modified when reading user input.
+ * This can be an issue on non-Windows platforms.
+ *
+ * Usage:
+ *
+ *     $inputHelper = new TerminalInputHelper($inputStream);
+ *
+ *     ...change terminal settings
+ *
+ *     // Wait for input before all input reads
+ *     $inputHelper->waitForInput();
+ *
+ *     ...read input
+ *
+ *     // Call finish to restore terminal settings and signal handlers
+ *     $inputHelper->finish()
+ *
+ * @internal
+ */
+final class TerminalInputHelper
+{
+    /** @var resource */
+    private $inputStream;
+    private bool $isStdin;
+    private string $initialState;
+    private int $signalToKill = 0;
+    private array $signalHandlers = [];
+    private array $targetSignals = [];
+
+    /**
+     * @param resource $inputStream
+     *
+     * @throws \RuntimeException If unable to read terminal settings
+     */
+    public function __construct($inputStream)
+    {
+        if (!\is_string($state = shell_exec('stty -g'))) {
+            throw new \RuntimeException('Unable to read the terminal settings.');
+        }
+        $this->inputStream = $inputStream;
+        $this->initialState = $state;
+        $this->isStdin = 'php://stdin' === stream_get_meta_data($inputStream)['uri'];
+        $this->createSignalHandlers();
+    }
+
+    /**
+     * Waits for input and terminates if sent a default signal.
+     */
+    public function waitForInput(): void
+    {
+        if ($this->isStdin) {
+            $r = [$this->inputStream];
+            $w = [];
+
+            // Allow signal handlers to run, either before Enter is pressed
+            // when icanon is enabled, or a single character is entered when
+            // icanon is disabled
+            while (0 === @stream_select($r, $w, $w, 0, 100)) {
+                $r = [$this->inputStream];
+            }
+        }
+        $this->checkForKillSignal();
+    }
+
+    /**
+     * Restores terminal state and signal handlers.
+     */
+    public function finish(): void
+    {
+        // Safeguard in case an unhandled kill signal exists
+        $this->checkForKillSignal();
+        shell_exec('stty '.$this->initialState);
+        $this->signalToKill = 0;
+
+        foreach ($this->signalHandlers as $signal => $originalHandler) {
+            pcntl_signal($signal, $originalHandler);
+        }
+        $this->signalHandlers = [];
+        $this->targetSignals = [];
+    }
+
+    private function createSignalHandlers(): void
+    {
+        if (!\function_exists('pcntl_async_signals') || !\function_exists('pcntl_signal')) {
+            return;
+        }
+
+        pcntl_async_signals(true);
+        $this->targetSignals = [\SIGINT, \SIGQUIT, \SIGTERM];
+
+        foreach ($this->targetSignals as $signal) {
+            $this->signalHandlers[$signal] = pcntl_signal_get_handler($signal);
+
+            pcntl_signal($signal, function ($signal) {
+                // Save current state, then restore to initial state
+                $currentState = shell_exec('stty -g');
+                shell_exec('stty '.$this->initialState);
+                $originalHandler = $this->signalHandlers[$signal];
+
+                if (\is_callable($originalHandler)) {
+                    $originalHandler($signal);
+                    // Handler did not exit, so restore to current state
+                    shell_exec('stty '.$currentState);
+
+                    return;
+                }
+
+                // Not a callable, so SIG_DFL or SIG_IGN
+                if (\SIG_DFL === $originalHandler) {
+                    $this->signalToKill = $signal;
+                }
+            });
+        }
+    }
+
+    private function checkForKillSignal(): void
+    {
+        if (\in_array($this->signalToKill, $this->targetSignals, true)) {
+            // Try posix_kill
+            if (\function_exists('posix_kill')) {
+                pcntl_signal($this->signalToKill, \SIG_DFL);
+                posix_kill(getmypid(), $this->signalToKill);
+            }
+
+            // Best attempt fallback
+            exit(128 + $this->signalToKill);
+        }
+    }
+}

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -2199,6 +2199,31 @@ class ApplicationTest extends TestCase
      */
     public function testSignalableRestoresStty()
     {
+        $params = [__DIR__.'/Fixtures/application_signalable.php'];
+        $this->runRestoresSttyTest($params, 254, true);
+    }
+
+    /**
+     * @group tty
+     *
+     * @dataProvider provideTerminalInputHelperOption
+     */
+    public function testTerminalInputHelperRestoresStty(string $option)
+    {
+        $params = [__DIR__.'/Fixtures/application_sttyhelper.php', $option];
+        $this->runRestoresSttyTest($params, 0, false);
+    }
+
+    public static function provideTerminalInputHelperOption()
+    {
+        return [
+            ['--choice'],
+            ['--hidden'],
+        ];
+    }
+
+    private function runRestoresSttyTest(array $params, int $expectedExitCode, bool $equals)
+    {
         if (!Terminal::hasSttyAvailable()) {
             $this->markTestSkipped('stty not available');
         }
@@ -2209,22 +2234,29 @@ class ApplicationTest extends TestCase
 
         $previousSttyMode = shell_exec('stty -g');
 
-        $p = new Process(['php', __DIR__.'/Fixtures/application_signalable.php']);
+        array_unshift($params, 'php');
+        $p = new Process($params);
         $p->setTty(true);
         $p->start();
 
         for ($i = 0; $i < 10 && shell_exec('stty -g') === $previousSttyMode; ++$i) {
-            usleep(100000);
+            usleep(200000);
         }
 
         $this->assertNotSame($previousSttyMode, shell_exec('stty -g'));
         $p->signal(\SIGINT);
-        $p->wait();
+        $exitCode = $p->wait();
 
         $sttyMode = shell_exec('stty -g');
         shell_exec('stty '.$previousSttyMode);
 
         $this->assertSame($previousSttyMode, $sttyMode);
+
+        if ($equals) {
+            $this->assertEquals($expectedExitCode, $exitCode);
+        } else {
+            $this->assertNotEquals($expectedExitCode, $exitCode);
+        }
     }
 
     private function createSignalableApplication(Command $command, ?EventDispatcherInterface $dispatcher): Application

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_signalable.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_signalable.php
@@ -20,7 +20,7 @@ require $vendor.'/vendor/autoload.php';
 
     public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false
     {
-        exit(0);
+        exit(254);
     }
 })
     ->setCode(function(InputInterface $input, OutputInterface $output) {

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_sttyhelper.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_sttyhelper.php
@@ -1,0 +1,37 @@
+<?php
+
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\SingleCommandApplication;
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = dirname($vendor);
+}
+require $vendor.'/vendor/autoload.php';
+
+(new class extends SingleCommandApplication {})
+    ->setDefinition(new InputDefinition([
+        new InputOption('choice', null, InputOption::VALUE_NONE, ''),
+        new InputOption('hidden', null, InputOption::VALUE_NONE, ''),
+    ]))
+    ->setCode(function (InputInterface $input, OutputInterface $output) {
+        if ($input->getOption('choice')) {
+            $this->getHelper('question')
+                 ->ask($input, $output, new ChoiceQuestion('😊', ['n']));
+        } else {
+            $question = new Question('😊');
+            $question->setHidden(true);
+            $this->getHelper('question')
+                 ->ask($input, $output, $question);
+        }
+
+        return 0;
+    })
+    ->run()
+
+;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Issues        | Fix #61732
| License       | MIT

This PR introduces a new helper `TerminalInputHelper` that restores the terminal to its original state after it has been modified when reading using input. This ensures that the terminal is not broken when a terminating signal, like Ctrl-C, is received.

QuestionHelper.php disables `icanon` and `echo` when accepting input from a selection, and disables `echo` when accepting hidden input. If these are not restored before termination, the user's terminal can end up in a broken state.

Usage:
```php

$inputHelper = new TerminalInputHelper($inputStream);

// Change terminal settings then wait for input before all input reads
$inputHelper->waitForInput();

// Read the input then call finish to restore terminal settings and signal handlers
$inputHelper->finish()
```

The helper creates its own signal handlers (for `SIGINT`, `SIGQUIT`,  and `SIGTERM`) that restore the original terminal settings then call any original handler callback. If the original handler callback does not terminate the process then the current terminal settings are restored.

If there is no original signal handler callback and the signal's disposition is set to the default action (`SIG_DFL`), then that action is invoked by a `posix_kill` call.

The `finish` method restores the terminal settings and replaces the new signal handlers with the original ones.
