### PR TITLE
[Config] Fix array shape for `canBeEnabled` / `canBeDisabled`

### DIFF
--- a/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
@@ -389,6 +389,14 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
             ->treatFalseLike(['enabled' => false])
             ->treatTrueLike(['enabled' => true])
             ->treatNullLike(['enabled' => true])
+            ->beforeNormalization()
+                ->ifArray()
+                ->then(static function ($v) {
+                    $v['enabled'] ??= true;
+
+                    return $v;
+                })
+            ->end()
             ->children()
                 ->booleanNode('enabled')
                     ->defaultTrue()

--- a/src/Symfony/Component/Config/Tests/Builder/ArrayShapeGeneratorTest.php
+++ b/src/Symfony/Component/Config/Tests/Builder/ArrayShapeGeneratorTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Builder\ArrayShapeGenerator;
 use Symfony\Component\Config\Definition\ArrayNode;
 use Symfony\Component\Config\Definition\BooleanNode;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\EnumNode;
 use Symfony\Component\Config\Definition\FloatNode;
 use Symfony\Component\Config\Definition\IntegerNode;
@@ -145,6 +146,30 @@ class ArrayShapeGeneratorTest extends TestCase
         $root->addChild($child);
 
         $this->assertStringMatchesFormat('array{%Achild?: array<%s>,%A}', ArrayShapeGenerator::generate($root));
+    }
+
+    public function testCanBeEnabled()
+    {
+        $root = new ArrayNodeDefinition('root');
+        $root->canBeEnabled();
+
+        $this->assertSame(<<<'CODE'
+            array{ // Default: {"enabled":false}
+             *     enabled?: bool, // Default: false
+             * }|bool
+            CODE, ArrayShapeGenerator::generate($root->getNode()));
+    }
+
+    public function testCanBeDisabled()
+    {
+        $root = new ArrayNodeDefinition('root');
+        $root->canBeDisabled();
+
+        $this->assertSame(<<<'CODE'
+            array{ // Default: {"enabled":true}
+             *     enabled?: bool, // Default: true
+             * }|bool
+            CODE, ArrayShapeGenerator::generate($root->getNode()));
     }
 
     #[DataProvider('provideQuotedNodes')]

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayValues/Symfony/Config/ArrayValues/ErrorPagesConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayValues/Symfony/Config/ArrayValues/ErrorPagesConfig.php
@@ -44,7 +44,7 @@ class ErrorPagesConfig
      * @param array{ // Default: {"enabled":false}
      *     enabled?: bool, // Default: false
      *     with_trace?: bool,
-     * } $config
+     * }|bool $config
      */
     public function __construct(array $config = [])
     {

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayValues/Symfony/Config/ArrayValues/TransportsConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayValues/Symfony/Config/ArrayValues/TransportsConfig.php
@@ -29,7 +29,7 @@ class TransportsConfig
     /**
      * @param array{
      *     dsn?: scalar|null,
-     * } $config
+     * }|string $config
      */
     public function __construct(array $config = [])
     {

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayValues/Symfony/Config/ArrayValuesConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayValues/Symfony/Config/ArrayValuesConfig.php
@@ -81,11 +81,11 @@ class ArrayValuesConfig implements \Symfony\Component\Config\Builder\ConfigBuild
      * @param array{
      *     transports?: array<string, array{
      *         dsn?: scalar|null,
-     *     }>,
+     *     }|string>,
      *     error_pages?: array{ // Default: {"enabled":false}
      *         enabled?: bool, // Default: false
      *         with_trace?: bool,
-     *     },
+     *     }|bool,
      * } $config
      */
     public function __construct(array $config = [])

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypesConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ScalarNormalizedTypes/Symfony/Config/ScalarNormalizedTypesConfig.php
@@ -151,7 +151,7 @@ class ScalarNormalizedTypesConfig implements \Symfony\Component\Config\Builder\C
     /**
      * @param array{
      *     simple_array?: list<scalar|null>,
-     *     keyed_array?: array<string, list<scalar|null>>,
+     *     keyed_array?: array<string, list<scalar|null>|string>,
      *     object?: array{ // Default: {"enabled":null}
      *         enabled?: bool|null, // Default: null
      *         date_format?: scalar|null,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When using `canBeDisabled` or `canBeEnabled`, the type `bool` must be allowed.

The new test uses the builder; the generated array-shape depend on multiple options set on the node.