### PR TITLE
[Serializer] fix inherited properties normalization

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -107,7 +107,7 @@ class ObjectNormalizer extends AbstractObjectNormalizer
                 'i' => str_starts_with($name, 'is') && isset($name[$i = 2]),
                 default => false,
             } && !ctype_lower($name[$i])) {
-                if ($reflClass->hasProperty($name)) {
+                if ($this->hasProperty($reflMethod, $name)) {
                     $attributeName = $name;
                 } else {
                     $attributeName = substr($name, $i);
@@ -137,6 +137,19 @@ class ObjectNormalizer extends AbstractObjectNormalizer
         }
 
         return array_keys($attributes);
+    }
+
+    private function hasProperty(\ReflectionMethod $method, string $propName): bool
+    {
+        $class = $method->getDeclaringClass();
+
+        do {
+            if ($class->hasProperty($propName)) {
+                return true;
+            }
+        } while ($class = $class->getParentClass());
+
+        return false;
     }
 
     protected function getAttributeValue(object $object, string $attribute, ?string $format = null, array $context = []): mixed

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -1017,13 +1017,63 @@ class ObjectNormalizerTest extends TestCase
         $this->assertSame('getFoo', $denormalized->getFoo());
 
         // On the initial object the value was 'foo', but the normalizer prefers the accessor method 'getFoo'
-        // Thus on the denoramilzed object the value is 'getFoo'
+        // Thus on the denormalized object the value is 'getFoo'
         $this->assertSame('foo', $object->foo);
         $this->assertSame('getFoo', $denormalized->foo);
 
         $this->assertSame('hasFoo', $denormalized->hasFoo());
         $this->assertSame('canFoo', $denormalized->canFoo());
         $this->assertSame('isFoo', $denormalized->isFoo());
+    }
+
+    public function testNormalizeChildExtendsObjectWithPropertyAndAccessorSameName()
+    {
+        // This test follows the same logic used in testNormalizeObjectWithPropertyAndAccessorMethodsWithSameName()
+        $normalizer = $this->getNormalizerForAccessors();
+
+        $object = new ChildExtendsObjectWithPropertyAndAccessorSameName(
+            'foo',
+            'getFoo',
+            'canFoo',
+            'hasFoo',
+            'isFoo'
+        );
+        $normalized = $normalizer->normalize($object);
+
+        $this->assertSame([
+            'getFoo' => 'getFoo',
+            'canFoo' => 'canFoo',
+            'hasFoo' => 'hasFoo',
+            'isFoo' => 'isFoo',
+            // The getFoo accessor method is used for foo, thus it's also 'getFoo' instead of 'foo'
+            'foo' => 'getFoo',
+        ], $normalized);
+
+        $denormalized = $this->normalizer->denormalize($normalized, ChildExtendsObjectWithPropertyAndAccessorSameName::class);
+
+        $this->assertSame('getFoo', $denormalized->getFoo());
+
+        // On the initial object the value was 'foo', but the normalizer prefers the accessor method 'getFoo'
+        // Thus on the denormalized object the value is 'getFoo'
+        $this->assertSame('foo', $object->foo);
+        $this->assertSame('getFoo', $denormalized->foo);
+
+        $this->assertSame('hasFoo', $denormalized->hasFoo());
+        $this->assertSame('canFoo', $denormalized->canFoo());
+        $this->assertSame('isFoo', $denormalized->isFoo());
+    }
+
+    public function testNormalizeChildWithPropertySameAsParentMethod()
+    {
+        $normalizer = $this->getNormalizerForAccessors();
+
+        $object = new ChildWithPropertySameAsParentMethod('foo');
+        $normalized = $normalizer->normalize($object);
+
+        $this->assertSame([
+            'foo' => 'foo',
+        ],
+            $normalized);
     }
 
     /**
@@ -1499,6 +1549,18 @@ class ObjectWithPropertyAndAccessorSameName
     {
         return $this->isFoo;
     }
+}
+
+class ChildExtendsObjectWithPropertyAndAccessorSameName extends ObjectWithPropertyAndAccessorSameName
+{
+}
+
+class ChildWithPropertySameAsParentMethod extends ObjectWithPropertyAndAllAccessorMethods
+{
+    private $canFoo;
+    private $getFoo;
+    private $hasFoo;
+    private $isFoo;
 }
 
 class ObjectWithPropertyHasserAndIsser


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61988 
| License       | MIT

Introduce `hasParentProperty()` to detect and use properties defined in parent classes.