### PR TITLE
[Process] Avoid EPIPE when child process closed STDIN (close STDIN early)

### DIFF
--- a/.github/workflows/.idea/.gitignore
+++ b/.github/workflows/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.github/workflows/.idea/copilot.data.migration.agent.xml
+++ b/.github/workflows/.idea/copilot.data.migration.agent.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AgentMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/.github/workflows/.idea/modules.xml
+++ b/.github/workflows/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/workflows.iml" filepath="$PROJECT_DIR$/.idea/workflows.iml" />
+    </modules>
+  </component>
+</project>

--- a/.github/workflows/.idea/php.xml
+++ b/.github/workflows/.idea/php.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MessDetectorOptionsConfiguration">
+    <option name="transferred" value="true" />
+  </component>
+  <component name="PHPCSFixerOptionsConfiguration">
+    <option name="transferred" value="true" />
+  </component>
+  <component name="PHPCodeSnifferOptionsConfiguration">
+    <option name="highlightLevel" value="WARNING" />
+    <option name="transferred" value="true" />
+  </component>
+  <component name="PhpStanOptionsConfiguration">
+    <option name="transferred" value="true" />
+  </component>
+  <component name="PsalmOptionsConfiguration">
+    <option name="transferred" value="true" />
+  </component>
+</project>

--- a/.github/workflows/.idea/workflows.iml
+++ b/.github/workflows/.idea/workflows.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,14 +9,13 @@ defaults:
     shell: bash
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-    cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
 
 jobs:
-
   tests:
     name: Unit Tests
 
@@ -45,6 +44,13 @@ jobs:
         with:
           fetch-depth: 2
 
+      # >>> Instala as dependências nativas exigidas pelo amqp (PECL)
+      # Faça isso ANTES do setup-php, pois o setup-php instala as extensões listadas.
+      - name: Install system deps for AMQP
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y librabbitmq-dev pkg-config
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -53,6 +59,11 @@ jobs:
           php-version: "${{ matrix.php }}"
           extensions: "${{ matrix.extensions || env.extensions }}"
           tools: flex
+
+      # Verifica se o amqp carregou (principalmente em 8.5)
+      - name: Verify AMQP extension
+        run: |
+          php -m | grep -qi '^amqp$' && echo "amqp loaded" || (echo "::error::amqp not loaded" && php --ri amqp || true)
 
       - name: Configure environment
         run: |
