### PR TITLE
[PropertyInfo][TypeInfo] Fix resolving constructor type with templates

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
@@ -245,11 +245,12 @@ final class PhpStanExtractor implements PropertyDescriptionExtractorInterface, P
 
     public function getTypeFromConstructor(string $class, string $property): ?Type
     {
-        if (!$tagDocNode = $this->getDocBlockFromConstructor($class, $property)) {
+        $declaringClass = $class;
+        if (!$tagDocNode = $this->getDocBlockFromConstructor($declaringClass, $property)) {
             return null;
         }
 
-        $typeContext = $this->typeContextFactory->createFromClassName($class);
+        $typeContext = $this->typeContextFactory->createFromClassName($class, $declaringClass);
 
         return $this->stringTypeResolver->resolve((string) $tagDocNode->type, $typeContext);
     }

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
@@ -26,6 +26,9 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyGeneric;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyNamespace;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyPropertyAndGetterWithDifferentTypes;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyUnionType;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyWithTemplateAndParent;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor\DummyInDifferentNs;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor\DummyWithTemplateAndParentInDifferentNs;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\IFace;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\IntRangeDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\InvalidDummy;
@@ -945,6 +948,21 @@ class PhpStanExtractorTest extends TestCase
     }
 
     /**
+     * @dataProvider constructorTypesOfParentClassProvider
+     */
+    public function testExtractTypeFromConstructorOfParentClass(string $class, string $property, Type $type)
+    {
+        $this->assertEquals($type, $this->extractor->getTypeFromConstructor($class, $property));
+    }
+
+    public static function constructorTypesOfParentClassProvider(): iterable
+    {
+        yield [Dummy::class, 'rootDummyItem', Type::nullable(Type::object(RootDummyItem::class))];
+        yield [DummyWithTemplateAndParent::class, 'items', Type::list(Type::template('T', Type::object(DummyInDifferentNs::class)))];
+        yield [DummyWithTemplateAndParentInDifferentNs::class, 'items', Type::list(Type::template('T', Type::object(DummyInDifferentNs::class)))];
+    }
+
+    /**
      * @dataProvider unionTypesProvider
      */
     public function testExtractorUnionTypes(string $property, ?Type $type)
@@ -1142,11 +1160,6 @@ class PhpStanExtractorTest extends TestCase
         yield ['baz', 'Should be used.', null];
         yield ['bal', 'A short description ignoring template.', "A long description...\n\n...over several lines."];
         yield ['foo2', null, null];
-    }
-
-    public function testGetTypeFromConstructorOfParentClass()
-    {
-        $this->assertEquals(Type::nullable(Type::object(RootDummyItem::class)), $this->extractor->getTypeFromConstructor(Dummy::class, 'rootDummyItem'));
     }
 }
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyWithTemplateAndParent.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyWithTemplateAndParent.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+use Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor\DummyInDifferentNs;
+
+/**
+ * @template T of DummyInDifferentNs
+ *
+ * @extends ParentDummyWithTemplate<T>
+ */
+class DummyWithTemplateAndParent extends ParentDummyWithTemplate
+{
+}

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Extractor/DummyInDifferentNs.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Extractor/DummyInDifferentNs.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor;
+
+class DummyInDifferentNs
+{
+}

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Extractor/DummyWithTemplateAndParentInDifferentNs.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Extractor/DummyWithTemplateAndParentInDifferentNs.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor;
+
+use Symfony\Component\PropertyInfo\Tests\Fixtures\ParentDummyWithTemplate;
+
+/**
+ * @template T of DummyInDifferentNs
+ *
+ * @extends ParentDummyWithTemplate<T>
+ */
+class DummyWithTemplateAndParentInDifferentNs extends ParentDummyWithTemplate
+{
+}

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/ParentDummyWithTemplate.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/ParentDummyWithTemplate.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+/**
+ * @template T of object
+ */
+abstract class ParentDummyWithTemplate
+{
+    /**
+     * @param list<T> $items
+     */
+    public function __construct(
+        public array $items,
+    ) {
+    }
+}

--- a/src/Symfony/Component/PropertyInfo/composer.json
+++ b/src/Symfony/Component/PropertyInfo/composer.json
@@ -26,7 +26,7 @@
         "php": ">=8.2",
         "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/string": "^6.4|^7.0",
