### PR TITLE
[Messenger] Add retry delay on amazon sqs transport

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/CHANGELOG.md
@@ -4,7 +4,8 @@ CHANGELOG
 7.4
 ---
 
-* Allow SQS to handle it's own retry/DLQ
+* Allow SQS to handle its own retry/DLQ
+* Add `retry_delay` option to configure the delay between retries when using SQS retry/DLQ handling
 
 7.3
 ---

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
@@ -391,13 +391,28 @@ class ConnectionTest extends TestCase
         $expectedParams = [
             'QueueUrl' => $queueUrl = 'https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue',
             'ReceiptHandle' => $id = 'abc',
-            'VisibilityTimeout' => $visibilityTimeout = 10,
+            'VisibilityTimeout' => 0,
         ];
 
         $client = $this->createMock(SqsClient::class);
         $client->expects($this->once())->method('changeMessageVisibility')->with($expectedParams);
 
-        $connection = new Connection(['delete_on_rejection' => false, 'visibility_timeout' => $visibilityTimeout], $client, $queueUrl);
+        $connection = new Connection(['delete_on_rejection' => false, 'visibility_timeout' => 30], $client, $queueUrl);
+        $connection->reject($id);
+    }
+
+    public function testDoNotDeleteOnRejectionWithRetryDelay()
+    {
+        $expectedParams = [
+            'QueueUrl' => $queueUrl = 'https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue',
+            'ReceiptHandle' => $id = 'abc',
+            'VisibilityTimeout' => $retryDelay = 5,
+        ];
+
+        $client = $this->createMock(SqsClient::class);
+        $client->expects($this->once())->method('changeMessageVisibility')->with($expectedParams);
+
+        $connection = new Connection(['delete_on_rejection' => false, 'retry_delay' => $retryDelay], $client, $queueUrl);
         $connection->reject($id);
     }
 

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
@@ -40,6 +40,7 @@ class Connection
         'poll_timeout' => 0.1,
         'visibility_timeout' => null,
         'delete_on_rejection' => true,
+        'retry_delay' => 0,
         'auto_setup' => true,
         'access_key' => null,
         'secret_key' => null,
@@ -103,6 +104,7 @@ class Connection
      * * poll_timeout: amount of seconds the transport should wait for new message
      * * visibility_timeout: amount of seconds the message won't be visible
      * * delete_on_rejection: Whether to delete message on rejection or allow SQS to handle retries. (Default: true).
+     * * retry_delay: amount of seconds the message won't be visible before retry. (Default: 0).
      * * sslmode: Can be "disable" to use http for a custom endpoint
      * * auto_setup: Whether the queue should be created automatically during send / get (Default: true)
      * * debug: Log all HTTP requests and responses as LoggerInterface::DEBUG (Default: false)
@@ -137,6 +139,7 @@ class Connection
             'poll_timeout' => $options['poll_timeout'],
             'visibility_timeout' => null !== $options['visibility_timeout'] ? (int) $options['visibility_timeout'] : null,
             'delete_on_rejection' => filter_var($options['delete_on_rejection'], \FILTER_VALIDATE_BOOL),
+            'retry_delay' => (int) $options['retry_delay'],
             'auto_setup' => filter_var($options['auto_setup'], \FILTER_VALIDATE_BOOL),
             'queue_name' => (string) $options['queue_name'],
             'queue_attributes' => $options['queue_attributes'],
@@ -323,7 +326,7 @@ class Connection
             $this->client->changeMessageVisibility([
                 'QueueUrl' => $this->getQueueUrl(),
                 'ReceiptHandle' => $id,
-                'VisibilityTimeout' => $this->configuration['visibility_timeout'] ?? 30,
+                'VisibilityTimeout' => $this->configuration['retry_delay'],
             ]);
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

This follows https://github.com/symfony/symfony/pull/60754 by allowing to configure a retry delay other than the queue visibility timeout when using the retry mechanism from AWS.
The new configuration parameter only works when `delete_on_rejection` is set to `false`
