### PR TITLE
[Translation][Loco] filter should be empty when filtering on all domains

### DIFF
--- a/src/Symfony/Component/Translation/Bridge/Loco/LocoProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/LocoProvider.php
@@ -106,7 +106,7 @@ final class LocoProvider implements ProviderInterface
                 // Loco forbids concurrent requests, so the requests must be synchronous in order to prevent "429 Too Many Requests" errors.
                 $response = $this->client->request('GET', \sprintf('export/locale/%s.xlf', rawurlencode($locale)), [
                     'query' => [
-                        'filter' => $domain,
+                        'filter' => '*' !== $domain ? $domain : '',
                         'status' => 'translated,blank-translation',
                     ],
                     'headers' => [

--- a/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderTest.php
@@ -967,8 +967,7 @@ class LocoProviderTest extends ProviderTestCase
     </body>
   </file>
 </xliff>
-XLIFF
-            ,
+XLIFF,
             $expectedTranslatorBagEn,
         ];
 
@@ -997,8 +996,7 @@ XLIFF
     </body>
   </file>
 </xliff>
-XLIFF
-            ,
+XLIFF,
             $expectedTranslatorBagFr,
         ];
     }
@@ -1049,8 +1047,7 @@ XLIFF
     </body>
   </file>
 </xliff>
-XLIFF
-                    ,
+XLIFF,
                     'messages+intl-icu' => <<<'XLIFF'
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
@@ -1066,8 +1063,7 @@ XLIFF
     </body>
   </file>
 </xliff>
-XLIFF
-                    ,
+XLIFF,
                     'validators' => <<<'XLIFF'
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
@@ -1087,8 +1083,7 @@ XLIFF
     </body>
   </file>
 </xliff>
-XLIFF
-                    ,
+XLIFF,
                 ],
                 'fr' => [
                     'messages' => <<<'XLIFF'
@@ -1106,8 +1101,7 @@ XLIFF
     </body>
   </file>
 </xliff>
-XLIFF
-                    ,
+XLIFF,
                     'messages+intl-icu' => <<<'XLIFF'
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
@@ -1123,8 +1117,7 @@ XLIFF
     </body>
   </file>
 </xliff>
-XLIFF
-                    ,
+XLIFF,
                     'validators' => <<<'XLIFF'
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
@@ -1144,8 +1137,7 @@ XLIFF
     </body>
   </file>
 </xliff>
-XLIFF
-                    ,
+XLIFF,
                 ],
             ],
             $expectedTranslatorBag,
@@ -1169,5 +1161,33 @@ XLIFF
 
             yield [$locales, $domains, $responseContents, $lastModifieds, $expectedTranslatorBag];
         }
+    }
+
+    public function testReadForAllDomains()
+    {
+        $loader = $this->getLoader();
+
+        $loader
+            ->expects($this->once())
+            ->method('load')
+            ->willReturn($this->createMock(MessageCatalogue::class));
+
+        $provider = self::createProvider(
+            new MockHttpClient([
+                function (string $method, string $url, array $options = []): ResponseInterface {
+                    $this->assertSame('GET', $method);
+                    $this->assertSame('https://localise.biz/api/export/locale/fr.xlf?filter=&status=translated%2Cblank-translation', $url);
+                    $this->assertSame(['filter' => '', 'status' => 'translated,blank-translation'], $options['query']);
+
+                    return new MockResponse();
+                },
+            ], 'https://localise.biz/api/'),
+            $this->getLoader(),
+            $this->getLogger(),
+            $this->getDefaultLocale(),
+            'localise.biz/api/',
+        );
+
+        $this->translatorBag = $provider->read(['*'], ['fr']);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

When pulling translations for all domains (`*`), the `filter` query parameter value is set to `*` but that filters only translations that do have at least one tag. 

Using an empty value for `filter` fetches also translations that don’t have any tag.