### PR TITLE
[Config] Add array-shapes to generated config builders

### DIFF
--- a/src/Symfony/Component/Config/Builder/ArrayShapeGenerator.php
+++ b/src/Symfony/Component/Config/Builder/ArrayShapeGenerator.php
@@ -1,0 +1,133 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Builder;
+
+use Symfony\Component\Config\Definition\ArrayNode;
+use Symfony\Component\Config\Definition\BaseNode;
+use Symfony\Component\Config\Definition\BooleanNode;
+use Symfony\Component\Config\Definition\EnumNode;
+use Symfony\Component\Config\Definition\FloatNode;
+use Symfony\Component\Config\Definition\IntegerNode;
+use Symfony\Component\Config\Definition\NodeInterface;
+use Symfony\Component\Config\Definition\NumericNode;
+use Symfony\Component\Config\Definition\PrototypedArrayNode;
+use Symfony\Component\Config\Definition\ScalarNode;
+use Symfony\Component\Config\Definition\StringNode;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ *
+ * @internal
+ */
+final class ArrayShapeGenerator
+{
+    public static function generate(NodeInterface $node): string
+    {
+        return str_replace("\n", "\n * ", self::doGeneratePhpDoc($node));
+    }
+
+    private static function doGeneratePhpDoc(NodeInterface $node, int $nestingLevel = 1): string
+    {
+        if (!$node instanceof ArrayNode) {
+            return match (true) {
+                $node instanceof BooleanNode => $node->hasDefaultValue() && null === $node->getDefaultValue() ? 'bool|null' : 'bool',
+                $node instanceof StringNode => 'string',
+                $node instanceof NumericNode => self::handleNumericNode($node),
+                $node instanceof EnumNode => $node->getPermissibleValues('|'),
+                $node instanceof ScalarNode => 'scalar|null',
+                default => 'mixed',
+            };
+        }
+
+        if ($node instanceof PrototypedArrayNode) {
+            $isHashmap = (bool) $node->getKeyAttribute();
+            $arrayType = ($isHashmap ? 'array<string, ' : 'list<').self::doGeneratePhpDoc($node->getPrototype(), 1 + $nestingLevel).'>';
+
+            return $node->hasDefaultValue() && null === $node->getDefaultValue() ? $arrayType.'|null' : $arrayType;
+        }
+
+        if (!($children = $node->getChildren()) && !$node->getParent() instanceof PrototypedArrayNode) {
+            return $node->hasDefaultValue() && null === $node->getDefaultValue() ? 'array<mixed>|null' : 'array<mixed>';
+        }
+
+        $arrayShape = \sprintf("array{%s\n", self::generateInlinePhpDocForNode($node));
+
+        foreach ($children as $child) {
+            $arrayShape .= str_repeat('    ', $nestingLevel).self::dumpNodeKey($child).': ';
+
+            if ($child instanceof PrototypedArrayNode) {
+                $isHashmap = (bool) $child->getKeyAttribute();
+                $childArrayType = ($isHashmap ? 'array<string, ' : 'list<').self::doGeneratePhpDoc($child->getPrototype(), 1 + $nestingLevel).'>';
+                $arrayShape .= $child->hasDefaultValue() && null === $child->getDefaultValue() ? $childArrayType.'|null' : $childArrayType;
+            } else {
+                $arrayShape .= self::doGeneratePhpDoc($child, 1 + $nestingLevel);
+            }
+
+            $arrayShape .= \sprintf(",%s\n", !$child instanceof ArrayNode ? self::generateInlinePhpDocForNode($child) : '');
+        }
+
+        if ($node->shouldIgnoreExtraKeys()) {
+            $arrayShape .= str_repeat('    ', $nestingLevel)."...<mixed>\n";
+        }
+
+        $arrayShape = $arrayShape.str_repeat('    ', $nestingLevel - 1).'}';
+
+        return $node->hasDefaultValue() && null === $node->getDefaultValue() ? $arrayShape.'|null' : $arrayShape;
+    }
+
+    private static function dumpNodeKey(NodeInterface $node): string
+    {
+        $name = $node->getName();
+        $quoted = str_starts_with($name, '@')
+            || \in_array(strtolower($name), ['int', 'float', 'bool', 'null', 'scalar'], true)
+            || strpbrk($name, '\'"');
+
+        if ($quoted) {
+            $name = "'".addslashes($name)."'";
+        }
+
+        return $name.($node->isRequired() ? '' : '?');
+    }
+
+    private static function handleNumericNode(NumericNode $node): string
+    {
+        $min = $node->getMin() ?? 'min';
+        $max = $node->getMax() ?? 'max';
+
+        if ($node instanceof IntegerNode) {
+            return \sprintf('int<%s, %s>', $min, $max);
+        }
+        if ($node instanceof FloatNode) {
+            return 'float';
+        }
+
+        return \sprintf('int<%s, %s>|float', $min, $max);
+    }
+
+    private static function generateInlinePhpDocForNode(BaseNode $node): string
+    {
+        $comment = '';
+        if ($node->isDeprecated()) {
+            $comment .= ' // Deprecated: '.$node->getDeprecation($node->getName(), $node->getPath())['message'];
+        }
+
+        if ($info = $node->getInfo()) {
+            $comment .= ' // '.$info;
+        }
+
+        if ($node->hasDefaultValue()) {
+            $comment .= ' // Default: '.json_encode($node->getDefaultValue(), \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE | \JSON_PRESERVE_ZERO_FRACTION);
+        }
+
+        return rtrim(preg_replace('/\s+/', ' ', $comment));
+    }
+}

--- a/src/Symfony/Component/Config/CHANGELOG.md
+++ b/src/Symfony/Component/Config/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add argument `$singular` to `NodeBuilder::arrayNode()` to decouple plurals/singulars from XML
  * Add support for `defaultNull()` on `ArrayNodeDefinition`
  * Add `ArrayNodeDefinition::acceptAndWrap()` to list alternative types that should be accepted and wrapped in an array
+ * Add array-shapes to generated config builders
 
 7.3
 ---

--- a/src/Symfony/Component/Config/Definition/NumericNode.php
+++ b/src/Symfony/Component/Config/Definition/NumericNode.php
@@ -50,6 +50,16 @@ class NumericNode extends ScalarNode
         return $value;
     }
 
