### PR TITLE
[JsonStreamer] Rebuild cache on class update

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/json_streamer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/json_streamer.php
@@ -32,6 +32,7 @@ return static function (ContainerConfigurator $container) {
                 tagged_locator('json_streamer.value_transformer'),
                 service('json_streamer.write.property_metadata_loader'),
                 param('.json_streamer.stream_writers_dir'),
+                service('config_cache_factory')->ignoreOnInvalid(),
             ])
         ->set('json_streamer.stream_reader', JsonStreamReader::class)
             ->args([
@@ -39,6 +40,7 @@ return static function (ContainerConfigurator $container) {
                 service('json_streamer.read.property_metadata_loader'),
                 param('.json_streamer.stream_readers_dir'),
                 param('.json_streamer.lazy_ghosts_dir'),
+                service('config_cache_factory')->ignoreOnInvalid(),
             ])
         ->alias(JsonStreamWriter::class, 'json_streamer.stream_writer')
         ->alias(JsonStreamReader::class, 'json_streamer.stream_reader')
@@ -106,6 +108,7 @@ return static function (ContainerConfigurator $container) {
                 param('.json_streamer.stream_writers_dir'),
                 param('.json_streamer.stream_readers_dir'),
                 service('logger')->ignoreOnInvalid(),
+                service('config_cache_factory')->ignoreOnInvalid(),
             ])
             ->tag('kernel.cache_warmer')
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/JsonStreamerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/JsonStreamerTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
 use Symfony\Bundle\FrameworkBundle\Tests\Functional\app\JsonStreamer\Dto\Dummy;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\JsonStreamer\StreamerDumper;
 use Symfony\Component\JsonStreamer\StreamReaderInterface;
 use Symfony\Component\JsonStreamer\StreamWriterInterface;
 use Symfony\Component\TypeInfo\Type;
@@ -62,6 +63,13 @@ class JsonStreamerTest extends AbstractWebTestCase
         static::getContainer()->get('json_streamer.cache_warmer.streamer.alias')->warmUp(static::getContainer()->getParameter('kernel.cache_dir'));
 
         $this->assertFileExists($streamWritersDir);
-        $this->assertCount(2, glob($streamWritersDir.'/*'));
+
+        if (!class_exists(StreamerDumper::class)) {
+            $this->assertCount(2, glob($streamWritersDir.'/*'));
+        } else {
+            $this->assertCount(2, glob($streamWritersDir.'/*.php'));
+            $this->assertCount(2, glob($streamWritersDir.'/*.php.meta'));
+            $this->assertCount(2, glob($streamWritersDir.'/*.php.meta.json'));
+        }
     }
 }

--- a/src/Symfony/Component/JsonStreamer/CacheWarmer/StreamerCacheWarmer.php
+++ b/src/Symfony/Component/JsonStreamer/CacheWarmer/StreamerCacheWarmer.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\JsonStreamer\CacheWarmer;
 
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Symfony\Component\Config\ConfigCacheFactoryInterface;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 use Symfony\Component\JsonStreamer\Exception\ExceptionInterface;
 use Symfony\Component\JsonStreamer\Mapping\PropertyMetadataLoaderInterface;
@@ -42,9 +43,10 @@ final class StreamerCacheWarmer implements CacheWarmerInterface
         string $streamWritersDir,
         string $streamReadersDir,
         private LoggerInterface $logger = new NullLogger(),
+        ?ConfigCacheFactoryInterface $configCacheFactory = null,
     ) {
-        $this->streamWriterGenerator = new StreamWriterGenerator($streamWriterPropertyMetadataLoader, $streamWritersDir);
-        $this->streamReaderGenerator = new StreamReaderGenerator($streamReaderPropertyMetadataLoader, $streamReadersDir);
+        $this->streamWriterGenerator = new StreamWriterGenerator($streamWriterPropertyMetadataLoader, $streamWritersDir, $configCacheFactory);
+        $this->streamReaderGenerator = new StreamReaderGenerator($streamReaderPropertyMetadataLoader, $streamReadersDir, $configCacheFactory);
     }
 
     public function warmUp(string $cacheDir, ?string $buildDir = null): array

--- a/src/Symfony/Component/JsonStreamer/JsonStreamReader.php
+++ b/src/Symfony/Component/JsonStreamer/JsonStreamReader.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\JsonStreamer;
 
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
 use Psr\Container\ContainerInterface;
+use Symfony\Component\Config\ConfigCacheFactoryInterface;
 use Symfony\Component\JsonStreamer\Mapping\GenericTypePropertyMetadataLoader;
 use Symfony\Component\JsonStreamer\Mapping\PropertyMetadataLoader;
 use Symfony\Component\JsonStreamer\Mapping\PropertyMetadataLoaderInterface;
@@ -46,8 +47,9 @@ final class JsonStreamReader implements StreamReaderInterface
         PropertyMetadataLoaderInterface $propertyMetadataLoader,
         string $streamReadersDir,
         ?string $lazyGhostsDir = null,
+        ?ConfigCacheFactoryInterface $configCacheFactory = null,
     ) {
-        $this->streamReaderGenerator = new StreamReaderGenerator($propertyMetadataLoader, $streamReadersDir);
+        $this->streamReaderGenerator = new StreamReaderGenerator($propertyMetadataLoader, $streamReadersDir, $configCacheFactory);
         $this->instantiator = new Instantiator();
         $this->lazyInstantiator = new LazyInstantiator($lazyGhostsDir);
     }

--- a/src/Symfony/Component/JsonStreamer/JsonStreamWriter.php
+++ b/src/Symfony/Component/JsonStreamer/JsonStreamWriter.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\JsonStreamer;
 
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
 use Psr\Container\ContainerInterface;
+use Symfony\Component\Config\ConfigCacheFactoryInterface;
 use Symfony\Component\JsonStreamer\Mapping\GenericTypePropertyMetadataLoader;
 use Symfony\Component\JsonStreamer\Mapping\PropertyMetadataLoader;
 use Symfony\Component\JsonStreamer\Mapping\PropertyMetadataLoaderInterface;
@@ -41,8 +42,9 @@ final class JsonStreamWriter implements StreamWriterInterface
         private ContainerInterface $valueTransformers,
         PropertyMetadataLoaderInterface $propertyMetadataLoader,
         string $streamWritersDir,
+        ?ConfigCacheFactoryInterface $configCacheFactory = null,
     ) {
-        $this->streamWriterGenerator = new StreamWriterGenerator($propertyMetadataLoader, $streamWritersDir);
+        $this->streamWriterGenerator = new StreamWriterGenerator($propertyMetadataLoader, $streamWritersDir, $configCacheFactory);
     }
 
     public function write(mixed $data, Type $type, array $options = []): \Traversable&\Stringable

--- a/src/Symfony/Component/JsonStreamer/StreamerDumper.php
+++ b/src/Symfony/Component/JsonStreamer/StreamerDumper.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonStreamer;
+
+use Symfony\Component\Config\ConfigCacheFactoryInterface;
+use Symfony\Component\Config\ConfigCacheInterface;
+use Symfony\Component\Config\Resource\ReflectionClassResource;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\JsonStreamer\Mapping\PropertyMetadataLoaderInterface;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\Type\GenericType;
+use Symfony\Component\TypeInfo\Type\ObjectType;
+
+/**
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ *
+ * @internal
+ */
+final class StreamerDumper
+{
+    private ?Filesystem $fs = null;
+
+    public function __construct(
+        private PropertyMetadataLoaderInterface $propertyMetadataLoader,
+        private string $cacheDir,
+        private ?ConfigCacheFactoryInterface $cacheFactory = null,
+    ) {
+    }
+
+    /**
+     * Dumps the generated content to the given path, optionally using config cache.
+     *
+     * @param callable(): string $generateContent
+     */
+    public function dump(Type $type, string $path, callable $generateContent): void
+    {
+        if ($this->cacheFactory) {
+            $this->cacheFactory->cache(
+                $path,
+                function (ConfigCacheInterface $cache) use ($generateContent, $type) {
+                    $resourceClasses = $this->getResourceClassNames($type);
+                    $cache->write(
+                        $generateContent(),
+                        array_map(fn (string $c) => new ReflectionClassResource(new \ReflectionClass($c)), $resourceClasses),
+                    );
+                },
+            );
+
+            return;
+        }
+
+        $this->fs ??= new Filesystem();
+
+        if (!$this->fs->exists($this->cacheDir)) {
+            $this->fs->mkdir($this->cacheDir);
+        }
+
+        if (!$this->fs->exists($path)) {
+            $this->fs->dumpFile($path, $generateContent());
+        }
+    }
+
+    /**
+     * Retrieves resources class names required for caching based on the provided type.
+     *
+     * @param list<class-string>   $classNames
+     * @param array<string, mixed> $context
+     *
+     * @return list<class-string>
+     */
+    private function getResourceClassNames(Type $type, array $classNames = [], array $context = []): array
+    {
+        $context['original_type'] ??= $type;
+
+        foreach ($type->traverse() as $t) {
+            if ($t instanceof ObjectType) {
+                if (\in_array($t->getClassName(), $classNames, true)) {
+                    return $classNames;
+                }
+
+                $classNames[] = $t->getClassName();
+
+                foreach ($this->propertyMetadataLoader->load($t->getClassName(), [], $context) as $property) {
+                    $classNames = [...$classNames, ...$this->getResourceClassNames($property->getType(), $classNames)];
+                }
+            }
+
+            if ($t instanceof GenericType) {
+                foreach ($t->getVariableTypes() as $variableType) {
+                    $classNames = [...$classNames, ...$this->getResourceClassNames($variableType, $classNames)];
+                }
+            }
+        }
+
+        return array_values(array_unique($classNames));
+    }
+}

--- a/src/Symfony/Component/JsonStreamer/Tests/StreamerDumperTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/StreamerDumperTest.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonStreamer\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\ConfigCacheFactory;
+use Symfony\Component\JsonStreamer\Mapping\PropertyMetadataLoader;
+use Symfony\Component\JsonStreamer\Mapping\PropertyMetadataLoaderInterface;
+use Symfony\Component\JsonStreamer\StreamerDumper;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithArray;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithOtherDummies;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummy;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\TypeResolver\TypeResolver;
+
+class StreamerDumperTest extends TestCase
+{
+    private string $cacheDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->cacheDir = \sprintf('%s/symfony_json_streamer_test/any', sys_get_temp_dir());
+
+        if (is_dir($this->cacheDir)) {
+            array_map('unlink', glob($this->cacheDir.'/*'));
+            rmdir($this->cacheDir);
+        }
+    }
+
+    public function testDumpWithConfigCache()
+    {
+        $path = $this->cacheDir.'/streamer.php';
+
+        $dumper = new StreamerDumper($this->createMock(PropertyMetadataLoaderInterface::class), $this->cacheDir, new ConfigCacheFactory(true));
+        $dumper->dump(Type::int(), $path, fn () => 'CONTENT');
+
+        $this->assertFileExists($path);
+        $this->assertFileExists($path.'.meta');
+        $this->assertFileExists($path.'.meta.json');
+
+        $this->assertStringEqualsFile($path, 'CONTENT');
+    }
+
+    public function testDumpWithoutConfigCache()
+    {
+        $path = $this->cacheDir.'/streamer.php';
+
+        $dumper = new StreamerDumper($this->createMock(PropertyMetadataLoaderInterface::class), $this->cacheDir);
+        $dumper->dump(Type::int(), $path, fn () => 'CONTENT');
+
+        $this->assertFileExists($path);
+        $this->assertStringEqualsFile($path, 'CONTENT');
+    }
+
+    /**
+     * @dataProvider getCacheResourcesDataProvider
+     *
+     * @param list<class-string> $expectedClassNames
+     */
+    public function testGetCacheResources(Type $type, array $expectedClassNames)
+    {
+        $path = $this->cacheDir.'/streamer.php';
+
+        $dumper = new StreamerDumper(new PropertyMetadataLoader(TypeResolver::create()), $this->cacheDir, new ConfigCacheFactory(true));
+        $dumper->dump($type, $path, fn () => 'CONTENT');
+
+        $resources = json_decode(file_get_contents($path.'.meta.json'), true)['resources'];
+        $classNames = array_column($resources, 'className');
+
+        $this->assertSame($expectedClassNames, $classNames);
+    }
+
+    /**
+     * @return iterable<array{0: Type, 1: list<class-string>}>
+     */
+    public static function getCacheResourcesDataProvider(): iterable
+    {
+        yield 'scalar' => [Type::int(), []];
+        yield 'enum' => [Type::enum(DummyBackedEnum::class), [DummyBackedEnum::class]];
+        yield 'object' => [Type::object(ClassicDummy::class), [ClassicDummy::class]];
+        yield 'collection of objects' => [
+            Type::list(Type::object(ClassicDummy::class)),
+            [ClassicDummy::class],
+        ];
+        yield 'generic with objects' => [
+            Type::generic(Type::object(ClassicDummy::class), Type::object(DummyWithArray::class)),
+            [DummyWithArray::class, ClassicDummy::class],
+        ];
+        yield 'union with objects' => [
+            Type::union(Type::int(), Type::object(ClassicDummy::class), Type::object(DummyWithArray::class)),
+            [ClassicDummy::class, DummyWithArray::class],
+        ];
+        yield 'intersection with objects' => [
+            Type::intersection(Type::object(ClassicDummy::class), Type::object(DummyWithArray::class)),
+            [ClassicDummy::class, DummyWithArray::class],
+        ];
+        yield 'object with object properties' => [
+            Type::object(DummyWithOtherDummies::class),
+            [DummyWithOtherDummies::class, DummyWithNameAttributes::class, ClassicDummy::class],
+        ];
+        yield 'object with self reference' => [Type::object(SelfReferencingDummy::class), [SelfReferencingDummy::class]];
+    }
+}

--- a/src/Symfony/Component/JsonStreamer/composer.json
+++ b/src/Symfony/Component/JsonStreamer/composer.json
@@ -26,6 +26,7 @@
     },
     "require-dev": {
         "phpstan/phpdoc-parser": "^1.0",
+        "symfony/config": "^7.2",
         "symfony/dependency-injection": "^7.2",
         "symfony/http-kernel": "^7.2"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62030
| License       | MIT

Having outdated stream PHP files can lead to unexpected results.

Therefore, this PR leverages the use of `ConfigCache` to regenerate streamers on resource (ie: class) change.