### PR TITLE
[Config] Generate JSON schema for config

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -32,6 +32,7 @@ CHANGELOG
  * Add support for configuring JsonStreamer's `default_options`
  * Add project-scoped `flock` and `semaphore` lock store services
  * Add `createFormFlowBuilder` method to `AbstractController` and `ControllerHelper`
+ * Generate JSON schema for YAML configuration of bundles
  * Deprecate setting the `framework.profiler.collect_serializer_data` config option
  * Deprecate the `framework.http_cache.terminate_on_cache_hit` config option
  * Add support for `framework.secrets.decryption_env_var` to contain dots

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/JsonSchemaConfigDumpPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/JsonSchemaConfigDumpPass.php
@@ -1,0 +1,163 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\Config\Definition\ArrayNode;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\Dumper\JsonSchemaDumper;
+use Symfony\Component\Config\Definition\PrototypedArrayNode;
+use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\ConfigurationExtensionInterface;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+use Symfony\Component\DependencyInjection\Kernel\BundleInterface;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * @internal
+ */
+class JsonSchemaConfigDumpPass implements CompilerPassInterface
+{
+    /**
+     * @param array<class-string, array<string, bool>> $bundlesDefinition
+     */
+    public function __construct(
+        private string $schemaFile,
+        private array $bundlesDefinition,
+    ) {
+    }
+
+    public function process(ContainerBuilder $container): void
+    {
+        if (!class_exists(Yaml::class) || !class_exists(JsonSchemaDumper::class)) {
+            return;
+        }
+
+        $generator = new JsonSchemaDumper(parameterSchemas: [['$ref' => '#/$defs/types/param']]);
+
+        $defs = [];
+        $allAliases = [];
+        $envAliases = [];
+
+        $registeredExtensions = $container->getExtensions();
+        foreach ($this->bundlesDefinition as $bundle => $envs) {
+            if (!is_subclass_of($bundle, BundleInterface::class)) {
+                continue;
+            }
+
+            if (!$extension = new $bundle()->getContainerExtension()) {
+                continue;
+            }
+
+            $extensionAlias = $extension->getAlias();
+            if (isset($registeredExtensions[$extensionAlias])) {
+                $extension = $registeredExtensions[$extensionAlias];
+                unset($registeredExtensions[$extensionAlias]);
+            }
+
+            if (!$configuration = $this->getConfiguration($extension, $container)) {
+                continue;
+            }
+
+            $tree = $configuration->getConfigTreeBuilder()->buildTree();
+            if ($tree instanceof ArrayNode && !$tree instanceof PrototypedArrayNode && !$tree->getChildren()) {
+                continue;
+            }
+
+            $defs[$extensionAlias] = $generator->dumpNode($tree);
+
+            if ($envs['all'] ?? false) {
+                $allAliases[] = $extensionAlias;
+            }
+            foreach ($envs as $env => $active) {
+                if ($active && 'all' !== $env) {
+                    $envAliases[$env][] = $extensionAlias;
+                }
+            }
+        }
+
+        foreach ($registeredExtensions as $alias => $extension) {
+            if (!$configuration = $this->getConfiguration($extension, $container)) {
+                continue;
+            }
+
+            $tree = $configuration->getConfigTreeBuilder()->buildTree();
+            if ($tree instanceof ArrayNode && !$tree instanceof PrototypedArrayNode && !$tree->getChildren()) {
+                continue;
+            }
+
+            $defs[$alias] = $generator->dumpNode($tree);
+            $allAliases[] = $alias;
+        }
+
+        $allDefs = $generator->getAllDefs();
+        $allDefs['types']['param'] = ['type' => 'string', 'pattern' => '^%[^%]+%$'];
+        ksort($allDefs['types']);
+        ksort($defs);
+        $allDefs['nodes'] = $defs;
+        $allProperties = [];
+        foreach ($allAliases as $alias) {
+            $allProperties[$alias] = ['$ref' => '#/$defs/nodes/'.$alias];
+        }
+
+        ksort($allProperties);
+        ksort($envAliases);
+        $rootProperties = $allProperties;
+        foreach ($envAliases as $env => $aliases) {
+            $whenProperties = $allProperties;
+            foreach ($aliases as $alias) {
+                $whenProperties[$alias] = ['$ref' => '#/$defs/nodes/'.$alias];
+            }
+            ksort($whenProperties);
+            $rootProperties['when@'.$env] = [
+                'type' => 'object',
+                'properties' => $whenProperties,
+                'additionalProperties' => false,
+            ];
+        }
+
+        $schema = [
+            '$schema' => 'https://json-schema.org/draft/2020-12/schema',
+            '$comment' => 'This file is auto-generated and is for apps only. Bundles SHOULD NOT rely on its content.',
+            '$defs' => $allDefs,
+            'type' => 'object',
+            'properties' => $rootProperties,
+            'patternProperties' => [
+                '^when@[a-zA-Z0-9]+$' => [
+                    'type' => 'object',
+                    'properties' => $allProperties,
+                ],
+            ],
+        ];
+
+        $content = json_encode($schema, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE | \JSON_THROW_ON_ERROR)."\n";
+
+        $dir = \dirname($this->schemaFile);
+        if (is_dir($dir) && is_writable($dir)) {
+            if (!is_file($this->schemaFile) || file_get_contents($this->schemaFile) !== $content) {
+                file_put_contents($this->schemaFile, $content);
+            }
+
+            $container->addResource(new FileResource($this->schemaFile));
+        }
+    }
+
+    private function getConfiguration(ExtensionInterface $extension, ContainerBuilder $container): ?ConfigurationInterface
+    {
+        return match (true) {
+            $extension instanceof ConfigurationInterface => $extension,
+            $extension instanceof ConfigurationExtensionInterface => $extension->getConfiguration([], $container),
+            default => null,
+        };
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -18,6 +18,7 @@ use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ContainerBuilder
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\DeprecateJsonStreamerValueTransformerTagPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ErrorLoggerCompilerPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\JsonPathPass;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\JsonSchemaConfigDumpPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\PhpConfigReferenceDumpPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ProfilerPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\RemoveUnusedSessionMarshallingHandlerPass;
@@ -222,6 +223,7 @@ class FrameworkBundle extends Bundle
         if ($container->getParameter('kernel.debug')) {
             if ($container->hasParameter('.kernel.config_dir') && $container->hasParameter('.kernel.bundles_definition')) {
                 $container->addCompilerPass(new PhpConfigReferenceDumpPass($container->getParameter('.kernel.config_dir').'/reference.php', $container->getParameter('.kernel.bundles_definition')));
+                $container->addCompilerPass(new JsonSchemaConfigDumpPass($container->getParameter('.kernel.config_dir').'/schema.json', $container->getParameter('.kernel.bundles_definition')));
             }
             $container->addCompilerPass(new AddDebugLogProcessorPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 2);
             $container->addCompilerPass(new UnusedTagsPass(), PassConfig::TYPE_AFTER_REMOVING);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/JsonSchemaConfigDumpPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/JsonSchemaConfigDumpPassTest.php
@@ -1,0 +1,234 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
+
+use PHPUnit\Framework\Attributes\RequiresMethod;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\JsonSchemaConfigDumpPass;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\Dumper\JsonSchemaDumper;
+use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\Yaml\Yaml;
+
+#[RequiresMethod(Yaml::class, 'parse')]
+class JsonSchemaConfigDumpPassTest extends TestCase
+{
+    private string $readOnlyDir;
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        if (!class_exists(JsonSchemaDumper::class)) {
+            $this->markTestSkipped(JsonSchemaDumper::class.' is not available.');
+        }
+
+        $this->tempDir = sys_get_temp_dir().'/sf_test_json_schema';
+        mkdir($this->tempDir, 0o777, true);
+
+        $this->readOnlyDir = $this->tempDir.'/readonly';
+        mkdir($this->readOnlyDir, 0o444, true);
+
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            exec('attrib +r '.escapeshellarg($this->readOnlyDir));
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->tempDir)) {
+            if ('\\' === \DIRECTORY_SEPARATOR) {
+                exec('attrib -r '.escapeshellarg($this->readOnlyDir));
+            }
+
+            $fs = new Filesystem();
+            $fs->remove($this->tempDir);
+        }
+    }
+
+    public function testProcessGeneratesSchemaFile()
+    {
+        $container = new ContainerBuilder();
+
+        $pass = new JsonSchemaConfigDumpPass($this->tempDir.'/schema.json', [
+            JsonSchemaTestBundle::class => ['all' => true],
+        ]);
+        $pass->process($container);
+
+        $schemaFile = $this->tempDir.'/schema.json';
+        $this->assertFileExists($schemaFile);
+
+        $schema = json_decode(file_get_contents($schemaFile), true);
+        $this->assertSame('https://json-schema.org/draft/2020-12/schema', $schema['$schema']);
+        $this->assertSame('object', $schema['type']);
+        $this->assertArrayHasKey('json_schema_test', $schema['$defs']['nodes']);
+        $this->assertSame(['$ref' => '#/$defs/nodes/json_schema_test'], $schema['properties']['json_schema_test']);
+        $this->assertArrayNotHasKey('when@all', $schema['properties']);
+        // patternProperties allows any when@<custom-env> with 'all' bundles
+        $this->assertSame(['$ref' => '#/$defs/nodes/json_schema_test'], $schema['patternProperties']['^when@[a-zA-Z0-9]+$']['properties']['json_schema_test']);
+        $this->assertEquals([new FileResource(realpath($this->tempDir).'/schema.json')], $container->getResources());
+    }
+
+    public function testProcessCreatesWhenEnvProperties()
+    {
+        $container = new ContainerBuilder();
+
+        $pass = new JsonSchemaConfigDumpPass($this->tempDir.'/schema_env.json', [
+            JsonSchemaTestBundle::class => ['dev' => true, 'test' => true],
+        ]);
+        $pass->process($container);
+
+        $schema = json_decode(file_get_contents($this->tempDir.'/schema_env.json'), true);
+        $this->assertArrayNotHasKey('json_schema_test', $schema['properties']);
+        $this->assertArrayHasKey('when@dev', $schema['properties']);
+        $this->assertArrayHasKey('json_schema_test', $schema['properties']['when@dev']['properties']);
+        $this->assertSame(['$ref' => '#/$defs/nodes/json_schema_test'], $schema['properties']['when@dev']['properties']['json_schema_test']);
+        $this->assertArrayHasKey('when@test', $schema['properties']);
+    }
+
+    public function testProcessMixedEnvs()
+    {
+        $container = new ContainerBuilder();
+
+        $pass = new JsonSchemaConfigDumpPass($this->tempDir.'/schema_mixed.json', [
+            JsonSchemaTestBundle::class => ['all' => true],
+            JsonSchemaDevBundle::class => ['dev' => true],
+        ]);
+        $pass->process($container);
+
+        $schema = json_decode(file_get_contents($this->tempDir.'/schema_mixed.json'), true);
+        // 'all' bundle in root properties
+        $this->assertSame(['$ref' => '#/$defs/nodes/json_schema_test'], $schema['properties']['json_schema_test']);
+        // dev-only bundle not in root properties
+        $this->assertArrayNotHasKey('json_schema_dev', $schema['properties']);
+        // when@dev contains both the 'all' bundle and the dev-only bundle, with additionalProperties: false
+        $this->assertArrayHasKey('when@dev', $schema['properties']);
+        $this->assertArrayHasKey('json_schema_test', $schema['properties']['when@dev']['properties']);
+        $this->assertArrayHasKey('json_schema_dev', $schema['properties']['when@dev']['properties']);
+        $this->assertFalse($schema['properties']['when@dev']['additionalProperties']);
+        // when@dev must not be nested inside another when@
+        $this->assertArrayNotHasKey('when@dev', $schema['properties']['when@dev']['properties']);
+    }
+
+    public function testProcessWhenEnvNotNested()
+    {
+        $container = new ContainerBuilder();
+
+        $pass = new JsonSchemaConfigDumpPass($this->tempDir.'/schema_nested.json', [
+            JsonSchemaTestBundle::class => ['all' => true],
+            JsonSchemaDevBundle::class => ['dev' => true, 'test' => true],
+        ]);
+        $pass->process($container);
+
+        $schema = json_decode(file_get_contents($this->tempDir.'/schema_nested.json'), true);
+        // when@test must not contain when@dev
+        $this->assertArrayNotHasKey('when@dev', $schema['properties']['when@test']['properties']);
+        $this->assertArrayNotHasKey('when@test', $schema['properties']['when@dev']['properties']);
+    }
+
+    public function testProcessIgnoresFileWriteErrors()
+    {
+        $container = new ContainerBuilder();
+
+        $pass = new JsonSchemaConfigDumpPass($this->readOnlyDir.'/schema.json', [
+            JsonSchemaTestBundle::class => ['all' => true],
+        ]);
+        $pass->process($container);
+
+        $this->assertFileDoesNotExist($this->readOnlyDir.'/schema.json');
+        $this->assertEmpty($container->getResources());
+    }
+}
+
+class JsonSchemaTestBundle extends Bundle
+{
+    public function getContainerExtension(): ?ExtensionInterface
+    {
+        return new JsonSchemaTestExtension();
+    }
+}
+
+class JsonSchemaTestExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+    }
+
+    public function getAlias(): string
+    {
+        return 'json_schema_test';
+    }
+
+    public function getConfiguration(array $config, ContainerBuilder $container): ConfigurationInterface
+    {
+        return new JsonSchemaTestConfiguration();
+    }
+}
+
+class JsonSchemaTestConfiguration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder('json_schema_test');
+        $treeBuilder->getRootNode()
+            ->children()
+                ->scalarNode('name')->end()
+                ->booleanNode('enabled')->defaultFalse()->end()
+            ->end();
+
+        return $treeBuilder;
+    }
+}
+
+class JsonSchemaDevBundle extends Bundle
+{
+    public function getContainerExtension(): ?ExtensionInterface
+    {
+        return new JsonSchemaDevExtension();
+    }
+}
+
+class JsonSchemaDevExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+    }
+
+    public function getAlias(): string
+    {
+        return 'json_schema_dev';
+    }
+
+    public function getConfiguration(array $config, ContainerBuilder $container): ConfigurationInterface
+    {
+        return new JsonSchemaDevConfiguration();
+    }
+}
+
+class JsonSchemaDevConfiguration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder('json_schema_dev');
+        $treeBuilder->getRootNode()
+            ->children()
+                ->booleanNode('toolbar')->defaultTrue()->end()
+            ->end();
+
+        return $treeBuilder;
+    }
+}

