### PR TITLE
[Security] Add support for `Sec-Fetch-Site` to `SameOriginCsrfTokenManager`

### DIFF
--- a/src/Symfony/Component/Security/Csrf/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Csrf/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+ * Add support for `Sec-Fetch-Site` to `SameOriginCsrfTokenManager`
+
 7.2
 ---
 

--- a/src/Symfony/Component/Security/Csrf/Tests/SameOriginCsrfTokenManagerTest.php
+++ b/src/Symfony/Component/Security/Csrf/Tests/SameOriginCsrfTokenManagerTest.php
@@ -115,6 +115,31 @@ class SameOriginCsrfTokenManagerTest extends TestCase
         $this->assertSame(1 << 8, $request->attributes->get('csrf-token'));
     }
 
+    public function testSecFetchSiteSameOrigin()
+    {
+        $request = new Request();
+        $request->headers->set('Sec-Fetch-Site', 'same-origin');
+        $this->requestStack->push($request);
+
+        $token = new CsrfToken('test_token', str_repeat('a', 24));
+
+        $this->logger->expects($this->once())->method('debug')->with('CSRF validation accepted using origin info.');
+        $this->assertTrue($this->csrfTokenManager->isTokenValid($token));
+        $this->assertSame(1 << 8, $request->attributes->get('csrf-token'));
+    }
+
+    public function testSecFetchSiteCrossSite()
+    {
+        $request = new Request();
+        $request->headers->set('Sec-Fetch-Site', 'cross-site');
+        $this->requestStack->push($request);
+
+        $token = new CsrfToken('test_token', str_repeat('a', 24));
+
+        $this->logger->expects($this->once())->method('warning')->with('CSRF validation failed: origin info doesn\'t match.');
+        $this->assertFalse($this->csrfTokenManager->isTokenValid($token));
+    }
+
     public function testValidOriginAfterDoubleSubmit()
     {
         $session = $this->createMock(Session::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Thanks to @dunglas for pointing me at https://www.alexedwards.net/blog/preventing-csrf-in-go

This check allows confirming the same-origin of the request without having to configure the X-Forwarded et al header when using a reverse-proxy.

Nice DX improvement! Browser support is almost as good as for Origin/Referer headers: https://caniuse.com/mdn-http_headers_sec-fetch-site