### PR TITLE
[JsonStreamer] Add synthetic properties support

### DIFF
--- a/src/Symfony/Component/JsonStreamer/CHANGELOG.md
+++ b/src/Symfony/Component/JsonStreamer/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Remove `nikic/php-parser` dependency
  * Add `_current_object` to the context passed to value transformers during write operations
  * Add `include_null_properties` option to encode the properties with `null` value
+ * Add synthetic properties support
 
 7.3
 ---

--- a/src/Symfony/Component/JsonStreamer/Mapping/PropertyMetadata.php
+++ b/src/Symfony/Component/JsonStreamer/Mapping/PropertyMetadata.php
@@ -25,19 +25,31 @@ final class PropertyMetadata
      * @param list<string|\Closure> $streamToNativeValueTransformers
      */
     public function __construct(
-        private string $name,
+        private ?string $name,
         private Type $type,
         private array $nativeToStreamValueTransformers = [],
         private array $streamToNativeValueTransformers = [],
     ) {
     }
 
-    public function getName(): string
+    /**
+     * @param list<string|\Closure> $nativeToStreamValueTransformers
+     * @param list<string|\Closure> $streamToNativeValueTransformers
+     */
+    public static function createSynthetic(
+        Type $type,
+        array $nativeToStreamValueTransformers = [],
+        array $streamToNativeValueTransformers = [],
+    ): self {
+        return new self(null, $type, $nativeToStreamValueTransformers, $streamToNativeValueTransformers);
+    }
+
+    public function getName(): ?string
     {
         return $this->name;
     }
 
-    public function withName(string $name): self
+    public function withName(?string $name): self
     {
         return new self($name, $this->type, $this->nativeToStreamValueTransformers, $this->streamToNativeValueTransformers);
     }

