### PR TITLE
[Mailer][SES] Allow configuring port and tls options

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add support for configuring the port and tls options
+
 7.3
 ---
 

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/README.md
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/README.md
@@ -7,7 +7,7 @@ Configuration example:
 
 ```env
 # SMTP
-MAILER_DSN=ses+smtp://USERNAME:PASSWORD@default?region=REGION&session_token=SESSION_TOKEN
+MAILER_DSN=ses+smtp://USERNAME:PASSWORD@default:PORT?region=REGION&session_token=SESSION_TOKEN
 
 # HTTP
 MAILER_DSN=ses+https://ACCESS_KEY:SECRET_KEY@default?region=REGION&session_token=SESSION_TOKEN
@@ -21,6 +21,7 @@ where:
  - `SECRET_KEY` is your Amazon SES access key secret
  - `REGION` is Amazon SES selected region (optional, default `eu-west-1`)
  - `SESSION_TOKEN` is your Amazon SES session token (optional)
+ - `PORT` is the port you want to communicate to SES with (optional, default `465`)
 
 Resources
 ---------

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesSmtpTransport.php
@@ -28,13 +28,13 @@ class SesSmtpTransport extends EsmtpTransport
     /**
      * @param string|null $region Amazon SES region
      */
-    public function __construct(string $username, #[\SensitiveParameter] string $password, ?string $region = null, ?EventDispatcherInterface $dispatcher = null, ?LoggerInterface $logger = null, string $host = 'default')
+    public function __construct(string $username, #[\SensitiveParameter] string $password, ?string $region = null, ?EventDispatcherInterface $dispatcher = null, ?LoggerInterface $logger = null, string $host = 'default', int $port = 465)
     {
         if ('default' === $host) {
             $host = \sprintf('email-smtp.%s.amazonaws.com', $region ?: 'eu-west-1');
         }
 
-        parent::__construct($host, 465, true, $dispatcher, $logger);
+        parent::__construct($host, $port, \in_array($port, [465, 2465], true), $dispatcher, $logger);
 
         $this->setUsername($username);
         $this->setPassword($password);

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesTransportFactory.php
@@ -28,9 +28,10 @@ final class SesTransportFactory extends AbstractTransportFactory
     {
         $scheme = $dsn->getScheme();
         $region = $dsn->getOption('region');
+        $port = $dsn->getPort() ?? 465;
 
         if ('ses+smtp' === $scheme || 'ses+smtps' === $scheme) {
-            $transport = new SesSmtpTransport($this->getUser($dsn), $this->getPassword($dsn), $region, $this->dispatcher, $this->logger, $dsn->getHost());
+            $transport = new SesSmtpTransport($this->getUser($dsn), $this->getPassword($dsn), $region, $this->dispatcher, $this->logger, $dsn->getHost(), $port);
 
             if (null !== $pingThreshold = $dsn->getOption('ping_threshold')) {
                 $transport->setPingThreshold((int) $pingThreshold);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #62024 
| License       | MIT

This feature addresses feature request on  #62024
User's now have ability to select a different port when using ses+smtp

It takes the port from DSN and backward compatiblity is maintained by passing 465 as the default parameter. 