### PR TITLE
 Add `TEST_GENERATE_FIXTURES=1` to generate fixtures in tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,6 +27,7 @@
         <env name="COUCHBASE_HOST" value="localhost" />
         <env name="COUCHBASE_USER" value="Administrator" />
         <env name="COUCHBASE_PASS" value="111111@" />
+        <env name="TEST_GENERATE_FIXTURES" value="0" />
     </php>
 
     <testsuites>

--- a/src/Symfony/Component/Config/Tests/Builder/GeneratedConfigTest.php
+++ b/src/Symfony/Component/Config/Tests/Builder/GeneratedConfigTest.php
@@ -86,10 +86,11 @@ class GeneratedConfigTest extends TestCase
         $expectedOutput = include $basePath.$name.'.output.php';
         $expectedCode = $basePath.$name;
 
-        // to regenerate snapshot files, uncomment these lines
-        // (new Filesystem())->remove($expectedCode);
-        // $this->generateConfigBuilder('Symfony\\Component\\Config\\Tests\\Builder\\Fixtures\\'.$name, $expectedCode);
-        // $this->markTestIncomplete('Re-comment the line above and relaunch the tests');
+        if ($_ENV['TEST_GENERATE_FIXTURES'] ?? false) {
+            (new Filesystem())->remove($expectedCode);
+            $this->generateConfigBuilder('Symfony\\Component\\Config\\Tests\\Builder\\Fixtures\\'.$name, $expectedCode);
+            $this->markTestIncomplete('TEST_GENERATE_FIXTURES is set');
+        }
 
         $this->generateConfigBuilder('Symfony\\Component\\Config\\Tests\\Builder\\Fixtures\\'.$name, $outputDir);
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/GraphvizDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/GraphvizDumperTest.php
@@ -23,22 +23,22 @@ class GraphvizDumperTest extends TestCase
 
     public static function setUpBeforeClass(): void
     {
-        self::$fixturesPath = __DIR__.'/../Fixtures/';
+        self::$fixturesPath = realpath(__DIR__.'/../Fixtures');
     }
 
     public function testDump()
     {
         $dumper = new GraphvizDumper($container = new ContainerBuilder());
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/graphviz/services1.dot', $dumper->dump(), '->dump() dumps an empty container as an empty dot file');
+        $this->assertStringEqualsGeneratedFile('services1.dot', $dumper->dump(), '->dump() dumps an empty container as an empty dot file');
 
         $container = include self::$fixturesPath.'/containers/container9.php';
         $dumper = new GraphvizDumper($container);
-        $this->assertStringEqualsFile(self::$fixturesPath.'/graphviz/services9.dot', $dumper->dump(), '->dump() dumps services');
+        $this->assertStringEqualsGeneratedFile('services9.dot', $dumper->dump(), '->dump() dumps services');
 
         $container = include self::$fixturesPath.'/containers/container10.php';
         $dumper = new GraphvizDumper($container);
-        $this->assertStringEqualsFile(self::$fixturesPath.'/graphviz/services10.dot', $dumper->dump(), '->dump() dumps services');
+        $this->assertStringEqualsGeneratedFile('services10.dot', $dumper->dump(), '->dump() dumps services');
 
         $container = include self::$fixturesPath.'/containers/container10.php';
         $dumper = new GraphvizDumper($container);
@@ -56,14 +56,14 @@ class GraphvizDumperTest extends TestCase
     {
         $container = include self::$fixturesPath.'/containers/container13.php';
         $dumper = new GraphvizDumper($container);
-        $this->assertStringEqualsFile(self::$fixturesPath.'/graphviz/services13.dot', $dumper->dump(), '->dump() dumps services');
+        $this->assertStringEqualsGeneratedFile('services13.dot', $dumper->dump(), '->dump() dumps services');
     }
 
     public function testDumpWithFrozenCustomClassContainer()
     {
         $container = include self::$fixturesPath.'/containers/container14.php';
         $dumper = new GraphvizDumper($container);
-        $this->assertStringEqualsFile(self::$fixturesPath.'/graphviz/services14.dot', $dumper->dump(), '->dump() dumps services');
+        $this->assertStringEqualsGeneratedFile('services14.dot', $dumper->dump(), '->dump() dumps services');
     }
 
     public function testDumpWithUnresolvedParameter()
@@ -71,7 +71,7 @@ class GraphvizDumperTest extends TestCase
         $container = include self::$fixturesPath.'/containers/container17.php';
         $dumper = new GraphvizDumper($container);
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/graphviz/services17.dot', $dumper->dump(), '->dump() dumps services');
+        $this->assertStringEqualsGeneratedFile('services17.dot', $dumper->dump(), '->dump() dumps services');
     }
 
     public function testDumpWithInlineDefinition()
@@ -83,6 +83,18 @@ class GraphvizDumperTest extends TestCase
         $container->register('bar', 'stdClass');
         $dumper = new GraphvizDumper($container);
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/graphviz/services_inline.dot', $dumper->dump(), '->dump() dumps nested references');
+        $this->assertStringEqualsGeneratedFile('services_inline.dot', $dumper->dump(), '->dump() dumps nested references');
+    }
+
+    private static function assertStringEqualsGeneratedFile(string $expectedFile, string $dumpedCode): void
+    {
+        $expectedFile = self::$fixturesPath.'/graphviz/'.$expectedFile;
+
+        if ($_ENV['TEST_GENERATE_FIXTURES'] ?? false) {
+            file_put_contents($expectedFile, $dumpedCode);
+            self::markTestIncomplete('TEST_GENERATE_FIXTURES is set');
+        }
+
+        self::assertStringEqualsFile($expectedFile, $dumpedCode);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -87,7 +87,7 @@ class PhpDumperTest extends TestCase
 
     public static function setUpBeforeClass(): void
     {
-        self::$fixturesPath = realpath(__DIR__.'/../Fixtures/');
+        self::$fixturesPath = realpath(__DIR__.'/../Fixtures');
     }
 
     public function testDump()
@@ -96,8 +96,8 @@ class PhpDumperTest extends TestCase
         $container->compile();
         $dumper = new PhpDumper($container);
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services1.php', $dumper->dump(), '->dump() dumps an empty container as an empty PHP class');
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services1-1.php', $dumper->dump(['class' => 'Container', 'base_class' => 'AbstractContainer', 'namespace' => 'Symfony\Component\DependencyInjection\Dump']), '->dump() takes a class and a base_class options');
+        $this->assertStringEqualsGeneratedFile('services1.php', $dumper->dump(), '->dump() dumps an empty container as an empty PHP class');
+        $this->assertStringEqualsGeneratedFile('services1-1.php', $dumper->dump(['class' => 'Container', 'base_class' => 'AbstractContainer', 'namespace' => 'Symfony\Component\DependencyInjection\Dump']), '->dump() takes a class and a base_class options');
     }
 
     public function testDumpOptimizationString()
