### PR TITLE
[Translation] Keep the XLIFF source element on a load and dump round trip

### DIFF
--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Preserve the XLIFF `<source>` element when loading and dumping a file, instead of overwriting it with the message key
+
 8.1
 ---
 

--- a/src/Symfony/Component/Translation/Dumper/XliffFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/XliffFileDumper.php
@@ -96,8 +96,11 @@ class XliffFileDumper extends FileDumper
             $translation->setAttribute('id', strtr(substr(base64_encode(hash('xxh128', $source, true)), 0, 7), '/+', '._'));
             $translation->setAttribute('resname', $source);
 
+            $metadata = $messages->getMetadata($source, $domain);
+            $sourceText = $this->getSourceText($metadata, $source);
+
             $s = $translation->appendChild($dom->createElement('source'));
-            $s->appendChild($dom->createTextNode($source));
+            $s->appendChild($dom->createTextNode($sourceText));
 
             // Does the target contain characters requiring a CDATA section?
             $text = 1 === preg_match('/[&<>]/', $target) ? $dom->createCDATASection($target) : $dom->createTextNode($target);
@@ -170,11 +173,15 @@ class XliffFileDumper extends FileDumper
             $translation = $dom->createElement('unit');
             $translation->setAttribute('id', strtr(substr(base64_encode(hash('xxh128', $source, true)), 0, 7), '/+', '._'));
 
-            if (\strlen($source) <= 80) {
+            // the loader falls back to <source> for the key when there is no name attribute,
+            // so the key must stay in <source> for units that cannot carry one
+            $hasName = \strlen($source) <= 80;
+            if ($hasName) {
                 $translation->setAttribute('name', $source);
             }
 
             $metadata = $messages->getMetadata($source, $domain);
+            $sourceText = $hasName ? $this->getSourceText($metadata, $source) : $source;
 
             // Add notes section
             if ($this->hasMetadataArrayInfo('notes', $metadata) && $metadata['notes']) {
@@ -201,7 +208,7 @@ class XliffFileDumper extends FileDumper
             }
 
             $s = $segment->appendChild($dom->createElement('source'));
-            $s->appendChild($dom->createTextNode($source));
+            $s->appendChild($dom->createTextNode($sourceText));
 
             // Does the target contain characters requiring a CDATA section?
             $text = 1 === preg_match('/[&<>]/', $target) ? $dom->createCDATASection($target) : $dom->createTextNode($target);
@@ -219,6 +226,11 @@ class XliffFileDumper extends FileDumper
         }
 
         return $dom->saveXML();
+    }
+
+    private function getSourceText(?array $metadata, string $source): string
+    {
+        return \is_string($metadata['source'] ?? null) ? $metadata['source'] : $source;
     }
 
     private function hasMetadataArrayInfo(string $key, ?array $metadata = null): bool

--- a/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
@@ -183,7 +183,9 @@ class XliffFileLoader implements LoaderInterface
 
                 $catalogue->set((string) $source, $target, $domain);
 
