### PR TITLE
[FrameworkBundle] Fix secrets:encrypt-from-local

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/SecretsEncryptFromLocalCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/SecretsEncryptFromLocalCommand.php
@@ -61,14 +61,13 @@ EOF
         }
 
         foreach ($this->vault->list(true) as $name => $value) {
-            $localValue = $this->localVault->reveal($name);
+            if (null === $localValue = $this->localVault->reveal($name)) {
+                continue;
+            }
 
-            if (null !== $localValue && $value !== $localValue) {
+            if ($value !== $localValue) {
                 $this->vault->seal($name, $localValue);
-            } elseif (null !== $message = $this->localVault->getLastMessage()) {
-                $io->error($message);
-
-                return 1;
+                $io->note($this->vault->getLastMessage());
             }
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -204,7 +204,7 @@ class Configuration implements ConfigurationInterface
                     ->canBeDisabled()
                     ->children()
                         ->scalarNode('vault_directory')->defaultValue('%kernel.project_dir%/config/secrets/%kernel.runtime_environment%')->cannotBeEmpty()->end()
-                        ->scalarNode('local_dotenv_file')->defaultValue('%kernel.project_dir%/.env.%kernel.environment%.local')->end()
+                        ->scalarNode('local_dotenv_file')->defaultValue('%kernel.project_dir%/.env.%kernel.runtime_environment%.local')->end()
                         ->scalarNode('decryption_env_var')->defaultValue('base64:default::SYMFONY_DECRYPTION_SECRET')->end()
                     ->end()
                 ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/SecretsEncryptFromLocalCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/SecretsEncryptFromLocalCommandTest.php
@@ -92,7 +92,7 @@ class SecretsEncryptFromLocalCommandTest extends TestCase
         $this->assertSame('same-value', $revealed);
     }
 
-    public function testFailsIfLocalSecretIsMissing()
+    public function testStillSucceedsIfLocalSecretIsMissing()
     {
         $vault = new SodiumVault($this->vaultDir);
         $vault->generateKeys();
@@ -105,7 +105,8 @@ class SecretsEncryptFromLocalCommandTest extends TestCase
         $command = new SecretsEncryptFromLocalCommand($vault, $localVault);
         $tester = new CommandTester($command);
 
-        $this->assertSame(1, $tester->execute([]));
-        $this->assertStringContainsString('Secret "MISSING_IN_LOCAL" not found', $tester->getDisplay());
+        $this->assertSame(0, $tester->execute([]));
+        $revealed = $vault->reveal('MISSING_IN_LOCAL');
+        $this->assertSame('prod-only', $revealed);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -856,7 +856,7 @@ class ConfigurationTest extends TestCase
             'secrets' => [
                 'enabled' => true,
                 'vault_directory' => '%kernel.project_dir%/config/secrets/%kernel.runtime_environment%',
-                'local_dotenv_file' => '%kernel.project_dir%/.env.%kernel.environment%.local',
+                'local_dotenv_file' => '%kernel.project_dir%/.env.%kernel.runtime_environment%.local',
                 'decryption_env_var' => 'base64:default::SYMFONY_DECRYPTION_SECRET',
             ],
             'http_cache' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The config change fixes the "local-vault" not accounting for `APP_RUNTIME_ENV`
The command change skips values not found in the local-vault, because why fail? this is just annoying... (encrypting from local shouldn't fail if not all variables are listed in the local vault. When this happens, we should just keep the existing value in the encrypted vault)