### PR TITLE
[Config][DependencyInjection] Deprecate the fluent PHP format for semantic configuration

### DIFF
--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -23,6 +23,7 @@ Config
 
  * Deprecate accessing the internal scope of the loader in PHP config files, use only its public API instead
  * Deprecate setting a default value to a node that is required, and vice versa
+ * Deprecate generating fluent methods in config builders
 
 Console
 -------
@@ -40,6 +41,15 @@ DependencyInjection
  * Deprecate `ExtensionInterface::getXsdValidationBasePath()` and `getNamespace()`;
    bundles that need to support older versions of Symfony can keep the methods
    but need to add the `@deprecated` annotation on them
+ * Deprecate the fluent PHP format for semantic configuration, instantiate builders inline with the config array as argument and return them instead:
+   ```diff
+   -return function (AcmeConfig $config) {
+   -    $config->color('red');
+   -}
+   +return new AcmeConfig([
+   +    'color' => 'red',
+   +]);
+   ```
 
 DoctrineBridge
 --------------

--- a/src/Symfony/Component/Config/Builder/ClassBuilder.php
+++ b/src/Symfony/Component/Config/Builder/ClassBuilder.php
@@ -38,6 +38,7 @@ class ClassBuilder
         private string $namespace,
         string $name,
         private NodeInterface $node,
+        public readonly bool $isRoot = false,
     ) {
         $this->name = ucfirst($this->camelCase($name)).'Config';
     }
@@ -73,7 +74,7 @@ class ClassBuilder
             $use .= \sprintf('use %s;', $statement)."\n";
         }
 
