### PR TITLE
[Form] Fix `DateType` handling of julian calendar dates

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -49,7 +49,12 @@ class DateType extends AbstractType
     {
         $dateFormat = \is_int($options['format']) ? $options['format'] : self::DEFAULT_FORMAT;
         $timeFormat = \IntlDateFormatter::NONE;
-        $calendar = $options['calendar'] ?? \IntlDateFormatter::GREGORIAN;
+        if (isset($options['calendar'])) {
+            $calendar = $options['calendar'];
+        } else {
+            $calendar = new \IntlGregorianCalendar();
+            $calendar->setGregorianChange(\PHP_INT_MIN);
+        }
         $pattern = \is_string($options['format']) ? $options['format'] : '';
 
         if (!\in_array($dateFormat, self::ACCEPTED_FORMATS, true)) {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -396,6 +396,21 @@ class DateTypeTest extends BaseTypeTestCase
         $this->assertEquals('06*2010*02', $form->getViewData());
     }
 
+    public function testSubmitJulianCalendarDate()
+    {
+        if (\PHP_INT_SIZE === 4) {
+            $this->markTestSkipped('32-bit systems cannot represent julian calendar dates.');
+        }
+
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'widget' => 'single_text',
+        ]);
+        $form->submit('950-12-19');
+
+        $this->assertSame('0950-12-19', $form->getData()->format('Y-m-d'));
+        $this->assertSame('0950-12-19', $form->getViewData());
+    }
+
     /**
      * @dataProvider provideDateFormats
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #31057, close #29610
| License       | MIT

From https://github.com/symfony/symfony/issues/29610#issuecomment-1094384588 and https://stackoverflow.com/q/71779588; I guess this wasn’t fixed before because it needed #57960 (which is why this PR targets 7.3).