### PR TITLE
[HttpFoundation] drop support for HTTP method override for GET, HEAD, CONNECT and TRACE requests

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -199,6 +199,7 @@ HtmlSanitizer
 HttpFoundation
 --------------
 
+ * Drop HTTP method override support for methods GET, HEAD, CONNECT and TRACE
  * Add argument `$subtypeFallback` to `Request::getFormat()`
  * Remove the following deprecated session options from `NativeSessionStorage`: `referer_check`, `use_only_cookies`, `use_trans_sid`, `sid_length`, `sid_bits_per_character`, `trans_sid_hosts`, `trans_sid_tags`
  * Trigger PHP warning when using `Request::sendHeaders()` after headers have already been sent; use a `StreamedResponse` instead

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.0
 ---
 
+ * Drop HTTP method override support for methods GET, HEAD, CONNECT and TRACE
  * Add argument `$subtypeFallback` to `Request::getFormat()`
  * Remove the following deprecated session options from `NativeSessionStorage`: `referer_check`, `use_only_cookies`, `use_trans_sid`, `sid_length`, `sid_bits_per_character`, `trans_sid_hosts`, `trans_sid_tags`
  * Trigger PHP warning when using `Request::sendHeaders()` after headers have already been sent; use a `StreamedResponse` instead

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1210,7 +1210,7 @@ class Request
         $method = strtoupper($method);
 
         if (\in_array($method, ['GET', 'HEAD', 'CONNECT', 'TRACE'], true)) {
-            trigger_deprecation('symfony/http-foundation', '7.4', 'HTTP method override is deprecated for methods GET, HEAD, CONNECT and TRACE; it will be ignored in Symfony 8.0.', $method);
+            return $this->method;
         }
 
         if (self::$allowedHttpMethodOverride && !\in_array($method, self::$allowedHttpMethodOverride, true)) {

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1076,16 +1076,13 @@ b'])]
         $this->assertSame('POST', $request->getMethod(), '->getMethod() returns the request method if invalid type is defined in query');
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testUnsafeMethodOverride()
     {
         $request = new Request();
         $request->setMethod('POST');
         $request->headers->set('X-HTTP-METHOD-OVERRIDE', 'get');
 
-        $this->expectUserDeprecationMessage('Since symfony/http-foundation 7.4: HTTP method override is deprecated for methods GET, HEAD, CONNECT and TRACE; it will be ignored in Symfony 8.0.');
-        $this->assertSame('GET', $request->getMethod());
+        $this->assertSame('POST', $request->getMethod());
     }
 
     #[DataProvider('getClientIpsProvider')]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT