### PR TITLE
[WebProfilerBundle] Simplify toolbar CSS

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
@@ -125,13 +125,15 @@
 
             <div class="sf-toolbar-info-piece sf-toolbar-info-php-ext">
                 <b>PHP Extensions</b>
-                {% if collector.hasXdebugInfo %}
-                    <a href="{{ path('_profiler_xdebug') }}" title="View xdebug_info()">
-                {% endif %}
-                <span class="sf-toolbar-status sf-toolbar-status-{{ collector.hasXdebug ? 'green' : 'gray' }}">Xdebug {{ collector.hasXdebug ? '✓' : '✗' }}</span>
-                {% if collector.hasXdebugInfo %}
-                    </a>
-                {% endif %}
+                <span class="sf-toolbar-status sf-toolbar-status-{{ collector.hasXdebug ? 'green' : 'gray' }}">
+                    {% if collector.hasXdebugInfo %}
+                        <a href="{{ path('_profiler_xdebug') }}" title="View xdebug_info()">
+                    {% endif %}
+                    Xdebug {{ collector.hasXdebug ? '✓' : '✗' }}
+                    {% if collector.hasXdebugInfo %}
+                        </a>
+                    {% endif %}
+                </span>
                 <span class="sf-toolbar-status sf-toolbar-status-{{ collector.hasapcu ? 'green' : 'gray' }}">APCu {{ collector.hasapcu ? '✓' : '✗' }}</span>
                 <span class="sf-toolbar-status sf-toolbar-status-{{ collector.haszendopcache ? 'green' : 'red' }}">OPcache {{ collector.haszendopcache ? '✓' : '✗' }}</span>
             </div>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
@@ -92,7 +92,7 @@
             <div class="sf-toolbar-info-group">
                 <div class="sf-toolbar-info-piece">
                     <b>
-                        <span class="sf-toolbar-redirection-status sf-toolbar-status-yellow">{{ collector.redirect.status_code }}</span>
+                        <span class="sf-toolbar-status sf-toolbar-status-yellow">{{ collector.redirect.status_code }}</span>
                         Redirect from
                     </b>
                     <span>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -162,9 +162,6 @@
     color: inherit;
 }
 
-.sf-toolbar-block span {
-    display: inline-block;
-}
 .sf-toolbar-block .sf-toolbar-value {
     color: var(--sf-toolbar-gray-100);
     font-size: 13px;
@@ -217,10 +214,6 @@
     margin-left: 4px;
 }
 
-.sf-toolbar-block .sf-toolbar-info-piece:last-child {
-    margin-bottom: 0;
-}
-
 div.sf-toolbar .sf-toolbar-block .sf-toolbar-info-piece a {
     color: #99CDD8;
     text-decoration: underline;
@@ -270,16 +263,12 @@ div.sf-toolbar  .sf-toolbar-block .sf-toolbar-info-piece.sf-toolbar-info-php-ext
     color: var(--sf-toolbar-white);
     background-color: var(--sf-toolbar-gray-600);
     padding: 3px 6px;
-    margin: 0 4px;
     min-width: 15px;
-    min-height: 13px;
     text-align: center;
 }
 
-.sf-toolbar-block .sf-toolbar-status.sf-toolbar-status-green,
-.sf-toolbar-block .sf-toolbar-info .sf-toolbar-status.sf-toolbar-status-green {
+.sf-toolbar-block .sf-toolbar-status.sf-toolbar-status-green {
     background-color: #059669;
-    color: var(--white);
 }
 .sf-toolbar-block .sf-toolbar-status.sf-toolbar-status-red,
 .sf-toolbar-block .sf-toolbar-info .sf-toolbar-status.sf-toolbar-status-red {
@@ -317,32 +306,15 @@ div.sf-toolbar  .sf-toolbar-block .sf-toolbar-info-piece.sf-toolbar-info-php-ext
     display: none;
 }
 
+.sf-toolbar-block.sf-toolbar-block-request .sf-toolbar-icon {
+    padding: 0 4px;
+}
 .sf-toolbar-block-request .sf-toolbar-status {
     border-radius: 6px;
-    color: #fff;
-    display: inline-block;
     flex-shrink: 0;
     font-size: 13px;
     font-weight: 500;
     padding: 4px 8px;
-}
-.sf-toolbar-block-request .sf-toolbar-info-piece a {
-    background-color: transparent;
-    text-decoration: none;
-}
-.sf-toolbar-block-request .sf-toolbar-info-piece a:hover {
-    text-decoration: underline;
-}
-.sf-toolbar-block-request .sf-toolbar-redirection-status {
-    font-weight: normal;
-    padding: 2px 4px;
-    line-height: 18px;
-}
-.sf-toolbar-block.sf-toolbar-block-request .sf-toolbar-redirection-status.sf-toolbar-status-yellow {
-    background-color: var(--sf-toolbar-yellow-300);
-    border-radius: 4px;
-    color: var(--sf-toolbar-yellow-800);
-    padding: 1px 4px;
 }
 .sf-toolbar-block.sf-toolbar-block-request .sf-toolbar-info-piece .sf-toolbar-redirection-method {
     background: transparent;
@@ -390,11 +362,6 @@ div.sf-toolbar  .sf-toolbar-block .sf-toolbar-info-piece.sf-toolbar-info-php-ext
 }
 .sf-toolbar-block.sf-toolbar-block-right:hover .sf-toolbar-icon {
     box-shadow: -1px 0 0 var(--sf-toolbar-black), inset 0 -1px 0 var(--sf-toolbar-black);
-}
-
-.sf-toolbar-block-request .sf-toolbar-icon {
-    padding-left: 0;
-    padding-right: 0;
 }
 
 .sf-toolbar-block .sf-toolbar-icon img,
@@ -575,18 +542,6 @@ div.sf-toolbar  .sf-toolbar-block .sf-toolbar-info-piece.sf-toolbar-info-php-ext
     .sf-toolbar-block .sf-toolbar-icon {
         padding: 0 10px;
     }
-    .sf-toolbar-block-time .sf-toolbar-icon {
-        padding-right: 5px;
-    }
-    .sf-toolbar-block-memory .sf-toolbar-icon {
-        padding-left: 5px;
-    }
-    .sf-toolbar-block-request .sf-toolbar-icon {
-        display: flex;
-        align-items: center;
-        padding-left: 0;
-        padding-right: 0;
-    }
     .sf-toolbar-block-request .sf-toolbar-label {
         margin-left: 4px;
         margin-right: 1px;
@@ -597,9 +552,6 @@ div.sf-toolbar  .sf-toolbar-block .sf-toolbar-info-piece.sf-toolbar-info-php-ext
     }
     .sf-toolbar-block-request .sf-toolbar-icon .sf-toolbar-request-icon + .sf-toolbar-label {
         margin-left: 0;
-     }
-    .sf-toolbar-block-request .sf-toolbar-label + .sf-toolbar-value {
-        margin-right: 5px;
     }
 
     .sf-toolbar-block-request:hover .sf-toolbar-info {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

When working on the toolbar I saw “status” were not aligned with other “info pieces”.

Before:

<img width="347" height="242" alt="toolbar-info-before" src="https://github.com/user-attachments/assets/eaca8f04-80ff-40a8-a5b3-0926f16fb124" />

After:

<img width="331" height="242" alt="toolbar-info-after" src="https://github.com/user-attachments/assets/35103610-7c4a-45d3-9c6b-0fe58fe24240" />


When looking into it I also noticed some obsolete rules which this PR removes/updates.