+    public function getMin(): float|int|null
+    {
+        return $this->min;
+    }
+
+    public function getMax(): float|int|null
+    {
+        return $this->max;
+    }
+
     protected function isValueEmpty(mixed $value): bool
     {
         // a numeric value cannot be empty

--- a/src/Symfony/Component/Config/Tests/Builder/ArrayShapeGeneratorTest.php
+++ b/src/Symfony/Component/Config/Tests/Builder/ArrayShapeGeneratorTest.php
@@ -1,0 +1,170 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Tests\Builder;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Builder\ArrayShapeGenerator;
+use Symfony\Component\Config\Definition\ArrayNode;
+use Symfony\Component\Config\Definition\BooleanNode;
+use Symfony\Component\Config\Definition\EnumNode;
+use Symfony\Component\Config\Definition\FloatNode;
+use Symfony\Component\Config\Definition\IntegerNode;
+use Symfony\Component\Config\Definition\NodeInterface;
+use Symfony\Component\Config\Definition\PrototypedArrayNode;
+use Symfony\Component\Config\Definition\ScalarNode;
+use Symfony\Component\Config\Definition\StringNode;
+use Symfony\Component\Config\Definition\VariableNode;
+
+class ArrayShapeGeneratorTest extends TestCase
+{
+    #[DataProvider('provideNodes')]
+    public function testPhpDocHandlesNodeTypes(NodeInterface $node, string $expected)
+    {
+        $arrayNode = new ArrayNode('root');
+        $arrayNode->addChild($node);
+
+        $expected = 'node?: '.$expected;
+
+        $this->assertStringContainsString($expected, ArrayShapeGenerator::generate($arrayNode));
+    }
+
+    public static function provideNodes(): iterable
+    {
+        yield [new ArrayNode('node'), 'array<mixed>'];
+
+        yield [new StringNode('node'), 'string'];
+
+        yield [new BooleanNode('node'), 'bool'];
+
+        $nullableBooleanNode = new BooleanNode('node');
+        $nullableBooleanNode->setDefaultValue(null);
+
+        yield [$nullableBooleanNode, 'bool|null'];
+        yield [new EnumNode('node', values: ['a', 'b']), '"a"|"b"'];
+        yield [new ScalarNode('node'), 'scalar|null'];
+        yield [new VariableNode('node'), 'mixed'];
+
+        yield [new IntegerNode('node'), 'int<min, max>'];
+        yield [new IntegerNode('node', min: 1), 'int<1, max>'];
+        yield [new IntegerNode('node', max: 10), 'int<min, 10>'];
+        yield [new IntegerNode('node', min: 1, max: 10), 'int<1, 10>'];
+
+        yield [new FloatNode('node'), 'float'];
+        yield [new FloatNode('node', min: 1.1), 'float'];
+        yield [new FloatNode('node', max: 10.1), 'float'];
+        yield [new FloatNode('node', min: 1.1, max: 10.1), 'float'];
+    }
+
+    public function testPrototypedArrayNodePhpDoc()
+    {
+        $prototype = new PrototypedArrayNode('proto');
+        $prototype->setPrototype(new StringNode('child'));
+
+        $root = new ArrayNode('root');
+        $root->addChild($prototype);
+
+        $expected = "array{\n *     proto?: list<string>,\n * }";
+
+        $this->assertStringContainsString($expected, ArrayShapeGenerator::generate($root));
+    }
+
+    public function testPrototypedArrayNodePhpDocWithKeyAttribute()
+    {
+        $prototype = new PrototypedArrayNode('proto');
+        $prototype->setPrototype(new StringNode('child'));
+        $prototype->setKeyAttribute('name');
+
+        $root = new ArrayNode('root');
+        $root->addChild($prototype);
+
+        $expected = "array{\n *     proto?: array<string, string>,\n * }";
+
+        $this->assertStringContainsString($expected, ArrayShapeGenerator::generate($root));
+    }
+
+    public function testPhpDocHandlesRequiredNode()
+    {
+        $child = new BooleanNode('node');
+        $child->setRequired(true);
+
+        $root = new ArrayNode('root');
+        $root->addChild($child);
+
+        $expected = 'node: bool';
+
+        $this->assertStringContainsString($expected, ArrayShapeGenerator::generate($root));
+    }
+
+    public function testPhpDocHandleAdditionalDocumentation()
+    {
+        $child = new BooleanNode('node');
+        $child->setDeprecated('vendor/package', '1.0', 'The "%path%" option is deprecated.');
+        $child->setDefaultValue(true);
+        $child->setInfo('This is a boolean node.');
+
+        $root = new ArrayNode('root');
+        $root->addChild($child);
+
+        $this->assertStringContainsString('node?: bool, // Deprecated: The "node" option is deprecated. // This is a boolean node. // Default: true', ArrayShapeGenerator::generate($root));
+    }
+
+    public function testPhpDocHandleMultilineDoc()
+    {
+        $child = new BooleanNode('node');
+        $child->setDeprecated('vendor/package', '1.0', 'The "%path%" option is deprecated.');
+        $child->setDefaultValue(true);
+        $child->setInfo("This is a boolean node.\nSet to true to enable it.\r\nSet to false to disable it.");
+
+        $root = new ArrayNode('root');
+        $root->addChild($child);
+
+        $this->assertStringContainsString('node?: bool, // Deprecated: The "node" option is deprecated. // This is a boolean node. Set to true to enable it. Set to false to disable it. // Default: true', ArrayShapeGenerator::generate($root));
+    }
+
+    public function testPhpDocShapeSingleLevel()
+    {
+        $root = new ArrayNode('root');
+
+        $this->assertStringMatchesFormat('array<%s>', ArrayShapeGenerator::generate($root));
+    }
+
+    public function testPhpDocShapeMultiLevel()
+    {
+        $root = new ArrayNode('root');
+        $child = new ArrayNode('child');
+        $root->addChild($child);
+
+        $this->assertStringMatchesFormat('array{%Achild?: array<%s>,%A}', ArrayShapeGenerator::generate($root));
+    }
+
+    #[DataProvider('provideQuotedNodes')]
+    public function testPhpdocQuoteNodeName(NodeInterface $node, string $expected)
+    {
+        $arrayNode = new ArrayNode('root');
+        $arrayNode->addChild($node);
+
+        $this->assertStringContainsString($expected, ArrayShapeGenerator::generate($arrayNode));
+    }
+
+    public static function provideQuotedNodes(): \Generator
+    {
+        yield [new StringNode('int'), "'int'"];
+        yield [new StringNode('float'), "'float'"];
+        yield [new StringNode('null'), "'null'"];
+        yield [new StringNode('bool'), "'bool'"];
+        yield [new StringNode('scalar'), "'scalar'"];
+        yield [new StringNode('hell"o'), "'hell\\\"o'"];
+        yield [new StringNode("hell'o"), "'hell\\'o'"];
+        yield [new StringNode('@key'), "'@key'"];
+    }
+}

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/Messenger/ReceivingConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/Messenger/ReceivingConfig.php
@@ -40,22 +40,45 @@ class ReceivingConfig
         return $this;
     }
 
-    public function __construct(array $value = [])
+    /**
+     * @param array{
+     *     translator?: array{
+     *         fallbacks?: list<scalar|null>,
+     *         sources?: array<string, scalar|null>,
+     *         books?: array{ // Deprecated: The child node "books" at path "add_to_list.translator.books" is deprecated. // looks for translation in old fashion way
+     *             page?: list<array{
+     *                 number?: int<min, max>,
+     *                 content?: scalar|null,
+     *             }>,
+     *         },
+     *     },
+     *     messenger?: array{
+     *         routing?: array<string, array{
+     *             senders?: list<scalar|null>,
+     *         }>,
+     *         receiving?: list<array{
+     *             priority?: int<min, max>,
+     *             color?: scalar|null,
+     *         }>,
+     *     },
+     * } $config
+     */
+    public function __construct(array $config = [])
     {
-        if (array_key_exists('priority', $value)) {
+        if (array_key_exists('priority', $config)) {
             $this->_usedProperties['priority'] = true;
-            $this->priority = $value['priority'];
-            unset($value['priority']);
+            $this->priority = $config['priority'];
+            unset($config['priority']);
         }
 
-        if (array_key_exists('color', $value)) {
+        if (array_key_exists('color', $config)) {
             $this->_usedProperties['color'] = true;
-            $this->color = $value['color'];
-            unset($value['color']);
+            $this->color = $config['color'];
+            unset($config['color']);
         }
 
-        if ([] !== $value) {
-            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        if ($config) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($config)));
         }
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/Messenger/RoutingConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/Messenger/RoutingConfig.php
@@ -26,16 +26,39 @@ class RoutingConfig
         return $this;
     }
 
-    public function __construct(array $value = [])
+    /**
+     * @param array{
+     *     translator?: array{
+     *         fallbacks?: list<scalar|null>,
+     *         sources?: array<string, scalar|null>,
+     *         books?: array{ // Deprecated: The child node "books" at path "add_to_list.translator.books" is deprecated. // looks for translation in old fashion way
+     *             page?: list<array{
+     *                 number?: int<min, max>,
+     *                 content?: scalar|null,
+     *             }>,
+     *         },
+     *     },
+     *     messenger?: array{
+     *         routing?: array<string, array{
+     *             senders?: list<scalar|null>,
+     *         }>,
+     *         receiving?: list<array{
+     *             priority?: int<min, max>,
+     *             color?: scalar|null,
+     *         }>,
+     *     },
+     * } $config
+     */
+    public function __construct(array $config = [])
     {
-        if (array_key_exists('senders', $value)) {
+        if (array_key_exists('senders', $config)) {
             $this->_usedProperties['senders'] = true;
-            $this->senders = $value['senders'];
-            unset($value['senders']);
+            $this->senders = $config['senders'];
+            unset($config['senders']);
         }
 
-        if ([] !== $value) {
-            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        if ($config) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($config)));
         }
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/MessengerConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/MessengerConfig.php
@@ -35,22 +35,45 @@ class MessengerConfig
         return $this->receiving[] = new \Symfony\Config\AddToList\Messenger\ReceivingConfig($value);
     }
 
