### PR TITLE
 Add ValidationException to improve request payload validation

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Add `#[IsSignatureValid]` attribute to validate URI signatures
  * Make `Profile` final and `Profiler::__sleep()` internal
  * Collect the application runner class
+ * Add `ValidationException` to improve request payload validation
 
 7.3
 ---

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -10,7 +10,7 @@ CHANGELOG
  * Add `#[IsSignatureValid]` attribute to validate URI signatures
  * Make `Profile` final and `Profiler::__sleep()` internal
  * Collect the application runner class
- * Add `ValidationException` to improve request payload validation
+ * Add `ValidationException` to improve request payload validation by throwing a dedicated exception when validation fails
 
 7.3
 ---

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
@@ -24,6 +24,7 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NearMissValueResolverException;
 use Symfony\Component\HttpKernel\Exception\UnsupportedMediaTypeHttpException;
+use Symfony\Component\HttpKernel\Exception\ValidationException;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Serializer\Exception\NotEncodableValueException;
 use Symfony\Component\Serializer\Exception\PartialDenormalizationException;
@@ -34,7 +35,6 @@ use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
-use Symfony\Component\Validator\Exception\ValidationFailedException;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -151,7 +151,7 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
                 }
 
                 if (\count($violations)) {
-                    throw HttpException::fromStatusCode($validationFailedCode, implode("\n", array_map(static fn ($e) => $e->getMessage(), iterator_to_array($violations))), new ValidationFailedException($payload, $violations));
+                    throw new ValidationException($payload, $violations, $validationFailedCode);
                 }
             } else {
                 try {

--- a/src/Symfony/Component/HttpKernel/Exception/ValidationException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/ValidationException.php
@@ -14,19 +14,19 @@ namespace Symfony\Component\HttpKernel\Exception;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 use Symfony\Component\Validator\Exception\ValidationFailedException;
 
-class ValidationException extends HttpException
+final class ValidationException extends HttpException
 {
     public function __construct(
         private mixed $value,
         private ConstraintViolationListInterface $violations,
         int $statusCode = 422,
-        string $message = 'Validation failed',
-        ?\Throwable $previous = null,
         array $headers = [],
+        ?\Throwable $previous = null,
         int $code = 0,
     ) {
-        $validationFailedException = new ValidationFailedException($value, $violations);
-        parent::__construct($statusCode, $message, $previous ?? $validationFailedException, $headers, $code);
+        $message = implode("\n", array_map(static fn ($e) => $e->getMessage(), iterator_to_array($violations)));
+        parent::__construct($statusCode, $message, $previous ?? new ValidationFailedException($value, $violations, $previous), $headers, $code);
+
     }
 
     public function getValue(): mixed

--- a/src/Symfony/Component/HttpKernel/Exception/ValidationException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/ValidationException.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Exception;
 
 use Symfony\Component\Validator\ConstraintViolationListInterface;
+use Symfony\Component\Validator\Exception\ValidationFailedException;
 
 class ValidationException extends HttpException
 {
@@ -24,7 +25,8 @@ class ValidationException extends HttpException
         array $headers = [],
         int $code = 0,
     ) {
-        parent::__construct($statusCode, $message, $previous, $headers, $code);
+        $validationFailedException = new ValidationFailedException($value, $violations);
+        parent::__construct($statusCode, $message, $previous ?? $validationFailedException, $headers, $code);
     }
 
     public function getValue(): mixed

--- a/src/Symfony/Component/HttpKernel/Exception/ValidationException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/ValidationException.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Exception;
+
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+
+class ValidationException extends HttpException
+{
+    public function __construct(
+        private mixed $value,
+        private ConstraintViolationListInterface $violations,
+        int $statusCode = 422,
+        string $message = 'Validation failed',
+        ?\Throwable $previous = null,
+        array $headers = [],
+        int $code = 0,
+    ) {
+        parent::__construct($statusCode, $message, $previous, $headers, $code);
+    }
+
+    public function getValue(): mixed
+    {
+        return $this->value;
+    }
+
+    public function getViolations(): ConstraintViolationListInterface
+    {
+        return $this->violations;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Exception/ValidationException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/ValidationException.php
@@ -14,6 +14,9 @@ namespace Symfony\Component\HttpKernel\Exception;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 use Symfony\Component\Validator\Exception\ValidationFailedException;
 
+/**
+ * @author Mohamed Senoussi <lesfootix@gmail.com>
+ */
 final class ValidationException extends HttpException
 {
     public function __construct(
@@ -26,7 +29,6 @@ final class ValidationException extends HttpException
     ) {
         $message = implode("\n", array_map(static fn ($e) => $e->getMessage(), iterator_to_array($violations)));
         parent::__construct($statusCode, $message, $previous ?? new ValidationFailedException($value, $violations, $previous), $headers, $code);
-
     }
 
     public function getValue(): mixed

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php
@@ -23,6 +23,7 @@ use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NearMissValueResolverException;
+use Symfony\Component\HttpKernel\Exception\ValidationException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
@@ -37,7 +38,6 @@ use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
-use Symfony\Component\Validator\Exception\ValidationFailedException;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\Validator\ValidatorBuilder;
 
@@ -255,10 +255,9 @@ class RequestPayloadValueResolverTest extends TestCase
             $resolver->onKernelControllerArguments($event);
             $this->fail(\sprintf('Expected "%s" to be thrown.', HttpException::class));
         } catch (HttpException $e) {
-            $validationFailedException = $e->getPrevious();
             $this->assertSame(422, $e->getStatusCode());
-            $this->assertInstanceOf(ValidationFailedException::class, $validationFailedException);
-            $this->assertSame('This value should be of type string.', $validationFailedException->getViolations()[0]->getMessage());
+            $this->assertInstanceOf(ValidationException::class, $e);
+            $this->assertSame('This value should be of type string.', $e->getViolations()->get(0)->getMessage());
         }
     }
 
@@ -286,9 +285,9 @@ class RequestPayloadValueResolverTest extends TestCase
             $resolver->onKernelControllerArguments($event);
             $this->fail(\sprintf('Expected "%s" to be thrown.', HttpException::class));
         } catch (HttpException $e) {
-            $validationFailedException = $e->getPrevious();
-            $this->assertInstanceOf(ValidationFailedException::class, $validationFailedException);
-            $this->assertSame('This value should be of type string.', $validationFailedException->getViolations()[0]->getMessage());
+            $this->assertSame(422, $e->getStatusCode());
+            $this->assertInstanceOf(ValidationException::class, $e);
+            $this->assertSame('This value should be of type string.', $e->getViolations()->get(0)->getMessage());
         }
     }
 
@@ -346,8 +345,6 @@ class RequestPayloadValueResolverTest extends TestCase
     #[TestWith([[]])]
     public function testRequestContentWithUntypedErrors(?array $types)
     {
-        $this->expectException(HttpException::class);
-        $this->expectExceptionMessage('This value was of an unexpected type.');
         $serializer = $this->createMock(SerializerDenormalizer::class);
 
         if (null === $types) {
@@ -365,7 +362,14 @@ class RequestPayloadValueResolverTest extends TestCase
         ]));
         $event = new ControllerArgumentsEvent($this->createMock(HttpKernelInterface::class), function () {}, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
 
-        $resolver->onKernelControllerArguments($event);
+        try {
+            $resolver->onKernelControllerArguments($event);
+            $this->fail(\sprintf('Expected "%s" to be thrown.', HttpException::class));
+        } catch (HttpException $e) {
+            $this->assertSame(422, $e->getStatusCode());
+            $this->assertInstanceOf(ValidationException::class, $e);
+            $this->assertSame('This value was of an unexpected type.', $e->getViolations()->get(0)->getMessage());
+        }
     }
 
     public function testQueryStringValidationPassed()
@@ -422,9 +426,8 @@ class RequestPayloadValueResolverTest extends TestCase
             $resolver->onKernelControllerArguments($event);
             $this->fail(\sprintf('Expected "%s" to be thrown.', HttpException::class));
         } catch (HttpException $e) {
-            $validationFailedException = $e->getPrevious();
-            $this->assertInstanceOf(ValidationFailedException::class, $validationFailedException);
-            $this->assertSame('This value should be of type float.', $validationFailedException->getViolations()[0]->getMessage());
+            $this->assertInstanceOf(ValidationException::class, $e);
+            $this->assertSame('This value should be of type float.', $e->getViolations()->get(0)->getMessage());
         }
     }
 
