### PR TITLE
[Console] Rename `#[Input]` to `#[MapInput]`

### DIFF
--- a/src/Symfony/Component/Console/Attribute/MapInput.php
+++ b/src/Symfony/Component/Console/Attribute/MapInput.php
@@ -15,8 +15,11 @@ use Symfony\Component\Console\Attribute\Reflection\ReflectionMember;
 use Symfony\Component\Console\Exception\LogicException;
 use Symfony\Component\Console\Input\InputInterface;
 
+/**
+ * Maps a command input into an object (DTO).
+ */
 #[\Attribute(\Attribute::TARGET_PARAMETER | \Attribute::TARGET_PROPERTY)]
-final class Input
+final class MapInput
 {
     /**
      * @var array<string, Argument|Option|self>

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -11,7 +11,7 @@ CHANGELOG
  * Add `BackedEnum` support with `#[Argument]` and `#[Option]` inputs in invokable commands
  * Allow Usages to be specified via `#[AsCommand]` attribute.
  * Allow passing invokable commands to `Symfony\Component\Console\Tester\CommandTester`
- * Add `#[Input]` attribute to support DTOs in commands
+ * Add `#[MapInput]` attribute to support DTOs in commands
  * Add optional timeout for interaction in `QuestionHelper`
 
 7.3

--- a/src/Symfony/Component/Console/Command/InvokableCommand.php
+++ b/src/Symfony/Component/Console/Command/InvokableCommand.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Console\Command;
 
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Attribute\Argument;
-use Symfony\Component\Console\Attribute\Input;
+use Symfony\Component\Console\Attribute\MapInput;
 use Symfony\Component\Console\Attribute\Option;
 use Symfony\Component\Console\Exception\LogicException;
 use Symfony\Component\Console\Exception\RuntimeException;
@@ -87,7 +87,7 @@ class InvokableCommand implements SignalableCommandInterface
                 continue;
             }
 
-            if ($input = Input::tryFrom($parameter)) {
+            if ($input = MapInput::tryFrom($parameter)) {
                 $inputArguments = array_map(fn (Argument $a) => $a->toInputArgument(), iterator_to_array($input->getArguments(), false));
 
                 // make sure optional arguments are defined after required ones
@@ -149,7 +149,7 @@ class InvokableCommand implements SignalableCommandInterface
                 continue;
             }
 
-            if ($in = Input::tryFrom($parameter)) {
+            if ($in = MapInput::tryFrom($parameter)) {
                 $parameters[] = $in->resolveValue($input);
 
                 continue;

--- a/src/Symfony/Component/Console/Tests/Fixtures/InvokableWithInputTestCommand.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/InvokableWithInputTestCommand.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Console\Tests\Fixtures;
 
 use Symfony\Component\Console\Attribute\Argument;
 use Symfony\Component\Console\Attribute\AsCommand;
-use Symfony\Component\Console\Attribute\Input;
+use Symfony\Component\Console\Attribute\MapInput;
 use Symfony\Component\Console\Attribute\Option;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -21,7 +21,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 #[AsCommand('invokable:input:test')]
 class InvokableWithInputTestCommand
 {
-    public function __invoke(SymfonyStyle $io, #[Input] UserDto $user): int
+    public function __invoke(SymfonyStyle $io, #[MapInput] UserDto $user): int
     {
         $io->writeln($user->name);
         $io->writeln($user->email);
@@ -47,7 +47,7 @@ final class UserDto
     #[Argument]
     public string $password;
 
-    #[Input]
+    #[MapInput]
     public UserGroupDto $group;
 
     #[Option]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Reasoning:
- One may confuse `Input` with `InputInterface` implementations
- The `Map` convention from controllers is nice, sticking with it makes sense and brings consistency
- I'm gonna add more, `#[MapEntity]` on its way

Fabbot's fail is a false positive.
