### PR TITLE
[Config] Add getter of definition nodes properties

### DIFF
--- a/src/Symfony/Component/Config/Builder/ArrayShapeGenerator.php
+++ b/src/Symfony/Component/Config/Builder/ArrayShapeGenerator.php
@@ -39,7 +39,7 @@ final class ArrayShapeGenerator
     {
         if (!$node instanceof ArrayNode) {
             return match (true) {
-                $node instanceof BooleanNode => $node->hasDefaultValue() && null === $node->getDefaultValue() ? 'bool|null' : 'bool',
+                $node instanceof BooleanNode => $node->isNullable() ? 'bool|null' : 'bool',
                 $node instanceof StringNode => 'string',
                 $node instanceof NumericNode => self::handleNumericNode($node),
                 $node instanceof EnumNode => $node->getPermissibleValues('|', false),

--- a/src/Symfony/Component/Config/CHANGELOG.md
+++ b/src/Symfony/Component/Config/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 7.4
 ---
 
- * Add TagAwareAdapterInterface to NullAdapter
+ * Add `TagAwareAdapterInterface` to `NullAdapter`
  * Add argument `$singular` to `NodeBuilder::arrayNode()` to decouple plurals/singulars from XML
  * Add support for `defaultNull()` on `ArrayNodeDefinition`
  * Add `ArrayNodeDefinition::acceptAndWrap()` to list alternative types that should be accepted and wrapped in an array
@@ -12,6 +12,7 @@ CHANGELOG
  * Deprecate accessing the internal scope of the loader in PHP config files, use only its public API instead
  * Deprecate setting a default value to a node that is required, and vice versa
  * Deprecate generating fluent methods in config builders
+ * Add getters `BaseNode::getEquivalentValues()`, `VariableNode::getAllowEmptyValue()`, `NumericNode::getMin()`, `NumericNode::getMax()` and `BooleanNode::isNullable()`
 
 7.3
 ---

--- a/src/Symfony/Component/Config/Definition/BaseNode.php
+++ b/src/Symfony/Component/Config/Definition/BaseNode.php
@@ -170,6 +170,16 @@ abstract class BaseNode implements NodeInterface
     }
 
     /**
+     * Gets the list of equivalent values [original, equivalent].
+     *
+     * @return list<array{0: mixed, 1: mixed}>
+     */
+    public function getEquivalentValues(): array
+    {
+        return $this->equivalentValues;
+    }
+
+    /**
      * Set this node as required.
      */
     public function setRequired(bool $boolean): void

--- a/src/Symfony/Component/Config/Definition/BooleanNode.php
+++ b/src/Symfony/Component/Config/Definition/BooleanNode.php
@@ -29,6 +29,11 @@ class BooleanNode extends ScalarNode
         parent::__construct($name, $parent, $pathSeparator);
     }
 
+    public function isNullable(): bool
+    {
+        return $this->nullable;
+    }
+
     protected function validateType(mixed $value): void
     {
         if (!\is_bool($value)) {

--- a/src/Symfony/Component/Config/Definition/VariableNode.php
+++ b/src/Symfony/Component/Config/Definition/VariableNode.php
@@ -48,11 +48,16 @@ class VariableNode extends BaseNode implements PrototypeNodeInterface
     /**
      * Sets if this node is allowed to have an empty value.
      *
-     * @param bool $boolean True if this entity will accept empty values
+     * @param bool $boolean True if this entity accepts empty values
      */
     public function setAllowEmptyValue(bool $boolean): void
     {
         $this->allowEmptyValue = $boolean;
+    }
+
+    public function getAllowEmptyValue(): bool
+    {
+        return $this->allowEmptyValue;
     }
 
     public function setName(string $name): void

--- a/src/Symfony/Component/Config/Tests/Builder/ArrayShapeGeneratorTest.php
+++ b/src/Symfony/Component/Config/Tests/Builder/ArrayShapeGeneratorTest.php
@@ -47,20 +47,24 @@ class ArrayShapeGeneratorTest extends TestCase
 
         yield [new BooleanNode('node'), 'bool'];
 
-        yield [new BooleanNode('node', nullable: true), 'bool|null'];
-        yield [new EnumNode('node', values: ['a', 'b']), '"a"|"b"'];
+        yield [
+            new BooleanNode('node', null, BooleanNode::DEFAULT_PATH_SEPARATOR, true),
+            'bool|null',
+        ];
+
+        yield [new EnumNode('node', null, ['a', 'b']), '"a"|"b"'];
         yield [new ScalarNode('node'), 'scalar|null'];
         yield [new VariableNode('node'), 'mixed'];
 
         yield [new IntegerNode('node'), 'int<min, max>'];
-        yield [new IntegerNode('node', min: 1), 'int<1, max>'];
-        yield [new IntegerNode('node', max: 10), 'int<min, 10>'];
-        yield [new IntegerNode('node', min: 1, max: 10), 'int<1, 10>'];
+        yield [new IntegerNode('node', null, 1), 'int<1, max>'];
+        yield [new IntegerNode('node', null, null, 10), 'int<min, 10>'];
+        yield [new IntegerNode('node', null, 1, max: 10), 'int<1, 10>'];
 
         yield [new FloatNode('node'), 'float'];
-        yield [new FloatNode('node', min: 1.1), 'float'];
-        yield [new FloatNode('node', max: 10.1), 'float'];
-        yield [new FloatNode('node', min: 1.1, max: 10.1), 'float'];
+        yield [new FloatNode('node', null, 1.1), 'float'];
+        yield [new FloatNode('node', null, null, 10.1), 'float'];
+        yield [new FloatNode('node', null, 1.1, 10.1), 'float'];
     }
 
     public function testPrototypedArrayNodePhpDoc()

--- a/src/Symfony/Component/Config/Tests/Builder/ArrayShapeGeneratorTest.php
+++ b/src/Symfony/Component/Config/Tests/Builder/ArrayShapeGeneratorTest.php
@@ -47,10 +47,7 @@ class ArrayShapeGeneratorTest extends TestCase
 
         yield [new BooleanNode('node'), 'bool'];
 
-        $nullableBooleanNode = new BooleanNode('node');
-        $nullableBooleanNode->setDefaultValue(null);
-
-        yield [$nullableBooleanNode, 'bool|null'];
+        yield [new BooleanNode('node', nullable: true), 'bool|null'];
         yield [new EnumNode('node', values: ['a', 'b']), '"a"|"b"'];
         yield [new ScalarNode('node'), 'scalar|null'];
         yield [new VariableNode('node'), 'mixed'];

--- a/src/Symfony/Component/Config/Tests/Definition/BooleanNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/BooleanNodeTest.php
@@ -25,6 +25,18 @@ class BooleanNodeTest extends TestCase
         $this->assertSame($value, $node->normalize($value));
     }
 
+    public function testEquivalentValues()
+    {
+        $node = new BooleanNode('test', null);
+        $node->addEquivalentValue(null, true);
+
+        $this->assertSame([
+            [null, true],
+        ], $node->getEquivalentValues());
+
+        $this->assertTrue($node->normalize(null));
+    }
+
     public function testNullValueOnNullable()
     {
         $node = new BooleanNode('test', null, '.', true);

--- a/src/Symfony/Component/Config/Tests/Definition/BooleanNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/BooleanNodeTest.php
@@ -29,12 +29,15 @@ class BooleanNodeTest extends TestCase
     {
         $node = new BooleanNode('test', null, '.', true);
 
+        $this->assertTrue($node->isNullable());
         $this->assertNull($node->normalize(null));
     }
 
     public function testNullValueOnNotNullable()
     {
         $node = new BooleanNode('test', null, '.', false);
+        $this->assertFalse($node->isNullable());
+        $this->assertTrue($node->getAllowEmptyValue());
 
         $this->expectException(InvalidTypeException::class);
         $this->expectExceptionMessage('Invalid type for path "test". Expected "bool", but got "null".');
@@ -45,6 +48,7 @@ class BooleanNodeTest extends TestCase
     public function testInvalidValueOnNullable()
     {
         $node = new BooleanNode('test', null, '.', true);
+        $this->assertTrue($node->isNullable());
         $this->assertTrue($node->getAllowEmptyValue());
 
         $this->expectException(InvalidTypeException::class);

--- a/src/Symfony/Component/Config/Tests/Definition/BooleanNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/BooleanNodeTest.php
@@ -45,6 +45,7 @@ class BooleanNodeTest extends TestCase
     public function testInvalidValueOnNullable()
     {
         $node = new BooleanNode('test', null, '.', true);
+        $this->assertTrue($node->getAllowEmptyValue());
 
         $this->expectException(InvalidTypeException::class);
         $this->expectExceptionMessage('Invalid type for path "test". Expected "bool" or "null", but got "int".');
@@ -58,6 +59,7 @@ class BooleanNodeTest extends TestCase
         $node = new BooleanNode('test');
         $node->setAllowEmptyValue(false);
 
+        $this->assertFalse($node->getAllowEmptyValue());
         $this->assertSame($value, $node->finalize($value));
     }
 

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/BooleanNodeDefinitionTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/BooleanNodeDefinitionTest.php
@@ -25,6 +25,17 @@ class BooleanNodeDefinitionTest extends TestCase
         $def->cannotBeEmpty();
     }
 
+    public function testBooleanNodeNotNullable()
+    {
+        $def = new BooleanNodeDefinition('foo');
+
+        $node = $def->getNode();
+        $this->assertFalse($node->hasDefaultValue());
+        $this->assertFalse($node->isNullable());
+
+        $this->assertTrue($node->normalize(null));
+    }
+
     public function testBooleanNodeWithDefaultNull()
     {
         $def = new BooleanNodeDefinition('foo');
@@ -33,6 +44,7 @@ class BooleanNodeDefinitionTest extends TestCase
         $node = $def->getNode();
         $this->assertTrue($node->hasDefaultValue());
         $this->assertNull($node->getDefaultValue());
+        $this->assertTrue($node->isNullable());
 
         $this->assertNull($node->normalize(null));
     }
@@ -45,6 +57,7 @@ class BooleanNodeDefinitionTest extends TestCase
         $node = $def->getNode();
         $this->assertTrue($node->hasDefaultValue());
         $this->assertNull($node->getDefaultValue());
+        $this->assertTrue($node->isNullable());
 
         $this->assertNull($node->normalize(null));
     }

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/NumericNodeDefinitionTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/NumericNodeDefinitionTest.php
@@ -42,21 +42,27 @@ class NumericNodeDefinitionTest extends TestCase
     public function testIntegerMinAssertion()
     {
         $node = new IntegerNodeDefinition('foo');
+        $node = $node->min(5)->getNode();
+        $this->assertSame(5, $node->getMin());
+        $this->assertNull($node->getMax());
 
         $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage('The value 4 is too small for path "foo". Should be greater than or equal to 5');
 
-        $node->min(5)->getNode()->finalize(4);
+        $node->finalize(4);
     }
 
     public function testIntegerMaxAssertion()
     {
         $node = new IntegerNodeDefinition('foo');
+        $node = $node->max(3)->getNode();
+        $this->assertSame(3, $node->getMax());
+        $this->assertNull($node->getMin());
 
         $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage('The value 4 is too big for path "foo". Should be less than or equal to 3');
 
-        $node->max(3)->getNode()->finalize(4);
+        $node->finalize(4);
     }
 
     public function testIntegerValidMinMaxAssertion()

--- a/src/Symfony/Component/Config/Tests/Definition/FloatNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/FloatNodeTest.php
@@ -22,6 +22,7 @@ class FloatNodeTest extends TestCase
     public function testNormalize(int|float $value)
     {
         $node = new FloatNode('test');
+        $this->assertTrue($node->getAllowEmptyValue());
         $this->assertSame($value, $node->normalize($value));
     }
 
@@ -31,6 +32,7 @@ class FloatNodeTest extends TestCase
         $node = new FloatNode('test');
         $node->setAllowEmptyValue(false);
 
+        $this->assertFalse($node->getAllowEmptyValue());
         $this->assertSame($value, $node->finalize($value));
     }
 

--- a/src/Symfony/Component/Config/Tests/Definition/FloatNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/FloatNodeTest.php
@@ -26,6 +26,18 @@ class FloatNodeTest extends TestCase
         $this->assertSame($value, $node->normalize($value));
     }
 
