### PR TITLE
[Routing] Allow when@env inside `new RoutesConfig()` trees

### DIFF
--- a/src/Symfony/Component/Routing/Loader/Config/RoutesConfig.php
+++ b/src/Symfony/Component/Routing/Loader/Config/RoutesConfig.php
@@ -51,7 +51,7 @@ namespace Symfony\Config;
  *     alias: string,
  *     deprecated?: array{package:string, version:string, message?:string},
  * }
- * @psalm-type Routes = array<string, Route|Import|Alias>
+ * @psalm-type Routes = array<string, Route|Import|Alias|RoutesConfig|array<string, Route|Import|Alias>>
  */
 class RoutesConfig
 {

--- a/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
@@ -74,33 +74,7 @@ class YamlFileLoader extends FileLoader
             throw new \InvalidArgumentException(\sprintf('The file "%s" must contain a YAML array.', $path));
         }
 
-        foreach ($parsedConfig as $name => $config) {
-            if (str_starts_with($name, 'when@')) {
-                if (!$this->env || 'when@'.$this->env !== $name) {
-                    continue;
-                }
-
-                foreach ($config as $name => $config) {
-                    $this->validate($config, $name.'" when "@'.$this->env, $path);
-
-                    if (isset($config['resource'])) {
-                        $this->parseImport($collection, $config, $path, $file);
-                    } else {
-                        $this->parseRoute($collection, $name, $config, $path);
-                    }
-                }
-
-                continue;
-            }
-
-            $this->validate($config, $name, $path);
-
-            if (isset($config['resource'])) {
-                $this->parseImport($collection, $config, $path, $file);
-            } else {
-                $this->parseRoute($collection, $name, $config, $path);
-            }
-        }
+        $this->loadContent($collection, $parsedConfig, $path, $file);
 
         return $collection;
     }
@@ -270,6 +244,29 @@ class YamlFileLoader extends FileLoader
         }
         if (isset($config['stateless']) && isset($config['defaults']['_stateless'])) {
             throw new \InvalidArgumentException(\sprintf('The routing file "%s" must not specify both the "stateless" key and the defaults key "_stateless" for "%s".', $path, $name));
+        }
+    }
+
+    private function loadContent(RouteCollection $collection, array $config, string $path, string $file): void
+    {
+        foreach ($config as $name => $config) {
+            if (!str_starts_with($when = $name, 'when@')) {
+                $config = [$name => $config];
+            } elseif (!$this->env || 'when@'.$this->env !== $name) {
+                continue;
+            } else {
+                $when .= '" when "@'.$this->env;
+            }
+
+            foreach ($config as $name => $config) {
+                $this->validate($config, $when, $path);
+
+                if (isset($config['resource'])) {
+                    $this->parseImport($collection, $config, $path, $file);
+                } else {
+                    $this->parseRoute($collection, $name, $config, $path);
+                }
+            }
         }
     }
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/routes_object.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/routes_object.php
@@ -10,4 +10,14 @@ return new RoutesConfig([
         'path' => '/b',
         'methods' => ['GET'],
     ],
+    'when@dev' => new RoutesConfig([
+        'c' => [
+            'path' => '/c',
+        ],
+    ]),
+    'when@test' => [
+        'd' => [
+            'path' => '/d',
+        ],
+    ],
 ]);

--- a/src/Symfony/Component/Routing/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/PhpFileLoaderTest.php
@@ -381,6 +381,20 @@ class PhpFileLoaderTest extends TestCase
         $this->assertSame('/a', $routes->get('a')->getPath());
         $this->assertSame('/b', $routes->get('b')->getPath());
         $this->assertSame(['GET'], $routes->get('b')->getMethods());
+        $this->assertNull($routes->get('c'));
+        $this->assertNull($routes->get('d'));
+
+        $loader = new PhpFileLoader(new FileLocator([__DIR__.'/../Fixtures']), 'dev');
+        $routes = $loader->load('routes_object.php');
+        $this->assertSame('/a', $routes->get('a')->getPath());
+        $this->assertSame('/b', $routes->get('b')->getPath());
+        $this->assertSame('/c', $routes->get('c')->getPath());
+        $this->assertNull($routes->get('d'));
+
+        $loader = new PhpFileLoader(new FileLocator([__DIR__.'/../Fixtures']), 'test');
+        $routes = $loader->load('routes_object.php');
+        $this->assertNull($routes->get('c'));
+        $this->assertSame('/d', $routes->get('d')->getPath());
     }
 
     public function testWhenEnvWithArray()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

I had implemented this restriction by symmetry with `when@env` for DI array-shapes, but this has no other ground and is actually surprising. The only symmetry that sticks is the one with the routing `YamlFileLoader`, that's why I factorized the logic in a new method of its.

Before:

```php
return [
    new RoutesConfig([
        'route1_name' => ['path' => '/path1'],
    ]),
    'when@dev' => new RoutesConfig([
        'route2_name' => ['path' => '/path2'],
    ]),
]);
```

After:
```php
return new RoutesConfig([
    'route1_name' => ['path' => '/path1'],
    'when@dev' => new RoutesConfig([
        'route2_name' => ['path' => '/path2'],
    ]),
]);
```

The mental model is: `new RoutesConfig()` is just a decorator of a routes' shape.