### PR TITLE
[Security] fix small typo in PasswordAuthenticatedUserInterface

### DIFF
--- a/src/Symfony/Component/Security/Core/User/PasswordAuthenticatedUserInterface.php
+++ b/src/Symfony/Component/Security/Core/User/PasswordAuthenticatedUserInterface.php
@@ -32,7 +32,7 @@ namespace Symfony\Component\Security\Core\User;
  *         return $data;
  *     }
  *
- * Implement EquatableInteface if you need another logic.
+ * Implement EquatableInterface if you need another logic.
  *
  * @author Robin Chalas <robin.chalas@gmail.com>
  * @author Wouter de Jong <wouter@wouterj.nl>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | no
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
