### PR TITLE
[Process] Add missing return type for docblock Closure

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -52,7 +52,7 @@ class Process implements \IteratorAggregate
     public const ITER_SKIP_ERR = 8;     // Use this flag to skip STDERR while iterating
 
     /**
-     * @var \Closure('out'|'err', string)|null
+     * @var \Closure('out'|'err', string):bool|null
      */
     private ?\Closure $callback = null;
     private array|string $commandline;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Mini fix: the private property `$callback` gets its value from `buildCallback()` which always returns a closure with a bool return type: `@return \Closure('out'|'err', string):bool`