### PR TITLE
[HttpFoundation] Deprecate Request::get() in favor of using properties ->attributes, query or request directly

### DIFF
--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -78,8 +78,9 @@ HttpClient
 HttpFoundation
 --------------
 
- * Deprecate using `Request::sendHeaders()` after headers have already been sent; use a `StreamedResponse` instead
  * Add argument `$subtypeFallback` to `Request::getFormat()`
+ * Deprecate using `Request::sendHeaders()` after headers have already been sent; use a `StreamedResponse` instead
+ * Deprecate method `Request::get()`, use properties `->attributes`, `query` or `request` directly instead
 
 HttpKernel
 ----------

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -4,10 +4,11 @@ CHANGELOG
 7.4
 ---
 
- * Deprecate using `Request::sendHeaders()` after headers have already been sent; use a `StreamedResponse` instead
  * Add `#[WithHttpStatus]` to define status codes: 404 for `SignedUriException` and 403 for `ExpiredSignedUriException`
  * Add support for the `QUERY` HTTP method
  * Add support for structured MIME suffix
+ * Deprecate using `Request::sendHeaders()` after headers have already been sent; use a `StreamedResponse` instead
+ * Deprecate method `Request::get()`, use properties `->attributes`, `query` or `request` directly instead
 
 7.3
 ---

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -468,8 +468,8 @@ class Request
         $dup->method = null;
         $dup->format = null;
 
