### PR TITLE
[Console] Ensure `SHELL_VERBOSITY` is always restored properly

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -186,7 +186,8 @@ class Application implements ResetInterface
             }
         }
 
-        $prevShellVerbosity = getenv('SHELL_VERBOSITY');
+        $empty = new \stdClass();
+        $prevShellVerbosity = [$_ENV['SHELL_VERBOSITY'] ?? $empty, $_SERVER['SHELL_VERBOSITY'] ?? $empty, getenv('SHELL_VERBOSITY')];
 
         try {
             $this->configureIO($input, $output);
@@ -228,18 +229,14 @@ class Application implements ResetInterface
 
             // SHELL_VERBOSITY is set by Application::configureIO so we need to unset/reset it
             // to its previous value to avoid one command verbosity to spread to other commands
-            if (false === $prevShellVerbosity) {
-                if (\function_exists('putenv')) {
-                    @putenv('SHELL_VERBOSITY');
-                }
+            if ($empty === $_ENV['SHELL_VERBOSITY'] = $prevShellVerbosity[0]) {
                 unset($_ENV['SHELL_VERBOSITY']);
+            }
+            if ($empty === $_SERVER['SHELL_VERBOSITY'] = $prevShellVerbosity[1]) {
                 unset($_SERVER['SHELL_VERBOSITY']);
-            } else {
-                if (\function_exists('putenv')) {
-                    @putenv('SHELL_VERBOSITY='.$prevShellVerbosity);
-                }
-                $_ENV['SHELL_VERBOSITY'] = $prevShellVerbosity;
-                $_SERVER['SHELL_VERBOSITY'] = $prevShellVerbosity;
+            }
+            if (\function_exists('putenv')) {
+                @putenv('SHELL_VERBOSITY'.(false === ($prevShellVerbosity[2] ?? false) ? '' : '='.$prevShellVerbosity[2]));
             }
         }
 
@@ -945,57 +942,31 @@ class Application implements ResetInterface
      */
     protected function configureIO(InputInterface $input, OutputInterface $output): void
     {
-        if (true === $input->hasParameterOption(['--ansi'], true)) {
+        if ($input->hasParameterOption(['--ansi'], true)) {
             $output->setDecorated(true);
-        } elseif (true === $input->hasParameterOption(['--no-ansi'], true)) {
+        } elseif ($input->hasParameterOption(['--no-ansi'], true)) {
             $output->setDecorated(false);
         }
 
-        if (true === $input->hasParameterOption(['--no-interaction', '-n'], true)) {
-            $input->setInteractive(false);
-        }
+        $shellVerbosity = match (true) {
+            $input->hasParameterOption(['--silent'], true) => -2,
+            $input->hasParameterOption(['--quiet', '-q'], true) => -1,
+            $input->hasParameterOption('-vvv', true) || $input->hasParameterOption('--verbose=3', true) || 3 === $input->getParameterOption('--verbose', false, true) => 3,
+            $input->hasParameterOption('-vv', true) || $input->hasParameterOption('--verbose=2', true) || 2 === $input->getParameterOption('--verbose', false, true) => 2,
+            $input->hasParameterOption('-v', true) || $input->hasParameterOption('--verbose=1', true) || $input->hasParameterOption('--verbose', true) || $input->getParameterOption('--verbose', false, true) => 1,
+            default => (int) ($_ENV['SHELL_VERBOSITY'] ?? $_SERVER['SHELL_VERBOSITY'] ?? getenv('SHELL_VERBOSITY')),
+        };
 
-        switch ($shellVerbosity = (int) getenv('SHELL_VERBOSITY')) {
-            case -2:
-                $output->setVerbosity(OutputInterface::VERBOSITY_SILENT);
-                break;
-            case -1:
-                $output->setVerbosity(OutputInterface::VERBOSITY_QUIET);
-                break;
-            case 1:
-                $output->setVerbosity(OutputInterface::VERBOSITY_VERBOSE);
-                break;
-            case 2:
-                $output->setVerbosity(OutputInterface::VERBOSITY_VERY_VERBOSE);
-                break;
-            case 3:
-                $output->setVerbosity(OutputInterface::VERBOSITY_DEBUG);
-                break;
-            default:
-                $shellVerbosity = 0;
-                break;
-        }
+        $output->setVerbosity(match ($shellVerbosity) {
+            -2 => OutputInterface::VERBOSITY_SILENT,
+            -1 => OutputInterface::VERBOSITY_QUIET,
+            1 => OutputInterface::VERBOSITY_VERBOSE,
+            2 => OutputInterface::VERBOSITY_VERY_VERBOSE,
+            3 => OutputInterface::VERBOSITY_DEBUG,
+            default => ($shellVerbosity = 0) ?: $output->getVerbosity(),
+        });
 
-        if (true === $input->hasParameterOption(['--silent'], true)) {
-            $output->setVerbosity(OutputInterface::VERBOSITY_SILENT);
-            $shellVerbosity = -2;
-        } elseif (true === $input->hasParameterOption(['--quiet', '-q'], true)) {
-            $output->setVerbosity(OutputInterface::VERBOSITY_QUIET);
-            $shellVerbosity = -1;
-        } else {
-            if ($input->hasParameterOption('-vvv', true) || $input->hasParameterOption('--verbose=3', true) || 3 === $input->getParameterOption('--verbose', false, true)) {
-                $output->setVerbosity(OutputInterface::VERBOSITY_DEBUG);
-                $shellVerbosity = 3;
-            } elseif ($input->hasParameterOption('-vv', true) || $input->hasParameterOption('--verbose=2', true) || 2 === $input->getParameterOption('--verbose', false, true)) {
-                $output->setVerbosity(OutputInterface::VERBOSITY_VERY_VERBOSE);
-                $shellVerbosity = 2;
-            } elseif ($input->hasParameterOption('-v', true) || $input->hasParameterOption('--verbose=1', true) || $input->hasParameterOption('--verbose', true) || $input->getParameterOption('--verbose', false, true)) {
-                $output->setVerbosity(OutputInterface::VERBOSITY_VERBOSE);
-                $shellVerbosity = 1;
-            }
-        }
-
-        if (0 > $shellVerbosity) {
+        if (0 > $shellVerbosity || $input->hasParameterOption(['--no-interaction', '-n'], true)) {
             $input->setInteractive(false);
         }
 

--- a/src/Symfony/Component/HttpKernel/Log/Logger.php
+++ b/src/Symfony/Component/HttpKernel/Log/Logger.php
@@ -59,19 +59,13 @@ class Logger extends AbstractLogger implements DebugLoggerInterface
      */
     public function __construct(?string $minLevel = null, $output = null, ?callable $formatter = null, private readonly ?RequestStack $requestStack = null, bool $debug = false)
     {
-        if (null === $minLevel) {
-            $minLevel = null === $output || 'php://stdout' === $output || 'php://stderr' === $output ? LogLevel::ERROR : LogLevel::WARNING;
-
-            if (isset($_ENV['SHELL_VERBOSITY']) || isset($_SERVER['SHELL_VERBOSITY'])) {
-                $minLevel = match ((int) ($_ENV['SHELL_VERBOSITY'] ?? $_SERVER['SHELL_VERBOSITY'])) {
-                    -1 => LogLevel::ERROR,
-                    1 => LogLevel::NOTICE,
-                    2 => LogLevel::INFO,
-                    3 => LogLevel::DEBUG,
-                    default => $minLevel,
-                };
-            }
-        }
+        $minLevel ??= match ((int) ($_ENV['SHELL_VERBOSITY'] ?? $_SERVER['SHELL_VERBOSITY'] ?? 0)) {
+            -1 => LogLevel::ERROR,
+            1 => LogLevel::NOTICE,
+            2 => LogLevel::INFO,
+            3 => LogLevel::DEBUG,
+            default => null === $output || 'php://stdout' === $output || 'php://stderr' === $output ? LogLevel::ERROR : LogLevel::WARNING,
+        };
 
         if (!isset(self::LEVELS[$minLevel])) {
             throw new InvalidArgumentException(\sprintf('The log level "%s" does not exist.', $minLevel));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Related to #61033
| License       | MIT

There was a bug where if only `$_SERVER['SHELL_VERBOSITY']` or `$_ENV['SHELL_VERBOSITY']` had a value, they would be erroneously unset after command execution.

For example, in [PHPUnit's default configuration](https://github.com/symfony/recipes/blob/main/phpunit/phpunit/11.1/phpunit.dist.xml#L17), `SHELL_VERBOSITY` is set only to `$_SERVER['SHELL_VERBOSITY']`.

This caused the `SHELL_VERBOSITY` setting to be invalid after [a console command was executed internally](https://github.com/zenstruck/foundry/blob/v2.7.5/src/Test/ResetDatabase.php) using the `ResetDatabase` trait of [zenstruck/foundry](https://github.com/zenstruck/foundry).
