### PR TITLE
[Security] Fix `HttpUtils::createRequest()` when the context’s base URL isn’t empty

### DIFF
--- a/src/Symfony/Component/Security/Http/HttpUtils.php
+++ b/src/Symfony/Component/Security/Http/HttpUtils.php
@@ -73,9 +73,21 @@ class HttpUtils
         if ($trustedProxies = Request::getTrustedProxies()) {
             Request::setTrustedProxies([], Request::getTrustedHeaderSet());
         }
-        $newRequest = Request::create($this->generateUri($request, $path), 'get', [], $request->cookies->all(), [], $request->server->all());
-        if ($trustedProxies) {
-            Request::setTrustedProxies($trustedProxies, Request::getTrustedHeaderSet());
+
+        $context = $this->urlGenerator?->getContext();
+        if ($baseUrl = $context?->getBaseUrl()) {
+            $context->setBaseUrl('');
+        }
+
+        try {
+            $newRequest = Request::create($this->generateUri($request, $path), 'get', [], $request->cookies->all(), [], $request->server->all());
+        } finally {
+            if ($trustedProxies) {
+                Request::setTrustedProxies($trustedProxies, Request::getTrustedHeaderSet());
+            }
+            if ($baseUrl) {
+                $context->setBaseUrl($baseUrl);
+            }
         }
 
         static $setSession;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony/pull/61659#issuecomment-3414332085
| License       | MIT