### PR TITLE
[JsonStreamer] Merge `PropertyMetadata` value transformers

### DIFF
--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -104,6 +104,14 @@ HttpKernel
  * Deprecate implementing `__sleep/wakeup()` on data collectors; use `__(un)serialize()` instead
  * Make `Profile` final and `Profiler::__sleep()` internal
 
+JsonStreamer
+------------
+
+ * Deprecate `PropertyMetadata::$streamToNativeValueTransformers`, use `PropertyMetadata::$valueTransformers` instead
+ * Deprecate `PropertyMetadata::getNativeToStreamValueTransformer()` and `PropertyMetadata::getStreamToNativeValueTransformers()`, use `PropertyMetadata::getValueTransformers()` instead
+ * Deprecate `PropertyMetadata::withNativeToStreamValueTransformers()` and `PropertyMetadata::withStreamToNativeValueTransformers()`, use `PropertyMetadata::withValueTransformers()` instead
+ * Deprecate `PropertyMetadata::withAdditionalNativeToStreamValueTransformer()` and `PropertyMetadata::withAdditionalStreamToNativeValueTransformer`, use `PropertyMetadata::withAdditionalValueTransformer()` instead
+
 Mime
 ----
 

--- a/src/Symfony/Component/JsonStreamer/CHANGELOG.md
+++ b/src/Symfony/Component/JsonStreamer/CHANGELOG.md
@@ -9,6 +9,10 @@ CHANGELOG
  * Add `_current_object` to the context passed to value transformers during write operations
  * Add `include_null_properties` option to encode the properties with `null` value
  * Add synthetic properties support
+ * Deprecate `PropertyMetadata::$streamToNativeValueTransformers`, use `PropertyMetadata::$valueTransformers` instead
+ * Deprecate `PropertyMetadata::getNativeToStreamValueTransformer()` and `PropertyMetadata::getStreamToNativeValueTransformers()`, use `PropertyMetadata::getValueTransformers()` instead
+ * Deprecate `PropertyMetadata::withNativeToStreamValueTransformers()` and `PropertyMetadata::withStreamToNativeValueTransformers()`, use `PropertyMetadata::withValueTransformers()` instead
+ * Deprecate `PropertyMetadata::withAdditionalNativeToStreamValueTransformer()` and `PropertyMetadata::withAdditionalStreamToNativeValueTransformer`, use `PropertyMetadata::withAdditionalValueTransformer()` instead
 
 7.3
 ---

