### PR TITLE
[Cache] Add `prefix` option to Redis DSN configuration

### DIFF
--- a/src/Symfony/Component/Cache/CHANGELOG.md
+++ b/src/Symfony/Component/Cache/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Bump ext-redis to 6.2 and ext-relay to 0.12 minimum
+ * Add support for `prefix` option in Redis DSN
 
 7.3
 ---

--- a/src/Symfony/Component/Cache/Tests/Traits/RedisTraitTest.php
+++ b/src/Symfony/Component/Cache/Tests/Traits/RedisTraitTest.php
@@ -201,4 +201,45 @@ class RedisTraitTest extends TestCase
             ],
         ];
     }
+
+    #[DataProvider('providePrefixDsnParameter')]
+    public function testPrefixDsnParameter(string $dsn, ?string $expectedPrefix)
+    {
+        if (!getenv('REDIS_AUTHENTICATED_HOST')) {
+            self::markTestSkipped('REDIS_AUTHENTICATED_HOST env var is not defined.');
+        }
+
+        $mock = new class {
+            use RedisTrait;
+        };
+        $connection = $mock::createConnection($dsn);
+        self::assertInstanceOf(\Redis::class, $connection);
+        self::assertSame($expectedPrefix, $connection->getOption(\Redis::OPT_PREFIX));
+    }
+
+    public static function providePrefixDsnParameter(): array
+    {
+        return [
+            [
+                'redis://:p%40ssword@'.getenv('REDIS_AUTHENTICATED_HOST'),
+                null,
+            ],
+            [
+                'redis:?host['.getenv('REDIS_HOST').']',
+                null,
+            ],
+            [
+                'redis:?host['.getenv('REDIS_HOST').']&prefix=prefix1:',
+                'prefix1:',
+            ],
+            [
+                'redis://:p%40ssword@'.getenv('REDIS_AUTHENTICATED_HOST').'?prefix=prefix2:',
+                'prefix2:',
+            ],
+            [
+                'redis://:p%40ssword@'.getenv('REDIS_AUTHENTICATED_HOST').'/?prefix=prefix3:',
+                'prefix3:',
+            ],
+        ];
+    }
 }

--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -52,6 +52,7 @@ trait RedisTrait
         'dbindex' => 0,
         'failover' => 'none',
         'ssl' => null, // see https://php.net/context.ssl
+        'prefix' => null,
     ];
     private \Redis|Relay|RelayCluster|\RedisArray|\RedisCluster|\Predis\ClientInterface $redis;
     private MarshallerInterface $marshaller;
@@ -318,6 +319,9 @@ trait RedisTrait
                     if (0 < $params['tcp_keepalive'] && (!$isRedisExt || \defined('Redis::OPT_TCP_KEEPALIVE'))) {
                         $redis->setOption($isRedisExt ? \Redis::OPT_TCP_KEEPALIVE : Relay::OPT_TCP_KEEPALIVE, $params['tcp_keepalive']);
                     }
+                    if (isset($params['prefix']) && (!$isRedisExt || \defined('Redis::OPT_PREFIX'))) {
+                        $redis->setOption($isRedisExt ? \Redis::OPT_PREFIX : Relay::OPT_PREFIX, $params['prefix']);
+                    }
                 } catch (\RedisException|\Relay\Exception $e) {
                     throw new InvalidArgumentException('Redis connection failed: '.$e->getMessage());
                 }
@@ -349,6 +353,9 @@ trait RedisTrait
 
             if (0 < $params['tcp_keepalive'] && (!$isRedisExt || \defined('Redis::OPT_TCP_KEEPALIVE'))) {
                 $redis->setOption($isRedisExt ? \Redis::OPT_TCP_KEEPALIVE : Relay::OPT_TCP_KEEPALIVE, $params['tcp_keepalive']);
+            }
+            if (isset($params['prefix']) && (!$isRedisExt || \defined('Redis::OPT_PREFIX'))) {
+                $redis->setOption($isRedisExt ? \Redis::OPT_PREFIX : Relay::OPT_PREFIX, $params['prefix']);
             }
         } elseif (is_a($class, RelayCluster::class, true)) {
             $initializer = static function () use ($class, $params, $hosts) {
@@ -395,6 +402,10 @@ trait RedisTrait
                     $relayCluster->setOption(Relay::OPT_READ_TIMEOUT, $params['read_timeout']);
                 }
 
+                if (isset($params['prefix'])) {
+                    $relayCluster->setOption(Relay::OPT_PREFIX, $params['prefix']);
+                }
+
                 return $relayCluster;
             };
 
@@ -417,6 +428,9 @@ trait RedisTrait
 
                 if (0 < $params['tcp_keepalive'] && (!$isRedisExt || \defined('Redis::OPT_TCP_KEEPALIVE'))) {
                     $redis->setOption($isRedisExt ? \Redis::OPT_TCP_KEEPALIVE : Relay::OPT_TCP_KEEPALIVE, $params['tcp_keepalive']);
+                }
+                if (isset($params['prefix']) && (!$isRedisExt || \defined('Redis::OPT_PREFIX'))) {
+                    $redis->setOption($isRedisExt ? \Redis::OPT_PREFIX : Relay::OPT_PREFIX, $params['prefix']);
                 }
                 $redis->setOption(\RedisCluster::OPT_SLAVE_FAILOVER, match ($params['failover']) {
                     'error' => \RedisCluster::FAILOVER_ERROR,
@@ -473,7 +487,7 @@ trait RedisTrait
             }
             $params['exceptions'] = false;
 
-            $redis = new $class($hosts, array_diff_key($params, array_diff_key(self::$defaultConnectionOptions, ['cluster' => null])));
+            $redis = new $class($hosts, array_diff_key($params, array_diff_key(self::$defaultConnectionOptions, ['cluster' => null, 'prefix' => null])));
             if (isset($params['sentinel'])) {
                 $redis->getConnection()->setSentinelTimeout($params['timeout']);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      |no
| New feature?  | yes<!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no<!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | - <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->

This adds the ability to set the Redis client `prefix` using the DSN configuration. When setting a prefix, the Redis clients automatically add a prefix to all keys.

Currently it's not possible to set the prefix easily and it requires multiple lines of service configuration. Setting the prefix option depends on the support in the Redis clients. All clients that are currently supported, also support setting this prefix.