-                $metadata = [];
+                $metadata = [
+                    'source' => (string) $segment->source,
+                ];
                 if ($segment->attributes()) {
                     $metadata['segment-attributes'] = [];
                     foreach ($segment->attributes() as $key => $value) {

--- a/src/Symfony/Component/Translation/Tests/Dumper/XliffFileDumperTest.php
+++ b/src/Symfony/Component/Translation/Tests/Dumper/XliffFileDumperTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Translation\Tests\Dumper;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Translation\Dumper\XliffFileDumper;
+use Symfony\Component\Translation\Loader\XliffFileLoader;
 use Symfony\Component\Translation\MessageCatalogue;
 
 class XliffFileDumperTest extends TestCase
@@ -183,5 +184,117 @@ class XliffFileDumperTest extends TestCase
             __DIR__.'/../Fixtures/resources-2.0-segment-attributes.xlf',
             $dumper->formatCatalogue($catalogue, 'messages', ['default_locale' => 'fr_FR', 'xliff_version' => '2.0'])
         );
+    }
+
+    public function testFormatCatalogueWithSourceMetadata()
+    {
+        $catalogue = new MessageCatalogue('fr');
+        $catalogue->add([
+            'navbar.home' => 'Accueil',
+            'navbar.about' => 'À propos',
+        ]);
+        $catalogue->setMetadata('navbar.home', ['source' => 'Home']);
+        $catalogue->setMetadata('navbar.about', ['source' => 'About']);
+
+        $dumper = new XliffFileDumper();
+        $output = $dumper->formatCatalogue($catalogue, 'messages', ['default_locale' => 'en']);
+
+        $this->assertStringContainsString('<source>Home</source>', $output);
+        $this->assertStringContainsString('<source>About</source>', $output);
+        $this->assertStringContainsString('<target>Accueil</target>', $output);
+        $this->assertStringContainsString('<target>À propos</target>', $output);
+        $this->assertStringContainsString('resname="navbar.home"', $output);
+        $this->assertStringContainsString('resname="navbar.about"', $output);
+    }
+
+    public function testFormatCatalogueXliff2WithSourceMetadata()
+    {
+        $catalogue = new MessageCatalogue('fr');
+        $catalogue->add([
+            'navbar.home' => 'Accueil',
+            'navbar.about' => 'À propos',
+        ]);
+        $catalogue->setMetadata('navbar.home', ['source' => 'Home']);
+        $catalogue->setMetadata('navbar.about', ['source' => 'About']);
+
+        $dumper = new XliffFileDumper();
+        $output = $dumper->formatCatalogue($catalogue, 'messages', ['default_locale' => 'en', 'xliff_version' => '2.0']);
+
+        $this->assertStringContainsString('<source>Home</source>', $output);
+        $this->assertStringContainsString('<source>About</source>', $output);
+        $this->assertStringContainsString('<target>Accueil</target>', $output);
+        $this->assertStringContainsString('<target>À propos</target>', $output);
+        $this->assertStringContainsString('name="navbar.home"', $output);
+        $this->assertStringContainsString('name="navbar.about"', $output);
+    }
+
+    public function testFormatCatalogueWithoutSourceMetadataFallsBackToKey()
+    {
+        $catalogue = new MessageCatalogue('fr');
+        $catalogue->add([
+            'navbar.home' => 'Accueil',
+        ]);
+
+        $dumper = new XliffFileDumper();
+        $output = $dumper->formatCatalogue($catalogue, 'messages', ['default_locale' => 'en']);
+
+        $this->assertStringContainsString('<source>navbar.home</source>', $output);
+        $this->assertStringContainsString('resname="navbar.home"', $output);
+    }
+
+    public function testFormatCatalogueXliff2KeepsTheKeyWhenItIsTooLongForTheNameAttribute()
+    {
+        $key = str_repeat('a', 101);
+
+        $catalogue = new MessageCatalogue('fr');
+        $catalogue->add([$key => 'Accueil']);
+        $catalogue->setMetadata($key, ['source' => 'Home']);
+
+        $dumper = new XliffFileDumper();
+        $output = $dumper->formatCatalogue($catalogue, 'messages', ['default_locale' => 'en', 'xliff_version' => '2.0']);
+
+        $this->assertStringNotContainsString('name=', $output);
+        $this->assertStringContainsString('<source>'.$key.'</source>', $output);
+
+        $reloaded = new XliffFileLoader()->load($output, 'fr', 'messages');
+        $this->assertSame([$key], array_keys($reloaded->all('messages')));
+    }
+
+    public function testFormatCatalogueIgnoresNonStringSourceMetadata()
+    {
+        $catalogue = new MessageCatalogue('fr');
+        $catalogue->add(['navbar.home' => 'Accueil']);
+        $catalogue->setMetadata('navbar.home', ['source' => ['not', 'a', 'string']]);
+
+        $dumper = new XliffFileDumper();
+        $output = $dumper->formatCatalogue($catalogue, 'messages', ['default_locale' => 'en']);
+
+        $this->assertStringContainsString('<source>navbar.home</source>', $output);
+    }
+
+    public function testSourceSurvivesALoadDumpRoundTrip()
+    {
+        $xliff = <<<'XLIFF'
+            <?xml version="1.0" encoding="utf-8"?>
+            <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+              <file source-language="en" target-language="fr" datatype="plaintext" original="file.ext">
+                <body>
+                  <trans-unit id="1" resname="navbar.home">
+                    <source>Home</source>
+                    <target>Accueil</target>
+                  </trans-unit>
+                </body>
+              </file>
+            </xliff>
+            XLIFF;
+
+        $catalogue = new XliffFileLoader()->load($xliff, 'fr', 'messages');
+
+        $this->assertSame(['navbar.home' => 'Accueil'], $catalogue->all('messages'));
+
+        $output = new XliffFileDumper()->formatCatalogue($catalogue, 'messages', ['default_locale' => 'en']);
+
+        $this->assertStringContainsString('resname="navbar.home"', $output);
+        $this->assertStringContainsString('<source>Home</source>', $output);
     }
 }

--- a/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
@@ -257,7 +257,7 @@ class XliffFileLoaderTest extends TestCase
         $this->assertContainsOnlyString($catalogue->all('domain1'));
 
         // target attributes
-        $this->assertEquals(['target-attributes' => ['order' => 1]], $catalogue->getMetadata('bar', 'domain1'));
+        $this->assertEquals(['source' => 'bar', 'target-attributes' => ['order' => 1]], $catalogue->getMetadata('bar', 'domain1'));
     }
 
     public function testLoadVersion21()
@@ -275,7 +275,7 @@ class XliffFileLoaderTest extends TestCase
         $this->assertContainsOnlyString($catalogue->all('domain1'));
 
         // target attributes
-        $this->assertEquals(['target-attributes' => ['order' => 1]], $catalogue->getMetadata('bar', 'domain1'));
+        $this->assertEquals(['target-attributes' => ['order' => 1], 'source' => 'bar'], $catalogue->getMetadata('bar', 'domain1'));
     }
 
     public function testLoadVersion22()
@@ -293,7 +293,7 @@ class XliffFileLoaderTest extends TestCase
         $this->assertContainsOnlyString($catalogue->all('domain1'));
 
         // target attributes
-        $this->assertEquals(['target-attributes' => ['order' => 1]], $catalogue->getMetadata('bar', 'domain1'));
+        $this->assertEquals(['target-attributes' => ['order' => 1], 'source' => 'bar'], $catalogue->getMetadata('bar', 'domain1'));
     }
 
     public function testLoadVersion2WithCatalogMeta()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #33041
| License       | MIT

The XLIFF 1.2 loader has always stored the `<source>` text in the message metadata, but both dumpers wrote the catalogue key instead. So loading a file whose `<source>` differs from its `resname` and dumping it back replaced the source text with the key. The XLIFF 2.0 loader did not capture `<source>` at all, so the same round trip lost it there before the dumper was even reached.

Classified as a feature rather than a bugfix: the effect is a change in generated files that projects commit, and it reaches `translation:pull` and `translation:extract --force` for every 1.2 file whose source differs from its resname. The underlying asymmetry is identical on 6.4, 7.4, 8.1 and 8.2, but it should not be backported for that reason. This answers @welcoMattic's concern on the loader: the behaviour change is real, it is intended, and it is now documented in the CHANGELOG.

Fixed during review:

* **XLIFF 2.0 keys longer than 80 characters lost their key.** The dumper only writes a `name` attribute up to 80 characters, and the loader falls back to `<source>` for the key when there is none. That is harmless while `<source>` holds the key, but once it holds the source text the key is destroyed on the next load. The substitution now applies only to units that carry a `name`;
* **non-string metadata threw.** `$metadata['source']` went straight into `createTextNode`, so a catalogue with a non-string under that key produced a `TypeError` where the base branch emits valid XML. It now falls back to the key;
* the 2.1 and 2.2 loader tests were failing after rebase. The loader change applies to them too, so their expected metadata now includes the source.

Tests added: a load-then-dump round trip on a 1.2 file whose `<source>` differs from its `resname`, which is the scenario from the issue and fails on a clean 8.2; the over-80-character key case, asserting the dumped file still reloads under the original key; and the non-string metadata case.

Note on scope. This makes the round trip lossless for files that already carry a meaningful `<source>`, which covers hand-written files and files produced by external tools. It does not populate `metadata['source']` for files Symfony generated itself, so those see no change. Filling the source from the default-locale catalogue during extraction, as sketched by @squrious on the issue, is the other half and is not part of this PR.
