### PR TITLE
[FrameworkBundle] remove deprecated --show-arguments from debug:container command

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -184,6 +184,7 @@ FrameworkBundle
  * Remove the `router.cache_dir` config option
  * Remove the `validation.cache` option
  * Remove `TranslationUpdateCommand` in favor of `TranslationExtractCommand`
+ * Remove deprecated `--show-arguments` option from `debug:container` command
 
 HtmlSanitizer
 -------------

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -43,7 +43,6 @@ class ContainerDebugCommand extends Command
         $this
             ->setDefinition([
                 new InputArgument('name', InputArgument::OPTIONAL, 'A service name (foo)'),
-                new InputOption('show-arguments', null, InputOption::VALUE_NONE, 'Show arguments in services'),
                 new InputOption('show-hidden', null, InputOption::VALUE_NONE, 'Show hidden (internal) services'),
                 new InputOption('tag', null, InputOption::VALUE_REQUIRED, 'Show all services with a specific tag'),
                 new InputOption('tags', null, InputOption::VALUE_NONE, 'Display tagged services for an application'),
@@ -68,10 +67,6 @@ class ContainerDebugCommand extends Command
                 To get specific information about a service, specify its name:
 
                   <info>php %command.full_name% validator</info>
-
-                To get specific information about a service including all its arguments, use the <info>--show-arguments</info> flag:
-
-                  <info>php %command.full_name% validator --show-arguments</info>
 
                 To see available types that can be used for autowiring, use the <info>--types</info> flag:
 
@@ -151,10 +146,6 @@ class ContainerDebugCommand extends Command
             $tag = $this->findProperTagName($input, $errorIo, $object, $tag);
             $options = ['tag' => $tag];
         } elseif ($name = $input->getArgument('name')) {
-            if ($input->getOption('show-arguments')) {
-                $errorIo->warning('The "--show-arguments" option is deprecated.');
-            }
-
             $name = $this->findProperServiceName($input, $errorIo, $object, $name, $input->getOption('show-hidden'));
             $options = ['id' => $name];
         } elseif ($input->getOption('deprecations')) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
@@ -342,22 +342,4 @@ class ContainerDebugCommandTest extends AbstractWebTestCase
             ['txt', 'xml', 'json', 'md'],
         ];
     }
-
-    public function testShowArgumentsProvidedShouldTriggerDeprecation()
-    {
-        static::bootKernel(['test_case' => 'ContainerDebug', 'root_config' => 'config.yml', 'debug' => true]);
-        $path = \sprintf('%s/%sDeprecations.log', static::$kernel->getContainer()->getParameter('kernel.build_dir'), static::$kernel->getContainer()->getParameter('kernel.container_class'));
-        @unlink($path);
-
-        $application = new Application(static::$kernel);
-        $application->setAutoExit(false);
-
-        @unlink(static::getContainer()->getParameter('debug.container.dump'));
-
-        $tester = new ApplicationTester($application);
-        $tester->run(['command' => 'debug:container', 'name' => 'router', '--show-arguments' => true]);
-
-        $tester->assertCommandIsSuccessful();
-        $this->assertStringContainsString('[WARNING] The "--show-arguments" option is deprecated.', $tester->getDisplay());
-    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| License       | MIT


Removed at 8.0 per this discussion: https://github.com/symfony/symfony/pull/59225#issuecomment-2550701864 