### PR TITLE
[Security] Allow `AuthorizationChecker::isGrantedForUser` to check for guest permissions

### DIFF
--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Render an `id` attribute on the `<form>` element when a child uses `form_attr`, so that the reference resolves
  * Render the `name` attribute of the `<form>` element through `attr`, so that `attr: {name: false}` disables it and `attr: {name: '...'}` overrides it
  * Render `<optgroup>` labels from `ChoiceGroupView::$label`, which allows translatable choice group labels
+ * Allow passing a null user to the `is_granted_for_user()` and `access_decision_for_user()` functions to check guest permissions
  * Deprecate the `render_hinclude()` Twig function; use `render_esi()` or `render()`, or Symfony UX Turbo, instead
  * Add a `for _self` modifier to the `trans_default_domain` tag to apply the domain to the whole template, `embed` bodies included
 

--- a/src/Symfony/Bridge/Twig/Extension/SecurityExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/SecurityExtension.php
@@ -14,6 +14,7 @@ namespace Symfony\Bridge\Twig\Extension;
 use Symfony\Component\Security\Acl\Voter\FieldVote;
 use Symfony\Component\Security\Core\Authorization\AccessDecision;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Authorization\GuestAuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Authorization\UserAuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -67,7 +68,7 @@ final class SecurityExtension extends AbstractExtension
         return $accessDecision;
     }
 