@@ -127,7 +127,7 @@ class PhpDumperTest extends TestCase
         $container->compile();
 
         $dumper = new PhpDumper($container);
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services10.php', $dumper->dump(), '->dump() dumps an empty container as an empty PHP class');
+        $this->assertStringEqualsGeneratedFile('services10.php', $dumper->dump(), '->dump() dumps an empty container as an empty PHP class');
     }
 
     public function testDumpRelativeDir()
@@ -147,7 +147,7 @@ class PhpDumperTest extends TestCase
         $container->compile();
 
         $dumper = new PhpDumper($container);
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services12.php', $dumper->dump(['file' => __FILE__]), '->dump() dumps __DIR__ relative strings');
+        $this->assertStringEqualsGeneratedFile('services12.php', $dumper->dump(['file' => __FILE__]), '->dump() dumps __DIR__ relative strings');
     }
 
     public function testDumpCustomContainerClassWithoutConstructor()
@@ -157,7 +157,7 @@ class PhpDumperTest extends TestCase
 
         $dumper = new PhpDumper($container);
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/custom_container_class_without_constructor.php', $dumper->dump(['base_class' => 'NoConstructorContainer', 'namespace' => 'Symfony\Component\DependencyInjection\Tests\Fixtures\Container']));
+        $this->assertStringEqualsGeneratedFile('custom_container_class_without_constructor.php', $dumper->dump(['base_class' => 'NoConstructorContainer', 'namespace' => 'Symfony\Component\DependencyInjection\Tests\Fixtures\Container']));
     }
 
     public function testDumpCustomContainerClassConstructorWithoutArguments()
@@ -167,7 +167,7 @@ class PhpDumperTest extends TestCase
 
         $dumper = new PhpDumper($container);
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/custom_container_class_constructor_without_arguments.php', $dumper->dump(['base_class' => 'ConstructorWithoutArgumentsContainer', 'namespace' => 'Symfony\Component\DependencyInjection\Tests\Fixtures\Container']));
+        $this->assertStringEqualsGeneratedFile('custom_container_class_constructor_without_arguments.php', $dumper->dump(['base_class' => 'ConstructorWithoutArgumentsContainer', 'namespace' => 'Symfony\Component\DependencyInjection\Tests\Fixtures\Container']));
     }
 
     public function testDumpCustomContainerClassWithOptionalArgumentLessConstructor()
@@ -177,7 +177,7 @@ class PhpDumperTest extends TestCase
 
         $dumper = new PhpDumper($container);
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/custom_container_class_with_optional_constructor_arguments.php', $dumper->dump(['base_class' => 'ConstructorWithOptionalArgumentsContainer', 'namespace' => 'Symfony\Component\DependencyInjection\Tests\Fixtures\Container']));
+        $this->assertStringEqualsGeneratedFile('custom_container_class_with_optional_constructor_arguments.php', $dumper->dump(['base_class' => 'ConstructorWithOptionalArgumentsContainer', 'namespace' => 'Symfony\Component\DependencyInjection\Tests\Fixtures\Container']));
     }
 
     public function testDumpCustomContainerClassWithMandatoryArgumentLessConstructor()
@@ -187,7 +187,7 @@ class PhpDumperTest extends TestCase
 
         $dumper = new PhpDumper($container);
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/custom_container_class_with_mandatory_constructor_arguments.php', $dumper->dump(['base_class' => 'ConstructorWithMandatoryArgumentsContainer', 'namespace' => 'Symfony\Component\DependencyInjection\Tests\Fixtures\Container']));
+        $this->assertStringEqualsGeneratedFile('custom_container_class_with_mandatory_constructor_arguments.php', $dumper->dump(['base_class' => 'ConstructorWithMandatoryArgumentsContainer', 'namespace' => 'Symfony\Component\DependencyInjection\Tests\Fixtures\Container']));
     }
 
     public function testAddParameters()
@@ -195,7 +195,7 @@ class PhpDumperTest extends TestCase
         $container = include self::$fixturesPath.'/containers/container8.php';
         $container->compile();
         $dumper = new PhpDumper($container);
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services8.php', $dumper->dump(), '->dump() dumps parameters');
+        $this->assertStringEqualsGeneratedFile('services8.php', $dumper->dump(), '->dump() dumps parameters');
     }
 
     public function testAddServiceWithoutCompilation()
@@ -211,7 +211,7 @@ class PhpDumperTest extends TestCase
         $container = include self::$fixturesPath.'/containers/container9.php';
         $container->compile();
         $dumper = new PhpDumper($container);
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services9_compiled.php', str_replace(str_replace('\\', '\\\\', self::$fixturesPath.\DIRECTORY_SEPARATOR.'includes'.\DIRECTORY_SEPARATOR), '%path%', $dumper->dump()), '->dump() dumps services');
+        $this->assertStringEqualsGeneratedFile('services9_compiled.php', str_replace(str_replace('\\', '\\\\', self::$fixturesPath.\DIRECTORY_SEPARATOR.'includes'.\DIRECTORY_SEPARATOR), '%path%', $dumper->dump()), '->dump() dumps services');
 
         $container = new ContainerBuilder();
         $container->register('foo', 'FooClass')->addArgument(new \stdClass())->setPublic(true);
