### PR TITLE
[Messenger] Simplify code

### DIFF
--- a/src/Symfony/Component/Messenger/Event/SendMessageToTransportsEvent.php
+++ b/src/Symfony/Component/Messenger/Event/SendMessageToTransportsEvent.php
@@ -19,8 +19,8 @@ use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
  *
  * The event is *only* dispatched if the message will actually
  * be sent to at least one transport. If the message is sent
- * to multiple transports, the message is dispatched only once.
- * This message is only dispatched the first time a message
+ * to multiple transports, the event is dispatched only once.
+ * This event is only dispatched the first time a message
  * is sent to a transport, not also if it is retried.
  *
  * @author Ryan Weaver <ryan@symfonycasts.com>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Noticed while working on #61843.

There's no reason for the event to be dispatched inside the loop anymore:

1. The event was [originally dispatched outside the loop](https://github.com/symfony/symfony/pull/30650).
2. It was later [moved inside the loop](https://github.com/symfony/symfony/pull/30676) because of the retry mechanism.
3. [The retry mechanism was later extracted](https://github.com/symfony/symfony/pull/34185), so there's no longer a need for the event to be dispatched inside the loop.