### PR TITLE
[JsonStreamer] Fix documentation link in README

### DIFF
--- a/src/Symfony/Component/JsonStreamer/README.md
+++ b/src/Symfony/Component/JsonStreamer/README.md
@@ -11,7 +11,7 @@ are not covered by Symfony's
 Resources
 ---------
 
- * [Documentation](https://symfony.com/doc/current/components/ser-des.html)
+ * [Documentation](https://symfony.com/doc/current/serializer/streaming_json.html)
  * [Contributing](https://symfony.com/doc/current/contributing/index.html)
  * [Report issues](https://github.com/symfony/symfony/issues) and
    [send Pull Requests](https://github.com/symfony/symfony/pulls)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

The current documentation link in JsonStreamer's README.md returns a 404.