### PR TITLE
[Mailer][MailJet] Fix forbidden headers case-sensitive comparison

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
@@ -51,8 +51,6 @@ class MailjetApiTransport extends AbstractApiTransport
         'X-Mailjet-TrackOpen' => ['TrackOpens', 'string'],
     ];
 
-    private ?array $forbiddenHeadersLowercase = null;
-
     public function __construct(
         private string $publicKey,
         #[\SensitiveParameter] private string $privateKey,
@@ -141,13 +139,15 @@ class MailjetApiTransport extends AbstractApiTransport
             $message['HTMLPart'] = $html;
         }
 
+        $forbiddenHeadersLowercase = \array_map('strtolower', self::FORBIDDEN_HEADERS);
+
         foreach ($email->getHeaders()->all() as $headerName => $header) {
             if ($convertConf = self::HEADER_TO_MESSAGE[$headerName] ?? false) {
                 $message[$convertConf[0]] = $this->castCustomHeader($header->getBodyAsString(), $convertConf[1]);
                 continue;
             }
 
-            if ($this->isHeaderForbidden($headerName)) {
+            if (\in_array($headerName, $forbiddenHeadersLowercase, TRUE)) {
                 continue;
             }
 
@@ -208,14 +208,5 @@ class MailjetApiTransport extends AbstractApiTransport
             'json' => json_decode($value, true, 512, \JSON_THROW_ON_ERROR),
             'string' => $value,
         };
-    }
-
-    private function isHeaderForbidden(string $headerName): bool
-    {
-        if (NULL === $this->forbiddenHeadersLowercase) {
-            $this->forbiddenHeadersLowercase = \array_map('strtolower', self::FORBIDDEN_HEADERS);
-        }
-
-        return \in_array($headerName, $this->forbiddenHeadersLowercase, TRUE);
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
@@ -140,9 +140,10 @@ class MailjetApiTransport extends AbstractApiTransport
         }
 
         $forbiddenHeadersLowercase = \array_map('strtolower', self::FORBIDDEN_HEADERS);