@@ -75,12 +86,7 @@ jobs:
           SYMFONY_FEATURE_BRANCH=$(curl -s https://raw.githubusercontent.com/symfony/recipes/flex/main/index.json | jq -r '.versions."dev-name"')
 
           # Install the phpunit-bridge from a PR if required
-          #
-          # To run a PR with a patched phpunit-bridge, first submit the patch for the
-          # phpunit-bridge as a separate PR against the next feature-branch then
-          # uncomment and update the following line with that PR number
           #SYMFONY_PHPUNIT_BRIDGE_PR=32886
-
           if [[ $SYMFONY_PHPUNIT_BRIDGE_PR ]]; then
             git fetch --depth=2 origin refs/pull/$SYMFONY_PHPUNIT_BRIDGE_PR/head
             git rm -rq src/Symfony/Bridge/PhpUnit
@@ -90,7 +96,7 @@ jobs:
             rm -rf .phpunit
           fi
 
-          # Create local composer packages for each patched components and reference them in composer.json files when cross-testing components
+          # Create local composer packages for each patched component
           if [[ ! "${{ matrix.mode }}" = *-deps ]]; then
             php .github/build-packages.php HEAD^ $SYMFONY_VERSION src/Symfony/Bridge/PhpUnit
           else
@@ -106,7 +112,7 @@ jobs:
             git diff --staged -- src/Symfony/Bridge/PhpUnit/ | git apply -R --index
           fi
 
-          # For the highest branch, in high-deps mode, the version before it is checked out and tested with the locally patched components
+          # For the highest branch, in high-deps mode, test previous major
           if [[ "${{ matrix.mode }}" = high-deps && $SYMFONY_VERSION = $(echo "$SYMFONY_VERSIONS" | tail -n 1 | sed s/.//) ]]; then
             echo FLIP='^' >> $GITHUB_ENV
             SYMFONY_VERSION=$(echo "$SYMFONY_VERSIONS" | grep -FB1 /$SYMFONY_VERSION | head -n 1 | sed s/.//)
@@ -115,14 +121,14 @@ jobs:
             echo COMPONENTS=$(find src/Symfony -mindepth 2 -type f -name phpunit.xml.dist -printf '%h ') >> $GITHUB_ENV
           fi
 
-          # Skip the phpunit-bridge on bugfix-branches when not in *-deps mode
+          # Skip phpunit-bridge on bugfix-branches when not in *-deps
           if [[ ! "${{ matrix.mode }}" = *-deps && $SYMFONY_VERSION != $SYMFONY_FEATURE_BRANCH ]]; then
             echo COMPONENTS=$(find src/Symfony -mindepth 2 -type f -name phpunit.xml.dist -not -wholename '*/Bridge/PhpUnit/*' | xargs -I{} dirname {}) >> $GITHUB_ENV
           else
             echo COMPONENTS=$(find src/Symfony -mindepth 2 -type f -name phpunit.xml.dist | xargs -I{} dirname {}) >> $GITHUB_ENV
           fi
 
-          # Legacy tests are skipped when deps=high and when the current branch version has not the same major version number as the next one
+          # Legacy tests skipped when deps=high and branch ends with .4
           [[ "${{ matrix.mode }}" = high-deps && $SYMFONY_VERSION = *.4 ]] && echo LEGACY=,legacy >> $GITHUB_ENV || true
 
           echo SYMFONY_VERSION=$SYMFONY_VERSION >> $GITHUB_ENV
@@ -152,7 +158,7 @@ jobs:
           composer install -q --optimize-autoloader || composer install --optimize-autoloader
           SYMFONY_PATCH_TYPE_DECLARATIONS='force=2&php=8.1' php .github/patch-types.php
           git checkout src/Symfony/Contracts/Service/ResetInterface.php
-          SYMFONY_PATCH_TYPE_DECLARATIONS='force=2&php=8.1' php .github/patch-types.php # ensure the script is idempotent
+          SYMFONY_PATCH_TYPE_DECLARATIONS='force=2&php=8.1' php .github/patch-types.php # ensure idempotency
           git checkout src/Symfony/Contracts/Service/ResetInterface.php
           git diff --exit-code
 
@@ -187,23 +193,20 @@ jobs:
 
           if [[ ! "${{ matrix.mode }}" = *-deps ]]; then
             echo "$COMPONENTS" | xargs -n1 | parallel -j +3 "_run_tests {} '$PHPUNIT {}'"
-
             exit 0
           fi
 
           if [[ "${{ matrix.mode }}" = low-deps ]]; then
             echo "$COMPONENTS" | xargs -n1 | parallel -j +3 "_run_tests {} 'cd {} && $COMPOSER_UP --prefer-lowest --prefer-stable && $PHPUNIT'"
-
             exit 0
           fi
 
           # matrix.mode = high-deps
           echo "$COMPONENTS" | xargs -n1 | parallel -j +3 "_run_tests {} 'cd {} && $COMPOSER_UP && $PHPUNIT$LEGACY'" || X=1
 
-          # get a list of the patched components (relies on .github/build-packages.php being called in the previous step)
           PATCHED_COMPONENTS=$(git diff --name-only src/ | grep composer.json || true)
 
-          # for 6.4 LTS, checkout and test previous major with the patched components (only for patched components)
+          # for 6.4 LTS, checkout and test previous major with patched components (only for patched components)
           if [[ $PATCHED_COMPONENTS && $SYMFONY_VERSION = 6.4 ]]; then
               export FLIP='^'
               SYMFONY_VERSION=$(echo $SYMFONY_VERSION | awk '{print $1 - 1}')
@@ -226,7 +229,7 @@ jobs:
       - name: Run TTY tests
         if: "! matrix.mode"
         run: |
-            script -e -c './phpunit --group tty' /dev/null
+          script -e -c './phpunit --group tty' /dev/null
 
       - name: Run tests with SIGCHLD enabled PHP
         if: "matrix.php == '8.1' && ! matrix.mode"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #61792
| License       | MIT
| Doc PR        | n/a

**Type:** bug fix
**Component:** symfony/process
**Related:** #61792
**Target branch:** 6.4

### Context / Problem

When a child process exits before consuming all input sent via stdin, Process may still attempt to write the remaining buffer. On POSIX this triggers EPIPE, and with ErrorHandler promoting notices to exceptions, the error surfaces in run(), stop(), and even __destruct(). This prevents clean teardown and causes intermittent failures with large inputs.

### What was done

1) Process::updateStatus() closes child STDIN as soon as running === false, before calling readPipes().

2) AbstractPipes::write() uses @fwrite() and, on write failure, closes STDIN idempotently and clears input buffers (prevents any further writes).

3) Process::__destruct() wraps stop(0) in try/catch (destructors must not throw).

### Safety

STDIN is closed only when the child is no longer running or when the OS already reports a write failure. Writing in that condition is useless and the root cause of EPIPE.

Reading from stdout/stderr, exit codes, timeouts, TTY, and other behaviors remain unchanged.

The race between “checking running” and “writing” is covered because write() also closes STDIN on any write error.

### Repro / Test
```
<?php

require __DIR__ . '/vendor/autoload.php';

use Symfony\Component\ErrorHandler\Debug;
use Symfony\Component\Process\Process;

$level = E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED;
Debug::enable($level);

$payload = str_repeat(str_repeat('A', 1024) . "\n", 1024);

// Child closes STDIN immediately, waits a bit, writes to STDERR, exits(1).
$child = [
    PHP_BINARY, '-r',
    'fclose(STDIN); usleep(200000); fwrite(STDERR, "child: closed STDIN\n"); exit(1);'
];

$process = new Process($child, null, null, null, 5);
$process->setInput($payload);

echo ">> Starting child that closes STDIN early...\n";

try {
    // Do not use mustRun(): we want raw behavior, not ProcessFailedException
    $process->run();
    echo ">> run() returned. ExitCode={$process->getExitCode()}\n";
} catch (\Throwable $e) {
    echo "!! Exception run(): " . get_class($e) . " - " . $e->getMessage() . PHP_EOL;
}

if ($process->isStarted()) {
    echo ">> Calling stop(0)...\n";
    try {
        $process->stop(0);
    } catch (\Throwable $e) {
        echo "!! Exception stop(): " . get_class($e) . " - " . $e->getMessage() . PHP_EOL;
    }

    echo ">> Child STDERR:\n" . $process->getErrorOutput() . PHP_EOL;
}

echo ">> Finish\n";
```
### Before fix (typical)
```
>> Starting child that closes STDIN early...
!! Exception run(): ErrorException - Notice: fwrite(): Write of 1049600 bytes failed with errno=32 Broken pipe
>> Calling stop(0)...
!! Exception stop(): ErrorException - Notice: fwrite(): Write of 1049600 bytes failed with errno=22 Invalid argument
>> Child STDERR:
child: closed STDIN
```
### After Fix (Expected)
```
>> Starting child that closes STDIN early...
>> run() returned. ExitCode=1
>> Calling stop(0)...
>> Child STDERR:
child: closed STDIN
>> Finish
```
### BC
No existing public signatures changed. A small public utility closeStdin() was added to AbstractPipes (idempotent).

### Technical Note
In theory, if someone directly extends AbstractPipes and already defines a closeStdin() method with an incompatible signature, it could conflict. In practice, this is very unlikely, because AbstractPipes is an internal building block and most projects interact only with Process.