@@ -516,9 +519,9 @@ class RequestPayloadValueResolverTest extends TestCase
             $resolver->onKernelControllerArguments($event);
             $this->fail(\sprintf('Expected "%s" to be thrown.', HttpException::class));
         } catch (HttpException $e) {
-            $validationFailedException = $e->getPrevious();
-            $this->assertInstanceOf(ValidationFailedException::class, $validationFailedException);
-            $this->assertSame('This value should be of type float.', $validationFailedException->getViolations()[0]->getMessage());
+            $this->assertSame(422, $e->getStatusCode());
+            $this->assertInstanceOf(ValidationException::class, $e);
+            $this->assertSame('This value should be of type float.', $e->getViolations()->get(0)->getMessage());
         }
     }
 
@@ -747,10 +750,9 @@ class RequestPayloadValueResolverTest extends TestCase
             $resolver->onKernelControllerArguments($event);
             $this->fail(\sprintf('Expected "%s" to be thrown.', HttpException::class));
         } catch (HttpException $e) {
-            $validationFailedException = $e->getPrevious();
-            $this->assertInstanceOf(ValidationFailedException::class, $validationFailedException);
-            $this->assertSame('title', $validationFailedException->getViolations()[0]->getPropertyPath());
-            $this->assertSame('This value is too short. It should have 10 characters or more.', $validationFailedException->getViolations()[0]->getMessage());
+            $this->assertInstanceOf(ValidationException::class, $e);
+            $this->assertSame('title', $e->getViolations()->get(0)->getPropertyPath());
+            $this->assertSame('This value is too short. It should have 10 characters or more.', $e->getViolations()->get(0)->getMessage());
         }
     }
 
