### PR TITLE
[MonologBridge] Improve error in logstash handler when the HttpClient component is not installed

### DIFF
--- a/src/Symfony/Bridge/Monolog/Handler/ElasticsearchLogstashHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/ElasticsearchLogstashHandler.php
@@ -63,7 +63,7 @@ class ElasticsearchLogstashHandler extends AbstractHandler
 
     public function __construct(string $endpoint = 'http://127.0.0.1:9200', string $index = 'monolog', ?HttpClientInterface $client = null, string|int|Level $level = Logger::DEBUG, bool $bubble = true, string $elasticsearchVersion = '1.0.0')
     {
-        if (!interface_exists(HttpClientInterface::class)) {
+        if (!$client && !class_exists(HttpClient::class)) {
             throw new \LogicException(\sprintf('The "%s" handler needs an HTTP client. Try running "composer require symfony/http-client".', __CLASS__));
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/monolog-bundle/issues/498
| License       | MIT

When the `symfony/http-client-contracts` is installed, but not `symfony/http-client` component, the user doesn't get the informative error message.
Fixed the message by checking if `HttpClient` class is available when `$client` parameter is not provider.