### PR TITLE
[DependencyInjection] remove getNamespace() and getXsdValidationBasePath() from ExtensionInterface

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -95,6 +95,7 @@ Console
 DependencyInjection
 -------------------
 
+ * Remove `ExtensionInterface::getXsdValidationBasePath()` and `getNamespace()` without alternatives, the XML configuration format is no longer supported
  * Add argument `$throwOnAbstract` to `ContainerBuilder::findTaggedResourceIds()`
  * Registering a service without a class when its id is a non-existing FQCN throws an error
  * Replace `#[TaggedIterator]` and `#[TaggedLocator]` attributes with `#[AutowireLocator]` and `#[AutowireIterator]`

--- a/src/Symfony/Bundle/DebugBundle/DependencyInjection/DebugExtension.php
+++ b/src/Symfony/Bundle/DebugBundle/DependencyInjection/DebugExtension.php
@@ -84,20 +84,4 @@ class DebugExtension extends Extension
             $container->removeDefinition('monolog.command.server_log');
         }
     }
-
-    /**
-     * @deprecated since Symfony 7.4, to be removed in Symfony 8.0 together with XML support.
-     */
-    public function getXsdValidationBasePath(): string|false
-    {
-        return __DIR__.'/../Resources/config/schema';
-    }
-
-    /**
-     * @deprecated since Symfony 7.4, to be removed in Symfony 8.0 together with XML support.
-     */
-    public function getNamespace(): string
-    {
-        return 'http://symfony.com/schema/dic/debug';
-    }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpReferenceCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpReferenceCommand.php
@@ -142,7 +142,7 @@ class ConfigDumpReferenceCommand extends AbstractConfigCommand
                 throw new InvalidArgumentException(\sprintf('Supported formats are "%s".', implode('", "', $this->getAvailableFormatOptions())));
         }
 
-        $io->writeln(null === $path ? $dumper->dump($configuration, $extension->getNamespace()) : $dumper->dumpAtPath($configuration, $path));
+        $io->writeln(null === $path ? $dumper->dump($configuration) : $dumper->dumpAtPath($configuration, $path));
 
         return 0;
     }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -3420,22 +3420,6 @@ class FrameworkExtension extends Extension
         }
     }
 