+    public function testEquivalentValues()
+    {
+        $node = new FloatNode('test');
+        $node->addEquivalentValue(true, 4.2);
+
+        $this->assertSame([
+            [true, 4.2],
+        ], $node->getEquivalentValues());
+
+        $this->assertSame(4.2, $node->normalize(true));
+    }
+
     #[DataProvider('getValidValues')]
     public function testValidNonEmptyValues(int|float $value)
     {

--- a/src/Symfony/Component/Config/Tests/Definition/IntegerNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/IntegerNodeTest.php
@@ -26,6 +26,18 @@ class IntegerNodeTest extends TestCase
         $this->assertSame($value, $node->normalize($value));
     }
 
+    public function testEquivalentValues()
+    {
+        $node = new IntegerNode('test');
+        $node->addEquivalentValue(true, 42);
+
+        $this->assertSame([
+            [true, 42],
+        ], $node->getEquivalentValues());
+
+        $this->assertSame(42, $node->normalize(true));
+    }
+
     #[DataProvider('getValidValues')]
     public function testValidNonEmptyValues(int $value)
     {

--- a/src/Symfony/Component/Config/Tests/Definition/IntegerNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/IntegerNodeTest.php
@@ -22,6 +22,7 @@ class IntegerNodeTest extends TestCase
     public function testNormalize(int $value)
     {
         $node = new IntegerNode('test');
+        $this->assertTrue($node->getAllowEmptyValue());
         $this->assertSame($value, $node->normalize($value));
     }
 
@@ -31,6 +32,7 @@ class IntegerNodeTest extends TestCase
         $node = new IntegerNode('test');
         $node->setAllowEmptyValue(false);
 
+        $this->assertFalse($node->getAllowEmptyValue());
         $this->assertSame($value, $node->finalize($value));
     }
 

