### PR TITLE
[Cache][RedisTagAwareAdapter] Add Predis2 Replication Interface check

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisTagAwareReplicationAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisTagAwareReplicationAdapterTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Tests\Adapter;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\RedisTagAwareAdapter;
+
+/**
+ * @group integration
+ */
+class PredisTagAwareReplicationAdapterTest extends PredisRedisReplicationAdapterTest
+{
+    use TagAwareTestTrait;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->skippedTests['testTagItemExpiry'] = 'Testing expiration slows down the test suite';
+    }
+
+    public function createCachePool(int $defaultLifetime = 0, ?string $testMethod = null): CacheItemPoolInterface
+    {
+        $this->assertInstanceOf(\Predis\Client::class, self::$redis);
+        $adapter = new RedisTagAwareAdapter(self::$redis, str_replace('\\', '.', __CLASS__), $defaultLifetime);
+
+        return $adapter;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60050
| License       | MIT

Predis 2 moved ReplicationInterface to a different path.
Check was already added in RedisTrait: https://github.com/symfony/symfony/pull/59751/files#diff-38029e8e3e92a47fb8091876d3e8bc7fc61c2fc793cabf842ed933bf6985134c but missing from RedisTagAwareAdapter. This causes issue when when using TagAware adapter with Replicated Predis2 while it worked with Predis1
This PR add a similar check to RedisTagAwareAdapter