-        "symfony/type-info": "~7.2.8|^7.3.1"
+        "symfony/type-info": "^7.3.5"
     },
     "require-dev": {
         "symfony/serializer": "^6.4|^7.0",

--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/AnotherNamespace/DummyInDifferentNs.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/AnotherNamespace/DummyInDifferentNs.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Tests\Fixtures\AnotherNamespace;
+
+use Symfony\Component\TypeInfo\Tests\Fixtures\AbstractDummy;
+
+class DummyInDifferentNs extends AbstractDummy
+{
+}

--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/AnotherNamespace/DummyWithTemplateAndParentInDifferentNs.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/AnotherNamespace/DummyWithTemplateAndParentInDifferentNs.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Tests\Fixtures\AnotherNamespace;
+
+use Symfony\Component\TypeInfo\Tests\Fixtures\ParentDummyWithTemplate;
+
+/**
+ * @template T of DummyInDifferentNs
+ *
+ * @extends ParentDummyWithTemplate<T>
+ */
+class DummyWithTemplateAndParentInDifferentNs extends ParentDummyWithTemplate
+{
+}

--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithTemplateAndParent.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithTemplateAndParent.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Tests\Fixtures;
+
+use Symfony\Component\TypeInfo\Tests\Fixtures\AnotherNamespace\DummyInDifferentNs;
+
+/**
+ * @template T of DummyInDifferentNs
+ *
+ * @extends ParentDummyWithTemplate<T>
+ */
+class DummyWithTemplateAndParent extends ParentDummyWithTemplate
+{
+}

--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/ParentDummyWithTemplate.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/ParentDummyWithTemplate.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Tests\Fixtures;
+
+/**
+ * @template T of object
+ */
+abstract class ParentDummyWithTemplate
+{
+}

--- a/src/Symfony/Component/TypeInfo/Tests/TypeContext/TypeContextFactoryTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeContext/TypeContextFactoryTest.php
@@ -14,11 +14,14 @@ namespace Symfony\Component\TypeInfo\Tests\TypeContext;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\TypeInfo\Exception\LogicException;
 use Symfony\Component\TypeInfo\Tests\Fixtures\AbstractDummy;
+use Symfony\Component\TypeInfo\Tests\Fixtures\AnotherNamespace\DummyInDifferentNs;
+use Symfony\Component\TypeInfo\Tests\Fixtures\AnotherNamespace\DummyWithTemplateAndParentInDifferentNs;
 use Symfony\Component\TypeInfo\Tests\Fixtures\Dummy;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithImportedOnlyTypeAliases;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithInvalidTypeAlias;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithInvalidTypeAliasImport;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithRecursiveTypeAliases;
+use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithTemplateAndParent;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithTemplates;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithTemplateTypeAlias;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithTypeAliases;
@@ -138,6 +141,14 @@ class TypeContextFactoryTest extends TestCase
             'U' => Type::mixed(),
             'V' => Type::mixed(),
         ], $this->typeContextFactory->createFromReflection(new \ReflectionParameter([DummyWithTemplates::class, 'getPrice'], 'inCents'))->templates);
+
+        $this->assertEquals([
+            'T' => Type::object(DummyInDifferentNs::class),
+        ], $this->typeContextFactory->createFromReflection(new \ReflectionClass(DummyWithTemplateAndParent::class))->templates);
+
+        $this->assertEquals([
+            'T' => Type::object(DummyInDifferentNs::class),
+        ], $this->typeContextFactory->createFromReflection(new \ReflectionClass(DummyWithTemplateAndParentInDifferentNs::class))->templates);
     }
 
     public function testDoNotCollectTemplatesWhenToStringTypeResolver()

--- a/src/Symfony/Component/TypeInfo/TypeContext/TypeContextFactory.php
+++ b/src/Symfony/Component/TypeInfo/TypeContext/TypeContextFactory.php
@@ -56,7 +56,15 @@ final class TypeContextFactory
         $calledClassPath = explode('\\', $calledClassName);
         $declaringClassPath = explode('\\', $declaringClassName);
 
+        $calledClassNameReflection = self::$reflectionClassCache[$calledClassName] ??= new \ReflectionClass($calledClassName);
         $declaringClassReflection = self::$reflectionClassCache[$declaringClassName] ??= new \ReflectionClass($declaringClassName);
+
+        $calledClassTypeContext = new TypeContext(
+            end($calledClassPath),
+            end($declaringClassPath),
+            trim($calledClassNameReflection->getNamespaceName(), '\\'),
+            $this->collectUses($calledClassNameReflection),
+        );
 
         $typeContext = new TypeContext(
             end($calledClassPath),
@@ -70,7 +78,7 @@ final class TypeContextFactory
             $typeContext->declaringClassName,
             $typeContext->namespace,
             $typeContext->uses,
-            $this->collectTemplates($declaringClassReflection, $typeContext),
+            $this->collectTemplates($calledClassNameReflection, $calledClassTypeContext) + $this->collectTemplates($declaringClassReflection, $typeContext),
         );
 
         return new TypeContext(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

#61752 broke the resolution of templated types.

Consider the following code:

```php
/**
 * @template T of object
 */
abstract class ParentClass
{
    /**
     * @param list<T> $items
     */
    public function __construct(
        public array $items,
    ) {
    }
}

/**
 * @template T of SomeClass
 *
 * @extends ParentClass<T>
 */
class ChildClass extends ParentClass
{
}

$serializer->deserialize($jsonPayload, ChildClass::class, 'json');
```

Before that PR, after deserialization, `$items` would correctly contain a list of `SomeClass` instances.
Now it no longer works, `$items` is a list of associative arrays instead.