### PR TITLE
[BrowserKit] The BrowserKit history with parameter separator without slash.

### DIFF
--- a/src/Symfony/Component/BrowserKit/AbstractBrowser.php
+++ b/src/Symfony/Component/BrowserKit/AbstractBrowser.php
@@ -656,7 +656,7 @@ abstract class AbstractBrowser
             $uri = $path.$uri;
         }
 
-        return preg_replace('#^(.*?//[^/]+)\/.*$#', '$1', $currentUri).$uri;
+        return preg_replace('#^(.*?//[^/?]+)[/?].*$#', '$1', $currentUri).$uri;
     }
 
     /**

--- a/src/Symfony/Component/BrowserKit/Tests/AbstractBrowserTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/AbstractBrowserTest.php
@@ -889,4 +889,13 @@ class AbstractBrowserTest extends TestCase
 
         $client->getInternalRequest();
     }
+
+    public function testHistoryWithParametersAndNoSlash()
+    {
+        $client = $this->getBrowser();
+        $client->request('GET', 'https://www.example.com?the=value');
+        $client->request('GET', '/path/?parameter=value');
+
+        $this->assertSame('https://www.example.com/path/?parameter=value', $client->getRequest()->getUri(), '->request() history provides proper base.');
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| License       | MIT

When the test browser hits the page with the `?` parameters separator without the slash `/`, and next call requires query parameters, the test is failing.
