### PR TITLE
[Validator] Add missing Polish plural form for word count validator

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.pl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.pl.xlf
@@ -448,7 +448,7 @@
             </trans-unit>
             <trans-unit id="115">
                 <source>This value is too long. It should contain one word.|This value is too long. It should contain {{ max }} words or less.</source>
-                <target>Ta wartość jest zbyt długa. Powinna zawierać jedno słowo.|Ta wartość jest zbyt długa. Powinna zawierać {{ max }} słów lub mniej.</target>
+                <target>Ta wartość jest zbyt długa. Powinna zawierać jedno słowo.|Ta wartość jest zbyt długa. Powinna zawierać {{ max }} słowa lub mniej.|Ta wartość jest zbyt długa. Powinna zawierać {{ max }} słów lub mniej.</target>
             </trans-unit>
             <trans-unit id="116">
                 <source>This value does not represent a valid week in the ISO 8601 format.</source>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | none
| License       | MIT

Fixed the Polish translation for word count validation message by adding all three required plural forms (instead of two).

Problem:
Locale set to `pl`. If the validation `Symfony\Component\Validator\Constraints\WordCount` was triggered for the example configuration:

```
new WordCount(max: 50)
```

the exception SymfonyComponentTranslationExceptionInvalidArgumentException is thrown if the string exceeds 50 words. The exact message is:

> Symfony\Component\Translation\Exception\InvalidArgumentException: "Unable to choose a translation for "Ta wartość jest zbyt długa. Powinna zawierać jedno słowo.|Ta wartość jest zbyt długa. Powinna zawierać {{ max }} słów lub mniej." with locale "pl" for value "50". Double check that this translation has the correct plural options (e.g. "There is one apple|There are %count% apples")." at TranslatorTrait.php line 117

The cause is a missing third plural form: the original translation contained only two forms.