### PR TITLE
[TypeInfo] ArrayShape can resolve key type as callable instead of string

### DIFF
--- a/src/Symfony/Component/TypeInfo/Tests/TypeFactoryTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeFactoryTest.php
@@ -226,6 +226,12 @@ class TypeFactoryTest extends TestCase
         ), Type::arrayShape(['foo' => Type::bool()], extraKeyType: Type::string(), extraValueType: Type::bool()));
     }
 
+    public function testCreateArrayShapeWithCallableKey()
+    {
+        $arrayShape = new ArrayShapeType(['substr' => ['type' => Type::string(), 'optional' => false]]);
+        $this->assertEquals(Type::string(), $arrayShape->getCollectionKeyType());
+    }
+
     public function testCreateArrayKey()
     {
         $this->assertEquals(new UnionType(Type::int(), Type::string()), Type::arrayKey());

--- a/src/Symfony/Component/TypeInfo/Type/ArrayShapeType.php
+++ b/src/Symfony/Component/TypeInfo/Type/ArrayShapeType.php
@@ -41,7 +41,7 @@ final class ArrayShapeType extends CollectionType
         $valueTypes = [];
 
         foreach ($shape as $k => $v) {
-            $keyTypes[] = self::fromValue($k);
+            $keyTypes[] = \is_int($k) ? Type::int() : Type::string();
             $valueTypes[] = $v['type'];
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | N/A
| License       | MIT

In PHP, array key type is either string or int. Although callable is not entirely false as long as it's a string callable, using callable as a key type for an array seems wrong, and it's unlikely to be what we expect. This is peculiarly true in environment when key name might collide with global function name.
Proposed change is to check for int/string instead of resolving type.
Because the input is an array, the key is already narrowed down to string|int in the input

This bugfix is also a change of behavior, as callable was likely to be fed in keyTypes, and it won't longer occur with that change.