### PR TITLE
[HttpKernel] Fix StreamedResponse with chunks support in HttpKernelBrowser

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpKernelBrowser.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernelBrowser.php
@@ -180,10 +180,16 @@ EOF;
      */
     protected function filterResponse(object $response): DomResponse
     {
-        // this is needed to support StreamedResponse
-        ob_start();
-        $response->sendContent();
-        $content = ob_get_clean();
+        $content = '';
+        ob_start(static function ($chunk) use (&$content) {
+            $content .= $chunk;
+        });
+
+        try {
+            $response->sendContent();
+        } finally {
+            ob_end_clean();
+        }
 
         return new DomResponse($content, $response->getStatusCode(), $response->headers->all());
     }

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelBrowserTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelBrowserTest.php
@@ -89,6 +89,19 @@ class HttpKernelBrowserTest extends TestCase
         $this->assertEquals('foo', $domResponse->getContent());
     }
 
+    public function testFilterResponseSupportsStreamedResponsesWithChunks()
+    {
+        $client = new HttpKernelBrowser(new TestHttpKernel());
+
+        $r = new \ReflectionObject($client);
+        $m = $r->getMethod('filterResponse');
+
+        $response = new StreamedResponse(new \ArrayIterator(['foo']));
+
+        $domResponse = $m->invoke($client, $response);
+        $this->assertEquals('foo', $domResponse->getContent());
+    }
+
     public function testUploadedFile()
     {
         $source = tempnam(sys_get_temp_dir(), 'source');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| License       | MIT

This PR fixes changes done in https://github.com/symfony/symfony/pull/60262 that breaks `HttpKernelBrowser` when it comes to deal with `StreamedResponse` created with an iterator.