### PR TITLE
[Routing] Initialize `router.request_context`'s `_locale` parameter to `%kernel.default_locale%`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -16,6 +16,7 @@ CHANGELOG
  * Add support for weighted transitions in workflows
  * Add support for union types with `Symfony\Component\EventDispatcher\Attribute\AsEventListener`
  * Add `framework.allowed_http_method_override` option
+ * Initialize `router.request_context`'s `_locale` parameter to `%kernel.default_locale%`
 
 7.3
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.php
@@ -171,10 +171,10 @@ return static function (ContainerConfigurator $container) {
                 param('request_listener.http_port'),
                 param('request_listener.https_port'),
             ])
-            ->call('setParameter', [
-                '_functions',
-                service('router.expression_language_provider')->ignoreOnInvalid(),
-            ])
+            ->call('setParameters', [[
+                '_functions' => service('router.expression_language_provider')->ignoreOnInvalid(),
+                '_locale' => '%kernel.default_locale%',
+            ]])
         ->alias(RequestContext::class, 'router.request_context')
 
         ->set('router.expression_language_provider', ExpressionLanguageProvider::class)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #61577
| License       | MIT

This allows to use `%kernel.default_locale%` as default value for `_locale` routes parameter in a non-HTTP context.