### PR TITLE
[Doctrine][Messenger] Add composite index on queue_name

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
@@ -566,7 +566,7 @@ class Connection implements ResetInterface
         } else {
             $table->setPrimaryKey(['id']);
         }
-        $table->addIndex(['queue_name']);
+        $table->addIndex(['queue_name', 'available_at', 'delivered_at']);
         $table->addIndex(['available_at']);
         $table->addIndex(['delivered_at']);
 


### PR DESCRIPTION
  | Q                    | A
  | ------------- | ---
  | Branch?         | 7.4
  | Bug fix?         | no
  | New feature?  | no
  | Deprecations? | no
  | Issues        | 
  | License       | MIT

This PR optimizes the Doctrine Messenger transport by replacing the single-column index on `queue_name` with a composite index covering `queue_name`, `available_at`, and `delivered_at`.

This improves query performance when fetching messages from specific queues, as the database can use a single covering index instead of multiple separate indexes for the common query pattern that filters by queue name and checks availability/delivery status.

The previous index is removed because it's covered by the new one.

On our production, even if individual calls are fast, lots of workers are querying quite often, so this small update reduced the total load.

Here are the explain plans before and after for the usual query (tested on 200 000 rows)
```
SELECT `m` . * FROM `messenger_messages` `m` WHERE ( `m` . `queue_name` = ? ) AND ( `m` . `delivered_at` IS NULL OR `m` . `delivered_at` < ? ) AND ( `m` . `available_at` <= ? ) ORDER BY `available_at` ASC LIMIT ? FOR UPDATE SKIP LOCKED
```

* Explain plan BEFORE*
```
-> Limit: 1 row(s)  (cost=1.02 rows=1) (actual time=0.337..0.337 rows=1 loops=1)
    -> Sort row IDs: m.available_at, limit input to 1 row(s) per chunk  (cost=1.02 rows=1) (actual time=0.335..0.335 rows=1 loops=1)
        -> Filter: (((m.delivered_at is null) or (m.delivered_at < TIMESTAMP'2025-10-08 23:51:07')) and (m.available_at <= TIMESTAMP'2025-10-09 00:51:07'))  (cost=1.02 rows=1) (actual time=0.146..0.157 rows=1 loops=1)
            -> Index lookup on m using IDX_75EA56E0FB7336F0 (queue_name='owner_ghosting_detection')  (cost=1.02 rows=1) (actual time=0.14..0.151 rows=1 loops=1)
```

* Explain plan AFTER* 

```
-> Limit: 1 row(s)  (cost=0.6 rows=1) (actual time=0.163..0.163 rows=1 loops=1)
    -> Index range scan on m using messenger_delayed_messages_queue_name_IDX over (queue_name = 'owner_ghosting_detection' AND available_at <= '2025-10-09 00:51:07' AND delivered_at < '2025-10-08 23:51:07'), with index condition: ((m.queue_name = 'owner_ghosting_detection') and ((m.delivered_at is null) or (m.delivered_at < TIMESTAMP'2025-10-08 23:51:07')) and (m.available_at <= TIMESTAMP'2025-10-09 00:51:07'))  (cost=0.6 rows=1) (actual time=0.143..0.143 rows=1 loops=1)

```