-    /**
-     * @deprecated since Symfony 7.4, to be removed in Symfony 8.0 together with XML support.
-     */
-    public function getXsdValidationBasePath(): string|false
-    {
-        return \dirname(__DIR__).'/Resources/config/schema';
-    }
-
-    /**
-     * @deprecated since Symfony 7.4, to be removed in Symfony 8.0 together with XML support.
-     */
-    public function getNamespace(): string
-    {
-        return 'http://symfony.com/schema/dic/symfony';
-    }
-
     protected function isConfigEnabled(ContainerBuilder $container, array $config): bool
     {
         throw new \LogicException('To prevent using outdated configuration, you must use the "readConfigEnabled" method instead.');

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/ConfigBuilderCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/ConfigBuilderCacheWarmerTest.php
@@ -231,22 +231,6 @@ class ConfigBuilderCacheWarmerTest extends TestCase
             {
             }
 
-            /**
-             * @deprecated since Symfony 7.4, to be removed in Symfony 8.0 together with XML support.
-             */
-            public function getXsdValidationBasePath(): string|false
-            {
-                return false;
-            }
-
-            /**
-             * @deprecated since Symfony 7.4, to be removed in Symfony 8.0 together with XML support.
-             */
-            public function getNamespace(): string
-            {
-                return 'http://www.example.com/schema/acme';
-            }
-
             public function getAlias(): string
             {
                 return 'kernel';

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/ExtensionWithoutConfigTestBundle/DependencyInjection/ExtensionWithoutConfigTestExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/ExtensionWithoutConfigTestBundle/DependencyInjection/ExtensionWithoutConfigTestExtension.php
@@ -20,22 +20,6 @@ class ExtensionWithoutConfigTestExtension implements ExtensionInterface
     {
     }
 
-    /**
-     * @deprecated since Symfony 7.4, to be removed in Symfony 8.0 together with XML support.
-     */
-    public function getNamespace(): string
-    {
-        return '';
-    }
-
-    /**
-     * @deprecated since Symfony 7.4, to be removed in Symfony 8.0 together with XML support.
-     */
-    public function getXsdValidationBasePath(): string|false
-    {
-        return false;
-    }
-
     public function getAlias(): string
     {
         return 'extension_without_config_test';

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AppKernel.php
@@ -128,22 +128,6 @@ class AppKernel extends Kernel implements ExtensionInterface, ConfigurationInter
     {
     }
 
-    /**
-     * @deprecated since Symfony 7.4, to be removed in Symfony 8.0 together with XML support.
-     */
-    public function getNamespace(): string
-    {
-        return '';
-    }
-
-    /**
-     * @deprecated since Symfony 7.4, to be removed in Symfony 8.0 together with XML support.
-     */
-    public function getXsdValidationBasePath(): string|false
-    {
-        return false;
-    }
-
     public function getAlias(): string
     {
         return 'foo';

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -1037,22 +1037,6 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
         $this->userProviderFactories[] = $factory;
     }
 
-    /**
-     * @deprecated since Symfony 7.4, to be removed in Symfony 8.0 together with XML support.
-     */
-    public function getXsdValidationBasePath(): string|false
-    {
-        return __DIR__.'/../Resources/config/schema';
-    }
-
-    /**
-     * @deprecated since Symfony 7.4, to be removed in Symfony 8.0 together with XML support.
-     */
-    public function getNamespace(): string
-    {
-        return 'http://symfony.com/schema/dic/security';
-    }
-
     public function getConfiguration(array $config, ContainerBuilder $container): ?ConfigurationInterface
     {
         // first assemble the factories

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -232,20 +232,4 @@ class TwigExtension extends Extension
 
         return $name;
     }
-
-    /**
-     * @deprecated since Symfony 7.4, to be removed in Symfony 8.0 together with XML support.
-     */
-    public function getXsdValidationBasePath(): string|false
-    {
-        return __DIR__.'/../Resources/config/schema';
-    }
-
-    /**
-     * @deprecated since Symfony 7.4, to be removed in Symfony 8.0 together with XML support.
-     */
-    public function getNamespace(): string
-    {
-        return 'http://symfony.com/schema/dic/twig';
-    }
 }

--- a/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/WebProfilerExtension.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/WebProfilerExtension.php
@@ -57,20 +57,4 @@ class WebProfilerExtension extends Extension
         $container->getDefinition('debug.file_link_formatter')
             ->replaceArgument(3, new ServiceClosureArgument(new Reference('debug.file_link_formatter.url_format')));
     }
-
-    /**
-     * @deprecated since Symfony 7.4, to be removed in Symfony 8.0 together with XML support.
-     */
-    public function getXsdValidationBasePath(): string|false
-    {
-        return __DIR__.'/../Resources/config/schema';
-    }
-
-    /**
-     * @deprecated since Symfony 7.4, to be removed in Symfony 8.0 together with XML support.
-     */
-    public function getNamespace(): string
-    {
-        return 'http://symfony.com/schema/dic/webprofiler';
-    }
 }

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.0
 ---
 