+        $headerToMessageLowercase = \array_map('strtolower', self::HEADER_TO_MESSAGE);
 
         foreach ($email->getHeaders()->all() as $headerName => $header) {
-            if ($convertConf = self::HEADER_TO_MESSAGE[$headerName] ?? false) {
+            if ($convertConf = $headerToMessageLowercase[$headerName] ?? false) {
                 $message[$convertConf[0]] = $this->castCustomHeader($header->getBodyAsString(), $convertConf[1]);
                 continue;
             }

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
@@ -30,25 +30,25 @@ class MailjetApiTransport extends AbstractApiTransport
     private const HOST = 'api.mailjet.com';
     private const API_VERSION = '3.1';
     private const FORBIDDEN_HEADERS = [
-        'Date', 'X-CSA-Complaints', 'Message-Id', 'X-MJ-StatisticsContactsListID',
-        'DomainKey-Status', 'Received-SPF', 'Authentication-Results', 'Received',
-        'From', 'Sender', 'Subject', 'To', 'Cc', 'Bcc', 'Reply-To', 'Return-Path', 'Delivered-To', 'DKIM-Signature',
-        'X-Feedback-Id', 'X-Mailjet-Segmentation', 'List-Id', 'X-MJ-MID', 'X-MJ-ErrorMessage',
-        'X-Mailjet-Debug', 'User-Agent', 'X-Mailer', 'X-MJ-WorkflowID',
+        'date', 'x-csa-complaints', 'message-id', 'x-mj-statisticscontactslistid',
+        'domainkey-status', 'received-spf', 'authentication-results', 'received',
+        'from', 'sender', 'subject', 'to', 'cc', 'bcc', 'reply-to', 'return-path', 'delivered-to', 'dkim-signature',
+        'x-feedback-id', 'x-mailjet-segmentation', 'list-id', 'x-mj-mid', 'x-mj-errormessage',
+        'x-mailjet-debug', 'user-agent', 'x-mailer', 'x-mj-workflowid',
     ];
     private const HEADER_TO_MESSAGE = [
-        'X-MJ-TemplateLanguage' => ['TemplateLanguage', 'bool'],
-        'X-MJ-TemplateID' => ['TemplateID', 'int'],
-        'X-MJ-TemplateErrorReporting' => ['TemplateErrorReporting', 'json'],
-        'X-MJ-TemplateErrorDeliver' => ['TemplateErrorDeliver', 'bool'],
-        'X-MJ-Vars' => ['Variables', 'json'],
-        'X-MJ-CustomID' => ['CustomID', 'string'],
-        'X-MJ-EventPayload' => ['EventPayload', 'string'],
-        'X-Mailjet-Campaign' => ['CustomCampaign', 'string'],
-        'X-Mailjet-DeduplicateCampaign' => ['DeduplicateCampaign', 'bool'],
-        'X-Mailjet-Prio' => ['Priority', 'int'],
-        'X-Mailjet-TrackClick' => ['TrackClicks', 'string'],
-        'X-Mailjet-TrackOpen' => ['TrackOpens', 'string'],
+        'x-mj-templatelanguage' => ['TemplateLanguage', 'bool'],
+        'x-mj-templateid' => ['TemplateID', 'int'],
+        'x-mj-templateerrorreporting' => ['TemplateErrorReporting', 'json'],
+        'x-mj-templateerrordeliver' => ['TemplateErrorDeliver', 'bool'],
+        'x-mj-vars' => ['Variables', 'json'],
+        'x-mj-customid' => ['CustomID', 'string'],
+        'x-mj-eventpayload' => ['EventPayload', 'string'],
+        'x-mailjet-campaign' => ['CustomCampaign', 'string'],
+        'x-mailjet-deduplicatecampaign' => ['DeduplicateCampaign', 'bool'],
+        'x-mailjet-prio' => ['Priority', 'int'],
+        'x-mailjet-trackclick' => ['TrackClicks', 'string'],
+        'x-mailjet-trackopen' => ['TrackOpens', 'string'],
     ];
 
     public function __construct(
@@ -139,20 +139,13 @@ class MailjetApiTransport extends AbstractApiTransport
             $message['HTMLPart'] = $html;
         }
 
-        $forbiddenHeadersLowercase = array_map('strtolower', self::FORBIDDEN_HEADERS);
-
-        $headerToMessageLowercase = array_combine(
-            array_map('strtolower', array_keys(self::HEADER_TO_MESSAGE)),
-            array_values(self::HEADER_TO_MESSAGE)
-        );
-
         foreach ($email->getHeaders()->all() as $headerName => $header) {
-            if ($convertConf = $headerToMessageLowercase[$headerName] ?? false) {
+            if ($convertConf = self::HEADER_TO_MESSAGE[$headerName] ?? false) {
                 $message[$convertConf[0]] = $this->castCustomHeader($header->getBodyAsString(), $convertConf[1]);
                 continue;
             }
 
-            if (\in_array($headerName, $forbiddenHeadersLowercase, true)) {
+            if (\in_array($headerName, self::FORBIDDEN_HEADERS, true)) {
                 continue;
             }
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
@@ -139,11 +139,11 @@ class MailjetApiTransport extends AbstractApiTransport
             $message['HTMLPart'] = $html;
         }
 
-        $forbiddenHeadersLowercase = \array_map('strtolower', self::FORBIDDEN_HEADERS);
+        $forbiddenHeadersLowercase = array_map('strtolower', self::FORBIDDEN_HEADERS);
 
-        $headerToMessageLowercase = \array_combine(
-            \array_map('strtolower', \array_keys(self::HEADER_TO_MESSAGE)),
-            \array_values(self::HEADER_TO_MESSAGE)
+        $headerToMessageLowercase = array_combine(
+            array_map('strtolower', array_keys(self::HEADER_TO_MESSAGE)),
+            array_values(self::HEADER_TO_MESSAGE)
         );
 
         foreach ($email->getHeaders()->all() as $headerName => $header) {
@@ -152,7 +152,7 @@ class MailjetApiTransport extends AbstractApiTransport
                 continue;
             }
 
-            if (\in_array($headerName, $forbiddenHeadersLowercase, TRUE)) {
+            if (\in_array($headerName, $forbiddenHeadersLowercase, true)) {
                 continue;
             }
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
@@ -140,7 +140,11 @@ class MailjetApiTransport extends AbstractApiTransport
         }
 
         $forbiddenHeadersLowercase = \array_map('strtolower', self::FORBIDDEN_HEADERS);
-        $headerToMessageLowercase = \array_map('strtolower', self::HEADER_TO_MESSAGE);
+
+        $headerToMessageLowercase = \array_combine(
+            \array_map('strtolower', \array_keys(self::HEADER_TO_MESSAGE)),
+            \array_values(self::HEADER_TO_MESSAGE)
+        );
 
         foreach ($email->getHeaders()->all() as $headerName => $header) {
             if ($convertConf = $headerToMessageLowercase[$headerName] ?? false) {

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
@@ -20,7 +20,6 @@ use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractApiTransport;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
-use Symfony\Component\Mime\Header\HeaderInterface;
 use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -142,13 +141,13 @@ class MailjetApiTransport extends AbstractApiTransport
             $message['HTMLPart'] = $html;
         }
 
-        foreach ($email->getHeaders()->all() as $header) {
-            if ($convertConf = self::HEADER_TO_MESSAGE[$header->getName()] ?? false) {
+        foreach ($email->getHeaders()->all() as $headerName => $header) {
+            if ($convertConf = self::HEADER_TO_MESSAGE[$headerName] ?? false) {
                 $message[$convertConf[0]] = $this->castCustomHeader($header->getBodyAsString(), $convertConf[1]);
                 continue;
             }
 
-            if ($this->isHeaderForbidden($header)) {
+            if ($this->isHeaderForbidden($headerName)) {
                 continue;
             }
 
@@ -211,14 +210,12 @@ class MailjetApiTransport extends AbstractApiTransport
         };
     }
 
-    private function isHeaderForbidden(HeaderInterface $header): bool
+    private function isHeaderForbidden(string $headerName): bool
     {
         if (NULL === $this->forbiddenHeadersLowercase) {
             $this->forbiddenHeadersLowercase = \array_map('strtolower', self::FORBIDDEN_HEADERS);
         }
 
-        return \in_array(
-            \strtolower($header->getName()), $this->forbiddenHeadersLowercase, TRUE
-        );
+        return \in_array($headerName, $this->forbiddenHeadersLowercase, TRUE);
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
@@ -20,6 +20,7 @@ use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractApiTransport;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Header\HeaderInterface;
 use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -50,6 +51,8 @@ class MailjetApiTransport extends AbstractApiTransport
         'X-Mailjet-TrackClick' => ['TrackClicks', 'string'],
         'X-Mailjet-TrackOpen' => ['TrackOpens', 'string'],
     ];
+
+    private ?array $forbiddenHeadersLowercase = null;
 
     public function __construct(
         private string $publicKey,
@@ -144,7 +147,8 @@ class MailjetApiTransport extends AbstractApiTransport
                 $message[$convertConf[0]] = $this->castCustomHeader($header->getBodyAsString(), $convertConf[1]);
                 continue;
             }
-            if (\in_array($header->getName(), self::FORBIDDEN_HEADERS, true)) {
+
+            if ($this->isHeaderForbidden($header)) {
                 continue;
             }
 
@@ -205,5 +209,16 @@ class MailjetApiTransport extends AbstractApiTransport
             'json' => json_decode($value, true, 512, \JSON_THROW_ON_ERROR),
             'string' => $value,
         };
+    }
+
+    private function isHeaderForbidden(HeaderInterface $header): bool
+    {
+        if (NULL === $this->forbiddenHeadersLowercase) {
+            $this->forbiddenHeadersLowercase = \array_map('strtolower', self::FORBIDDEN_HEADERS);
+        }
+
+        return \in_array(
+            \strtolower($header->getName()), $this->forbiddenHeadersLowercase, TRUE
+        );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #44000
| License       | MIT

We need to ensure that forbidden headers are not sent, regardless of their case, e.g. "Sender" and "sender" should both be forbidden.
