### PR TITLE
[PhpUnitBridge] Move Doctrine deprecations setup to extension

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/SymfonyExtension.php
+++ b/src/Symfony/Bridge/PhpUnit/SymfonyExtension.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bridge\PhpUnit;
 
+use Doctrine\Deprecations\Deprecation;
 use PHPUnit\Event\Code\Test;
 use PHPUnit\Event\Code\TestMethod;
 use PHPUnit\Event\Test\BeforeTestMethodErrored;
@@ -40,6 +41,10 @@ class SymfonyExtension implements Extension
     {
         if (class_exists(DebugClassLoader::class)) {
             DebugClassLoader::enable();
+        }
+
+        if (class_exists(Deprecation::class)) {
+            Deprecation::withoutDeduplication();
         }
 
         $reader = new AttributeReader();

--- a/src/Symfony/Bridge/PhpUnit/bootstrap.php
+++ b/src/Symfony/Bridge/PhpUnit/bootstrap.php
@@ -12,12 +12,13 @@
 use Doctrine\Deprecations\Deprecation;
 use Symfony\Bridge\PhpUnit\DeprecationErrorHandler;
 
+// Skip if we're using PHPUnit >=10
+if (class_exists(PHPUnit\Metadata\Metadata::class, false)) {
+    return;
+}
+
 // Detect if we need to serialize deprecations to a file.
-if (
-    // Skip if we're using PHPUnit >=10
-    !class_exists(PHPUnit\Metadata\Metadata::class)
-    && in_array(\PHP_SAPI, ['cli', 'phpdbg'], true) && $file = getenv('SYMFONY_DEPRECATIONS_SERIALIZE')
-) {
+if (in_array(\PHP_SAPI, ['cli', 'phpdbg'], true) && $file = getenv('SYMFONY_DEPRECATIONS_SERIALIZE')) {
     DeprecationErrorHandler::collectDeprecations($file);
 
     return;
@@ -36,10 +37,6 @@ if (class_exists(Deprecation::class)) {
     Deprecation::withoutDeduplication();
 }
 
-if (
-    // Skip if we're using PHPUnit >=10
-    !class_exists(PHPUnit\Metadata\Metadata::class, false)
-    && 'disabled' !== getenv('SYMFONY_DEPRECATIONS_HELPER')
-) {
+if ('disabled' !== getenv('SYMFONY_DEPRECATIONS_HELPER')) {
     DeprecationErrorHandler::register(getenv('SYMFONY_DEPRECATIONS_HELPER'));
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow-up to #60645 

The `SymfonyExtension::bootstrap()` method seems like a more appropriate place to configure Doctrine deprecations behavior.

With this, once support for PHPUnit <10 i dropped, the `bootstrap.php` file can be completely removed. 