### PR TITLE
[Validator] fix handling Doctrine-style options handling

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Callback.php
+++ b/src/Symfony/Component/Validator/Constraints/Callback.php
@@ -49,6 +49,7 @@ class Callback extends Constraint
             trigger_deprecation('symfony/validator', '7.3', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
 
             $options = array_merge($callback, $options ?? []);
+            $callback = null;
         }
 
         parent::__construct($options, $groups, $payload);

--- a/src/Symfony/Component/Validator/Constraints/CssColor.php
+++ b/src/Symfony/Component/Validator/Constraints/CssColor.php
@@ -77,6 +77,7 @@ class CssColor extends Constraint
             trigger_deprecation('symfony/validator', '7.3', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
 
             $options = array_merge($formats, $options ?? []);
+            $formats = null;
         } elseif (\is_array($formats)) {
             if ([] === array_intersect(self::$validationModes, $formats)) {
                 throw new InvalidArgumentException(\sprintf('The "formats" parameter value is not valid. It must contain one or more of the following values: "%s".', $validationModesAsString));

--- a/src/Symfony/Component/Validator/Constraints/DateTime.php
+++ b/src/Symfony/Component/Validator/Constraints/DateTime.php
@@ -48,6 +48,7 @@ class DateTime extends Constraint
             trigger_deprecation('symfony/validator', '7.3', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
 
             $options = array_merge($format, $options ?? []);
+            $format = null;
         } elseif (null !== $format) {
             if (\is_array($options)) {
                 trigger_deprecation('symfony/validator', '7.3', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);

--- a/src/Symfony/Component/Validator/Constraints/Timezone.php
+++ b/src/Symfony/Component/Validator/Constraints/Timezone.php
@@ -63,6 +63,7 @@ class Timezone extends Constraint
             trigger_deprecation('symfony/validator', '7.3', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
 
             $options = array_merge($zone, $options ?? []);
+            $zone = null;
         } elseif (null !== $zone) {
             if (\is_array($options)) {
                 trigger_deprecation('symfony/validator', '7.3', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);

--- a/src/Symfony/Component/Validator/Tests/Constraints/CallbackTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CallbackTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints\Callback;
+
+class CallbackTest extends TestCase
+{
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
+    public function testDoctrineStyle()
+    {
+        $constraint = new Callback(['callback' => 'validate']);
+
+        $this->assertSame('validate', $constraint->callback);
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/CssColorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CssColorTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\CssColor;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
@@ -59,6 +61,15 @@ final class CssColorTest extends TestCase
             CssColor::HSL,
             CssColor::HSLA,
         ], $constraint->formats);
+    }
+
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
+    public function testDoctrineStyle()
+    {
+        $constraint = new CssColor(['formats' => CssColor::RGB]);
+
+        $this->assertSame(CssColor::RGB, $constraint->formats);
     }
 }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateTimeTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateTimeTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\DateTime;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
@@ -36,6 +38,15 @@ class DateTimeTest extends TestCase
         self::assertSame('m/d/Y', $cConstraint->format);
         self::assertSame(['my_group'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);
+    }
+
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
+    public function testDoctrineStyle()
+    {
+        $constraint = new DateTime(['format' => 'm/d/Y']);
+
+        $this->assertSame('m/d/Y', $constraint->format);
     }
 }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/DivisibleByTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DivisibleByTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\DivisibleBy;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
@@ -38,6 +40,15 @@ class DivisibleByTest extends TestCase
         self::assertSame('b', $cConstraint->propertyPath);
         self::assertSame('myMessage', $cConstraint->message);
         self::assertSame(['foo'], $cConstraint->groups);
+    }
+
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
+    public function testDoctrineStyle()
+    {
+        $constraint = new DivisibleBy(['value' => 5]);
+
+        $this->assertSame(5, $constraint->value);
     }
 }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/EqualToTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EqualToTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\EqualTo;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
@@ -38,6 +40,15 @@ class EqualToTest extends TestCase
         self::assertSame('b', $cConstraint->propertyPath);
         self::assertSame('myMessage', $cConstraint->message);
         self::assertSame(['foo'], $cConstraint->groups);
+    }
+
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
+    public function testDoctrineStyle()
+    {
+        $constraint = new EqualTo(['value' => 5]);
+
+        $this->assertSame(5, $constraint->value);
     }
 }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
@@ -38,6 +40,15 @@ class GreaterThanOrEqualTest extends TestCase
         self::assertSame('b', $cConstraint->propertyPath);
         self::assertSame('myMessage', $cConstraint->message);
         self::assertSame(['foo'], $cConstraint->groups);
+    }
+
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
+    public function testDoctrineStyle()
+    {
+        $constraint = new GreaterThanOrEqual(['value' => 5]);
+
+        $this->assertSame(5, $constraint->value);
     }
 }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\GreaterThan;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
@@ -38,6 +40,15 @@ class GreaterThanTest extends TestCase
         self::assertSame('b', $cConstraint->propertyPath);
         self::assertSame('myMessage', $cConstraint->message);
         self::assertSame(['foo'], $cConstraint->groups);
+    }
+
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
+    public function testDoctrineStyle()
+    {
+        $constraint = new GreaterThan(['value' => 5]);
+
+        $this->assertSame(5, $constraint->value);
     }
 }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/IdenticalToTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IdenticalToTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\IdenticalTo;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
@@ -38,6 +40,15 @@ class IdenticalToTest extends TestCase
         self::assertSame('b', $cConstraint->propertyPath);
         self::assertSame('myMessage', $cConstraint->message);
         self::assertSame(['foo'], $cConstraint->groups);
+    }
+
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
+    public function testDoctrineStyle()
+    {
+        $constraint = new IdenticalTo(['value' => 5]);
+
+        $this->assertSame(5, $constraint->value);
     }
 }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\LessThanOrEqual;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
@@ -38,6 +40,15 @@ class LessThanOrEqualTest extends TestCase
         self::assertSame('b', $cConstraint->propertyPath);
         self::assertSame('myMessage', $cConstraint->message);
         self::assertSame(['foo'], $cConstraint->groups);
+    }
+
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
+    public function testDoctrineStyle()
+    {
+        $constraint = new LessThanOrEqual(['value' => 5]);
+
+        $this->assertSame(5, $constraint->value);
     }
 }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\LessThan;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
@@ -38,6 +40,15 @@ class LessThanTest extends TestCase
         self::assertSame('b', $cConstraint->propertyPath);
         self::assertSame('myMessage', $cConstraint->message);
         self::assertSame(['foo'], $cConstraint->groups);
+    }
+
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
+    public function testDoctrineStyle()
+    {
+        $constraint = new LessThan(['value' => 5]);
+
+        $this->assertSame(5, $constraint->value);
     }
 }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotEqualToTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotEqualToTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\NotEqualTo;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
@@ -38,6 +40,15 @@ class NotEqualToTest extends TestCase
         self::assertSame('b', $cConstraint->propertyPath);
         self::assertSame('myMessage', $cConstraint->message);
         self::assertSame(['foo'], $cConstraint->groups);
+    }
+
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
+    public function testDoctrineStyle()
+    {
+        $constraint = new NotEqualTo(['value' => 5]);
+
+        $this->assertSame(5, $constraint->value);
     }
 }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotIdenticalToTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotIdenticalToTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\NotIdenticalTo;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
@@ -38,6 +40,15 @@ class NotIdenticalToTest extends TestCase
         self::assertSame('b', $cConstraint->propertyPath);
         self::assertSame('myMessage', $cConstraint->message);
         self::assertSame(['foo'], $cConstraint->groups);
+    }
+
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
+    public function testDoctrineStyle()
+    {
+        $constraint = new NotIdenticalTo(['value' => 5]);
+
+        $this->assertSame(5, $constraint->value);
     }
 }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimezoneTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimezoneTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Validator\Tests\Constraints;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Timezone;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
@@ -82,6 +84,15 @@ class TimezoneTest extends TestCase
         [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
         self::assertSame(['my_group'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);
+    }
+
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
+    public function testDoctrineStyle()
+    {
+        $constraint = new Timezone(['zone' => \DateTimeZone::ALL]);
+
+        $this->assertSame(\DateTimeZone::ALL, $constraint->zone);
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61900
| License       | MIT

I noticed that constraints extending `AbstractComparison` are not the only constraints behaving as described in #61900.
