### PR TITLE
[HttpFoundation] Remove `Request::get()`

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -202,6 +202,7 @@ HttpFoundation
  * Add arguments `$v4Bytes` and `$v6Bytes` to `IpUtils::anonymize()`
  * Add argument `$partitioned` to `ResponseHeaderBag::clearCookie()`
  * Add argument `$expiration` to `UriSigner::sign()`
+ * Remove `Request::get()`, use properties `->attributes`, `query` or `request` directly instead
 
 HttpClient
 ----------

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Add arguments `$v4Bytes` and `$v6Bytes` to `IpUtils::anonymize()`
  * Add argument `$partitioned` to `ResponseHeaderBag::clearCookie()`
  * Add argument `$expiration` to `UriSigner::sign()`
+ * Remove `Request::get()`, use properties `->attributes`, `query` or `request` directly instead
 
 7.4
 ---

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -671,36 +671,6 @@ class Request
     }
 
     /**
-     * Gets a "parameter" value from any bag.
-     *
-     * This method is mainly useful for libraries that want to provide some flexibility. If you don't need the
-     * flexibility in controllers, it is better to explicitly get request parameters from the appropriate
-     * public property instead (attributes, query, request).
-     *
-     * Order of precedence: PATH (routing placeholders or custom attributes), GET, POST
-     *
-     * @deprecated since Symfony 7.4, use properties `->attributes`, `query` or `request` directly instead
-     */
-    public function get(string $key, mixed $default = null): mixed
-    {
-        trigger_deprecation('symfony/http-foundation', '7.4', 'Request::get() is deprecated, use properties ->attributes, query or request directly instead.');
-
-        if ($this !== $result = $this->attributes->get($key, $this)) {
-            return $result;
-        }
-
-        if ($this->query->has($key)) {
-            return $this->query->all()[$key];
-        }
-
-        if ($this->request->has($key)) {
-            return $this->request->all()[$key];
-        }
-
-        return $default;
-    }
-
-    /**
      * Gets the Session.
      *
      * @throws SessionNotFoundException When session is not set properly

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -12,8 +12,6 @@
 namespace Symfony\Component\HttpFoundation\Tests;
 
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
@@ -1508,27 +1506,6 @@ b'])]
         $request->initialize([], [], [], [], [], $server);
 
         $this->assertEquals('/', $request->getPathInfo());
-    }
-
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
-    public function testGetParameterPrecedence()
-    {
-        $request = new Request();
-        $request->attributes->set('foo', 'attr');
-        $request->query->set('foo', 'query');
-        $request->request->set('foo', 'body');
-
-        $this->assertSame('attr', $request->get('foo'));
-
-        $request->attributes->remove('foo');
-        $this->assertSame('query', $request->get('foo'));
-
-        $request->query->remove('foo');
-        $this->assertSame('body', $request->get('foo'));
-
-        $request->request->remove('foo');
-        $this->assertNull($request->get('foo'));
     }
 
     public function testGetPreferredLanguage()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | yes 
| Deprecations? | no
| License       | MIT

Following https://github.com/symfony/symfony/pull/61948
