### PR TITLE
[FrameworkBundle] Update the changelog about Workflow command changes

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -172,7 +172,7 @@ Form
 FrameworkBundle
 ---------------
 
- * Remove the `WorkflowDumpCommand`, use the command from the Workflow component instead
+ * Remove the `WorkflowDumpCommand` class; the `workflow:dump` command and its class were moved to the Workflow component, but the command still works as before
  * Remove `errors.xml` and `webhook.xml` routing configuration files (use their PHP equivalent instead)
  * Make `Router` class `final`
  * Make `SerializerCacheWarmer` class `final`

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 8.0
 ---
 
- * Remove the `WorkflowDumpCommand`, use the command from the Workflow component instead
+ * Remove the `WorkflowDumpCommand` class; the `workflow:dump` command works the same as before but its class is now defined in the Workflow component
  * Remove `errors.xml` and `webhook.xml` routing configuration files (use their PHP equivalent instead)
  * Enable the property info constructor extractor by default
  * Remove deprecated `Symfony\Bundle\FrameworkBundle\Console\Application::add()` method in favor of `Symfony\Bundle\FrameworkBundle\Console\Application::addCommand()`


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | -
| License       | MIT

The changes in #61976 are a bit confusing because it looks like the `workflow:dump` command no longer works.