### PR TITLE
[DebugBundle][HttpKernel] Collect dumps when console profiling is enabled

### DIFF
--- a/src/Symfony/Bundle/DebugBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/DebugBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+ * Wire the `$profilerDumper` argument in `DumpListener`
+
 4.1.0
 -----
 

--- a/src/Symfony/Bundle/DebugBundle/Resources/config/services.php
+++ b/src/Symfony/Bundle/DebugBundle/Resources/config/services.php
@@ -59,11 +59,17 @@ return static function (ContainerConfigurator $container) {
                 'priority' => 240,
             ])
 
+        ->set('.lazy.data_collector.dump', DumpDataCollector::class)
+            ->factory('current')
+            ->args([[service('data_collector.dump')]])
+            ->lazy()
+
         ->set('debug.dump_listener', DumpListener::class)
             ->args([
                 service('var_dumper.cloner'),
                 service('var_dumper.cli_dumper'),
                 null,
+                service('.lazy.data_collector.dump'),
             ])
             ->tag('kernel.event_subscriber')
 

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Add `#[IsSignatureValid]` attribute to validate URI signatures
  * Make `Profile` final and `Profiler::__sleep()` internal
  * Collect the application runner class
+ * Allow configuring `DumpListener` to use a different dumper when CLI profiling is enabled
 
 7.3
 ---

--- a/src/Symfony/Component/HttpKernel/EventListener/DumpListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/DumpListener.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\EventListener;
 
 use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\VarDumper\Cloner\ClonerInterface;
 use Symfony\Component\VarDumper\Dumper\DataDumperInterface;
@@ -25,17 +26,28 @@ use Symfony\Component\VarDumper\VarDumper;
  */
 class DumpListener implements EventSubscriberInterface
 {
+    /**
+     * @param ?DataDumperInterface $profilerDumper The dumper to use when CLI profiling is enabled.
+     *                                             If null, the default $dumper will be used instead.
+     */
     public function __construct(
         private ClonerInterface $cloner,
         private DataDumperInterface $dumper,
         private ?Connection $connection = null,
+        private ?DataDumperInterface $profilerDumper = null,
     ) {
     }
 
-    public function configure(): void
+    /**
+     * @param ?ConsoleCommandEvent $event
+     */
+    public function configure(/* ?ConsoleCommandEvent $event = null */): void
     {
+        $event = 1 <= \func_num_args() ? func_get_arg(0) : null;
+        $input = $event?->getInput();
+
         $cloner = $this->cloner;
-        $dumper = $this->dumper;
+        $dumper = !$this->profilerDumper || !$input?->hasOption('profile') || !$input?->getOption('profile') ? $this->dumper : $this->profilerDumper;
         $connection = $this->connection;
 
         VarDumper::setHandler(static function ($var, ?string $label = null) use ($cloner, $dumper, $connection) {

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/DumpListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/DumpListenerTest.php
@@ -11,8 +11,12 @@
 
 namespace Symfony\Component\HttpKernel\Tests\EventListener;
 
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\HttpKernel\EventListener\DumpListener;
 use Symfony\Component\VarDumper\Cloner\ClonerInterface;
 use Symfony\Component\VarDumper\Cloner\Data;
@@ -62,6 +66,44 @@ class DumpListenerTest extends TestCase
             throw $exception;
         }
     }
+
+    #[TestWith([false, false, '+foo-+bar-', []])]
+    #[TestWith([true, false, '+foo-+bar-', []])]
+    #[TestWith([true, true, '', ['foo-', 'bar-']])]
+    public function testConfigureWithProfilerDumper(bool $hasOption, bool $option, string $expectedOutput, array $expectedData)
+    {
+        $prevDumper = VarDumper::setHandler('var_dump');
+        VarDumper::setHandler($prevDumper);
+
+        $cloner = new MockCloner();
+        $dumper = new MockDumper();
+        $profilerDumper = new MockProfilerDumper();
+
+        $input = $this->createMock(InputInterface::class);
+        $input->method('hasOption')->willReturn($hasOption);
+        $input->method('getOption')->willReturn($option);
+
+        ob_start();
+        $exception = null;
+        $listener = new DumpListener($cloner, $dumper, null, $profilerDumper);
+
+        try {
+            $listener->configure(new ConsoleCommandEvent(null, $input, new BufferedOutput()));
+
+            VarDumper::dump('foo');
+            VarDumper::dump('bar');
+
+            $this->assertSame($expectedOutput, ob_get_clean());
+            $this->assertSame($expectedData, $profilerDumper->data);
+        } catch (\Exception $exception) {
+        }
+
+        VarDumper::setHandler($prevDumper);
+
+        if (null !== $exception) {
+            throw $exception;
+        }
+    }
 }
 
 class MockCloner implements ClonerInterface
@@ -77,6 +119,18 @@ class MockDumper implements DataDumperInterface
     public function dump(Data $data): ?string
     {
         echo '+'.$data->getValue();
+
+        return null;
+    }
+}
+
+class MockProfilerDumper implements DataDumperInterface
+{
+    public array $data = [];
+
+    public function dump(Data $data): ?string
+    {
+        $this->data[] = $data->getValue();
 
         return null;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #61971
| License       | MIT

Currently, when profiling a console command, calls to `dump()` aren't collected.
With this PR, they'll be collected when profiling is enabled, or output directly when it's not.

Not entirely sure whether this should be considered a bug or simply a missing feature.