--- a/src/Symfony/Component/JsonStreamer/Mapping/PropertyMetadata.php
+++ b/src/Symfony/Component/JsonStreamer/Mapping/PropertyMetadata.php
@@ -20,16 +20,23 @@ use Symfony\Component\TypeInfo\Type;
  */
 final class PropertyMetadata
 {
+    private ?array $streamToNativeValueTransformers;
+
     /**
-     * @param list<string|\Closure> $nativeToStreamValueTransformers
-     * @param list<string|\Closure> $streamToNativeValueTransformers
+     * @param list<string|\Closure>      $valueTransformers
+     * @param list<string|\Closure>|null $streamToNativeValueTransformers
      */
     public function __construct(
         private ?string $name,
         private Type $type,
-        private array $nativeToStreamValueTransformers = [],
-        private array $streamToNativeValueTransformers = [],
+        private array $valueTransformers = [],
+        ?array $streamToNativeValueTransformers = null,
     ) {
+        if (null !== $streamToNativeValueTransformers) {
+            trigger_deprecation('symfony/json-streamer', '7.4', 'The "streamToNativeValueTransformers" parameter of the "%s()" method is deprecated. Use "valueTransformers" instead.', __METHOD__);
+        }
+
+        $this->streamToNativeValueTransformers = $streamToNativeValueTransformers;
     }
 
     /**
@@ -51,7 +58,7 @@ final class PropertyMetadata
 
     public function withName(?string $name): self
     {
-        return new self($name, $this->type, $this->nativeToStreamValueTransformers, $this->streamToNativeValueTransformers);
+        return new self($name, $this->type, $this->valueTransformers, $this->streamToNativeValueTransformers);
     }
 
     public function getType(): Type
@@ -61,28 +68,67 @@ final class PropertyMetadata
 
     public function withType(Type $type): self
     {
-        return new self($this->name, $type, $this->nativeToStreamValueTransformers, $this->streamToNativeValueTransformers);
+        return new self($this->name, $type, $this->valueTransformers, $this->streamToNativeValueTransformers);
     }
 
     /**
      * @return list<string|\Closure>
      */
-    public function getNativeToStreamValueTransformer(): array
+    public function getValueTransformers(): array
     {
-        return $this->nativeToStreamValueTransformers;
+        return $this->valueTransformers;
     }
 
     /**
+     * @param list<string|\Closure> $valueTransformers
+     */
+    public function withValueTransformers(array $valueTransformers): self
+    {
+        return new self($this->name, $this->type, $valueTransformers);
+    }
+
+    public function withAdditionalValueTransformer(string|\Closure $valueTransformer): self
+    {
+        $valueTransformers = $this->valueTransformers;
+
+        $valueTransformers[] = $valueTransformer;
+        $valueTransformers = array_values(array_unique($valueTransformers));
+
+        return $this->withValueTransformers($valueTransformers);
+    }
+
+    /**
+     * @deprecated since Symfony 7.4, use "getValueTransformers" instead
+     *
+     * @return list<string|\Closure>
+     */
+    public function getNativeToStreamValueTransformer(): array
+    {
+        trigger_deprecation('symfony/json-streamer', '7.4', 'The "%s()" method is deprecated, use "%s::getValueTransformers()" instead.', __METHOD__, self::class);
+
+        return $this->valueTransformers;
+    }
+
+    /**
+     * @deprecated since Symfony 7.4, use "withValueTransformers" instead
+     *
      * @param list<string|\Closure> $nativeToStreamValueTransformers
      */
     public function withNativeToStreamValueTransformers(array $nativeToStreamValueTransformers): self
     {
+        trigger_deprecation('symfony/json-streamer', '7.4', 'The "%s()" method is deprecated, use "%s::withValueTransformers()" instead.', __METHOD__, self::class);
+
         return new self($this->name, $this->type, $nativeToStreamValueTransformers, $this->streamToNativeValueTransformers);
     }
 
+    /**
+     * @deprecated since Symfony 7.4, use "withAdditionalValueTransformer" instead
+     */
     public function withAdditionalNativeToStreamValueTransformer(string|\Closure $nativeToStreamValueTransformer): self
     {
-        $nativeToStreamValueTransformers = $this->nativeToStreamValueTransformers;
+        trigger_deprecation('symfony/json-streamer', '7.4', 'The "%s()" method is deprecated, use "%s::withAdditionalValueTransformer()" instead.', __METHOD__, self::class);
+
+        $nativeToStreamValueTransformers = $this->valueTransformers;
 
         $nativeToStreamValueTransformers[] = $nativeToStreamValueTransformer;
         $nativeToStreamValueTransformers = array_values(array_unique($nativeToStreamValueTransformers));
@@ -91,24 +137,37 @@ final class PropertyMetadata
     }
 
     /**
+     * @deprecated since Symfony 7.4, use "getValueTransformers" instead
+     *
      * @return list<string|\Closure>
      */
     public function getStreamToNativeValueTransformers(): array
     {
-        return $this->streamToNativeValueTransformers;
+        trigger_deprecation('symfony/json-streamer', '7.4', 'The "%s()" method is deprecated, use "%s::getValueTransformers()" instead.', __METHOD__, self::class);
+
+        return $this->streamToNativeValueTransformers ?? [];
     }
 
     /**
+     * @deprecated since Symfony 7.4, use "withValueTransformers" instead
+     *
      * @param list<string|\Closure> $streamToNativeValueTransformers
      */
     public function withStreamToNativeValueTransformers(array $streamToNativeValueTransformers): self
     {
-        return new self($this->name, $this->type, $this->nativeToStreamValueTransformers, $streamToNativeValueTransformers);
+        trigger_deprecation('symfony/json-streamer', '7.4', 'The "%s()" method is deprecated, use "%s::withValueTransformers()" instead.', __METHOD__, self::class);
+
+        return new self($this->name, $this->type, $this->valueTransformers, $streamToNativeValueTransformers);
     }
 
+    /**
+     * @deprecated since Symfony 7.4, use "withAdditionalValueTransformer" instead
+     */
     public function withAdditionalStreamToNativeValueTransformer(string|\Closure $streamToNativeValueTransformer): self
     {
-        $streamToNativeValueTransformers = $this->streamToNativeValueTransformers;
+        trigger_deprecation('symfony/json-streamer', '7.4', 'The "%s()" method is deprecated, use "%s::withAdditionalValueTransformer()" instead.', __METHOD__, self::class);
+
+        $streamToNativeValueTransformers = $this->streamToNativeValueTransformers ?? [];
 
         $streamToNativeValueTransformers[] = $streamToNativeValueTransformer;
         $streamToNativeValueTransformers = array_values(array_unique($streamToNativeValueTransformers));

--- a/src/Symfony/Component/JsonStreamer/Mapping/Read/AttributePropertyMetadataLoader.php
+++ b/src/Symfony/Component/JsonStreamer/Mapping/Read/AttributePropertyMetadataLoader.php
@@ -66,7 +66,7 @@ final class AttributePropertyMetadataLoader implements PropertyMetadataLoaderInt
 
                 $result[$streamedName] = $initialMetadata
                     ->withType($valueTransformerService::getStreamValueType())
-                    ->withAdditionalStreamToNativeValueTransformer($valueTransformer);
+                    ->withAdditionalValueTransformer($valueTransformer);
 
                 continue;
             }
@@ -83,7 +83,7 @@ final class AttributePropertyMetadataLoader implements PropertyMetadataLoaderInt
 
             $result[$streamedName] = $initialMetadata
                 ->withType($this->typeResolver->resolve($parameterReflection))
-                ->withAdditionalStreamToNativeValueTransformer($valueTransformer);
+                ->withAdditionalValueTransformer($valueTransformer);
         }
 
         return $result;

