### PR TITLE
 Fix generating logout link with stateless csrf

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/LogoutListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/LogoutListener.php
@@ -69,7 +69,7 @@ class LogoutListener extends AbstractListener
         $request = $event->getRequest();
 
         if (null !== $this->csrfTokenManager) {
-            $csrfToken = ParameterBagUtils::getRequestParameterValue($request, $this->options['csrf_parameter']);
+            $csrfToken = ParameterBagUtils::getRequestParameterValue($request, $this->options['csrf_parameter'], $request->request->all());
 
             if (!\is_string($csrfToken) || false === $this->csrfTokenManager->isTokenValid(new CsrfToken($this->options['csrf_token_id'], $csrfToken))) {
                 throw new LogoutException('Invalid CSRF token.');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

When using the `logout_path` (or `logout_url`) twig function with stateless csrf, the generator creates a link with an invalid CSRF token parameter (`/logout?_csrf_token=csrf-token`), which then causes an error during logout (`Invalid CSRF token`), since the LogoutListener reads the token from the query parameter first.

Reproducer:

```yaml
framework:
    csrf_protection:
        stateless_token_ids: ['logout']
```

```twig
<form method="post" action="{{ logout_path() }}">
    <input type="hidden" data-controller="csrf-protection" name="_csrf_token" value="{{ csrf_token('logout') }}"/>
    <button type="submit">Logout</button>
</form>
```
