### PR TITLE
[Mailer] Revert " Fix memory leak with `mailer.message_logger_listener`"

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer.php
@@ -15,6 +15,7 @@ use Symfony\Component\Mailer\Command\MailerTestCommand;
 use Symfony\Component\Mailer\EventListener\DkimSignedMessageListener;
 use Symfony\Component\Mailer\EventListener\EnvelopeListener;
 use Symfony\Component\Mailer\EventListener\MessageListener;
+use Symfony\Component\Mailer\EventListener\MessageLoggerListener;
 use Symfony\Component\Mailer\EventListener\MessengerTransportListener;
 use Symfony\Component\Mailer\EventListener\SmimeEncryptedMessageListener;
 use Symfony\Component\Mailer\EventListener\SmimeSignedMessageListener;
@@ -70,6 +71,10 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('headers'),
             ])
             ->tag('kernel.event_subscriber')
+
+        ->set('mailer.message_logger_listener', MessageLoggerListener::class)
+            ->tag('kernel.event_subscriber')
+            ->tag('kernel.reset', ['method' => 'reset'])
 
         ->set('mailer.messenger_transport_listener', MessengerTransportListener::class)
             ->tag('kernel.event_subscriber')

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer_debug.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer_debug.php
@@ -12,17 +12,9 @@
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Component\Mailer\DataCollector\MessageDataCollector;
-use Symfony\Component\Mailer\EventListener\MessageLoggerListener;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
-        ->set('mailer.message_logger_listener', MessageLoggerListener::class)
-            ->args([
-                service('profiler.is_disabled_state_checker')->nullOnInvalid(),
-            ])
-            ->tag('kernel.event_subscriber')
-            ->tag('kernel.reset', ['method' => 'reset'])
-
         ->set('mailer.data_collector', MessageDataCollector::class)
             ->args([
                 service('mailer.message_logger_listener'),

--- a/src/Symfony/Component/Mailer/EventListener/MessageLoggerListener.php
+++ b/src/Symfony/Component/Mailer/EventListener/MessageLoggerListener.php
@@ -25,9 +25,8 @@ class MessageLoggerListener implements EventSubscriberInterface, ResetInterface
 {
     private MessageEvents $events;
 
-    public function __construct(
-        protected ?\Closure $disabled = null,
-    ) {
+    public function __construct()
+    {
         $this->events = new MessageEvents();
     }
 
@@ -38,10 +37,6 @@ class MessageLoggerListener implements EventSubscriberInterface, ResetInterface
 
     public function onMessage(MessageEvent $event): void
     {
-        if ($this->disabled?->__invoke()) {
-            return;
-        }
-
         $this->events->add($event);
     }
 


### PR DESCRIPTION
As [discussed](https://github.com/symfony/symfony/issues/61873) in profiler should not be forced in order to make use of mailer assertions.
This reverts commit b63317d2cf694fbc4169b91ee369dc594845aa51.

| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #61873 <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT
