### PR TITLE
[Console] Fine-tuning the interactive `#[Ask]` attribute

### DIFF
--- a/src/Symfony/Component/Console/Attribute/Argument.php
+++ b/src/Symfony/Component/Console/Attribute/Argument.php
@@ -134,4 +134,12 @@ class Argument
     {
         return $this->interactiveAttribute;
     }
+
+    /**
+     * @internal
+     */
+    public function isRequired(): bool
+    {
+        return InputArgument::REQUIRED === (InputArgument::REQUIRED & $this->mode);
+    }
 }

--- a/src/Symfony/Component/Console/Attribute/MapInput.php
+++ b/src/Symfony/Component/Console/Attribute/MapInput.php
@@ -93,7 +93,7 @@ final class MapInput
 
         foreach ($this->definition as $name => $spec) {
             // ignore required arguments that are not set yet (may happen in interactive mode)
-            if ($spec instanceof Argument && null === $input->getArgument($spec->name) && $spec->toInputArgument()->isRequired()) {
+            if ($spec instanceof Argument && $spec->isRequired() && \in_array($input->getArgument($spec->name), [null, []], true)) {
                 continue;
             }
 
@@ -111,7 +111,7 @@ final class MapInput
         foreach ($this->definition as $name => $spec) {
             $property = $this->class->getProperty($name);
 
-            if (!$property->isInitialized($object) || null === $value = $property->getValue($object)) {
+            if (!$property->isInitialized($object) || \in_array($value = $property->getValue($object), [null, []], true)) {
                 continue;
             }
 

--- a/src/Symfony/Component/Console/Attribute/Reflection/ReflectionMember.php
+++ b/src/Symfony/Component/Console/Attribute/Reflection/ReflectionMember.php
@@ -97,11 +97,6 @@ class ReflectionMember
         return $this->member instanceof \ReflectionParameter ? 'parameter' : 'property';
     }
 
-    public function isBackedEnumType(): bool
-    {
-        return $this->member->getType() instanceof \ReflectionNamedType && is_subclass_of($this->member->getType()->getName(), \BackedEnum::class);
-    }
-
     public function isParameter(): bool
     {
         return $this->member instanceof \ReflectionParameter;

--- a/src/Symfony/Component/Console/Tests/Fixtures/InvokableWithInteractiveAttributesTestCommand.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/InvokableWithInteractiveAttributesTestCommand.php
@@ -44,6 +44,8 @@ class InvokableWithInteractiveAttributesTestCommand
         $io->writeln('Arg5: '.$dto->arg5);
         $io->writeln('Arg6: '.$dto->dummyDto2->arg6);
         $io->writeln('Arg7: '.$dto->dummyDto2->arg7);
+        $io->writeln('Arg8: '.($dto->dummyDto2->arg8 ? 'yes' : 'no'));
+        $io->writeln('Arg9: '.implode(',', $dto->dummyDto2->arg9));
 
         return Command::SUCCESS;
     }
@@ -84,6 +86,14 @@ class DummyDto2
     #[Argument]
     #[Ask('Enter arg7')]
     public string $arg7;
+
+    #[Argument]
+    #[Ask('Enter arg8')]
+    public bool $arg8;
+
+    #[Argument]
+    #[Ask('Enter arg9')]
+    public array $arg9;
 
     #[Interact]
     public function prompt(SymfonyStyle $io): void

--- a/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
@@ -472,7 +472,7 @@ class CommandTesterTest extends TestCase
     public function testInvokableWithInteractiveQuestionParameter()
     {
         $tester = new CommandTester(new InvokableWithInteractiveAttributesTestCommand());
-        $tester->setInputs(['arg1-value', 'arg2-value', 'arg3-value', 'arg6-value', 'arg7-value', 'arg4-value', 'arg5-value']);
+        $tester->setInputs(['arg1-value', 'arg2-value', 'arg3-value', 'arg6-value', 'arg7-value', 'yes', 'arg9-v1', 'arg9-v2', '', 'arg4-value', 'arg5-value']);
         $tester->execute([], ['interactive' => true]);
         $tester->assertCommandIsSuccessful();
 
@@ -486,6 +486,10 @@ class CommandTesterTest extends TestCase
         self::assertStringContainsString('Arg6: arg6-value', $tester->getDisplay());
         self::assertStringContainsString('Enter arg7', $tester->getDisplay());
         self::assertStringContainsString('Arg7: arg7-value', $tester->getDisplay());
+        self::assertStringContainsString('Enter arg8 (yes/no) [no]', $tester->getDisplay());
+        self::assertStringContainsString('Arg8: yes', $tester->getDisplay());
+        self::assertStringContainsString('Enter arg9', $tester->getDisplay());
+        self::assertStringContainsString('Arg9: arg9-v1,arg9-v2', $tester->getDisplay());
         self::assertStringContainsString('Enter arg4', $tester->getDisplay());
         self::assertStringContainsString('Arg4: arg4-value', $tester->getDisplay());
         self::assertStringContainsString('Enter arg5', $tester->getDisplay());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Complements https://github.com/symfony/symfony/pull/61748, concerning interactive array and boolean arguments.

**Definition:**
```php
public function __invoke(
    #[Argument, Ask('Must be unique?')]
    bool $unique,

    #[Argument, Ask('Enter the tag (leave blank to finish)')]
    array $tags,
): int
```
**Input:**
```sh
$ bin/console app:add-tags

Must be unique? (yes/no) [no]:
> yes

Enter the tag (leave blank to finish):
> tag1

Enter the tag (leave blank to finish):
> tag2

Enter the tag (leave blank to finish):
> 
```
As expected, you'll get a `true` value in `$unique`, and `["tag1", "tag2"]` in `$tags`.