### PR TITLE
[HttpFoundation] Add ParameterBag::isSet() method

### DIFF
--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -83,9 +83,9 @@ class ParameterBag implements \IteratorAggregate, \Countable
     }
 
     /**
-     * @param bool $acceptNull
+     * @param bool $allowNull
      */
-    public function has(string $key/*, bool $acceptNull = true */): bool
+    public function has(string $key/* , bool $allowNull = true */): bool
     {
         if (2 > \func_num_args() || func_get_arg(1)) {
             return \array_key_exists($key, $this->parameters);

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -87,9 +87,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
      */
     public function has(string $key/*, bool $acceptNull = true */): bool
     {
-        $acceptNull = 2 > \func_num_args() || func_get_arg(1);
-
-        if ($acceptNull) {
+        if (2 > \func_num_args() || func_get_arg(1)) {
             return \array_key_exists($key, $this->parameters);
         }
 

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -90,6 +90,11 @@ class ParameterBag implements \IteratorAggregate, \Countable
         return \array_key_exists($key, $this->parameters);
     }
 
+    public function isSet(string $key): bool
+    {
+        return isset($this->parameters[$key]);
+    }
+
     /**
      * Removes a parameter.
      */

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -83,15 +83,16 @@ class ParameterBag implements \IteratorAggregate, \Countable
     }
 
     /**
-     * Returns true if the parameter is defined.
+     * @param bool $acceptNull
      */
-    public function has(string $key): bool
+    public function has(string $key/*, bool $acceptNull = true */): bool
     {
-        return \array_key_exists($key, $this->parameters);
-    }
+        $acceptNull = 2 > \func_num_args() || func_get_arg(1);
 
-    public function isSet(string $key): bool
-    {
+        if ($acceptNull) {
+            return \array_key_exists($key, $this->parameters);
+        }
+
         return isset($this->parameters[$key]);
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -366,4 +366,33 @@ class ParameterBagTest extends TestCase
 
         $this->assertNull($bag->getEnum('invalid-value', FooEnum::class));
     }
+
+    public function testIsSetReturnsExpectedValues(): void
+    {
+        $bag = new ParameterBag([
+            'string' => 'bar',
+            'null' => null,
+            'empty' => '',
+            'zero' => 0,
+            'false' => false,
+        ]);
+
+        $this->assertTrue($bag->isSet('string'));
+        $this->assertFalse($bag->isSet('null'));
+        $this->assertTrue($bag->isSet('empty'));
+        $this->assertTrue($bag->isSet('zero'));
+        $this->assertTrue($bag->isSet('false'));
+        $this->assertFalse($bag->isSet('missing'));
+    }
+
+    public function testIsSetWorksSafelyWithGetString(): void
+    {
+        $bag = new ParameterBag(['foo' => 'bar', 'nullValue' => null]);
+
+        if ($bag->isSet('foo')) {
+            $this->assertSame('bar', $bag->getString('foo'));
+        }
+
+        $this->assertFalse($bag->isSet('nullValue'));
+    }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -367,32 +367,13 @@ class ParameterBagTest extends TestCase
         $this->assertNull($bag->getEnum('invalid-value', FooEnum::class));
     }
 
-    public function testIsSetReturnsExpectedValues(): void
-    {
-        $bag = new ParameterBag([
-            'string' => 'bar',
-            'null' => null,
-            'empty' => '',
-            'zero' => 0,
-            'false' => false,
-        ]);
-
-        $this->assertTrue($bag->isSet('string'));
-        $this->assertFalse($bag->isSet('null'));
-        $this->assertTrue($bag->isSet('empty'));
-        $this->assertTrue($bag->isSet('zero'));
-        $this->assertTrue($bag->isSet('false'));
-        $this->assertFalse($bag->isSet('missing'));
-    }
-
-    public function testIsSetWorksSafelyWithGetString(): void
+    public function testHasWithAcceptNullFlag(): void
     {
         $bag = new ParameterBag(['foo' => 'bar', 'nullValue' => null]);
 
-        if ($bag->isSet('foo')) {
-            $this->assertSame('bar', $bag->getString('foo'));
-        }
-
-        $this->assertFalse($bag->isSet('nullValue'));
+        $this->assertTrue($bag->has('foo'));
+        $this->assertTrue($bag->has('nullValue'));
+        $this->assertTrue($bag->has('foo', false));
+        $this->assertFalse($bag->has('nullValue', false));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #62032
| License       | MIT

### Description

This PR adds a new `ParameterBag::isSet()` method to check whether a parameter **exists and is not null**.

Currently, `ParameterBag::has()` only verifies if a key exists, even if the value is `null`.  
This new method complements it by using PHP’s native `isset()` check, allowing safer use of type-safe getters like `getString()`.