### PR TITLE
[DoctrineBridge] Deprecate `AbstractDoctrineExtension`

### DIFF
--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -44,6 +44,7 @@ DoctrineBridge
 --------------
 
  * Deprecate `UniqueEntity::getRequiredOptions()` and `UniqueEntity::getDefaultOption()`
+ * Deprecate the `AbstractDoctrineExtension` class; its code is incorporated into the extension classes of Doctrine bundles
 
 DomCrawler
 ----------

--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Deprecate `UniqueEntity::getRequiredOptions()` and `UniqueEntity::getDefaultOption()`
  * Use a single table named `_schema_subscriber_check` in schema listeners to detect same database connections
  * Add support for `Symfony\Component\Clock\DatePoint` as `DayPointType` and `TimePointType` Doctrine type
+ * Deprecate the `AbstractDoctrineExtension` class; its code is incorporated into the extension classes of Doctrine bundles
 
 7.3
 ---

--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
@@ -17,10 +17,14 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
+trigger_deprecation('symfony/doctrine-bridge', '7.4', 'The "%s" class is deprecated, the code is incorporated into the extension classes of Doctrine bundles.', AbstractDoctrineExtension::class);
+
 /**
  * This abstract classes groups common code that Doctrine Object Manager extensions (ORM, MongoDB, CouchDB) need.
  *
  * @author Benjamin Eberlei <kontakt@beberlei.de>
+ *
+ * @deprecated since Symfony 7.4, the code is incorporated into the extension classes of Doctrine bundles
  */
 abstract class AbstractDoctrineExtension extends Extension
 {

--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Bridge\Doctrine\Tests\DependencyInjection;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\DependencyInjection\AbstractDoctrineExtension;
@@ -23,6 +25,8 @@ use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 /**
  * @author  Fabio B. Silva <fabio.bat.silva@gmail.com>
  */
+#[IgnoreDeprecations]
+#[Group('legacy')]
 class DoctrineExtensionTest extends TestCase
 {
     private MockObject&AbstractDoctrineExtension $extension;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes (no instruction necessary)
| Issues        | -
| License       | MIT

The `AbstractDoctrineExtension` is only used by `DoctrineBundle` and `DoctrineMongoDBODMBundle`. It's not used directly by applications. 
Having this abstract class makes changing the configuration structure complex. In order to ease maintenance and evolution, the class is inlined into bundle's extension classes.

- [x] `DoctrineBundle`: https://github.com/doctrine/DoctrineBundle/pull/2076
- [x] `DoctrineMongoDBBundle`: https://github.com/doctrine/DoctrineMongoDBBundle/pull/923
