### PR TITLE
[Serializer] xml empty array encoding

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -378,7 +378,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
                     }
                 } elseif (\is_array($data) && !is_numeric($key)) {
                     // Is this array fully numeric keys?
-                    if (!$preserveNumericKeys && null === array_find_key($data, static fn ($v, $k) => is_string($k))) {
+                    if (!$preserveNumericKeys && $data && null === array_find_key($data, static fn ($v, $k) => \is_string($k))) {
                         /*
                          * Create nodes to append to $parentNode based on the $key of this array
                          * Produces <xml><item>0</item><item>1</item></xml>

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -1069,12 +1069,24 @@ class XmlEncoderTest extends TestCase
             </response>
             XML;
         $expected = ['person' => [
-            ['@key' => 0, 'firstname' => 'Benjamin', 'lastname' => 'Alexandre', ],
-            ['@key' => 1, 'firstname' => 'Damien', 'lastname' => 'Clay', ],
+            ['@key' => 0, 'firstname' => 'Benjamin', 'lastname' => 'Alexandre'],
+            ['@key' => 1, 'firstname' => 'Damien', 'lastname' => 'Clay'],
         ]];
 
         $this->assertSame($expected, $this->encoder->decode($source, 'xml', [
             XmlEncoder::PRESERVE_NUMERIC_KEYS => true,
         ]));
+    }
+
+    public function testEncodeEmptyArrayWithoutPreservingKeys()
+    {
+        $source = ['person' => []];
+        $expected = <<<'XML'
+            <?xml version="1.0"?>
+            <response><person/></response>
+
+            XML;
+
+        $this->assertSame($expected, $this->encoder->encode($source, 'xml'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | n/a
| License       | MIT

This fixes a BC break introduced in https://github.com/symfony/symfony/pull/60228.

At https://github.com/symfony/symfony/pull/60228/files#diff-b031dbb2186367839adfe20696612866da91513dd315f00ad6df23b5d38fca74R381 the condition change breaks encoding of an empty array:

```diff
-     if (ctype_digit(implode('', array_keys($data)))) {
+    if (!$preserveNumericKeys && null === array_find_key($data, static fn ($v, $k) => is_string($k))) {
```

Indeed, `array_find_key` on an empty array correctly finds no string keys and returns null, making the condition true. The previous version using `ctype_digit` was false. 