### PR TITLE
[ObjectMapper] remove not needed legacy test group

### DIFF
--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -12,8 +12,6 @@
 namespace Symfony\Component\ObjectMapper\Tests;
 
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -425,8 +423,6 @@ final class ObjectMapperTest extends TestCase
         yield [new ObjectMapper(new ReflectionObjectMapperMetadataFactory(), PropertyAccess::createPropertyAccessor())];
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testMapInitializesLazyObject()
     {
         $lazy = new LazyFoo();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

related to #61192 and #61197 (here the group was removed by rewriting the test in the `7.3` branch, the change was lost when merging up)