### PR TITLE
[TypeInfo] Fix resolving use statements with line breaks

### DIFF
--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithUses.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithUses.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\TypeInfo\Tests\Fixtures;
 
 use Symfony\Component\TypeInfo\Type;
 use \DateTimeInterface;
+
 use \DateTimeImmutable as DateTime;
 
 final class DummyWithUses

--- a/src/Symfony/Component/TypeInfo/TypeContext/TypeContextFactory.php
+++ b/src/Symfony/Component/TypeInfo/TypeContext/TypeContextFactory.php
@@ -147,7 +147,7 @@ final class TypeContextFactory
             return [];
         }
 
-        if (false === $lines = @file($fileName, \FILE_IGNORE_NEW_LINES)) {
+        if (false === $lines = @file($fileName, \FILE_IGNORE_NEW_LINES | \FILE_SKIP_EMPTY_LINES)) {
             throw new RuntimeException(\sprintf('Unable to read file "%s".', $fileName));
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

We started to hit errors after we upgraded api-platform/metadata to 4.2.0. Turns out, they switched to TypeInfo component and there is bug here which doesn't recognize use statements if there is a line break in between them, which is the case in [brick/money](https://github.com/brick/money/blob/0.10.3/src/Money.php) for instance.