### PR TITLE
[Config] Generate the array-shape of the current node instead of the whole root node in Config classes

### DIFF
--- a/src/Symfony/Component/Config/Builder/ClassBuilder.php
+++ b/src/Symfony/Component/Config/Builder/ClassBuilder.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Config\Builder;
 
+use Symfony\Component\Config\Definition\NodeInterface;
+
 /**
  * Build PHP classes to generate config.
  *
@@ -35,6 +37,7 @@ class ClassBuilder
     public function __construct(
         private string $namespace,
         string $name,
+        private NodeInterface $node,
     ) {
         $this->name = ucfirst($this->camelCase($name)).'Config';
     }
@@ -165,5 +168,10 @@ BODY
     public function shouldAllowExtraKeys(): bool
     {
         return $this->allowExtraKeys;
+    }
+
+    public function getNode(): NodeInterface
+    {
+        return $this->node;
     }
 }

--- a/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
+++ b/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
@@ -51,7 +51,7 @@ class ConfigBuilderGenerator implements ConfigBuilderGeneratorInterface
         $this->classes = [];
 
         $rootNode = $configuration->getConfigTreeBuilder()->buildTree();
-        $rootClass = new ClassBuilder('Symfony\\Config', $rootNode->getName());
+        $rootClass = new ClassBuilder('Symfony\\Config', $rootNode->getName(), $rootNode);
 
         $path = $this->getFullPath($rootClass);
         if (!is_file($path)) {
@@ -65,7 +65,7 @@ public function NAME(): string
     return \'ALIAS\';
 }', ['ALIAS' => $rootNode->getPath()]);
 
-            $this->writeClasses($rootNode);
+            $this->writeClasses();
         }
 
         return function () use ($path, $rootClass) {
@@ -86,10 +86,10 @@ public function NAME(): string
         return $directory.\DIRECTORY_SEPARATOR.$class->getFilename();
     }
 
-    private function writeClasses(NodeInterface $node): void
+    private function writeClasses(): void
     {
         foreach ($this->classes as $class) {
-            $this->buildConstructor($class, $node);
+            $this->buildConstructor($class, $class->getNode());
             $this->buildToArray($class);
             if ($class->getProperties()) {
                 $class->addProperty('_usedProperties', null, '[]');
@@ -121,7 +121,7 @@ public function NAME(): string
 
     private function handleArrayNode(ArrayNode $node, ClassBuilder $class, string $namespace): void
     {
-        $childClass = new ClassBuilder($namespace, $node->getName());
+        $childClass = new ClassBuilder($namespace, $node->getName(), $node);
         $childClass->setAllowExtraKeys($node->shouldIgnoreExtraKeys());
         $class->addRequire($childClass);
         $this->classes[] = $childClass;
@@ -271,7 +271,7 @@ public function NAME(string $VAR, TYPE $VALUE): static
             return;
         }
 
-        $childClass = new ClassBuilder($namespace, $name);
+        $childClass = new ClassBuilder($namespace, $name, $prototype);
         if ($prototype instanceof ArrayNode) {
             $childClass->setAllowExtraKeys($prototype->shouldIgnoreExtraKeys());
         }

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/Messenger/ReceivingConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/Messenger/ReceivingConfig.php
@@ -42,25 +42,8 @@ class ReceivingConfig
 
     /**
      * @param array{
-     *     translator?: array{
-     *         fallbacks?: list<scalar|null>,
-     *         sources?: array<string, scalar|null>,
-     *         books?: array{ // Deprecated: The child node "books" at path "add_to_list.translator.books" is deprecated. // looks for translation in old fashion way
-     *             page?: list<array{
-     *                 number?: int<min, max>,
-     *                 content?: scalar|null,
-     *             }>,
-     *         },
-     *     },
-     *     messenger?: array{
-     *         routing?: array<string, array{
-     *             senders?: list<scalar|null>,
-     *         }>,
-     *         receiving?: list<array{
-     *             priority?: int<min, max>,
-     *             color?: scalar|null,
-     *         }>,
-     *     },
+     *     priority?: int<min, max>,
+     *     color?: scalar|null,
      * } $config
      */
     public function __construct(array $config = [])

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/Messenger/RoutingConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/Messenger/RoutingConfig.php
@@ -28,25 +28,7 @@ class RoutingConfig
 
     /**
      * @param array{
-     *     translator?: array{
-     *         fallbacks?: list<scalar|null>,
-     *         sources?: array<string, scalar|null>,
-     *         books?: array{ // Deprecated: The child node "books" at path "add_to_list.translator.books" is deprecated. // looks for translation in old fashion way
-     *             page?: list<array{
-     *                 number?: int<min, max>,
-     *                 content?: scalar|null,
-     *             }>,
-     *         },
-     *     },
-     *     messenger?: array{
-     *         routing?: array<string, array{
-     *             senders?: list<scalar|null>,
-     *         }>,
-     *         receiving?: list<array{
-     *             priority?: int<min, max>,
-     *             color?: scalar|null,
-     *         }>,
-     *     },
+     *     senders?: list<scalar|null>,
      * } $config
      */
     public function __construct(array $config = [])

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/MessengerConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/MessengerConfig.php
@@ -37,25 +37,13 @@ class MessengerConfig
 
     /**
      * @param array{
-     *     translator?: array{
-     *         fallbacks?: list<scalar|null>,
-     *         sources?: array<string, scalar|null>,
-     *         books?: array{ // Deprecated: The child node "books" at path "add_to_list.translator.books" is deprecated. // looks for translation in old fashion way
-     *             page?: list<array{
-     *                 number?: int<min, max>,
-     *                 content?: scalar|null,
-     *             }>,
-     *         },
-     *     },
-     *     messenger?: array{
-     *         routing?: array<string, array{
-     *             senders?: list<scalar|null>,
-     *         }>,
-     *         receiving?: list<array{
-     *             priority?: int<min, max>,
-     *             color?: scalar|null,
-     *         }>,
-     *     },
+     *     routing?: array<string, array{
+     *         senders?: list<scalar|null>,
+     *     }>,
+     *     receiving?: list<array{
+     *         priority?: int<min, max>,
+     *         color?: scalar|null,
+     *     }>,
      * } $config
      */
     public function __construct(array $config = [])

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/Translator/Books/PageConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/Translator/Books/PageConfig.php
@@ -42,25 +42,8 @@ class PageConfig
 
     /**
      * @param array{
-     *     translator?: array{
-     *         fallbacks?: list<scalar|null>,
-     *         sources?: array<string, scalar|null>,
-     *         books?: array{ // Deprecated: The child node "books" at path "add_to_list.translator.books" is deprecated. // looks for translation in old fashion way
-     *             page?: list<array{
-     *                 number?: int<min, max>,
-     *                 content?: scalar|null,
-     *             }>,
-     *         },
-     *     },
-     *     messenger?: array{
-     *         routing?: array<string, array{
-     *             senders?: list<scalar|null>,
-     *         }>,
-     *         receiving?: list<array{
-     *             priority?: int<min, max>,
-     *             color?: scalar|null,
-     *         }>,
-     *     },
+     *     number?: int<min, max>,
+     *     content?: scalar|null,
      * } $config
      */
     public function __construct(array $config = [])

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/Translator/BooksConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/Translator/BooksConfig.php
@@ -26,26 +26,11 @@ class BooksConfig
     }
 
     /**
-     * @param array{
-     *     translator?: array{
-     *         fallbacks?: list<scalar|null>,
-     *         sources?: array<string, scalar|null>,
-     *         books?: array{ // Deprecated: The child node "books" at path "add_to_list.translator.books" is deprecated. // looks for translation in old fashion way
-     *             page?: list<array{
-     *                 number?: int<min, max>,
-     *                 content?: scalar|null,
-     *             }>,
-     *         },
-     *     },
-     *     messenger?: array{
-     *         routing?: array<string, array{
-     *             senders?: list<scalar|null>,
-     *         }>,
-     *         receiving?: list<array{
-     *             priority?: int<min, max>,
-     *             color?: scalar|null,
-     *         }>,
-     *     },
+     * @param array{ // Deprecated: The child node "books" at path "add_to_list.translator.books" is deprecated. // looks for translation in old fashion way
+     *     page?: list<array{
+     *         number?: int<min, max>,
+     *         content?: scalar|null,
+     *     }>,
      * } $config
      */
     public function __construct(array $config = [])

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/TranslatorConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/TranslatorConfig.php
@@ -59,23 +59,12 @@ class TranslatorConfig
 
     /**
      * @param array{
-     *     translator?: array{
-     *         fallbacks?: list<scalar|null>,
-     *         sources?: array<string, scalar|null>,
-     *         books?: array{ // Deprecated: The child node "books" at path "add_to_list.translator.books" is deprecated. // looks for translation in old fashion way
-     *             page?: list<array{
-     *                 number?: int<min, max>,
-     *                 content?: scalar|null,
-     *             }>,
-     *         },
-     *     },
-     *     messenger?: array{
-     *         routing?: array<string, array{
-     *             senders?: list<scalar|null>,
-     *         }>,
-     *         receiving?: list<array{
-     *             priority?: int<min, max>,
-     *             color?: scalar|null,
+     *     fallbacks?: list<scalar|null>,
+     *     sources?: array<string, scalar|null>,
+     *     books?: array{ // Deprecated: The child node "books" at path "add_to_list.translator.books" is deprecated. // looks for translation in old fashion way
+     *         page?: list<array{
+     *             number?: int<min, max>,
+     *             content?: scalar|null,
      *         }>,
      *     },
      * } $config

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeys/BarConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeys/BarConfig.php
@@ -42,17 +42,9 @@ class BarConfig
 
     /**
      * @param array{
-     *     foo?: array{
-     *         baz?: scalar|null,
-     *         qux?: scalar|null,
-     *         ...<mixed>
-     *     },
-     *     bar?: list<array{
-     *         corge?: scalar|null,
-     *         grault?: scalar|null,
-     *         ...<mixed>
-     *     }>,
-     *     baz?: array<mixed>,
+     *     corge?: scalar|null,
+     *     grault?: scalar|null,
+     *     ...<mixed>
      * } $config
      */
     public function __construct(array $config = [])

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeys/BazConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeys/BazConfig.php
@@ -12,19 +12,7 @@ class BazConfig
     private $_extraKeys;
 
     /**
-     * @param array{
-     *     foo?: array{
-     *         baz?: scalar|null,
-     *         qux?: scalar|null,
-     *         ...<mixed>
-     *     },
-     *     bar?: list<array{
-     *         corge?: scalar|null,
-     *         grault?: scalar|null,
-     *         ...<mixed>
-     *     }>,
-     *     baz?: array<mixed>,
-     * } $config
+     * @param array<mixed> $config
      */
     public function __construct(array $config = [])
     {

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeys/FooConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeys/FooConfig.php
@@ -42,17 +42,9 @@ class FooConfig
 
     /**
      * @param array{
-     *     foo?: array{
-     *         baz?: scalar|null,
-     *         qux?: scalar|null,
-     *         ...<mixed>
-     *     },
-     *     bar?: list<array{
-     *         corge?: scalar|null,
-     *         grault?: scalar|null,
-     *         ...<mixed>
-     *     }>,
-     *     baz?: array<mixed>,
+     *     baz?: scalar|null,
+     *     qux?: scalar|null,
+     *     ...<mixed>
      * } $config
      */
     public function __construct(array $config = [])

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayValues/Symfony/Config/ArrayValues/ErrorPagesConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayValues/Symfony/Config/ArrayValues/ErrorPagesConfig.php
@@ -41,14 +41,9 @@ class ErrorPagesConfig
     }
 
     /**
-     * @param array{
-     *     transports?: array<string, array{
-     *         dsn?: scalar|null,
-     *     }>,
-     *     error_pages?: array{ // Default: {"enabled":false}
-     *         enabled?: bool, // Default: false
-     *         with_trace?: bool,
-     *     },
+     * @param array{ // Default: {"enabled":false}
+     *     enabled?: bool, // Default: false
+     *     with_trace?: bool,
      * } $config
      */
     public function __construct(array $config = [])

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayValues/Symfony/Config/ArrayValues/TransportsConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayValues/Symfony/Config/ArrayValues/TransportsConfig.php
@@ -28,13 +28,7 @@ class TransportsConfig
 
     /**
      * @param array{
-     *     transports?: array<string, array{
-     *         dsn?: scalar|null,
-     *     }>,
-     *     error_pages?: array{ // Default: {"enabled":false}
-     *         enabled?: bool, // Default: false
-     *         with_trace?: bool,
-     *     },
+     *     dsn?: scalar|null,
      * } $config
      */
     public function __construct(array $config = [])

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValues/Messenger/TransportsConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValues/Messenger/TransportsConfig.php
@@ -59,18 +59,9 @@ class TransportsConfig
 
     /**
      * @param array{
-     *     some_clever_name?: array{
-     *         first?: scalar|null,
-     *         second?: scalar|null,
-     *         third?: scalar|null,
-     *     },
-     *     messenger?: array{
-     *         transports?: array<string, array{
-     *             dsn?: scalar|null, // The DSN to use. This is a required option. The info is used to describe the DSN, it can be multi-line.
-     *             serializer?: scalar|null, // Default: null
-     *             options?: list<mixed>,
-     *         }>,
-     *     },
+     *     dsn?: scalar|null, // The DSN to use. This is a required option. The info is used to describe the DSN, it can be multi-line.
+     *     serializer?: scalar|null, // Default: null
+     *     options?: list<mixed>,
      * } $config
      */
     public function __construct(array $config = [])

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValues/MessengerConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValues/MessengerConfig.php
@@ -28,18 +28,11 @@ class MessengerConfig
 
     /**
      * @param array{
-     *     some_clever_name?: array{
-     *         first?: scalar|null,
-     *         second?: scalar|null,
-     *         third?: scalar|null,
-     *     },
-     *     messenger?: array{
-     *         transports?: array<string, array{
-     *             dsn?: scalar|null, // The DSN to use. This is a required option. The info is used to describe the DSN, it can be multi-line.
-     *             serializer?: scalar|null, // Default: null
-     *             options?: list<mixed>,
-     *         }>,
-     *     },
+     *     transports?: array<string, array{
+     *         dsn?: scalar|null, // The DSN to use. This is a required option. The info is used to describe the DSN, it can be multi-line.
+     *         serializer?: scalar|null, // Default: null
+     *         options?: list<mixed>,
+     *     }>,
      * } $config
      */
     public function __construct(array $config = [])

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValues/SomeCleverNameConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValues/SomeCleverNameConfig.php
@@ -56,18 +56,9 @@ class SomeCleverNameConfig
 
     /**
      * @param array{
-     *     some_clever_name?: array{
-     *         first?: scalar|null,
-     *         second?: scalar|null,
-     *         third?: scalar|null,
-     *     },
-     *     messenger?: array{
-     *         transports?: array<string, array{
-     *             dsn?: scalar|null, // The DSN to use. This is a required option. The info is used to describe the DSN, it can be multi-line.
-     *             serializer?: scalar|null, // Default: null
-     *             options?: list<mixed>,
-     *         }>,
-     *     },
+     *     first?: scalar|null,
+     *     second?: scalar|null,
+     *     third?: scalar|null,
      * } $config
      */
     public function __construct(array $config = [])

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/KeyedListObjectConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/KeyedListObjectConfig.php
@@ -42,29 +42,8 @@ class KeyedListObjectConfig
 
     /**
      * @param array{
-     *     simple_array?: list<scalar|null>,
-     *     keyed_array?: array<string, list<scalar|null>>,
-     *     object?: array{ // Default: {"enabled":null}
-     *         enabled?: bool|null, // Default: null
-     *         date_format?: scalar|null,
-     *         remove_used_context_fields?: bool,
-     *     },
-     *     list_object: list<array{
-     *         name: scalar|null,
-     *         data?: list<mixed>,
-     *     }>,
-     *     keyed_list_object?: array<string, array{
-     *         enabled?: bool, // Default: true
-     *         settings?: list<scalar|null>,
-     *     }>,
-     *     nested?: array{
-     *         nested_object?: array{ // Default: {"enabled":null}
-     *             enabled?: bool|null, // Default: null
-     *         },
-     *         nested_list_object?: list<array{
-     *             name: scalar|null,
-     *         }>,
-     *     },
+     *     enabled?: bool, // Default: true
+     *     settings?: list<scalar|null>,
      * } $config
      */
     public function __construct(array $config = [])

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/ListObjectConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/ListObjectConfig.php
@@ -42,29 +42,8 @@ class ListObjectConfig
 
     /**
      * @param array{
-     *     simple_array?: list<scalar|null>,
-     *     keyed_array?: array<string, list<scalar|null>>,
-     *     object?: array{ // Default: {"enabled":null}
-     *         enabled?: bool|null, // Default: null
-     *         date_format?: scalar|null,
-     *         remove_used_context_fields?: bool,
-     *     },
-     *     list_object: list<array{
-     *         name: scalar|null,
-     *         data?: list<mixed>,
-     *     }>,
-     *     keyed_list_object?: array<string, array{
-     *         enabled?: bool, // Default: true
-     *         settings?: list<scalar|null>,
-     *     }>,
-     *     nested?: array{
-     *         nested_object?: array{ // Default: {"enabled":null}
-     *             enabled?: bool|null, // Default: null
-     *         },
-     *         nested_list_object?: list<array{
-     *             name: scalar|null,
-     *         }>,
-     *     },
+     *     name: scalar|null,
+     *     data?: list<mixed>,
      * } $config
      */
     public function __construct(array $config = [])

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/Nested/NestedListObjectConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/Nested/NestedListObjectConfig.php
@@ -28,29 +28,7 @@ class NestedListObjectConfig
 
     /**
      * @param array{
-     *     simple_array?: list<scalar|null>,
-     *     keyed_array?: array<string, list<scalar|null>>,
-     *     object?: array{ // Default: {"enabled":null}
-     *         enabled?: bool|null, // Default: null
-     *         date_format?: scalar|null,
-     *         remove_used_context_fields?: bool,
-     *     },
-     *     list_object: list<array{
-     *         name: scalar|null,
-     *         data?: list<mixed>,
-     *     }>,
-     *     keyed_list_object?: array<string, array{
-     *         enabled?: bool, // Default: true
-     *         settings?: list<scalar|null>,
-     *     }>,
-     *     nested?: array{
-     *         nested_object?: array{ // Default: {"enabled":null}
-     *             enabled?: bool|null, // Default: null
-     *         },
-     *         nested_list_object?: list<array{
-     *             name: scalar|null,
-     *         }>,
-     *     },
+     *     name: scalar|null,
      * } $config
      */
     public function __construct(array $config = [])

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/Nested/NestedObjectConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/Nested/NestedObjectConfig.php
@@ -27,30 +27,8 @@ class NestedObjectConfig
     }
 
     /**
-     * @param array{
-     *     simple_array?: list<scalar|null>,
-     *     keyed_array?: array<string, list<scalar|null>>,
-     *     object?: array{ // Default: {"enabled":null}
-     *         enabled?: bool|null, // Default: null
-     *         date_format?: scalar|null,
-     *         remove_used_context_fields?: bool,
-     *     },
-     *     list_object: list<array{
-     *         name: scalar|null,
-     *         data?: list<mixed>,
-     *     }>,
-     *     keyed_list_object?: array<string, array{
-     *         enabled?: bool, // Default: true
-     *         settings?: list<scalar|null>,
-     *     }>,
-     *     nested?: array{
-     *         nested_object?: array{ // Default: {"enabled":null}
-     *             enabled?: bool|null, // Default: null
-     *         },
-     *         nested_list_object?: list<array{
-     *             name: scalar|null,
-     *         }>,
-     *     },
+     * @param array{ // Default: {"enabled":null}
+     *     enabled?: bool|null, // Default: null
      * } $config
      */
     public function __construct(array $config = [])

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/NestedConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/NestedConfig.php
@@ -62,29 +62,12 @@ class NestedConfig
 
     /**
      * @param array{
-     *     simple_array?: list<scalar|null>,
-     *     keyed_array?: array<string, list<scalar|null>>,
-     *     object?: array{ // Default: {"enabled":null}
+     *     nested_object?: array{ // Default: {"enabled":null}
      *         enabled?: bool|null, // Default: null
-     *         date_format?: scalar|null,
-     *         remove_used_context_fields?: bool,
      *     },
-     *     list_object: list<array{
+     *     nested_list_object?: list<array{
      *         name: scalar|null,
-     *         data?: list<mixed>,
      *     }>,
-     *     keyed_list_object?: array<string, array{
-     *         enabled?: bool, // Default: true
-     *         settings?: list<scalar|null>,
-     *     }>,
-     *     nested?: array{
-     *         nested_object?: array{ // Default: {"enabled":null}
-     *             enabled?: bool|null, // Default: null
-     *         },
-     *         nested_list_object?: list<array{
-     *             name: scalar|null,
-     *         }>,
-     *     },
      * } $config
      */
     public function __construct(array $config = [])

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/ObjectConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypes/ObjectConfig.php
@@ -55,30 +55,10 @@ class ObjectConfig
     }
 
     /**
-     * @param array{
-     *     simple_array?: list<scalar|null>,
-     *     keyed_array?: array<string, list<scalar|null>>,
-     *     object?: array{ // Default: {"enabled":null}
-     *         enabled?: bool|null, // Default: null
-     *         date_format?: scalar|null,
-     *         remove_used_context_fields?: bool,
-     *     },
-     *     list_object: list<array{
-     *         name: scalar|null,
-     *         data?: list<mixed>,
-     *     }>,
-     *     keyed_list_object?: array<string, array{
-     *         enabled?: bool, // Default: true
-     *         settings?: list<scalar|null>,
-     *     }>,
-     *     nested?: array{
-     *         nested_object?: array{ // Default: {"enabled":null}
-     *             enabled?: bool|null, // Default: null
-     *         },
-     *         nested_list_object?: list<array{
-     *             name: scalar|null,
-     *         }>,
-     *     },
+     * @param array{ // Default: {"enabled":null}
+     *     enabled?: bool|null, // Default: null
+     *     date_format?: scalar|null,
+     *     remove_used_context_fields?: bool,
      * } $config
      */
     public function __construct(array $config = [])

--- a/src/Symfony/Component/Config/Tests/Builder/GeneratedConfigTest.php
+++ b/src/Symfony/Component/Config/Tests/Builder/GeneratedConfigTest.php
@@ -170,7 +170,7 @@ class GeneratedConfigTest extends TestCase
 
         $configuration = new $configurationClass();
         $rootNode = $configuration->getConfigTreeBuilder()->buildTree();
-        $rootClass = new ClassBuilder('Symfony\\Config', $rootNode->getName());
+        $rootClass = new ClassBuilder('Symfony\\Config', $rootNode->getName(), $rootNode);
         if (class_exists($fqcn = $rootClass->getFqcn())) {
             // Avoid generating the class again
             return new $fqcn();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The array shape of the whole hierarchy was generated even in child nodes. This PR fixes this concern and only dumps the shape for the current node.