--- a/src/Symfony/Component/JsonStreamer/Mapping/Read/DateTimeTypePropertyMetadataLoader.php
+++ b/src/Symfony/Component/JsonStreamer/Mapping/Read/DateTimeTypePropertyMetadataLoader.php
@@ -44,7 +44,7 @@ final class DateTimeTypePropertyMetadataLoader implements PropertyMetadataLoader
 
                 $metadata = $metadata
                     ->withType(StringToDateTimeValueTransformer::getStreamValueType())
-                    ->withAdditionalStreamToNativeValueTransformer('json_streamer.value_transformer.string_to_date_time');
+                    ->withAdditionalValueTransformer('json_streamer.value_transformer.string_to_date_time');
             }
         }
 

--- a/src/Symfony/Component/JsonStreamer/Mapping/Write/AttributePropertyMetadataLoader.php
+++ b/src/Symfony/Component/JsonStreamer/Mapping/Write/AttributePropertyMetadataLoader.php
@@ -66,7 +66,7 @@ final class AttributePropertyMetadataLoader implements PropertyMetadataLoaderInt
 
                 $result[$streamedName] = $initialMetadata
                     ->withType($valueTransformerService::getStreamValueType())
-                    ->withAdditionalNativeToStreamValueTransformer($valueTransformer);
+                    ->withAdditionalValueTransformer($valueTransformer);
 
                 continue;
             }
@@ -79,7 +79,7 @@ final class AttributePropertyMetadataLoader implements PropertyMetadataLoaderInt
 
             $result[$streamedName] = $initialMetadata
                 ->withType($this->typeResolver->resolve($valueTransformerReflection))
-                ->withAdditionalNativeToStreamValueTransformer($valueTransformer);
+                ->withAdditionalValueTransformer($valueTransformer);
         }
 
         return $result;

--- a/src/Symfony/Component/JsonStreamer/Mapping/Write/DateTimeTypePropertyMetadataLoader.php
+++ b/src/Symfony/Component/JsonStreamer/Mapping/Write/DateTimeTypePropertyMetadataLoader.php
@@ -39,7 +39,7 @@ final class DateTimeTypePropertyMetadataLoader implements PropertyMetadataLoader
             if ($type instanceof ObjectType && is_a($type->getClassName(), \DateTimeInterface::class, true)) {
                 $metadata = $metadata
                     ->withType(DateTimeToStringValueTransformer::getStreamValueType())
-                    ->withAdditionalNativeToStreamValueTransformer('json_streamer.value_transformer.date_time_to_string');
+                    ->withAdditionalValueTransformer('json_streamer.value_transformer.date_time_to_string');
             }
         }
 

