### PR TITLE
[Console] Add support for OSC 9;4 escape sequence for progress reporting

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -25,6 +25,7 @@ CHANGELOG
  * Deprecate passing both `InputArgument::REQUIRED` and `InputArgument::OPTIONAL` modes to `InputArgument` constructor
  * Deprecate passing more than one out of `InputOption::VALUE_NONE`, `InputOption::VALUE_REQUIRED` and `InputOption::VALUE_OPTIONAL` modes to `InputOption` constructor
  * Add `RawInputInterface` to expose the original arguments and options and to unparse options, implemented by `Input`
+ * Add support for OSC 9;4 for progress reporting
 
 8.0
 ---

--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -60,9 +60,13 @@ final class ProgressBar
     private ?string $previousMessage = null;
     private Cursor $cursor;
     private array $placeholders = [];
+    private ?int $oscProgressState = null;
+    private ?int $oscProgressPercent = null;
 
     private static array $formatters;
     private static array $formats;
+    private static \WeakMap $activeInstances;
+    private static int $pausedCount = 0;
 
     /**
      * @param int $max Maximum steps (0 if unknown)
@@ -358,6 +362,11 @@ final class ProgressBar
             $this->setMaxSteps($max);
         }
 
+        if ($this->output->isDecorated()) {
+            self::$activeInstances ??= new \WeakMap();
+            self::$activeInstances[$this] = true;
+        }
+
         $this->display();
     }
 
@@ -441,12 +450,12 @@ final class ProgressBar
             $this->max = $this->step;
         }
 
-        if (($this->step === $this->max || null === $this->max) && !$this->overwrite) {
-            // prevent double 100% output
-            return;
+        if (!(($this->step === $this->max || null === $this->max) && !$this->overwrite)) {
+            $this->setProgress($this->max ?? $this->step);
         }
 
-        $this->setProgress($this->max ?? $this->step);
+        unset(self::$activeInstances[$this]);
+        $this->writeOscProgressReset();
     }
 
     /**
@@ -463,6 +472,7 @@ final class ProgressBar
         }
 
         $this->overwrite($this->buildLine());
+        $this->writeOscProgress();
     }
 
     /**
@@ -483,6 +493,8 @@ final class ProgressBar
         }
 
         $this->overwrite('');
+        unset(self::$activeInstances[$this]);
+        $this->writeOscProgressReset();
     }
 
     private function setRealFormat(string $format): void
@@ -550,6 +562,108 @@ final class ProgressBar
 
         $this->output->write($message);
         ++$this->writeCount;
+    }
+
+    /**
+     * Pauses the OSC 9;4 taskbar progress indicator on all active progress bars.
+     *
+     * Calls are reentrant; each call must be paired with a {@see resumeAll()}.
+     * Useful when prompting the user for input while a progress bar is running.
+     */
+    public static function pauseAll(): void
+    {
+        if (1 !== ++self::$pausedCount) {
+            return;
+        }
+
+        foreach (self::$activeInstances ?? [] as $bar => $_) {
+            $bar->writeOscProgress();
+        }
+    }
+
+    /**
+     * Counterpart of {@see pauseAll()}.
+     */
+    public static function resumeAll(): void
+    {
+        if (0 !== --self::$pausedCount) {
+            return;
+        }
+
+        foreach (self::$activeInstances ?? [] as $bar => $_) {
+            $bar->writeOscProgress();
+        }
+    }
+
+    private function writeOscProgress(): void
+    {
+        if (!$this->output->isDecorated()) {
+            return;
+        }
+
+        if (null === $this->max) {
+            $state = 3;
+            $percent = 0;
+        } else {
+            $state = 1;
+            $percent = (int) floor(max(0.0, min(1.0, $this->percent)) * 100);
+        }
+
+        if (1 === $state && \count(self::$activeInstances ?? []) > 1) {
+            // Multiple active determinate bars: collapse to indeterminate so the taskbar
+            // doesn't flicker between unrelated percentages from each bar.
+            $state = 3;
+            $percent = 0;
+        }
+
+        if (self::$pausedCount > 0) {
+            $state = 4;
+        }
+
+        if ($this->oscProgressState === $state && $this->oscProgressPercent === $percent) {
+            return;
+        }
+
+        $this->oscProgressState = $state;
+        $this->oscProgressPercent = $percent;
+
+        $this->writeOscRaw(\sprintf("\033]9;4;%d;%d\033\\", $state, $percent));
+    }
+
+    private function writeOscProgressReset(): void
+    {
+        if (null === $this->oscProgressState) {
+            return;
+        }
+
+        $this->oscProgressState = null;
+        $this->oscProgressPercent = null;
+
+        if (\count(self::$activeInstances ?? []) > 0) {
+            // Other bars still active: let them re-evaluate their state instead of clearing the taskbar.
+            foreach (self::$activeInstances as $bar => $_) {
+                $bar->writeOscProgress();
+            }
+
+            return;
+        }
+
+        if ($this->output->isDecorated()) {
+            $this->writeOscRaw("\033]9;4;0;0\033\\");
+        }
+    }
+
+    private function writeOscRaw(string $bytes): void
+    {
+        // OSC sequences address the terminal (taskbar progress) and have no display width.
+        // For ConsoleSectionOutput, bypass section content tracking so line counting stays correct.
+        if ($this->output instanceof ConsoleSectionOutput) {
+            fwrite($this->output->getStream(), $bytes);
+
+            return;
+        }
+
+        $this->output->write($bytes);
     }
 
     private function determineBestFormat(): string

--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -68,6 +68,8 @@ class QuestionHelper extends Helper
         $inputStream = $input instanceof StreamableInputInterface ? $input->getStream() : null;
         $inputStream ??= \STDIN;
 