--- a/src/Symfony/Component/JsonStreamer/Mapping/Read/AttributePropertyMetadataLoader.php
+++ b/src/Symfony/Component/JsonStreamer/Mapping/Read/AttributePropertyMetadataLoader.php
@@ -42,8 +42,12 @@ final class AttributePropertyMetadataLoader implements PropertyMetadataLoaderInt
         $result = [];
 
         foreach ($initialResult as $initialStreamedName => $initialMetadata) {
+            if (!$initialName = $initialMetadata->getName()) {
+                continue;
+            }
+
             try {
-                $propertyReflection = new \ReflectionProperty($className, $initialMetadata->getName());
+                $propertyReflection = new \ReflectionProperty($className, $initialName);
             } catch (\ReflectionException $e) {
                 throw new RuntimeException($e->getMessage(), $e->getCode(), $e);
             }

--- a/src/Symfony/Component/JsonStreamer/Mapping/Write/AttributePropertyMetadataLoader.php
+++ b/src/Symfony/Component/JsonStreamer/Mapping/Write/AttributePropertyMetadataLoader.php
@@ -42,8 +42,12 @@ final class AttributePropertyMetadataLoader implements PropertyMetadataLoaderInt
         $result = [];
 
         foreach ($initialResult as $initialStreamedName => $initialMetadata) {
+            if (!$initialName = $initialMetadata->getName()) {
+                continue;
+            }
+
             try {
-                $propertyReflection = new \ReflectionProperty($className, $initialMetadata->getName());
+                $propertyReflection = new \ReflectionProperty($className, $initialName);
             } catch (\ReflectionException $e) {
                 throw new RuntimeException($e->getMessage(), $e->getCode(), $e);
             }

--- a/src/Symfony/Component/JsonStreamer/Read/StreamReaderGenerator.php
+++ b/src/Symfony/Component/JsonStreamer/Read/StreamReaderGenerator.php
@@ -127,6 +127,10 @@ final class StreamReaderGenerator
             $propertiesMetadata = $this->propertyMetadataLoader->load($className, $options, $context);
 
             foreach ($propertiesMetadata as $streamedName => $propertyMetadata) {
+                if (!$propertyMetadata->getName()) {
+                    continue;
+                }
+
                 $propertiesNodes[$streamedName] = [
                     'name' => $propertyMetadata->getName(),
                     'value' => $this->createDataModel($propertyMetadata->getType(), $options, $context),

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Mapping/SyntheticPropertyMetadataLoader.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Mapping/SyntheticPropertyMetadataLoader.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonStreamer\Tests\Fixtures\Mapping;
+
+use Symfony\Component\JsonStreamer\Mapping\PropertyMetadata;
+use Symfony\Component\JsonStreamer\Mapping\PropertyMetadataLoaderInterface;
+use Symfony\Component\TypeInfo\Type;
+
+final class SyntheticPropertyMetadataLoader implements PropertyMetadataLoaderInterface
+{
+    public function load(string $className, array $options = [], array $context = []): array
+    {
+        return [
+            'synthetic' => PropertyMetadata::createSynthetic(Type::true(), [
+                self::true(...),
+            ]),
+        ];
+    }
+
+    public static function true(): true
+    {
+        return true;
+    }
+}

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Model/DummyWithSyntheticProperties.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Model/DummyWithSyntheticProperties.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\JsonStreamer\Tests\Fixtures\Model;
+
+class DummyWithSyntheticProperties
+{
+}

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_synthetic_properties.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_synthetic_properties.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithSyntheticProperties
+ */
+return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
+    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithSyntheticProperties'] = static function ($data) use ($options, $valueTransformers, $instantiator, &$providers) {
+        return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithSyntheticProperties::class, \array_filter([], static function ($v) {
+            return '_symfony_missing_value' !== $v;
+        }));
+    };
+    return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithSyntheticProperties'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
+};

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_synthetic_properties.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_synthetic_properties.stream.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithSyntheticProperties
+ */
+return static function (mixed $stream, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
+    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithSyntheticProperties'] = static function ($stream, $offset, $length) use ($options, $valueTransformers, $instantiator, &$providers) {
+        $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitDict($stream, $offset, $length);
+        return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithSyntheticProperties::class, static function ($object) use ($stream, $data, $options, $valueTransformers, $instantiator, &$providers) {
+            foreach ($data as $k => $v) {
+                match ($k) {
+                    default => null,
+                };
+            }
+        });
+    };
+    return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithSyntheticProperties']($stream, 0, null);
+};

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_synthetic_properties.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_synthetic_properties.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @param Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithSyntheticProperties $data
+ */
+return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
+    try {
+        $prefix1 = '';
+        yield "{{$prefix1}\"synthetic\":";
+        yield \json_encode(Symfony\Component\JsonStreamer\Tests\Fixtures\Mapping\SyntheticPropertyMetadataLoader::true(null, ['_current_object' => $data] + $options), \JSON_THROW_ON_ERROR, 511);
+        yield "}";
+    } catch (\JsonException $e) {
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+    }
+};

--- a/src/Symfony/Component/JsonStreamer/Tests/JsonStreamReaderTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/JsonStreamReaderTest.php
@@ -12,14 +12,17 @@
 namespace Symfony\Component\JsonStreamer\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 use Symfony\Component\JsonStreamer\JsonStreamReader;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Mapping\SyntheticPropertyMetadataLoader;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDateTimes;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithGenerics;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNullableProperties;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithPhpDoc;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithSyntheticProperties;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithValueTransformerAttributes;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\ValueTransformer\DivideStringAndCastToIntValueTransformer;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\ValueTransformer\StringToBooleanValueTransformer;
@@ -174,6 +177,16 @@ class JsonStreamReaderTest extends TestCase
             $this->assertEquals(new \DateTimeImmutable('2024-11-20'), $read->interface);
             $this->assertEquals(new \DateTimeImmutable('2025-11-20'), $read->immutable);
         }, '{"interface":"2024-11-20","immutable":"2025-11-20"}', Type::object(DummyWithDateTimes::class));
