### PR TITLE
[FrameworkBundle] fix using lock from service id when previous locks used env vars

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2207,6 +2207,7 @@ class FrameworkExtension extends Extension
                     $resourceStore = 'null';
                 }
 
+                $usedEnvs = [];
                 $storeDsn = $container->resolveEnvPlaceholders($resourceStore, null, $usedEnvs);
                 if (!$usedEnvs && !str_contains($resourceStore, ':') && !\in_array($resourceStore, ['flock', 'semaphore', 'in-memory', 'null'], true)) {
                     $resourceStore = new Reference($resourceStore);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/lock_service_and_env.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/lock_service_and_env.php
@@ -1,0 +1,14 @@
+<?php
+
+$container->setParameter('env(REDIS_DSN)', 'redis://paas.com');
+
+$container->loadFromExtension('framework', [
+    'annotations' => false,
+    'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
+    'lock' => [
+        'foo' => '%env(REDIS_DSN)%',
+        'bar' => 'my_service',
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/lock_service_and_env.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/lock_service_and_env.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:framework="http://symfony.com/schema/dic/symfony"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <parameters>
+        <parameter key="env(REDIS_URL)">redis://paas.com</parameter>
+    </parameters>
+
+    <framework:config http-method-override="false" handle-all-throwables="true">
+        <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
+        <framework:lock>
+            <framework:resource name="foo">%env(REDIS_DSN)%</framework:resource>
+            <framework:resource name="bar">my_service</framework:resource>
+        </framework:lock>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/lock_service_and_env.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/lock_service_and_env.yml
@@ -1,0 +1,13 @@
+services:
+    my_service:
+        class: \Redis
+
+framework:
+    annotations: false
+    http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
+    lock:
+      foo: "%env(REDIS_DSN)%"
+      bar: my_service

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -2629,6 +2629,21 @@ abstract class FrameworkExtensionTestCase extends TestCase
         self::assertEquals(new Reference('my_service'), $storeDef->getArgument(0));
     }
 
+    public function testLockWithServiceAndEnv()
+    {
+        $container = $this->createContainerFromFile('lock_service_and_env', [], true, false);
+        $container->getCompilerPassConfig()->setOptimizationPasses([new ResolveChildDefinitionsPass()]);
+        $container->compile();
+
+        self::assertTrue($container->hasDefinition('lock.foo.factory'));
+        self::assertTrue($container->hasDefinition('lock.bar.factory'));
+        $storeDef = $container->getDefinition($container->getDefinition('lock.bar.factory')->getArgument(0));
+
+        $connection = $storeDef->getArgument(0);
+        self::assertInstanceOf(Reference::class, $connection);
+        self::assertEquals('my_service', $connection->__toString());
+    }
+
     public function testDefaultSemaphore()
     {
         $container = $this->createContainerFromFile('semaphore');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | n/a
| License       | MIT

When specifying multiple locks including one which references a service id, and a previous one used an env var, the service id is not converted in to a reference. This is because `usedEnvs` is not reset in the loop and is passed by reference. Not sure if this is intentional or not but it looks like a mistake to me. A similar reset is done [here](https://github.com/symfony/symfony/blob/0cf7a9af6b2b8eeb0ac218f45c0eff56ce2f9f87/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php#L354-L355).
