### PR TITLE
[Messenger][Sqs] Add SQS fair queues support

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Allow auto-setup to create the queue when the DSN names the account the client already authenticates as
+ * Add `AmazonSqsFairQueueStamp` to set a `MessageGroupId` on standard queues, enabling SQS fair queues
 
 7.4
 ---

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/README.md
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/README.md
@@ -3,6 +3,34 @@ Amazon SQS Messenger
 
 Provides Amazon SQS integration for Symfony Messenger.
 
+Available stamps
+----------------
+
+- `Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsFifoStamp`
+  - Use with [FIFO queues](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-fifo-queues.html) (queue name ends with `.fifo`).
+  - Set per-message "Message group ID" and optional "Message deduplication ID".
+  - If both FIFO and FairQueue stamps are present, FIFO takes precedence.
+
+- `Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsFairQueueStamp`
+  - Enables [fair queue](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-fair-queues.html) processing on standard queues by setting `MessageGroupId`.
+  - Use a tenant/group identifier to balance processing across groups.
+  - Has no effect on FIFO queues. Ignored when FIFO stamp is present.
+
+- `Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsXrayTraceHeaderStamp`
+  - Adds an AWS X-Ray `TraceId` to the outgoing SQS message attributes.
+
+- `Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsReceivedStamp`
+  - Carries the SQS `ReceiptHandle`/message identifier for received messages.
+
+Notes
+-----
+
+- Middleware: `Symfony\Component\Messenger\Bridge\AmazonSqs\Middleware\AddFifoStampMiddleware`
+  - If the message implements `MessageDeduplicationAwareInterface`, the middleware adds `AmazonSqsFifoStamp` and sets the deduplication ID.
+  - If the message implements `MessageGroupAwareInterface`, the middleware sets the group ID on the stamp.
+
+- FIFO queues do not support per-message delay. Configure retry strategy with `delay: 0`.
+
 Sponsor
 -------
 

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsSenderTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsSenderTest.php
@@ -13,7 +13,10 @@ namespace Symfony\Component\Messenger\Bridge\AmazonSqs\Tests\Transport;
 
 use AsyncAws\Core\Exception\Http\NetworkException;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerTrait;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsFairQueueStamp;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsFifoStamp;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsSender;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsXrayTraceHeaderStamp;
@@ -88,6 +91,58 @@ class AmazonSqsSenderTest extends TestCase
 
         $sender = new AmazonSqsSender($connection, $serializer);
         $sender->send($envelope);
+    }
+
+    public function testSendWithAmazonSqsFairQueueStamp()
+    {
+        $envelope = (new Envelope(new DummyMessage('Oy')))
+            ->with($stamp = new AmazonSqsFairQueueStamp('tenant-123'));
+
+        $encoded = ['body' => '...', 'headers' => ['type' => DummyMessage::class]];
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())->method('send')
+            ->with($encoded['body'], $encoded['headers'], 0, $stamp->getMessageGroupId());
+
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->method('encode')->with($envelope)->willReturn($encoded);
+
+        $sender = new AmazonSqsSender($connection, $serializer);
+        $sender->send($envelope);
+    }
+
+    public function testSendWithAmazonSqsFairQueueStampWontWorkAlongsideFifoStamp()
+    {
+        $envelope = (new Envelope(new DummyMessage('Oy')))
+            ->with($fifoStamp = new AmazonSqsFifoStamp('testGroup', 'testDeduplicationId'))
+            ->with(new AmazonSqsFairQueueStamp('tenant-123'));
+
+        $encoded = ['body' => '...', 'headers' => ['type' => DummyMessage::class]];
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())->method('send')
+            ->with($encoded['body'], $encoded['headers'], 0, $fifoStamp->getMessageGroupId(), $fifoStamp->getMessageDeduplicationId());
+
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->method('encode')->with($envelope)->willReturn($encoded);
+
+        $logger = new class implements LoggerInterface {
+            use LoggerTrait;
+
+            public array $records = [];
+
+            public function log($level, string|\Stringable $message, array $context = []): void
+            {
+                $this->records[] = [$level, (string) $message, $context];
+            }
+        };
+
+        $sender = new AmazonSqsSender($connection, $serializer, $logger);
+        $sender->send($envelope);
+
+        $this->assertCount(1, $logger->records);
+        $this->assertSame('debug', $logger->records[0][0]);
+        $this->assertStringContainsString('takes precedence', $logger->records[0][1]);
     }
 
     public function testItConvertsNetworkExceptionDuringSendIntoTransportException()

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsFairQueueStamp.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsFairQueueStamp.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\AmazonSqs\Transport;
+
+use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
+
+final class AmazonSqsFairQueueStamp implements NonSendableStampInterface
+{
+    public function __construct(
+        private string $messageGroupId,
+    ) {
+    }
+
+    public function getMessageGroupId(): string
+    {
+        return $this->messageGroupId;
+    }
+}

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsSender.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsSender.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Messenger\Bridge\AmazonSqs\Transport;
 
 use AsyncAws\Core\Exception\Exception as AsyncAwsException;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Component\Messenger\Stamp\DelayStamp;
