### PR TITLE
 remove getNamespace() and getXsdValidationBasePath() from ExtensionInterface

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/ExtensionWithoutConfigTestBundle/DependencyInjection/ExtensionWithoutConfigTestExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/ExtensionWithoutConfigTestBundle/DependencyInjection/ExtensionWithoutConfigTestExtension.php
@@ -20,6 +20,22 @@ class ExtensionWithoutConfigTestExtension implements ExtensionInterface
     {
     }
 
+    /**
+     * To be removed when symfony/dependency-injection is bumped to 8.0+.
+     */
+    public function getNamespace(): string
+    {
+        return '';
+    }
+
+    /**
+     * To be removed when symfony/dependency-injection is bumped to 8.0+.
+     */
+    public function getXsdValidationBasePath(): string|false
+    {
+        return false;
+    }
+
     public function getAlias(): string
     {
         return 'extension_without_config_test';

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AppKernel.php
@@ -128,6 +128,22 @@ class AppKernel extends Kernel implements ExtensionInterface, ConfigurationInter
     {
     }
 
+    /**
+     * To be removed when symfony/dependency-injection is bumped to 8.0+.
+     */
+    public function getNamespace(): string
+    {
+        return '';
+    }
+
+    /**
+     * To be removed when symfony/dependency-injection is bumped to 8.0+.
+     */
+    public function getXsdValidationBasePath(): string|false
+    {
+        return false;
+    }
+
     public function getAlias(): string
     {
         return 'foo';

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/MergeExtensionConfigurationPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/MergeExtensionConfigurationPassTest.php
@@ -33,12 +33,6 @@ class MergeExtensionConfigurationPassTest extends TestCase
 
         $extension = $this->createMock(ExtensionInterface::class);
         $extension->expects($this->any())
-            ->method('getXsdValidationBasePath')
-            ->willReturn(false);
-        $extension->expects($this->any())
-            ->method('getNamespace')
-            ->willReturn('http://example.org/schema/dic/foo');
-        $extension->expects($this->any())
             ->method('getAlias')
             ->willReturn('foo');
         $extension->expects($this->once())


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

finishes #61986
