### PR TITLE
[Validator] bad value on AbstractComparison constructor using array parameter

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/AbstractComparison.php
+++ b/src/Symfony/Component/Validator/Constraints/AbstractComparison.php
@@ -36,6 +36,7 @@ abstract class AbstractComparison extends Constraint
             trigger_deprecation('symfony/validator', '7.3', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
 
             $options = array_merge($value, $options ?? []);
+            $value = null;
         } elseif (null !== $value) {
             if (\is_array($options)) {
                 trigger_deprecation('symfony/validator', '7.3', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);

--- a/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints\AbstractComparison;
+
+class AbstractComparisonTest extends TestCase
+{
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
+    public function testConstructorWithArrayOption()
+    {
+        $comparison = new class(['value' => 42, 'message' => 'my error']) extends AbstractComparison {};
+
+        $this->assertSame(42, $comparison->value);
+        $this->assertSame('my error', $comparison->message);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61900
| License       | MIT

On the AbstractComparison constraint the value parameter is directly used to fill the value property, so when an array of options is used, the value is not correctly extracted.
This change simply let the parent constructor extracts the value option, and fill the property with the correct value.