### PR TITLE
[HttpFoundation] Deprecate HTTP method override for methods GET, HEAD, CONNECT and TRACE

### DIFF
--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -82,6 +82,7 @@ HttpFoundation
  * Add argument `$subtypeFallback` to `Request::getFormat()`
  * Deprecate using `Request::sendHeaders()` after headers have already been sent; use a `StreamedResponse` instead
  * Deprecate method `Request::get()`, use properties `->attributes`, `query` or `request` directly instead
+ * Deprecate HTTP method override for methods GET, HEAD, CONNECT and TRACE; it will be ignored in Symfony 8.0
 
 HttpKernel
 ----------

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/ProfilerControllerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/ProfilerControllerTest.php
@@ -182,7 +182,7 @@ class ProfilerControllerTest extends WebTestCase
         $controller = new ProfilerController($urlGenerator, $profiler, $twig, [], null, __DIR__.'/../..');
 
         try {
-            $response = $controller->openAction(Request::create('/_wdt/open', Request::METHOD_GET, ['file' => $path]));
+            $response = $controller->openAction(Request::create('/_wdt/open', 'GET', ['file' => $path]));
             $this->assertEquals(200, $response->getStatusCode());
             $this->assertTrue($isAllowed);
         } catch (NotFoundHttpException $e) {

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Deprecate using `Request::sendHeaders()` after headers have already been sent; use a `StreamedResponse` instead
  * Deprecate method `Request::get()`, use properties `->attributes`, `query` or `request` directly instead
  * Make `Request::createFromGlobals()` parse the body of PUT, DELETE, PATCH and QUERY requests
+ * Deprecate HTTP method override for methods GET, HEAD, CONNECT and TRACE; it will be ignored in Symfony 8.0
 
 7.3
 ---

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1244,6 +1244,10 @@ class Request
 
         $method = strtoupper($method);
 
+        if (\in_array($method, ['GET', 'HEAD', 'CONNECT', 'TRACE'], true)) {
+            trigger_deprecation('symfony/http-foundation', '7.4', 'HTTP method override is deprecated for methods GET, HEAD, CONNECT and TRACE; it will be ignored in Symfony 8.0.', $method);
+        }
+
         if (self::$allowedHttpMethodOverride && !\in_array($method, self::$allowedHttpMethodOverride, true)) {
             return $this->method;
         }

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1079,6 +1079,18 @@ b'])]
         $this->assertSame('POST', $request->getMethod(), '->getMethod() returns the request method if invalid type is defined in query');
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
+    public function testUnsafeMethodOverride()
+    {
+        $request = new Request();
+        $request->setMethod('POST');
+        $request->headers->set('X-HTTP-METHOD-OVERRIDE', 'get');
+
+        $this->expectUserDeprecationMessage('Since symfony/http-foundation 7.4: HTTP method override is deprecated for methods GET, HEAD, CONNECT and TRACE; it will be ignored in Symfony 8.0.');
+        $this->assertSame('GET', $request->getMethod());
+    }
+
     #[DataProvider('getClientIpsProvider')]
     public function testGetClientIp($expected, $remoteAddr, $httpForwardedFor, $trustedProxies)
     {

--- a/src/Symfony/Component/HttpKernel/HttpCache/AbstractSurrogate.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/AbstractSurrogate.php
@@ -70,7 +70,7 @@ abstract class AbstractSurrogate implements SurrogateInterface
 
     public function handle(HttpCache $cache, string $uri, string $alt, bool $ignoreErrors): string
     {
-        $subRequest = Request::create($uri, Request::METHOD_GET, [], $cache->getRequest()->cookies->all(), [], $cache->getRequest()->server->all());
+        $subRequest = Request::create($uri, 'GET', [], $cache->getRequest()->cookies->all(), [], $cache->getRequest()->server->all());
 
         try {
             $response = $cache->handle($subRequest, HttpKernelInterface::SUB_REQUEST, true);

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php
@@ -937,7 +937,7 @@ class RequestPayloadValueResolverTest extends TestCase
         $argument = new ArgumentMetadata('filtered', QueryPayload::class, false, false, null, false, [
             MapQueryString::class => new MapQueryString(key: 'value'),
         ]);
-        $request = Request::create('/', Request::METHOD_GET, ['value' => ['page' => 1.0]]);
+        $request = Request::create('/', 'GET', ['value' => ['page' => 1.0]]);
 
         $kernel = $this->createMock(HttpKernelInterface::class);
         $arguments = $resolver->resolve($request, $argument);

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/AbstractLoginFormAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/AbstractLoginFormAuthenticatorTest.php
@@ -34,7 +34,7 @@ class AbstractLoginFormAuthenticatorTest extends TestCase
     {
         yield [
             '/login',
-            Request::create('http://localhost/login', Request::METHOD_POST, [], [], [], [
+            Request::create('http://localhost/login', 'POST', [], [], [], [
                 'DOCUMENT_ROOT' => '/var/www/app/public',
                 'PHP_SELF' => '/index.php',
                 'SCRIPT_FILENAME' => '/var/www/app/public/index.php',
@@ -44,7 +44,7 @@ class AbstractLoginFormAuthenticatorTest extends TestCase
         ];
         yield [
             '/login',
-            Request::create('http://localhost/somepath', Request::METHOD_POST, [], [], [], [
+            Request::create('http://localhost/somepath', 'POST', [], [], [], [
                 'DOCUMENT_ROOT' => '/var/www/app/public',
                 'PHP_SELF' => '/index.php',
                 'SCRIPT_FILENAME' => '/var/www/app/public/index.php',
@@ -54,7 +54,7 @@ class AbstractLoginFormAuthenticatorTest extends TestCase
         ];
         yield [
             '/folder/login',
-            Request::create('http://localhost/folder/login', Request::METHOD_POST, [], [], [], [
+            Request::create('http://localhost/folder/login', 'POST', [], [], [], [
                 'DOCUMENT_ROOT' => '/var/www/app/public',
                 'PHP_SELF' => '/folder/index.php',
                 'SCRIPT_FILENAME' => '/var/www/app/public/index.php',
@@ -64,7 +64,7 @@ class AbstractLoginFormAuthenticatorTest extends TestCase
         ];
         yield [
             '/folder/login',
-            Request::create('http://localhost/folder/somepath', Request::METHOD_POST, [], [], [], [
+            Request::create('http://localhost/folder/somepath', 'POST', [], [], [], [
                 'DOCUMENT_ROOT' => '/var/www/app/public',
                 'PHP_SELF' => '/folder/index.php',
                 'SCRIPT_FILENAME' => '/var/www/app/public/index.php',
@@ -74,7 +74,7 @@ class AbstractLoginFormAuthenticatorTest extends TestCase
         ];
         yield [
             '/index.php/login',
-            Request::create('http://localhost/index.php/login', Request::METHOD_POST, [], [], [], [
+            Request::create('http://localhost/index.php/login', 'POST', [], [], [], [
                 'DOCUMENT_ROOT' => '/var/www/app/public',
                 'PHP_SELF' => '/index.php',
                 'SCRIPT_FILENAME' => '/var/www/app/public/index.php',
@@ -84,7 +84,7 @@ class AbstractLoginFormAuthenticatorTest extends TestCase
         ];
         yield [
             '/index.php/login',
-            Request::create('http://localhost/index.php/somepath', Request::METHOD_POST, [], [], [], [
+            Request::create('http://localhost/index.php/somepath', 'POST', [], [], [], [
                 'DOCUMENT_ROOT' => '/var/www/app/public',
                 'PHP_SELF' => '/index.php',
                 'SCRIPT_FILENAME' => '/var/www/app/public/index.php',

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/AccessToken/FormEncodedBodyAccessTokenAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/AccessToken/FormEncodedBodyAccessTokenAuthenticatorTest.php
@@ -40,7 +40,7 @@ class FormEncodedBodyAccessTokenAuthenticatorTest extends TestCase
         $this->setUpAuthenticator();
         $request = new Request([], [], [], [], [], ['CONTENT_TYPE' => 'application/x-www-form-urlencoded']);
         $request->request->set('access_token', 'INVALID_ACCESS_TOKEN');
-        $request->setMethod(Request::METHOD_POST);
+        $request->setMethod('POST');
 
         $this->assertNull($this->authenticator->supports($request));
     }
@@ -50,7 +50,7 @@ class FormEncodedBodyAccessTokenAuthenticatorTest extends TestCase
         $this->setUpAuthenticator('protection-token');
         $request = new Request([], [], [], [], [], ['CONTENT_TYPE' => 'application/x-www-form-urlencoded']);
         $request->request->set('protection-token', 'INVALID_ACCESS_TOKEN');
-        $request->setMethod(Request::METHOD_POST);
+        $request->setMethod('POST');
 
         $this->assertNull($this->authenticator->supports($request));
     }
@@ -61,7 +61,7 @@ class FormEncodedBodyAccessTokenAuthenticatorTest extends TestCase
         $this->setUpAuthenticator();
         $request = new Request([], [], [], [], [], ['CONTENT_TYPE' => 'application/x-www-form-urlencoded'], 'access_token=VALID_ACCESS_TOKEN');
         $request->request->set('access_token', 'VALID_ACCESS_TOKEN');
-        $request->setMethod(Request::METHOD_POST);
+        $request->setMethod('POST');
 
         $passport = $this->authenticator->authenticate($request);
         $this->assertInstanceOf(SelfValidatingPassport::class, $passport);
@@ -73,7 +73,7 @@ class FormEncodedBodyAccessTokenAuthenticatorTest extends TestCase
         $this->setUpAuthenticator('protection-token');
         $request = new Request([], [], [], [], [], ['CONTENT_TYPE' => 'application/x-www-form-urlencoded']);
         $request->request->set('protection-token', 'VALID_ACCESS_TOKEN');
-        $request->setMethod(Request::METHOD_POST);
+        $request->setMethod('POST');
 
         $passport = $this->authenticator->authenticate($request);
         $this->assertInstanceOf(SelfValidatingPassport::class, $passport);
@@ -93,24 +93,24 @@ class FormEncodedBodyAccessTokenAuthenticatorTest extends TestCase
     public static function provideInvalidAuthenticateData(): iterable
     {
         $request = new Request();
-        $request->setMethod(Request::METHOD_GET);
+        $request->setMethod('GET');
         yield [$request, 'Invalid credentials.', BadCredentialsException::class];
 
         $request = new Request();
-        $request->setMethod(Request::METHOD_POST);
+        $request->setMethod('POST');
         yield [$request, 'Invalid credentials.', BadCredentialsException::class];
 
         $request = new Request([], [], [], [], [], ['HTTP_AUTHORIZATION' => 'Bearer VALID_ACCESS_TOKEN']);
-        $request->setMethod(Request::METHOD_POST);
+        $request->setMethod('POST');
         yield [$request, 'Invalid credentials.', BadCredentialsException::class];
 
         $request = new Request();
-        $request->setMethod(Request::METHOD_POST);
+        $request->setMethod('POST');
         $request->request->set('foo', 'VALID_ACCESS_TOKEN');
         yield [$request, 'Invalid credentials.', BadCredentialsException::class];
 
         $request = new Request([], [], [], [], [], ['CONTENT_TYPE' => 'application/x-www-form-urlencoded']);
-        $request->setMethod(Request::METHOD_POST);
+        $request->setMethod('POST');
         $request->request->set('access_token', 'INVALID_ACCESS_TOKEN');
         yield [$request, 'Invalid access token or invalid user.', BadCredentialsException::class];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | -
| License       | MIT

Using HTTP method overriding (or HTTP verb tunneling) for those methods is dangerous and unneeded: the technique has been created to submit forms using HTTP verbs that browsers don't support. GET is not one of them, so that the trick shouldn't be applied to it. HEAD, CONNECT, TRACE are also NOT something browser should do - there's no point for a Symfony app to be the recipient of such requests (well, HEAD maybe, but since it should mimic a GET, it has to be in the list).

This should make Symfony safer by default, since using a POST to tunnel a GET might lead to security-sensitive stuff.