### PR TITLE
 Remove _wakeup/sleep() relicate property

### DIFF
--- a/src/Symfony/Component/Mime/Part/SMimePart.php
+++ b/src/Symfony/Component/Mime/Part/SMimePart.php
@@ -18,9 +18,6 @@ use Symfony\Component\Mime\Header\Headers;
  */
 class SMimePart extends AbstractPart
 {
-    /** @internal, to be removed in 8.0 */
-    protected Headers $_headers;
-
     public function __construct(
         private iterable|string $body,
         private string $type,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | no 
| Deprecations? | yes
| License       | MIT

Small relicate from ```_wakeup/sleep()``` removal effort #61424