-    public function isGrantedForUser(UserInterface $user, mixed $attribute, mixed $subject = null, ?string $field = null, ?AccessDecision $accessDecision = null): bool
+    public function isGrantedForUser(?UserInterface $user, mixed $attribute, mixed $subject = null, ?string $field = null, ?AccessDecision $accessDecision = null): bool
     {
         if (null === $this->securityChecker) {
             return false;
@@ -75,6 +76,10 @@ final class SecurityExtension extends AbstractExtension
 
         if (!$this->securityChecker instanceof UserAuthorizationCheckerInterface) {
             throw new \LogicException(\sprintf('You cannot use "%s()" if the authorization checker doesn\'t implement "%s".', __METHOD__, UserAuthorizationCheckerInterface::class));
+        }
+
+        if (null === $user && !$this->securityChecker instanceof GuestAuthorizationCheckerInterface) {
+            throw new \LogicException(\sprintf('You cannot use "%s()" with a null user if the authorization checker doesn\'t implement "%s".%s', __METHOD__, GuestAuthorizationCheckerInterface::class, interface_exists(GuestAuthorizationCheckerInterface::class) ? '' : ' Try upgrading the "symfony/security-core" package to version 8.2 or newer.'));
         }
 
         if (null !== $field) {
@@ -92,7 +97,7 @@ final class SecurityExtension extends AbstractExtension
         }
     }
 
-    public function getAccessDecisionForUser(UserInterface $user, mixed $attribute, mixed $subject = null, ?string $field = null): AccessDecision
+    public function getAccessDecisionForUser(?UserInterface $user, mixed $attribute, mixed $subject = null, ?string $field = null): AccessDecision
     {
         if (!class_exists(AccessDecision::class)) {
             throw new \LogicException(\sprintf('Using the "access_decision_for_user()" function requires symfony/security-core >= 7.3. Try running "%s".', $this->securityChecker ? 'composer update symfony/security-core' : 'composer require symfony/security-core'));

--- a/src/Symfony/Bridge/Twig/Tests/Extension/SecurityExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/SecurityExtensionTest.php
@@ -18,6 +18,7 @@ use Symfony\Bridge\Twig\Extension\SecurityExtension;
 use Symfony\Component\Security\Acl\Voter\FieldVote;
 use Symfony\Component\Security\Core\Authorization\AccessDecision;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Authorization\GuestAuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Authorization\UserAuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -84,6 +85,27 @@ class SecurityExtensionTest extends TestCase
         $securityExtension = new SecurityExtension($securityChecker);
         $this->assertTrue($securityExtension->isGrantedForUser($user, 'ROLE', $object, $field));
         $this->assertSame($user, $securityChecker->user);
+        $this->assertSame('ROLE', $securityChecker->attribute);
+
+        if (null === $field) {
+            $this->assertSame($object, $securityChecker->subject);
+        } else {
+            $this->assertEquals($expectedSubject, $securityChecker->subject);
+        }
+    }
+
+    #[DataProvider('provideObjectFieldAclCases')]
+    public function testIsGrantedForGuestCreatesFieldVoteObjectWhenFieldNotNull($object, $field, $expectedSubject)
+    {
+        if (!interface_exists(GuestAuthorizationCheckerInterface::class)) {
+            $this->markTestSkipped('This test requires symfony/security-core 8.2 or superior.');
+        }
+
+        $securityChecker = $this->createMockAuthorizationChecker();
+
+        $securityExtension = new SecurityExtension($securityChecker);
+        $this->assertTrue($securityExtension->isGrantedForUser(null, 'ROLE', $object, $field));
+        $this->assertNull($securityChecker->user);
         $this->assertSame('ROLE', $securityChecker->attribute);
 
         if (null === $field) {
@@ -219,6 +241,24 @@ class SecurityExtensionTest extends TestCase
         $this->assertEquals(new FieldVote('object', 'field'), $securityChecker->subject);
     }
 
+    public function testAccessDecisionForGuestWithField()
+    {
+        if (!interface_exists(GuestAuthorizationCheckerInterface::class)) {
+            $this->markTestSkipped('This test requires symfony/security-core 8.2 or superior.');
+        }
+
+        $securityChecker = $this->createMockAuthorizationChecker();
+
+        $securityExtension = new SecurityExtension($securityChecker);
+        $accessDecision = $securityExtension->getAccessDecisionForUser(null, 'ROLE', 'object', 'field');
+
+        $this->assertInstanceOf(AccessDecision::class, $accessDecision);
+        $this->assertTrue($accessDecision->isGranted);
+        $this->assertNull($securityChecker->user);
+        $this->assertSame('ROLE', $securityChecker->attribute);
+        $this->assertEquals(new FieldVote('object', 'field'), $securityChecker->subject);
+    }
+
     public function testAccessDecisionForUserThrowsWhenAccessDecisionClassDoesNotExist()
     {
         if (!interface_exists(UserAuthorizationCheckerInterface::class)) {
@@ -236,30 +276,61 @@ class SecurityExtensionTest extends TestCase
         $securityExtension->getAccessDecisionForUser(new InMemoryUser('john', 'password'), 'ROLE', 'object');
     }
 
-    private function createMockAuthorizationChecker(): AuthorizationCheckerInterface&UserAuthorizationCheckerInterface
+    public function testFunctionsForUserAreRegisteredWithAGuestChecker()
     {
-        return new class implements AuthorizationCheckerInterface, UserAuthorizationCheckerInterface {
-            public UserInterface $user;
-            public mixed $attribute;
-            public mixed $subject;
+        if (!interface_exists(GuestAuthorizationCheckerInterface::class)) {
+            $this->markTestSkipped('This test requires symfony/security-core 8.2 or superior.');
+        }
 
+        $securityChecker = new class implements AuthorizationCheckerInterface, GuestAuthorizationCheckerInterface {
             public function isGranted(mixed $attribute, mixed $subject = null, ?AccessDecision $accessDecision = null): bool
             {
                 throw new \BadMethodCallException('This method should not be called.');
             }
 
-            public function isGrantedForUser(UserInterface $user, mixed $attribute, mixed $subject = null, ?AccessDecision $accessDecision = null): bool
+            public function isGrantedForUser(?UserInterface $user, mixed $attribute, mixed $subject = null, ?AccessDecision $accessDecision = null): bool
             {
-                $this->user = $user;
-                $this->attribute = $attribute;
-                $this->subject = $subject;
-
-                if ($accessDecision) {
-                    $accessDecision->isGranted = true;
-                }
-
-                return true;
+                throw new \BadMethodCallException('This method should not be called.');
             }
         };
+
+        $functions = array_map(static fn ($function) => $function->getName(), (new SecurityExtension($securityChecker))->getFunctions());
+
+        $this->assertContains('is_granted_for_user', $functions);
+        $this->assertContains('access_decision_for_user', $functions);
+    }
+
+    private function createMockAuthorizationChecker(): MockAuthorizationChecker
+    {
+        if (interface_exists(GuestAuthorizationCheckerInterface::class)) {
+            return new class extends MockAuthorizationChecker implements GuestAuthorizationCheckerInterface {};
+        }
+
+        return new class extends MockAuthorizationChecker {};
+    }
+}
+
+class MockAuthorizationChecker implements AuthorizationCheckerInterface, UserAuthorizationCheckerInterface
+{
+    public ?UserInterface $user;
+    public mixed $attribute;
+    public mixed $subject;
+
+    public function isGranted(mixed $attribute, mixed $subject = null, ?AccessDecision $accessDecision = null): bool
+    {
+        throw new \BadMethodCallException('This method should not be called.');
+    }
+
+    public function isGrantedForUser(?UserInterface $user, mixed $attribute, mixed $subject = null, ?AccessDecision $accessDecision = null): bool
+    {
+        $this->user = $user;
+        $this->attribute = $attribute;
+        $this->subject = $subject;
+
+        if ($accessDecision) {
+            $accessDecision->isGranted = true;
+        }
+
+        return true;
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -23,6 +23,7 @@ CHANGELOG
  * Add a `start_path` option to the `oidc_login` authenticator and declare a route there that starts the flow by redirecting to the provider, for login pages linking to it
  * Add `user_data_source` and `user_identifier_claim` options to the `oidc_login` authenticator
  * Add `enable_end_session` and `post_logout_redirect_path` options to the `oidc_login` authenticator for RP-Initiated Logout
+ * Allow passing a null user to `Security::isGrantedForUser()` and `Security::getAccessDecisionForUser()` to check guest permissions
 
 8.1
 ---

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
@@ -33,6 +33,7 @@ use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface
 use Symfony\Component\Security\Core\Authorization\AuthorizationChecker;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Authorization\ExpressionLanguage;
+use Symfony\Component\Security\Core\Authorization\GuestAuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Authorization\UserAuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Core\Authorization\Voter\ClosureVoter;
@@ -77,6 +78,7 @@ return static function (ContainerConfigurator $container) {
             ])
         ->alias(AuthorizationCheckerInterface::class, 'security.authorization_checker')
         ->alias(UserAuthorizationCheckerInterface::class, 'security.authorization_checker')
+        ->alias(GuestAuthorizationCheckerInterface::class, 'security.authorization_checker')
 
         ->set('security.token_storage', UsageTrackingTokenStorage::class)
             ->args([

--- a/src/Symfony/Bundle/SecurityBundle/Security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security.php
@@ -21,7 +21,7 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecision;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
-use Symfony\Component\Security\Core\Authorization\UserAuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Authorization\GuestAuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\LogicException;
 use Symfony\Component\Security\Core\Exception\LogoutException;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -41,7 +41,7 @@ use Symfony\Contracts\Service\ServiceProviderInterface;
  *
  * @final
  */
-class Security implements AuthorizationCheckerInterface, UserAuthorizationCheckerInterface
+class Security implements AuthorizationCheckerInterface, GuestAuthorizationCheckerInterface
 {
     public function __construct(
         private readonly ContainerInterface $container,
@@ -79,14 +79,15 @@ class Security implements AuthorizationCheckerInterface, UserAuthorizationChecke
      * Checks if the attribute is granted against the user and optionally supplied subject.
      *
      * This should be used over isGranted() when checking permissions against a user that is not currently logged in or while in a CLI context.
+     * A null user means a guest: the attribute is voted on with no user and no roles.
      */
-    public function isGrantedForUser(UserInterface $user, mixed $attribute, mixed $subject = null, ?AccessDecision $accessDecision = null): bool
+    public function isGrantedForUser(?UserInterface $user, mixed $attribute, mixed $subject = null, ?AccessDecision $accessDecision = null): bool
     {
         return $this->container->get('security.user_authorization_checker')
             ->isGrantedForUser($user, $attribute, $subject, $accessDecision);
     }
 
-    public function getAccessDecisionForUser(UserInterface $user, mixed $attributes, mixed $subject = null): AccessDecision
+    public function getAccessDecisionForUser(?UserInterface $user, mixed $attributes, mixed $subject = null): AccessDecision
     {
         $accessDecision = new AccessDecision();
         $this->isGrantedForUser($user, $attributes, $subject, $accessDecision);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SecurityTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SecurityTest.php
@@ -66,6 +66,7 @@ class SecurityTest extends AbstractWebTestCase
         $this->assertFalse($security->isGranted('ROLE_BAR'));
         $this->assertTrue($security->isGrantedForUser($offlineUser, 'ROLE_BAR'));
         $this->assertFalse($security->isGrantedForUser($offlineUser, 'ROLE_FOO'));
+        $this->assertFalse($security->isGrantedForUser(null, 'ROLE_BAR'));
     }
 
     #[DataProvider('userWillBeMarkedAsChangedIfRolesHasChangedProvider')]

--- a/src/Symfony/Bundle/SecurityBundle/Tests/SecurityTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/SecurityTest.php
@@ -27,6 +27,7 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Authorization\AccessDecision;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Authorization\GuestAuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Authorization\UserAuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\LogicException;
 use Symfony\Component\Security\Core\User\InMemoryUser;
@@ -135,6 +136,28 @@ class SecurityTest extends TestCase
 
         $security = new Security($container);
         $accessDecision = $security->getAccessDecisionForUser($user, 'SOME_ATTRIBUTE', 'SOME_SUBJECT');
+
+        $this->assertInstanceOf(AccessDecision::class, $accessDecision);
+        $this->assertFalse($accessDecision->isGranted);
+    }
+
+    public function testAccessDecisionForGuest()
+    {
+        $userAuthorizationChecker = $this->createMock(GuestAuthorizationCheckerInterface::class);
+
+        $userAuthorizationChecker->expects($this->once())
+            ->method('isGrantedForUser')
+            ->with(null, 'SOME_ATTRIBUTE', 'SOME_SUBJECT', $this->isInstanceOf(AccessDecision::class))
+            ->willReturnCallback(static function ($user, $attribute, $subject, $accessDecision) {
+                $accessDecision->isGranted = false;
+
+                return false;
+            });
+
+        $container = $this->createContainer('security.user_authorization_checker', $userAuthorizationChecker);
+
+        $security = new Security($container);
+        $accessDecision = $security->getAccessDecisionForUser(null, 'SOME_ATTRIBUTE', 'SOME_SUBJECT');
 
         $this->assertInstanceOf(AccessDecision::class, $accessDecision);
         $this->assertFalse($accessDecision->isGranted);

--- a/src/Symfony/Component/Security/Core/Authorization/AuthorizationChecker.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AuthorizationChecker.php
@@ -29,7 +29,7 @@ class_exists(OfflineTokenInterface::class);
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-class AuthorizationChecker implements AuthorizationCheckerInterface, UserAuthorizationCheckerInterface
+class AuthorizationChecker implements AuthorizationCheckerInterface, GuestAuthorizationCheckerInterface
 {
     private array $tokenStack = [];
     private array $accessDecisionStack = [];
@@ -42,10 +42,12 @@ class AuthorizationChecker implements AuthorizationCheckerInterface, UserAuthori
 
     final public function isGranted(mixed $attribute, mixed $subject = null, ?AccessDecision $accessDecision = null): bool
     {
-        $token = end($this->tokenStack) ?: $this->tokenStorage->getToken();
+        if (!$token = end($this->tokenStack)) {
+            $token = $this->tokenStorage->getToken();
 
-        if (!$token || !$token->getUser()) {
-            $token = new NullToken();
+            if (!$token || !$token->getUser()) {
+                $token = new NullToken();
+            }
         }
         $accessDecision ??= end($this->accessDecisionStack) ?: new AccessDecision();
         $this->accessDecisionStack[] = $accessDecision;
@@ -57,10 +59,14 @@ class AuthorizationChecker implements AuthorizationCheckerInterface, UserAuthori
         }
     }
 
-    final public function isGrantedForUser(UserInterface $user, mixed $attribute, mixed $subject = null, ?AccessDecision $accessDecision = null): bool
+    final public function isGrantedForUser(?UserInterface $user, mixed $attribute, mixed $subject = null, ?AccessDecision $accessDecision = null): bool
     {
-        $token = new class($user->getRoles()) extends AbstractToken implements OfflineTokenInterface {};
-        $token->setUser($user);
+        $token = new class($user?->getRoles() ?? []) extends AbstractToken implements OfflineTokenInterface {};
+
+        if ($user) {
+            $token->setUser($user);
+        }
+
         $this->tokenStack[] = $token;
 
         try {

--- a/src/Symfony/Component/Security/Core/Authorization/GuestAuthorizationCheckerInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/GuestAuthorizationCheckerInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Authorization;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * Extends the user authorization checker with support for guests.
+ *
+ * @author Nate Wiebe <nate@northern.co>
+ * @author Andreas Schempp <andreas.schempp@terminal42.ch>
+ */
+interface GuestAuthorizationCheckerInterface extends UserAuthorizationCheckerInterface
+{
+    /**
+     * Checks if the attribute is granted against the user and optionally supplied subject.
+     *
+     * A null user means a guest: the attribute is voted on with no user and no roles.
+     *
+     * @param mixed               $attribute      A single attribute to vote on (can be of any type, string and instance of Expression are supported by the core)
+     * @param AccessDecision|null $accessDecision Should be used to explain the decision
+     */
+    public function isGrantedForUser(?UserInterface $user, mixed $attribute, mixed $subject = null, ?AccessDecision $accessDecision = null): bool;
+}

--- a/src/Symfony/Component/Security/Core/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Core/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add argument `$parameters` to `SignatureHasher::computeSignatureHash()`, `acceptSignatureHash()` and `verifySignatureHash()`
  * Add `OidcUser::fromClaims()` to build a user from the claims returned by an OIDC provider
  * Add `OidcUserProvider`, which builds the OIDC users of the `oidc_login` authenticator from those claims
+ * Add `GuestAuthorizationCheckerInterface` and allow passing a null user to `AuthorizationChecker::isGrantedForUser()` to check guest permissions
 
 8.1
 ---

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/AuthorizationCheckerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/AuthorizationCheckerTest.php
@@ -12,8 +12,10 @@
 namespace Symfony\Component\Security\Core\Tests\Authorization;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
 use Symfony\Component\Security\Core\Authentication\Token\NullToken;
 use Symfony\Component\Security\Core\Authentication\Token\OfflineTokenInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
@@ -43,6 +45,15 @@ class AuthorizationCheckerTest extends TestCase
         $this->accessDecisionManager->expects($this->once())->method('decide')->with($this->isInstanceOf(NullToken::class))->willReturn(false);
 
         $authorizationChecker->isGranted('ROLE_FOO');
+    }
+
+    public function testVoteWithStoredOfflineTokenWithoutUser()
+    {
+        $this->tokenStorage->setToken(new class extends AbstractToken implements OfflineTokenInterface {});
+
+        $this->accessDecisionManager->expects($this->once())->method('decide')->with($this->callback(static fn ($token) => $token instanceof NullToken))->willReturn(false);
+
+        $this->assertFalse($this->authorizationChecker->isGranted('ROLE_FOO'));
     }
 
     #[DataProvider('isGrantedProvider')]
@@ -90,6 +101,19 @@ class AuthorizationCheckerTest extends TestCase
             ->willReturn($decide);
 
         $this->assertSame($decide, $this->authorizationChecker->isGrantedForUser($user, 'ROLE_FOO'));
+    }
+
+    #[TestWith([false])]
+    #[TestWith([true])]
+    public function testIsGrantedForGuest(bool $decide)
+    {
+        $this->accessDecisionManager
+            ->expects($this->once())
+            ->method('decide')
+            ->with($this->callback(static fn (OfflineTokenInterface $token) => null === $token->getUser() && [] === $token->getRoleNames()), ['ROLE_FOO'])
+            ->willReturn($decide);
+
+        $this->assertSame($decide, $this->authorizationChecker->isGrantedForUser(null, 'ROLE_FOO'));
     }
 
     public static function isGrantedForUserProvider(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

The `User authorization checker` added in https://github.com/symfony/symfony/pull/48142 does not allow checking permissions for a guest (no user). This PR fills that gap:

- New `GuestAuthorizationCheckerInterface` in security-core. It extends `UserAuthorizationCheckerInterface` and widens the first argument of `isGrantedForUser()` to `?UserInterface`, so every checker that accepts a guest is also a user authorization checker;
- `AuthorizationChecker` and `SecurityBundle`'s `Security` implement it: passing `null` votes on an offline token with no user and no roles, so a guest's permissions can be checked without touching the token storage;
- The Twig `is_granted_for_user()` and `access_decision_for_user()` functions accept `null` as well.

```php
// can a guest see this post?
$authorizationChecker->isGrantedForUser(null, 'view', $post);
```

Existing behavior is unchanged: `isGrantedForUser()` with a user, `isGranted()`, and tokens already present in the storage all behave exactly as before. Implementing only `UserAuthorizationCheckerInterface` stays valid, which is why nothing is deprecated.

For the documentation:

- `isGrantedForUser(null, ...)` asks what a guest is allowed to do: the voters run against a token with no user and no roles;
- type hint `GuestAuthorizationCheckerInterface` to get a checker that accepts a guest, `UserAuthorizationCheckerInterface` keeps working and accepts a user only;
- in Twig, `is_granted_for_user(null, 'view', post)` and `access_decision_for_user(null, 'view', post)`.

/cc @natewiebe13