@@ -812,10 +814,9 @@ class RequestPayloadValueResolverTest extends TestCase
             $resolver->onKernelControllerArguments($event);
             $this->fail(\sprintf('Expected "%s" to be thrown.', HttpException::class));
         } catch (HttpException $e) {
-            $validationFailedException = $e->getPrevious();
             $this->assertSame(400, $e->getStatusCode());
-            $this->assertInstanceOf(ValidationFailedException::class, $validationFailedException);
-            $this->assertSame('Page is invalid', $validationFailedException->getViolations()[0]->getMessage());
+            $this->assertInstanceOf(ValidationException::class, $e);
+            $this->assertSame('Page is invalid', $e->getViolations()->get(0)->getMessage());
         }
     }
 
@@ -843,10 +844,9 @@ class RequestPayloadValueResolverTest extends TestCase
             $resolver->onKernelControllerArguments($event);
             $this->fail(\sprintf('Expected "%s" to be thrown.', HttpException::class));
         } catch (HttpException $e) {
-            $validationFailedException = $e->getPrevious();
             $this->assertSame(400, $e->getStatusCode());
-            $this->assertInstanceOf(ValidationFailedException::class, $validationFailedException);
-            $this->assertSame('This value should be of type string.', $validationFailedException->getViolations()[0]->getMessage());
+            $this->assertInstanceOf(ValidationException::class, $e);
+            $this->assertSame('This value should be of type string.', $e->getViolations()->get(0)->getMessage());
         }
     }
 

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/UploadedFileValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/UploadedFileValueResolverTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestPayloadValue
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\ValidationException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -193,10 +194,14 @@ class UploadedFileValueResolverTest extends TestCase
             HttpKernelInterface::MAIN_REQUEST
         );
 