@@ -26,6 +27,7 @@ class AmazonSqsSender implements SenderInterface
     public function __construct(
         private Connection $connection,
         private SerializerInterface $serializer,
+        private ?LoggerInterface $logger = null,
     ) {
     }
 
@@ -46,6 +48,19 @@ class AmazonSqsSender implements SenderInterface
         if (null !== $amazonSqsFifoStamp) {
             $messageGroupId = $amazonSqsFifoStamp->getMessageGroupId();
             $messageDeduplicationId = $amazonSqsFifoStamp->getMessageDeduplicationId();
+        }
+
+        $amazonSqsFairQueueStamp = $envelope->last(AmazonSqsFairQueueStamp::class);
+        if (null !== $amazonSqsFairQueueStamp) {
+            if (null === $amazonSqsFifoStamp) {
+                $messageGroupId = $amazonSqsFairQueueStamp->getMessageGroupId();
+            } else {
+                $this->logger?->debug('Ignoring the "{fair_stamp}" of message "{class}": a "{fifo_stamp}" is also present and takes precedence.', [
+                    'fair_stamp' => AmazonSqsFairQueueStamp::class,
+                    'fifo_stamp' => AmazonSqsFifoStamp::class,
+                    'class' => $envelope->getMessage()::class,
+                ]);
+            }
         }
 
         /** @var AmazonSqsXrayTraceHeaderStamp|null $amazonSqsXrayTraceHeaderStamp */

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsTransport.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsTransport.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Messenger\Bridge\AmazonSqs\Transport;
 
 use AsyncAws\Core\Exception\Exception as AsyncAwsException;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
@@ -39,6 +40,7 @@ class AmazonSqsTransport implements TransportInterface, KeepaliveReceiverInterfa
         private (ReceiverInterface&MessageCountAwareInterface)|null $receiver = null,
         private ?SenderInterface $sender = null,
         private bool $handleRetries = true,
+        private ?LoggerInterface $logger = null,
     ) {
         $this->serializer = $serializer ?? new PhpSerializer();
     }
@@ -115,7 +117,7 @@ class AmazonSqsTransport implements TransportInterface, KeepaliveReceiverInterfa
 
     private function getSender(): SenderInterface
     {
-        return $this->sender ??= new AmazonSqsSender($this->connection, $this->serializer);
+        return $this->sender ??= new AmazonSqsSender($this->connection, $this->serializer, $this->logger);
     }
 
     private function isRedelivered(Envelope $envelope): bool

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsTransportFactory.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsTransportFactory.php
@@ -34,7 +34,7 @@ class AmazonSqsTransportFactory implements TransportFactoryInterface
     {
         unset($options['transport_name']);
 
-        return new AmazonSqsTransport(Connection::fromDsn($dsn, $options, $this->httpClient, $this->logger), $serializer, null, null, !($options['delete_on_rejection'] ?? false));
+        return new AmazonSqsTransport(Connection::fromDsn($dsn, $options, $this->httpClient, $this->logger), $serializer, null, null, !($options['delete_on_rejection'] ?? false), $this->logger);
     }
 
     public function supports(#[\SensitiveParameter] string $dsn, array $options): bool

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
@@ -421,6 +421,8 @@ class Connection
             $parameters['MessageGroupId'] = $messageGroupId ?? __METHOD__;
             $parameters['MessageDeduplicationId'] = $messageDeduplicationId ?? sha1(json_encode(['body' => $body, 'headers' => $headers]));
             unset($parameters['DelaySeconds']);
+        } elseif (null !== $messageGroupId) {
+            $parameters['MessageGroupId'] = $messageGroupId;
         }
 
         $this->client->sendMessage($parameters);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Feature #61946
| License       | MIT


## What it does and why it's needed

This PR adds support for AWS SQS fair queues by introducing a new `AmazonSqsFairQueueStamp`. Fair queues allow messages to be processed fairly across multiple message groups without requiring a FIFO queue, which is useful for multi-tenant applications where you want to prevent one tenant from monopolizing queue processing.

According to the [AWS SQS fair queues documentation](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-fair-queues.html), you can achieve fair processing in standard queues by setting the `MessageGroupId` parameter without converting to a FIFO queue.

## How it works

Add the `AmazonSqsFairQueueStamp` to your message envelope with a tenant/group identifier:

```php
use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsFairQueueStamp;

$envelope = new Envelope($message, [
    new AmazonSqsFairQueueStamp('tenant-123'),
]);

$messageBus->dispatch($envelope);
```


The stamp sets the `MessageGroupId` parameter on standard SQS queues, enabling fair message distribution across different message groups without the overhead of FIFO queues.

## Important notes

- The `AmazonSqsFairQueueStamp` only works on **standard queues** (not FIFO)
- If both `AmazonSqsFifoStamp` and `AmazonSqsFairQueueStamp` are present, the FIFO stamp takes precedence

## Changes

- Added `AmazonSqsFairQueueStamp` class
- Modified `AmazonSqsSender` to handle the fair queue stamp
- Updated `Connection` to support `MessageGroupId` on standard queues
- Added comprehensive test coverage
- Updated CHANGELOG

---
