### PR TITLE
[FrameworkBundle] Fix support of dumping workflow when workflow is decorated by TraceableWorkflow

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/WorkflowDumpCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/WorkflowDumpCommand.php
@@ -21,6 +21,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\Workflow\Debug\TraceableWorkflow;
 use Symfony\Component\Workflow\Dumper\GraphvizDumper;
 use Symfony\Component\Workflow\Dumper\MermaidDumper;
 use Symfony\Component\Workflow\Dumper\PlantUmlDumper;
@@ -78,6 +79,9 @@ EOF
             throw new InvalidArgumentException(\sprintf('The workflow named "%s" cannot be found.', $workflowName));
         }
         $workflow = $this->workflows->get($workflowName);
+        if ($workflow instanceof TraceableWorkflow) {
+            $workflow = $workflow->getInner();
+        }
         $type = $workflow instanceof StateMachine ? 'state_machine' : 'workflow';
         $definition = $workflow->getDefinition();
 

--- a/src/Symfony/Component/Workflow/Debug/TraceableWorkflow.php
+++ b/src/Symfony/Component/Workflow/Debug/TraceableWorkflow.php
@@ -89,6 +89,11 @@ class TraceableWorkflow implements WorkflowInterface
         return $this->calls;
     }
 
+    public function getInner(): WorkflowInterface
+    {
+        return $this->workflow;
+    }
+
     private function callInner(string $method, array $args): mixed
     {
         if ($this->disabled?->__invoke()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3 (the bug is not on 6.4, it has been introduced by 6baa3d282c)
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60215
| License       | MIT