--- a/src/Symfony/Component/JsonStreamer/Read/StreamReaderGenerator.php
+++ b/src/Symfony/Component/JsonStreamer/Read/StreamReaderGenerator.php
@@ -135,7 +135,7 @@ final class StreamReaderGenerator
                     'name' => $propertyMetadata->getName(),
                     'value' => $this->createDataModel($propertyMetadata->getType(), $options, $context),
                     'accessor' => function (string $accessor) use ($propertyMetadata): string {
-                        foreach ($propertyMetadata->getStreamToNativeValueTransformers() as $valueTransformer) {
+                        foreach ($propertyMetadata->getValueTransformers() as $valueTransformer) {
                             if (\is_string($valueTransformer)) {
                                 $accessor = "\$valueTransformers->get('$valueTransformer')->transform($accessor, \$options)";
 

--- a/src/Symfony/Component/JsonStreamer/Tests/Mapping/Read/AttributePropertyMetadataLoaderTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Mapping/Read/AttributePropertyMetadataLoaderTest.php
@@ -42,10 +42,10 @@ class AttributePropertyMetadataLoaderTest extends TestCase
         ]), TypeResolver::create());
 
         $this->assertEquals([
-            'id' => new PropertyMetadata('id', Type::string(), [], [DivideStringAndCastToIntValueTransformer::class]),
-            'active' => new PropertyMetadata('active', Type::string(), [], [StringToBooleanValueTransformer::class]),
-            'name' => new PropertyMetadata('name', Type::string(), [], [\Closure::fromCallable('strtoupper')]),
-            'range' => new PropertyMetadata('range', Type::string(), [], [\Closure::fromCallable(DummyWithValueTransformerAttributes::explodeRange(...))]),
+            'id' => new PropertyMetadata('id', Type::string(), [DivideStringAndCastToIntValueTransformer::class]),
+            'active' => new PropertyMetadata('active', Type::string(), [StringToBooleanValueTransformer::class]),
+            'name' => new PropertyMetadata('name', Type::string(), [\Closure::fromCallable('strtoupper')]),
+            'range' => new PropertyMetadata('range', Type::string(), [\Closure::fromCallable(DummyWithValueTransformerAttributes::explodeRange(...))]),
         ], $loader->load(DummyWithValueTransformerAttributes::class));
     }
 

--- a/src/Symfony/Component/JsonStreamer/Tests/Mapping/Read/DateTimeTypePropertyMetadataLoaderTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Mapping/Read/DateTimeTypePropertyMetadataLoaderTest.php
@@ -29,8 +29,8 @@ class DateTimeTypePropertyMetadataLoaderTest extends TestCase
         ]));
 
         $this->assertEquals([
-            'interface' => new PropertyMetadata('interface', Type::string(), [], ['json_streamer.value_transformer.string_to_date_time']),
-            'immutable' => new PropertyMetadata('immutable', Type::string(), [], ['json_streamer.value_transformer.string_to_date_time']),
+            'interface' => new PropertyMetadata('interface', Type::string(), ['json_streamer.value_transformer.string_to_date_time']),
+            'immutable' => new PropertyMetadata('immutable', Type::string(), ['json_streamer.value_transformer.string_to_date_time']),
             'other' => new PropertyMetadata('other', Type::object(self::class)),
         ], $loader->load(self::class));
     }

--- a/src/Symfony/Component/JsonStreamer/Write/StreamWriterGenerator.php
+++ b/src/Symfony/Component/JsonStreamer/Write/StreamWriterGenerator.php
@@ -135,7 +135,7 @@ final class StreamWriterGenerator
             foreach ($propertiesMetadata as $streamedName => $propertyMetadata) {
                 $propertyAccessor = $propertyMetadata->getName() ? $accessor.'->'.$propertyMetadata->getName() : 'null';
 
-                foreach ($propertyMetadata->getNativeToStreamValueTransformer() as $valueTransformer) {
+                foreach ($propertyMetadata->getValueTransformers() as $valueTransformer) {
                     if (\is_string($valueTransformer)) {
                         $valueTransformerServiceAccessor = "\$valueTransformers->get('$valueTransformer')";
                         $propertyAccessor = "{$valueTransformerServiceAccessor}->transform($propertyAccessor, ['_current_object' => $accessor] + \$options)";

--- a/src/Symfony/Component/JsonStreamer/composer.json
+++ b/src/Symfony/Component/JsonStreamer/composer.json
@@ -19,6 +19,7 @@
         "php": ">=8.2",
         "psr/container": "^1.1|^2.0",
         "psr/log": "^1|^2|^3",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/filesystem": "^7.2|^8.0",
         "symfony/type-info": "^7.3.3|^8.0",
         "symfony/var-exporter": "^7.2|^8.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Issues        | 
| License       | MIT

This PR merges `PropertyMetadata::$streamToNativeValueTransformers` and `PropertyMetadata::$nativeToStreamValueTransformers` to `PropertyMetadata::$valueTransformers`.

Indeed, as property metadata is computed in one way at the time (reading or writing), there is no benefit keeping a distinction between native to stream and stream to native.
