### PR TITLE
[HttpKernel] add new attribute `RequestRateLimit`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
@@ -76,6 +76,7 @@ class UnusedTagsPass implements CompilerPassInterface
         'property_info.list_extractor',
         'property_info.type_extractor',
         'proxy',
+        'rate_limiter',
         'remote_event.consumer',
         'routing.condition_service',
         'routing.controller',

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -112,6 +112,7 @@ use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
 use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\HttpKernel\EventListener\IsSignatureValidAttributeListener;
+use Symfony\Component\HttpKernel\EventListener\RequestRateLimiterListener;
 use Symfony\Component\HttpKernel\Log\DebugLoggerConfigurator;
 use Symfony\Component\HttpKernel\Profiler\ProfilerStateChecker;
 use Symfony\Component\JsonStreamer\Attribute\JsonStreamable;
@@ -300,6 +301,9 @@ class FrameworkExtension extends Extension
         }
         if (!class_exists(ConfigBuilderGenerator::class)) {
             $container->removeDefinition('config_builder.warmer');
+        }
+        if (!class_exists(RequestRateLimiterListener::class)) {
+            $container->removeDefinition('controller.request_rate_limiter_listener');
         }
 
         if ($this->hasConsole()) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
@@ -50,6 +50,7 @@ use Symfony\Component\HttpKernel\HttpKernel;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\HttpKernel\RateLimiter\RequestRateLimiter;
 use Symfony\Component\Runtime\Runner\Symfony\HttpKernelRunner;
 use Symfony\Component\Runtime\Runner\Symfony\ResponseRunner;
 use Symfony\Component\Runtime\SymfonyRuntime;
@@ -226,6 +227,12 @@ return static function (ContainerConfigurator $container) {
                 [tagged_locator('routing.condition_service', 'alias'), 'get'],
             ])
             ->tag('routing.expression_language_function', ['function' => 'service'])
+
+        ->set('request_rate_limiter', RequestRateLimiter::class)
+            ->args([
+                tagged_locator('rate_limiter'),
+                new Parameter('container.build_hash'),
+            ])
 
         // inherit from this service to lazily access env vars
         ->set('container.env', LazyString::class)

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
@@ -34,6 +34,7 @@ use Symfony\Component\HttpKernel\EventListener\DisallowRobotsIndexingListener;
 use Symfony\Component\HttpKernel\EventListener\ErrorListener;
 use Symfony\Component\HttpKernel\EventListener\IsSignatureValidAttributeListener;
 use Symfony\Component\HttpKernel\EventListener\LocaleListener;
+use Symfony\Component\HttpKernel\EventListener\RequestRateLimiterListener;
 use Symfony\Component\HttpKernel\EventListener\ResponseListener;
 use Symfony\Component\HttpKernel\EventListener\ValidateRequestListener;
 
