### PR TITLE
[Console] Add support for `Cursor` helper in invokable commands

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG
  * Add `#[MapInput]` attribute to support DTOs in commands
  * Add optional timeout for interaction in `QuestionHelper`
  * Add support for interactive invokable commands with `#[Interact]` and `#[Ask]` attributes
+ * Add support for `Cursor` helper in invokable commands
 
 7.3
 ---

--- a/src/Symfony/Component/Console/Command/InvokableCommand.php
+++ b/src/Symfony/Component/Console/Command/InvokableCommand.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Attribute\Argument;
 use Symfony\Component\Console\Attribute\Interact;
 use Symfony\Component\Console\Attribute\MapInput;
 use Symfony\Component\Console\Attribute\Option;
+use Symfony\Component\Console\Cursor;
 use Symfony\Component\Console\Exception\LogicException;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputArgument;
@@ -174,6 +175,7 @@ class InvokableCommand implements SignalableCommandInterface
             $parameters[] = match ($type->getName()) {
                 InputInterface::class => $input,
                 OutputInterface::class => $output,
+                Cursor::class => new Cursor($output),
                 SymfonyStyle::class => new SymfonyStyle($input, $output),
                 Application::class => $this->command->getApplication(),
                 default => throw new RuntimeException(\sprintf('Unsupported type "%s" for parameter "$%s".', $type->getName(), $parameter->getName())),

--- a/src/Symfony/Component/Console/Tests/Command/InvokableCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/InvokableCommandTest.php
@@ -14,12 +14,14 @@ namespace Symfony\Component\Console\Tests\Command;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Attribute\Argument;
 use Symfony\Component\Console\Attribute\Option;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\Console\Completion\Suggestion;
+use Symfony\Component\Console\Cursor;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Console\Exception\LogicException;
@@ -27,6 +29,7 @@ use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Console\Tests\Fixtures\InvokableTestCommand;
 
 class InvokableCommandTest extends TestCase
@@ -460,6 +463,25 @@ class InvokableCommandTest extends TestCase
         $this->expectExceptionMessage('The "--a" option requires a value.');
 
         $command->run(new ArrayInput(['--a' => null]), new NullOutput());
+    }
+
+    public function testHelpersInjection()
+    {
+        $command = new Command('foo');
+        $command->setApplication(new Application());
+        $command->setCode(function (
+            InputInterface $input,
+            OutputInterface $output,
+            Cursor $cursor,
+            SymfonyStyle $io,
+            Application $application,
+        ): int {
+            $this->addToAssertionCount(1);
+
+            return 0;
+        });
+
+        $command->run(new ArrayInput([]), new NullOutput());
     }
 
     public function getSuggestedRoles(CompletionInput $input): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

I missed including this helper in https://github.com/symfony/symfony/pull/59340 and it's particularly useful for creating dynamic console commands.

**Before:**
```php
#[AsCommand('make:pizza')]
class MakePizza
{
    public function __invoke(OutputInterface $output): int
    {
        $cursor = new Cursor($output);

        // ...
    }
}
```
**After:**
```php
#[AsCommand('make:pizza')]
class MakePizza
{
    public function __invoke(Cursor $cursor): int
    {
        // ...
    }
}
```

Cheers!