-    public function __construct(array $value = [])
+    /**
+     * @param array{
+     *     translator?: array{
+     *         fallbacks?: list<scalar|null>,
+     *         sources?: array<string, scalar|null>,
+     *         books?: array{ // Deprecated: The child node "books" at path "add_to_list.translator.books" is deprecated. // looks for translation in old fashion way
+     *             page?: list<array{
+     *                 number?: int<min, max>,
+     *                 content?: scalar|null,
+     *             }>,
+     *         },
+     *     },
+     *     messenger?: array{
+     *         routing?: array<string, array{
+     *             senders?: list<scalar|null>,
+     *         }>,
+     *         receiving?: list<array{
+     *             priority?: int<min, max>,
+     *             color?: scalar|null,
+     *         }>,
+     *     },
+     * } $config
+     */
+    public function __construct(array $config = [])
     {
-        if (array_key_exists('routing', $value)) {
+        if (array_key_exists('routing', $config)) {
             $this->_usedProperties['routing'] = true;
-            $this->routing = array_map(fn ($v) => new \Symfony\Config\AddToList\Messenger\RoutingConfig($v), $value['routing']);
-            unset($value['routing']);
+            $this->routing = array_map(fn ($v) => new \Symfony\Config\AddToList\Messenger\RoutingConfig($v), $config['routing']);
+            unset($config['routing']);
         }
 
-        if (array_key_exists('receiving', $value)) {
+        if (array_key_exists('receiving', $config)) {
             $this->_usedProperties['receiving'] = true;
-            $this->receiving = array_map(fn ($v) => new \Symfony\Config\AddToList\Messenger\ReceivingConfig($v), $value['receiving']);
-            unset($value['receiving']);
+            $this->receiving = array_map(fn ($v) => new \Symfony\Config\AddToList\Messenger\ReceivingConfig($v), $config['receiving']);
+            unset($config['receiving']);
         }
 
-        if ([] !== $value) {
-            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        if ($config) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($config)));
         }
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/Translator/Books/PageConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/Translator/Books/PageConfig.php
@@ -40,22 +40,45 @@ class PageConfig
         return $this;
     }
 
-    public function __construct(array $value = [])
+    /**
+     * @param array{
+     *     translator?: array{
+     *         fallbacks?: list<scalar|null>,
+     *         sources?: array<string, scalar|null>,
+     *         books?: array{ // Deprecated: The child node "books" at path "add_to_list.translator.books" is deprecated. // looks for translation in old fashion way
+     *             page?: list<array{
+     *                 number?: int<min, max>,
+     *                 content?: scalar|null,
+     *             }>,
+     *         },
+     *     },
+     *     messenger?: array{
+     *         routing?: array<string, array{
+     *             senders?: list<scalar|null>,
+     *         }>,
+     *         receiving?: list<array{
+     *             priority?: int<min, max>,
+     *             color?: scalar|null,
+     *         }>,
+     *     },
+     * } $config
+     */
+    public function __construct(array $config = [])
     {
-        if (array_key_exists('number', $value)) {
+        if (array_key_exists('number', $config)) {
             $this->_usedProperties['number'] = true;
-            $this->number = $value['number'];
-            unset($value['number']);
+            $this->number = $config['number'];
+            unset($config['number']);
         }
 
-        if (array_key_exists('content', $value)) {
+        if (array_key_exists('content', $config)) {
             $this->_usedProperties['content'] = true;
-            $this->content = $value['content'];
-            unset($value['content']);
+            $this->content = $config['content'];
+            unset($config['content']);
         }
 
-        if ([] !== $value) {
-            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        if ($config) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($config)));
         }
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/Translator/BooksConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/Translator/BooksConfig.php
@@ -25,16 +25,39 @@ class BooksConfig
         return $this->page[] = new \Symfony\Config\AddToList\Translator\Books\PageConfig($value);
     }
 
-    public function __construct(array $value = [])
+    /**
+     * @param array{
+     *     translator?: array{
+     *         fallbacks?: list<scalar|null>,
+     *         sources?: array<string, scalar|null>,
+     *         books?: array{ // Deprecated: The child node "books" at path "add_to_list.translator.books" is deprecated. // looks for translation in old fashion way
+     *             page?: list<array{
+     *                 number?: int<min, max>,
+     *                 content?: scalar|null,
+     *             }>,
+     *         },
+     *     },
+     *     messenger?: array{
+     *         routing?: array<string, array{
+     *             senders?: list<scalar|null>,
+     *         }>,
+     *         receiving?: list<array{
+     *             priority?: int<min, max>,
+     *             color?: scalar|null,
+     *         }>,
+     *     },
+     * } $config
+     */
+    public function __construct(array $config = [])
     {
-        if (array_key_exists('page', $value)) {
+        if (array_key_exists('page', $config)) {
             $this->_usedProperties['page'] = true;
-            $this->page = array_map(fn ($v) => new \Symfony\Config\AddToList\Translator\Books\PageConfig($v), $value['page']);
-            unset($value['page']);
+            $this->page = array_map(fn ($v) => new \Symfony\Config\AddToList\Translator\Books\PageConfig($v), $config['page']);
+            unset($config['page']);
         }
 
-        if ([] !== $value) {
-            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        if ($config) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($config)));
         }
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/TranslatorConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/TranslatorConfig.php
@@ -57,28 +57,51 @@ class TranslatorConfig
         return $this->books;
     }
 
