### PR TITLE
[Console] Handle signals on text input

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
  * Allow passing invokable commands to `Symfony\Component\Console\Tester\CommandTester`
  * Add `#[Input]` attribute to support DTOs in commands
  * Add optional timeout for interaction in `QuestionHelper`
+ * Handle signals for text inputs in `QuestionHelper`
 
 7.3
 ---

--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -516,7 +516,7 @@ class QuestionHelper extends Helper
 
         if (!$question->isMultiline()) {
             $cp = $this->setIOCodepage();
-            $ret = fgets($inputStream, 4096);
+            $ret = $this->doReadInput($inputStream, "\n");
 
             return $this->resetIOCodepage($cp, $ret);
         }
@@ -526,14 +526,8 @@ class QuestionHelper extends Helper
             return false;
         }
 
-        $ret = '';
         $cp = $this->setIOCodepage();
-        while (false !== ($char = fgetc($multiLineStreamReader))) {
-            if ("\x4" === $char || \PHP_EOL === "{$ret}{$char}") {
-                break;
-            }
-            $ret .= $char;
-        }
+        $ret = $this->doReadInput($multiLineStreamReader, "\x4");
 
         if (stream_get_meta_data($inputStream)['seekable']) {
             fseek($inputStream, ftell($multiLineStreamReader));
@@ -602,5 +596,37 @@ class QuestionHelper extends Helper
         }
 
         return $cloneStream;
+    }
+
+    /**
+     * @param resource $inputStream
+     */
+    private function doReadInput($inputStream, string $exitChar): string
+    {
+        $ret = '';
+        $isStdin = 'php://stdin' === (stream_get_meta_data($inputStream)['uri'] ?? null);
+        $r = [$inputStream];
+        $w = [];
+
+        while (!feof($inputStream)) {
+            while ($isStdin && 0 === @stream_select($r, $w, $w, 0, 100)) {
+                // Give signal handlers a chance to run
+                $r = [$inputStream];
+            }
+            $char = fread($inputStream, 1);
+
+            // as opposed to fgets(), fread() returns an empty string when the stream content is empty, not false.
+            if (false === $char || ('' === $ret && '' === $char)) {
+                throw new MissingInputException('Aborted.');
+            }
+
+            if ($exitChar === $char || \PHP_EOL === "{$ret}{$char}") {
+                break;
+            }
+
+            $ret .= $char;
+        }
+
+        return $ret;
     }
 }

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_test_sigint.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_test_sigint.php
@@ -1,0 +1,45 @@
+<?php
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = \dirname($vendor);
+}
+require $vendor.'/vendor/autoload.php';
+
+(new class extends Command {
+    protected function configure(): void
+    {
+        $this->addArgument('mode', InputArgument::OPTIONAL, default: 'single');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $mode = $input->getArgument('mode');
+
+        $question = new Question('Enter text: ');
+        $question->setMultiline($mode !== 'single');
+
+        $helper = new QuestionHelper();
+
+        pcntl_async_signals(true);
+        pcntl_alarm(1);
+        pcntl_signal(\SIGALRM, function () {
+            posix_kill(posix_getpid(), \SIGINT);
+        });
+
+        $helper->ask($input, $output, $question);
+
+        return Command::SUCCESS;
+    }
+})
+    ->run(new ArgvInput($argv), new ConsoleOutput())
+;

--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -26,8 +26,11 @@ use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\SignalRegistry\SignalRegistry;
 use Symfony\Component\Console\Terminal;
 use Symfony\Component\Console\Tester\ApplicationTester;
+use Symfony\Component\Process\Exception\ProcessSignaledException;
+use Symfony\Component\Process\Process;
 
 #[Group('tty')]
 class QuestionHelperTest extends AbstractQuestionHelperTestCase
@@ -956,6 +959,31 @@ class QuestionHelperTest extends AbstractQuestionHelperTestCase
         $stream = $output->getStream();
         rewind($stream);
         $this->assertStringEndsWith("\033[1D\033[K\033[2D\033[K\033[1D\033[K", stream_get_contents($stream));
+    }
+
+    #[DataProvider('modeProvider')]
+    public function testExitCommandOnEmptySingleLineInputSIGINT(string $mode)
+    {
+        if (!SignalRegistry::isSupported()) {
+            $this->markTestSkipped('pcntl signals not available');
+        }
+
+        $p = new Process(['php', dirname(__DIR__).'/Fixtures/application_test_sigint.php', $mode]);
+        $p->setPty(true);
+        $p->setTimeout(2); // the process will auto shutdown if not killed by SIGINT, to prevent blocking
+        $p->start();
+
+        $this->expectException(ProcessSignaledException::class);
+        $this->expectExceptionMessage('The process has been signaled with signal "2".');
+        $p->wait();
+    }
+
+    public static function modeProvider(): array
+    {
+        return [
+            ['single'],
+            ['multi'],
+        ];
     }
 
     protected function getInputStream($input)

--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -962,7 +962,7 @@ class QuestionHelperTest extends AbstractQuestionHelperTestCase
     }
 
     #[DataProvider('modeProvider')]
-    public function testExitCommandOnEmptySingleLineInputSIGINT(string $mode)
+    public function testExitCommandOnInputSIGINT(string $mode)
     {
         if (!SignalRegistry::isSupported()) {
             $this->markTestSkipped('pcntl signals not available');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

`QuestionHelper` is blocking signals because of its `fgets`/`fgetc` use.
This PR uses `fread` so signals can be dispatched in text inputs.
Since Windows is not supported by the PCNTL extension, it was working fine on this OS.

> [!NOTE]
>  This change has been tested in Windows, Linux and MacOS.


---

Snippet to test the behavior manually:
```php
use Symfony\Component\Console\Attribute\Argument;
use Symfony\Component\Console\Attribute\AsCommand;
use Symfony\Component\Console\Command\Command;
use Symfony\Component\Console\Helper\QuestionHelper;
use Symfony\Component\Console\Input\InputInterface;
use Symfony\Component\Console\Output\OutputInterface;
use Symfony\Component\Console\Question\Question;

#[AsCommand(name: 'app:test')]
class TestCommand
{
    public function __invoke(
        InputInterface $input,
        OutputInterface $output,
        #[Argument('Mode (single / multi)')] string $mode = 'single'
    ): int {
        $question = new Question('Enter text: ');
        $question->setMultiline($mode !== 'single');

        $helper = new QuestionHelper();
        $result = $helper->ask($input, $output, $question);

        $output->writeln('Result: '.$result);

        return Command::SUCCESS;
    }
}
```

Usage:
- Single line input: `php bin/console app:test single`
- Multiline input: `php bin/console app:test multi`