### PR TITLE
[Config] Ensure configuration nodes do not have both `isRequired()` and `defaultValue()`

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -30,6 +30,7 @@ Config
  * Remove support for accessing the internal scope of the loader in PHP config files, use only its public API instead
  * Add argument `$singular` to `NodeBuilder::arrayNode()`
  * Add argument `$info` to `ArrayNodeDefinition::canBeDisabled()` and `canBeEnabled()`
+ * Ensure configuration nodes do not have both `isRequired()` and `defaultValue()`
 
 Console
 -------

--- a/src/Symfony/Component/Config/CHANGELOG.md
+++ b/src/Symfony/Component/Config/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Remove support for accessing the internal scope of the loader in PHP config files, use only its public API instead
  * Add argument `$singular` to `NodeBuilder::arrayNode()`
  * Add argument `$info` to `ArrayNodeDefinition::canBeDisabled()` and `canBeEnabled()`
+ * Ensure configuration nodes do not have both `isRequired()` and `defaultValue()`
 
 7.4
 ---

--- a/src/Symfony/Component/Config/Definition/Builder/NodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NodeDefinition.php
@@ -179,8 +179,7 @@ abstract class NodeDefinition implements NodeParentInterface
     public function defaultValue(mixed $value): static
     {
         if ($this->required) {
-            // throw new InvalidDefinitionException(sprintf('The node "%s" cannot be required and have a default value.', $this->name));
-            trigger_deprecation('symfony/config', '7.4', 'Setting a default value to a required node is deprecated. Remove the default value from the node "%s" or make it optional.', $this->name);
+            throw new InvalidDefinitionException(\sprintf('The node "%s" cannot be required and have a default value.', $this->name));
         }
 
         $this->default = true;
@@ -197,8 +196,7 @@ abstract class NodeDefinition implements NodeParentInterface
     public function isRequired(): static
     {
         if ($this->default) {
-            // throw new InvalidDefinitionException(sprintf('The node "%s" cannot be required and have a default value.', $this->name));
-            trigger_deprecation('symfony/config', '7.4', 'Flagging a node with a default value as required is deprecated. Remove the default from node "%s" or make it optional.', $this->name);
+            throw new InvalidDefinitionException(\sprintf('The node "%s" cannot be required and have a default value.', $this->name));
         }
 
         $this->required = true;

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/NodeDefinitionTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/NodeDefinitionTest.php
@@ -12,8 +12,6 @@
 namespace Symfony\Component\Config\Tests\Definition\Builder;
 
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\BooleanNodeDefinition;
@@ -76,32 +74,26 @@ class NodeDefinitionTest extends TestCase
         $node->docUrl('https://example.com/doc/{package}/{version:major}.{version:minor}', 'phpunit/invalid');
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     #[DataProvider('provideDefinitionClassesAndDefaultValues')]
     public function testIncoherentRequiredAndDefaultValue(string $class, mixed $defaultValue)
     {
         $node = new $class('foo');
         self::assertInstanceOf(NodeDefinition::class, $node);
 
-        // $this->expectException(InvalidDefinitionException::class);
-        // $this->expectExceptionMessage('The node "foo" cannot be required and have a default value.');
-        $this->expectUserDeprecationMessage('Since symfony/config 7.4: Flagging a node with a default value as required is deprecated. Remove the default from node "foo" or make it optional.');
+        $this->expectException(InvalidDefinitionException::class);
+        $this->expectExceptionMessage('The node "foo" cannot be required and have a default value.');
 
         $node->defaultValue($defaultValue)->isRequired();
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     #[DataProvider('provideDefinitionClassesAndDefaultValues')]
     public function testIncoherentDefaultValueAndRequired(string $class, mixed $defaultValue)
     {
         $node = new $class('foo');
         self::assertInstanceOf(NodeDefinition::class, $node);
 
-        // $this->expectException(InvalidDefinitionException::class);
-        // $this->expectExceptionMessage('The node "foo" cannot be required and have a default value.');
-        $this->expectUserDeprecationMessage('Since symfony/config 7.4: Setting a default value to a required node is deprecated. Remove the default value from the node "foo" or make it optional.');
+        $this->expectException(InvalidDefinitionException::class);
+        $this->expectExceptionMessage('The node "foo" cannot be required and have a default value.');
 
         $node->isRequired()->defaultValue($defaultValue);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony/issues/62076
| License       | MIT

Convert deprecation introduced in https://github.com/symfony/symfony/pull/62090 into an exception.