### PR TITLE
[Messenger] Allow Pheanstalk v8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -148,7 +148,7 @@
         "monolog/monolog": "^3.0",
         "nikic/php-parser": "^5.0",
         "nyholm/psr7": "^1.0",
-        "pda/pheanstalk": "^5.1|^7.0",
+        "pda/pheanstalk": "^5.1|^7.0|^8.0",
         "php-http/discovery": "^1.15",
         "php-http/httplug": "^1.0|^2.0",
         "phpdocumentor/reflection-docblock": "^5.2",

--- a/src/Symfony/Component/Messenger/Bridge/Beanstalkd/composer.json
+++ b/src/Symfony/Component/Messenger/Bridge/Beanstalkd/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=8.2",
-        "pda/pheanstalk": "^5.1|^7.0",
+        "pda/pheanstalk": "^5.1|^7.0|^8.0",
         "symfony/messenger": "^7.3|^8.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Version 8 is compatible with the current code.