### PR TITLE
[HttpClient] Add option `auto_upgrade_http_version` to control how the request HTTP version is handled in `HttplugClient` and `Psr18Client`

### DIFF
--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Deprecate using amphp/http-client < 5
  * Add RFC 9111–based caching support to `CachingHttpClient`
  * Deprecate passing an instance of `StoreInterface` as `$cache` argument to `CachingHttpClient` constructor
+ * Add option `auto_upgrade_http_version` to control how the request HTTP version is handled in `HttplugClient` and `Psr18Client`
 
 7.3
 ---

--- a/src/Symfony/Component/HttpClient/HttplugClient.php
+++ b/src/Symfony/Component/HttpClient/HttplugClient.php
@@ -61,6 +61,7 @@ final class HttplugClient implements ClientInterface, HttpAsyncClient, RequestFa
     private HttpClientInterface $client;
     private ResponseFactoryInterface $responseFactory;
     private StreamFactoryInterface $streamFactory;
+    private bool $autoUpgradeHttpVersion = true;
 
     /**
      * @var \SplObjectStorage<ResponseInterface, array{RequestInterface, Promise}>|null
@@ -96,6 +97,10 @@ final class HttplugClient implements ClientInterface, HttpAsyncClient, RequestFa
     public function withOptions(array $options): static
     {
         $clone = clone $this;
+        if (\array_key_exists('auto_upgrade_http_version', $options)) {
+            $clone->autoUpgradeHttpVersion = $options['auto_upgrade_http_version'];
+            unset($options['auto_upgrade_http_version']);
+        }
         $clone->client = $clone->client->withOptions($options);
 
         return $clone;
@@ -265,8 +270,8 @@ final class HttplugClient implements ClientInterface, HttpAsyncClient, RequestFa
                 'buffer' => $buffer,
             ];
 
-            if ('1.0' === $request->getProtocolVersion()) {
-                $options['http_version'] = '1.0';
+            if (!$this->autoUpgradeHttpVersion || '1.0' === $request->getProtocolVersion()) {
+                $options['http_version'] = $request->getProtocolVersion();
             }
 
             return $this->client->request($request->getMethod(), (string) $request->getUri(), $options);

--- a/src/Symfony/Component/HttpClient/Psr18Client.php
+++ b/src/Symfony/Component/HttpClient/Psr18Client.php
@@ -53,6 +53,7 @@ final class Psr18Client implements ClientInterface, RequestFactoryInterface, Str
     private HttpClientInterface $client;
     private ResponseFactoryInterface $responseFactory;
     private StreamFactoryInterface $streamFactory;
+    private bool $autoUpgradeHttpVersion = true;
 
     public function __construct(?HttpClientInterface $client = null, ?ResponseFactoryInterface $responseFactory = null, ?StreamFactoryInterface $streamFactory = null)
     {
@@ -79,6 +80,10 @@ final class Psr18Client implements ClientInterface, RequestFactoryInterface, Str
     public function withOptions(array $options): static
     {
         $clone = clone $this;
+        if (\array_key_exists('auto_upgrade_http_version', $options)) {
+            $clone->autoUpgradeHttpVersion = $options['auto_upgrade_http_version'];
+            unset($options['auto_upgrade_http_version']);
+        }
         $clone->client = $clone->client->withOptions($options);
 
         return $clone;
@@ -128,8 +133,8 @@ final class Psr18Client implements ClientInterface, RequestFactoryInterface, Str
                 'body' => $body,
             ];
 
-            if ('1.0' === $request->getProtocolVersion()) {
-                $options['http_version'] = '1.0';
+            if (!$this->autoUpgradeHttpVersion || '1.0' === $request->getProtocolVersion()) {
+                $options['http_version'] = $request->getProtocolVersion();
             }
 
             $response = $this->client->request($request->getMethod(), (string) $request->getUri(), $options);

--- a/src/Symfony/Component/HttpClient/Tests/HttplugClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttplugClientTest.php
@@ -299,4 +299,35 @@ class HttplugClientTest extends TestCase
         $resultResponse = $client->sendRequest($request);
         $this->assertSame('Very Early Hints', $resultResponse->getReasonPhrase());
     }
+
+    public function testAutoUpgradeHttpVersion()
+    {
+        $clientWithoutOption = new HttplugClient(new MockHttpClient(function (string $method, string $url, array $options) {
+            return new MockResponse(json_encode([
+                'SERVER_PROTOCOL' => 'HTTP/'.$options['http_version'] ?? '',
+            ]), [
+                'response_headers' => [
+                    'Content-Type' => 'application/json',
+                ],
+            ]);
+        }));
+        $clientWithOptionFalse = $clientWithoutOption->withOptions(['auto_upgrade_http_version' => false]);
+
+        foreach (['1.0', '1.1', '2.0', '3.0'] as $httpVersion) {
+            $request = $clientWithoutOption->createRequest('GET', 'http://localhost:8057')
+                ->withProtocolVersion($httpVersion);
+
+            $responseWithoutOption = $clientWithoutOption->sendRequest($request);
+            $bodyWithoutOption = json_decode((string) $responseWithoutOption->getBody(), true);
+            if ('1.0' === $httpVersion) {
+                $this->assertSame('HTTP/1.0', $bodyWithoutOption['SERVER_PROTOCOL']);
+            } else {
+                $this->assertSame('HTTP/', $bodyWithoutOption['SERVER_PROTOCOL']);
+            }
+
+            $responseWithOptionFalse = $clientWithOptionFalse->sendRequest($request);
+            $bodyWithOptionFalse = json_decode((string) $responseWithOptionFalse->getBody(), true);
+            $this->assertSame('HTTP/'.$httpVersion, $bodyWithOptionFalse['SERVER_PROTOCOL']);
+        }
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        |
| License       | MIT

When a PSR-7 request is sent using `Psr18Client`, the PSR-7 request protocol version is only converted to the underlying `http_version` option when is set to `1.0`, so we cannot control that option for `1.1` or `2.0`.

I have a project where I need to dynamically force the use of protocol version `1.1` but the final request is always sent using version `2.0`.

This PR add option `auto_upgrade_http_version` to control how the request HTTP version is handled in `HttplugClient` and `Psr18Client`.

```php
$psr18Client = $psr18Client->withOptions(['auto_upgrade_http_version' => false]);

$request = $psr18Client->createRequest()->withProtocolVersion('1.1');

// [...]

// The request will use HTTP/1.1, whereas the defaults would upgrade to 2.0
$response = $psr18Client->sendRequest($request);
```