### PR TITLE
[DebugBundle] Wire `DumpDataCollector`'s `webMode` argument

### DIFF
--- a/src/Symfony/Bundle/DebugBundle/Resources/config/services.php
+++ b/src/Symfony/Bundle/DebugBundle/Resources/config/services.php
@@ -52,6 +52,7 @@ return static function (ContainerConfigurator $container) {
                 param('kernel.charset'),
                 service('.virtual_request_stack'),
                 null, // var_dumper.cli_dumper or var_dumper.server_connection when debug.dump_destination is set
+                param('kernel.runtime_mode.web'),
             ])
             ->tag('data_collector', [
                 'id' => 'dump',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | maybe
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

I've noticed that the `DumpDataCollector::$webMode` that was added in #52079 was never wired. I'm not sure if this was intentional or an oversight. 