### PR TITLE
[Security] revert trying different CSRF tokens in logout listener

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/LogoutListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/LogoutListener.php
@@ -69,7 +69,7 @@ class LogoutListener extends AbstractListener
         $request = $event->getRequest();
 
         if (null !== $this->csrfTokenManager) {
-            $csrfToken = ParameterBagUtils::getRequestParameterValue($request, $this->options['csrf_parameter'], $request->request->all());
+            $csrfToken = ParameterBagUtils::getRequestParameterValue($request, $this->options['csrf_parameter']);
 
             if (!\is_string($csrfToken) || false === $this->csrfTokenManager->isTokenValid(new CsrfToken($this->options['csrf_token_id'], $csrfToken))) {
                 throw new LogoutException('Invalid CSRF token.');

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/LogoutListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/LogoutListenerTest.php
@@ -50,15 +50,15 @@ class LogoutListenerTest extends TestCase
         $this->assertFalse($logoutEventDispatched, 'LogoutEvent should not have been dispatched.');
     }
 
-    public function testHandleMatchedPathWithCsrfValidation()
+    /**
+     * @dataProvider requestWithCsrfTokenProvider
+     */
+    public function testHandleMatchedPathWithCsrfValidation(Request $request)
     {
         $tokenManager = $this->getTokenManager();
         $dispatcher = $this->getEventDispatcher();
 
         [$listener, $tokenStorage, $httpUtils, $options] = $this->getListener($dispatcher, $tokenManager);
-
-        $request = new Request();
-        $request->query->set('_csrf_token', 'token');
 
         $httpUtils->expects($this->once())
             ->method('checkRequestPath')
@@ -67,6 +67,9 @@ class LogoutListenerTest extends TestCase
 
         $tokenManager->expects($this->once())
             ->method('isTokenValid')
+            ->with($this->callback(static function (CsrfToken $token): bool {
+                return 'token' === $token->getValue();
+            }))
             ->willReturn(true);
 
         $response = new Response();
@@ -89,47 +92,12 @@ class LogoutListenerTest extends TestCase
         $this->assertSame($response, $event->getResponse());
     }
 
-    public function testHandleMatchedPathWithCsrfInQueryParamAndBody()
+    public function requestWithCsrfTokenProvider()
     {
-        $tokenManager = $this->getTokenManager();
-        $dispatcher = $this->getEventDispatcher();
-
-        [$listener, $tokenStorage, $httpUtils, $options] = $this->getListener($dispatcher, $tokenManager);
-
-        $request = new Request();
-        $request->query->set('_csrf_token', 'token');
-        $request->request->set('_csrf_token', 'token2');
-
-        $httpUtils->expects($this->once())
-            ->method('checkRequestPath')
-            ->with($request, $options['logout_path'])
-            ->willReturn(true);
-
-        $tokenManager->expects($this->once())
-            ->method('isTokenValid')
-            ->with($this->callback(function ($token) {
-                return $token instanceof CsrfToken && 'token2' === $token->getValue();
-            }))
-            ->willReturn(true);
-
-        $response = new Response();
-        $dispatcher->addListener(LogoutEvent::class, function (LogoutEvent $event) use ($response) {
-            $event->setResponse($response);
-        });
-
-        $tokenStorage->expects($this->once())
-            ->method('getToken')
-            ->willReturn($token = $this->getToken());
-
-        $tokenStorage->expects($this->once())
-            ->method('setToken')
-            ->with(null);
-
-        $event = new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
-
-        $listener($event);
-
-        $this->assertSame($response, $event->getResponse());
+        return [
+            'GET' => [Request::create('/', 'GET', ['_csrf_token' => 'token'])],
+            'POST' => [Request::create('/', 'POST', ['_csrf_token' => 'token'])],
+        ];
     }
 
     public function testHandleMatchedPathWithoutCsrfValidation()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

I suggest to revert #62037 as I doubt that the proposed fix is the solution for the problem described. First, we are now always reading data from the request body as mentioned in https://github.com/symfony/symfony/pull/62037#discussion_r2426130233.

Then, the issue the PR tries to fix is described as follows:

> When using the `logout_path` (or `logout_url`) twig function with stateless csrf, the generator creates a link with an invalid CSRF token parameter (`/logout?_csrf_token=csrf-token`), which then causes an error during logout (`Invalid CSRF token`), since the LogoutListener reads the token from the query parameter first.

IMO what this really means is that the shouldn't be a URL with an invalid token being generated in the first place instead of doing guess work in the listener about which one to pick.

I have added a test to prove that the listener is able to properly validate CSRF tokens as part of the request body as well as tokens provided as URL parameters.