### PR TITLE
[WebProfilerBundle] ”finish” errored requests

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -429,7 +429,7 @@
                                 var pending = pendingRequests;
                                 for (var i = 0; i < requestStack.length; i++) {
                                     startAjaxRequest(i);
-                                    if (requestStack[i].duration) {
+                                    if (requestStack[i].duration || requestStack[i].error) {
                                         finishAjaxRequest(i);
                                     }
                                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61923
| License       | MIT

If one request errors out before the toolbar is loaded, it won’t be “finished” because it won’t have a `duration`: https://github.com/symfony/symfony/blob/40d3c4ba4cbd695d046ced4c88a4cb4247dd85fa/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig#L479-L481

Its timer will then keep on ticking.