### PR TITLE
[DoctrineBridge] Remove unnecassary check

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php
+++ b/src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php
@@ -125,7 +125,7 @@ class DoctrineOrmTypeGuesser implements FormTypeGuesserInterface
     public function guessMaxLength(string $class, string $property): ?ValueGuess
     {
         $ret = $this->getMetadata($class);
-        if ($ret && isset($ret[0]->fieldMappings[$property]) && !$ret[0]->hasAssociation($property)) {
+        if ($ret && isset($ret[0]->fieldMappings[$property])) {
             $mapping = $ret[0]->getFieldMapping($property);
 
             $length = $mapping instanceof FieldMapping ? $mapping->length : ($mapping['length'] ?? null);
@@ -145,7 +145,7 @@ class DoctrineOrmTypeGuesser implements FormTypeGuesserInterface
     public function guessPattern(string $class, string $property): ?ValueGuess
     {
         $ret = $this->getMetadata($class);
-        if ($ret && isset($ret[0]->fieldMappings[$property]) && !$ret[0]->hasAssociation($property)) {
+        if ($ret && isset($ret[0]->fieldMappings[$property])) {
             if (\in_array($ret[0]->getTypeOfField($property), [Types::DECIMAL, Types::FLOAT], true)) {
                 return new ValueGuess(null, Guess::MEDIUM_CONFIDENCE);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | ~~6.4~~  7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Mini refactoring.

~~Branch 6.4 because https://symfony.com/doc/current/contributing/code/maintenance.html says refactoring MAY be accepted~~
- ~~for consistency with the existing code base~~
- ~~if not too invasive~~
- ~~if merging into higher branches would not lead to complex branch merging~~

Removes the check because Doctrine does not allow a property to have a `FieldMapping` and an `AssociationMapping` at the same time and it's not the responsibility of client code to check that again.

Details: 
Before adding a field mapping Doctrine ORM (v2, v3, v4) checks if a mapping (may it be a field, embeddable or association mapping) for the property already exists. And vice versa it checks it before adding an association mapping.

Links to Doctrine ORM:
- https://github.com/doctrine/orm/blob/18d07a1003c294950695637b0b7fce9c43b46ce2/src/Mapping/ClassMetadataInfo.php#L2727
- https://github.com/doctrine/orm/blob/18d07a1003c294950695637b0b7fce9c43b46ce2/src/Mapping/ClassMetadataInfo.php#L3817C1-L3826C6