### PR TITLE
[Process] Avoid EPIPE when child process closed STDIN (close STDIN early)

### DIFF
--- a/src/Symfony/Component/Process/Pipes/AbstractPipes.php
+++ b/src/Symfony/Component/Process/Pipes/AbstractPipes.php
@@ -28,6 +28,8 @@ abstract class AbstractPipes implements PipesInterface
     private bool $blocked = true;
     private ?string $lastError = null;
 
+    private bool $stdinClosed = false;
+
     /**
      * @param resource|string|\Iterator $input
      */
@@ -100,6 +102,9 @@ abstract class AbstractPipes implements PipesInterface
      */
     protected function write(): ?array
     {
+        if ($this->stdinClosed) {
+            return null;
+        }
         if (!isset($this->pipes[0])) {
             return null;
         }
@@ -135,7 +140,11 @@ abstract class AbstractPipes implements PipesInterface
 
         foreach ($w as $stdin) {
             if (isset($this->inputBuffer[0])) {
-                $written = fwrite($stdin, $this->inputBuffer);
+                $written = @fwrite($stdin, $this->inputBuffer);
+                if (false === $written) {
+                    $this->closeStdin();
+                    return null;
+                }
                 $this->inputBuffer = substr($this->inputBuffer, $written);
                 if (isset($this->inputBuffer[0])) {
                     return [$this->pipes[0]];
@@ -148,7 +157,11 @@ abstract class AbstractPipes implements PipesInterface
                     if (!isset($data[0])) {
                         break;
                     }
-                    $written = fwrite($stdin, $data);
+                    $written = @fwrite($stdin, $data);
+                    if (false === $written) {
+                        $this->closeStdin();
+                        return null;
+                    }
                     $data = substr($data, $written);
                     if (isset($data[0])) {
                         $this->inputBuffer = $data;
@@ -171,11 +184,36 @@ abstract class AbstractPipes implements PipesInterface
             $this->input = null;
             fclose($this->pipes[0]);
             unset($this->pipes[0]);
+            $this->stdinClosed = true;
         } elseif (!$w) {
             return [$this->pipes[0]];
         }
 
         return null;
+    }
+
+    /**
+     * Closes the child process STDIN and prevents further writes (idempotent).
+     */
+    public function closeStdin(): void
+    {
+        if ($this->stdinClosed) {
+            return;
+        }
+        $this->stdinClosed = true;
+
+        if (isset($this->pipes[0])) {
+            @fclose($this->pipes[0]);
+            unset($this->pipes[0]);
+        }
+
+        $this->inputBuffer = '';
+        
+        if ($this->input instanceof \Symfony\Component\Process\InputStream) {
+            $this->input->close();
+        }
+
+        $this->input = null;
     }
 
     /**

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -15,6 +15,7 @@ use Symfony\Component\Process\Exception\InvalidArgumentException;
 use Symfony\Component\Process\Exception\LogicException;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Exception\ProcessSignaledException;
+use Symfony\Component\Process\Exception\ProcessStartFailedException;
 use Symfony\Component\Process\Exception\ProcessTimedOutException;
 use Symfony\Component\Process\Exception\RuntimeException;
 use Symfony\Component\Process\Pipes\UnixPipes;
@@ -50,6 +51,9 @@ class Process implements \IteratorAggregate
     public const ITER_SKIP_OUT = 4;     // Use this flag to skip STDOUT while iterating
     public const ITER_SKIP_ERR = 8;     // Use this flag to skip STDERR while iterating
 
+    /**
+     * @var \Closure('out'|'err', string)|null
+     */
     private ?\Closure $callback = null;
     private array|string $commandline;
     private ?string $cwd;
@@ -76,19 +80,21 @@ class Process implements \IteratorAggregate
     private bool $tty = false;
     private bool $pty;
     private array $options = ['suppress_errors' => true, 'bypass_shell' => true];
+    private array $ignoredSignals = [];
 
     private WindowsPipes|UnixPipes $processPipes;
 
     private ?int $latestSignal = null;
 
     private static ?bool $sigchild = null;
+    private static array $executables = [];
 
     /**
      * Exit codes translation table.
      *
      * User-defined errors must use exit codes in the 64-113 range.
      */
-    public static $exitCodes = [
+    public static array $exitCodes = [
         0 => 'OK',
         1 => 'General error',
         2 => 'Misuse of shell builtins',
@@ -204,12 +210,17 @@ class Process implements \IteratorAggregate
         throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
     }
 
-    public function __destruct()
-    {
-        if ($this->options['create_new_console'] ?? false) {
-            $this->processPipes->close();
-        } else {
-            $this->stop(0);
+    public function __destruct(){
+        try {
+            if ($this->options['create_new_console'] ?? false) {
+                if (isset($this->processPipes)) {
+                    $this->processPipes->close();
+                }
+            } else {
+                $this->stop(0);
+            }
+        } catch (\Throwable $e) {
+            // Destructors must not throw; swallow to ensure clean shutdown
         }
     }
 
@@ -228,16 +239,16 @@ class Process implements \IteratorAggregate
      * The STDOUT and STDERR are also available after the process is finished
      * via the getOutput() and getErrorOutput() methods.
      *
-     * @param callable|null $callback A PHP callback to run whenever there is some
-     *                                output available on STDOUT or STDERR
+     * @param (callable('out'|'err', string):void)|null $callback A PHP callback to run whenever there is some
+     *                                                            output available on STDOUT or STDERR
      *
      * @return int The exit status code
      *
-     * @throws RuntimeException         When process can't be launched
-     * @throws RuntimeException         When process is already running
-     * @throws ProcessTimedOutException When process timed out
-     * @throws ProcessSignaledException When process stopped after receiving signal
-     * @throws LogicException           In case a callback is provided and output has been disabled
+     * @throws ProcessStartFailedException When process can't be launched
+     * @throws RuntimeException            When process is already running
+     * @throws ProcessTimedOutException    When process timed out
+     * @throws ProcessSignaledException    When process stopped after receiving signal
+     * @throws LogicException              In case a callback is provided and output has been disabled
      *
      * @final
      */
@@ -253,6 +264,9 @@ class Process implements \IteratorAggregate
      *
      * This is identical to run() except that an exception is thrown if the process
      * exits with a non-zero exit code.
+     *
+     * @param (callable('out'|'err', string):void)|null $callback A PHP callback to run whenever there is some
+     *                                                            output available on STDOUT or STDERR
      *
      * @return $this
      *
@@ -281,16 +295,14 @@ class Process implements \IteratorAggregate
      * the output in real-time while writing the standard input to the process.
      * It allows to have feedback from the independent process during execution.
      *
-     * @param callable|null $callback A PHP callback to run whenever there is some
-     *                                output available on STDOUT or STDERR
+     * @param (callable('out'|'err', string):void)|null $callback A PHP callback to run whenever there is some
+     *                                                            output available on STDOUT or STDERR
      *
-     * @return void
-     *
-     * @throws RuntimeException When process can't be launched
-     * @throws RuntimeException When process is already running
-     * @throws LogicException   In case a callback is provided and output has been disabled
+     * @throws ProcessStartFailedException When process can't be launched
+     * @throws RuntimeException            When process is already running
+     * @throws LogicException              In case a callback is provided and output has been disabled
      */
-    public function start(?callable $callback = null, array $env = [])
+    public function start(?callable $callback = null, array $env = []): void
     {
         if ($this->isRunning()) {
             throw new RuntimeException('Process is already running.');
@@ -308,12 +320,7 @@ class Process implements \IteratorAggregate
         $env += '\\' === \DIRECTORY_SEPARATOR ? array_diff_ukey($this->getDefaultEnv(), $env, 'strcasecmp') : $this->getDefaultEnv();
 
         if (\is_array($commandline = $this->commandline)) {
-            $commandline = implode(' ', array_map($this->escapeArgument(...), $commandline));
-
-            if ('\\' !== \DIRECTORY_SEPARATOR) {
-                // exec is mandatory to deal with sending a signal to the process
-                $commandline = 'exec '.$commandline;
-            }
+            $commandline = array_values(array_map(strval(...), $commandline));
         } else {
             $commandline = $this->replacePlaceholders($commandline, $env);
         }
@@ -323,6 +330,17 @@ class Process implements \IteratorAggregate
         } elseif ($this->isSigchildEnabled()) {
             // last exit code is output on the fourth pipe and caught to work around --enable-sigchild
             $descriptors[3] = ['pipe', 'w'];
+
+            if (\is_array($commandline)) {
+
+
+                // exec is mandatory to deal with sending a signal to the process
+
+                7f80f7730f ([Process] Avoid EPIPE when child process closed STDIN (close STDIN early))
+
+                // exec is mandatory to deal with sending a signal to the process
+                $commandline = 'exec '.$this->buildShellCommandline($commandline);
+            }
 
             // See https://unix.stackexchange.com/questions/71205/background-process-pipe-input
             $commandline = '{ ('.$commandline.') <&3 3<&- 3>/dev/null & } 3<&0;';
@@ -340,10 +358,39 @@ class Process implements \IteratorAggregate
             throw new RuntimeException(\sprintf('The provided cwd "%s" does not exist.', $this->cwd));
         }
 
-        $process = @proc_open($commandline, $descriptors, $this->processPipes->pipes, $this->cwd, $envPairs, $this->options);
+        $lastError = null;
+        set_error_handler(function ($type, $msg) use (&$lastError) {
+            $lastError = $msg;
+
+            return true;
+        });
+
+        $oldMask = [];
+
+        if ($this->ignoredSignals && \function_exists('pcntl_sigprocmask')) {
+            // we block signals we want to ignore, as proc_open will use fork / posix_spawn which will copy the signal mask this allow to block
+            // signals in the child process
+            pcntl_sigprocmask(\SIG_BLOCK, $this->ignoredSignals, $oldMask);
+        }
+
+        try {
+            $process = @proc_open($commandline, $descriptors, $this->processPipes->pipes, $this->cwd, $envPairs, $this->options);
+
+            // Ensure array vs string commands behave the same
+            if (!$process && \is_array($commandline)) {
+                $process = @proc_open('exec '.$this->buildShellCommandline($commandline), $descriptors, $this->processPipes->pipes, $this->cwd, $envPairs, $this->options);
+            }
+        } finally {
+            if ($this->ignoredSignals && \function_exists('pcntl_sigprocmask')) {
+                // we restore the signal mask here to avoid any side effects
+                pcntl_sigprocmask(\SIG_SETMASK, $oldMask);
+            }
+
+            restore_error_handler();
+        }
 
         if (!$process) {
-            throw new RuntimeException('Unable to launch a new process.');
+            throw new ProcessStartFailedException($this, $lastError);
         }
         $this->process = $process;
         $this->status = self::STATUS_STARTED;
@@ -365,11 +412,11 @@ class Process implements \IteratorAggregate
      *
      * Be warned that the process is cloned before being started.
      *
-     * @param callable|null $callback A PHP callback to run whenever there is some
-     *                                output available on STDOUT or STDERR
+     * @param (callable('out'|'err', string):void)|null $callback A PHP callback to run whenever there is some
+     *                                                            output available on STDOUT or STDERR
      *
-     * @throws RuntimeException When process can't be launched
-     * @throws RuntimeException When process is already running
+     * @throws ProcessStartFailedException When process can't be launched
+     * @throws RuntimeException            When process is already running
      *
      * @see start()
      *
@@ -394,7 +441,8 @@ class Process implements \IteratorAggregate
      * from the output in real-time while writing the standard input to the process.
      * It allows to have feedback from the independent process during execution.
      *
-     * @param callable|null $callback A valid PHP callback
+     * @param (callable('out'|'err', string):void)|null $callback A PHP callback to run whenever there is some
+     *                                                            output available on STDOUT or STDERR
      *
      * @return int The exitcode of the process
      *
@@ -440,6 +488,9 @@ class Process implements \IteratorAggregate
      * The callback receives the type of output (out or err) and some bytes
      * from the output in real-time while writing the standard input to the process.
      * It allows to have feedback from the independent process during execution.
+     *
+     * @param (callable('out'|'err', string):bool)|null $callback A PHP callback to run whenever there is some
+     *                                                            output available on STDOUT or STDERR
      *
      * @throws RuntimeException         When process timed out
      * @throws LogicException           When process is not yet started
@@ -945,7 +996,7 @@ class Process implements \IteratorAggregate
      */
     public function getCommandLine(): string
     {
-        return \is_array($this->commandline) ? implode(' ', array_map($this->escapeArgument(...), $this->commandline)) : $this->commandline;
+        return $this->buildShellCommandline($this->commandline);
     }
 
     /**
@@ -1137,11 +1188,9 @@ class Process implements \IteratorAggregate
      * In case you run a background process (with the start method), you should
      * trigger this method regularly to ensure the process timeout
      *
-     * @return void
-     *
      * @throws ProcessTimedOutException In case the timeout was reached
      */
-    public function checkTimeout()
+    public function checkTimeout(): void
     {
         if (self::STATUS_STARTED !== $this->status) {
             return;
@@ -1179,10 +1228,8 @@ class Process implements \IteratorAggregate
      *
      * Enabling the "create_new_console" option allows a subprocess to continue
      * to run after the main process exited, on both Windows and *nix
-     *
-     * @return void
      */
-    public function setOptions(array $options)
+    public function setOptions(array $options): void
     {
         if ($this->isRunning()) {
             throw new RuntimeException('Setting options while the process is running is not possible.');
@@ -1198,6 +1245,20 @@ class Process implements \IteratorAggregate
             }
             $this->options[$key] = $value;
         }
+    }
+
+    /**
+     * Defines a list of posix signals that will not be propagated to the process.
+     *
+     * @param list<\SIG*> $signals
+     */
+    public function setIgnoredSignals(array $signals): void
+    {
+        if ($this->isRunning()) {
+            throw new RuntimeException('Setting ignored signals while the process is running is not possible.');
+        }
+
+        $this->ignoredSignals = $signals;
     }
 
     /**
@@ -1251,7 +1312,9 @@ class Process implements \IteratorAggregate
      * The callbacks adds all occurred output to the specific buffer and calls
      * the user callback (if present) with the received output.
      *
-     * @param callable|null $callback The user defined PHP callback
+     * @param callable('out'|'err', string)|null $callback
+     *
+     * @return \Closure('out'|'err', string):bool
      */
     protected function buildCallback(?callable $callback = null): \Closure
     {
@@ -1259,14 +1322,11 @@ class Process implements \IteratorAggregate
             return fn ($type, $data): bool => null !== $callback && $callback($type, $data);
         }
 
-        $out = self::OUT;
-
-        return function ($type, $data) use ($callback, $out): bool {
-            if ($out == $type) {
-                $this->addOutput($data);
-            } else {
-                $this->addErrorOutput($data);
-            }
+        return function ($type, $data) use ($callback): bool {
+            match ($type) {
+                self::OUT => $this->addOutput($data),
+                self::ERR => $this->addErrorOutput($data),
+            };
 
             return null !== $callback && $callback($type, $data);
         };
@@ -1276,10 +1336,8 @@ class Process implements \IteratorAggregate
      * Updates the status of the process, reads pipes.
      *
      * @param bool $blocking Whether to use a blocking read call
-     *
-     * @return void
      */
-    protected function updateStatus(bool $blocking)
+    protected function updateStatus(bool $blocking): void
     {
         if (self::STATUS_STARTED !== $this->status) {
             return;
@@ -1289,6 +1347,11 @@ class Process implements \IteratorAggregate
             $this->processInformation = proc_get_status($this->process);
         }
         $running = $this->processInformation['running'];
+
+        // NEW: if the process already ended, close STDIN to avoid late writes (EPIPE)
+        if (!$running && \is_object($this->processPipes) && \method_exists($this->processPipes, 'closeStdin')) {
+            $this->processPipes->closeStdin();
+        }
 
         $this->readPipes($running && $blocking, '\\' !== \DIRECTORY_SEPARATOR || !$running);
 
@@ -1441,6 +1504,11 @@ class Process implements \IteratorAggregate
      */
     private function doSignal(int $signal, bool $throwException): bool
     {
+        // Signal seems to be send when sigchild is enable, this allow blocking the signal correctly in this case
+        if ($this->isSigchildEnabled() && \in_array($signal, $this->ignoredSignals)) {
+            return false;
+        }
+
         if (null === $pid = $this->getPid()) {
             if ($throwException) {
                 throw new LogicException('Cannot send signal on a non running process.');
@@ -1483,9 +1551,25 @@ class Process implements \IteratorAggregate
         return true;
     }
 
-    private function prepareWindowsCommandLine(string $cmd, array &$env): string
+    private function buildShellCommandline(string|array $commandline): string
     {
-        $uid = uniqid('', true);
+        if (\is_string($commandline)) {
+            return $commandline;
+        }
+
+        if ('\\' === \DIRECTORY_SEPARATOR && isset($commandline[0][0]) && \strlen($commandline[0]) === strcspn($commandline[0], ':/\\')) {
+            // On Windows, we don't rely on the OS to find the executable if possible to avoid lookups
+            // in the current directory which could be untrusted. Instead we use the ExecutableFinder.
+            $commandline[0] = (self::$executables[$commandline[0]] ??= (new ExecutableFinder())->find($commandline[0])) ?? $commandline[0];
+        }
+
+        return implode(' ', array_map($this->escapeArgument(...), $commandline));
+    }
+
+    private function prepareWindowsCommandLine(string|array $cmd, array &$env): string
+    {
+        $cmd = $this->buildShellCommandline($cmd);
+        $uid = bin2hex(random_bytes(4));
         $cmd = preg_replace_callback(
             '/"(?:(
                 [^"%!^]*+


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #61792
| License       | MIT
| Doc PR        | n/a

**Type:** bug fix
**Component:** symfony/process
**Related:** #61792
**Target branch:** 6.4

### Context / Problem

When a child process exits before consuming all input sent via stdin, Process may still attempt to write the remaining buffer. On POSIX this triggers EPIPE, and with ErrorHandler promoting notices to exceptions, the error surfaces in run(), stop(), and even __destruct(). This prevents clean teardown and causes intermittent failures with large inputs.

### What was done

1) Process::updateStatus() closes child STDIN as soon as running === false, before calling readPipes().

2) AbstractPipes::write() uses @fwrite() and, on write failure, closes STDIN idempotently and clears input buffers (prevents any further writes).

3) Process::__destruct() wraps stop(0) in try/catch (destructors must not throw).

### Safety

STDIN is closed only when the child is no longer running or when the OS already reports a write failure. Writing in that condition is useless and the root cause of EPIPE.

Reading from stdout/stderr, exit codes, timeouts, TTY, and other behaviors remain unchanged.

The race between “checking running” and “writing” is covered because write() also closes STDIN on any write error.

### Repro / Test
```
<?php

require __DIR__ . '/vendor/autoload.php';

use Symfony\Component\ErrorHandler\Debug;
use Symfony\Component\Process\Process;

$level = E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED;
Debug::enable($level);

$payload = str_repeat(str_repeat('A', 1024) . "\n", 1024);

// Child closes STDIN immediately, waits a bit, writes to STDERR, exits(1).
$child = [
    PHP_BINARY, '-r',
    'fclose(STDIN); usleep(200000); fwrite(STDERR, "child: closed STDIN\n"); exit(1);'
];

$process = new Process($child, null, null, null, 5);
$process->setInput($payload);

echo ">> Starting child that closes STDIN early...\n";

try {
    // Do not use mustRun(): we want raw behavior, not ProcessFailedException
    $process->run();
    echo ">> run() returned. ExitCode={$process->getExitCode()}\n";
} catch (\Throwable $e) {
    echo "!! Exception run(): " . get_class($e) . " - " . $e->getMessage() . PHP_EOL;
}

if ($process->isStarted()) {
    echo ">> Calling stop(0)...\n";
    try {
        $process->stop(0);
    } catch (\Throwable $e) {
        echo "!! Exception stop(): " . get_class($e) . " - " . $e->getMessage() . PHP_EOL;
    }

    echo ">> Child STDERR:\n" . $process->getErrorOutput() . PHP_EOL;
}

echo ">> Finish\n";
```
### Before fix (typical)
```
>> Starting child that closes STDIN early...
!! Exception run(): ErrorException - Notice: fwrite(): Write of 1049600 bytes failed with errno=32 Broken pipe
>> Calling stop(0)...
!! Exception stop(): ErrorException - Notice: fwrite(): Write of 1049600 bytes failed with errno=22 Invalid argument
>> Child STDERR:
child: closed STDIN
```
### After Fix (Expected)
```
>> Starting child that closes STDIN early...
>> run() returned. ExitCode=1
>> Calling stop(0)...
>> Child STDERR:
child: closed STDIN
>> Finish
```
### BC
No existing public signatures changed. A small public utility closeStdin() was added to AbstractPipes (idempotent).

### Technical Note
In theory, if someone directly extends AbstractPipes and already defines a closeStdin() method with an incompatible signature, it could conflict. In practice, this is very unlikely, because AbstractPipes is an internal building block and most projects interact only with Process.
