### PR TITLE
[Serializer] Escape values starting with line feed when using `csv_escape_formulas`

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
@@ -39,7 +39,7 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
 
     private const UTF8_BOM = "\xEF\xBB\xBF";
 
-    private const FORMULAS_START_CHARACTERS = ['=', '-', '+', '@', "\t", "\r"];
+    private const FORMULAS_START_CHARACTERS = ['=', '-', '+', '@', "\t", "\r", "\n"];
 
     private array $defaultContext = [
         self::DELIMITER_KEY => ',',

--- a/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
@@ -312,6 +312,15 @@ class CsvEncoderTest extends TestCase
 
         $this->assertSame(<<<'CSV'
             0
+            "'
+            line feed"
+
+            CSV,
+            $this->encoder->encode(["\nline feed"], 'csv')
+        );
+
+        $this->assertSame(<<<'CSV'
+            0
             "'=1+2"";=1+2"
 
             CSV,
@@ -434,6 +443,17 @@ class CsvEncoderTest extends TestCase
 
             CSV,
             $this->encoder->encode(["\ttab"], 'csv', [
+                CsvEncoder::ESCAPE_FORMULAS_KEY => true,
+            ])
+        );
+
+        $this->assertSame(<<<'CSV'
+            0
+            "'
+            line feed"
+
+            CSV,
+            $this->encoder->encode(["\nline feed"], 'csv', [
                 CsvEncoder::ESCAPE_FORMULAS_KEY => true,
             ])
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Change `CsvEncoder` so that it follows the latest OWASP guidelines on CSV injection.  When escape formulas is enabled it will escape values starting with a line feed.  This is in addition other the other starting characters of equals, plus, minus, at sign, tab, and carriage return.

[OWASP: CSV Injection](https://owasp.org/www-community/attacks/CSV_Injection)