+        ProgressBar::pauseAll();
+
         try {
             if (!$question->getValidator() && !$question->getConstraints()) {
                 return $this->doAsk($inputStream, $output, $question);
@@ -84,6 +86,8 @@ class QuestionHelper extends Helper
             }
 
             return $fallbackOutput;
+        } finally {
+            ProgressBar::resumeAll();
         }
     }
 

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -46,7 +46,7 @@ class ProgressBarTest extends TestCase
 
         rewind($output->getStream());
         $this->assertEquals(
-            '    0 [>---------------------------]'.
+            '    0 [>---------------------------]'.$this->osc(3, 0).
             $this->generateOutput('    1 [->--------------------------]').
             $this->generateOutput('    0 [>---------------------------]'),
             stream_get_contents($output->getStream())
@@ -61,7 +61,7 @@ class ProgressBarTest extends TestCase
 
         rewind($output->getStream());
         $this->assertEquals(
-            '    0 [>---------------------------]'.
+            '    0 [>---------------------------]'.$this->osc(3, 0).
             $this->generateOutput('    1 [->--------------------------]'),
             stream_get_contents($output->getStream())
         );
@@ -76,7 +76,7 @@ class ProgressBarTest extends TestCase
         rewind($output->getStream());
 
         $this->assertEquals(
-            '   15 [--------------->------------]'.
+            '   15 [--------------->------------]'.$this->osc(3, 0).
             $this->generateOutput('   16 [---------------->-----------]'),
             stream_get_contents($output->getStream())
         );
@@ -90,7 +90,7 @@ class ProgressBarTest extends TestCase
         rewind($output->getStream());
 
         $this->assertEquals(
-            ' 1000/5000 [=====>----------------------]  20%',
+            ' 1000/5000 [=====>----------------------]  20%'.$this->osc(1, 20),
             stream_get_contents($output->getStream())
         );
     }
@@ -148,7 +148,7 @@ class ProgressBarTest extends TestCase
 
         rewind($output->getStream());
         $this->assertEquals(
-            '    0 [>---------------------------]'.
+            '    0 [>---------------------------]'.$this->osc(3, 0).
             $this->generateOutput('    5 [----->----------------------]'),
             stream_get_contents($output->getStream())
         );
@@ -163,7 +163,7 @@ class ProgressBarTest extends TestCase
 
         rewind($output->getStream());
         $this->assertEquals(
-            '    0 [>---------------------------]'.
+            '    0 [>---------------------------]'.$this->osc(3, 0).
             $this->generateOutput('    3 [--->------------------------]').
             $this->generateOutput('    5 [----->----------------------]'),
             stream_get_contents($output->getStream())
@@ -179,8 +179,8 @@ class ProgressBarTest extends TestCase
 
         rewind($output->getStream());
         $this->assertEquals(
-            '  9/10 [=========================>--]  90%'.
-            $this->generateOutput(' 10/10 [============================] 100%').
+            '  9/10 [=========================>--]  90%'.$this->osc(1, 90).
+            $this->generateOutput(' 10/10 [============================] 100%').$this->osc(1, 100).
             $this->generateOutput(' 11/11 [============================] 100%'),
             stream_get_contents($output->getStream())
         );
@@ -196,7 +196,7 @@ class ProgressBarTest extends TestCase
 
         rewind($output->getStream());
         $this->assertEquals(
-            '    0 [>---------------------------]'.
+            '    0 [>---------------------------]'.$this->osc(3, 0).
             $this->generateOutput('    1 [->--------------------------]').
             $this->generateOutput('    2 [-->-------------------------]').
             $this->generateOutput('    1 [->--------------------------]'),
@@ -214,7 +214,7 @@ class ProgressBarTest extends TestCase
 
         rewind($output->getStream());
         $this->assertEquals(
-            '    0 [>---------------------------]'.
+            '    0 [>---------------------------]'.$this->osc(3, 0).
             $this->generateOutput('    4 [---->-----------------------]').
             $this->generateOutput('    8 [-------->-------------------]').
             $this->generateOutput('    6 [------>---------------------]'),
@@ -233,7 +233,7 @@ class ProgressBarTest extends TestCase
 
         rewind($output->getStream());
         $this->assertEquals(
-            '    0 [>---------------------------]'.
+            '    0 [>---------------------------]'.$this->osc(3, 0).
             $this->generateOutput('    3 [--->------------------------]').
             $this->generateOutput('    6 [------>---------------------]').
             $this->generateOutput('    5 [----->----------------------]').
@@ -251,8 +251,8 @@ class ProgressBarTest extends TestCase
 
         rewind($output->getStream());
         $this->assertEquals(
-            '  1/10 [==>-------------------------]  10%'.
-            $this->generateOutput('  0/10 [>---------------------------]   0%'),
+            '  1/10 [==>-------------------------]  10%'.$this->osc(1, 10).
+            $this->generateOutput('  0/10 [>---------------------------]   0%').$this->osc(1, 0),
             stream_get_contents($output->getStream())
         );
     }
@@ -260,8 +260,8 @@ class ProgressBarTest extends TestCase
     public function testFormat()
     {
         $expected =
-            '  0/10 [>---------------------------]   0%'.
-            $this->generateOutput(' 10/10 [============================] 100%')
+            '  0/10 [>---------------------------]   0%'.$this->osc(1, 0).
+            $this->generateOutput(' 10/10 [============================] 100%').$this->osc(1, 100).$this->osc(0, 0)
         ;
 
         // max in construct, no format
@@ -316,8 +316,8 @@ class ProgressBarTest extends TestCase
 
         rewind($output->getStream());
         $this->assertEquals(
-            '  0/10 [/         ]   0%'.
-            $this->generateOutput('  1/10 [_/        ]  10%'),
+            '  0/10 [/         ]   0%'.$this->osc(1, 0).
+            $this->generateOutput('  1/10 [_/        ]  10%').$this->osc(1, 10),
             stream_get_contents($output->getStream())
         );
     }
@@ -329,7 +329,7 @@ class ProgressBarTest extends TestCase
 
         rewind($output->getStream());
         $this->assertEquals(
-            '  0/50 [>---------------------------]   0%',
+            '  0/50 [>---------------------------]   0%'.$this->osc(1, 0),
             stream_get_contents($output->getStream())
         );
     }
@@ -353,7 +353,7 @@ class ProgressBarTest extends TestCase
 
         rewind($output->getStream());
         $this->assertEquals(
-            ' 50/50 [============================] 100%',
+            ' 50/50 [============================] 100%'.$this->osc(1, 100).$this->osc(0, 0),
             stream_get_contents($output->getStream())
         );
     }
@@ -368,9 +368,9 @@ class ProgressBarTest extends TestCase
 
         rewind($output->getStream());
         $this->assertEquals(
-            '  0/50 [>---------------------------]   0%'.
-            $this->generateOutput('  1/50 [>---------------------------]   2%').
-            $this->generateOutput('  2/50 [=>--------------------------]   4%'),
+            '  0/50 [>---------------------------]   0%'.$this->osc(1, 0).
+            $this->generateOutput('  1/50 [>---------------------------]   2%').$this->osc(1, 2).
+            $this->generateOutput('  2/50 [=>--------------------------]   4%').$this->osc(1, 4),
             stream_get_contents($output->getStream())
         );
     }
@@ -389,9 +389,9 @@ class ProgressBarTest extends TestCase
 
         rewind($output->getStream());
         $this->assertEquals(
-            '  0/50 [>---------------------------]   0%'.
-            $this->generateOutput('  1/50 [>---------------------------]   2%').
-            $this->generateOutput('  2/50 [=>--------------------------]'),
+            '  0/50 [>---------------------------]   0%'.$this->osc(1, 0).
+            $this->generateOutput('  1/50 [>---------------------------]   2%').$this->osc(1, 2).
+            $this->generateOutput('  2/50 [=>--------------------------]').$this->osc(1, 4),
             stream_get_contents($output->getStream())
         );
     }
@@ -410,9 +410,9 @@ class ProgressBarTest extends TestCase
 
         rewind($output->getStream());
         $this->assertEquals(
-            '  0/50 [>---------------------------]   0%'.\PHP_EOL.
-            "\x1b[1A\x1b[0J".'  1/50 [>---------------------------]   2%'.\PHP_EOL.
-            "\x1b[1A\x1b[0J".'  2/50 [=>--------------------------]   4%'.\PHP_EOL,
+            '  0/50 [>---------------------------]   0%'.\PHP_EOL.$this->osc(1, 0).
+            "\x1b[1A\x1b[0J".'  1/50 [>---------------------------]   2%'.\PHP_EOL.$this->osc(1, 2).
+            "\x1b[1A\x1b[0J".'  2/50 [=>--------------------------]   4%'.\PHP_EOL.$this->osc(1, 4),
             stream_get_contents($output->getStream())
         );
     }
@@ -435,9 +435,9 @@ class ProgressBarTest extends TestCase
 
         rewind($output->getStream());
         $this->assertEquals(escapeshellcmd(
-            '[>---------------------------]   0%'.\PHP_EOL.\PHP_EOL.
-            "\x1b[2A\x1b[0J".'[>---------------------------]   2%'.\PHP_EOL.'Doing something...'.\PHP_EOL.
-            "\x1b[2A\x1b[0J".'[=>--------------------------]   4%'.\PHP_EOL.'Doing something foo...'.\PHP_EOL),
+            '[>---------------------------]   0%'.\PHP_EOL.\PHP_EOL.$this->osc(1, 0).
+            "\x1b[2A\x1b[0J".'[>---------------------------]   2%'.\PHP_EOL.'Doing something...'.\PHP_EOL.$this->osc(1, 2).
+            "\x1b[2A\x1b[0J".'[=>--------------------------]   4%'.\PHP_EOL.'Doing something foo...'.\PHP_EOL.$this->osc(1, 4)),
             escapeshellcmd(stream_get_contents($output->getStream()))
         );
     }
@@ -460,9 +460,9 @@ class ProgressBarTest extends TestCase
 
         rewind($output->getStream());
         $this->assertEquals(escapeshellcmd(
-            '[>---------------------------]   0%'.\PHP_EOL.'Start'.\PHP_EOL.
-            "\x1b[2A\x1b[0J".'[>---------------------------]   2%'.\PHP_EOL.
-            "\x1b[1A\x1b[0J".'[=>--------------------------]   4%'.\PHP_EOL.'Doing something...'.\PHP_EOL),
+            '[>---------------------------]   0%'.\PHP_EOL.'Start'.\PHP_EOL.$this->osc(1, 0).
+            "\x1b[2A\x1b[0J".'[>---------------------------]   2%'.\PHP_EOL.$this->osc(1, 2).
+            "\x1b[1A\x1b[0J".'[=>--------------------------]   4%'.\PHP_EOL.'Doing something...'.\PHP_EOL.$this->osc(1, 4)),
             escapeshellcmd(stream_get_contents($output->getStream()))
         );
     }
@@ -485,9 +485,9 @@ class ProgressBarTest extends TestCase
 
         rewind($output->getStream());
         $this->assertEquals(escapeshellcmd(
-            '[>---------------------------]   0%'.\PHP_EOL."\x1b[33mStart\x1b[39m".\PHP_EOL.
-            "\x1b[2A\x1b[0J".'[>---------------------------]   2%'.\PHP_EOL.
-            "\x1b[1A\x1b[0J".'[=>--------------------------]   4%'.\PHP_EOL."\x1b[33mDoing something...\x1b[39m".\PHP_EOL),
+            '[>---------------------------]   0%'.\PHP_EOL."\x1b[33mStart\x1b[39m".\PHP_EOL.$this->osc(1, 0).
+            "\x1b[2A\x1b[0J".'[>---------------------------]   2%'.\PHP_EOL.$this->osc(1, 2).
+            "\x1b[1A\x1b[0J".'[=>--------------------------]   4%'.\PHP_EOL."\x1b[33mDoing something...\x1b[39m".\PHP_EOL.$this->osc(1, 4)),
             escapeshellcmd(stream_get_contents($output->getStream()))
         );
     }
@@ -509,9 +509,9 @@ class ProgressBarTest extends TestCase
 
         rewind($output->getStream());
         $this->assertSame(
-            " \033[44;37m 0/50\033[0m [>---------------------------]   0%".\PHP_EOL.
-            "\x1b[1A\x1b[0J \033[44;37m 1/50\033[0m [>---------------------------]   2%".\PHP_EOL.
-            "\x1b[1A\x1b[0J \033[44;37m 2/50\033[0m [=>--------------------------]   4%".\PHP_EOL,
+            " \033[44;37m 0/50\033[0m [>---------------------------]   0%".\PHP_EOL.$this->osc(1, 0).
+            "\x1b[1A\x1b[0J \033[44;37m 1/50\033[0m [>---------------------------]   2%".\PHP_EOL.$this->osc(1, 2).
+            "\x1b[1A\x1b[0J \033[44;37m 2/50\033[0m [=>--------------------------]   4%".\PHP_EOL.$this->osc(1, 4),
             stream_get_contents($output->getStream())
         );
         putenv('COLUMNS=120');
@@ -536,12 +536,12 @@ class ProgressBarTest extends TestCase
         rewind($stream->getStream());
 
         $this->assertEquals(
-            '  0/50 [>---------------------------]   0%'.\PHP_EOL.
-            '  0/50 [>---------------------------]   0%'.\PHP_EOL.
+            '  0/50 [>---------------------------]   0%'.\PHP_EOL.$this->osc(1, 0).
+            '  0/50 [>---------------------------]   0%'.\PHP_EOL.$this->osc(3, 0).
             "\x1b[1A\x1b[0J".'  1/50 [>---------------------------]   2%'.\PHP_EOL.
             "\x1b[2A\x1b[0J".'  1/50 [>---------------------------]   2%'.\PHP_EOL.
             "\x1b[1A\x1b[0J".'  1/50 [>---------------------------]   2%'.\PHP_EOL.
-            '  1/50 [>---------------------------]   2%'.\PHP_EOL,
+            '  1/50 [>---------------------------]   2%'.\PHP_EOL.$this->osc(3, 0),
             stream_get_contents($stream->getStream())
         );
     }
@@ -561,9 +561,9 @@ class ProgressBarTest extends TestCase
 
         rewind($output->getStream());
         $this->assertEquals(
-            " 0/50 [>]   0% %message% Fruitcake marzipan toffee. Cupcake gummi bears tart dessert ice cream chupa chups cupcake chocolate bar sesame snaps. Croissant halvah cookie jujubes powder macaroon. Fruitcake bear claw bonbon jelly beans oat cake pie muffin Fruitcake marzipan toffee.\x1b[1G\x1b[2K 1/50 [>]   2% Twas brillig, and the slithy toves. Did gyre and gimble in the wabe: All mimsy were the borogoves, And the mome raths outgrabe.
-Beware the Jabberwock, my son! The jaws that bite, the claws that catch! Beware the Jubjub bird, and shun The frumious Bandersnatch! Fruitcake marzipan toffee. Cupcake gummi bears tart dessert ice cream chupa chups cupcake chocolate bar sesame snaps. Croissant halvah cookie jujubes powder macaroon. Fruitcake bear claw bonbon jelly beans oat cake pie muffin Fruitcake marzipan toffee.\x1b[1G\x1b[2K\x1b[1A\x1b[1G\x1b[2K 2/50 [>]   4% He took his vorpal sword in hand; Long time the manxome foe he sought— So rested he by the Tumtum tree And stood awhile in thought.
-And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whiffling through the tulgey wood, And burbled as it came! Fruitcake marzipan toffee. Cupcake gummi bears tart dessert ice cream chupa chups cupcake chocolate bar sesame snaps. Croissant halvah cookie jujubes powder macaroon. Fruitcake bear claw bonbon jelly beans oat cake pie muffin Fruitcake marzipan toffee.",
+            ' 0/50 [>]   0% %message% Fruitcake marzipan toffee. Cupcake gummi bears tart dessert ice cream chupa chups cupcake chocolate bar sesame snaps. Croissant halvah cookie jujubes powder macaroon. Fruitcake bear claw bonbon jelly beans oat cake pie muffin Fruitcake marzipan toffee.'.$this->osc(1, 0)."\x1b[1G\x1b[2K 1/50 [>]   2% Twas brillig, and the slithy toves. Did gyre and gimble in the wabe: All mimsy were the borogoves, And the mome raths outgrabe.
+Beware the Jabberwock, my son! The jaws that bite, the claws that catch! Beware the Jubjub bird, and shun The frumious Bandersnatch! Fruitcake marzipan toffee. Cupcake gummi bears tart dessert ice cream chupa chups cupcake chocolate bar sesame snaps. Croissant halvah cookie jujubes powder macaroon. Fruitcake bear claw bonbon jelly beans oat cake pie muffin Fruitcake marzipan toffee.".$this->osc(1, 2)."\x1b[1G\x1b[2K\x1b[1A\x1b[1G\x1b[2K 2/50 [>]   4% He took his vorpal sword in hand; Long time the manxome foe he sought— So rested he by the Tumtum tree And stood awhile in thought.
+And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whiffling through the tulgey wood, And burbled as it came! Fruitcake marzipan toffee. Cupcake gummi bears tart dessert ice cream chupa chups cupcake chocolate bar sesame snaps. Croissant halvah cookie jujubes powder macaroon. Fruitcake bear claw bonbon jelly beans oat cake pie muffin Fruitcake marzipan toffee.".$this->osc(1, 4),
             stream_get_contents($output->getStream())
         );
     }
@@ -587,11 +587,11 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
 
         rewind($output->getStream());
         $this->assertEquals(
-            ' 0/50 [>]   0% %message% Fruitcake marzipan toffee. Cupcake gummi bears tart dessert ice cream chupa chups cupcake chocolate bar sesame snaps. Croissant halvah cookie jujubes powder macaroon. Fruitcake bear claw bonbon jelly beans oat cake pie muffin Fruitcake marzipan toffee.'.\PHP_EOL.
+            ' 0/50 [>]   0% %message% Fruitcake marzipan toffee. Cupcake gummi bears tart dessert ice cream chupa chups cupcake chocolate bar sesame snaps. Croissant halvah cookie jujubes powder macaroon. Fruitcake bear claw bonbon jelly beans oat cake pie muffin Fruitcake marzipan toffee.'.\PHP_EOL.$this->osc(1, 0).
             "\x1b[3A\x1b[0J 1/50 [>]   2% Twas brillig, and the slithy toves. Did gyre and gimble in the wabe: All mimsy were the borogoves, And the mome raths outgrabe.
-Beware the Jabberwock, my son! The jaws that bite, the claws that catch! Beware the Jubjub bird, and shun The frumious Bandersnatch! Fruitcake marzipan toffee. Cupcake gummi bears tart dessert ice cream chupa chups cupcake chocolate bar sesame snaps. Croissant halvah cookie jujubes powder macaroon. Fruitcake bear claw bonbon jelly beans oat cake pie muffin Fruitcake marzipan toffee.".\PHP_EOL.
+Beware the Jabberwock, my son! The jaws that bite, the claws that catch! Beware the Jubjub bird, and shun The frumious Bandersnatch! Fruitcake marzipan toffee. Cupcake gummi bears tart dessert ice cream chupa chups cupcake chocolate bar sesame snaps. Croissant halvah cookie jujubes powder macaroon. Fruitcake bear claw bonbon jelly beans oat cake pie muffin Fruitcake marzipan toffee.".\PHP_EOL.$this->osc(1, 2).
             "\x1b[6A\x1b[0J 2/50 [>]   4% He took his vorpal sword in hand; Long time the manxome foe he sought— So rested he by the Tumtum tree And stood awhile in thought.
-And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whiffling through the tulgey wood, And burbled as it came! Fruitcake marzipan toffee. Cupcake gummi bears tart dessert ice cream chupa chups cupcake chocolate bar sesame snaps. Croissant halvah cookie jujubes powder macaroon. Fruitcake bear claw bonbon jelly beans oat cake pie muffin Fruitcake marzipan toffee.".\PHP_EOL,
+And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whiffling through the tulgey wood, And burbled as it came! Fruitcake marzipan toffee. Cupcake gummi bears tart dessert ice cream chupa chups cupcake chocolate bar sesame snaps. Croissant halvah cookie jujubes powder macaroon. Fruitcake bear claw bonbon jelly beans oat cake pie muffin Fruitcake marzipan toffee.".\PHP_EOL.$this->osc(1, 4),
             stream_get_contents($output->getStream())
         );
     }
@@ -617,11 +617,11 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
 
         rewind($stream->getStream());
 
-        $this->assertEquals('  0/50 [>---------------------------]   0%'.\PHP_EOL.
-            ' 0/50 [>]   0% Fruitcake marzipan toffee. Cupcake gummi bears tart dessert ice cream chupa chups cupcake chocolate bar sesame snaps. Croissant halvah cookie jujubes powder macaroon. Fruitcake bear claw bonbon jelly beans oat cake pie muffin Fruitcake marzipan toffee.'.\PHP_EOL.
+        $this->assertEquals('  0/50 [>---------------------------]   0%'.\PHP_EOL.$this->osc(1, 0).
+            ' 0/50 [>]   0% Fruitcake marzipan toffee. Cupcake gummi bears tart dessert ice cream chupa chups cupcake chocolate bar sesame snaps. Croissant halvah cookie jujubes powder macaroon. Fruitcake bear claw bonbon jelly beans oat cake pie muffin Fruitcake marzipan toffee.'.\PHP_EOL.$this->osc(3, 0).
             "\x1b[4A\x1b[0J".' 0/50 [>]   0% Fruitcake marzipan toffee. Cupcake gummi bears tart dessert ice cream chupa chups cupcake chocolate bar sesame snaps. Croissant halvah cookie jujubes powder macaroon. Fruitcake bear claw bonbon jelly beans oat cake pie muffin Fruitcake marzipan toffee.'.\PHP_EOL.
             "\x1b[3A\x1b[0J".'  1/50 [>---------------------------]   2%'.\PHP_EOL.
-            ' 0/50 [>]   0% Fruitcake marzipan toffee. Cupcake gummi bears tart dessert ice cream chupa chups cupcake chocolate bar sesame snaps. Croissant halvah cookie jujubes powder macaroon. Fruitcake bear claw bonbon jelly beans oat cake pie muffin Fruitcake marzipan toffee.'.\PHP_EOL.
+            ' 0/50 [>]   0% Fruitcake marzipan toffee. Cupcake gummi bears tart dessert ice cream chupa chups cupcake chocolate bar sesame snaps. Croissant halvah cookie jujubes powder macaroon. Fruitcake bear claw bonbon jelly beans oat cake pie muffin Fruitcake marzipan toffee.'.\PHP_EOL.$this->osc(3, 0).
             "\x1b[3A\x1b[0J".' 1/50 [>]   2% Fruitcake marzipan toffee. Cupcake gummi bears tart dessert ice cream chupa chups cupcake chocolate bar sesame snaps. Croissant halvah cookie jujubes powder macaroon. Fruitcake bear claw bonbon jelly beans oat cake pie muffin Fruitcake marzipan toffee.'.\PHP_EOL,
             stream_get_contents($stream->getStream())
         );
@@ -636,8 +636,8 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
 
         rewind($output->getStream());
         $this->assertEquals(
-            ' 0/50 [>---------------------------]'.
-            $this->generateOutput(' 1/50 [>---------------------------]'),
+            ' 0/50 [>---------------------------]'.$this->osc(1, 0).
+            $this->generateOutput(' 1/50 [>---------------------------]').$this->osc(1, 2),
             stream_get_contents($output->getStream())
         );
     }
@@ -653,10 +653,10 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
 
         rewind($output->getStream());
         $this->assertEquals(
-            '  0/50 [>---------------------------]   0%'.
-            $this->generateOutput('  1/50 [>---------------------------]   2%').
-            $this->generateOutput(' 15/50 [========>-------------------]  30%').
-            $this->generateOutput(' 25/50 [==============>-------------]  50%'),
+            '  0/50 [>---------------------------]   0%'.$this->osc(1, 0).
+            $this->generateOutput('  1/50 [>---------------------------]   2%').$this->osc(1, 2).
+            $this->generateOutput(' 15/50 [========>-------------------]  30%').$this->osc(1, 30).
+            $this->generateOutput(' 25/50 [==============>-------------]  50%').$this->osc(1, 50),
             stream_get_contents($output->getStream())
         );
     }
@@ -680,10 +680,10 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
 
         rewind($output->getStream());
         $this->assertEquals(
-            ' 0/6 [>---------------------------]   0%'.
-            $this->generateOutput(' 3/6 [==============>-------------]  50%').
-            $this->generateOutput(' 5/6 [=======================>----]  83%').
-            $this->generateOutput(' 6/6 [============================] 100%'),
+            ' 0/6 [>---------------------------]   0%'.$this->osc(1, 0).
+            $this->generateOutput(' 3/6 [==============>-------------]  50%').$this->osc(1, 50).
+            $this->generateOutput(' 5/6 [=======================>----]  83%').$this->osc(1, 83).
+            $this->generateOutput(' 6/6 [============================] 100%').$this->osc(1, 100),
             stream_get_contents($output->getStream())
         );
     }
@@ -697,7 +697,7 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
 
         rewind($output->getStream());
         $this->assertEquals(
-            '    0 [>---------------------------]'.
+            '    0 [>---------------------------]'.$this->osc(3, 0).
             $this->generateOutput('    1 [->--------------------------]'),
             stream_get_contents($output->getStream())
         );
@@ -712,7 +712,7 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
 
         rewind($output->getStream());
         $this->assertEquals(
-            '    0 [>---------------------------]'.
+            '    0 [>---------------------------]'.$this->osc(3, 0).
             $this->generateOutput('    1 [->--------------------------]'),
             stream_get_contents($output->getStream())
         );
@@ -727,7 +727,7 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
 
         rewind($output->getStream());
         $this->assertEquals(
-            '    0 [>---------------------------]'.
+            '    0 [>---------------------------]'.$this->osc(3, 0).
             $this->generateOutput('    3 [■■■>------------------------]'),
             stream_get_contents($output->getStream())
         );
@@ -742,9 +742,9 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
 
         rewind($output->getStream());
         $this->assertEquals(
-            '  0/50 [>---------------------------]   0%'.
-            $this->generateOutput(' 25/50 [==============>-------------]  50%').
-            $this->generateOutput(''),
+            '  0/50 [>---------------------------]   0%'.$this->osc(1, 0).
+            $this->generateOutput(' 25/50 [==============>-------------]  50%').$this->osc(1, 50).
+            $this->generateOutput('').$this->osc(0, 0),
             stream_get_contents($output->getStream())
         );
     }
@@ -759,9 +759,9 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
 
         rewind($output->getStream());
         $this->assertEquals(
-            '   0/200 [>---------------------------]   0%'.
-            $this->generateOutput(' 199/200 [===========================>]  99%').
-            $this->generateOutput(' 200/200 [============================] 100%'),
+            '   0/200 [>---------------------------]   0%'.$this->osc(1, 0).
+            $this->generateOutput(' 199/200 [===========================>]  99%').$this->osc(1, 99).
+            $this->generateOutput(' 200/200 [============================] 100%').$this->osc(1, 100),
             stream_get_contents($output->getStream())
         );
     }
@@ -858,12 +858,12 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
 
         rewind($output->getStream());
         $this->assertEquals(
-            ' 0/2 [>---------------------------]   0%'."\n".
-            ' 0/3 [#---------------------------]   0%'."\n".
-            rtrim('    0 [>---------------------------]').
+            ' 0/2 [>---------------------------]   0%'.$this->osc(1, 0)."\n".
+            ' 0/3 [#---------------------------]   0%'.$this->osc(3, 0)."\n".
+            rtrim('    0 [>---------------------------]').$this->osc(3, 0).
 
             "\033[2A".
-            $this->generateOutput(' 1/2 [==============>-------------]  50%')."\n".
+            $this->generateOutput(' 1/2 [==============>-------------]  50%').$this->osc(3, 0)."\n".
             $this->generateOutput(' 1/3 [=========#------------------]  33%')."\n".
             rtrim($this->generateOutput('    1 [->--------------------------]')).
 
@@ -898,11 +898,11 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
 
         rewind($output->getStream());
         $this->assertEquals(
-            rtrim('    0 [>---------------------------]').
+            rtrim('    0 [>---------------------------]').$this->osc(3, 0).
             rtrim($this->generateOutput('    1 [->--------------------------]')).
             rtrim($this->generateOutput('    2 [-->-------------------------]')).
             rtrim($this->generateOutput('    3 [--->------------------------]')).
-            rtrim($this->generateOutput('    3 [============================]')),
+            rtrim($this->generateOutput('    3 [============================]')).$this->osc(1, 100).$this->osc(0, 0),
             stream_get_contents($output->getStream())
         );
     }
@@ -921,11 +921,11 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
 
         rewind($output->getStream());
         $this->assertEquals(
-            rtrim('    0 [>---------------------------]').
+            rtrim('    0 [>---------------------------]').$this->osc(3, 0).
             rtrim($this->generateOutput('    2 [-->-------------------------]')).
-            rtrim($this->generateOutput('  5/10 [==============>-------------]  50%')).
-            rtrim($this->generateOutput('  10/100 [==>-------------------------]  10%')).
-            rtrim($this->generateOutput(' 100/100 [============================] 100%')),
+            rtrim($this->generateOutput('  5/10 [==============>-------------]  50%')).$this->osc(1, 50).
+            rtrim($this->generateOutput('  10/100 [==>-------------------------]  10%')).$this->osc(1, 10).
+            rtrim($this->generateOutput(' 100/100 [============================] 100%')).$this->osc(1, 100).$this->osc(0, 0),
             stream_get_contents($output->getStream())
         );
     }
@@ -942,7 +942,7 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
 
         rewind($output->getStream());
         $this->assertEquals(
-            '    0 [>---]'.
+            '    0 [>---]'.$this->osc(3, 0).
             $this->generateOutput('    1 [->--]'),
             stream_get_contents($output->getStream())
         );
@@ -960,9 +960,9 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
 
         rewind($output->getStream());
         $this->assertEquals(
-            ' 3 [>---------------------------]'.
-            $this->generateOutput(' 2 [=========>------------------]').
-            $this->generateOutput(' 0 [============================]'),
+            ' 3 [>---------------------------]'.$this->osc(1, 0).
+            $this->generateOutput(' 2 [=========>------------------]').$this->osc(1, 33).
+            $this->generateOutput(' 0 [============================]').$this->osc(1, 100).$this->osc(0, 0),
             stream_get_contents($output->getStream())
         );
     }
@@ -981,9 +981,9 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
 
         rewind($output->getStream());
         $this->assertEquals(
-            ' 3 [>---------------------------]'.
-            $this->generateOutput(' 2 [=========>------------------]').
-            $this->generateOutput(' 0 [============================]'),
+            ' 3 [>---------------------------]'.$this->osc(1, 0).
+            $this->generateOutput(' 2 [=========>------------------]').$this->osc(1, 33).
+            $this->generateOutput(' 0 [============================]').$this->osc(1, 100).$this->osc(0, 0),
             stream_get_contents($output->getStream())
         );
     }
@@ -1000,12 +1000,12 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
 
         rewind($output->getStream());
         $this->assertEquals(
-            ">---------------------------\nfoobar".
-            $this->generateOutput("=========>------------------\nfoobar").
+            ">---------------------------\nfoobar".$this->osc(1, 0).
+            $this->generateOutput("=========>------------------\nfoobar").$this->osc(1, 33).
             "\x1B[1G\x1B[2K\x1B[1A".
-            $this->generateOutput('').
+            $this->generateOutput('').$this->osc(0, 0).
             $this->generateOutput('============================').
-            "\nfoobar",
+            "\nfoobar".$this->osc(1, 100).$this->osc(0, 0),
             stream_get_contents($output->getStream())
         );
     }
@@ -1034,7 +1034,7 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
         $this->assertEquals(
             " \033[44;37m Starting the demo... fingers crossed  \033[0m\n".
             '  0/15 '.$progress.str_repeat($empty, 26)."   0%\n".
-            " \xf0\x9f\x8f\x81  < 1 ms                         \033[44;37m 0 B \033[0m",
+            " \xf0\x9f\x8f\x81  < 1 ms                         \033[44;37m 0 B \033[0m".$this->osc(1, 0),
             stream_get_contents($output->getStream())
         );
         ftruncate($output->getStream(), 0);
@@ -1049,7 +1049,7 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
                 " \033[44;37m Looks good to me...                   \033[0m\n".
                 '  4/15 '.str_repeat($done, 7).$progress.str_repeat($empty, 19)."  26%\n".
                 " \xf0\x9f\x8f\x81  < 1 ms                      \033[41;37m 97 KiB \033[0m"
-            ),
+            ).$this->osc(1, 26),
             stream_get_contents($output->getStream())
         );
         ftruncate($output->getStream(), 0);
@@ -1064,7 +1064,7 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
                 " \033[44;37m Thanks, bye                           \033[0m\n".
                 ' 15/15 '.str_repeat($done, 28)." 100%\n".
                 " \xf0\x9f\x8f\x81  < 1 ms                     \033[41;37m 195 KiB \033[0m"
-            ),
+            ).$this->osc(1, 100).$this->osc(0, 0),
             stream_get_contents($output->getStream())
         );
         putenv('COLUMNS=120');
@@ -1077,7 +1077,7 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
         $bar->start();
         rewind($output->getStream());
         $this->assertEquals(
-            '    0 [>---------------------------]',
+            '    0 [>---------------------------]'.$this->osc(3, 0),
             stream_get_contents($output->getStream())
         );
 
@@ -1086,7 +1086,7 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
         $bar->start();
         rewind($output->getStream());
         $this->assertEquals(
-            '  0/10 [>---------------------------]   0%',
+            '  0/10 [>---------------------------]   0%'.$this->osc(1, 0),
             stream_get_contents($output->getStream())
         );
     }
@@ -1098,7 +1098,7 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
         $bar->start();
         rewind($output->getStream());
         $this->assertEquals(
-            ' 0/15 [>---------------------------]   0% < 1 ms/< 1 ms/< 1 ms',
+            ' 0/15 [>---------------------------]   0% < 1 ms/< 1 ms/< 1 ms'.$this->osc(1, 0),
             stream_get_contents($output->getStream())
         );
     }
@@ -1150,9 +1150,9 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
 
         rewind($output->getStream());
         $this->assertEquals(
-            ' 0/2 [>---------------------------]   0%'.
-            $this->generateOutput(' 1/2 [==============>-------------]  50%').
-            $this->generateOutput(' 2/2 [============================] 100%'),
+            ' 0/2 [>---------------------------]   0%'.$this->osc(1, 0).
+            $this->generateOutput(' 1/2 [==============>-------------]  50%').$this->osc(1, 50).
+            $this->generateOutput(' 2/2 [============================] 100%').$this->osc(1, 100).$this->osc(0, 0),
             stream_get_contents($output->getStream())
         );
     }
@@ -1168,10 +1168,10 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
 
         rewind($output->getStream());
         $this->assertEquals(
-            '    0 [>---------------------------]'.
+            '    0 [>---------------------------]'.$this->osc(3, 0).
             $this->generateOutput('    1 [->--------------------------]').
             $this->generateOutput('    2 [-->-------------------------]').
-            $this->generateOutput('    2 [============================]'),
+            $this->generateOutput('    2 [============================]').$this->osc(1, 100).$this->osc(0, 0),
             stream_get_contents($output->getStream())
         );
     }
@@ -1185,7 +1185,7 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
 
         rewind($output->getStream());
         $this->assertEquals(
-            ' 0/0 [============================] 100% < 1 ms/< 1 ms',
+            ' 0/0 [============================] 100% < 1 ms/< 1 ms'.$this->osc(1, 100).$this->osc(0, 0),
             stream_get_contents($output->getStream())
         );
     }
@@ -1200,6 +1200,11 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
         $count = substr_count($expected, "\n");
 
         return ($count ? str_repeat("\x1B[1G\x1b[2K\x1B[1A", $count) : '')."\x1B[1G\x1B[2K".$expected;
+    }
+
+    private function osc(int $state, int $percent): string
+    {
+        return \sprintf("\033]9;4;%d;%d\033\\", $state, $percent);
     }
 
     public function testBarWidthWithMultilineFormat()
@@ -1236,7 +1241,7 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
 
         rewind($output->getStream());
         $this->assertEquals(
-            '    0 [>---------------------------]'.
+            '    0 [>---------------------------]'.$this->osc(3, 0).
             $this->generateOutput('    2 [-->-------------------------]').
             $this->generateOutput('    3 [--->------------------------]'),
             stream_get_contents($output->getStream())
@@ -1265,12 +1270,142 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
 
         rewind($output->getStream());
         $this->assertEquals(
-            '    0 [>---------------------------]'.
+            '    0 [>---------------------------]'.$this->osc(3, 0).
             $this->generateOutput('    3 [--->------------------------]').
             $this->generateOutput('    4 [---->-----------------------]').
             $this->generateOutput('    7 [------->--------------------]'),
             stream_get_contents($output->getStream())
         );
+    }
+
+    public function testOscProgressDeterminate()
+    {
+        $bar = new ProgressBar($output = $this->getOutputStream(), 100, 0);
+        $bar->start();
+        $bar->setProgress(50);
+
+        rewind($output->getStream());
+        $contents = stream_get_contents($output->getStream());
+
+        $this->assertStringContainsString("\033]9;4;1;0\033\\", $contents);
+        $this->assertStringContainsString("\033]9;4;1;50\033\\", $contents);
+    }
+
+    public function testOscProgressIndeterminate()
+    {
+        $bar = new ProgressBar($output = $this->getOutputStream(), 0, 0);
+        $bar->start();
+        $bar->advance();
+
+        rewind($output->getStream());
+        $contents = stream_get_contents($output->getStream());
+
+        $this->assertStringContainsString("\033]9;4;3;0\033\\", $contents);
+    }
+
+    public function testOscProgressResetOnFinish()
+    {
+        $bar = new ProgressBar($output = $this->getOutputStream(), 3, 0);
+        $bar->start();
+        $bar->finish();
+
+        rewind($output->getStream());
+        $contents = stream_get_contents($output->getStream());
+
+        $this->assertStringContainsString("\033]9;4;1;0\033\\", $contents);
+        $this->assertStringContainsString("\033]9;4;1;100\033\\", $contents);
+        $this->assertStringContainsString("\033]9;4;0;0\033\\", $contents);
+    }
+
+    public function testOscProgressTreatsZeroMaxAsComplete()
+    {
+        $bar = new ProgressBar($output = $this->getOutputStream(), -5, 0);
+        $bar->start();
+        $bar->finish();
+
+        rewind($output->getStream());
+        $contents = stream_get_contents($output->getStream());
+
+        $this->assertStringContainsString("\033]9;4;1;0\033\\", $contents);
+        $this->assertStringContainsString("\033]9;4;1;100\033\\", $contents);
+    }
+
+    public function testOscProgressNotEmittedWhenOutputIsNotDecorated()
+    {
+        $bar = new ProgressBar($output = $this->getOutputStream(false), 10, 0);
+        $bar->start();
+        $bar->setProgress(5);
+        $bar->finish();
+
+        rewind($output->getStream());
+        $contents = stream_get_contents($output->getStream());
+
+        $this->assertStringNotContainsString("\033]9;4;", $contents);
+    }
+
+    public function testOscProgressMultipleBarsCollapseToIndeterminate()
+    {
+        $bar1 = new ProgressBar($output1 = $this->getOutputStream(), 100, 0);
+        $bar2 = new ProgressBar($output2 = $this->getOutputStream(), 100, 0);
+
+        $bar1->start();
+        $bar2->start();
+        $bar1->setProgress(50);
+        $bar2->finish();
+
+        rewind($output1->getStream());
+        $rewound = stream_get_contents($output1->getStream());
+        rewind($output2->getStream());
+        $rewound .= stream_get_contents($output2->getStream());
+
+        // First bar emits state=1 alone, then state=3 once second bar joins.
+        $this->assertStringContainsString("\033]9;4;1;0\033\\", $rewound);
+        $this->assertStringContainsString("\033]9;4;3;0\033\\", $rewound);
+        // Second bar's finish leaves the first one alone again, transitioning back to state=1.
+        $this->assertStringContainsString("\033]9;4;1;50\033\\", $rewound);
+    }
+
+    public function testOscProgressPauseResume()
+    {
+        $bar = new ProgressBar($output = $this->getOutputStream(), 100, 0);
+        $bar->start();
+        $bar->setProgress(40);
+
+        ProgressBar::pauseAll();
+        ProgressBar::resumeAll();
+
+        $bar->finish();
+
+        rewind($output->getStream());
+        $contents = stream_get_contents($output->getStream());
+
+        $this->assertStringContainsString("\033]9;4;1;40\033\\", $contents);
+        $this->assertStringContainsString("\033]9;4;4;40\033\\", $contents);
+        // After resume, the bar returns to state=1.
+        $this->assertStringContainsString("\033]9;4;1;100\033\\", $contents);
+        $this->assertStringContainsString("\033]9;4;0;0\033\\", $contents);
+    }
+
+    public function testOscProgressPauseAllIsReentrant()
+    {
+        $bar = new ProgressBar($output = $this->getOutputStream(), 100, 0);
+        $bar->start();
+
+        ProgressBar::pauseAll();
+        ProgressBar::pauseAll();
+        ProgressBar::resumeAll();
+        $bar->setProgress(20);
+        ProgressBar::resumeAll();
+
+        $bar->finish();
+
+        rewind($output->getStream());
+        $contents = stream_get_contents($output->getStream());
+
+        // Still paused after the inner pair, so progress emits state=4.
+        $this->assertStringContainsString("\033]9;4;4;20\033\\", $contents);
+        // Once both pauses are resumed, the bar's state=1 returns.
+        $this->assertStringContainsString("\033]9;4;1;20\033\\", $contents);
     }
 
     public function testMinSecondsBetweenRedraws()
@@ -1291,7 +1426,7 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
 
         rewind($output->getStream());
         $this->assertEquals(
-            '    0 [>---------------------------]'.
+            '    0 [>---------------------------]'.$this->osc(3, 0).
             $this->generateOutput('    2 [-->-------------------------]').
             $this->generateOutput('    4 [---->-----------------------]'),
             stream_get_contents($output->getStream())
@@ -1306,8 +1441,8 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
         $bar->display();
         rewind($output->getStream());
         $this->assertEquals(
-            ' 0/2 [>---------------------------]   0%'.
-            $this->generateOutput(' 1/2 [==============>-------------]  50%'),
+            ' 0/2 [>---------------------------]   0%'.$this->osc(1, 0).
+            $this->generateOutput(' 1/2 [==============>-------------]  50%').$this->osc(1, 50),
             stream_get_contents($output->getStream())
         );
     }
@@ -1333,10 +1468,10 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
 
         rewind($output->getStream());
         $this->assertEquals(
-            "0/3\n1234567890\nFoo".
-            $this->generateOutput("1/3\nABC\nFoo").
-            $this->generateOutput("2/3\nA\nFoo").
-            $this->generateOutput("3/3\nA\nFoo"),
+            "0/3\n1234567890\nFoo".$this->osc(1, 0).
+            $this->generateOutput("1/3\nABC\nFoo").$this->osc(1, 33).
+            $this->generateOutput("2/3\nA\nFoo").$this->osc(1, 66).
+            $this->generateOutput("3/3\nA\nFoo").$this->osc(1, 100).$this->osc(0, 0),
             stream_get_contents($output->getStream())
         );
     }
@@ -1355,13 +1490,13 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
         rewind($output->getStream());
         $this->assertEquals(
             "[>---------------------------]\n".
-            'Processing "foobar"...'.
+            'Processing "foobar"...'.$this->osc(3, 0).
             "\x1B[1G\x1B[2K\x1B[1A".
-            $this->generateOutput('').
+            $this->generateOutput('').$this->osc(0, 0).
             'Foo!'.\PHP_EOL.
             $this->generateOutput('[--->------------------------]').
-            "\nProcessing \"foobar\"...".
-            $this->generateOutput("[============================]\nProcessing \"foobar\"..."),
+            "\nProcessing \"foobar\"...".$this->osc(3, 0).
+            $this->generateOutput("[============================]\nProcessing \"foobar\"...").$this->osc(1, 100).$this->osc(0, 0),
             stream_get_contents($output->getStream())
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        |
| License       | MIT

This PR adds support for OSC 9;4 escape sequence for progress bars. More info [here](https://learn.microsoft.com/en-us/windows/terminal/tutorials/progress-bar-sequences). It looks like this (notice the blue bar just under the window title):

![screen_cast_20_10_2025_12_15_46](https://github.com/user-attachments/assets/64f2436f-9363-4344-a571-88fb8ecd297b)

<details><summary>Test script used in the GIF</summary>
<p>

```php
<?php

  require __DIR__.'/vendor/autoload.php';

  use Symfony\Component\Console\Helper\ProgressBar;
  use Symfony\Component\Console\Output\ConsoleOutput;

  $output = new ConsoleOutput();

  // Determinate bar (0–100%)
  $determinate = new ProgressBar($output, 100);
  $determinate->setOscProgressEnabled(true);

  $determinate->start();
  for ($i = 0; $i <= 100; ++$i) {
      $determinate->setProgress($i);
      usleep(50_000); // let the OSC indicator update visibly
  }
  $determinate->finish();
  $output->writeln('');

  // Indeterminate bar (no max)
  $indeterminate = new ProgressBar($output);
  $indeterminate->setOscProgressEnabled(true);

  $indeterminate->start();
  for ($i = 0; $i < 40; ++$i) {
      $indeterminate->advance();
      usleep(80_000);
  }
  $indeterminate->clear();
  $output->writeln('');
```

</p>
</details> 

It'll work on the supported terminals. And do nothing on terminals that do not support this sequence. 

