### PR TITLE
[Meta] Better exception when symfony link cannot read a JSON

### DIFF
--- a/link
+++ b/link
@@ -49,7 +49,11 @@ $directories = array_merge(...array_values(array_map(function ($part) {
 $directories[] = __DIR__.'/src/Symfony/Contracts';
 foreach ($directories as $dir) {
     if ($filesystem->exists($composer = "$dir/composer.json")) {
-        $sfPackages[json_decode(file_get_contents($composer))->name] = $dir;
+        try {
+            $sfPackages[json_decode(file_get_contents($composer), null, 512, JSON_THROW_ON_ERROR)->name] = $dir;
+        } catch (JsonException $e) {
+            throw new RuntimeException(sprintf('Error parsing "%s": %s', $composer, $e->getMessage()), previous: $e);
+        }
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | kind of
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT

While working on SF, during a rebase, a composer.json was conflicting, and so broken.
I was not able to link my vendor.

Now the code throw a better error, with the culprit