-        $this->expectException(HttpException::class);
-        $this->expectExceptionMessageMatches('/^The file is too large/');
-
-        $resolver->onKernelControllerArguments($event);
+        try {
+            $resolver->onKernelControllerArguments($event);
+            $this->fail(\sprintf('Expected "%s" to be thrown.', HttpException::class));
+        } catch (HttpException $e) {
+            $this->assertSame(422, $e->getStatusCode());
+            $this->assertInstanceOf(ValidationException::class, $e);
+            $this->assertMatchesRegularExpression('/^The file is too large/', $e->getViolations()->get(0)->getMessage());
+        }
     }
 
     #[DataProvider('provideContext')]
@@ -252,10 +257,14 @@ class UploadedFileValueResolverTest extends TestCase
             HttpKernelInterface::MAIN_REQUEST
         );
 
-        $this->expectException(HttpException::class);
-        $this->expectExceptionMessageMatches('/^The file is too large/');
-
-        $resolver->onKernelControllerArguments($event);
+        try {
+            $resolver->onKernelControllerArguments($event);
+            $this->fail(\sprintf('Expected "%s" to be thrown.', HttpException::class));
+        } catch (HttpException $e) {
+            $this->assertSame(422, $e->getStatusCode());
+            $this->assertInstanceOf(ValidationException::class, $e);
+            $this->assertMatchesRegularExpression('/^The file is too large/', $e->getViolations()->get(0)->getMessage());
+        }
     }
 
     #[DataProvider('provideContext')]
@@ -311,10 +320,14 @@ class UploadedFileValueResolverTest extends TestCase
             HttpKernelInterface::MAIN_REQUEST
         );
 
-        $this->expectException(HttpException::class);
-        $this->expectExceptionMessageMatches('/^The file is too large/');
-
-        $resolver->onKernelControllerArguments($event);
+        try {
+            $resolver->onKernelControllerArguments($event);
+            $this->fail(\sprintf('Expected "%s" to be thrown.', HttpException::class));
+        } catch (HttpException $e) {
+            $this->assertSame(422, $e->getStatusCode());
+            $this->assertInstanceOf(ValidationException::class, $e);
+            $this->assertMatchesRegularExpression('/^The file is too large/', $e->getViolations()->get(0)->getMessage());
+        }
     }
 
     #[DataProvider('provideContext')]

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/ValidationExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/ValidationExceptionTest.php
@@ -20,7 +20,7 @@ class ValidationExceptionTest extends HttpExceptionTest
 {
     protected function createException(string $message = '', ?\Throwable $previous = null, int $code = 0, array $headers = []): HttpException
     {
-        return new ValidationException('invalid value', new ConstraintViolationList(), 422, $message, $previous, $headers, $code);
+        return new ValidationException('invalid value', new ConstraintViolationList(), 422, $headers, $previous, $code);
     }
 
     public function testGetValue()
@@ -51,3 +51,4 @@ class ValidationExceptionTest extends HttpExceptionTest
         $this->assertSame($violations, $exception->getPrevious()->getViolations());
     }
 }
+

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/ValidationExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/ValidationExceptionTest.php
@@ -40,6 +40,16 @@ class ValidationExceptionTest extends HttpExceptionTest
         $this->assertSame($violations, $exception->getViolations());
     }
 
+    public function testGetMessage()
+    {
+        $value = 'test';
+        $violations = new ConstraintViolationList();
+        $exception = new ValidationException($value, $violations);
+        $message = implode("\n", array_map(static fn ($e) => $e->getMessage(), iterator_to_array($violations)));
+
+        $this->assertSame($message, $exception->getMessage());
+    }
+
     public function testDefaultPreviousIsValidationFailedException()
     {
         $value = 'test';
@@ -51,4 +61,3 @@ class ValidationExceptionTest extends HttpExceptionTest
         $this->assertSame($violations, $exception->getPrevious()->getViolations());
     }
 }