-    public function __construct(array $value = [])
+    /**
+     * @param array{
+     *     translator?: array{
+     *         fallbacks?: list<scalar|null>,
+     *         sources?: array<string, scalar|null>,
+     *         books?: array{ // Deprecated: The child node "books" at path "add_to_list.translator.books" is deprecated. // looks for translation in old fashion way
+     *             page?: list<array{
+     *                 number?: int<min, max>,
+     *                 content?: scalar|null,
+     *             }>,
+     *         },
+     *     },
+     *     messenger?: array{
+     *         routing?: array<string, array{
+     *             senders?: list<scalar|null>,
+     *         }>,
+     *         receiving?: list<array{
+     *             priority?: int<min, max>,
+     *             color?: scalar|null,
+     *         }>,
+     *     },
+     * } $config
+     */
+    public function __construct(array $config = [])
     {
-        if (array_key_exists('fallbacks', $value)) {
+        if (array_key_exists('fallbacks', $config)) {
             $this->_usedProperties['fallbacks'] = true;
-            $this->fallbacks = $value['fallbacks'];
-            unset($value['fallbacks']);
+            $this->fallbacks = $config['fallbacks'];
+            unset($config['fallbacks']);
         }
 
-        if (array_key_exists('sources', $value)) {
+        if (array_key_exists('sources', $config)) {
             $this->_usedProperties['sources'] = true;
-            $this->sources = $value['sources'];
-            unset($value['sources']);
+            $this->sources = $config['sources'];
+            unset($config['sources']);
         }
 
-        if (array_key_exists('books', $value)) {
+        if (array_key_exists('books', $config)) {
             $this->_usedProperties['books'] = true;
-            $this->books = new \Symfony\Config\AddToList\Translator\BooksConfig($value['books']);
-            unset($value['books']);
+            $this->books = new \Symfony\Config\AddToList\Translator\BooksConfig($config['books']);
+            unset($config['books']);
         }
 
-        if ([] !== $value) {
-            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        if ($config) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($config)));
         }
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToListConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToListConfig.php
@@ -45,22 +45,45 @@ class AddToListConfig implements \Symfony\Component\Config\Builder\ConfigBuilder
         return 'add_to_list';
     }
 
-    public function __construct(array $value = [])
+    /**
+     * @param array{
+     *     translator?: array{
+     *         fallbacks?: list<scalar|null>,
+     *         sources?: array<string, scalar|null>,
+     *         books?: array{ // Deprecated: The child node "books" at path "add_to_list.translator.books" is deprecated. // looks for translation in old fashion way
+     *             page?: list<array{
+     *                 number?: int<min, max>,
+     *                 content?: scalar|null,
+     *             }>,
+     *         },
+     *     },
+     *     messenger?: array{
+     *         routing?: array<string, array{
+     *             senders?: list<scalar|null>,
+     *         }>,
+     *         receiving?: list<array{
+     *             priority?: int<min, max>,
+     *             color?: scalar|null,
+     *         }>,
+     *     },
+     * } $config
+     */
+    public function __construct(array $config = [])
     {
-        if (array_key_exists('translator', $value)) {
+        if (array_key_exists('translator', $config)) {
             $this->_usedProperties['translator'] = true;
-            $this->translator = new \Symfony\Config\AddToList\TranslatorConfig($value['translator']);
-            unset($value['translator']);
+            $this->translator = new \Symfony\Config\AddToList\TranslatorConfig($config['translator']);
+            unset($config['translator']);
         }
 
-        if (array_key_exists('messenger', $value)) {
+        if (array_key_exists('messenger', $config)) {
             $this->_usedProperties['messenger'] = true;
-            $this->messenger = new \Symfony\Config\AddToList\MessengerConfig($value['messenger']);
-            unset($value['messenger']);
+            $this->messenger = new \Symfony\Config\AddToList\MessengerConfig($config['messenger']);
+            unset($config['messenger']);
         }
 
-        if ([] !== $value) {
-            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        if ($config) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($config)));
         }
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeys/BarConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeys/BarConfig.php
@@ -40,21 +40,36 @@ class BarConfig
         return $this;
     }
 
-    public function __construct(array $value = [])
+    /**
+     * @param array{
+     *     foo?: array{
+     *         baz?: scalar|null,
+     *         qux?: scalar|null,
+     *         ...<mixed>
+     *     },
+     *     bar?: list<array{
+     *         corge?: scalar|null,
+     *         grault?: scalar|null,
+     *         ...<mixed>
+     *     }>,
+     *     baz?: array<mixed>,
+     * } $config
+     */
+    public function __construct(array $config = [])
     {
-        if (array_key_exists('corge', $value)) {
+        if (array_key_exists('corge', $config)) {
             $this->_usedProperties['corge'] = true;
-            $this->corge = $value['corge'];
-            unset($value['corge']);
+            $this->corge = $config['corge'];
+            unset($config['corge']);
         }
 
-        if (array_key_exists('grault', $value)) {
+        if (array_key_exists('grault', $config)) {
             $this->_usedProperties['grault'] = true;
-            $this->grault = $value['grault'];
-            unset($value['grault']);
+            $this->grault = $config['grault'];
+            unset($config['grault']);
         }
 
-        $this->_extraKeys = $value;
+        $this->_extraKeys = $config;
 
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeys/BazConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeys/BazConfig.php
@@ -11,9 +11,24 @@ class BazConfig
 {
     private $_extraKeys;
 
-    public function __construct(array $value = [])
+    /**
+     * @param array{
+     *     foo?: array{
+     *         baz?: scalar|null,
+     *         qux?: scalar|null,
+     *         ...<mixed>
+     *     },
+     *     bar?: list<array{
+     *         corge?: scalar|null,
+     *         grault?: scalar|null,
+     *         ...<mixed>
+     *     }>,
+     *     baz?: array<mixed>,
+     * } $config
+     */
+    public function __construct(array $config = [])
     {
-        $this->_extraKeys = $value;
+        $this->_extraKeys = $config;
 
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeys/FooConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeys/FooConfig.php
@@ -40,21 +40,36 @@ class FooConfig
         return $this;
     }
 
-    public function __construct(array $value = [])
+    /**
+     * @param array{
+     *     foo?: array{
+     *         baz?: scalar|null,
+     *         qux?: scalar|null,
+     *         ...<mixed>
+     *     },
+     *     bar?: list<array{
+     *         corge?: scalar|null,
+     *         grault?: scalar|null,
+     *         ...<mixed>
+     *     }>,
+     *     baz?: array<mixed>,
+     * } $config
+     */
+    public function __construct(array $config = [])
     {
-        if (array_key_exists('baz', $value)) {
+        if (array_key_exists('baz', $config)) {
             $this->_usedProperties['baz'] = true;
-            $this->baz = $value['baz'];
-            unset($value['baz']);
+            $this->baz = $config['baz'];
+            unset($config['baz']);
         }
 
-        if (array_key_exists('qux', $value)) {
+        if (array_key_exists('qux', $config)) {
             $this->_usedProperties['qux'] = true;
-            $this->qux = $value['qux'];
-            unset($value['qux']);
+            $this->qux = $config['qux'];
+            unset($config['qux']);
         }
 
-        $this->_extraKeys = $value;
+        $this->_extraKeys = $config;
 
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeysConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeysConfig.php
@@ -54,28 +54,43 @@ class ArrayExtraKeysConfig implements \Symfony\Component\Config\Builder\ConfigBu
         return 'array_extra_keys';
     }
 
-    public function __construct(array $value = [])
+    /**
+     * @param array{
+     *     foo?: array{
+     *         baz?: scalar|null,
+     *         qux?: scalar|null,
+     *         ...<mixed>
+     *     },
+     *     bar?: list<array{
+     *         corge?: scalar|null,
+     *         grault?: scalar|null,
+     *         ...<mixed>
+     *     }>,
+     *     baz?: array<mixed>,
+     * } $config
+     */
+    public function __construct(array $config = [])
     {
-        if (array_key_exists('foo', $value)) {
+        if (array_key_exists('foo', $config)) {
             $this->_usedProperties['foo'] = true;
-            $this->foo = new \Symfony\Config\ArrayExtraKeys\FooConfig($value['foo']);
-            unset($value['foo']);
+            $this->foo = new \Symfony\Config\ArrayExtraKeys\FooConfig($config['foo']);
+            unset($config['foo']);
         }
 
-        if (array_key_exists('bar', $value)) {
+        if (array_key_exists('bar', $config)) {
             $this->_usedProperties['bar'] = true;
-            $this->bar = array_map(fn ($v) => new \Symfony\Config\ArrayExtraKeys\BarConfig($v), $value['bar']);
-            unset($value['bar']);
+            $this->bar = array_map(fn ($v) => new \Symfony\Config\ArrayExtraKeys\BarConfig($v), $config['bar']);
+            unset($config['bar']);
         }
 
-        if (array_key_exists('baz', $value)) {
+        if (array_key_exists('baz', $config)) {
             $this->_usedProperties['baz'] = true;
-            $this->baz = new \Symfony\Config\ArrayExtraKeys\BazConfig($value['baz']);
-            unset($value['baz']);
+            $this->baz = new \Symfony\Config\ArrayExtraKeys\BazConfig($config['baz']);
+            unset($config['baz']);
         }
 
-        if ([] !== $value) {
-            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        if ($config) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($config)));
         }
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayValues/Symfony/Config/ArrayValues/ErrorPagesConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayValues/Symfony/Config/ArrayValues/ErrorPagesConfig.php
@@ -40,22 +40,33 @@ class ErrorPagesConfig
         return $this;
     }
 
-    public function __construct(array $value = [])
+    /**
+     * @param array{
+     *     transports?: array<string, array{
+     *         dsn?: scalar|null,
+     *     }>,
+     *     error_pages?: array{ // Default: {"enabled":false}
+     *         enabled?: bool, // Default: false
+     *         with_trace?: bool,
+     *     },
+     * } $config
+     */
+    public function __construct(array $config = [])
     {
-        if (array_key_exists('enabled', $value)) {
+        if (array_key_exists('enabled', $config)) {
             $this->_usedProperties['enabled'] = true;
-            $this->enabled = $value['enabled'];
-            unset($value['enabled']);
+            $this->enabled = $config['enabled'];
+            unset($config['enabled']);
         }
 
-        if (array_key_exists('with_trace', $value)) {
+        if (array_key_exists('with_trace', $config)) {
             $this->_usedProperties['withTrace'] = true;
-            $this->withTrace = $value['with_trace'];
-            unset($value['with_trace']);
+            $this->withTrace = $config['with_trace'];
+            unset($config['with_trace']);
         }
 
-        if ([] !== $value) {
-            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        if ($config) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($config)));
         }
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayValues/Symfony/Config/ArrayValues/TransportsConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayValues/Symfony/Config/ArrayValues/TransportsConfig.php
@@ -26,16 +26,27 @@ class TransportsConfig
         return $this;
     }
 
-    public function __construct(array $value = [])
+    /**
+     * @param array{
+     *     transports?: array<string, array{
+     *         dsn?: scalar|null,
+     *     }>,
+     *     error_pages?: array{ // Default: {"enabled":false}
+     *         enabled?: bool, // Default: false
+     *         with_trace?: bool,
+     *     },
+     * } $config
+     */
+    public function __construct(array $config = [])
     {
-        if (array_key_exists('dsn', $value)) {
+        if (array_key_exists('dsn', $config)) {
             $this->_usedProperties['dsn'] = true;
-            $this->dsn = $value['dsn'];
-            unset($value['dsn']);
+            $this->dsn = $config['dsn'];
+            unset($config['dsn']);
         }
 
-        if ([] !== $value) {
-            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        if ($config) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($config)));
         }
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayValues/Symfony/Config/ArrayValuesConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayValues/Symfony/Config/ArrayValuesConfig.php
@@ -72,22 +72,33 @@ class ArrayValuesConfig implements \Symfony\Component\Config\Builder\ConfigBuild
         return 'array_values';
     }
 
-    public function __construct(array $value = [])
+    /**
+     * @param array{
+     *     transports?: array<string, array{
+     *         dsn?: scalar|null,
+     *     }>,
+     *     error_pages?: array{ // Default: {"enabled":false}
+     *         enabled?: bool, // Default: false
+     *         with_trace?: bool,
+     *     },
+     * } $config
+     */
+    public function __construct(array $config = [])
     {
-        if (array_key_exists('transports', $value)) {
+        if (array_key_exists('transports', $config)) {
             $this->_usedProperties['transports'] = true;
-            $this->transports = array_map(fn ($v) => \is_array($v) ? new \Symfony\Config\ArrayValues\TransportsConfig($v) : $v, $value['transports']);
-            unset($value['transports']);
+            $this->transports = array_map(fn ($v) => \is_array($v) ? new \Symfony\Config\ArrayValues\TransportsConfig($v) : $v, $config['transports']);
+            unset($config['transports']);
         }
 
-        if (array_key_exists('error_pages', $value)) {
+        if (array_key_exists('error_pages', $config)) {
             $this->_usedProperties['errorPages'] = true;
-            $this->errorPages = \is_array($value['error_pages']) ? new \Symfony\Config\ArrayValues\ErrorPagesConfig($value['error_pages']) : $value['error_pages'];
-            unset($value['error_pages']);
+            $this->errorPages = \is_array($config['error_pages']) ? new \Symfony\Config\ArrayValues\ErrorPagesConfig($config['error_pages']) : $config['error_pages'];
+            unset($config['error_pages']);
         }
 
-        if ([] !== $value) {
-            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        if ($config) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($config)));
         }
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValues/Messenger/TransportsConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValues/Messenger/TransportsConfig.php
@@ -57,28 +57,44 @@ class TransportsConfig
         return $this;
     }
 
-    public function __construct(array $value = [])
+    /**
+     * @param array{
+     *     some_clever_name?: array{
+     *         first?: scalar|null,
+     *         second?: scalar|null,
+     *         third?: scalar|null,
+     *     },
+     *     messenger?: array{
+     *         transports?: array<string, array{
+     *             dsn?: scalar|null, // The DSN to use. This is a required option. The info is used to describe the DSN, it can be multi-line.
+     *             serializer?: scalar|null, // Default: null
+     *             options?: list<mixed>,
+     *         }>,
+     *     },
+     * } $config
+     */
+    public function __construct(array $config = [])
     {
-        if (array_key_exists('dsn', $value)) {
+        if (array_key_exists('dsn', $config)) {
             $this->_usedProperties['dsn'] = true;
-            $this->dsn = $value['dsn'];
-            unset($value['dsn']);
+            $this->dsn = $config['dsn'];
+            unset($config['dsn']);
         }
 
-        if (array_key_exists('serializer', $value)) {
+        if (array_key_exists('serializer', $config)) {
             $this->_usedProperties['serializer'] = true;
-            $this->serializer = $value['serializer'];
-            unset($value['serializer']);
+            $this->serializer = $config['serializer'];
+            unset($config['serializer']);
         }
 
-        if (array_key_exists('options', $value)) {
+        if (array_key_exists('options', $config)) {
             $this->_usedProperties['options'] = true;
-            $this->options = $value['options'];
-            unset($value['options']);
+            $this->options = $config['options'];
+            unset($config['options']);
         }
 
-        if ([] !== $value) {
-            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        if ($config) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($config)));
         }
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValues/MessengerConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValues/MessengerConfig.php
@@ -26,16 +26,32 @@ class MessengerConfig
         return $this->transports[$name];
     }
 
-    public function __construct(array $value = [])
+    /**
+     * @param array{
+     *     some_clever_name?: array{
+     *         first?: scalar|null,
+     *         second?: scalar|null,
+     *         third?: scalar|null,
+     *     },
+     *     messenger?: array{
+     *         transports?: array<string, array{
+     *             dsn?: scalar|null, // The DSN to use. This is a required option. The info is used to describe the DSN, it can be multi-line.
+     *             serializer?: scalar|null, // Default: null
+     *             options?: list<mixed>,
+     *         }>,
+     *     },
+     * } $config
+     */
+    public function __construct(array $config = [])
     {
-        if (array_key_exists('transports', $value)) {
+        if (array_key_exists('transports', $config)) {
             $this->_usedProperties['transports'] = true;
-            $this->transports = array_map(fn ($v) => new \Symfony\Config\NodeInitialValues\Messenger\TransportsConfig($v), $value['transports']);
-            unset($value['transports']);
+            $this->transports = array_map(fn ($v) => new \Symfony\Config\NodeInitialValues\Messenger\TransportsConfig($v), $config['transports']);
+            unset($config['transports']);
         }
 
-        if ([] !== $value) {
-            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        if ($config) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($config)));
         }
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValues/SomeCleverNameConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValues/SomeCleverNameConfig.php
@@ -54,28 +54,44 @@ class SomeCleverNameConfig
         return $this;
     }
 
-    public function __construct(array $value = [])
+    /**
+     * @param array{
+     *     some_clever_name?: array{
+     *         first?: scalar|null,
+     *         second?: scalar|null,
+     *         third?: scalar|null,
+     *     },
+     *     messenger?: array{
+     *         transports?: array<string, array{
+     *             dsn?: scalar|null, // The DSN to use. This is a required option. The info is used to describe the DSN, it can be multi-line.
+     *             serializer?: scalar|null, // Default: null
+     *             options?: list<mixed>,
+     *         }>,
+     *     },
+     * } $config
+     */
+    public function __construct(array $config = [])
     {
-        if (array_key_exists('first', $value)) {
+        if (array_key_exists('first', $config)) {
             $this->_usedProperties['first'] = true;
-            $this->first = $value['first'];
-            unset($value['first']);
+            $this->first = $config['first'];
+            unset($config['first']);
         }
 
-        if (array_key_exists('second', $value)) {
+        if (array_key_exists('second', $config)) {
             $this->_usedProperties['second'] = true;
-            $this->second = $value['second'];
-            unset($value['second']);
+            $this->second = $config['second'];
+            unset($config['second']);
         }
 
-        if (array_key_exists('third', $value)) {
+        if (array_key_exists('third', $config)) {
             $this->_usedProperties['third'] = true;
-            $this->third = $value['third'];
-            unset($value['third']);
+            $this->third = $config['third'];
+            unset($config['third']);
         }
 
-        if ([] !== $value) {
-            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        if ($config) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($config)));
         }
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValuesConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValuesConfig.php
@@ -45,22 +45,38 @@ class NodeInitialValuesConfig implements \Symfony\Component\Config\Builder\Confi
         return 'node_initial_values';
     }
 
-    public function __construct(array $value = [])
+    /**
+     * @param array{
+     *     some_clever_name?: array{
+     *         first?: scalar|null,
+     *         second?: scalar|null,
+     *         third?: scalar|null,
+     *     },
+     *     messenger?: array{
+     *         transports?: array<string, array{
+     *             dsn?: scalar|null, // The DSN to use. This is a required option. The info is used to describe the DSN, it can be multi-line.
+     *             serializer?: scalar|null, // Default: null
+     *             options?: list<mixed>,
+     *         }>,
+     *     },
+     * } $config
+     */
+    public function __construct(array $config = [])
     {
-        if (array_key_exists('some_clever_name', $value)) {
+        if (array_key_exists('some_clever_name', $config)) {
             $this->_usedProperties['someCleverName'] = true;
-            $this->someCleverName = new \Symfony\Config\NodeInitialValues\SomeCleverNameConfig($value['some_clever_name']);
-            unset($value['some_clever_name']);
+            $this->someCleverName = new \Symfony\Config\NodeInitialValues\SomeCleverNameConfig($config['some_clever_name']);
+            unset($config['some_clever_name']);
         }
 
-        if (array_key_exists('messenger', $value)) {
+        if (array_key_exists('messenger', $config)) {
             $this->_usedProperties['messenger'] = true;
-            $this->messenger = new \Symfony\Config\NodeInitialValues\MessengerConfig($value['messenger']);
-            unset($value['messenger']);
+            $this->messenger = new \Symfony\Config\NodeInitialValues\MessengerConfig($config['messenger']);
+            unset($config['messenger']);
         }
 
-        if ([] !== $value) {
-            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        if ($config) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($config)));
         }
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/Placeholders/Symfony/Config/PlaceholdersConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/Placeholders/Symfony/Config/PlaceholdersConfig.php
@@ -59,28 +59,35 @@ class PlaceholdersConfig implements \Symfony\Component\Config\Builder\ConfigBuil
         return 'placeholders';
     }
 
-    public function __construct(array $value = [])
+    /**
+     * @param array{
+     *     enabled?: bool, // Default: false
+     *     favorite_float?: float,
+     *     good_integers?: list<int<min, max>>,
+     * } $config
+     */
+    public function __construct(array $config = [])
     {
-        if (array_key_exists('enabled', $value)) {
+        if (array_key_exists('enabled', $config)) {
             $this->_usedProperties['enabled'] = true;
-            $this->enabled = $value['enabled'];
-            unset($value['enabled']);
+            $this->enabled = $config['enabled'];
+            unset($config['enabled']);
         }
 
-        if (array_key_exists('favorite_float', $value)) {
+        if (array_key_exists('favorite_float', $config)) {
             $this->_usedProperties['favoriteFloat'] = true;
-            $this->favoriteFloat = $value['favorite_float'];
-            unset($value['favorite_float']);
+            $this->favoriteFloat = $config['favorite_float'];
+            unset($config['favorite_float']);
         }
 
-        if (array_key_exists('good_integers', $value)) {
+        if (array_key_exists('good_integers', $config)) {
             $this->_usedProperties['goodIntegers'] = true;
-            $this->goodIntegers = $value['good_integers'];
-            unset($value['good_integers']);
+            $this->goodIntegers = $config['good_integers'];
+            unset($config['good_integers']);
         }
 
-        if ([] !== $value) {
-            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        if ($config) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($config)));
         }
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/PrimitiveTypes/Symfony/Config/PrimitiveTypesConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/PrimitiveTypes/Symfony/Config/PrimitiveTypesConfig.php
@@ -129,58 +129,70 @@ class PrimitiveTypesConfig implements \Symfony\Component\Config\Builder\ConfigBu
         return 'primitive_types';
     }
 
-    public function __construct(array $value = [])
+    /**
+     * @param array{
+     *     boolean_node?: bool,
+     *     enum_node?: "foo"|"bar"|"baz"|Symfony\Component\Config\Tests\Fixtures\TestEnum::Bar,
+     *     fqcn_enum_node?: foo|bar,
+     *     fqcn_unit_enum_node?: Symfony\Component\Config\Tests\Fixtures\TestEnum::Foo|Symfony\Component\Config\Tests\Fixtures\TestEnum::Bar|Symfony\Component\Config\Tests\Fixtures\TestEnum::Ccc,
+     *     float_node?: float,
+     *     integer_node?: int<min, max>,
+     *     scalar_node?: scalar|null,
+     *     scalar_node_with_default?: scalar|null, // Default: true
+     * } $config
+     */
+    public function __construct(array $config = [])
     {
-        if (array_key_exists('boolean_node', $value)) {
+        if (array_key_exists('boolean_node', $config)) {
             $this->_usedProperties['booleanNode'] = true;
-            $this->booleanNode = $value['boolean_node'];
-            unset($value['boolean_node']);
+            $this->booleanNode = $config['boolean_node'];
+            unset($config['boolean_node']);
         }
 
-        if (array_key_exists('enum_node', $value)) {
+        if (array_key_exists('enum_node', $config)) {
             $this->_usedProperties['enumNode'] = true;
-            $this->enumNode = $value['enum_node'];
-            unset($value['enum_node']);
+            $this->enumNode = $config['enum_node'];
+            unset($config['enum_node']);
         }
 
-        if (array_key_exists('fqcn_enum_node', $value)) {
+        if (array_key_exists('fqcn_enum_node', $config)) {
             $this->_usedProperties['fqcnEnumNode'] = true;
-            $this->fqcnEnumNode = $value['fqcn_enum_node'];
-            unset($value['fqcn_enum_node']);
+            $this->fqcnEnumNode = $config['fqcn_enum_node'];
+            unset($config['fqcn_enum_node']);
         }
 
-        if (array_key_exists('fqcn_unit_enum_node', $value)) {
+        if (array_key_exists('fqcn_unit_enum_node', $config)) {
             $this->_usedProperties['fqcnUnitEnumNode'] = true;
-            $this->fqcnUnitEnumNode = $value['fqcn_unit_enum_node'];
-            unset($value['fqcn_unit_enum_node']);
+            $this->fqcnUnitEnumNode = $config['fqcn_unit_enum_node'];
+            unset($config['fqcn_unit_enum_node']);
         }
 
-        if (array_key_exists('float_node', $value)) {
+        if (array_key_exists('float_node', $config)) {
             $this->_usedProperties['floatNode'] = true;
-            $this->floatNode = $value['float_node'];
-            unset($value['float_node']);
+            $this->floatNode = $config['float_node'];
+            unset($config['float_node']);
         }
 
-        if (array_key_exists('integer_node', $value)) {
+        if (array_key_exists('integer_node', $config)) {
             $this->_usedProperties['integerNode'] = true;
-            $this->integerNode = $value['integer_node'];
-            unset($value['integer_node']);
+            $this->integerNode = $config['integer_node'];
+            unset($config['integer_node']);
         }
 
-        if (array_key_exists('scalar_node', $value)) {
+        if (array_key_exists('scalar_node', $config)) {
             $this->_usedProperties['scalarNode'] = true;
-            $this->scalarNode = $value['scalar_node'];
-            unset($value['scalar_node']);
+            $this->scalarNode = $config['scalar_node'];
+            unset($config['scalar_node']);
         }
 
-        if (array_key_exists('scalar_node_with_default', $value)) {
+        if (array_key_exists('scalar_node_with_default', $config)) {
             $this->_usedProperties['scalarNodeWithDefault'] = true;
-            $this->scalarNodeWithDefault = $value['scalar_node_with_default'];
-            unset($value['scalar_node_with_default']);
+            $this->scalarNodeWithDefault = $config['scalar_node_with_default'];
+            unset($config['scalar_node_with_default']);
         }
 
-        if ([] !== $value) {
-            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        if ($config) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($config)));
         }
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/KeyedListObjectConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/KeyedListObjectConfig.php
@@ -40,22 +40,49 @@ class KeyedListObjectConfig
         return $this;
     }
 
-    public function __construct(array $value = [])
+    /**
+     * @param array{
+     *     simple_array?: list<scalar|null>,
+     *     keyed_array?: array<string, list<scalar|null>>,
+     *     object?: array{ // Default: {"enabled":null}
+     *         enabled?: bool|null, // Default: null
+     *         date_format?: scalar|null,
+     *         remove_used_context_fields?: bool,
+     *     },
+     *     list_object: list<array{
+     *         name: scalar|null,
+     *         data?: list<mixed>,
+     *     }>,
+     *     keyed_list_object?: array<string, array{
+     *         enabled?: bool, // Default: true
+     *         settings?: list<scalar|null>,
+     *     }>,
+     *     nested?: array{
+     *         nested_object?: array{ // Default: {"enabled":null}
+     *             enabled?: bool|null, // Default: null
+     *         },
+     *         nested_list_object?: list<array{
+     *             name: scalar|null,
+     *         }>,
+     *     },
+     * } $config
+     */
+    public function __construct(array $config = [])
     {
-        if (array_key_exists('enabled', $value)) {
+        if (array_key_exists('enabled', $config)) {
             $this->_usedProperties['enabled'] = true;
-            $this->enabled = $value['enabled'];
-            unset($value['enabled']);
+            $this->enabled = $config['enabled'];
+            unset($config['enabled']);
         }
 
-        if (array_key_exists('settings', $value)) {
+        if (array_key_exists('settings', $config)) {
             $this->_usedProperties['settings'] = true;
-            $this->settings = $value['settings'];
-            unset($value['settings']);
+            $this->settings = $config['settings'];
+            unset($config['settings']);
         }
 
-        if ([] !== $value) {
-            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        if ($config) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($config)));
         }
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/ListObjectConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/ListObjectConfig.php
@@ -40,22 +40,49 @@ class ListObjectConfig
         return $this;
     }
 
-    public function __construct(array $value = [])
+    /**
+     * @param array{
+     *     simple_array?: list<scalar|null>,
+     *     keyed_array?: array<string, list<scalar|null>>,
+     *     object?: array{ // Default: {"enabled":null}
+     *         enabled?: bool|null, // Default: null
+     *         date_format?: scalar|null,
+     *         remove_used_context_fields?: bool,
+     *     },
+     *     list_object: list<array{
+     *         name: scalar|null,
+     *         data?: list<mixed>,
+     *     }>,
+     *     keyed_list_object?: array<string, array{
+     *         enabled?: bool, // Default: true
+     *         settings?: list<scalar|null>,
+     *     }>,
+     *     nested?: array{
+     *         nested_object?: array{ // Default: {"enabled":null}
+     *             enabled?: bool|null, // Default: null
+     *         },
+     *         nested_list_object?: list<array{
+     *             name: scalar|null,
+     *         }>,
+     *     },
+     * } $config
+     */
+    public function __construct(array $config = [])
     {
-        if (array_key_exists('name', $value)) {
+        if (array_key_exists('name', $config)) {
             $this->_usedProperties['name'] = true;
-            $this->name = $value['name'];
-            unset($value['name']);
+            $this->name = $config['name'];
+            unset($config['name']);
         }
 
-        if (array_key_exists('data', $value)) {
+        if (array_key_exists('data', $config)) {
             $this->_usedProperties['data'] = true;
-            $this->data = $value['data'];
-            unset($value['data']);
+            $this->data = $config['data'];
+            unset($config['data']);
         }
 
-        if ([] !== $value) {
-            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        if ($config) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($config)));
         }
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/Nested/NestedListObjectConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/Nested/NestedListObjectConfig.php
@@ -26,16 +26,43 @@ class NestedListObjectConfig
         return $this;
     }
 
-    public function __construct(array $value = [])
+    /**
+     * @param array{
+     *     simple_array?: list<scalar|null>,
+     *     keyed_array?: array<string, list<scalar|null>>,
+     *     object?: array{ // Default: {"enabled":null}
+     *         enabled?: bool|null, // Default: null
+     *         date_format?: scalar|null,
+     *         remove_used_context_fields?: bool,
+     *     },
+     *     list_object: list<array{
+     *         name: scalar|null,
+     *         data?: list<mixed>,
+     *     }>,
+     *     keyed_list_object?: array<string, array{
+     *         enabled?: bool, // Default: true
+     *         settings?: list<scalar|null>,
+     *     }>,
+     *     nested?: array{
+     *         nested_object?: array{ // Default: {"enabled":null}
+     *             enabled?: bool|null, // Default: null
+     *         },
+     *         nested_list_object?: list<array{
+     *             name: scalar|null,
+     *         }>,
+     *     },
+     * } $config
+     */
+    public function __construct(array $config = [])
     {
-        if (array_key_exists('name', $value)) {
+        if (array_key_exists('name', $config)) {
             $this->_usedProperties['name'] = true;
-            $this->name = $value['name'];
-            unset($value['name']);
+            $this->name = $config['name'];
+            unset($config['name']);
         }
 
-        if ([] !== $value) {
-            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        if ($config) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($config)));
         }
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/Nested/NestedObjectConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/Nested/NestedObjectConfig.php
@@ -26,16 +26,43 @@ class NestedObjectConfig
         return $this;
     }
 
-    public function __construct(array $value = [])
+    /**
+     * @param array{
+     *     simple_array?: list<scalar|null>,
+     *     keyed_array?: array<string, list<scalar|null>>,
+     *     object?: array{ // Default: {"enabled":null}
+     *         enabled?: bool|null, // Default: null
+     *         date_format?: scalar|null,
+     *         remove_used_context_fields?: bool,
+     *     },
+     *     list_object: list<array{
+     *         name: scalar|null,
+     *         data?: list<mixed>,
+     *     }>,
+     *     keyed_list_object?: array<string, array{
+     *         enabled?: bool, // Default: true
+     *         settings?: list<scalar|null>,
+     *     }>,
+     *     nested?: array{
+     *         nested_object?: array{ // Default: {"enabled":null}
+     *             enabled?: bool|null, // Default: null
+     *         },
+     *         nested_list_object?: list<array{
+     *             name: scalar|null,
+     *         }>,
+     *     },
+     * } $config
+     */
+    public function __construct(array $config = [])
     {
-        if (array_key_exists('enabled', $value)) {
+        if (array_key_exists('enabled', $config)) {
             $this->_usedProperties['enabled'] = true;
-            $this->enabled = $value['enabled'];
-            unset($value['enabled']);
+            $this->enabled = $config['enabled'];
+            unset($config['enabled']);
         }
 
-        if ([] !== $value) {
-            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        if ($config) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($config)));
         }
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/NestedConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/NestedConfig.php
@@ -60,22 +60,49 @@ class NestedConfig
         return $this->nestedListObject[] = new \Symfony\Config\ScalarNormalizedTypes\Nested\NestedListObjectConfig($value);
     }
 
-    public function __construct(array $value = [])
+    /**
+     * @param array{
+     *     simple_array?: list<scalar|null>,
+     *     keyed_array?: array<string, list<scalar|null>>,
+     *     object?: array{ // Default: {"enabled":null}
+     *         enabled?: bool|null, // Default: null
+     *         date_format?: scalar|null,
+     *         remove_used_context_fields?: bool,
+     *     },
+     *     list_object: list<array{
+     *         name: scalar|null,
+     *         data?: list<mixed>,
+     *     }>,
+     *     keyed_list_object?: array<string, array{
+     *         enabled?: bool, // Default: true
+     *         settings?: list<scalar|null>,
+     *     }>,
+     *     nested?: array{
+     *         nested_object?: array{ // Default: {"enabled":null}
+     *             enabled?: bool|null, // Default: null
+     *         },
+     *         nested_list_object?: list<array{
+     *             name: scalar|null,
+     *         }>,
+     *     },
+     * } $config
+     */
+    public function __construct(array $config = [])
     {
-        if (array_key_exists('nested_object', $value)) {
+        if (array_key_exists('nested_object', $config)) {
             $this->_usedProperties['nestedObject'] = true;
-            $this->nestedObject = \is_array($value['nested_object']) ? new \Symfony\Config\ScalarNormalizedTypes\Nested\NestedObjectConfig($value['nested_object']) : $value['nested_object'];
-            unset($value['nested_object']);
+            $this->nestedObject = \is_array($config['nested_object']) ? new \Symfony\Config\ScalarNormalizedTypes\Nested\NestedObjectConfig($config['nested_object']) : $config['nested_object'];
+            unset($config['nested_object']);
         }
 
-        if (array_key_exists('nested_list_object', $value)) {
+        if (array_key_exists('nested_list_object', $config)) {
             $this->_usedProperties['nestedListObject'] = true;
-            $this->nestedListObject = array_map(fn ($v) => \is_array($v) ? new \Symfony\Config\ScalarNormalizedTypes\Nested\NestedListObjectConfig($v) : $v, $value['nested_list_object']);
-            unset($value['nested_list_object']);
+            $this->nestedListObject = array_map(fn ($v) => \is_array($v) ? new \Symfony\Config\ScalarNormalizedTypes\Nested\NestedListObjectConfig($v) : $v, $config['nested_list_object']);
+            unset($config['nested_list_object']);
         }
 
-        if ([] !== $value) {
-            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        if ($config) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($config)));
         }
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/ObjectConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/ObjectConfig.php
@@ -54,28 +54,55 @@ class ObjectConfig
         return $this;
     }
 
-    public function __construct(array $value = [])
+    /**
+     * @param array{
+     *     simple_array?: list<scalar|null>,
+     *     keyed_array?: array<string, list<scalar|null>>,
+     *     object?: array{ // Default: {"enabled":null}
+     *         enabled?: bool|null, // Default: null
+     *         date_format?: scalar|null,
+     *         remove_used_context_fields?: bool,
+     *     },
+     *     list_object: list<array{
+     *         name: scalar|null,
+     *         data?: list<mixed>,
+     *     }>,
+     *     keyed_list_object?: array<string, array{
+     *         enabled?: bool, // Default: true
+     *         settings?: list<scalar|null>,
+     *     }>,
+     *     nested?: array{
+     *         nested_object?: array{ // Default: {"enabled":null}
+     *             enabled?: bool|null, // Default: null
+     *         },
+     *         nested_list_object?: list<array{
+     *             name: scalar|null,
+     *         }>,
+     *     },
+     * } $config
+     */
+    public function __construct(array $config = [])
     {
-        if (array_key_exists('enabled', $value)) {
+        if (array_key_exists('enabled', $config)) {
             $this->_usedProperties['enabled'] = true;
-            $this->enabled = $value['enabled'];
-            unset($value['enabled']);
+            $this->enabled = $config['enabled'];
+            unset($config['enabled']);
         }
 
-        if (array_key_exists('date_format', $value)) {
+        if (array_key_exists('date_format', $config)) {
             $this->_usedProperties['dateFormat'] = true;
-            $this->dateFormat = $value['date_format'];
-            unset($value['date_format']);
+            $this->dateFormat = $config['date_format'];
+            unset($config['date_format']);
         }
 
-        if (array_key_exists('remove_used_context_fields', $value)) {
+        if (array_key_exists('remove_used_context_fields', $config)) {
             $this->_usedProperties['removeUsedContextFields'] = true;
-            $this->removeUsedContextFields = $value['remove_used_context_fields'];
-            unset($value['remove_used_context_fields']);
+            $this->removeUsedContextFields = $config['remove_used_context_fields'];
+            unset($config['remove_used_context_fields']);
         }
 
-        if ([] !== $value) {
-            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        if ($config) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($config)));
         }
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypesConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypesConfig.php
@@ -133,46 +133,73 @@ class ScalarNormalizedTypesConfig implements \Symfony\Component\Config\Builder\C
         return 'scalar_normalized_types';
     }
 
-    public function __construct(array $value = [])
+    /**
+     * @param array{
+     *     simple_array?: list<scalar|null>,
+     *     keyed_array?: array<string, list<scalar|null>>,
+     *     object?: array{ // Default: {"enabled":null}
+     *         enabled?: bool|null, // Default: null
+     *         date_format?: scalar|null,
+     *         remove_used_context_fields?: bool,
+     *     },
+     *     list_object: list<array{
+     *         name: scalar|null,
+     *         data?: list<mixed>,
+     *     }>,
+     *     keyed_list_object?: array<string, array{
+     *         enabled?: bool, // Default: true
+     *         settings?: list<scalar|null>,
+     *     }>,
+     *     nested?: array{
+     *         nested_object?: array{ // Default: {"enabled":null}
+     *             enabled?: bool|null, // Default: null
+     *         },
+     *         nested_list_object?: list<array{
+     *             name: scalar|null,
+     *         }>,
+     *     },
+     * } $config
+     */
+    public function __construct(array $config = [])
     {
-        if (array_key_exists('simple_array', $value)) {
+        if (array_key_exists('simple_array', $config)) {
             $this->_usedProperties['simpleArray'] = true;
-            $this->simpleArray = $value['simple_array'];
-            unset($value['simple_array']);
+            $this->simpleArray = $config['simple_array'];
+            unset($config['simple_array']);
         }
 
-        if (array_key_exists('keyed_array', $value)) {
+        if (array_key_exists('keyed_array', $config)) {
             $this->_usedProperties['keyedArray'] = true;
-            $this->keyedArray = $value['keyed_array'];
-            unset($value['keyed_array']);
+            $this->keyedArray = $config['keyed_array'];
+            unset($config['keyed_array']);
         }
 
-        if (array_key_exists('object', $value)) {
+        if (array_key_exists('object', $config)) {
             $this->_usedProperties['object'] = true;
-            $this->object = \is_array($value['object']) ? new \Symfony\Config\ScalarNormalizedTypes\ObjectConfig($value['object']) : $value['object'];
-            unset($value['object']);
+            $this->object = \is_array($config['object']) ? new \Symfony\Config\ScalarNormalizedTypes\ObjectConfig($config['object']) : $config['object'];
+            unset($config['object']);
         }
 
-        if (array_key_exists('list_object', $value)) {
+        if (array_key_exists('list_object', $config)) {
             $this->_usedProperties['listObject'] = true;
-            $this->listObject = array_map(fn ($v) => \is_array($v) ? new \Symfony\Config\ScalarNormalizedTypes\ListObjectConfig($v) : $v, $value['list_object']);
-            unset($value['list_object']);
+            $this->listObject = array_map(fn ($v) => \is_array($v) ? new \Symfony\Config\ScalarNormalizedTypes\ListObjectConfig($v) : $v, $config['list_object']);
+            unset($config['list_object']);
         }
 
-        if (array_key_exists('keyed_list_object', $value)) {
+        if (array_key_exists('keyed_list_object', $config)) {
             $this->_usedProperties['keyedListObject'] = true;
-            $this->keyedListObject = array_map(fn ($v) => \is_array($v) ? new \Symfony\Config\ScalarNormalizedTypes\KeyedListObjectConfig($v) : $v, $value['keyed_list_object']);
-            unset($value['keyed_list_object']);
+            $this->keyedListObject = array_map(fn ($v) => \is_array($v) ? new \Symfony\Config\ScalarNormalizedTypes\KeyedListObjectConfig($v) : $v, $config['keyed_list_object']);
+            unset($config['keyed_list_object']);
         }
 
-        if (array_key_exists('nested', $value)) {
+        if (array_key_exists('nested', $config)) {
             $this->_usedProperties['nested'] = true;
-            $this->nested = new \Symfony\Config\ScalarNormalizedTypes\NestedConfig($value['nested']);
-            unset($value['nested']);
+            $this->nested = new \Symfony\Config\ScalarNormalizedTypes\NestedConfig($config['nested']);
+            unset($config['nested']);
         }
 
-        if ([] !== $value) {
-            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        if ($config) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($config)));
         }
     }
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/VariableType/Symfony/Config/VariableTypeConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/VariableType/Symfony/Config/VariableTypeConfig.php
@@ -32,16 +32,21 @@ class VariableTypeConfig implements \Symfony\Component\Config\Builder\ConfigBuil
         return 'variable_type';
     }
 
-    public function __construct(array $value = [])
+    /**
+     * @param array{
+     *     any_value?: mixed,
+     * } $config
+     */
+    public function __construct(array $config = [])
     {
-        if (array_key_exists('any_value', $value)) {
+        if (array_key_exists('any_value', $config)) {
             $this->_usedProperties['anyValue'] = true;
-            $this->anyValue = $value['any_value'];
-            unset($value['any_value']);
+            $this->anyValue = $config['any_value'];
+            unset($config['any_value']);
         }
 
-        if ([] !== $value) {
-            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($value)));
+        if ($config) {
+            throw new InvalidConfigurationException(sprintf('The following keys are not supported by "%s": ', __CLASS__).implode(', ', array_keys($config)));
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

A subset of #58771

Note that only constructors get the array-shape as that's what we're going to need first to achieve what we target in #58771. We could also add array shapes to the generated fluent methods. I left that as an exercise to a future contributor ;)

