### PR TITLE
[HtmlSanitizer] Remove redundant assignment to promoted property $con…

### DIFF
--- a/src/Symfony/Component/HtmlSanitizer/HtmlSanitizer.php
+++ b/src/Symfony/Component/HtmlSanitizer/HtmlSanitizer.php
@@ -34,7 +34,6 @@ final class HtmlSanitizer implements HtmlSanitizerInterface
         private HtmlSanitizerConfig $config,
         ?ParserInterface $parser = null,
     ) {
-        $this->config = $config;
         $this->parser = $parser ?? (\PHP_VERSION_ID < 80400 ? new MastermindsParser() : new NativeParser());
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony/issues/61904
| License       | MIT

In the HtmlSanitizer class constructor, there is a redundant assignment to the promoted property `$this->config`:
Since **$config** is already a promoted property, the explicit assignment `$this->config = $config;` is unnecessary and can be safely removed.