### PR TITLE
[WebProfilerBundle] Add link to `xdebug_info()` to config panel

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
@@ -286,8 +286,14 @@
             </div>
 
             <div class="metric">
+                {% if collector.hasXdebugInfo %}
+                    <a href="{{ path('_profiler_xdebug') }}" title="View xdebug_info()" class="link">
+                {% endif %}
                 <span class="value value-is-icon {{ not collector.hasxdebug ? 'value-shows-no-color' }}" title="{{ collector.xdebugstatus|default('') }}">{{ source('@WebProfiler/Icon/' ~ (collector.hasxdebug ? 'yes' : 'no') ~ '.svg') }}</span>
                 <span class="label">Xdebug</span>
+                {% if collector.hasXdebugInfo %}
+                    </a>
+                {% endif %}
             </div>
         </div>
     </div>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -789,6 +789,10 @@ div.table-with-search-field .no-results-message {
     border-left: 1px solid var(--table-border-color);
 }
 
+.metric .link {
+    display: inline-flex;
+    flex-direction: column-reverse;
+}
 .metric .value {
     display: block;
     font-size: 24px;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

A follow-up to #44483

I noticed that the link was only added to the tool bar, not the config panel, so it feels a bit inconsistent.

This add the link to the panel as well:

<img width="497" height="198" alt="Screenshot" src="https://github.com/user-attachments/assets/87062787-72af-4824-adf2-4569716c2425" />

I don't think this is really a feature, but if I'm wrong, please let me know. 