+    }
+
+    public function testReadObjectWithSyntheticProperties()
+    {
+        $reader = new JsonStreamReader($this->createMock(ContainerInterface::class), new SyntheticPropertyMetadataLoader(), $this->streamReadersDir, $this->lazyGhostsDir);
+
+        $this->assertRead($reader, function (mixed $read) {
+            $this->assertInstanceOf(DummyWithSyntheticProperties::class, $read);
+            $this->assertSame([], get_object_vars($read));
+        }, '{"synthetic":true}', Type::object(DummyWithSyntheticProperties::class));
     }
 
     public function testCreateStreamReaderFile()

--- a/src/Symfony/Component/JsonStreamer/Tests/JsonStreamWriterTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/JsonStreamWriterTest.php
@@ -13,9 +13,11 @@ namespace Symfony\Component\JsonStreamer\Tests;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 use Symfony\Component\JsonStreamer\Exception\NotEncodableValueException;
 use Symfony\Component\JsonStreamer\JsonStreamWriter;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Mapping\SyntheticPropertyMetadataLoader;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithArray;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDateTimes;
@@ -25,6 +27,7 @@ use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNestedArray;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNullableProperties;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithPhpDoc;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithSyntheticProperties;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithUnionProperties;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithValueTransformerAttributes;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummy;
@@ -271,6 +274,13 @@ class JsonStreamWriterTest extends TestCase
     public function testWriteObjectWithDollarNamedProperties()
     {
         $this->assertWritten('{"$foo":true,"{$foo->bar}":true}', new DummyWithDollarNamedProperties(), Type::object(DummyWithDollarNamedProperties::class));
+    }
+
+    public function testWriteObjectWithSyntheticProperty()
+    {
+        $writer = new JsonStreamWriter($this->createMock(ContainerInterface::class), new SyntheticPropertyMetadataLoader(), $this->streamWritersDir);
+
+        $this->assertSame('{"synthetic":true}', (string) $writer->write(new DummyWithSyntheticProperties(), Type::object(DummyWithSyntheticProperties::class)));
     }
 
     #[DataProvider('throwWhenMaxDepthIsReachedDataProvider')]

--- a/src/Symfony/Component/JsonStreamer/Tests/Read/StreamReaderGeneratorTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Read/StreamReaderGeneratorTest.php
@@ -22,10 +22,12 @@ use Symfony\Component\JsonStreamer\Mapping\Read\DateTimeTypePropertyMetadataLoad
 use Symfony\Component\JsonStreamer\Read\StreamReaderGenerator;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyEnum;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Mapping\SyntheticPropertyMetadataLoader;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNullableProperties;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithOtherDummies;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithSyntheticProperties;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithUnionProperties;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithValueTransformerAttributes;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\ValueTransformer\DivideStringAndCastToIntValueTransformer;
@@ -53,9 +55,9 @@ class StreamReaderGeneratorTest extends TestCase
     }
 
     #[DataProvider('generatedStreamReaderDataProvider')]