-        $implements = [] === $this->implements ? '' : 'implements '.implode(', ', $this->implements);
+        $implements = $this->implements ? 'implements '.implode(', ', $this->implements) : '';
         $body = '';
         foreach ($this->properties as $property) {
             $body .= '    '.$property->getContent()."\n";

--- a/src/Symfony/Component/Config/CHANGELOG.md
+++ b/src/Symfony/Component/Config/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Add array-shapes to generated config builders
  * Deprecate accessing the internal scope of the loader in PHP config files, use only its public API instead
  * Deprecate setting a default value to a node that is required, and vice versa
+ * Deprecate generating fluent methods in config builders
 
 7.3
 ---

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList.config.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList.config.php
@@ -11,27 +11,35 @@
 
 use Symfony\Config\AddToListConfig;
 
-return static function (AddToListConfig $config) {
-    $config->translator()->fallbacks(['sv', 'fr', 'es']);
-    $config->translator()->source('\\Acme\\Foo', 'yellow');
-    $config->translator()->source('\\Acme\\Bar', 'green');
-
-    $config->messenger([
+return new AddToListConfig([
+    'translator' => [
+        'fallbacks' => ['sv', 'fr', 'es'],
+        'sources' => [
+            '\\Acme\\Foo' => 'yellow',
+            '\\Acme\\Bar' => 'green',
+        ],
+    ],
+    'messenger' => [
         'routing' => [
             'Foo\\MyArrayMessage' => [
                 'senders' => ['workqueue'],
             ],
+            'Foo\\Message' => [
+                'senders' => ['workqueue'],
+            ],
+            'Foo\\DoubleMessage' => [
+                'senders' => ['sync', 'workqueue'],
+            ],
         ],
-    ]);
-    $config->messenger()
-        ->routing('Foo\\Message')->senders(['workqueue']);
-    $config->messenger()
-        ->routing('Foo\\DoubleMessage')->senders(['sync', 'workqueue']);
-
-    $config->messenger()->receiving()
-        ->color('blue')
-        ->priority(10);
-    $config->messenger()->receiving()
-        ->color('red')
-        ->priority(5);
-};
+        'receiving' => [
+            [
+                'color' => 'blue',
+                'priority' => 10,
+            ],
+            [
+                'color' => 'red',
+                'priority' => 5,
+            ],
+        ],
+    ],
+]);

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList.legacy.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList.legacy.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Config\AddToListConfig;
+
+return static function (AddToListConfig $config) {
+    $config->translator()->fallbacks(['sv', 'fr', 'es']);
+    $config->translator()->source('\\Acme\\Foo', 'yellow');
+    $config->translator()->source('\\Acme\\Bar', 'green');
+
+    $config->messenger([
+        'routing' => [
+            'Foo\\MyArrayMessage' => [
+                'senders' => ['workqueue'],
+            ],
+        ],
+    ]);
+    $config->messenger()
+        ->routing('Foo\\Message')->senders(['workqueue']);
+    $config->messenger()
+        ->routing('Foo\\DoubleMessage')->senders(['sync', 'workqueue']);
+
+    $config->messenger()->receiving()
+        ->color('blue')
+        ->priority(10);
+    $config->messenger()->receiving()
+        ->color('red')
+        ->priority(5);
+};

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/Translator/BooksConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/Translator/BooksConfig.php
@@ -17,7 +17,7 @@ class BooksConfig
     /**
      * @example "page 1"
      * @default {"number":1,"content":""}
-    */
+     */
     public function page(array $value = []): \Symfony\Config\AddToList\Translator\Books\PageConfig
     {
         $this->_usedProperties['page'] = true;

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/TranslatorConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToList/TranslatorConfig.php
@@ -44,7 +44,7 @@ class TranslatorConfig
     /**
      * looks for translation in old fashion way
      * @deprecated Since symfony/config 6.0: The child node "books" at path "add_to_list.translator" is deprecated.
-    */
+     */
     public function books(array $value = []): \Symfony\Config\AddToList\Translator\BooksConfig
     {
         if (null === $this->books) {

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToListConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList/Symfony/Config/AddToListConfig.php
@@ -15,9 +15,14 @@ class AddToListConfig implements \Symfony\Component\Config\Builder\ConfigBuilder
     private $translator;
     private $messenger;
     private $_usedProperties = [];
+    private $_hasDeprecatedCalls = false;
 
+    /**
+     * @deprecated since Symfony 7.4
+     */
     public function translator(array $value = []): \Symfony\Config\AddToList\TranslatorConfig
     {
+        $this->_hasDeprecatedCalls = true;
         if (null === $this->translator) {
             $this->_usedProperties['translator'] = true;
             $this->translator = new \Symfony\Config\AddToList\TranslatorConfig($value);
@@ -28,8 +33,12 @@ class AddToListConfig implements \Symfony\Component\Config\Builder\ConfigBuilder
         return $this->translator;
     }
 
+    /**
+     * @deprecated since Symfony 7.4
+     */
     public function messenger(array $value = []): \Symfony\Config\AddToList\MessengerConfig
     {
+        $this->_hasDeprecatedCalls = true;
         if (null === $this->messenger) {
             $this->_usedProperties['messenger'] = true;
             $this->messenger = new \Symfony\Config\AddToList\MessengerConfig($value);
@@ -95,6 +104,9 @@ class AddToListConfig implements \Symfony\Component\Config\Builder\ConfigBuilder
         }
         if (isset($this->_usedProperties['messenger'])) {
             $output['messenger'] = $this->messenger->toArray();
+        }
+        if ($this->_hasDeprecatedCalls) {
+            trigger_deprecation('symfony/config', '7.4', 'Calling any fluent method on "%s" is deprecated; pass the configuration to the constructor instead.', $this::class);
         }
 
         return $output;

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys.config.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys.config.php
@@ -11,30 +11,29 @@
 
 use Symfony\Config\ArrayExtraKeysConfig;
 
-return static function (ArrayExtraKeysConfig $config) {
-    $config->foo([
+return new ArrayExtraKeysConfig([
+    'foo' => [
+        'baz' => 'foo_baz',
+        'qux' => 'foo_qux',
         'extra1' => 'foo_extra1',
-    ])
-        ->baz('foo_baz')
-        ->qux('foo_qux')
-        ->set('extra2', 'foo_extra2')
-        ->set('extra3', 'foo_extra3');
-
-    $config->bar([
-        'extra1' => 'bar1_extra1',
-    ])
-        ->corge('bar1_corge')
-        ->grault('bar1_grault')
-        ->set('extra2', 'bar1_extra2')
-        ->set('extra3', 'bar1_extra3');
-
-    $config->bar([
-        'extra1' => 'bar2_extra1',
-        'extra4' => 'bar2_extra4',
-    ])
-        ->corge('bar2_corge')
-        ->grault('bar2_grault')
-        ->set('extra2', 'bar2_extra2')
-        ->set('extra3', 'bar2_extra3')
-        ->set('extra4', null);
-};
+        'extra2' => 'foo_extra2',
+        'extra3' => 'foo_extra3',
+    ],
+    'bar' => [
+        [
+            'corge' => 'bar1_corge',
+            'grault' => 'bar1_grault',
+            'extra1' => 'bar1_extra1',
+            'extra2' => 'bar1_extra2',
+            'extra3' => 'bar1_extra3',
+        ],
+        [
+            'corge' => 'bar2_corge',
+            'grault' => 'bar2_grault',
+            'extra1' => 'bar2_extra1',
+            'extra4' => null,
+            'extra2' => 'bar2_extra2',
+            'extra3' => 'bar2_extra3',
+        ],
+    ],
+]);

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys.legacy.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys.legacy.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Config\ArrayExtraKeysConfig;
+
+return static function (ArrayExtraKeysConfig $config) {
+    $config->foo([
+        'extra1' => 'foo_extra1',
+    ])
+        ->baz('foo_baz')
+        ->qux('foo_qux')
+        ->set('extra2', 'foo_extra2')
+        ->set('extra3', 'foo_extra3');
+
+    $config->bar([
+        'extra1' => 'bar1_extra1',
+    ])
+        ->corge('bar1_corge')
+        ->grault('bar1_grault')
+        ->set('extra2', 'bar1_extra2')
+        ->set('extra3', 'bar1_extra3');
+
+    $config->bar([
+        'extra1' => 'bar2_extra1',
+        'extra4' => 'bar2_extra4',
+    ])
+        ->corge('bar2_corge')
+        ->grault('bar2_grault')
+        ->set('extra2', 'bar2_extra2')
+        ->set('extra3', 'bar2_extra3')
+        ->set('extra4', null);
+};

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeysConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys/Symfony/Config/ArrayExtraKeysConfig.php
@@ -17,9 +17,14 @@ class ArrayExtraKeysConfig implements \Symfony\Component\Config\Builder\ConfigBu
     private $bar;
     private $baz;
     private $_usedProperties = [];
+    private $_hasDeprecatedCalls = false;
 
+    /**
+     * @deprecated since Symfony 7.4
+     */
     public function foo(array $value = []): \Symfony\Config\ArrayExtraKeys\FooConfig
     {
+        $this->_hasDeprecatedCalls = true;
         if (null === $this->foo) {
             $this->_usedProperties['foo'] = true;
             $this->foo = new \Symfony\Config\ArrayExtraKeys\FooConfig($value);
@@ -30,15 +35,23 @@ class ArrayExtraKeysConfig implements \Symfony\Component\Config\Builder\ConfigBu
         return $this->foo;
     }
 
+    /**
+     * @deprecated since Symfony 7.4
+     */
     public function bar(array $value = []): \Symfony\Config\ArrayExtraKeys\BarConfig
     {
+        $this->_hasDeprecatedCalls = true;
         $this->_usedProperties['bar'] = true;
 
         return $this->bar[] = new \Symfony\Config\ArrayExtraKeys\BarConfig($value);
     }
 
+    /**
+     * @deprecated since Symfony 7.4
+     */
     public function baz(array $value = []): \Symfony\Config\ArrayExtraKeys\BazConfig
     {
+        $this->_hasDeprecatedCalls = true;
         if (null === $this->baz) {
             $this->_usedProperties['baz'] = true;
             $this->baz = new \Symfony\Config\ArrayExtraKeys\BazConfig($value);
@@ -105,6 +118,9 @@ class ArrayExtraKeysConfig implements \Symfony\Component\Config\Builder\ConfigBu
         }
         if (isset($this->_usedProperties['baz'])) {
             $output['baz'] = $this->baz->toArray();
+        }
+        if ($this->_hasDeprecatedCalls) {
+            trigger_deprecation('symfony/config', '7.4', 'Calling any fluent method on "%s" is deprecated; pass the configuration to the constructor instead.', $this::class);
         }
 
         return $output;

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayValues.config.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayValues.config.php
@@ -11,9 +11,12 @@
 
 use Symfony\Config\ArrayValuesConfig;
 
-return static function (ArrayValuesConfig $config) {
-    $config->transports('foo')->dsn('bar');
-    $config->transports('bar', ['dsn' => 'foobar']);
-
-    $config->errorPages()->withTrace(false);
-};
+return new ArrayValuesConfig([
+    'transports' => [
+        'foo' => ['dsn' => 'bar'],
+        'bar' => ['dsn' => 'foobar'],
+    ],
+    'error_pages' => [
+        'with_trace' => false,
+    ],
+]);

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayValues.legacy.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayValues.legacy.php
@@ -9,8 +9,11 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\Config\VariableTypeConfig;
+use Symfony\Config\ArrayValuesConfig;
 
-return new VariableTypeConfig([
-    'any_value' => 'foobar',
-]);
+return static function (ArrayValuesConfig $config) {
+    $config->transports('foo')->dsn('bar');
+    $config->transports('bar', ['dsn' => 'foobar']);
+
+    $config->errorPages()->withTrace(false);
+};

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayValues/Symfony/Config/ArrayValuesConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayValues/Symfony/Config/ArrayValuesConfig.php
@@ -15,15 +15,18 @@ class ArrayValuesConfig implements \Symfony\Component\Config\Builder\ConfigBuild
     private $transports;
     private $errorPages;
     private $_usedProperties = [];
+    private $_hasDeprecatedCalls = false;
 
     /**
      * @template TValue of string|array
      * @param TValue $value
      * @return \Symfony\Config\ArrayValues\TransportsConfig|$this
      * @psalm-return (TValue is array ? \Symfony\Config\ArrayValues\TransportsConfig : static)
+     * @deprecated since Symfony 7.4
      */
     public function transports(string $name, string|array $value = []): \Symfony\Config\ArrayValues\TransportsConfig|static
     {
+        $this->_hasDeprecatedCalls = true;
         if (!\is_array($value)) {
             $this->_usedProperties['transports'] = true;
             $this->transports[$name] = $value;
@@ -47,9 +50,11 @@ class ArrayValuesConfig implements \Symfony\Component\Config\Builder\ConfigBuild
      * @default {"enabled":false}
      * @return \Symfony\Config\ArrayValues\ErrorPagesConfig|$this
      * @psalm-return (TValue is array ? \Symfony\Config\ArrayValues\ErrorPagesConfig : static)
+     * @deprecated since Symfony 7.4
      */
     public function errorPages(array|bool $value = []): \Symfony\Config\ArrayValues\ErrorPagesConfig|static
     {
+        $this->_hasDeprecatedCalls = true;
         if (!\is_array($value)) {
             $this->_usedProperties['errorPages'] = true;
             $this->errorPages = $value;
@@ -110,6 +115,9 @@ class ArrayValuesConfig implements \Symfony\Component\Config\Builder\ConfigBuild
         }
         if (isset($this->_usedProperties['errorPages'])) {
             $output['error_pages'] = $this->errorPages instanceof \Symfony\Config\ArrayValues\ErrorPagesConfig ? $this->errorPages->toArray() : $this->errorPages;
+        }
+        if ($this->_hasDeprecatedCalls) {
+            trigger_deprecation('symfony/config', '7.4', 'Calling any fluent method on "%s" is deprecated; pass the configuration to the constructor instead.', $this::class);
         }
 
         return $output;

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues.config.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues.config.php
@@ -11,14 +11,22 @@
 
 use Symfony\Config\NodeInitialValuesConfig;
 
-return static function (NodeInitialValuesConfig $config) {
-    $config->someCleverName(['second' => 'foo', 'third' => null])->first('bar');
-    $config->messenger()
-        ->transports('fast_queue', ['dsn' => 'sync://'])
-        ->serializer('acme');
-
-    $config->messenger()
-        ->transports('slow_queue')
-        ->dsn('doctrine://')
-        ->options(['table' => 'my_messages']);
-};
+return new NodeInitialValuesConfig([
+    'some_clever_name' => [
+        'first' => 'bar',
+        'second' => 'foo',
+        'third' => null,
+    ],
+    'messenger' => [
+        'transports' => [
+            'fast_queue' => [
+                'dsn' => 'sync://',
+                'serializer' => 'acme',
+            ],
+            'slow_queue' => [
+                'dsn' => 'doctrine://',
+                'options' => ['table' => 'my_messages'],
+            ],
+        ],
+    ],
+]);

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues.legacy.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues.legacy.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Config\NodeInitialValuesConfig;
+
+return static function (NodeInitialValuesConfig $config) {
+    $config->someCleverName(['second' => 'foo', 'third' => null])->first('bar');
+    $config->messenger()
+        ->transports('fast_queue', ['dsn' => 'sync://'])
+        ->serializer('acme');
+
+    $config->messenger()
+        ->transports('slow_queue')
+        ->dsn('doctrine://')
+        ->options(['table' => 'my_messages']);
+};

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValuesConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues/Symfony/Config/NodeInitialValuesConfig.php
@@ -15,9 +15,14 @@ class NodeInitialValuesConfig implements \Symfony\Component\Config\Builder\Confi
     private $someCleverName;
     private $messenger;
     private $_usedProperties = [];
+    private $_hasDeprecatedCalls = false;
 
+    /**
+     * @deprecated since Symfony 7.4
+     */
     public function someCleverName(array $value = []): \Symfony\Config\NodeInitialValues\SomeCleverNameConfig
     {
+        $this->_hasDeprecatedCalls = true;
         if (null === $this->someCleverName) {
             $this->_usedProperties['someCleverName'] = true;
             $this->someCleverName = new \Symfony\Config\NodeInitialValues\SomeCleverNameConfig($value);
@@ -28,8 +33,12 @@ class NodeInitialValuesConfig implements \Symfony\Component\Config\Builder\Confi
         return $this->someCleverName;
     }
 
+    /**
+     * @deprecated since Symfony 7.4
+     */
     public function messenger(array $value = []): \Symfony\Config\NodeInitialValues\MessengerConfig
     {
+        $this->_hasDeprecatedCalls = true;
         if (null === $this->messenger) {
             $this->_usedProperties['messenger'] = true;
             $this->messenger = new \Symfony\Config\NodeInitialValues\MessengerConfig($value);
@@ -88,6 +97,9 @@ class NodeInitialValuesConfig implements \Symfony\Component\Config\Builder\Confi
         }
         if (isset($this->_usedProperties['messenger'])) {
             $output['messenger'] = $this->messenger->toArray();
+        }
+        if ($this->_hasDeprecatedCalls) {
+            trigger_deprecation('symfony/config', '7.4', 'Calling any fluent method on "%s" is deprecated; pass the configuration to the constructor instead.', $this::class);
         }
 
         return $output;

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/Placeholders.legacy.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/Placeholders.legacy.php
@@ -13,8 +13,8 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Config\PlaceholdersConfig;
 
-return new PlaceholdersConfig([
-    'enabled' => env('FOO_ENABLED')->bool(),
-    'favorite_float' => param('eulers_number'),
-    'good_integers' => env('MY_INTEGERS')->json(),
-]);
+return static function (PlaceholdersConfig $config) {
+    $config->enabled(env('FOO_ENABLED')->bool());
+    $config->favoriteFloat(param('eulers_number'));
+    $config->goodIntegers(env('MY_INTEGERS')->json());
+};

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/Placeholders/Symfony/Config/PlaceholdersConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/Placeholders/Symfony/Config/PlaceholdersConfig.php
@@ -14,14 +14,17 @@ class PlaceholdersConfig implements \Symfony\Component\Config\Builder\ConfigBuil
     private $favoriteFloat;
     private $goodIntegers;
     private $_usedProperties = [];
+    private $_hasDeprecatedCalls = false;
 
     /**
      * @default false
      * @param ParamConfigurator|bool $value
      * @return $this
+     * @deprecated since Symfony 7.4
      */
     public function enabled($value): static
     {
+        $this->_hasDeprecatedCalls = true;
         $this->_usedProperties['enabled'] = true;
         $this->enabled = $value;
 
@@ -32,9 +35,11 @@ class PlaceholdersConfig implements \Symfony\Component\Config\Builder\ConfigBuil
      * @default null
      * @param ParamConfigurator|float $value
      * @return $this
+     * @deprecated since Symfony 7.4
      */
     public function favoriteFloat($value): static
     {
+        $this->_hasDeprecatedCalls = true;
         $this->_usedProperties['favoriteFloat'] = true;
         $this->favoriteFloat = $value;
 
@@ -45,9 +50,11 @@ class PlaceholdersConfig implements \Symfony\Component\Config\Builder\ConfigBuil
      * @param ParamConfigurator|list<ParamConfigurator|int> $value
      *
      * @return $this
+     * @deprecated since Symfony 7.4
      */
     public function goodIntegers(ParamConfigurator|array $value): static
     {
+        $this->_hasDeprecatedCalls = true;
         $this->_usedProperties['goodIntegers'] = true;
         $this->goodIntegers = $value;
 
@@ -102,6 +109,9 @@ class PlaceholdersConfig implements \Symfony\Component\Config\Builder\ConfigBuil
         }
         if (isset($this->_usedProperties['goodIntegers'])) {
             $output['good_integers'] = $this->goodIntegers;
+        }
+        if ($this->_hasDeprecatedCalls) {
+            trigger_deprecation('symfony/config', '7.4', 'Calling any fluent method on "%s" is deprecated; pass the configuration to the constructor instead.', $this::class);
         }
 
         return $output;

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/PrimitiveTypes.config.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/PrimitiveTypes.config.php
@@ -11,13 +11,13 @@
 
 use Symfony\Config\PrimitiveTypesConfig;
 
-return static function (PrimitiveTypesConfig $config) {
-    $config->booleanNode(true);
-    $config->enumNode('foo');
-    $config->fqcnEnumNode('bar');
-    $config->fqcnUnitEnumNode(\Symfony\Component\Config\Tests\Fixtures\TestEnum::Bar);
-    $config->floatNode(47.11);
-    $config->integerNode(1337);
-    $config->scalarNode('foobar');
-    $config->scalarNodeWithDefault(null);
-};
+return new PrimitiveTypesConfig([
+    'boolean_node' => true,
+    'enum_node' => 'foo',
+    'fqcn_enum_node' => 'bar',
+    'fqcn_unit_enum_node' => \Symfony\Component\Config\Tests\Fixtures\TestEnum::Bar,
+    'float_node' => 47.11,
+    'integer_node' => 1337,
+    'scalar_node' => 'foobar',
+    'scalar_node_with_default' => null,
+]);

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/PrimitiveTypes.legacy.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/PrimitiveTypes.legacy.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Config\PrimitiveTypesConfig;
+
+return static function (PrimitiveTypesConfig $config) {
+    $config->booleanNode(true);
+    $config->enumNode('foo');
+    $config->fqcnEnumNode('bar');
+    $config->fqcnUnitEnumNode(\Symfony\Component\Config\Tests\Fixtures\TestEnum::Bar);
+    $config->floatNode(47.11);
+    $config->integerNode(1337);
+    $config->scalarNode('foobar');
+    $config->scalarNodeWithDefault(null);
+};

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/PrimitiveTypes/Symfony/Config/PrimitiveTypesConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/PrimitiveTypes/Symfony/Config/PrimitiveTypesConfig.php
@@ -19,14 +19,17 @@ class PrimitiveTypesConfig implements \Symfony\Component\Config\Builder\ConfigBu
     private $scalarNode;
     private $scalarNodeWithDefault;
     private $_usedProperties = [];
+    private $_hasDeprecatedCalls = false;
 
     /**
      * @default null
      * @param ParamConfigurator|bool $value
      * @return $this
+     * @deprecated since Symfony 7.4
      */
     public function booleanNode($value): static
     {
+        $this->_hasDeprecatedCalls = true;
         $this->_usedProperties['booleanNode'] = true;
         $this->booleanNode = $value;
 
@@ -37,9 +40,11 @@ class PrimitiveTypesConfig implements \Symfony\Component\Config\Builder\ConfigBu
      * @default null
      * @param ParamConfigurator|'foo'|'bar'|'baz'|\Symfony\Component\Config\Tests\Fixtures\TestEnum::Bar $value
      * @return $this
+     * @deprecated since Symfony 7.4
      */
     public function enumNode($value): static
     {
+        $this->_hasDeprecatedCalls = true;
         $this->_usedProperties['enumNode'] = true;
         $this->enumNode = $value;
 
@@ -50,9 +55,11 @@ class PrimitiveTypesConfig implements \Symfony\Component\Config\Builder\ConfigBu
      * @default null
      * @param ParamConfigurator|\Symfony\Component\Config\Tests\Fixtures\StringBackedTestEnum::Foo|\Symfony\Component\Config\Tests\Fixtures\StringBackedTestEnum::Bar $value
      * @return $this
+     * @deprecated since Symfony 7.4
      */
     public function fqcnEnumNode($value): static
     {
+        $this->_hasDeprecatedCalls = true;
         $this->_usedProperties['fqcnEnumNode'] = true;
         $this->fqcnEnumNode = $value;
 
@@ -63,9 +70,11 @@ class PrimitiveTypesConfig implements \Symfony\Component\Config\Builder\ConfigBu
      * @default null
      * @param ParamConfigurator|\Symfony\Component\Config\Tests\Fixtures\TestEnum::Foo|\Symfony\Component\Config\Tests\Fixtures\TestEnum::Bar|\Symfony\Component\Config\Tests\Fixtures\TestEnum::Ccc $value
      * @return $this
+     * @deprecated since Symfony 7.4
      */
     public function fqcnUnitEnumNode($value): static
     {
+        $this->_hasDeprecatedCalls = true;
         $this->_usedProperties['fqcnUnitEnumNode'] = true;
         $this->fqcnUnitEnumNode = $value;
 
@@ -76,9 +85,11 @@ class PrimitiveTypesConfig implements \Symfony\Component\Config\Builder\ConfigBu
      * @default null
      * @param ParamConfigurator|float $value
      * @return $this
+     * @deprecated since Symfony 7.4
      */
     public function floatNode($value): static
     {
+        $this->_hasDeprecatedCalls = true;
         $this->_usedProperties['floatNode'] = true;
         $this->floatNode = $value;
 
@@ -89,9 +100,11 @@ class PrimitiveTypesConfig implements \Symfony\Component\Config\Builder\ConfigBu
      * @default null
      * @param ParamConfigurator|int $value
      * @return $this
+     * @deprecated since Symfony 7.4
      */
     public function integerNode($value): static
     {
+        $this->_hasDeprecatedCalls = true;
         $this->_usedProperties['integerNode'] = true;
         $this->integerNode = $value;
 
@@ -102,9 +115,11 @@ class PrimitiveTypesConfig implements \Symfony\Component\Config\Builder\ConfigBu
      * @default null
      * @param ParamConfigurator|mixed $value
      * @return $this
+     * @deprecated since Symfony 7.4
      */
     public function scalarNode($value): static
     {
+        $this->_hasDeprecatedCalls = true;
         $this->_usedProperties['scalarNode'] = true;
         $this->scalarNode = $value;
 
@@ -115,9 +130,11 @@ class PrimitiveTypesConfig implements \Symfony\Component\Config\Builder\ConfigBu
      * @default true
      * @param ParamConfigurator|mixed $value
      * @return $this
+     * @deprecated since Symfony 7.4
      */
     public function scalarNodeWithDefault($value): static
     {
+        $this->_hasDeprecatedCalls = true;
         $this->_usedProperties['scalarNodeWithDefault'] = true;
         $this->scalarNodeWithDefault = $value;
 
@@ -222,6 +239,9 @@ class PrimitiveTypesConfig implements \Symfony\Component\Config\Builder\ConfigBu
         }
         if (isset($this->_usedProperties['scalarNodeWithDefault'])) {
             $output['scalar_node_with_default'] = $this->scalarNodeWithDefault;
+        }
+        if ($this->_hasDeprecatedCalls) {
+            trigger_deprecation('symfony/config', '7.4', 'Calling any fluent method on "%s" is deprecated; pass the configuration to the constructor instead.', $this::class);
         }
 
         return $output;

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes.config.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes.config.php
@@ -11,21 +11,21 @@
 
 use Symfony\Config\ScalarNormalizedTypesConfig;
 
-return static function (ScalarNormalizedTypesConfig $config) {
-    $config
-        ->simpleArray('foo')
-        ->keyedArray('key', 'value')
-        ->object(true)
-        ->listObject('bar')
-        ->listObject('baz')
-        ->listObject()->name('qux');
-
-    $config
-        ->keyedListObject('Foo\\Bar', true)
-        ->keyedListObject('Foo\\Baz')->settings(['one', 'two']);
-
-    $config->nested([
+return new ScalarNormalizedTypesConfig([
+    'simple_array' => 'foo',
+    'keyed_array' => ['key' => 'value'],
+    'object' => true,
+    'list_object' => [
+        'bar',
+        'baz',
+        ['name' => 'qux'],
+    ],
+    'keyed_list_object' => [
+        'Foo\\Bar' => true,
+        'Foo\\Baz' => ['settings' => ['one', 'two']],
+    ],
+    'nested' => [
         'nested_object' => true,
         'nested_list_object' => ['one', 'two'],
-    ]);
-};
+    ],
+]);

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes.legacy.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes.legacy.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Config\ScalarNormalizedTypesConfig;
+
+return static function (ScalarNormalizedTypesConfig $config) {
+    $config
+        ->simpleArray('foo')
+        ->keyedArray('key', 'value')
+        ->object(true)
+        ->listObject('bar')
+        ->listObject('baz')
+        ->listObject()->name('qux');
+
+    $config
+        ->keyedListObject('Foo\\Bar', true)
+        ->keyedListObject('Foo\\Baz')->settings(['one', 'two']);
+
+    $config->nested([
+        'nested_object' => true,
+        'nested_list_object' => ['one', 'two'],
+    ]);
+};

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypesConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypesConfig.php
@@ -22,14 +22,17 @@ class ScalarNormalizedTypesConfig implements \Symfony\Component\Config\Builder\C
     private $keyedListObject;
     private $nested;
     private $_usedProperties = [];
+    private $_hasDeprecatedCalls = false;
 
     /**
      * @param ParamConfigurator|list<ParamConfigurator|mixed>|string $value
      *
      * @return $this
+     * @deprecated since Symfony 7.4
      */
     public function simpleArray(ParamConfigurator|string|array $value): static
     {
+        $this->_hasDeprecatedCalls = true;
         $this->_usedProperties['simpleArray'] = true;
         $this->simpleArray = $value;
 
@@ -38,9 +41,11 @@ class ScalarNormalizedTypesConfig implements \Symfony\Component\Config\Builder\C
 
     /**
      * @return $this
+     * @deprecated since Symfony 7.4
      */
     public function keyedArray(string $name, ParamConfigurator|string|array $value): static
     {
+        $this->_hasDeprecatedCalls = true;
         $this->_usedProperties['keyedArray'] = true;
         $this->keyedArray[$name] = $value;
 
@@ -53,9 +58,11 @@ class ScalarNormalizedTypesConfig implements \Symfony\Component\Config\Builder\C
      * @default {"enabled":null}
      * @return \Symfony\Config\ScalarNormalizedTypes\ObjectConfig|$this
      * @psalm-return (TValue is array ? \Symfony\Config\ScalarNormalizedTypes\ObjectConfig : static)
+     * @deprecated since Symfony 7.4
      */
     public function object(mixed $value = []): \Symfony\Config\ScalarNormalizedTypes\ObjectConfig|static
     {
+        $this->_hasDeprecatedCalls = true;
         if (!\is_array($value)) {
             $this->_usedProperties['object'] = true;
             $this->object = $value;
@@ -78,9 +85,11 @@ class ScalarNormalizedTypesConfig implements \Symfony\Component\Config\Builder\C
      * @param TValue $value
      * @return \Symfony\Config\ScalarNormalizedTypes\ListObjectConfig|$this
      * @psalm-return (TValue is array ? \Symfony\Config\ScalarNormalizedTypes\ListObjectConfig : static)
+     * @deprecated since Symfony 7.4
      */
     public function listObject(mixed $value = []): \Symfony\Config\ScalarNormalizedTypes\ListObjectConfig|static
     {
+        $this->_hasDeprecatedCalls = true;
         $this->_usedProperties['listObject'] = true;
         if (!\is_array($value)) {
             $this->listObject[] = $value;
@@ -96,9 +105,11 @@ class ScalarNormalizedTypesConfig implements \Symfony\Component\Config\Builder\C
      * @param TValue $value
      * @return \Symfony\Config\ScalarNormalizedTypes\KeyedListObjectConfig|$this
      * @psalm-return (TValue is array ? \Symfony\Config\ScalarNormalizedTypes\KeyedListObjectConfig : static)
+     * @deprecated since Symfony 7.4
      */
     public function keyedListObject(string $class, mixed $value = []): \Symfony\Config\ScalarNormalizedTypes\KeyedListObjectConfig|static
     {
+        $this->_hasDeprecatedCalls = true;
         if (!\is_array($value)) {
             $this->_usedProperties['keyedListObject'] = true;
             $this->keyedListObject[$class] = $value;
@@ -116,8 +127,12 @@ class ScalarNormalizedTypesConfig implements \Symfony\Component\Config\Builder\C
         return $this->keyedListObject[$class];
     }
 
+    /**
+     * @deprecated since Symfony 7.4
+     */
     public function nested(array $value = []): \Symfony\Config\ScalarNormalizedTypes\NestedConfig
     {
+        $this->_hasDeprecatedCalls = true;
         if (null === $this->nested) {
             $this->_usedProperties['nested'] = true;
             $this->nested = new \Symfony\Config\ScalarNormalizedTypes\NestedConfig($value);
@@ -223,6 +238,9 @@ class ScalarNormalizedTypesConfig implements \Symfony\Component\Config\Builder\C
         }
         if (isset($this->_usedProperties['nested'])) {
             $output['nested'] = $this->nested->toArray();
+        }
+        if ($this->_hasDeprecatedCalls) {
+            trigger_deprecation('symfony/config', '7.4', 'Calling any fluent method on "%s" is deprecated; pass the configuration to the constructor instead.', $this::class);
         }
 
         return $output;

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/VariableType.legacy.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/VariableType.legacy.php
@@ -11,6 +11,6 @@
 
 use Symfony\Config\VariableTypeConfig;
 
-return new VariableTypeConfig([
-    'any_value' => 'foobar',
-]);
+return static function (VariableTypeConfig $config) {
+    $config->anyValue('foobar');
+};

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/VariableType/Symfony/Config/VariableTypeConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/VariableType/Symfony/Config/VariableTypeConfig.php
@@ -12,15 +12,18 @@ class VariableTypeConfig implements \Symfony\Component\Config\Builder\ConfigBuil
 {
     private $anyValue;
     private $_usedProperties = [];
+    private $_hasDeprecatedCalls = false;
 
     /**
      * @default null
      * @param ParamConfigurator|mixed $value
      *
      * @return $this
+     * @deprecated since Symfony 7.4
      */
     public function anyValue(mixed $value): static
     {
+        $this->_hasDeprecatedCalls = true;
         $this->_usedProperties['anyValue'] = true;
         $this->anyValue = $value;
 
@@ -55,6 +58,9 @@ class VariableTypeConfig implements \Symfony\Component\Config\Builder\ConfigBuil
         $output = [];
         if (isset($this->_usedProperties['anyValue'])) {
             $output['any_value'] = $this->anyValue;
+        }
+        if ($this->_hasDeprecatedCalls) {
+            trigger_deprecation('symfony/config', '7.4', 'Calling any fluent method on "%s" is deprecated; pass the configuration to the constructor instead.', $this::class);
         }
 
         return $output;

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -16,6 +16,7 @@ CHANGELOG
  * Deprecate using `$this` or its internal scope from PHP config files; use the `$loader` variable instead
  * Deprecate XML configuration format, use YAML or PHP instead
  * Deprecate `ExtensionInterface::getXsdValidationBasePath()` and `getNamespace()`
+ * Deprecate the fluent PHP format for semantic configuration, instantiate builders inline with the config array as argument and return them instead
 
 7.3
 ---

--- a/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
@@ -253,6 +253,7 @@ class PhpFileLoader extends FileLoader
                     } catch (InvalidArgumentException|\LogicException $e) {
                         throw new \InvalidArgumentException(\sprintf('Could not resolve argument "%s" for "%s".', $type.' $'.$parameter->getName(), $path), 0, $e);
                     }
+                    trigger_deprecation('symfony/dependency-injection', '7.4', 'Using fluent builders for semantic configuration is deprecated, instantiate the "%s" class with the config array as argument and return it instead in "%s".', $type, $path);
                     $configBuilders[] = $configBuilder;
                     $arguments[] = $configBuilder;
             }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/config_builder_env_configurator.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/config_builder_env_configurator.php
@@ -3,6 +3,6 @@
 use Symfony\Component\DependencyInjection\Tests\Fixtures\AcmeConfig;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\env;
 
-return function (AcmeConfig $config) {
-    $config->color(env('COLOR'));
+return function () {
+    return new AcmeConfig(['color' => env('COLOR')]);
 };

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/env_param.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/env_param.php
@@ -2,10 +2,6 @@
 
 use Symfony\Component\DependencyInjection\Tests\Fixtures\AcmeConfig;
 
-return function (AcmeConfig $config, string $env) {
-    if ('prod' === $env) {
-        $config->color('blue');
-    } else {
-        $config->color('red');
-    }
+return function (string $env) {
+    return new AcmeConfig(['color' => 'prod' === $env ? 'blue' : 'red']);
 };

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/nested_config_builder.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/nested_config_builder.php
@@ -6,6 +6,4 @@ if ('prod' !== $env) {
     return;
 }
 
-return function (AcmeConfig $config) {
-    $config->color('red');
-};
+return new AcmeConfig(['color' => 'red']);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/return_config_builder.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/return_config_builder.php
@@ -2,7 +2,4 @@
 
 use Symfony\Component\DependencyInjection\Tests\Fixtures\AcmeConfig;
 
-$config = new AcmeConfig();
-$config->color('red');
-
-return $config;
+return new AcmeConfig(['color' => 'red']);

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
@@ -251,6 +251,8 @@ class PhpFileLoaderTest extends TestCase
         $this->assertSame([FooUnitEnum::BAR], $definition->getArguments());
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testNestedBundleConfigNotAllowed()
     {
         $fixtures = realpath(__DIR__.'/../Fixtures');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR deprecates the fluent PHP format for semantic configuration introduced in Symfony 5.4 by @Nyholm (see https://github.com/symfony/symfony/pull/40600).

It aims to replace it with the new array-based PHP config format (see https://github.com/symfony/symfony/pull/61490).

The fluent PHP config format was a great experiment:
- It helped us improve the Config component and the code generation of fluent config builders.
- It confirmed the community’s interest in PHP-based configuration.
- And it showed us its limits.

Those limits are structural. Writing fluent config is difficult and full of edge cases. Its rigidity comes from having to match one canonical interpretation of the semantic config tree. Automatic code generation can’t capture the custom logic that before-normalizers introduce, yet those normalizers are essential for flexibility and backward compatibility. This rigidity makes fluent config fragile. How do we deal with this fragility as config tree authors? At the moment, we don't care. Maybe this format is too niche for you to have experienced this issue, but we cannot guarantee that simple upgrades won't break your fluent PHP config.

The new array-based PHP format builds directly on the same code used for loading YAML configs.
That means:
- trivial conversion between YAML and PHP arrays,
- identical flexibility and behavior,
- and support for auto-completion and static analysis through generated array shapes.

The generated array shapes are rigid too, but that rigidity is non-breaking: even if your config no longer matches the canonical shape, your app keeps working. Static analyzers might warn you: that’s an invitation to update, not a failure.

I'm submitting this PR a bit l late for 7.4 but I think it's important to merge now. Deprecating the fluent PHP config format will:
- prevent new code from relying on a fragile approach,
- make room in the documentation for the array-based format,
- and consolidate Symfony’s configuration story around a robust PHP-based format.

Fluent PHP for semantic config served us well but it's time to retire it.

   ```diff
   -return function (AcmeConfig $config) {
   -    $config->color('red');
   -}
   +return new AcmeConfig([
   +    'color' => 'red',
   +]);
   ```

PS: there's another fluent config format for services and routes (see #23834 and #24180). This other format is handwritten. It doesn't have the issues listed above and it is *not* deprecated. It's actually the recommended way *for bundles* to declare their config (instead of XML, see #60568).