### PR TITLE
[Scheduler] Don’t get next run date from `null`

### DIFF
--- a/src/Symfony/Component/Scheduler/Generator/MessageGenerator.php
+++ b/src/Symfony/Component/Scheduler/Generator/MessageGenerator.php
@@ -77,7 +77,7 @@ final class MessageGenerator implements MessageGeneratorInterface
             $nextTime = $trigger->getNextRunDate($time);
 
             if ($this->schedule->shouldProcessOnlyLastMissedRun()) {
-                while ($nextTime < $this->clock->now()) {
+                while ($nextTime && $nextTime < $this->clock->now()) {
                     $nextTime = $trigger->getNextRunDate($nextTime);
                 }
             }

--- a/src/Symfony/Component/Scheduler/Tests/Generator/MessageGeneratorTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Generator/MessageGeneratorTest.php
@@ -217,7 +217,7 @@ class MessageGeneratorTest extends TestCase
 
         $scheduler = new MessageGenerator($schedule, 'dummy', clock: $clock, checkpoint: $checkpoint);
 
-        // Warmup. The first run is always returns nothing.
+        // Warmup. The first run always returns nothing.
         $this->assertSame([], iterator_to_array($scheduler->getMessages(), false));
         $this->assertEquals(self::makeDateTime('22:15:00'), $checkpoint->time());
 
@@ -240,7 +240,7 @@ class MessageGeneratorTest extends TestCase
     {
         $clock = new MockClock(self::makeDateTime('22:15:00'));
 
-        $message = RecurringMessage::every('1 minute', (object) ['id' => 'message']);
+        $message = RecurringMessage::every('1 minute', (object) ['id' => 'message'], until: self::makeDateTime('22:23:00'));
         $schedule = (new Schedule())->add($message);
 
         $cache = new ArrayAdapter();
@@ -249,7 +249,7 @@ class MessageGeneratorTest extends TestCase
 
         $scheduler = new MessageGenerator($schedule, 'dummy', clock: $clock, checkpoint: $checkpoint);
 
-        // Warmup. The first run is always returns nothing.
+        // Warmup. The first run always returns nothing.
         $this->assertSame([], iterator_to_array($scheduler->getMessages(), false));
         $this->assertEquals(self::makeDateTime('22:15:00'), $clock->now());
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Issues        | Fix #61872
| License       | MIT
