### PR TITLE
 Fix the link to the JsonStreamer documentation

### DIFF
--- a/src/Symfony/Component/JsonStreamer/README.md
+++ b/src/Symfony/Component/JsonStreamer/README.md
@@ -11,7 +11,7 @@ are not covered by Symfony's
 Resources
 ---------
 
- * [Documentation](https://symfony.com/doc/current/components/ser-des.html)
+ * [Documentation](https://symfony.com/doc/current/serializer/streaming_json.html)
  * [Contributing](https://symfony.com/doc/current/contributing/index.html)
  * [Report issues](https://github.com/symfony/symfony/issues) and
    [send Pull Requests](https://github.com/symfony/symfony/pulls)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | n/a
| License       | MIT

The previous link goes to a non-existent page.
Note that if https://github.com/symfony/symfony-docs/issues/21450 ends up moving the documentation, we might need to update it again (but the documentation should provide a redirect when moving the doc, while it does not provide it for wrong links that never worked)
