### PR TITLE
[FrameworkBundle] Document BC break in `AbstractController::render`

### DIFF
--- a/UPGRADE-6.4.md
+++ b/UPGRADE-6.4.md
@@ -126,6 +126,7 @@ FrameworkBundle
 ---------------
 
  * [BC break] Add native return type to `Translator` and to `Application::reset()`
+ * `AbstractController::render()` no longer calls `renderView()`
  * Deprecate the integration of Doctrine annotations, either uninstall the `doctrine/annotations` package or disable
    the integration by setting `framework.annotations` to `false`
  * Deprecate not setting some config options, their defaults will change in Symfony 7.0:

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add `HttpClientAssertionsTrait`
  * Add `AbstractController::renderBlock()` and `renderBlockView()`
+ * Remove call to `renderView()` in `AbstractController::render()`
  * Add native return type to `Translator` and to `Application::reset()`
  * Deprecate the integration of Doctrine annotations, either uninstall the `doctrine/annotations` package or disable the integration by setting `framework.annotations` to `false`
  * Enable `json_decode_detailed_errors` context for Serializer by default if `kernel.debug` is true and the `seld/jsonlint` package is installed


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62046
| License       | MIT

Document a breaking change introduced in https://github.com/symfony/symfony/commit/fbf381473b533a966289f9fce8020abb376c730d