### PR TITLE
[DependencyInjection] Handle returning arrays and config-builders from config files

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Add argument `$target` to `ContainerBuilder::registerAliasForArgument()`
  * Deprecate registering a service without a class when its id is a non-existing FQCN
  * Allow multiple `#[AsDecorator]` attributes
+ * Handle returning arrays and config-builders from config files
 
 7.3
 ---

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AcmeConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AcmeConfig.php
@@ -10,6 +10,12 @@ class AcmeConfig implements ConfigBuilderInterface
 
     private $nested;
 
+    public function __construct(array $config = [])
+    {
+        $this->color = $config['color'] ?? null;
+        $this->nested = $config['nested'] ?? null;
+    }
+
     public function color($value)
     {
         $this->color = $value;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/return_config_builder.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/return_config_builder.php
@@ -1,0 +1,8 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Tests\Fixtures\AcmeConfig;
+
+$config = new AcmeConfig();
+$config->color('red');
+
+return $config;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/return_generator.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/return_generator.php
@@ -1,0 +1,7 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Tests\Fixtures\AcmeConfig;
+
+return function () {
+    yield new AcmeConfig(['color' => 'red']);
+};

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/return_invalid_types.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/return_invalid_types.php
@@ -1,0 +1,3 @@
+<?php
+
+return new \stdClass();

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/return_iterable_configs.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/return_iterable_configs.php
@@ -1,0 +1,8 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Tests\Fixtures\AcmeConfig;
+
+return [
+    'acme' => ['color' => 'red'],
+    new AcmeConfig(),
+];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Another step on the path explored in #58771

This allows returning PHP arrays or config-builders from config files.

Several styles are supported, some examples below.

What this does *not* support is config trees under the `import`, `parameters` or `services` namespaces (that's for another PR).

Arrays:
```php
return [
    'framework' => [...],
];
```

```php
return static function () {
    yield 'framework' => [...];
];
```

Config builders (best DX together with #61879):

```php
return new FrameworkConfig([...]);
```

```php
return static function () {
    return new FrameworkConfig([...]);
];
```

```php
// $env is always available in config files
if ('dev' === $env) {
    return new FrameworkConfig([...]);
}
```

```php
return static function (string $env) {
    if ('dev' === $env) {
        yield new FrameworkConfig([...]);
    }
};
```