@@ -352,7 +352,7 @@ class PhpDumperTest extends TestCase
         $container->compile();
         $dumper = new PhpDumper($container);
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services19.php', $dumper->dump(), '->dump() dumps services with anonymous factories');
+        $this->assertStringEqualsGeneratedFile('services19.php', $dumper->dump(), '->dump() dumps services with anonymous factories');
     }
 
     public function testAddServiceIdWithUnsupportedCharacters()
@@ -366,7 +366,7 @@ class PhpDumperTest extends TestCase
         $container->compile();
         $dumper = new PhpDumper($container);
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services_unsupported_characters.php', $dumper->dump(['class' => $class]));
+        $this->assertStringEqualsGeneratedFile('services_unsupported_characters.php', $dumper->dump(['class' => $class]));
 
         require_once self::$fixturesPath.'/php/services_unsupported_characters.php';
 
@@ -476,7 +476,7 @@ class PhpDumperTest extends TestCase
         $container->compile();
         $dumper = new PhpDumper($container);
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services24.php', $dumper->dump());
+        $this->assertStringEqualsGeneratedFile('services24.php', $dumper->dump());
     }
 
     /**
@@ -493,7 +493,7 @@ class PhpDumperTest extends TestCase
 
         $dumper = new PhpDumper($container);
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services_deprecated_parameters.php', $dumper->dump());
+        $this->assertStringEqualsGeneratedFile('services_deprecated_parameters.php', $dumper->dump());
     }
 
     /**
@@ -521,7 +521,7 @@ class PhpDumperTest extends TestCase
 
         $dumper = new PhpDumper($container);
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services_nonempty_parameters.php', $dumper->dump());
+        $this->assertStringEqualsGeneratedFile('services_nonempty_parameters.php', $dumper->dump());
     }
 
     public function testNonEmptyParametersAsFiles()
@@ -541,7 +541,7 @@ class PhpDumperTest extends TestCase
         $container->compile();
         $dumper = new PhpDumper($container);
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services_env_in_id.php', $dumper->dump());
+        $this->assertStringEqualsGeneratedFile('services_env_in_id.php', $dumper->dump());
     }
 
     public function testEnvParameter()
@@ -555,7 +555,7 @@ class PhpDumperTest extends TestCase
         $container->compile();
         $dumper = new PhpDumper($container);
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services26.php', $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_EnvParameters', 'file' => self::$fixturesPath.'/php/services26.php', 'inline_factories' => false, 'inline_class_loader' => false]));
+        $this->assertStringEqualsGeneratedFile('services26.php', $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_EnvParameters', 'file' => self::$fixturesPath.'/php/services26.php', 'inline_factories' => false, 'inline_class_loader' => false]));
 
         require self::$fixturesPath.'/php/services26.php';
         $container = new \Symfony_DI_PhpDumper_Test_EnvParameters();
@@ -589,7 +589,7 @@ class PhpDumperTest extends TestCase
         $dumper = new PhpDumper($container);
         $dumper->dump();
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services_base64_env.php', $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_Base64Parameters']));
+        $this->assertStringEqualsGeneratedFile('services_base64_env.php', $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_Base64Parameters']));
 
         require self::$fixturesPath.'/php/services_base64_env.php';
         $container = new \Symfony_DI_PhpDumper_Test_Base64Parameters();
@@ -606,7 +606,7 @@ class PhpDumperTest extends TestCase
         $dumper = new PhpDumper($container);
         $dumper->dump();
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services_csv_env.php', $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_CsvParameters']));
+        $this->assertStringEqualsGeneratedFile('services_csv_env.php', $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_CsvParameters']));
 
         require self::$fixturesPath.'/php/services_csv_env.php';
         $container = new \Symfony_DI_PhpDumper_Test_CsvParameters();
@@ -627,7 +627,7 @@ class PhpDumperTest extends TestCase
         $dumper = new PhpDumper($container);
         $dumper->dump();
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services_default_env.php', $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_DefaultParameters']));
+        $this->assertStringEqualsGeneratedFile('services_default_env.php', $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_DefaultParameters']));
 
         require self::$fixturesPath.'/php/services_default_env.php';
         $container = new \Symfony_DI_PhpDumper_Test_DefaultParameters();
@@ -645,7 +645,7 @@ class PhpDumperTest extends TestCase
         $dumper = new PhpDumper($container);
         $dumper->dump();
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services_url_env.php', $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_UrlParameters']));
+        $this->assertStringEqualsGeneratedFile('services_url_env.php', $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_UrlParameters']));
 
         require self::$fixturesPath.'/php/services_url_env.php';
         $container = new \Symfony_DI_PhpDumper_Test_UrlParameters();
@@ -671,7 +671,7 @@ class PhpDumperTest extends TestCase
         $dumper = new PhpDumper($container);
         $dumper->dump();
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services_query_string_env.php', $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_QueryStringParameters']));
+        $this->assertStringEqualsGeneratedFile('services_query_string_env.php', $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_QueryStringParameters']));
 
         require self::$fixturesPath.'/php/services_query_string_env.php';
         $container = new \Symfony_DI_PhpDumper_Test_QueryStringParameters();
@@ -693,7 +693,7 @@ class PhpDumperTest extends TestCase
         $dumper = new PhpDumper($container);
         $dumper->dump();
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services_json_env.php', $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_JsonParameters']));
+        $this->assertStringEqualsGeneratedFile('services_json_env.php', $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_JsonParameters']));
 
         putenv('foobar="hello"');
         require self::$fixturesPath.'/php/services_json_env.php';
@@ -713,7 +713,7 @@ class PhpDumperTest extends TestCase
         $dumper = new PhpDumper($container);
         $dumper->dump();
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services_rot13_env.php', $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_Rot13Parameters']));
+        $this->assertStringEqualsGeneratedFile('services_rot13_env.php', $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_Rot13Parameters']));
 
         require self::$fixturesPath.'/php/services_rot13_env.php';
         $container = new \Symfony_DI_PhpDumper_Test_Rot13Parameters();
@@ -772,7 +772,7 @@ class PhpDumperTest extends TestCase
         $container->compile();
 
         $dumper = new PhpDumper($container);
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services13.php', $dumper->dump(), '->dump() dumps inline definitions which reference service_container');
+        $this->assertStringEqualsGeneratedFile('services13.php', $dumper->dump(), '->dump() dumps inline definitions which reference service_container');
     }
 
     public function testNonSharedLazy()
@@ -884,7 +884,7 @@ class PhpDumperTest extends TestCase
             $dumper->setProxyDumper(new \DummyProxyDumper());
         }
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/'.(\PHP_VERSION_ID < 80400 ? 'legacy_' : '').'services_non_shared_lazy'.($asGhostObject ? '_ghost' : '').'.php', $dumper->dump());
+        $this->assertStringEqualsGeneratedFile((\PHP_VERSION_ID < 80400 ? 'legacy_' : '').'services_non_shared_lazy'.($asGhostObject ? '_ghost' : '').'.php', $dumper->dump());
     }
 
     public function testNonSharedDuplicates()
@@ -901,7 +901,7 @@ class PhpDumperTest extends TestCase
 
         $dumper = new PhpDumper($container);
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services_non_shared_duplicates.php', $dumper->dump());
+        $this->assertStringEqualsGeneratedFile('services_non_shared_duplicates.php', $dumper->dump());
     }
 
     public function testInitializePropertiesBeforeMethodCalls()
@@ -957,7 +957,7 @@ class PhpDumperTest extends TestCase
 
         $dumper = new PhpDumper($container);
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/'.(\PHP_VERSION_ID < 80400 ? 'legacy_' : '').'services_dedup_lazy.php', $dumper->dump());
+        $this->assertStringEqualsGeneratedFile((\PHP_VERSION_ID < 80400 ? 'legacy_' : '').'services_dedup_lazy.php', $dumper->dump());
     }
 
     public function testLazyArgumentProvideGenerator()
@@ -1010,7 +1010,7 @@ class PhpDumperTest extends TestCase
         $container->compile();
         $dumper = new PhpDumper($container);
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services33.php', $dumper->dump());
+        $this->assertStringEqualsGeneratedFile('services33.php', $dumper->dump());
     }
 
     public function testDumpContainerBuilderWithFrozenConstructorIncludingPrivateServices()
@@ -1023,7 +1023,7 @@ class PhpDumperTest extends TestCase
 
         $dumper = new PhpDumper($container);
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services_private_frozen.php', $dumper->dump());
+        $this->assertStringEqualsGeneratedFile('services_private_frozen.php', $dumper->dump());
     }
 
     public function testServiceLocator()
@@ -1078,7 +1078,7 @@ class PhpDumperTest extends TestCase
 
         $dumper = new PhpDumper($container);
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services_locator.php', $dumper->dump());
+        $this->assertStringEqualsGeneratedFile('services_locator.php', $dumper->dump());
     }
 
     public function testServiceSubscriber()
@@ -1111,7 +1111,7 @@ class PhpDumperTest extends TestCase
 
         $dumper = new PhpDumper($container);
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services_subscriber.php', $dumper->dump());
+        $this->assertStringEqualsGeneratedFile('services_subscriber.php', $dumper->dump());
     }
 
     public function testPrivateWithIgnoreOnInvalidReference()
@@ -1162,7 +1162,7 @@ class PhpDumperTest extends TestCase
 
         $dumper = new PhpDumper($container);
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services_array_params.php', str_replace("'.\\DIRECTORY_SEPARATOR.'", '/', $dumper->dump(['file' => self::$fixturesPath.'/php/services_array_params.php', 'inline_factories' => false, 'inline_class_loader' => false])));
+        $this->assertStringEqualsGeneratedFile('services_array_params.php', str_replace("'.\\DIRECTORY_SEPARATOR.'", '/', $dumper->dump(['file' => self::$fixturesPath.'/php/services_array_params.php', 'inline_factories' => false, 'inline_class_loader' => false])));
     }
 
     public function testExpressionReferencingPrivateService()
@@ -1177,7 +1177,7 @@ class PhpDumperTest extends TestCase
         $container->compile();
         $dumper = new PhpDumper($container);
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services_private_in_expression.php', $dumper->dump());
+        $this->assertStringEqualsGeneratedFile('services_private_in_expression.php', $dumper->dump());
     }
 
     public function testUninitializedReference()
@@ -1186,7 +1186,7 @@ class PhpDumperTest extends TestCase
         $container->compile();
         $dumper = new PhpDumper($container);
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services_uninitialized_ref.php', $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_Uninitialized_Reference']));
+        $this->assertStringEqualsGeneratedFile('services_uninitialized_ref.php', $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_Uninitialized_Reference']));
 
         require self::$fixturesPath.'/php/services_uninitialized_ref.php';
 
@@ -1227,7 +1227,7 @@ class PhpDumperTest extends TestCase
         $dumper->setProxyDumper(new NullDumper());
 
         $container = 'Symfony_DI_PhpDumper_Test_Almost_Circular_'.ucfirst($visibility);
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services_almost_circular_'.$visibility.'.php', $dumper->dump(['class' => $container]));
+        $this->assertStringEqualsGeneratedFile('services_almost_circular_'.$visibility.'.php', $dumper->dump(['class' => $container]));
 
         require self::$fixturesPath.'/php/services_almost_circular_'.$visibility.'.php';
 
@@ -1293,7 +1293,7 @@ class PhpDumperTest extends TestCase
         $dumper = new PhpDumper($container);
         $dumper->dump();
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services_deep_graph.php', $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_Deep_Graph']));
+        $this->assertStringEqualsGeneratedFile('services_deep_graph.php', $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_Deep_Graph']));
 
         require self::$fixturesPath.'/php/services_deep_graph.php';
 
@@ -1322,7 +1322,7 @@ class PhpDumperTest extends TestCase
         $container->compile();
 
         $dumper = new PhpDumper($container);
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services_inline_self_ref.php', $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_Inline_Self_Ref']));
+        $this->assertStringEqualsGeneratedFile('services_inline_self_ref.php', $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_Inline_Self_Ref']));
     }
 
     public function testHotPathOptimizations()
@@ -1336,7 +1336,7 @@ class PhpDumperTest extends TestCase
             $dump = str_replace("'.\\DIRECTORY_SEPARATOR.'", '/', $dump);
         }
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services_inline_requires.php', $dump);
+        $this->assertStringEqualsGeneratedFile('services_inline_requires.php', $dump);
     }
 
     public function testDumpHandlesLiteralClassWithRootNamespace()
@@ -1389,7 +1389,7 @@ class PhpDumperTest extends TestCase
         $container->compile();
 
         $dumper = new PhpDumper($container);
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services_new_in_initializer.php', $dumper->dump());
+        $this->assertStringEqualsGeneratedFile('services_new_in_initializer.php', $dumper->dump());
     }
 
     public function testDumpHandlesEnumeration()
@@ -1474,7 +1474,7 @@ class PhpDumperTest extends TestCase
         $container->compile();
 
         $dumper = new PhpDumper($container);
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services_adawson.php', $dumper->dump());
+        $this->assertStringEqualsGeneratedFile('services_adawson.php', $dumper->dump());
     }
 
     public function testParameterWithMixedCase()
@@ -1500,7 +1500,7 @@ class PhpDumperTest extends TestCase
         $container->compile();
         $dumper = new PhpDumper($container);
         $dump = $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Errored_Definition']);
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services_errored_definition.php', str_replace(str_replace('\\', '\\\\', self::$fixturesPath.\DIRECTORY_SEPARATOR.'includes'.\DIRECTORY_SEPARATOR), '%path%', $dump));
+        $this->assertStringEqualsGeneratedFile('services_errored_definition.php', str_replace(str_replace('\\', '\\\\', self::$fixturesPath.\DIRECTORY_SEPARATOR.'includes'.\DIRECTORY_SEPARATOR), '%path%', $dump));
         eval('?>'.$dump);
 
         $container = new \Symfony_DI_PhpDumper_Errored_Definition();
@@ -1513,7 +1513,7 @@ class PhpDumperTest extends TestCase
         $container->compile();
         $dumper = new PhpDumper($container);
         $dump = $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Service_Locator_Argument']);
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services_service_locator_argument.php', str_replace(str_replace('\\', '\\\\', self::$fixturesPath.\DIRECTORY_SEPARATOR.'includes'.\DIRECTORY_SEPARATOR), '%path%', $dump));
+        $this->assertStringEqualsGeneratedFile('services_service_locator_argument.php', str_replace(str_replace('\\', '\\\\', self::$fixturesPath.\DIRECTORY_SEPARATOR.'includes'.\DIRECTORY_SEPARATOR), '%path%', $dump));
         eval('?>'.$dump);
 
         $container = new \Symfony_DI_PhpDumper_Service_Locator_Argument();
@@ -1597,7 +1597,7 @@ class PhpDumperTest extends TestCase
         $container->compile();
         $dumper = new PhpDumper($container);
         $dump = $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Service_Wither']);
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services_wither.php', $dump);
+        $this->assertStringEqualsGeneratedFile('services_wither.php', $dump);
         eval('?>'.$dump);
 
         $container = new \Symfony_DI_PhpDumper_Service_Wither();
@@ -1620,7 +1620,7 @@ class PhpDumperTest extends TestCase
         $container->compile();
         $dumper = new PhpDumper($container);
         $dump = $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Service_Wither_Lazy']);
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/'.(\PHP_VERSION_ID < 80400 ? 'legacy_' : '').'services_wither_lazy.php', $dump);
+        $this->assertStringEqualsGeneratedFile((\PHP_VERSION_ID < 80400 ? 'legacy_' : '').'services_wither_lazy.php', $dump);
         eval('?>'.$dump);
 
         $container = new \Symfony_DI_PhpDumper_Service_Wither_Lazy();
@@ -1649,7 +1649,7 @@ class PhpDumperTest extends TestCase
         $container->compile();
         $dumper = new PhpDumper($container);
         $dump = $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Service_Wither_Lazy_Non_Shared']);
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/'.(\PHP_VERSION_ID < 80400 ? 'legacy_' : '').'services_wither_lazy_non_shared.php', $dump);
+        $this->assertStringEqualsGeneratedFile((\PHP_VERSION_ID < 80400 ? 'legacy_' : '').'services_wither_lazy_non_shared.php', $dump);
         eval('?>'.$dump);
 
         $container = new \Symfony_DI_PhpDumper_Service_Wither_Lazy_Non_Shared();
@@ -1686,7 +1686,7 @@ class PhpDumperTest extends TestCase
         $container->compile();
         $dumper = new PhpDumper($container);
         $dump = $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Service_WitherStaticReturnType']);
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services_wither_staticreturntype.php', $dump);
+        $this->assertStringEqualsGeneratedFile('services_wither_staticreturntype.php', $dump);
         eval('?>'.$dump);
 
         $container = new \Symfony_DI_PhpDumper_Service_WitherStaticReturnType();
@@ -1768,7 +1768,7 @@ class PhpDumperTest extends TestCase
         $container->compile();
         $dumper = new PhpDumper($container);
         $dump = $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Service_CurrentFactoryInlining']);
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services_current_factory_inlining.php', $dump);
+        $this->assertStringEqualsGeneratedFile('services_current_factory_inlining.php', $dump);
         eval('?>'.$dump);
 
         $container = new \Symfony_DI_PhpDumper_Service_CurrentFactoryInlining();
@@ -1882,7 +1882,7 @@ class PhpDumperTest extends TestCase
         $container->compile();
         $dumper = new PhpDumper($container);
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/closure_proxy.php', $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_Closure_Proxy']));
+        $this->assertStringEqualsGeneratedFile('closure_proxy.php', $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_Closure_Proxy']));
 
         require self::$fixturesPath.'/php/closure_proxy.php';
 
@@ -1908,7 +1908,7 @@ class PhpDumperTest extends TestCase
         $container->compile();
         $dumper = new PhpDumper($container);
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/closure.php', $dumper->dump());
+        $this->assertStringEqualsGeneratedFile('closure.php', $dumper->dump());
     }
 
     public function testAutowireClosure()
@@ -1928,7 +1928,7 @@ class PhpDumperTest extends TestCase
         $container->compile();
         $dumper = new PhpDumper($container);
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/autowire_closure.php', $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_Autowire_Closure']));
+        $this->assertStringEqualsGeneratedFile('autowire_closure.php', $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_Autowire_Closure']));
 
         require self::$fixturesPath.'/php/autowire_closure.php';
 
@@ -1963,7 +1963,7 @@ class PhpDumperTest extends TestCase
         $container->compile();
         $dumper = new PhpDumper($container);
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/lazy_closure.php', $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_Lazy_Closure']));
+        $this->assertStringEqualsGeneratedFile('lazy_closure.php', $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_Lazy_Closure']));
 
         require self::$fixturesPath.'/php/lazy_closure.php';
 
@@ -1996,7 +1996,7 @@ class PhpDumperTest extends TestCase
         $container->compile();
         $dumper = new PhpDumper($container);
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/'.(\PHP_VERSION_ID < 80400 ? 'legacy_' : '').'lazy_autowire_attribute.php', $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_Lazy_Autowire_Attribute']));
+        $this->assertStringEqualsGeneratedFile((\PHP_VERSION_ID < 80400 ? 'legacy_' : '').'lazy_autowire_attribute.php', $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_Lazy_Autowire_Attribute']));
 
         require self::$fixturesPath.'/php/'.(\PHP_VERSION_ID < 80400 ? 'legacy_' : '').'lazy_autowire_attribute.php';
 
@@ -2034,9 +2034,9 @@ class PhpDumperTest extends TestCase
         $dumper = new PhpDumper($container);
 
         if (\PHP_VERSION_ID >= 80400) {
-            $this->assertStringEqualsFile(self::$fixturesPath.'/php/lazy_autowire_attribute_with_intersection.php', $dumper->dump());
+            $this->assertStringEqualsGeneratedFile('lazy_autowire_attribute_with_intersection.php', $dumper->dump());
         } else {
-            $this->assertStringEqualsFile(self::$fixturesPath.'/php/legacy_lazy_autowire_attribute_with_intersection.php', $dumper->dump());
+            $this->assertStringEqualsGeneratedFile('legacy_lazy_autowire_attribute_with_intersection.php', $dumper->dump());
         }
     }
 
@@ -2050,7 +2050,7 @@ class PhpDumperTest extends TestCase
         $container->compile();
         $dumper = new PhpDumper($container);
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/callable_adapter_consumer.php', $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_Callable_Adapter_Consumer']));
+        $this->assertStringEqualsGeneratedFile('callable_adapter_consumer.php', $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_Callable_Adapter_Consumer']));
 
         require self::$fixturesPath.'/php/callable_adapter_consumer.php';
 
@@ -2080,7 +2080,7 @@ class PhpDumperTest extends TestCase
         $container->compile();
         $dumper = new PhpDumper($container);
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/inline_adapter_consumer.php', $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_Inline_Adapter_Consumer']));
+        $this->assertStringEqualsGeneratedFile('inline_adapter_consumer.php', $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_Inline_Adapter_Consumer']));
 
         require self::$fixturesPath.'/php/inline_adapter_consumer.php';
 
@@ -2211,6 +2211,18 @@ class PhpDumperTest extends TestCase
                     EOF,
             ],
         ];
+    }
+
+    private static function assertStringEqualsGeneratedFile(string $expectedFile, string $dumpedCode): void
+    {
+        $expectedFile = self::$fixturesPath.'/php/'.$expectedFile;
+
+        if ($_ENV['TEST_GENERATE_FIXTURES'] ?? false) {
+            file_put_contents($expectedFile, $dumpedCode);
+            self::markTestIncomplete('TEST_GENERATE_FIXTURES is set');
+        }
+
+        self::assertStringEqualsFile($expectedFile, $dumpedCode);
     }
 }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
@@ -39,21 +39,21 @@ class XmlDumperTest extends TestCase
 
     public static function setUpBeforeClass(): void
     {
-        self::$fixturesPath = realpath(__DIR__.'/../Fixtures/');
+        self::$fixturesPath = realpath(__DIR__.'/../Fixtures');
     }
 
     public function testDump()
     {
         $dumper = new XmlDumper(new ContainerBuilder());
 
-        $this->assertXmlStringEqualsXmlFile(self::$fixturesPath.'/xml/services1.xml', $dumper->dump(), '->dump() dumps an empty container as an empty XML file');
+        $this->assertXmlStringEqualsGeneratedXmlFile('services1.xml', $dumper->dump(), '->dump() dumps an empty container as an empty XML file');
     }
 
     public function testExportParameters()
     {
-        $container = include self::$fixturesPath.'//containers/container8.php';
+        $container = include self::$fixturesPath.'/containers/container8.php';
         $dumper = new XmlDumper($container);
-        $this->assertXmlStringEqualsXmlFile(self::$fixturesPath.'/xml/services8.xml', $dumper->dump(), '->dump() dumps parameters');
+        $this->assertXmlStringEqualsGeneratedXmlFile('services8.xml', $dumper->dump(), '->dump() dumps parameters');
     }
 
     public function testAddService()
@@ -180,7 +180,7 @@ class XmlDumperTest extends TestCase
         $container = include self::$fixturesPath.'/containers/container21.php';
         $dumper = new XmlDumper($container);
 
-        $this->assertEquals(file_get_contents(self::$fixturesPath.'/xml/services21.xml'), $dumper->dump());
+        $this->assertXmlStringEqualsGeneratedXmlFile('services21.xml', $dumper->dump());
     }
 
     public function testDumpAutowireData()
@@ -188,7 +188,7 @@ class XmlDumperTest extends TestCase
         $container = include self::$fixturesPath.'/containers/container24.php';
         $dumper = new XmlDumper($container);
 
-        $this->assertEquals(file_get_contents(self::$fixturesPath.'/xml/services24.xml'), $dumper->dump());
+        $this->assertXmlStringEqualsGeneratedXmlFile('services24.xml', $dumper->dump());
     }
 
     #[IgnoreDeprecations]
@@ -204,7 +204,7 @@ class XmlDumperTest extends TestCase
         $this->assertEquals([new Reference('bar', ContainerInterface::IGNORE_ON_UNINITIALIZED_REFERENCE)], $container->getDefinition('foo')->getArguments());
 
         $dumper = new XmlDumper($container);
-        $this->assertStringEqualsFile(self::$fixturesPath.'/xml/services_dump_load.xml', $dumper->dump());
+        $this->assertXmlStringEqualsGeneratedXmlFile('services_dump_load.xml', $dumper->dump());
     }
 
     public function testTaggedArguments()
@@ -246,7 +246,7 @@ class XmlDumperTest extends TestCase
         ;
 
         $dumper = new XmlDumper($container);
-        $this->assertStringEqualsFile(self::$fixturesPath.'/xml/services_with_tagged_arguments.xml', $dumper->dump());
+        $this->assertXmlStringEqualsGeneratedXmlFile('services_with_tagged_arguments.xml', $dumper->dump());
     }
 
     public function testServiceClosure()
@@ -257,7 +257,7 @@ class XmlDumperTest extends TestCase
         ;
 
         $dumper = new XmlDumper($container);
-        $this->assertStringEqualsFile(self::$fixturesPath.'/xml/services_with_service_closure.xml', $dumper->dump());
+        $this->assertXmlStringEqualsGeneratedXmlFile('services_with_service_closure.xml', $dumper->dump());
     }
 
     public function testDumpAbstractServices()
@@ -265,7 +265,7 @@ class XmlDumperTest extends TestCase
         $container = include self::$fixturesPath.'/containers/container_abstract.php';
         $dumper = new XmlDumper($container);
 
-        $this->assertEquals(file_get_contents(self::$fixturesPath.'/xml/services_abstract.xml'), $dumper->dump());
+        $this->assertXmlStringEqualsGeneratedXmlFile('services_abstract.xml', $dumper->dump());
     }
 
     public function testDumpHandlesEnumeration()
@@ -282,7 +282,7 @@ class XmlDumperTest extends TestCase
         $container->compile();
         $dumper = new XmlDumper($container);
 
-        $this->assertEquals(file_get_contents(self::$fixturesPath.'/xml/services_with_enumeration.xml'), $dumper->dump());
+        $this->assertXmlStringEqualsGeneratedXmlFile('services_with_enumeration.xml', $dumper->dump());
     }
 
     #[DataProvider('provideDefaultClasses')]
@@ -317,7 +317,7 @@ class XmlDumperTest extends TestCase
             ->setArgument('$bar', 'test');
 
         $dumper = new XmlDumper($container);
-        $this->assertStringEqualsFile(self::$fixturesPath.'/xml/services_with_abstract_argument.xml', $dumper->dump());
+        $this->assertXmlStringEqualsGeneratedXmlFile('services_with_abstract_argument.xml', $dumper->dump());
     }
 
     public function testDumpNonScalarTags()
@@ -325,6 +325,18 @@ class XmlDumperTest extends TestCase
         $container = include self::$fixturesPath.'/containers/container_non_scalar_tags.php';
         $dumper = new XmlDumper($container);
 
-        $this->assertEquals(file_get_contents(self::$fixturesPath.'/xml/services_with_array_tags.xml'), $dumper->dump());
+        $this->assertXmlStringEqualsGeneratedXmlFile('services_with_array_tags.xml', $dumper->dump());
+    }
+
+    private static function assertXmlStringEqualsGeneratedXmlFile(string $expectedFile, string $dumpedCode): void
+    {
+        $expectedFile = self::$fixturesPath.'/xml/'.$expectedFile;
+
+        if ($_ENV['TEST_GENERATE_FIXTURES'] ?? false) {
+            file_put_contents($expectedFile, $dumpedCode);
+            self::markTestIncomplete('TEST_GENERATE_FIXTURES is set');
+        }
+
+        self::assertXmlStringEqualsXmlFile($expectedFile, $dumpedCode);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
@@ -40,14 +40,14 @@ class YamlDumperTest extends TestCase
 
     public static function setUpBeforeClass(): void
     {
-        self::$fixturesPath = realpath(__DIR__.'/../Fixtures/');
+        self::$fixturesPath = realpath(__DIR__.'/../Fixtures');
     }
 
     public function testDump()
     {
-        $dumper = new YamlDumper($container = new ContainerBuilder());
+        $dumper = new YamlDumper(new ContainerBuilder());
 
-        $this->assertEqualYamlStructure(file_get_contents(self::$fixturesPath.'/yaml/services1.yml'), $dumper->dump(), '->dump() dumps an empty container as an empty YAML file');
+        $this->assertStringEqualsGeneratedFile('services1.yml', $dumper->dump(), '->dump() dumps an empty container as an empty YAML file');
     }
 
     public function testAddParameters()
@@ -78,14 +78,14 @@ class YamlDumperTest extends TestCase
     {
         $container = include self::$fixturesPath.'/containers/container24.php';
         $dumper = new YamlDumper($container);
-        $this->assertStringEqualsFile(self::$fixturesPath.'/yaml/services24.yml', $dumper->dump());
+        $this->assertStringEqualsGeneratedFile('services24.yml', $dumper->dump());
     }
 
     public function testDumpDecoratedServices()
     {
         $container = include self::$fixturesPath.'/containers/container34.php';
         $dumper = new YamlDumper($container);
-        $this->assertStringEqualsFile(self::$fixturesPath.'/yaml/services34.yml', $dumper->dump());
+        $this->assertStringEqualsGeneratedFile('services34.yml', $dumper->dump());
     }
 
     public function testDumpLoad()
@@ -97,7 +97,7 @@ class YamlDumperTest extends TestCase
         $this->assertEquals([new Reference('bar', ContainerInterface::IGNORE_ON_UNINITIALIZED_REFERENCE)], $container->getDefinition('foo')->getArguments());
 
         $dumper = new YamlDumper($container);
-        $this->assertStringEqualsFile(self::$fixturesPath.'/yaml/services_dump_load.yml', $dumper->dump());
+        $this->assertStringEqualsGeneratedFile('services_dump_load.yml', $dumper->dump());
     }
 
     public function testInlineServices()
@@ -111,7 +111,7 @@ class YamlDumperTest extends TestCase
         ;
 
         $dumper = new YamlDumper($container);
-        $this->assertStringEqualsFile(self::$fixturesPath.'/yaml/services_inline.yml', $dumper->dump());
+        $this->assertStringEqualsGeneratedFile('services_inline.yml', $dumper->dump());
     }
 
     public function testTaggedArguments()
@@ -136,7 +136,7 @@ class YamlDumperTest extends TestCase
         $container->register('bar_service_tagged_locator', 'Bar')->addArgument(new ServiceLocatorArgument(new TaggedIteratorArgument('foo')));
 
         $dumper = new YamlDumper($container);
-        $this->assertStringEqualsFile(self::$fixturesPath.'/yaml/services_with_tagged_argument.yml', $dumper->dump());
+        $this->assertStringEqualsGeneratedFile('services_with_tagged_argument.yml', $dumper->dump());
     }
 
     public function testServiceClosure()
@@ -147,7 +147,7 @@ class YamlDumperTest extends TestCase
         ;
 
         $dumper = new YamlDumper($container);
-        $this->assertStringEqualsFile(self::$fixturesPath.'/yaml/services_with_service_closure.yml', $dumper->dump());
+        $this->assertStringEqualsGeneratedFile('services_with_service_closure.yml', $dumper->dump());
     }
 
     public function testDumpHandlesEnumeration()
@@ -165,9 +165,9 @@ class YamlDumperTest extends TestCase
         $dumper = new YamlDumper($container);
 
         if (str_starts_with(Yaml::dump(FooUnitEnum::BAR), '!php/enum')) {
-            $this->assertEquals(file_get_contents(self::$fixturesPath.'/yaml/services_with_enumeration_enum_tag.yml'), $dumper->dump());
+            $this->assertStringEqualsGeneratedFile('services_with_enumeration_enum_tag.yml', $dumper->dump());
         } else {
-            $this->assertEquals(file_get_contents(self::$fixturesPath.'/yaml/services_with_enumeration.yml'), $dumper->dump());
+            $this->assertStringEqualsGeneratedFile('services_with_enumeration.yml', $dumper->dump());
         }
     }
 
@@ -185,7 +185,7 @@ class YamlDumperTest extends TestCase
 
         $dumper = new YamlDumper($container);
 
-        $this->assertSame(file_get_contents(self::$fixturesPath.'/yaml/'.$expectedFile), $dumper->dump());
+        $this->assertStringEqualsGeneratedFile($expectedFile, $dumper->dump());
     }
 
     public static function provideDefaultClasses()
@@ -203,7 +203,7 @@ class YamlDumperTest extends TestCase
             ->setArgument('$bar', 'test');
 
         $dumper = new YamlDumper($container);
-        $this->assertStringEqualsFile(self::$fixturesPath.'/yaml/services_with_abstract_argument.yml', $dumper->dump());
+        $this->assertStringEqualsGeneratedFile('services_with_abstract_argument.yml', $dumper->dump());
     }
 
     public function testDumpNonScalarTags()
@@ -211,7 +211,7 @@ class YamlDumperTest extends TestCase
         $container = include self::$fixturesPath.'/containers/container_non_scalar_tags.php';
         $dumper = new YamlDumper($container);
 
-        $this->assertEquals(file_get_contents(self::$fixturesPath.'/yaml/services_with_array_tags.yml'), $dumper->dump());
+        $this->assertStringEqualsGeneratedFile('services_with_array_tags.yml', $dumper->dump());
     }
 
     public function testDumpResolvedEnvPlaceholders()
@@ -231,7 +231,7 @@ class YamlDumperTest extends TestCase
         $container->compile();
         $dumper = new YamlDumper($container);
 
-        $this->assertEquals(file_get_contents(self::$fixturesPath.'/yaml/container_with_env_placeholders.yml'), $dumper->dump());
+        $this->assertStringEqualsGeneratedFile('container_with_env_placeholders.yml', $dumper->dump());
     }
 
     private function assertEqualYamlStructure(string $expected, string $yaml, string $message = '')
@@ -239,5 +239,17 @@ class YamlDumperTest extends TestCase
         $parser = new Parser();
 
         $this->assertEquals($parser->parse($expected, Yaml::PARSE_CUSTOM_TAGS), $parser->parse($yaml, Yaml::PARSE_CUSTOM_TAGS), $message);
+    }
+
+    private static function assertStringEqualsGeneratedFile(string $expectedFile, string $dumpedCode): void
+    {
+        $expectedFile = self::$fixturesPath.'/yaml/'.$expectedFile;
+
+        if ($_ENV['TEST_GENERATE_FIXTURES'] ?? false) {
+            file_put_contents($expectedFile, $dumpedCode);
+            self::markTestIncomplete('TEST_GENERATE_FIXTURES is set');
+        }
+
+        self::assertStringEqualsFile($expectedFile, $dumpedCode);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services1.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services1.yml
@@ -1,3 +1,4 @@
+
 services:
     service_container:
         class: Symfony\Component\DependencyInjection\ContainerInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

We do a lot of snapshot testing without saying so, comparing what is generated with what is expected, which we generated previously.

By adding a new generic environment variable `TEST_GENERATE_FIXTURES=1`, you can enable/disable regeneration without having to uncomment/recomment code.