### PR TITLE
[Console] Specify types of interactive question choices - add Stringable

### DIFF
--- a/src/Symfony/Component/Console/Question/ChoiceQuestion.php
+++ b/src/Symfony/Component/Console/Question/ChoiceQuestion.php
@@ -26,9 +26,9 @@ class ChoiceQuestion extends Question
     private string $errorMessage = 'Value "%s" is invalid';
 
     /**
-     * @param string                       $question The question to ask to the user
-     * @param array<string|bool|int|float> $choices  The list of available choices
-     * @param string|bool|int|float|null   $default  The default answer to return
+     * @param string                                   $question The question to ask to the user
+     * @param array<string|bool|int|float|\Stringable> $choices  The list of available choices
+     * @param string|bool|int|float|null               $default  The default answer to return
      */
     public function __construct(string $question, array $choices, string|bool|int|float|null $default = null)
     {
@@ -44,7 +44,7 @@ class ChoiceQuestion extends Question
     }
 
     /**
-     * @return array<string|bool|int|float>
+     * @return array<string|bool|int|float|\Stringable>
      */
     public function getChoices(): array
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | See https://github.com/symfony/symfony/commit/802067ccf553f5f4634b3fb3a260e78b8b806745#commitcomment-167236175
| License       | MIT

Documentation at https://symfony.com/doc/6.4/components/console/helpers/questionhelper.html states:

> choices can also be PHP objects that implement __toString() method

Commit 802067c breaks that