-

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/ValidationExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/ValidationExceptionTest.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Exception;
+
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\ValidationException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+
+class ValidationExceptionTest extends HttpExceptionTest
+{
+    protected function createException(string $message = '', ?\Throwable $previous = null, int $code = 0, array $headers = []): HttpException
+    {
+        return new ValidationException('invalid value', $this->createMock(ConstraintViolationListInterface::class), 422, $message, $previous, $headers, $code);
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/ValidationExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/ValidationExceptionTest.php
@@ -13,12 +13,41 @@ namespace Symfony\Component\HttpKernel\Tests\Exception;
 
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\ValidationException;
-use Symfony\Component\Validator\ConstraintViolationListInterface;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\Exception\ValidationFailedException;
 
 class ValidationExceptionTest extends HttpExceptionTest
 {
     protected function createException(string $message = '', ?\Throwable $previous = null, int $code = 0, array $headers = []): HttpException
     {
-        return new ValidationException('invalid value', $this->createMock(ConstraintViolationListInterface::class), 422, $message, $previous, $headers, $code);
+        return new ValidationException('invalid value', new ConstraintViolationList(), 422, $message, $previous, $headers, $code);
+    }
+
+    public function testGetValue()
+    {
+        $value = ['test' => 'data'];
+        $exception = new ValidationException($value, new ConstraintViolationList());
+
+        $this->assertSame($value, $exception->getValue());
+    }
+
+    public function testGetViolations()
+    {
+        $value = 'test';
+        $violations = new ConstraintViolationList();
+        $exception = new ValidationException($value, $violations);
+
+        $this->assertSame($violations, $exception->getViolations());
+    }
+
+    public function testDefaultPreviousIsValidationFailedException()
+    {
+        $value = 'test';
+        $violations = new ConstraintViolationList();
+        $exception = new ValidationException($value, $violations);
+
+        $this->assertInstanceOf(ValidationFailedException::class, $exception->getPrevious());
+        $this->assertSame($value, $exception->getPrevious()->getValue());
+        $this->assertSame($violations, $exception->getPrevious()->getViolations());
     }
 }

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -188,6 +188,7 @@ CHANGELOG
        }
    }
    ```
+ * Fix `ValidationFailedException` constructor to properly pass string to parent
 
 7.3
 ---

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -188,7 +188,7 @@ CHANGELOG
        }
    }
    ```
- * Fix `ValidationFailedException` constructor to properly pass string to parent
+ * Add $previous optional parameter to `ValidationFailedException` constructor to allow exception chaining
 
 7.3
 ---

--- a/src/Symfony/Component/Validator/Exception/ValidationFailedException.php
+++ b/src/Symfony/Component/Validator/Exception/ValidationFailedException.php
@@ -35,6 +35,4 @@ class ValidationFailedException extends RuntimeException
     {
         return $this->violations;
     }
-
-
 }

--- a/src/Symfony/Component/Validator/Exception/ValidationFailedException.php
+++ b/src/Symfony/Component/Validator/Exception/ValidationFailedException.php
@@ -21,8 +21,9 @@ class ValidationFailedException extends RuntimeException
     public function __construct(
         private mixed $value,
         private ConstraintViolationListInterface $violations,
+        ?\Throwable $previous = null,
     ) {
-        parent::__construct((string) $violations);
+        parent::__construct($violations, 0, $previous);
     }
 
     public function getValue(): mixed
@@ -34,4 +35,6 @@ class ValidationFailedException extends RuntimeException
     {
         return $this->violations;
     }
+
+
 }

--- a/src/Symfony/Component/Validator/Exception/ValidationFailedException.php
+++ b/src/Symfony/Component/Validator/Exception/ValidationFailedException.php
@@ -22,7 +22,7 @@ class ValidationFailedException extends RuntimeException
         private mixed $value,
         private ConstraintViolationListInterface $violations,
     ) {
-        parent::__construct($violations);
+        parent::__construct((string) $violations);
     }
 
     public function getValue(): mixed


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony/issues/60234
| License       | MIT

This pull request introduces the **ValidationException** handling in the **RequestPayloadValueResolver**. It improves request payload validation by throwing a dedicated exception when validation fails, providing better error reporting and consistency. 