### PR TITLE
[ExpressionLanguage] Fix type error in expression language parse

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
+++ b/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
@@ -79,13 +79,17 @@ class ExpressionLanguage
 
         $cacheItem = $this->cache->getItem(rawurlencode($expression.'//'.implode('|', $cacheKeyItems)));
 
-        if (null === $parsedExpression = $cacheItem->get()) {
-            $nodes = $this->getParser()->parse($this->getLexer()->tokenize((string) $expression), $names, $flags);
-            $parsedExpression = new ParsedExpression((string) $expression, $nodes);
+        $parsedExpression = $cacheItem->get();
 
-            $cacheItem->set($parsedExpression);
-            $this->cache->save($cacheItem);
+        if ($parsedExpression instanceof ParsedExpression) {
+            return $parsedExpression;
         }
+
+        $nodes = $this->getParser()->parse($this->getLexer()->tokenize((string) $expression), $names, $flags);
+        $parsedExpression = new ParsedExpression((string) $expression, $nodes);
+
+        $cacheItem->set($parsedExpression);
+        $this->cache->save($cacheItem);
 
         return $parsedExpression;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #61965 <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

Add an `instanceof` check on cached value to fix `TypeError` when `ExpressionLanguage` cache pool returns a value of an unexpected type (`Closure` instead of `ParsedExpression`.

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
