### PR TITLE
 Honor psr7 protocol version

### DIFF
--- a/src/Symfony/Component/HttpClient/Psr18Client.php
+++ b/src/Symfony/Component/HttpClient/Psr18Client.php
@@ -102,9 +102,7 @@ final class Psr18Client implements ClientInterface, RequestFactoryInterface, Str
                 'body' => $body->getContents(),
             ];
 
-            if ('1.0' === $request->getProtocolVersion()) {
-                $options['http_version'] = '1.0';
-            }
+            $options['http_version'] = $request->getProtocolVersion();
 
             $response = $this->client->request($request->getMethod(), (string) $request->getUri(), $options);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? |no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | 
| License       | MIT

When a PSR-7 request is sent using `Psr18Client`, the PSR-7 request protocol version is only converted to the underlying `http_version` option when is set to `1.0`, so we cannot control that option for `1.1` or `2.0`.

I have a project where I need to dynamically force the use of protocol version `1.1` but the final request is always sent using version `2.0`.