### PR TITLE
[Messenger] Allow to respect retry strategy with `RecoverableMessageHandlingException`

### DIFF
--- a/UPGRADE-8.1.md
+++ b/UPGRADE-8.1.md
@@ -111,6 +111,7 @@ Messenger
    they are routed through the normal retry/failure transport path instead
  * Add argument `$fetchSize` to `ReceiverInterface::get()` and `QueueReceiverInterface::getFromQueues()`
  * Deprecate `StopWorkerOnTimeLimitListener` in favor of using the `time_limit` worker option
+ * Add `forceRetry()` method to `RecoverableExceptionInterface`
 
 Security
 --------

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.1
 ---
 
+ * Add `forceRetry()` method to `RecoverableExceptionInterface`
  * Add `DecodeFailedMessageMiddleware` to re-decode failed messages using the transport's serializer
  * Receivers no longer delete messages on decode failure; they are routed through the normal retry/failure transport path
  * Add regex support for transport name patterns in the `messenger:consume` command

--- a/src/Symfony/Component/Messenger/EventListener/SendFailedMessageForRetryListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/SendFailedMessageForRetryListener.php
@@ -116,7 +116,7 @@ class SendFailedMessageForRetryListener implements EventSubscriberInterface
 
     private function shouldRetry(\Throwable $e, Envelope $envelope, RetryStrategyInterface $retryStrategy): bool
     {
-        if ($e instanceof RecoverableExceptionInterface) {
+        if ($e instanceof RecoverableExceptionInterface && (!method_exists($e, 'forceRetry') || $e->forceRetry())) {
             return true;
         }
 
@@ -125,7 +125,7 @@ class SendFailedMessageForRetryListener implements EventSubscriberInterface
         if ($e instanceof HandlerFailedException) {
             $shouldNotRetry = true;
             foreach ($e->getWrappedExceptions() as $nestedException) {
-                if ($nestedException instanceof RecoverableExceptionInterface) {
+                if ($nestedException instanceof RecoverableExceptionInterface && (!method_exists($nestedException, 'forceRetry') || $nestedException->forceRetry())) {
                     return true;
                 }
 

--- a/src/Symfony/Component/Messenger/Exception/RecoverableExceptionInterface.php
+++ b/src/Symfony/Component/Messenger/Exception/RecoverableExceptionInterface.php
@@ -18,6 +18,8 @@ namespace Symfony\Component\Messenger\Exception;
  * and the message should be retried, a handler can throw such an exception.
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
+ *
+ * @method bool forceRetry() Whether the worker should retry even when the max retry count has been reached
  */
 interface RecoverableExceptionInterface extends \Throwable
 {

--- a/src/Symfony/Component/Messenger/Exception/RecoverableMessageHandlingException.php
+++ b/src/Symfony/Component/Messenger/Exception/RecoverableMessageHandlingException.php
@@ -18,13 +18,23 @@ namespace Symfony\Component\Messenger\Exception;
  */
 class RecoverableMessageHandlingException extends RuntimeException implements RecoverableExceptionInterface
 {
-    public function __construct(string $message = '', int $code = 0, ?\Throwable $previous = null, private readonly ?int $retryDelay = null)
-    {
+    public function __construct(
+        string $message = '',
+        int $code = 0,
+        ?\Throwable $previous = null,
+        private readonly ?int $retryDelay = null,
+        private readonly bool $forceRetry = true,
+    ) {
         parent::__construct($message, $code, $previous);
     }
 
     public function getRetryDelay(): ?int
     {
         return $this->retryDelay;
+    }
+
+    public function forceRetry(): bool
+    {
+        return $this->forceRetry;
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/EventListener/SendFailedMessageForRetryListenerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EventListener/SendFailedMessageForRetryListenerTest.php
@@ -201,6 +201,92 @@ class SendFailedMessageForRetryListenerTest extends TestCase
         ];
     }
 
+    public function testRecoverableExceptionWithoutForceRetryRespectsRetryStrategy()
+    {
+        $sender = $this->createMock(SenderInterface::class);
+        $sender->expects($this->never())->method('send');
+        $senderLocator = new Container();
+        $senderLocator->set('my_receiver', $sender);
+        $retryStrategy = $this->createMock(RetryStrategyInterface::class);
+        $retryStrategy->expects($this->once())->method('isRetryable')->willReturn(false);
+        $retryStrategy->expects($this->never())->method('getWaitingTime');
+        $retryStrategyLocator = new Container();
+        $retryStrategyLocator->set('my_receiver', $retryStrategy);
+
+        $listener = new SendFailedMessageForRetryListener($senderLocator, $retryStrategyLocator);
+
+        $exception = new RecoverableMessageHandlingException('retry', forceRetry: false);
+        $envelope = new Envelope(new \stdClass());
+        $event = new WorkerMessageFailedEvent($envelope, 'my_receiver', $exception);
+
+        $listener->onMessageFailed($event);
+
+        /** @var SentForRetryStamp|null $sentForRetryStamp */
+        $sentForRetryStamp = $event->getEnvelope()->last(SentForRetryStamp::class);
+
+        $this->assertInstanceOf(SentForRetryStamp::class, $sentForRetryStamp);
+        $this->assertFalse($sentForRetryStamp->isSent);
+    }
+
+    public function testRecoverableExceptionWithoutForceRetryStillUsesItsRetryDelay()
+    {
+        $sender = $this->createMock(SenderInterface::class);
+        $sender->expects($this->once())->method('send')->willReturnCallback(function (Envelope $envelope) {
+            $delayStamp = $envelope->last(DelayStamp::class);
+            $redeliveryStamp = $envelope->last(RedeliveryStamp::class);
+
+            $this->assertInstanceOf(DelayStamp::class, $delayStamp);
+            $this->assertSame(1234, $delayStamp->getDelay());
+
+            $this->assertInstanceOf(RedeliveryStamp::class, $redeliveryStamp);
+            $this->assertSame(1, $redeliveryStamp->getRetryCount());
+
+            return $envelope;
+        });
+        $senderLocator = new Container();
+        $senderLocator->set('my_receiver', $sender);
+        $retryStrategy = $this->createMock(RetryStrategyInterface::class);
+        $retryStrategy->expects($this->once())->method('isRetryable')->willReturn(true);
+        $retryStrategy->expects($this->never())->method('getWaitingTime');
+        $retryStrategyLocator = new Container();
+        $retryStrategyLocator->set('my_receiver', $retryStrategy);
+
+        $listener = new SendFailedMessageForRetryListener($senderLocator, $retryStrategyLocator);
+
+        $exception = new RecoverableMessageHandlingException('retry', retryDelay: 1234, forceRetry: false);
+        $envelope = new Envelope(new \stdClass());
+        $event = new WorkerMessageFailedEvent($envelope, 'my_receiver', $exception);
+
+        $listener->onMessageFailed($event);
+    }
+
+    public function testWrappedRecoverableExceptionWithoutForceRetryRespectsRetryStrategy()
+    {
+        $sender = $this->createMock(SenderInterface::class);
+        $sender->expects($this->never())->method('send');
+        $senderLocator = new Container();
+        $senderLocator->set('my_receiver', $sender);
+        $retryStrategy = $this->createMock(RetryStrategyInterface::class);
+        $retryStrategy->expects($this->once())->method('isRetryable')->willReturn(false);
+        $retryStrategy->expects($this->never())->method('getWaitingTime');
+        $retryStrategyLocator = new Container();
+        $retryStrategyLocator->set('my_receiver', $retryStrategy);
+
+        $listener = new SendFailedMessageForRetryListener($senderLocator, $retryStrategyLocator);
+
+        $envelope = new Envelope(new \stdClass());
+        $exception = new HandlerFailedException($envelope, [new RecoverableMessageHandlingException('retry', forceRetry: false)]);
+        $event = new WorkerMessageFailedEvent($envelope, 'my_receiver', $exception);
+
+        $listener->onMessageFailed($event);
+
+        /** @var SentForRetryStamp|null $sentForRetryStamp */
+        $sentForRetryStamp = $event->getEnvelope()->last(SentForRetryStamp::class);
+
+        $this->assertInstanceOf(SentForRetryStamp::class, $sentForRetryStamp);
+        $this->assertFalse($sentForRetryStamp->isSent);
+    }
+
     public function testEnvelopeIsSentToTransportOnRetry()
     {
         $exception = new \Exception('no!');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

Since `getRetryDelay` was added, the `RecoverableMessageHandlingException` is useful to override the defaut delay of the retry strategy (for instance if we get rate limited by some thing and would like to retry after some delay). BUT this imply the message will be retried again and again if we keep getting such error.

https://github.com/symfony/symfony/pull/49063 asked  RecoverableMessageHandlingException to respect the retryStrategy and https://github.com/symfony/symfony/pull/50655 revert it because if `RecoverableMessageHandlingException` respect the retry strategy it has no use. Now I think this feature would be useful, as an option:
- Use forceRetry to always retry (default behavior)
- Use forceRetry=false to retry if the retry strategy allows it, and if so override the delay with retryDelay.