+ * Remove `ExtensionInterface::getXsdValidationBasePath()` and `getNamespace()` without alternatives, the XML configuration format is no longer supported
  * Add argument `$throwOnAbstract` to `ContainerBuilder::findTaggedResourceIds()`
  * Registering a service without a class when its id is a non-existing FQCN throws an error
  * Remove `#[TaggedIterator]` and `#[TaggedLocator]` attributes, replaced by `#[AutowireLocator]` and `#[AutowireIterator]`

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -200,10 +200,6 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     public function registerExtension(ExtensionInterface $extension): void
     {
         $this->extensions[$extension->getAlias()] = $extension;
-
-        if (false !== $extension->getNamespace()) {
-            $this->extensionsByNs[$extension->getNamespace() ?? ''] = $extension;
-        }
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Extension/Extension.php
+++ b/src/Symfony/Component/DependencyInjection/Extension/Extension.php
@@ -29,22 +29,6 @@ abstract class Extension implements ExtensionInterface, ConfigurationExtensionIn
     private array $processedConfigs = [];
 
     /**
-     * @deprecated since Symfony 7.4, to be removed in Symfony 8.0 together with XML support.
-     */
-    public function getXsdValidationBasePath(): string|false
-    {
-        return false;
-    }
-
-    /**
-     * @deprecated since Symfony 7.4, to be removed in Symfony 8.0 together with XML support.
-     */
-    public function getNamespace(): string
-    {
-        return 'http://example.org/schema/dic/'.$this->getAlias();
-    }
-
-    /**
      * Returns the recommended alias to use in XML.
      *
      * This alias is also the mandatory prefix to use when using YAML.

--- a/src/Symfony/Component/DependencyInjection/Extension/ExtensionInterface.php
+++ b/src/Symfony/Component/DependencyInjection/Extension/ExtensionInterface.php
@@ -30,20 +30,6 @@ interface ExtensionInterface
     public function load(array $configs, ContainerBuilder $container): void;
 
     /**
-     * Returns the namespace to be used for this extension (XML namespace).
-     *
-     * @deprecated since Symfony 7.4, to be removed in Symfony 8.0 together with XML support.
-     */
-    public function getNamespace(): string;
-
-    /**
-     * Returns the base path for the XSD files.
-     *
-     * @deprecated since Symfony 7.4, to be removed in Symfony 8.0 together with XML support.
-     */
-    public function getXsdValidationBasePath(): string|false;
-
-    /**
      * Returns the recommended alias to use in XML.
      *
      * This alias is also the mandatory prefix to use when using YAML.

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/AcmeExtension.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/AcmeExtension.php
@@ -10,22 +10,6 @@ class AcmeExtension implements ExtensionInterface
         $configuration->setParameter('acme.configs', $configs);
     }
 
-    /**
-     * @deprecated since Symfony 7.4, to be removed in Symfony 8.0 together with XML support.
-     */
-    public function getXsdValidationBasePath(): string|false
-    {
-        return false;
-    }
-
-    /**
-     * @deprecated since Symfony 7.4, to be removed in Symfony 8.0 together with XML support.
-     */
-    public function getNamespace(): string
-    {
-        return 'http://www.example.com/schema/acme';
-    }
-
     public function getAlias(): string
     {
         return 'acme';

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/ProjectExtension.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/ProjectExtension.php
@@ -23,22 +23,6 @@ class ProjectExtension implements ExtensionInterface
         $configuration->setParameter('project.parameter.foo', $config['foo'] ?? 'foobar');
     }
 
-    /**
-     * @deprecated since Symfony 7.4, to be removed in Symfony 8.0 together with XML support.
-     */
-    public function getXsdValidationBasePath(): string|false
-    {
-        return false;
-    }
-
-    /**
-     * @deprecated since Symfony 7.4, to be removed in Symfony 8.0 together with XML support.
-     */
-    public function getNamespace(): string
-    {
-        return 'http://www.example.com/schema/project';
-    }
-
     public function getAlias(): string
     {
         return 'project';

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -417,22 +417,6 @@ class KernelTest extends TestCase
                 $container->setParameter('test.extension-registered', true);
             }
 
-            /**
-             * @deprecated since Symfony 7.4, to be removed in Symfony 8.0 together with XML support.
-             */
-            public function getNamespace(): string
-            {
-                return '';
-            }
-
-            /**
-             * @deprecated since Symfony 7.4, to be removed in Symfony 8.0 together with XML support.
-             */
-            public function getXsdValidationBasePath(): string|false
-            {
-                return false;
-            }
-
             public function getAlias(): string
             {
                 return 'test-extension';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT