### PR TITLE
[HttpKernel] Add release link to welcome page

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Add `#[IsSignatureValid]` attribute to validate URI signatures
  * Make `Profile` final and `Profiler::__sleep()` internal
  * Collect the application runner class
+ * Add release link to welcome page
 
 7.3
 ---

--- a/src/Symfony/Component/HttpKernel/Resources/welcome.html.php
+++ b/src/Symfony/Component/HttpKernel/Resources/welcome.html.php
@@ -247,7 +247,7 @@ SVG;
                 <ul>
                     <li>
                         <?php echo $renderBoxIconSvg; ?>
-                        <span>You are using Symfony <strong><?php echo $version; ?></strong> version</span>
+                        <span>You are using <a href="https://symfony.com/releases/<?php echo $docVersion; ?>" target="_blank"><strong>Symfony <?php echo $docVersion; ?></strong></a><?php echo substr($version, strlen($docVersion)); ?> version</span>
                     </li>
 
                     <li>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

## Description

Makes the version number on the welcome page clickable, linking to the official Symfony release page.

This allows developers to quickly access the full changelog and release information directly from the debug welcome screen.

<img width="828" height="341" alt="image" src="https://github.com/user-attachments/assets/46e192f4-7815-489b-8236-a2340f6ee709" />