-    public function testGeneratedStreamReader(string $fixture, Type $type)
+    public function testGeneratedStreamReader(string $fixture, Type $type, ?PropertyMetadataLoaderInterface $propertyMetadataLoader = null)
     {
-        $propertyMetadataLoader = new GenericTypePropertyMetadataLoader(
+        $propertyMetadataLoader ??= new GenericTypePropertyMetadataLoader(
             new DateTimeTypePropertyMetadataLoader(new AttributePropertyMetadataLoader(
                 new PropertyMetadataLoader(TypeResolver::create()),
                 new ServiceContainer([
@@ -81,7 +83,7 @@ class StreamReaderGeneratorTest extends TestCase
     }
 
     /**
-     * @return iterable<array{0: string, 1: Type}>
+     * @return iterable<array{0: string, 1: Type, 2?: PropertyMetadataLoaderInterface}>
      */
     public static function generatedStreamReaderDataProvider(): iterable
     {
@@ -107,6 +109,7 @@ class StreamReaderGeneratorTest extends TestCase
         yield ['object_in_object', Type::object(DummyWithOtherDummies::class)];
         yield ['object_with_nullable_properties', Type::object(DummyWithNullableProperties::class)];
         yield ['object_with_value_transformer', Type::object(DummyWithValueTransformerAttributes::class)];
+        yield ['object_with_synthetic_properties', Type::object(DummyWithSyntheticProperties::class), new SyntheticPropertyMetadataLoader()];
 
         yield ['union', Type::union(Type::int(), Type::list(Type::enum(DummyBackedEnum::class)), Type::object(DummyWithNameAttributes::class))];
         yield ['object_with_union', Type::object(DummyWithUnionProperties::class)];

--- a/src/Symfony/Component/JsonStreamer/Tests/Write/StreamWriterGeneratorTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Write/StreamWriterGeneratorTest.php
@@ -21,12 +21,14 @@ use Symfony\Component\JsonStreamer\Mapping\Write\AttributePropertyMetadataLoader
 use Symfony\Component\JsonStreamer\Mapping\Write\DateTimeTypePropertyMetadataLoader;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyEnum;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Mapping\SyntheticPropertyMetadataLoader;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithArray;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDollarNamedProperties;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNestedArray;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithOtherDummies;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithSyntheticProperties;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithUnionProperties;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithValueTransformerAttributes;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummy;
@@ -56,9 +58,9 @@ class StreamWriterGeneratorTest extends TestCase
     }
 
     #[DataProvider('generatedStreamWriterDataProvider')]
-    public function testGeneratedStreamWriter(string $fixture, Type $type)
+    public function testGeneratedStreamWriter(string $fixture, Type $type, ?PropertyMetadataLoaderInterface $propertyMetadataLoader = null)
     {
-        $propertyMetadataLoader = new GenericTypePropertyMetadataLoader(
+        $propertyMetadataLoader ??= new GenericTypePropertyMetadataLoader(
             new DateTimeTypePropertyMetadataLoader(new AttributePropertyMetadataLoader(
                 new PropertyMetadataLoader(TypeResolver::create()),
                 new ServiceContainer([
@@ -79,7 +81,7 @@ class StreamWriterGeneratorTest extends TestCase
     }
 
     /**
-     * @return iterable<array{0: string, 1: Type}>
+     * @return iterable<array{0: string, 1: Type, 2?: PropertyMetadataLoaderInterface}>
      */
     public static function generatedStreamWriterDataProvider(): iterable
     {
@@ -111,6 +113,7 @@ class StreamWriterGeneratorTest extends TestCase
         yield ['object_with_value_transformer', Type::object(DummyWithValueTransformerAttributes::class)];
         yield ['self_referencing_object', Type::object(SelfReferencingDummy::class)];
         yield ['object_with_dollar_named_properties', Type::object(DummyWithDollarNamedProperties::class)];
+        yield ['object_with_synthetic_properties', Type::object(DummyWithSyntheticProperties::class), new SyntheticPropertyMetadataLoader()];
 
         yield ['union', Type::union(Type::int(), Type::list(Type::enum(DummyBackedEnum::class)), Type::object(DummyWithNameAttributes::class))];
         yield ['object_with_union', Type::object(DummyWithUnionProperties::class)];

--- a/src/Symfony/Component/JsonStreamer/Write/StreamWriterGenerator.php
+++ b/src/Symfony/Component/JsonStreamer/Write/StreamWriterGenerator.php
@@ -133,7 +133,7 @@ final class StreamWriterGenerator
             $propertiesNodes = [];
 
             foreach ($propertiesMetadata as $streamedName => $propertyMetadata) {
-                $propertyAccessor = $accessor.'->'.$propertyMetadata->getName();
+                $propertyAccessor = $propertyMetadata->getName() ? $accessor.'->'.$propertyMetadata->getName() : 'null';
 
                 foreach ($propertyMetadata->getNativeToStreamValueTransformer() as $valueTransformer) {
                     if (\is_string($valueTransformer)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

This PR adds the support for ~virtual~ synthetic properties, which are basically values that are computed thanks to property metadata loaders only.
This could be useful for projects that are generating highly dynamic object shape, such as API Platform.

/cc @soyuka 
