### PR TITLE
[JsonPath] do not pass more than one byte to ord()

### DIFF
--- a/src/Symfony/Component/JsonPath/Tokenizer/JsonPathTokenizer.php
+++ b/src/Symfony/Component/JsonPath/Tokenizer/JsonPathTokenizer.php
@@ -88,9 +88,8 @@ final class JsonPathTokenizer
             if ($inQuote) {
                 // literal control characters (U+0000 through U+001F) in quoted strings
                 // are not be allowed unless they are part of escape sequences
-                $ord = \ord($char);
                 if ($inBracket) {
-                    if ($ord <= 31) {
+                    if (\ord($char[0]) <= 31) {
                         if (!self::isEscaped($chars, $i)) {
                             throw new InvalidJsonPathException('control characters are not allowed in quoted strings.', $position);
                         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

see php/php-src#19440