@@ -152,6 +153,12 @@ return static function (ContainerConfigurator $container) {
         ->set('controller.is_signature_valid_attribute_listener', IsSignatureValidAttributeListener::class)
             ->args([
                 service('uri_signer'),
+            ])
+            ->tag('kernel.event_subscriber')
+
+        ->set('controller.request_rate_limiter_listener', RequestRateLimiterListener::class)
+            ->args([
+                service('request_rate_limiter'),
             ])
             ->tag('kernel.event_subscriber')
 

--- a/src/Symfony/Component/HttpKernel/Attribute/RequestRateLimit.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/RequestRateLimit.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Attribute;
+
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+
+/**
+ * Applies rate limiting to a controller, or method for specific HTTP methods.
+ *
+ * @author Santiago San Martin <sanmartindev@gmail.com>
+ */
+#[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_FUNCTION)]
+final class RequestRateLimit
+{
+    /** @var string[] */
+    public readonly array $rateLimitersFactoriesIds;
+    /** @var string[] */
+    public readonly array $methods;
+
+    /**
+     * @param string[]|string $rateLimitersFactoriesIds The name or names of the configured rate limiter factories
+     * @param string[]|string $methods                  HTTP methods to apply rate limiting to. An empty array means all methods are affected
+     */
+    public function __construct(
+        array|string $rateLimitersFactoriesIds,
+        array|string $methods = [],
+    ) {
+        if (!class_exists(RateLimiterFactory::class)) {
+            throw new \LogicException('The "RequestRateLimit" attribute requires symfony/rate-limiter. Try running "composer require symfony/rate-limiter".');
+        }
+
+        $this->rateLimitersFactoriesIds = (array) $rateLimitersFactoriesIds;
+        if ([] === $this->rateLimitersFactoriesIds) {
+            throw new \InvalidArgumentException('"rateLimitersFactoriesIds" argument can not be an empty array.');
+        }
+        $this->methods = (array) $methods;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Make `Profile` final and `Profiler::__sleep()` internal
  * Collect the application runner class
  * Allow configuring `DumpListener` to use a different dumper when CLI profiling is enabled
+ * Add `#[RequestRateLimit]` attribute to enforce rate limiting validation
 
 7.3
 ---

--- a/src/Symfony/Component/HttpKernel/EventListener/RequestRateLimiterListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RequestRateLimiterListener.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Attribute\RequestRateLimit;
+use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpKernel\RateLimiter\RequestRateLimiter;
+
+/**
+ * Handles the RequestRateLimit attribute.
+ *
+ * @author Santiago San Martin <sanmartindev@gmail.com>
+ *
+ * @internal
+ */
+final class RequestRateLimiterListener implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly RequestRateLimiter $requestRateLimiter,
+    ) {
+    }
+
+    public function onKernelControllerArguments(ControllerArgumentsEvent $event): void
+    {
+        if (!$attributes = $event->getAttributes(RequestRateLimit::class)) {
+            return;
+        }
+
+        $request = $event->getRequest();
+        foreach ($attributes as $attribute) {
+            if ($attribute->methods && !\in_array($request->getMethod(), array_map('strtoupper', $attribute->methods), true)) {
+                continue;
+            }
+
+            $rateLimit = $this->requestRateLimiter->addRateLimiterFactories($attribute->rateLimitersFactoriesIds)->consume($request);
+            if (false === $rateLimit->isAccepted()) {
+                $delta = $rateLimit->getRetryAfter()->format('U.u') - microtime(true);
+                throw new TooManyRequestsHttpException((int) $delta);
+            }
+        }
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [KernelEvents::CONTROLLER_ARGUMENTS => ['onKernelControllerArguments', 40]];
+    }
+}

--- a/src/Symfony/Component/HttpKernel/RateLimiter/RequestRateLimiter.php
+++ b/src/Symfony/Component/HttpKernel/RateLimiter/RequestRateLimiter.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\RateLimiter;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\HttpFoundation\RateLimiter\AbstractRequestRateLimiter;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
+
+/**
+ * A rate limiter that limits requests based on the controller and method.
+ *
+ * @author Santiago San Martin <sanmartindev@gmail.com>
+ *
+ * @internal
+ */
+final class RequestRateLimiter extends AbstractRequestRateLimiter
+{
+    /** @var list<RateLimiterFactory> */
+    private array $rateLimiterFactories = [];
+
+    /**
+     * @param non-empty-string $secret A secret to use for hashing the IP address and controller
+     */
+    public function __construct(
+        private readonly ContainerInterface $rateLimiterFactoryLocator,
+        #[\SensitiveParameter] private readonly string $secret,
+    ) {
+        if (!$secret) {
+            throw new \InvalidArgumentException('A non-empty secret is required.');
+        }
+    }
+
+    /**
+     * @param string[] $rateLimiterFactoriesIds
+     */
+    public function addRateLimiterFactories(array $rateLimiterFactoriesIds): self
+    {
+        $expectedClass = interface_exists(RateLimiterFactoryInterface::class) ? RateLimiterFactoryInterface::class : RateLimiterFactory::class;
+
+        foreach ($rateLimiterFactoriesIds as $rateLimiterFactoryId) {
+            $rateLimiterFactory = $this->rateLimiterFactoryLocator->get($rateLimiterFactoryId);
+            if (!$rateLimiterFactory instanceof $expectedClass) {
+                throw new \InvalidArgumentException(\sprintf('The service "%s" is not an instance of "%s".', $rateLimiterFactoryId, $expectedClass));
+            }
+
+            $this->rateLimiterFactories[] = $rateLimiterFactory;
+        }
+
+        return $this;
+    }
+
+    protected function getLimiters(Request $request): array
+    {
+        $limiters = [];
+        $hash = $this->getHash($request);
+
+        foreach ($this->rateLimiterFactories as $rateLimiterFactory) {
+            $limiters[] = $rateLimiterFactory->create($hash);
+        }
+
+        return $limiters;
+    }
+
+    private function getHash(Request $request): string
+    {
+        $data = $this->parseController($request->attributes->get('_controller')).'-'.$request->getClientIp();
+
+        return strtr(substr(base64_encode(hash_hmac('sha256', $data, $this->secret, true)), 0, 8), '/+', '._');
+    }
+
+    /**
+     * @return string An string of controller data
+     */
+    private function parseController(array|object|string|null $controller): string
+    {
+        if (\is_string($controller) && str_contains($controller, '::')) {
+            $controller = explode('::', $controller);
+        }
+
+        if (\is_array($controller)) {
+            $class = \is_object($controller[0]) ? get_debug_type($controller[0]) : $controller[0];
+
+            return $class.'::'.$controller[1];
+        }
+
+        if ($controller instanceof \Closure) {
+            $r = new \ReflectionFunction($controller);
+
+            if ($r->isAnonymous()) {
+                return $r->getName();
+            }
+
+            if ($class = $r->getClosureCalledClass()) {
+                return $class.'::'.$r->name;
+            }
+
+            return $r->name;
+        }
+
+        if (\is_object($controller)) {
+            $r = new \ReflectionClass($controller);
+
+            return $r->getName();
+        }
+
+        return \is_string($controller) ? $controller : 'n/a';
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/RequestRateLimiterListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/RequestRateLimiterListenerTest.php
@@ -1,0 +1,255 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
+use Symfony\Component\HttpKernel\EventListener\RequestRateLimiterListener;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\RateLimiter\RequestRateLimiter;
+use Symfony\Component\HttpKernel\Tests\Fixtures\RequestRateLimitAttributeController;
+use Symfony\Component\HttpKernel\Tests\Fixtures\RequestRateLimitAttributeMethodsController;
+use Symfony\Component\RateLimiter\LimiterInterface;
+use Symfony\Component\RateLimiter\RateLimit;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
+
+class RequestRateLimiterListenerTest extends TestCase
+{
+    public function testInvokableControllerWithValidAvalibleRateLimit()
+    {
+        $listener = new RequestRateLimiterListener($this->createRequestRateLimiter([
+            'limiter.test' => new RateLimit(1, new \DateTimeImmutable(), true, 1),
+        ]));
+        $listener->onKernelControllerArguments(new ControllerArgumentsEvent(
+            $this->createMock(HttpKernelInterface::class),
+            new RequestRateLimitAttributeController(),
+            [],
+            new Request(),
+            null
+        ));
+    }
+
+    public function testWithDefaultBehaviorControllerWithValidAvalibleRateLimit()
+    {
+        $listener = new RequestRateLimiterListener($this->createRequestRateLimiter([
+            'limiter.test' => new RateLimit(1, new \DateTimeImmutable(), true, 1),
+        ]));
+        $listener->onKernelControllerArguments(new ControllerArgumentsEvent(
+            $this->createMock(HttpKernelInterface::class),
+            [new RequestRateLimitAttributeController(), 'withDefaultBehavior'],
+            [],
+            new Request(),
+            null
+        ));
+    }
+
+    public function testNoAttributeSkipsValidation()
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->never())->method('get');
+        $listener = new RequestRateLimiterListener(new RequestRateLimiter($container, 'foo'));
+        $listener->onKernelControllerArguments(new ControllerArgumentsEvent(
+            $this->createMock(HttpKernelInterface::class),
+            [new RequestRateLimitAttributeMethodsController(), 'noAttribute'],
+            [],
+            new Request(),
+            null
+        ));
+    }
+
+    public function testWithDefaultBehaviorCheckRequestSucceeds()
+    {
+        $listener = new RequestRateLimiterListener($this->createRequestRateLimiter([
+            'limiter.test' => new RateLimit(1, new \DateTimeImmutable(), true, 1),
+        ]));
+        $listener->onKernelControllerArguments(new ControllerArgumentsEvent(
+            $this->createMock(HttpKernelInterface::class),
+            [new RequestRateLimitAttributeMethodsController(), 'withDefaultBehavior'],
+            [],
+            new Request(),
+            null
+        ));
+    }
+
+    public function testWithDefaultBehaviorCheckThrowsTooManyRequestsHttpException()
+    {
+        $listener = new RequestRateLimiterListener($this->createRequestRateLimiter([
+            'limiter.test' => new RateLimit(1, new \DateTimeImmutable(), false, 1),
+        ]));
+        $this->expectException(TooManyRequestsHttpException::class);
+        $listener->onKernelControllerArguments(new ControllerArgumentsEvent(
+            $this->createMock(HttpKernelInterface::class),
+            [new RequestRateLimitAttributeMethodsController(), 'withDefaultBehavior'],
+            [],
+            new Request(),
+            null
+        ));
+    }
+
+    public function testWithMultipleFactoriesAllAvalible()
+    {
+        $listener = new RequestRateLimiterListener($this->createRequestRateLimiter([
+            'limiter.test_one' => new RateLimit(1, new \DateTimeImmutable(), true, 1),
+            'limiter.test_two' => new RateLimit(1, new \DateTimeImmutable(), true, 1),
+        ]));
+        $listener->onKernelControllerArguments(new ControllerArgumentsEvent(
+            $this->createMock(HttpKernelInterface::class),
+            [new RequestRateLimitAttributeMethodsController(), 'withMultipleFactories'],
+            [],
+            new Request(),
+            null
+        ));
+    }
+
+    public function testWithMultipleFactoriesOnlyOneAvalible()
+    {
+        $listener = new RequestRateLimiterListener($this->createRequestRateLimiter([
+            'limiter.test_one' => new RateLimit(1, new \DateTimeImmutable(), true, 1),
+            'limiter.test_two' => new RateLimit(1, new \DateTimeImmutable(), false, 1),
+        ]));
+        $this->expectException(TooManyRequestsHttpException::class);
+        $listener->onKernelControllerArguments(new ControllerArgumentsEvent(
+            $this->createMock(HttpKernelInterface::class),
+            [new RequestRateLimitAttributeMethodsController(), 'withMultipleFactories'],
+            [],
+            new Request(),
+            null
+        ));
+    }
+
+    public function testWithInvalidRateLimiterFactory()
+    {
+        $container = $this->createStub(ContainerInterface::class);
+        $container->method('get')->willReturn(new \stdClass());
+        $listener = new RequestRateLimiterListener(new RequestRateLimiter($container, 'foo'));
+        $this->expectException(\InvalidArgumentException::class);
+        $listener->onKernelControllerArguments(new ControllerArgumentsEvent(
+            $this->createMock(HttpKernelInterface::class),
+            [new RequestRateLimitAttributeMethodsController(), 'withInvalidService'],
+            [],
+            new Request(),
+            null
+        ));
+    }
+
+    public function testWithMultipleAttributesAllAvalible()
+    {
+        $listener = new RequestRateLimiterListener($this->createRequestRateLimiter([
+            'limiter.test_one' => new RateLimit(1, new \DateTimeImmutable(), true, 1),
+            'limiter.test_two' => new RateLimit(1, new \DateTimeImmutable(), true, 1),
+        ]));
+        $listener->onKernelControllerArguments(new ControllerArgumentsEvent(
+            $this->createMock(HttpKernelInterface::class),
+            [new RequestRateLimitAttributeMethodsController(), 'withMultipleFactories'],
+            [],
+            new Request(),
+            null
+        ));
+    }
+
+    public function testWithMultipleAttributesOnlyOneAvalible()
+    {
+        $listener = new RequestRateLimiterListener($this->createRequestRateLimiter([
+            'limiter.test_one' => new RateLimit(1, new \DateTimeImmutable(), false, 1),
+            'limiter.test_two' => new RateLimit(1, new \DateTimeImmutable(), true, 1),
+        ]));
+        $this->expectException(TooManyRequestsHttpException::class);
+        $listener->onKernelControllerArguments(new ControllerArgumentsEvent(
+            $this->createMock(HttpKernelInterface::class),
+            [new RequestRateLimitAttributeMethodsController(), 'withMultipleFactories'],
+            [],
+            new Request(),
+            null
+        ));
+    }
+
+    public function testWithPostOnlyCheckRequestSucceeds()
+    {
+        $listener = new RequestRateLimiterListener($this->createRequestRateLimiter([
+            'limiter.test' => new RateLimit(1, new \DateTimeImmutable(), true, 1),
+        ]));
+        $listener->onKernelControllerArguments(new ControllerArgumentsEvent(
+            $this->createMock(HttpKernelInterface::class),
+            [new RequestRateLimitAttributeMethodsController(), 'withPostOnly'],
+            [],
+            new Request(server: ['REQUEST_METHOD' => 'POST']),
+            null
+        ));
+    }
+
+    public function testWithPostOnlySkipsOnGet()
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->never())->method('get');
+        $listener = new RequestRateLimiterListener(new RequestRateLimiter($container, 'foo'));
+        $listener->onKernelControllerArguments(new ControllerArgumentsEvent(
+            $this->createMock(HttpKernelInterface::class),
+            [new RequestRateLimitAttributeMethodsController(), 'withPostOnly'],
+            [],
+            new Request(server: ['REQUEST_METHOD' => 'GET']),
+            null
+        ));
+    }
+
+    public function testWithGetAndPostCheckRequestSucceeds()
+    {
+        $listener = new RequestRateLimiterListener($this->createRequestRateLimiter([
+            'limiter.test' => new RateLimit(1, new \DateTimeImmutable(), true, 1),
+        ]));
+        $listener->onKernelControllerArguments(new ControllerArgumentsEvent(
+            $this->createMock(HttpKernelInterface::class),
+            [new RequestRateLimitAttributeMethodsController(), 'withGetAndPost'],
+            [],
+            new Request(server: ['REQUEST_METHOD' => 'GET']),
+            null
+        ));
+    }
+
+    public function testWithGetAndPostSkipsOnPut()
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->never())->method('get');
+        $listener = new RequestRateLimiterListener(new RequestRateLimiter($container, 'foo'));
+        $listener->onKernelControllerArguments(new ControllerArgumentsEvent(
+            $this->createMock(HttpKernelInterface::class),
+            [new RequestRateLimitAttributeMethodsController(), 'withGetAndPost'],
+            [],
+            new Request(server: ['REQUEST_METHOD' => 'PUT']),
+            null
+        ));
+    }
+
+    /**
+     * @param array<string, RateLimit> $rateLimits
+     */
+    private function createRequestRateLimiter(array $rateLimits, string $secret = 'foo'): RequestRateLimiter
+    {
+        $rateLimiterFactories = [];
+        foreach ($rateLimits as $key => $value) {
+            $limiter = $this->createMock(LimiterInterface::class);
+            $limiter->expects($this->once())->method('consume')->willReturn($value);
+            $rateLimiterFactory = $this->createMock(RateLimiterFactoryInterface::class);
+            $rateLimiterFactory->expects($this->once())->method('create')->willReturn($limiter);
+            $rateLimiterFactories[] = [$key, $rateLimiterFactory];
+        }
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->exactly(\count($rateLimiterFactories)))
+            ->method('get')
+            ->willReturnMap($rateLimiterFactories)
+        ;
+
+        return new RequestRateLimiter($container, $secret);
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/RequestRateLimitAttributeController.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/RequestRateLimitAttributeController.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures;
+
+use Symfony\Component\HttpKernel\Attribute\RequestRateLimit;
+
+#[RequestRateLimit('limiter.test')]
+class RequestRateLimitAttributeController
+{
+    public function __invoke()
+    {
+    }
+
+    public function withDefaultBehavior()
+    {
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/RequestRateLimitAttributeMethodsController.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/RequestRateLimitAttributeMethodsController.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures;
+
+use Symfony\Component\HttpKernel\Attribute\RequestRateLimit;
+
+class RequestRateLimitAttributeMethodsController
+{
+    public function noAttribute()
+    {
+    }
+
+    #[RequestRateLimit('limiter.test')]
+    public function withDefaultBehavior()
+    {
+    }
+
+    #[RequestRateLimit(['limiter.test_one', 'limiter.test_two'])]
+    public function withMultipleFactories()
+    {
+    }
+
+    #[RequestRateLimit('invalid_service')]
+    public function withInvalidService()
+    {
+    }
+
+    #[RequestRateLimit('limiter.test_one')]
+    #[RequestRateLimit('limiter.test_two')]
+    public function withMultipleAttributes()
+    {
+    }
+
+    #[RequestRateLimit('limiter.test', 'POST')]
+    public function withPostOnly()
+    {
+    }
+
+    #[RequestRateLimit('limiter.test', ['GET', 'POST'])]
+    public function withGetAndPost()
+    {
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/RateLimiter/RequestRateLimiterTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/RateLimiter/RequestRateLimiterTest.php
@@ -1,0 +1,160 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\RateLimiter;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\RateLimiter\RequestRateLimiter;
+use Symfony\Component\RateLimiter\LimiterInterface;
+use Symfony\Component\RateLimiter\RateLimit;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
+
+class RequestRateLimiterTest extends TestCase
+{
+    public function testAddRateLimiterFactoriesWithInvalidService()
+    {
+        $container = $this->createStub(ContainerInterface::class);
+        $container->method('get')
+            ->willReturnMap([
+                ['limiter.test', new \stdClass()],
+            ])
+        ;
+        $requestRateLimiter = new RequestRateLimiter($container, 'foo');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $requestRateLimiter->addRateLimiterFactories(['limiter.test']);
+    }
+
+    public function testConsumeWithMultipleRateLimiterFactories()
+    {
+        $now = new \DateTimeImmutable();
+        $limiter = $this->createStub(LimiterInterface::class);
+        $limiter->method('consume')
+            ->willReturn(
+                new RateLimit(0, $now, true, 1),
+                new RateLimit(0, $now->add(\DateInterval::createFromDateString('1 hour')), true, 1),
+                new RateLimit(0, $now->add(\DateInterval::createFromDateString('2 hour')), true, 1),
+            );
+        $rateLimiterFactory = $this->createStub(RateLimiterFactoryInterface::class);
+        $rateLimiterFactory->method('create')->with('GHz8dC4d')->willReturn($limiter);
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->exactly(3))
+            ->method('get')
+            ->willReturnMap([
+                ['limiter.test_one', $rateLimiterFactory],
+                ['limiter.test_two', $rateLimiterFactory],
+                ['limiter.test_three', $rateLimiterFactory],
+            ])
+        ;
+
+        $requestRateLimiter = new RequestRateLimiter($container, 'foo');
+
+        $requestRateLimiter->addRateLimiterFactories(['limiter.test_one', 'limiter.test_two', 'limiter.test_three']);
+        $requestRateLimiter->consume(new Request());
+    }
+
+    #[DataProvider('provideRequestsControllerFormats')]
+    public function testConsume(Request $request, string $secret, string $expectedHash)
+    {
+        $limiter = $this->createStub(LimiterInterface::class);
+        $rateLimiterFactory = $this->createStub(RateLimiterFactoryInterface::class);
+        $rateLimiterFactory->method('create')->with($expectedHash)->willReturn($limiter);
+        $container = $this->createStub(ContainerInterface::class);
+        $container->method('get')
+            ->willReturnMap([
+                ['limiter.test', $rateLimiterFactory],
+            ])
+        ;
+
+        $requestRateLimiter = new RequestRateLimiter($container, $secret);
+
+        $requestRateLimiter->addRateLimiterFactories(['limiter.test']);
+        $requestRateLimiter->consume($request);
+    }
+
+    public static function provideRequestsControllerFormats(): \Traversable
+    {
+        yield 'String controller with method' => [
+            new Request(
+                attributes: ['_controller' => 'ControllerTest::index'],
+                server: ['REMOTE_ADDR' => '127.0.0.1']
+            ),
+            'secret',
+            'mGpCqMCv',
+        ];
+
+        yield 'String controller with different secret' => [
+            new Request(
+                attributes: ['_controller' => 'ControllerTest::index'],
+                server: ['REMOTE_ADDR' => '127.0.0.1']
+            ),
+            'secret_two',
+            'AGaZrRhz',
+        ];
+
+        yield 'String controller with different IP' => [
+            new Request(
+                attributes: ['_controller' => 'ControllerTest::index'],
+                server: ['REMOTE_ADDR' => '172.16.254.1']
+            ),
+            'secret',
+            'Op6bV.fS',
+        ];
+
+        yield 'String controller without method' => [
+            new Request(
+                attributes: ['_controller' => 'ControllerTest'],
+                server: ['REMOTE_ADDR' => '127.0.0.1']
+            ),
+            'secret',
+            'LEjfNOfb',
+        ];
+
+        yield 'Array controller' => [
+            new Request(
+                attributes: ['_controller' => ['ControllerTest', 'index']],
+                server: ['REMOTE_ADDR' => '127.0.0.1']
+            ),
+            'secret',
+            'mGpCqMCv',
+        ];
+
+        yield 'Object controller' => [
+            new Request(
+                attributes: ['_controller' => new \stdClass()],
+                server: ['REMOTE_ADDR' => '127.0.0.1']
+            ),
+            'secret',
+            'vLU7vlaI',
+        ];
+
+        yield 'Closure controller' => [
+            new Request(
+                attributes: ['_controller' => trim(...)],
+                server: ['REMOTE_ADDR' => '127.0.0.1']
+            ),
+            'secret',
+            'cfjnamcd',
+        ];
+
+        yield 'Null controller' => [
+            new Request(
+                attributes: ['_controller' => null],
+                server: ['REMOTE_ADDR' => '127.0.0.1']
+            ),
+            'secret',
+            'p5SbHEUZ',
+        ];
+    }
+}

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -47,7 +47,8 @@
         "symfony/var-dumper": "^6.4|^7.0|^8.0",
         "symfony/var-exporter": "^6.4|^7.0|^8.0",
         "psr/cache": "^1.0|^2.0|^3.0",
-        "twig/twig": "^3.12"
+        "twig/twig": "^3.12",
+        "symfony/rate-limiter": "^7.3|^8.0"
     },
     "provide": {
         "psr/log-implementation": "1.0|2.0|3.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #52518
| License       | MIT

Hi everyone, before diving into the details of this PR, I'd like to mention that this feature takes into consideration the linked issue, as well as the discussion in this [comment](https://github.com/symfony/symfony/pull/59920#issuecomment-2704289997)

### Description

This PR introduces the `#[RequestRateLimit]` attribute, allowing developers to apply rate limiting at the controller and method levels. The rate limit key is generated by combining the controller name and method name (using the `parseController` method, inspired by `RequestDataCollector::parseController`). Additionally, the client’s IP address is incorporated using `Request::getClientIp`. These two values are then hashed to create a unique key for rate limiting. This approach is based on concepts from `DefaultLoginRateLimiter::hash`.

### Key Features
* **Per-method and per-controller rate limiting**: Apply rate limits at both the controller and method level using the `#[RequestRateLimit]` attribute
* **Client IP usage**: Rate limiting is tied to both the controller/method signature and the client IP, ensuring more granular control.
* **Hash-based rate limit key**: The rate limiting key is generated by hashing the controller, method, and client IP.

### Usage Examples
* **Single limiter for a method**
```php
#[RequestRateLimit('limiter.my_limit')]
public function myMethod()
```
* **Multiple limiters for a method**
```php
#[RequestRateLimit(['limiter.my_limit', 'limiter.my_second_limit'])]
public function multipleLimiters()
```
* **Multiple attributes on a method**
```php
#[RequestRateLimit('limiter.my_limit')]
#[RequestRateLimit('limiter.my_second_limit')]
public function multipleAttributes()
```
* **Limiting based on HTTP method**
```php
#[RequestRateLimit('limiter.my_limit', ['GET', 'POST'])]
public function filterByHttpMethod()
```
* **Rate limiting for an entire controller**
```php
#[RequestRateLimit('limiter.my_limit')]
final class MyController
```
### Possible Future Features
1. **Allow specifying HTTP method for "Too Many Requests" (429)**: By default, when no tokens are available, a 429 status code is returned, which aligns with the standard (RFC 6585). However, it could be useful to give developers the option to specify a different HTTP method for rate limiting. Personally, I don’t see a strong need for this, as 429 is the standard approach.
2. **Add wait time for no available tokens** There may be suggestions to introduce a feature where requests wait when tokens are unavailable, possibly via an argument like `waitMaximumTime` (or similar), with a default value of 0. While I’m not particularly fond of this approach, I want to mention it as a possible option for those who may want to control the wait time before receiving a 429 status code.
3. **Support for passing a custom `RequestRateLimiterServiceId`**
      1. This would allow developers to pass an argument like `requestRateLimiterServiceId`, which would point to a service implementing `RequestRateLimiterInterface` for custom rate limiting logic.
      2. If this option is enabled, passing both `requestRateLimiterServiceId` and `rateLimitersFactoriesIds` would be disallowed, since the custom service would manage the rate limiters internally.
      3. This could be useful when you want to share the same rate limiting key across multiple methods in different controllers, offering more flexibility for complex use cases.
4. Alternative to 3: we can passing `string|expression` like `IsCsrfTokenValid`

### Key Changes:
* Added the `#[RequestRateLimit]` attribute for controller and method-level rate limiting.
* Rate limit keys are now based on the controller, method, and client IP.
* Support for multiple limiters and filtering by HTTP method.