--- a/src/Symfony/Component/Config/CHANGELOG.md
+++ b/src/Symfony/Component/Config/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add `JsonSchemaDumper` to dump JSON Schema from configuration node definitions
+ * Add `BaseNode::isNullable()` to check if a node accepts null as input
+
 8.0
 ---
 

--- a/src/Symfony/Component/Config/Definition/BaseNode.php
+++ b/src/Symfony/Component/Config/Definition/BaseNode.php
@@ -170,6 +170,23 @@ abstract class BaseNode implements NodeInterface
     }
 
     /**
+     * Returns true if null is an acceptable input value for this node.
+     */
+    public function isNullable(): bool
+    {
+        foreach ($this->equivalentValues as [$from, $to]) {
+            // the builder registers a null equivalence on every node; only a mapping that
+            // replaces null makes it acceptable, as an identity mapping leaves it to be
+            // rejected by the type check
+            if (null === $from && null !== $to) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Set this node as required.
      */
     public function setRequired(bool $boolean): void

--- a/src/Symfony/Component/Config/Definition/BooleanNode.php
+++ b/src/Symfony/Component/Config/Definition/BooleanNode.php
@@ -29,6 +29,11 @@ class BooleanNode extends ScalarNode
         parent::__construct($name, $parent, $pathSeparator);
     }
 
+    public function isNullable(): bool
+    {
+        return $this->nullable;
+    }
+
     protected function validateType(mixed $value): void
     {
         if (!\is_bool($value)) {

--- a/src/Symfony/Component/Config/Definition/Dumper/JsonSchemaDumper.php
+++ b/src/Symfony/Component/Config/Definition/Dumper/JsonSchemaDumper.php
@@ -1,0 +1,245 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Definition\Dumper;
+
+use Symfony\Component\Config\Definition\ArrayNode;
+use Symfony\Component\Config\Definition\BaseNode;
+use Symfony\Component\Config\Definition\BooleanNode;
+use Symfony\Component\Config\Definition\Builder\ExprBuilder;
+use Symfony\Component\Config\Definition\EnumNode;
+use Symfony\Component\Config\Definition\IntegerNode;
+use Symfony\Component\Config\Definition\NodeInterface;
+use Symfony\Component\Config\Definition\NumericNode;
+use Symfony\Component\Config\Definition\PrototypedArrayNode;
+use Symfony\Component\Config\Definition\ScalarNode;
+use Symfony\Component\Config\Definition\StringNode;
+use Symfony\Component\Config\Definition\VariableNode;
+
+/**
+ * Dumps a JSON Schema from a Node definition.
+ *
+ * @author Jérôme Tamarelle<jerome@tamarelle.net>
+ */
+final class JsonSchemaDumper
+{
+    private const PARAMETERIZABLE_DEFS = [
+        'string' => ['type' => 'string'],
+        'string_null' => ['type' => ['string', 'null']],
+        'boolean' => ['type' => 'boolean'],
+        'boolean_null' => ['type' => ['boolean', 'null']],
+        'integer' => ['type' => 'integer'],
+        'integer_null' => ['type' => ['integer', 'null']],
+        'number' => ['type' => 'number'],
+        'number_null' => ['type' => ['number', 'null']],
+    ];
+
+    private const STRUCTURAL_DEFS = [
+        'variable' => ['type' => ['array', 'boolean', 'null', 'number', 'object', 'string']],
+        'scalar' => ['type' => ['boolean', 'null', 'number', 'string']],
+        'array' => ['type' => 'array'],
+        'array_null' => ['type' => ['array', 'null']],
+        'object' => ['type' => 'object'],
+        'object_null' => ['type' => ['object', 'null']],
+    ];
+
+    private array $typeDefs;
+
+    /**
+     * @param array<array<string, mixed>> $parameterSchemas additional JSON Schema fragments included as anyOf options for scalar nodes
+     */
+    public function __construct(
+        private readonly array $parameterSchemas = [],
+    ) {
+        $this->typeDefs = $this->buildTypeDefs();
+    }
+
+    /**
+     * Returns all shared definitions nested under "types".
+     * In a full schema, include this under "$defs" so that "$ref": "#/$defs/types/..." resolves correctly.
+     *
+     * @return array{types: array<string, mixed>}
+     */
+    public function getAllDefs(): array
+    {
+        return ['types' => array_merge(self::STRUCTURAL_DEFS, $this->typeDefs)];
+    }
+
+    /**
+     * Dump a full JSON Schema from the given root node.
+     *
+     * @param array<string, mixed> $meta Additional attributes to include in the schema root
+     */
+    public function dump(NodeInterface $node, array $meta = []): array
+    {
+        return [
+            '$schema' => 'https://json-schema.org/draft/2020-12/schema',
+            ...$meta,
+            '$defs' => $this->getAllDefs(),
+            ...$this->dumpNode($node),
+        ];
+    }
+
+    public function dumpNode(NodeInterface $node): array
+    {
+        if ($node instanceof PrototypedArrayNode) {
+            $prototypeSchema = $this->dumpNode($node->getPrototype());
+
+            if ($node->getKeyAttribute()) {
+                $schema = [
+                    '$ref' => $node->isNullable() ? '#/$defs/types/object_null' : '#/$defs/types/object',
+                    'additionalProperties' => $prototypeSchema,
+                ];
+
+                if ($node->getMinNumberOfElements()) {
+                    $schema['minProperties'] = $node->getMinNumberOfElements();
+                }
+            } else {
+                $schema = [
+                    '$ref' => $node->isNullable() ? '#/$defs/types/array_null' : '#/$defs/types/array',
+                    'items' => $prototypeSchema,
+                ];
+
+                if ($node->getMinNumberOfElements()) {
+                    $schema['minItems'] = $node->getMinNumberOfElements();
+                }
+            }
+        } elseif ($node instanceof ArrayNode) {
+            $schema = ['$ref' => $node->isNullable() ? '#/$defs/types/object_null' : '#/$defs/types/object'];
+            $children = $node->getChildren();
+            foreach ($children as $child) {
+                $schema['properties'] ??= [];
+                $schema['properties'][$child->getName()] = $this->dumpNode($child);
+                if ($child->isRequired()) {
+                    $schema['required'] ??= [];
+                    $schema['required'][] = $child->getName();
+                }
+            }
+
+            if (isset($schema['properties'])) {
+                $schema['additionalProperties'] = $node->shouldIgnoreExtraKeys();
+            }
+        } elseif ($node instanceof BooleanNode) {
+            $schema = ['$ref' => $node->isNullable() ? '#/$defs/types/boolean_null' : '#/$defs/types/boolean'];
+        } elseif ($node instanceof StringNode) {
+            $schema = ['$ref' => $node->isNullable() ? '#/$defs/types/string_null' : '#/$defs/types/string'];
+        } elseif ($node instanceof EnumNode) {
+            $enumValues = [];
+            foreach ($node->getValues() as $case) {
+                if ($case instanceof \BackedEnum) {
+                    $enumValues[] = \sprintf('!php/enum %s::%s', $case::class, $case->name);
+                    $enumValues[] = $case->value;
+                } elseif ($case instanceof \UnitEnum) {
+                    $enumValues[] = \sprintf('!php/enum %s::%s', $case::class, $case->name);
+                } else {
+                    $enumValues[] = $case;
+                }
+            }
+            if (null !== $node->getEnumFqcn() && !\in_array(null, $enumValues, true)) {
+                // a node bound to an enum FQCN accepts null and maps it to null
+                $enumValues[] = null;
+            }
+            $schema = ['enum' => $enumValues];
+            if ($this->parameterSchemas) {
+                $schema = ['anyOf' => [$schema, ...$this->parameterSchemas]];
+            }
+        } elseif ($node instanceof NumericNode) {
+            $type = $node instanceof IntegerNode ? 'integer' : 'number';
+            $schema = ['$ref' => '#/$defs/types/'.($node->isNullable() ? $type.'_null' : $type)];
+
+            if (null !== $node->getMin()) {
+                $schema['minimum'] = $node->getMin();
+            }
+
+            if (null !== $node->getMax()) {
+                $schema['maximum'] = $node->getMax();
+            }
+        } elseif ($node instanceof ScalarNode) {
+            $schema = ['$ref' => '#/$defs/types/scalar'];
+        } elseif ($node instanceof VariableNode) {
+            $schema = ['$ref' => '#/$defs/types/variable'];
+        } else {
+            $schema = ['type' => ['null']];
+        }
+
+        if ($node instanceof BaseNode) {
+            $normalizedTypes = array_diff($node->getNormalizedTypes(), [ExprBuilder::TYPE_ANY, ExprBuilder::TYPE_ARRAY]);
+
+            if (isset($schema['type']) && $node->hasDefaultValue() && null === $node->getDefaultValue()) {
+                $normalizedTypes[] = 'null';
+            }
+
+            if ($normalizedTypes) {
+                $normalizedTypesSchema = [
+                    'type' => array_values(
+                        array_unique(
+                            array_merge(
+                                ...array_map(static fn ($type) => match ($type) {
+                                    ExprBuilder::TYPE_INT => ['integer'],
+                                    ExprBuilder::TYPE_STRING => ['string'],
+                                    ExprBuilder::TYPE_BOOL => ['boolean'],
+                                    ExprBuilder::TYPE_ARRAY => ['array', 'object'],
+                                    ExprBuilder::TYPE_NULL => ['null'],
+                                    ExprBuilder::TYPE_BACKED_ENUM => ['string'],
+                                    ExprBuilder::TYPE_ANY => throw new \UnexpectedValueException('TYPE_ANY is not expected as normalized type.'),
+                                }, $normalizedTypes),
+                            ),
+                        ),
+                    ),
+                ];
+                if (isset($schema['anyOf'])) {
+                    $schema['anyOf'][] = $normalizedTypesSchema;
+                } else {
+                    $schema = ['anyOf' => [$schema, $normalizedTypesSchema]];
+                }
+            }
+
+            if ($node->hasDefaultValue() && !($node instanceof ArrayNode && [] === $node->getDefaultValue())) {
+                $schema['default'] = $node->getDefaultValue();
+            }
+
+            if ($node->getInfo()) {
+                $schema['description'] = $node->getInfo();
+            }
+
+            if ($node->getExample()) {
+                $schema['examples'] = [$node->getExample()];
+            }
+
+            if ($node->isDeprecated()) {
+                $schema['deprecated'] = true;
+                $deprecationMessage = $node->getDeprecationMessage($node);
+                if (str_starts_with($deprecationMessage, 'Since ')) {
+                    $deprecationMessage = 'Deprecated since '.substr($deprecationMessage, 6);
+                }
+                $schema['description'] = isset($schema['description'])
+                    ? $deprecationMessage."\n\n".$schema['description']
+                    : $deprecationMessage;
+            }
+        }
+
+        if (\is_array($schema['type'] ?? null) && 1 === \count($schema['type'])) {
+            $schema['type'] = $schema['type'][0];
+        }
+
+        return $schema;
+    }
+
+    /** @return array<string, mixed> */
+    private function buildTypeDefs(): array
+    {
+        if (!$this->parameterSchemas) {
+            return self::PARAMETERIZABLE_DEFS;
+        }
+
+        return array_map(fn ($def) => ['anyOf' => [$def, ...$this->parameterSchemas]], self::PARAMETERIZABLE_DEFS);
+    }
+}

--- a/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
@@ -45,6 +45,11 @@ class PrototypedArrayNode extends ArrayNode
         $this->minNumberOfElements = $number;
     }
 
+    public function getMinNumberOfElements(): int
+    {
+        return $this->minNumberOfElements;
+    }
+
     /**
      * Sets the attribute which value is to be used as key.
      *

--- a/src/Symfony/Component/Config/Definition/VariableNode.php
+++ b/src/Symfony/Component/Config/Definition/VariableNode.php
@@ -55,6 +55,11 @@ class VariableNode extends BaseNode implements PrototypeNodeInterface
         $this->allowEmptyValue = $boolean;
     }
 
+    public function getAllowEmptyValue(): bool
+    {
+        return $this->allowEmptyValue;
+    }
+
     public function setName(string $name): void
     {
         $this->name = $name;

--- a/src/Symfony/Component/Config/Tests/Definition/ArrayNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/ArrayNodeTest.php
@@ -324,4 +324,14 @@ class ArrayNodeTest extends TestCase
             ],
         ];
     }
+
+    public function testIsNullable()
+    {
+        $node = new ArrayNode('root');
+        $this->assertFalse($node->isNullable());
+
+        $node = new ArrayNode('root');
+        $node->addEquivalentValue(null, []);
+        $this->assertTrue($node->isNullable());
+    }
 }

--- a/src/Symfony/Component/Config/Tests/Definition/BooleanNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/BooleanNodeTest.php
@@ -93,4 +93,10 @@ class BooleanNodeTest extends TestCase
             [new \stdClass()],
         ];
     }
+
+    public function testIsNullable()
+    {
+        $this->assertFalse(new BooleanNode('root')->isNullable());
+        $this->assertTrue(new BooleanNode('root', nullable: true)->isNullable());
+    }
 }

--- a/src/Symfony/Component/Config/Tests/Definition/Dumper/JsonSchemaDumperTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Dumper/JsonSchemaDumperTest.php
@@ -1,0 +1,304 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Tests\Definition\Dumper;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\ArrayNode;
+use Symfony\Component\Config\Definition\BooleanNode;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\ExprBuilder;
+use Symfony\Component\Config\Definition\Dumper\JsonSchemaDumper;
+use Symfony\Component\Config\Definition\EnumNode;
+use Symfony\Component\Config\Definition\FloatNode;
+use Symfony\Component\Config\Definition\IntegerNode;
+use Symfony\Component\Config\Definition\NodeInterface;
+use Symfony\Component\Config\Definition\PrototypedArrayNode;
+use Symfony\Component\Config\Definition\ScalarNode;
+use Symfony\Component\Config\Definition\StringNode;
+use Symfony\Component\Config\Definition\VariableNode;
+use Symfony\Component\Config\Tests\Fixtures\Configuration\ExampleConfiguration;
+use Symfony\Component\Config\Tests\Fixtures\StringBackedTestEnum;
+use Symfony\Component\Config\Tests\Fixtures\TestEnum;
+
+class JsonSchemaDumperTest extends TestCase
+{
+    #[DataProvider('provideNodes')]
+    public function testJsonSchemaHandlesNodeTypes(NodeInterface $node, array|\stdClass $expected)
+    {
+        $actual = (new JsonSchemaDumper())->dumpNode($node);
+        $actualJson = json_encode($actual, \JSON_THROW_ON_ERROR);
+        $expectedJson = json_encode($expected, \JSON_THROW_ON_ERROR);
+        $this->assertJsonStringEqualsJsonString($expectedJson, $actualJson);
+    }
+
+    #[DataProvider('provideNodesWithParams')]
+    public function testJsonSchemaHandlesNodeTypesWithParams(NodeInterface $node, array|\stdClass $expected)
+    {
+        $actual = (new JsonSchemaDumper(parameterSchemas: [self::param()]))->dumpNode($node);
+        $actualJson = json_encode($actual, \JSON_THROW_ON_ERROR);
+        $expectedJson = json_encode($expected, \JSON_THROW_ON_ERROR);
+        $this->assertJsonStringEqualsJsonString($expectedJson, $actualJson);
+    }
+
+    private static function param(): array
+    {
+        return ['$ref' => '#/$defs/types/param'];
+    }
+
+    public static function provideNodes(): iterable
+    {
+        yield [new ArrayNode('node'), ['$ref' => '#/$defs/types/object']];
+
+        yield [new StringNode('node'), ['$ref' => '#/$defs/types/string']];
+
+        yield [new BooleanNode('node'), ['$ref' => '#/$defs/types/boolean']];
+
+        yield [new BooleanNode('node', nullable: true), ['$ref' => '#/$defs/types/boolean_null']];
+
+        yield [new EnumNode('node', values: ['a', 'b']), [
+            'enum' => ['a', 'b'],
+        ]];
+        yield [new EnumNode('node', values: ['a', 'b', null]), [
+            'enum' => ['a', 'b', null],
+        ]];
+        yield [new EnumNode('node', enumFqcn: TestEnum::class), [
+            'enum' => [
+                '!php/enum Symfony\\Component\\Config\\Tests\\Fixtures\\TestEnum::Foo',
+                '!php/enum Symfony\\Component\\Config\\Tests\\Fixtures\\TestEnum::Bar',
+                '!php/enum Symfony\\Component\\Config\\Tests\\Fixtures\\TestEnum::Ccc',
+                null,
+            ],
+        ]];
+        yield [new EnumNode('node', values: TestEnum::cases()), [
+            'enum' => [
+                '!php/enum Symfony\\Component\\Config\\Tests\\Fixtures\\TestEnum::Foo',
+                '!php/enum Symfony\\Component\\Config\\Tests\\Fixtures\\TestEnum::Bar',
+                '!php/enum Symfony\\Component\\Config\\Tests\\Fixtures\\TestEnum::Ccc',
+            ],
+        ]];
+        yield [new EnumNode('node', values: StringBackedTestEnum::cases()), [
+            'enum' => [
+                '!php/enum Symfony\\Component\\Config\\Tests\\Fixtures\\StringBackedTestEnum::Foo',
+                'foo',
+                '!php/enum Symfony\\Component\\Config\\Tests\\Fixtures\\StringBackedTestEnum::BarBaz',
+                'bar baz',
+            ],
+        ]];
+        yield [new ScalarNode('node'), ['$ref' => '#/$defs/types/scalar']];
+        yield [new VariableNode('node'), ['$ref' => '#/$defs/types/variable']];
+
+        yield [new IntegerNode('node'), ['$ref' => '#/$defs/types/integer']];
+        yield [new IntegerNode('node', min: 1), ['$ref' => '#/$defs/types/integer', 'minimum' => 1]];
+        yield [new IntegerNode('node', max: 10), ['$ref' => '#/$defs/types/integer', 'maximum' => 10]];
+        yield [new IntegerNode('node', min: 1, max: 10), ['$ref' => '#/$defs/types/integer', 'minimum' => 1, 'maximum' => 10]];
+
+        yield [new FloatNode('node'), ['$ref' => '#/$defs/types/number']];
+        yield [new FloatNode('node', min: 1.1), ['$ref' => '#/$defs/types/number', 'minimum' => 1.1]];
+        yield [new FloatNode('node', max: 10.1), ['$ref' => '#/$defs/types/number', 'maximum' => 10.1]];
+        yield [new FloatNode('node', min: 1.1, max: 10.1), ['$ref' => '#/$defs/types/number', 'minimum' => 1.1, 'maximum' => 10.1]];
+
+        $prototype = new PrototypedArrayNode('proto');
+        $prototype->setPrototype(new StringNode('child'));
+        $root = new ArrayNode('root');
+        $root->addChild($prototype);
+        yield [$prototype, [
+            '$ref' => '#/$defs/types/array',
+            'items' => ['$ref' => '#/$defs/types/string'],
+        ]];
+
+        $prototype = new PrototypedArrayNode('proto');
+        $prototype->setPrototype(new StringNode('child'));
+        $prototype->setKeyAttribute('name');
+        $root = new ArrayNode('root');
+        $root->addChild($prototype);
+        yield [$prototype, [
+            '$ref' => '#/$defs/types/object',
+            'additionalProperties' => ['$ref' => '#/$defs/types/string'],
+        ]];
+
+        $child = new BooleanNode('node');
+        $child->setRequired(true);
+        $root = new ArrayNode('root');
+        $root->addChild($child);
+        yield [$root, [
+            '$ref' => '#/$defs/types/object',
+            'properties' => ['node' => ['$ref' => '#/$defs/types/boolean']],
+            'required' => ['node'],
+            'additionalProperties' => false,
+        ]];
+
+        $child = new BooleanNode('node');
+        $child->setDeprecated('vendor/package', '1.0', 'The "%path%" option is deprecated.');
+        $child->setDefaultValue(true);
+        $child->setInfo('This is a boolean node.');
+        $root = new ArrayNode('root');
+        $root->addChild($child);
+        yield [$root, [
+            '$ref' => '#/$defs/types/object',
+            'properties' => [
+                'node' => [
+                    '$ref' => '#/$defs/types/boolean',
+                    'default' => true,
+                    'deprecated' => true,
+                    'description' => "Deprecated since vendor/package 1.0: The \"node\" option is deprecated.\n\nThis is a boolean node.",
+                ],
+            ],
+            'additionalProperties' => false,
+        ]];
+
+        $root = new ArrayNode('root');
+        $child = new ArrayNode('child');
+        $root->addChild($child);
+        yield [$root, [
+            '$ref' => '#/$defs/types/object',
+            'properties' => [
+                'child' => ['$ref' => '#/$defs/types/object'],
+            ],
+            'additionalProperties' => false,
+        ]];
+
+        $node = new ArrayNodeDefinition('foo');
+        $node->canBeEnabled()->children()->booleanNode('bar')->end();
+        yield [$node->getNode(), [
+            'anyOf' => [
+                [
+                    '$ref' => '#/$defs/types/object_null',
+                    'properties' => [
+                        'enabled' => ['$ref' => '#/$defs/types/boolean', 'default' => false],
+                        'bar' => ['$ref' => '#/$defs/types/boolean'],
+                    ],
+                    'additionalProperties' => false,
+                ],
+                [
+                    'type' => ['boolean'],
+                ],
+            ],
+            'default' => ['enabled' => false],
+        ]];
+
+        $node = new ArrayNodeDefinition('foo');
+        $node->canBeDisabled()->children()->booleanNode('bar')->end();
+        yield [$node->getNode(), [
+            'anyOf' => [
+                [
+                    '$ref' => '#/$defs/types/object_null',
+                    'properties' => [
+                        'enabled' => ['$ref' => '#/$defs/types/boolean', 'default' => true],
+                        'bar' => ['$ref' => '#/$defs/types/boolean'],
+                    ],
+                    'additionalProperties' => false,
+                ],
+                [
+                    'type' => ['boolean'],
+                ],
+            ],
+            'default' => ['enabled' => true],
+        ]];
+
+        $node = new ArrayNodeDefinition('foo');
+        $node->useAttributeAsKey('name')
+            ->prototype('array')
+            ->acceptAndWrap(['string', 'int'], 'name')
+            ->children()
+                ->stringNode('name')->end()
+                ->floatNode('price')->isRequired()->end()
+        ;
+        yield [$node->getNode(), [
+            '$ref' => '#/$defs/types/object_null',
+            'additionalProperties' => [
+                'anyOf' => [
+                    [
+                        '$ref' => '#/$defs/types/object_null',
+                        'properties' => [
+                            'name' => ['$ref' => '#/$defs/types/string_null'],
+                            'price' => ['$ref' => '#/$defs/types/number'],
+                        ],
+                        'required' => ['price'],
+                        'additionalProperties' => false,
+                    ],
+                    [
+                        'type' => ['string', 'integer'],
+                    ],
+                ],
+            ],
+        ]];
+    }
+
+    public static function provideNodesWithParams(): iterable
+    {
+        yield [new BooleanNode('node'), ['$ref' => '#/$defs/types/boolean']];
+        yield [new BooleanNode('node', nullable: true), ['$ref' => '#/$defs/types/boolean_null']];
+        yield [new IntegerNode('node'), ['$ref' => '#/$defs/types/integer']];
+        yield [new IntegerNode('node', min: 1), ['$ref' => '#/$defs/types/integer', 'minimum' => 1]];
+        yield [new FloatNode('node'), ['$ref' => '#/$defs/types/number']];
+        yield [new EnumNode('node', values: ['a', 'b']), ['anyOf' => [['enum' => ['a', 'b']], self::param()]]];
+
+        // When normalizedTypes are set on an EnumNode that already has anyOf from parameterSchemas,
+        // the result must be a flat anyOf (no nesting).
+        $node = new EnumNode('node', values: ['a', 'b']);
+        $node->setNormalizedTypes([ExprBuilder::TYPE_STRING]);
+        yield [$node, ['anyOf' => [['enum' => ['a', 'b']], self::param(), ['type' => ['string']]]]];
+    }
+
+    public function testGetAllDefs()
+    {
+        $allDefs = (new JsonSchemaDumper())->getAllDefs();
+        $this->assertArrayHasKey('types', $allDefs);
+        $types = $allDefs['types'];
+        $this->assertArrayHasKey('string', $types);
+        $this->assertArrayHasKey('string_null', $types);
+        $this->assertArrayHasKey('boolean', $types);
+        $this->assertArrayHasKey('boolean_null', $types);
+        $this->assertArrayHasKey('integer', $types);
+        $this->assertArrayHasKey('integer_null', $types);
+        $this->assertArrayHasKey('number', $types);
+        $this->assertArrayHasKey('number_null', $types);
+        $this->assertArrayHasKey('scalar', $types);
+        $this->assertArrayHasKey('variable', $types);
+        $this->assertArrayHasKey('array', $types);
+        $this->assertArrayHasKey('array_null', $types);
+        $this->assertArrayHasKey('object', $types);
+        $this->assertArrayHasKey('object_null', $types);
+
+        // Without parameterSchemas: simple type schemas
+        $this->assertSame(['type' => 'string'], $types['string']);
+        $this->assertSame(['type' => 'boolean'], $types['boolean']);
+        $this->assertSame(['type' => 'integer'], $types['integer']);
+
+        // With parameterSchemas: anyOf with param
+        $param = self::param();
+        $types = (new JsonSchemaDumper(parameterSchemas: [$param]))->getAllDefs()['types'];
+        $this->assertSame(['anyOf' => [['type' => 'boolean'], $param]], $types['boolean']);
+        $this->assertSame(['anyOf' => [['type' => 'integer'], $param]], $types['integer']);
+    }
+
+    public function testExampleConfiguration()
+    {
+        $configuration = new ExampleConfiguration();
+
+        $root = new ArrayNode(null);
+        $root->addChild($configuration->getConfigTreeBuilder()->buildTree());
+
+        $schema = (new JsonSchemaDumper())->dump($root, [
+            'title' => 'Example Configuration Schema',
+        ]);
+        $jsonSchema = json_encode($schema, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_THROW_ON_ERROR)."\n";
+
+        if ($_ENV['TEST_GENERATE_FIXTURES'] ?? false) {
+            file_put_contents(__DIR__.'/../../../Tests/Fixtures/Configuration/ExampleConfiguration.schema.json', $jsonSchema);
+            $this->markTestIncomplete('TEST_GENERATE_FIXTURES is set');
+        }
+
+        $this->assertJsonStringEqualsJsonFile(__DIR__.'/../../../Tests/Fixtures/Configuration/ExampleConfiguration.schema.json', $jsonSchema);
+    }
+}

--- a/src/Symfony/Component/Config/Tests/Definition/Dumper/YamlReferenceDumperTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Dumper/YamlReferenceDumperTest.php
@@ -24,7 +24,7 @@ class YamlReferenceDumperTest extends TestCase
 
         $dumper = new YamlReferenceDumper();
 
-        $this->assertEquals($this->getConfigurationAsString(), $dumper->dump($configuration));
+        $this->assertEquals($this->getConfigurationAsString(), "# \$schema: ExampleConfiguration.schema.json\n".$dumper->dump($configuration));
     }
 
     public static function provideDumpAtPath(): array
@@ -82,75 +82,6 @@ class YamlReferenceDumperTest extends TestCase
 
     private function getConfigurationAsString(): string
     {
-        return <<<'EOL'
-            acme_root:
-                boolean:              true
-                scalar_empty:         ~
-                scalar_null:          null
-                scalar_true:          true
-                scalar_false:         false
-                scalar_default:       default
-                scalar_array_empty:   []
-                scalar_array_defaults:
-
-                    # Defaults:
-                    - elem1
-                    - elem2
-                scalar_required:      ~ # Required
-                scalar_deprecated:    ~ # Deprecated (Since vendor/package 1.1: The child node "scalar_deprecated" at path "acme_root" is deprecated.)
-                scalar_deprecated_with_message: ~ # Deprecated (Since vendor/package 1.1: Deprecation custom message for "scalar_deprecated_with_message" at "acme_root")
-                node_with_a_looong_name: ~
-                enum_with_default:    this # One of "this"; "that"
-                enum:                 ~ # One of "this"; "that"; Symfony\Component\Config\Tests\Fixtures\TestEnum::Ccc
-                enum_with_class:      ~ # One of "foo"; "bar baz"
-                unit_enum_with_class: ~ # One of Symfony\Component\Config\Tests\Fixtures\TestEnum::Foo; Symfony\Component\Config\Tests\Fixtures\TestEnum::Bar; Symfony\Component\Config\Tests\Fixtures\TestEnum::Ccc
-
-                # some info
-                array:
-                    child1:               ~
-                    child2:               ~
-
-                    # this is a long
-                    # multi-line info text
-                    # which should be indented
-                    child3:               ~ # Example: 'example setting'
-                scalar_prototyped:    []
-                string_list_default_null: ~
-                variable:             ~
-
-                    # Examples:
-                    # - foo
-                    # - bar
-                parameters:
-
-                    # Prototype: Parameter name
-                    name:                 ~
-                connections:
-
-                    # Prototype
-                    -
-                        user:                 ~
-                        pass:                 ~
-                cms_pages:
-
-                    # Prototype
-                    page:
-
-                        # Prototype
-                        locale:
-                            title:                ~ # Required
-                            path:                 ~ # Required
-                pipou:
-
-                    # Prototype
-                    name:                 []
-                array_with_array_example_and_no_default_value: []
-
-                    # Examples:
-                    # - foo
-                    # - bar
-                custom_node:          true
-
-            EOL;
+        return file_get_contents(__DIR__.'/../../Fixtures/Configuration/ExampleConfiguration.yaml');
     }
 }

--- a/src/Symfony/Component/Config/Tests/Definition/ScalarNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/ScalarNodeTest.php
@@ -174,4 +174,14 @@ class ScalarNodeTest extends TestCase
             [''],
         ];
     }
+
+    public function testIsNullable()
+    {
+        $node = new ScalarNode('root');
+        $this->assertFalse($node->isNullable());
+
+        $node = new ScalarNode('root');
+        $node->addEquivalentValue(null, 'null');
+        $this->assertTrue($node->isNullable());
+    }
 }

--- a/src/Symfony/Component/Config/Tests/Fixtures/Configuration/ExampleConfiguration.schema.json
+++ b/src/Symfony/Component/Config/Tests/Fixtures/Configuration/ExampleConfiguration.schema.json
@@ -1,0 +1,287 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Example Configuration Schema",
+    "$defs": {
+        "types": {
+            "variable": {
+                "type": [
+                    "array",
+                    "boolean",
+                    "null",
+                    "number",
+                    "object",
+                    "string"
+                ]
+            },
+            "scalar": {
+                "type": [
+                    "boolean",
+                    "null",
+                    "number",
+                    "string"
+                ]
+            },
+            "array": {
+                "type": "array"
+            },
+            "array_null": {
+                "type": [
+                    "array",
+                    "null"
+                ]
+            },
+            "object": {
+                "type": "object"
+            },
+            "object_null": {
+                "type": [
+                    "object",
+                    "null"
+                ]
+            },
+            "string": {
+                "type": "string"
+            },
+            "string_null": {
+                "type": [
+                    "string",
+                    "null"
+                ]
+            },
+            "boolean": {
+                "type": "boolean"
+            },
+            "boolean_null": {
+                "type": [
+                    "boolean",
+                    "null"
+                ]
+            },
+            "integer": {
+                "type": "integer"
+            },
+            "integer_null": {
+                "type": [
+                    "integer",
+                    "null"
+                ]
+            },
+            "number": {
+                "type": "number"
+            },
+            "number_null": {
+                "type": [
+                    "number",
+                    "null"
+                ]
+            }
+        }
+    },
+    "$ref": "#/$defs/types/object",
+    "properties": {
+        "acme_root": {
+            "$ref": "#/$defs/types/object_null",
+            "properties": {
+                "boolean": {
+                    "$ref": "#/$defs/types/boolean",
+                    "default": true
+                },
+                "scalar_empty": {
+                    "$ref": "#/$defs/types/scalar"
+                },
+                "scalar_null": {
+                    "$ref": "#/$defs/types/scalar",
+                    "default": null
+                },
+                "scalar_true": {
+                    "$ref": "#/$defs/types/scalar",
+                    "default": true
+                },
+                "scalar_false": {
+                    "$ref": "#/$defs/types/scalar",
+                    "default": false
+                },
+                "scalar_default": {
+                    "$ref": "#/$defs/types/scalar",
+                    "default": "default"
+                },
+                "scalar_array_empty": {
+                    "$ref": "#/$defs/types/scalar",
+                    "default": []
+                },
+                "scalar_array_defaults": {
+                    "$ref": "#/$defs/types/scalar",
+                    "default": [
+                        "elem1",
+                        "elem2"
+                    ]
+                },
+                "scalar_required": {
+                    "$ref": "#/$defs/types/scalar"
+                },
+                "scalar_deprecated": {
+                    "$ref": "#/$defs/types/scalar",
+                    "deprecated": true,
+                    "description": "Deprecated since vendor/package 1.1: The child node \"scalar_deprecated\" at path \"acme_root.scalar_deprecated\" is deprecated."
+                },
+                "scalar_deprecated_with_message": {
+                    "$ref": "#/$defs/types/scalar",
+                    "deprecated": true,
+                    "description": "Deprecated since vendor/package 1.1: Deprecation custom message for \"scalar_deprecated_with_message\" at \"acme_root.scalar_deprecated_with_message\""
+                },
+                "node_with_a_looong_name": {
+                    "$ref": "#/$defs/types/scalar"
+                },
+                "enum_with_default": {
+                    "enum": [
+                        "this",
+                        "that"
+                    ],
+                    "default": "this"
+                },
+                "enum": {
+                    "enum": [
+                        "this",
+                        "that",
+                        "!php/enum Symfony\\Component\\Config\\Tests\\Fixtures\\TestEnum::Ccc"
+                    ]
+                },
+                "enum_with_class": {
+                    "enum": [
+                        "!php/enum Symfony\\Component\\Config\\Tests\\Fixtures\\StringBackedTestEnum::Foo",
+                        "foo",
+                        "!php/enum Symfony\\Component\\Config\\Tests\\Fixtures\\StringBackedTestEnum::BarBaz",
+                        "bar baz",
+                        null
+                    ]
+                },
+                "unit_enum_with_class": {
+                    "enum": [
+                        "!php/enum Symfony\\Component\\Config\\Tests\\Fixtures\\TestEnum::Foo",
+                        "!php/enum Symfony\\Component\\Config\\Tests\\Fixtures\\TestEnum::Bar",
+                        "!php/enum Symfony\\Component\\Config\\Tests\\Fixtures\\TestEnum::Ccc",
+                        null
+                    ]
+                },
+                "array": {
+                    "$ref": "#/$defs/types/object_null",
+                    "properties": {
+                        "child1": {
+                            "$ref": "#/$defs/types/scalar"
+                        },
+                        "child2": {
+                            "$ref": "#/$defs/types/scalar"
+                        },
+                        "child3": {
+                            "$ref": "#/$defs/types/scalar",
+                            "description": "this is a long\nmulti-line info text\nwhich should be indented",
+                            "examples": [
+                                "example setting"
+                            ]
+                        }
+                    },
+                    "additionalProperties": false,
+                    "description": "some info"
+                },
+                "scalar_prototyped": {
+                    "$ref": "#/$defs/types/array_null",
+                    "items": {
+                        "$ref": "#/$defs/types/scalar"
+                    }
+                },
+                "string_list_default_null": {
+                    "$ref": "#/$defs/types/array",
+                    "items": {
+                        "$ref": "#/$defs/types/string_null"
+                    },
+                    "default": null
+                },
+                "variable": {
+                    "$ref": "#/$defs/types/variable",
+                    "examples": [
+                        [
+                            "foo",
+                            "bar"
+                        ]
+                    ]
+                },
+                "parameters": {
+                    "$ref": "#/$defs/types/object_null",
+                    "additionalProperties": {
+                        "$ref": "#/$defs/types/scalar",
+                        "description": "Parameter name"
+                    }
+                },
+                "connections": {
+                    "$ref": "#/$defs/types/array_null",
+                    "items": {
+                        "$ref": "#/$defs/types/object_null",
+                        "properties": {
+                            "user": {
+                                "$ref": "#/$defs/types/scalar"
+                            },
+                            "pass": {
+                                "$ref": "#/$defs/types/scalar"
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                },
+                "cms_pages": {
+                    "$ref": "#/$defs/types/object_null",
+                    "additionalProperties": {
+                        "$ref": "#/$defs/types/object_null",
+                        "additionalProperties": {
+                            "$ref": "#/$defs/types/object_null",
+                            "properties": {
+                                "title": {
+                                    "$ref": "#/$defs/types/scalar"
+                                },
+                                "path": {
+                                    "$ref": "#/$defs/types/scalar"
+                                }
+                            },
+                            "required": [
+                                "title",
+                                "path"
+                            ],
+                            "additionalProperties": false
+                        }
+                    }
+                },
+                "pipou": {
+                    "$ref": "#/$defs/types/object_null",
+                    "additionalProperties": {
+                        "$ref": "#/$defs/types/array_null",
+                        "items": {
+                            "$ref": "#/$defs/types/object_null",
+                            "properties": {
+                                "didou": {
+                                    "$ref": "#/$defs/types/scalar"
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    }
+                },
+                "array_with_array_example_and_no_default_value": {
+                    "$ref": "#/$defs/types/object_null",
+                    "examples": [
+                        [
+                            "foo",
+                            "bar"
+                        ]
+                    ]
+                },
+                "custom_node": {
+                    "type": "null"
+                }
+            },
+            "required": [
+                "scalar_required"
+            ],
+            "additionalProperties": false
+        }
+    },
+    "additionalProperties": false
+}

--- a/src/Symfony/Component/Config/Tests/Fixtures/Configuration/ExampleConfiguration.yaml
+++ b/src/Symfony/Component/Config/Tests/Fixtures/Configuration/ExampleConfiguration.yaml
@@ -1,0 +1,68 @@
+# $schema: ExampleConfiguration.schema.json
+acme_root:
+    boolean:              true
+    scalar_empty:         ~
+    scalar_null:          null
+    scalar_true:          true
+    scalar_false:         false
+    scalar_default:       default
+    scalar_array_empty:   []
+    scalar_array_defaults:
+
+        # Defaults:
+        - elem1
+        - elem2
+    scalar_required:      ~ # Required
+    scalar_deprecated:    ~ # Deprecated (Since vendor/package 1.1: The child node "scalar_deprecated" at path "acme_root" is deprecated.)
+    scalar_deprecated_with_message: ~ # Deprecated (Since vendor/package 1.1: Deprecation custom message for "scalar_deprecated_with_message" at "acme_root")
+    node_with_a_looong_name: ~
+    enum_with_default:    this # One of "this"; "that"
+    enum:                 ~ # One of "this"; "that"; Symfony\Component\Config\Tests\Fixtures\TestEnum::Ccc
+    enum_with_class:      ~ # One of "foo"; "bar baz"
+    unit_enum_with_class: ~ # One of Symfony\Component\Config\Tests\Fixtures\TestEnum::Foo; Symfony\Component\Config\Tests\Fixtures\TestEnum::Bar; Symfony\Component\Config\Tests\Fixtures\TestEnum::Ccc
+
+    # some info
+    array:
+        child1:               ~
+        child2:               ~
+
+        # this is a long
+        # multi-line info text
+        # which should be indented
+        child3:               ~ # Example: 'example setting'
+    scalar_prototyped:    []
+    string_list_default_null: ~
+    variable:             ~
+
+        # Examples:
+        # - foo
+        # - bar
+    parameters:
+
+        # Prototype: Parameter name
+        name:                 ~
+    connections:
+
+        # Prototype
+        -
+            user:                 ~
+            pass:                 ~
+    cms_pages:
+
+        # Prototype
+        page:
+
+            # Prototype
+            locale:
+                title:                ~ # Required
+                path:                 ~ # Required
+    pipou:
+
+        # Prototype
+        name:                 []
+    array_with_array_example_and_no_default_value: []
+
+        # Examples:
+        # - foo
+        # - bar
+    custom_node:          true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony/issues/59603
| License       | MIT

Supersedes https://github.com/symfony/symfony/pull/59620, but generates nested objects instead of flattened definitions with a hash as id. This is easier to read.

Add a `JsonSchemaGenerator` class to the Config component that generates a JSON Schema from a config node tree, and a `JsonSchemaConfigDumpPass` compiler pass in FrameworkBundle that generates a combined `config/schema.json` file for all registered bundles during debug compilation (when `symfony/yaml` is available).

The generated JSON Schema can be used by IDEs for YAML config file autocompletion and validation.