--- a/src/Symfony/Component/Config/Tests/Definition/ScalarNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/ScalarNodeTest.php
@@ -43,6 +43,24 @@ class ScalarNodeTest extends TestCase
         ];
     }
 
+    public function testEquivalentValues()
+    {
+        $node = new ScalarNode('test');
+        $node->addEquivalentValue(0, 'equivalentZero');
+        $node->addEquivalentValue(null, 'equivalentNull');
+        $node->addEquivalentValue(true, 'equivalentTrue');
+
+        $this->assertSame([
+            [0, 'equivalentZero'],
+            [null, 'equivalentNull'],
+            [true, 'equivalentTrue'],
+        ], $node->getEquivalentValues());
+
+        $this->assertSame('equivalentZero', $node->normalize(0));
+        $this->assertSame('equivalentNull', $node->normalize(null));
+        $this->assertSame('equivalentTrue', $node->normalize(true));
+    }
+
     public function testSetDeprecated()
     {
         $childNode = new ScalarNode('foo');

--- a/src/Symfony/Component/Config/Tests/Definition/ScalarNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/ScalarNodeTest.php
@@ -127,6 +127,7 @@ class ScalarNodeTest extends TestCase
     {
         $node = new ScalarNode('test');
         $node->setInfo('"the test value"');
+        $this->assertTrue($node->getAllowEmptyValue());
 
         $this->expectException(InvalidTypeException::class);
         $this->expectExceptionMessage("Invalid type for path \"test\". Expected \"scalar\", but got \"array\".\nHint: \"the test value\"");
@@ -140,6 +141,7 @@ class ScalarNodeTest extends TestCase
         $node = new ScalarNode('test');
         $node->setAllowEmptyValue(false);
 
+        $this->assertFalse($node->getAllowEmptyValue());
         $this->assertSame($value, $node->finalize($value));
     }
 
@@ -161,6 +163,7 @@ class ScalarNodeTest extends TestCase
     {
         $node = new ScalarNode('test');
         $node->setAllowEmptyValue(false);
+        $this->assertFalse($node->getAllowEmptyValue());
 
         $this->expectException(InvalidConfigurationException::class);
 

--- a/src/Symfony/Component/Config/Tests/Definition/StringNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/StringNodeTest.php
@@ -43,4 +43,16 @@ class StringNodeTest extends TestCase
 
         $node->normalize($value);
     }
+
+    public function testEquivalentValues()
+    {
+        $node = new StringNode('test');
+        $node->addEquivalentValue(true, 'equivalentTrue');
+
+        $this->assertSame([
+            [true, 'equivalentTrue'],
+        ], $node->getEquivalentValues());
+
+        $this->assertSame('equivalentTrue', $node->normalize(true));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

In https://github.com/symfony/symfony/commit/b68f0e6349a8c287844bbea365db4823284f31d9, the methods `NumericNode::getMin()` et `NumericNode::getMax()` have been added so that they can be used to generate the array shape.

Other getters would be necessary for the `JsonSchema` generator (https://github.com/symfony/symfony/pull/59620)

- `BaseNode::getEquivalentValues()` indicate if `null`, `true`, `false` are allowed values
- `BooleanNode::isNullable()` indicates if `null` is an allowed value
- `VariableNode::getAllowEmptyValue()` indicates if an empty string is allowed
