### PR TITLE
[DependencyInjection] Split ImportsConfig and ParametersConfig out of ServicesConfig

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/Config/ImportsConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Config/ImportsConfig.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Config;
+
+/**
+ * @psalm-type Imports = list<string|array{
+ *   resource: string,
+ *   type?: string|null,
+ *   ignore_errors?: bool,
+ * }>
+ */
+class ImportsConfig
+{
+    /**
+     * @param Imports $config
+     */
+    public function __construct(
+        public readonly array $config,
+    ) {
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Loader/Config/ParametersConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Config/ParametersConfig.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Config;
+
+/**
+ * @psalm-type Parameters = array<string, scalar|\UnitEnum|array<scalar|\UnitEnum|array|null>|null>
+ */
+class ParametersConfig
+{
+    /**
+     * @param Parameters $config
+     */
+    public function __construct(
+        public readonly array $config,
+    ) {
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Loader/Config/ServicesConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Config/ServicesConfig.php
@@ -12,7 +12,6 @@
 namespace Symfony\Config;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ReferenceConfigurator;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\ExpressionLanguage\Expression;
@@ -21,16 +20,10 @@ require_once __DIR__.\DIRECTORY_SEPARATOR.'functions.php';
 
 /**
  * @psalm-type Arguments = list<mixed>|array<string, mixed>
- * @psalm-type Callback = string|array{0:string|Reference|ReferenceConfigurator,1:string}|\Closure|Reference|ReferenceConfigurator|Expression
- * @psalm-type Tags = list<string|array<string, array<string, mixed>>>
- * @psalm-type Deprecation = array{package: string, version: string, message?: string}
  * @psalm-type Call = array<string, Arguments>|array{0:string, 1?:Arguments, 2?:bool}|array{method:string, arguments?:Arguments, returns_clone?:bool}
- * @psalm-type Imports = list<string|array{
- *   resource: string,
- *   type?: string|null,
- *   ignore_errors?: bool,
- * }>
- * @psalm-type Parameters = array<string, scalar|\UnitEnum|array<scalar|\UnitEnum|array|null>|null>
+ * @psalm-type Tags = list<string|array<string, array<string, mixed>>>
+ * @psalm-type Callback = string|array{0:string|Reference|ReferenceConfigurator,1:string}|\Closure|Reference|ReferenceConfigurator|Expression
+ * @psalm-type Deprecation = array{package: string, version: string, message?: string}
  * @psalm-type Defaults = array{
  *   public?: bool,
  *   tags?: Tags,
@@ -111,32 +104,19 @@ require_once __DIR__.\DIRECTORY_SEPARATOR.'functions.php';
  *   public?: bool,
  *   deprecated?: Deprecation,
  * }
- * @psalm-type Services = array<string, Definition|Alias|Prototype|Stack>|array<class-string, Arguments|null>
+ * @psalm-type Services = array{
+ *   _defaults?: Defaults,
+ *   _instanceof?: Instanceof,
+ *   ...<string, Definition|Alias|Prototype|Stack|Arguments|null>
+ * }
  */
 class ServicesConfig
 {
-    public readonly array $services;
-
     /**
-     * @param Services   $services
-     * @param Imports    $imports
-     * @param Parameters $parameters
-     * @param Defaults   $defaults
-     * @param Instanceof $instanceof
+     * @param Services $config
      */
     public function __construct(
-        array $services = [],
-        public readonly array $imports = [],
-        public readonly array $parameters = [],
-        array $defaults = [],
-        array $instanceof = [],
+        public readonly array $config,
     ) {
-        if (isset($services['_defaults']) || isset($services['_instanceof'])) {
-            throw new InvalidArgumentException('The $services argument should not contain "_defaults" or "_instanceof" keys, use the $defaults and $instanceof parameters instead.');
-        }
-
-        $services['_defaults'] = $defaults;
-        $services['_instanceof'] = $instanceof;
-        $this->services = $services;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/object_array_config.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/object_array_config.php
@@ -1,19 +1,21 @@
 <?php
 
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Bar;
+use Symfony\Config\ParametersConfig;
 use Symfony\Config\ServicesConfig;
 
-return new ServicesConfig(
-    parameters: [
+return [
+    new ParametersConfig([
         'foo' => 'bar',
-    ],
-    defaults: [
-        'public' => true,
-    ],
-    services: [
+    ]),
+    new ServicesConfig([
+        '_defaults' => [
+            'public' => true,
+        ],
         Bar::class => null,
         'my_service' => [
             'class' => Bar::class,
             'arguments' => ['%foo%'],
         ],
-]);
+    ]),
+];

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/return_when_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/return_when_env.php
@@ -1,24 +1,23 @@
 <?php
 
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Bar;
+use Symfony\Config\ParametersConfig;
 use Symfony\Config\ServicesConfig;
 
 return [
     'when@prod' => [
-        'parameters' => [
+        new ParametersConfig([
             'foo_param' => 'bar_value',
-        ],
-        new ServicesConfig(
-            defaults: [
+        ]),
+        new ServicesConfig([
+            '_defaults' => [
                 'public' => true,
             ],
-            services: [
-                Bar::class => null,
-                'my_service' => [
-                    'class' => Bar::class,
-                    'arguments' => ['%foo_param%'],
-                ],
-            ]
-        ),
+            Bar::class => null,
+            'my_service' => [
+                'class' => Bar::class,
+                'arguments' => ['%foo_param%'],
+            ],
+        ]),
     ],
 ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62102
| License       | MIT

This fixes the root issue described in #62102: unlike the other generated `*Config` classes, the `ServicesConfig` class embedded special semantics, making special cases for the `imports` / `parameters` root keys, and `_instanceof` / `_defaults` nested keys.

This PR splits `ImportsConfig` and `ParametersConfig` out of `ServicesConfig`, and moves  `_instanceof` / `_defaults` as nested keys.

This makes the array-based format closer to yaml, with config classes acting a identity decorators.

```diff
-return new ServicesConfig(
-    parameters: [
-    ],
-    defaults: [
-        'public' => true,
-    ],
-    services: [
-        Bar::class => null,
-        'my_service' => [
-            'class' => Bar::class,
-            'arguments' => ['%foo%'],
-        ],
-]);
+return [
+    new ParametersConfig([
+        'foo' => 'bar',
+    ]),
+    new ServicesConfig([
+        '_defaults' => [
+            'public' => true,
+        ],
+        Bar::class => null,
+        'my_service' => [
+            'class' => Bar::class,
+            'arguments' => ['%foo%'],
+        ],
+    ]),
+];
```