### PR TITLE
[Notifier] Add support for `confirm` option in Slack buttons API

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Slack/Block/SlackActionsBlock.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Block/SlackActionsBlock.php
@@ -24,13 +24,13 @@ final class SlackActionsBlock extends AbstractSlackBlock
     /**
      * @return $this
      */
-    public function button(string $text, ?string $url = null, ?string $style = null, ?string $value = null): static
+    public function button(string $text, ?string $url = null, ?string $style = null, ?string $value = null, ?array $confirm = null): static
     {
         if (25 === \count($this->options['elements'] ?? [])) {
             throw new \LogicException('Maximum number of buttons should not exceed 25.');
         }
 
-        $element = new SlackButtonBlockElement($text, $url, $style, $value);
+        $element = new SlackButtonBlockElement($text, $url, $style, $value, $confirm);
 
         $this->options['elements'][] = $element->toArray();
 

--- a/src/Symfony/Component/Notifier/Bridge/Slack/Block/SlackButtonBlockElement.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Block/SlackButtonBlockElement.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\Notifier\Bridge\Slack\Block;
  */
 final class SlackButtonBlockElement extends AbstractSlackBlockElement
 {
-    public function __construct(string $text, ?string $url = null, ?string $style = null, ?string $value = null)
+    public function __construct(string $text, ?string $url = null, ?string $style = null, ?string $value = null, ?array $confirm = null)
     {
         $this->options = [
             'type' => 'button',
@@ -37,6 +37,10 @@ final class SlackButtonBlockElement extends AbstractSlackBlockElement
 
         if ($value) {
             $this->options['value'] = $value;
+        }
+
+        if ($confirm) {
+            $this->options['confirm'] = $confirm;
         }
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Slack/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+ * Add `confirm` option to `button` method in `SlackActionsBlock` block
+
 7.2
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Slack/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/README.md
@@ -52,7 +52,14 @@ $contributeToSymfonyBlocks = (new SlackActionsBlock())
     ->button(
         'Report bugs',
         'https://symfony.com/doc/current/contributing/code/bugs.html',
-        'danger'
+        'danger',
+        null,
+        [
+            'title' => ['type' => 'plaint_text', 'text' => 'Report a bug'],
+            'text' => ['type' => 'plaint_text', 'text' => 'By proceeding I confirm I\'ve read the guidelines.'],
+            'confirm' => ['type' => 'plaint_text', 'text' => 'Proceed'],
+            'deny' => ['type' => 'plaint_text', 'text' => 'Go back to reading']
+        ]
     );
 
 $slackOptions = (new SlackOptions())

--- a/src/Symfony/Component/Notifier/Bridge/Slack/Tests/Block/SlackActionsBlockTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Tests/Block/SlackActionsBlockTest.php
@@ -22,6 +22,31 @@ final class SlackActionsBlockTest extends TestCase
         $actions->button('first button text', 'https://example.org', null, 'test-value')
             ->button('second button text', 'https://example.org/slack', 'danger')
             ->button('third button text', null, null, 'test-value-3')
+            ->button(
+                'fourth button text',
+                null,
+                null,
+                'test-value-4',
+                [
+                    'title' => [
+                        'type' => 'plain_text',
+                        'text' => 'test-confirm-title-4',
+                    ],
+                    'text' => [
+                        'type' => 'plain_text',
+                        'text' => 'test-confirm-text-4',
+                    ],
+                    'confirm' => [
+                        'type' => 'plain_text',
+                        'text' => 'test-confirm-confirm-4',
+                    ],
+                    'deny' => [
+                        'type' => 'plain_text',
+                        'text' => 'test-confirm-deny-4',
+                    ],
+                    'style' => 'danger',
+                ]
+            )
         ;
 
         $this->assertSame([
@@ -52,6 +77,33 @@ final class SlackActionsBlockTest extends TestCase
                         'text' => 'third button text',
                     ],
                     'value' => 'test-value-3',
+                ],
+                [
+                    'type' => 'button',
+                    'text' => [
+                        'type' => 'plain_text',
+                        'text' => 'fourth button text',
+                    ],
+                    'value' => 'test-value-4',
+                    'confirm' => [
+                        'title' => [
+                            'type' => 'plain_text',
+                            'text' => 'test-confirm-title-4',
+                        ],
+                        'text' => [
+                            'type' => 'plain_text',
+                            'text' => 'test-confirm-text-4',
+                        ],
+                        'confirm' => [
+                            'type' => 'plain_text',
+                            'text' => 'test-confirm-confirm-4',
+                        ],
+                        'deny' => [
+                            'type' => 'plain_text',
+                            'text' => 'test-confirm-deny-4',
+                        ],
+                        'style' => 'danger',
+                    ],
                 ],
             ],
         ], $actions->toArray());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT


Allow sending `confirm` option to the Slack API to allow for the confirm dialog to be triggered upon press of a button in the Slack clients