-        if (!$dup->get('_format') && $this->get('_format')) {
-            $dup->attributes->set('_format', $this->get('_format'));
+        if (!$dup->attributes->has('_format') && $this->attributes->has('_format')) {
+            $dup->attributes->set('_format', $this->attributes->get('_format'));
         }
 
         if (!$dup->getRequestFormat(null)) {
@@ -679,10 +679,12 @@ class Request
      *
      * Order of precedence: PATH (routing placeholders or custom attributes), GET, POST
      *
-     * @internal use explicit input sources instead
+     * @deprecated since Symfony 7.4, use properties `->attributes`, `query` or `request` directly instead
      */
     public function get(string $key, mixed $default = null): mixed
     {
+        trigger_deprecation('symfony/http-foundation', '7.4', 'Request::get() is deprecated, use properties ->attributes, query or request directly instead.');
+
         if ($this !== $result = $this->attributes->get($key, $this)) {
             return $result;
         }
@@ -1109,10 +1111,8 @@ class Request
     {
         if ($this->isFromTrustedProxy() && $host = $this->getTrustedValues(self::HEADER_X_FORWARDED_HOST)) {
             $host = $host[0];
-        } elseif (!$host = $this->headers->get('HOST')) {
-            if (!$host = $this->server->get('SERVER_NAME')) {
-                $host = $this->server->get('SERVER_ADDR', '');
-            }
+        } else {
+            $host = $this->headers->get('HOST') ?: $this->server->get('SERVER_NAME') ?: $this->server->get('SERVER_ADDR', '');
         }
 
         // trim and remove port number from host

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\HttpFoundation\Tests;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
@@ -1508,6 +1510,8 @@ b'])]
         $this->assertEquals('/', $request->getPathInfo());
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testGetParameterPrecedence()
     {
         $request = new Request();

--- a/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
@@ -80,8 +80,8 @@ class ProfilerListener implements EventSubscriberInterface
         }
 
         $request = $event->getRequest();
-        if (null !== $this->collectParameter && null !== $collectParameterValue = $request->get($this->collectParameter)) {
-            true === $collectParameterValue || filter_var($collectParameterValue, \FILTER_VALIDATE_BOOL) ? $this->profiler->enable() : $this->profiler->disable();
+        if (null !== $this->collectParameter && null !== $collectParameterValue = $request->attributes->get($this->collectParameter) ?? $request->query->get($this->collectParameter) ?? $request->request->get($this->collectParameter)) {
+            filter_var($collectParameterValue, \FILTER_VALIDATE_BOOL) ? $this->profiler->enable() : $this->profiler->disable();
         }
 
         $exception = $this->exception;

--- a/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
@@ -118,8 +118,8 @@ class InlineFragmentRenderer extends RoutableFragmentRenderer
         $setSession ??= \Closure::bind(static function ($subRequest, $request) { $subRequest->session = $request->session; }, null, Request::class);
         $setSession($subRequest, $request);
 
-        if ($request->get('_format')) {
-            $subRequest->attributes->set('_format', $request->get('_format'));
+        if ($request->attributes->has('_format')) {
+            $subRequest->attributes->set('_format', $request->attributes->get('_format'));
         }
         if ($request->getDefaultLocale() !== $request->getLocale()) {
             $subRequest->setLocale($request->getLocale());

--- a/src/Symfony/Component/Security/Http/AccessToken/FormEncodedBodyExtractor.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/FormEncodedBodyExtractor.php
@@ -34,10 +34,7 @@ final class FormEncodedBodyExtractor implements AccessTokenExtractorInterface
 
     public function extractAccessToken(Request $request): ?string
     {
-        if (
-            Request::METHOD_POST !== $request->getMethod()
-            || !str_starts_with($request->headers->get('CONTENT_TYPE', ''), 'application/x-www-form-urlencoded')
-        ) {
+        if ('POST' !== $request->getMethod() || !str_starts_with($request->headers->get('CONTENT_TYPE', ''), 'application/x-www-form-urlencoded')) {
             return null;
         }
         $parameter = $request->request->get($this->parameter);

--- a/src/Symfony/Component/Security/Http/Authenticator/LoginLinkAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/LoginLinkAuthenticator.php
@@ -51,7 +51,7 @@ final class LoginLinkAuthenticator extends AbstractAuthenticator implements Inte
 
     public function authenticate(Request $request): Passport
     {
-        if (!$username = $request->get('user')) {
+        if (!$username = $request->query->get('user') ?? (!\in_array($request->getMethod(), ['GET', 'HEAD'], true) ? $request->request->get('user') : null)) {
             throw new InvalidLoginLinkAuthenticationException('Missing user from link.');
         }
 

--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -65,7 +65,7 @@ class SwitchUserListener extends AbstractListener
     public function supports(Request $request): ?bool
     {
         // usernames can be falsy
-        $username = $request->get($this->usernameParameter);
+        $username = $request->query->get($this->usernameParameter) ?? (!\in_array($request->getMethod(), ['GET', 'HEAD'], true) ? $request->request->get($this->usernameParameter) : null);
 
         if (null === $username || '' === $username) {
             $username = $request->headers->get($this->usernameParameter);

--- a/src/Symfony/Component/Security/Http/HttpUtils.php
+++ b/src/Symfony/Component/Security/Http/HttpUtils.php
@@ -88,8 +88,8 @@ class HttpUtils
             $newRequest->attributes->set(SecurityRequestAttributes::LAST_USERNAME, $request->attributes->get(SecurityRequestAttributes::LAST_USERNAME));
         }
 
-        if ($request->get('_format')) {
-            $newRequest->attributes->set('_format', $request->get('_format'));
+        if ($request->attributes->has('_format')) {
+            $newRequest->attributes->set('_format', $request->attributes->get('_format'));
         }
         if ($request->getDefaultLocale() !== $request->getLocale()) {
             $newRequest->setLocale($request->getLocale());

--- a/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandler.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandler.php
@@ -22,6 +22,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Http\LoginLink\Exception\ExpiredLoginLinkException;
 use Symfony\Component\Security\Http\LoginLink\Exception\InvalidLoginLinkException;
+use Symfony\Component\Security\Http\ParameterBagUtils;
 
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
@@ -79,16 +80,16 @@ final class LoginLinkHandler implements LoginLinkHandlerInterface
 
     public function consumeLoginLink(Request $request): UserInterface
     {
-        $userIdentifier = $request->get('user');
+        $userIdentifier = ParameterBagUtils::getRequestParameterValue($request, 'user');
 
-        if (!$hash = $request->get('hash')) {
+        if (!$hash = ParameterBagUtils::getRequestParameterValue($request, 'hash')) {
             throw new InvalidLoginLinkException('Missing "hash" parameter.');
         }
         if (!\is_string($hash)) {
             throw new InvalidLoginLinkException('Invalid "hash" parameter.');
         }
 
-        if (!$expires = $request->get('expires')) {
+        if (!$expires = ParameterBagUtils::getRequestParameterValue($request, 'expires')) {
             throw new InvalidLoginLinkException('Missing "expires" parameter.');
         }
         if (!preg_match('/^\d+$/', $expires)) {

--- a/src/Symfony/Component/Security/Http/ParameterBagUtils.php
+++ b/src/Symfony/Component/Security/Http/ParameterBagUtils.php
@@ -62,13 +62,15 @@ final class ParameterBagUtils
      */
     public static function getRequestParameterValue(Request $request, string $path, array $parameters = []): mixed
     {
+        $get = static fn ($path) => $request->attributes->get($path) ?? $request->query->all()[$path] ?? (!\in_array($request->getMethod(), ['GET', 'HEAD'], true) ? $request->request->all()[$path] ?? null : null);
+
         if (false === $pos = strpos($path, '[')) {
-            return $parameters[$path] ?? $request->get($path);
+            return $parameters[$path] ?? $get($path);
         }
 
         $root = substr($path, 0, $pos);
 
-        if (null === $value = $parameters[$root] ?? $request->get($root)) {
+        if (null === $value = $parameters[$root] ?? $get($root)) {
             return null;
         }
 
@@ -77,7 +79,7 @@ final class ParameterBagUtils
         try {
             $value = self::$propertyAccessor->getValue($value, substr($path, $pos));
 
-            if (null === $value && isset($parameters[$root]) && null !== $value = $request->get($root)) {
+            if (null === $value && isset($parameters[$root]) && null !== $value = $get($root)) {
                 $value = self::$propertyAccessor->getValue($value, substr($path, $pos));
             }
 

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationSuccessHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationSuccessHandlerTest.php
@@ -146,10 +146,8 @@ class DefaultAuthenticationSuccessHandlerTest extends TestCase
         $options = ['target_path_parameter' => '_my_target_path'];
         $token = $this->createMock(TokenInterface::class);
 
-        $request = $this->createMock(Request::class);
-        $request->expects($this->once())
-            ->method('get')->with('_my_target_path')
-            ->willReturn('some_route_name');
+        $request = Request::create('/');
+        $request->attributes->set('_my_target_path', 'some_route_name');
 
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects($this->once())
@@ -165,10 +163,8 @@ class DefaultAuthenticationSuccessHandlerTest extends TestCase
     {
         $options = ['target_path_parameter' => '_my_target_path'];
 
-        $request = $this->createMock(Request::class);
-        $request->expects($this->once())
-            ->method('get')->with('_my_target_path')
-            ->willReturn('https://localhost/some-path');
+        $request = Request::create('/');
+        $request->attributes->set('_my_target_path', 'https://localhost/some-path');
 
         $httpUtils = $this->createMock(HttpUtils::class);
         $httpUtils->expects($this->once())


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | -
| License       | MIT

This method is internal but used cross components (and outside of the Symfony namespace AFAIK).

But this method is dangerous, it blurs the origin of the input data.