### PR TITLE
[Messenger] Add MongoDB bridge

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -208,7 +208,7 @@ jobs:
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           coverage: "none"
-          extensions: "json,couchbase-3.2.2,memcached,mongodb-1.12.0,redis,rdkafka,xsl,ldap,relay"
+          extensions: "json,couchbase-3.2.2,memcached,mongodb,redis,rdkafka,xsl,ldap,relay"
           ini-values: date.timezone=UTC,memory_limit=-1,default_socket_timeout=10,session.gc_probability=0,apc.enable_cli=1,zend.assertions=1,intl.default_locale=en,intl.error_level=0
           php-version: "${{ matrix.php }}"
           tools: pecl
@@ -232,6 +232,7 @@ jobs:
           echo COMPOSER_ROOT_VERSION=$COMPOSER_ROOT_VERSION >> $GITHUB_ENV
 
           echo "::group::composer update"
+          composer require --dev --no-update "mongodb/mongodb:^2.1@stable"
           composer update --no-progress --ansi
           echo "::endgroup::"
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,7 +21,7 @@ jobs:
     name: Unit Tests
 
     env:
-      extensions: amqp,apcu,brotli,igbinary,intl,mbstring,memcached,redis,relay,zstd
+      extensions: amqp,apcu,brotli,igbinary,intl,mbstring,memcached,mongodb,redis,relay,zstd
 
     strategy:
       matrix:

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -42,3 +42,8 @@ parameters:
         -
             message: '#^Method Symfony\\Component\\Serializer\\Mapping\\AttributeMetadataInterface\:\:(get|set)Serialized(Name|Path)\(\) invoked with [12] parameters?, [01] required\.$#'
             path: src/Symfony/Component/Serializer/*.php
+        # the $fetchSize argument is a commented-out argument of ReceiverInterface::get(), documented
+        # with @param on implementations so DebugClassLoader does not report them
+        -
+            message: '#^PHPDoc tag @param references unknown parameter\: \$fetchSize$#'
+            path: src/Symfony/Component/Messenger/*

--- a/splitsh.json
+++ b/splitsh.json
@@ -71,6 +71,7 @@
         "amqp-messenger": "src/Symfony/Component/Messenger/Bridge/Amqp",
         "beanstalkd-messenger": "src/Symfony/Component/Messenger/Bridge/Beanstalkd",
         "doctrine-messenger": "src/Symfony/Component/Messenger/Bridge/Doctrine",
+        "mongodb-messenger": "src/Symfony/Component/Messenger/Bridge/MongoDb",
         "redis-messenger": "src/Symfony/Component/Messenger/Bridge/Redis",
         "mime": "src/Symfony/Component/Mime",
         "notifier": {

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2449,6 +2449,10 @@ class FrameworkExtension extends Extension
             $container->getDefinition('messenger.transport.beanstalkd.factory')->addTag('messenger.transport_factory');
         }
 
+        if (ContainerBuilder::willBeAvailable('symfony/mongodb-messenger', MessengerBridge\MongoDb\Transport\MongoDbTransportFactory::class, ['symfony/framework-bundle', 'symfony/messenger'])) {
+            $container->getDefinition('messenger.transport.mongodb.factory')->addTag('messenger.transport_factory');
+        }
+
         if ($config['stop_worker_on_signals'] && $this->hasConsole()) {
             $container->getDefinition('console.command.messenger_consume_messages')
                 ->replaceArgument(8, $config['stop_worker_on_signals']);
@@ -2531,6 +2535,7 @@ class FrameworkExtension extends Extension
             $container->removeDefinition('messenger.transport.redis.factory');
             $container->removeDefinition('messenger.transport.sqs.factory');
             $container->removeDefinition('messenger.transport.beanstalkd.factory');
+            $container->removeDefinition('messenger.transport.mongodb.factory');
             $container->removeAlias(SerializerInterface::class);
         } else {
             $container->getDefinition('messenger.transport.symfony_serializer')

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
@@ -16,6 +16,7 @@ use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsTransportFactory;
 use Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpTransportFactory;
 use Symfony\Component\Messenger\Bridge\Beanstalkd\Transport\BeanstalkdTransportFactory;
+use Symfony\Component\Messenger\Bridge\MongoDb\Transport\MongoDbTransportFactory;
 use Symfony\Component\Messenger\Bridge\Redis\Transport\RedisTransportFactory;
 use Symfony\Component\Messenger\EventListener\AddErrorDetailsStampListener;
 use Symfony\Component\Messenger\EventListener\DispatchPcntlSignalListener;
@@ -192,6 +193,8 @@ return static function (ContainerConfigurator $container) {
             ->tag('monolog.logger', ['channel' => 'messenger'])
 
         ->set('messenger.transport.beanstalkd.factory', BeanstalkdTransportFactory::class)
+
+        ->set('messenger.transport.mongodb.factory', MongoDbTransportFactory::class)
 
         // retry
         ->set('messenger.retry_strategy_locator', ServiceLocator::class)

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -82,6 +82,7 @@ use Symfony\Component\Messenger\Attribute\AsMessage;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsTransportFactory;
 use Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpTransportFactory;
 use Symfony\Component\Messenger\Bridge\Beanstalkd\Transport\BeanstalkdTransportFactory;
+use Symfony\Component\Messenger\Bridge\MongoDb\Transport\MongoDbTransportFactory;
 use Symfony\Component\Messenger\Bridge\Redis\Transport\RedisTransportFactory;
 use Symfony\Component\Messenger\DependencyInjection\MessengerPass;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -1089,6 +1090,10 @@ abstract class FrameworkExtensionTestCase extends TestCase
 
         if (class_exists(BeanstalkdTransportFactory::class)) {
             $expectedFactories[] = 'messenger.transport.beanstalkd.factory';
+        }
+
+        if (class_exists(MongoDbTransportFactory::class)) {
+            $expectedFactories[] = 'messenger.transport.mongodb.factory';
         }
 
         $this->assertTrue($container->hasDefinition('messenger.receiver_locator'));

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/stubs/mongodb.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/stubs/mongodb.php
@@ -14,9 +14,12 @@ namespace MongoDB;
 use MongoDB\Driver\Manager;
 
 /*
- * Stubs for the mongodb/mongodb library version ~1.16
+ * Stub for the mongodb/mongodb library, declared only when the real class
+ * cannot be autoloaded, so that it never shadows the library for other tests
+ * running in the same process. The autoload attempt is gated on the extension
+ * being loaded, as the library classes cannot be loaded without it.
  */
-if (!class_exists(Client::class, false)) {
+if (!class_exists(Client::class, \extension_loaded('mongodb'))) {
     abstract class Client
     {
         abstract public function getManager(): Manager;

--- a/src/Symfony/Component/Lock/Tests/Store/stubs/mongodb.php
+++ b/src/Symfony/Component/Lock/Tests/Store/stubs/mongodb.php
@@ -16,14 +16,14 @@ use MongoDB\Driver\Manager;
 /*
  * Stubs for the mongodb/mongodb library version ~1.16
  */
-if (!class_exists(Client::class)) {
+if (!class_exists(Client::class, \extension_loaded('mongodb'))) {
     abstract class Client
     {
         abstract public function getManager(): Manager;
     }
 }
 
-if (!class_exists(Database::class)) {
+if (!class_exists(Database::class, \extension_loaded('mongodb'))) {
     abstract class Database
     {
         abstract public function getManager(): Manager;
@@ -32,7 +32,7 @@ if (!class_exists(Database::class)) {
     }
 }
 
-if (!class_exists(Collection::class)) {
+if (!class_exists(Collection::class, \extension_loaded('mongodb'))) {
     abstract class Collection
     {
         abstract public function getManager(): Manager;

--- a/src/Symfony/Component/Messenger/Bridge/MongoDb/.gitattributes
+++ b/src/Symfony/Component/Messenger/Bridge/MongoDb/.gitattributes
@@ -1,0 +1,3 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Messenger/Bridge/MongoDb/.gitignore
+++ b/src/Symfony/Component/Messenger/Bridge/MongoDb/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+composer.lock
+phpunit.xml

--- a/src/Symfony/Component/Messenger/Bridge/MongoDb/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/MongoDb/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+8.2
+---
+
+ * Introduce the MongoDB Messenger bridge

--- a/src/Symfony/Component/Messenger/Bridge/MongoDb/LICENSE
+++ b/src/Symfony/Component/Messenger/Bridge/MongoDb/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2026-present Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/Messenger/Bridge/MongoDb/README.md
+++ b/src/Symfony/Component/Messenger/Bridge/MongoDb/README.md
@@ -1,0 +1,28 @@
+MongoDB Messenger
+=================
+
+Provides MongoDB integration for Symfony Messenger.
+
+DSN example
+-----------
+
+```
+MESSENGER_TRANSPORT_DSN=mongodb://user:pass@mongodb1.example.com:27017/db_name?collection_name=messenger_messages&queue_name=default
+```
+
+The transport reads its own settings (`database`, `collection_name`, `queue_name`,
+`redeliver_timeout`) from the query string and passes any other parameter to the
+MongoDB driver, so [connection options](https://www.mongodb.com/docs/manual/reference/connection-string-options/)
+keep working:
+
+```
+MESSENGER_TRANSPORT_DSN=mongodb+srv://mongodb.example.com/db_name?replicaSet=repl&connectTimeoutMS=3000
+```
+
+Resources
+---------
+
+ * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+ * [Report issues](https://github.com/symfony/symfony/issues) and
+   [send Pull Requests](https://github.com/symfony/symfony/pulls)
+   in the [main Symfony repository](https://github.com/symfony/symfony)

--- a/src/Symfony/Component/Messenger/Bridge/MongoDb/Stamp/MongoDbReceivedStamp.php
+++ b/src/Symfony/Component/Messenger/Bridge/MongoDb/Stamp/MongoDbReceivedStamp.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\MongoDb\Stamp;
+
+use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
+
+/**
+ * @author Alessandro Lai <alessandro.lai85@gmail.com>
+ */
+final class MongoDbReceivedStamp implements NonSendableStampInterface
+{
+    public function __construct(private string $id)
+    {
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+}

--- a/src/Symfony/Component/Messenger/Bridge/MongoDb/Stamp/MongoDbSessionStamp.php
+++ b/src/Symfony/Component/Messenger/Bridge/MongoDb/Stamp/MongoDbSessionStamp.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\MongoDb\Stamp;
+
+use MongoDB\Driver\Session;
+use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
+
+/**
+ * Allows sending a message inside a MongoDB transaction, by passing the
+ * session in which the transaction takes place.
+ *
+ * @author Alessandro Lai <alessandro.lai85@gmail.com>
+ */
+final class MongoDbSessionStamp implements NonSendableStampInterface
+{
+    public function __construct(private Session $session)
+    {
+    }
+
+    public function getSession(): Session
+    {
+        return $this->session;
+    }
+}

--- a/src/Symfony/Component/Messenger/Bridge/MongoDb/Tests/Fixtures/DummyMessage.php
+++ b/src/Symfony/Component/Messenger/Bridge/MongoDb/Tests/Fixtures/DummyMessage.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\MongoDb\Tests\Fixtures;
+
+class DummyMessage
+{
+    public function __construct(private string $message)
+    {
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+}

--- a/src/Symfony/Component/Messenger/Bridge/MongoDb/Tests/Stubs/mongodb.php
+++ b/src/Symfony/Component/Messenger/Bridge/MongoDb/Tests/Stubs/mongodb.php
@@ -1,0 +1,204 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/*
+ * The autoload attempts are gated on the extension being loaded: without it,
+ * the classes of the mongodb/mongodb library cannot be loaded anyway, as some
+ * of them implement interfaces provided by the extension.
+ */
+
+namespace MongoDB {
+    if (!class_exists(Client::class, \extension_loaded('mongodb'))) {
+        class Client
+        {
+            public function __construct(?string $uri = null, array $uriOptions = [], array $driverOptions = [])
+            {
+            }
+
+            public function getCollection(string $databaseName, string $collectionName, array $options = [])
+            {
+                return new Collection();
+            }
+        }
+    }
+
+    if (!class_exists(Collection::class, \extension_loaded('mongodb'))) {
+        class Collection
+        {
+            public function countDocuments($filter = [], array $options = [])
+            {
+            }
+
+            public function createIndex($key, array $options = [])
+            {
+            }
+
+            public function deleteMany($filter, array $options = [])
+            {
+            }
+
+            public function deleteOne($filter, array $options = [])
+            {
+            }
+
+            public function find($filter = [], array $options = [])
+            {
+            }
+
+            public function findOne($filter = [], array $options = [])
+            {
+            }
+
+            public function findOneAndUpdate($filter, $update, array $options = [])
+            {
+            }
+
+            public function insertOne($document, array $options = [])
+            {
+            }
+        }
+    }
+
+    if (!class_exists(DeleteResult::class, \extension_loaded('mongodb'))) {
+        class DeleteResult
+        {
+            public function getDeletedCount()
+            {
+            }
+        }
+    }
+
+    if (!class_exists(InsertOneResult::class, \extension_loaded('mongodb'))) {
+        class InsertOneResult
+        {
+            public function getInsertedId()
+            {
+            }
+        }
+    }
+}
+
+namespace MongoDB\BSON {
+    if (!class_exists(ObjectId::class, \extension_loaded('mongodb'))) {
+        class ObjectId
+        {
+            private string $oid;
+
+            public function __construct(?string $id = null)
+            {
+                if (null !== $id && !preg_match('/^[0-9a-f]{24}$/i', $id)) {
+                    throw new \InvalidArgumentException(\sprintf('Error parsing ObjectId string: "%s"', $id));
+                }
+
+                $this->oid = $id ?? bin2hex(random_bytes(12));
+            }
+
+            public function __toString(): string
+            {
+                return $this->oid;
+            }
+        }
+    }
+
+    if (!class_exists(UTCDateTime::class, \extension_loaded('mongodb'))) {
+        class UTCDateTime
+        {
+            public readonly string $milliseconds;
+
+            public function __construct(int|string|\DateTimeInterface|null $milliseconds = null)
+            {
+                if ($milliseconds instanceof \DateTimeInterface) {
+                    $milliseconds = $milliseconds->format('Uv');
+                }
+
+                $this->milliseconds = (string) ($milliseconds ?? (new \DateTimeImmutable())->format('Uv'));
+            }
+
+            public function toDateTime(): \DateTime
+            {
+                return \DateTime::createFromFormat('U.v', \sprintf('%d.%03d', intdiv((int) $this->milliseconds, 1000), (int) $this->milliseconds % 1000));
+            }
+
+            public function __toString(): string
+            {
+                return $this->milliseconds;
+            }
+        }
+    }
+}
+
+namespace MongoDB\Driver {
+    if (!class_exists(WriteConcern::class, \extension_loaded('mongodb'))) {
+        class WriteConcern
+        {
+            public const MAJORITY = 'majority';
+
+            public function __construct(
+                public string|int $w,
+                ?int $wtimeout = null,
+                ?bool $journal = null,
+            ) {
+            }
+        }
+    }
+
+    if (!class_exists(Session::class, \extension_loaded('mongodb'))) {
+        class Session
+        {
+            public function isInTransaction(): bool
+            {
+                return false;
+            }
+        }
+    }
+
+    if (!interface_exists(CursorInterface::class, \extension_loaded('mongodb'))) {
+        interface CursorInterface extends \Traversable
+        {
+        }
+    }
+}
+
+namespace MongoDB\Driver\Exception {
+    if (!interface_exists(Exception::class, \extension_loaded('mongodb'))) {
+        interface Exception extends \Throwable
+        {
+        }
+    }
+
+    if (!class_exists(RuntimeException::class, \extension_loaded('mongodb'))) {
+        class RuntimeException extends \RuntimeException implements Exception
+        {
+        }
+    }
+}
+
+namespace MongoDB\Model {
+    if (!class_exists(BSONDocument::class, \extension_loaded('mongodb'))) {
+        #[\AllowDynamicProperties]
+        class BSONDocument extends \ArrayObject
+        {
+            public function __construct(array $input = [], int $flags = \ArrayObject::ARRAY_AS_PROPS, string $iteratorClass = \ArrayIterator::class)
+            {
+                parent::__construct($input, $flags, $iteratorClass);
+            }
+        }
+    }
+}
+
+namespace MongoDB\Operation {
+    if (!class_exists(FindOneAndUpdate::class, \extension_loaded('mongodb'))) {
+        class FindOneAndUpdate
+        {
+            public const RETURN_DOCUMENT_AFTER = 2;
+        }
+    }
+}

--- a/src/Symfony/Component/Messenger/Bridge/MongoDb/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/MongoDb/Tests/Transport/ConnectionTest.php
@@ -1,0 +1,441 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\MongoDb\Tests\Transport;
+
+require_once __DIR__.'/../Stubs/mongodb.php';
+
+use MongoDB\BSON\ObjectId;
+use MongoDB\BSON\UTCDateTime;
+use MongoDB\Client;
+use MongoDB\Collection;
+use MongoDB\DeleteResult;
+use MongoDB\Driver\CursorInterface;
+use MongoDB\Driver\Exception\RuntimeException;
+use MongoDB\Driver\WriteConcern;
+use MongoDB\InsertOneResult;
+use MongoDB\Model\BSONDocument;
+use MongoDB\Operation\FindOneAndUpdate;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Clock\MockClock;
+use Symfony\Component\Messenger\Bridge\MongoDb\Transport\Connection;
+use Symfony\Component\Messenger\Exception\InvalidArgumentException;
+use Symfony\Component\Messenger\Exception\TransportException;
+
+class ConnectionTest extends TestCase
+{
+    public function testFromDsn()
+    {
+        $collection = $this->createStub(Collection::class);
+        $client = $this->createMock(Client::class);
+        $client->expects($this->once())
+            ->method('getCollection')
+            ->with('db', 'messenger_messages')
+            ->willReturn($collection);
+
+        $this->assertInstanceOf(Connection::class, Connection::fromDsn('mongodb://localhost:27017/db', [], $client));
+    }
+
+    public function testFromDsnWithOptions()
+    {
+        $collection = $this->createStub(Collection::class);
+        $client = $this->createMock(Client::class);
+        $client->expects($this->once())
+            ->method('getCollection')
+            ->with('some_db', 'some_collection')
+            ->willReturn($collection);
+
+        $this->assertInstanceOf(Connection::class, Connection::fromDsn('mongodb://localhost:27017', ['database' => 'some_db', 'collection_name' => 'some_collection'], $client));
+    }
+
+    /**
+     * @param array{database: string, collection_name: string, queue_name: string, redeliver_timeout: int} $expectedConfiguration
+     */
+    #[DataProvider('buildConfigurationProvider')]
+    public function testBuildConfiguration(string $dsn, array $options, array $expectedConfiguration, string $expectedUri)
+    {
+        [$configuration, $uri] = Connection::buildConfiguration($dsn, $options);
+
+        $this->assertEquals($expectedConfiguration, $configuration);
+        $this->assertSame($expectedUri, $uri);
+    }
+
+    public static function buildConfigurationProvider(): iterable
+    {
+        $defaultConfiguration = [
+            'database' => 'db',
+            'collection_name' => 'messenger_messages',
+            'queue_name' => 'default',
+            'redeliver_timeout' => 3600,
+        ];
+
+        yield 'database from the DSN path' => [
+            'mongodb://localhost:27017/db',
+            [],
+            $defaultConfiguration,
+            'mongodb://localhost:27017/db',
+        ];
+
+        yield 'settings from the DSN query string are extracted' => [
+            'mongodb://localhost:27017/db?collection_name=my_collection&queue_name=my_queue&redeliver_timeout=100',
+            [],
+            ['database' => 'db', 'collection_name' => 'my_collection', 'queue_name' => 'my_queue', 'redeliver_timeout' => 100] + $defaultConfiguration,
+            'mongodb://localhost:27017/db',
+        ];
+
+        yield 'driver options in the query string are kept' => [
+            'mongodb+srv://localhost/db?replicaSet=repl&queue_name=my_queue&appname=my_app',
+            [],
+            ['queue_name' => 'my_queue'] + $defaultConfiguration,
+            'mongodb+srv://localhost/db?replicaSet=repl&appname=my_app',
+        ];
+
+        yield 'options take precedence over the DSN' => [
+            'mongodb://localhost:27017/db?queue_name=from_query',
+            ['database' => 'other_db', 'queue_name' => 'from_options'],
+            ['database' => 'other_db', 'queue_name' => 'from_options'] + $defaultConfiguration,
+            'mongodb://localhost:27017/db',
+        ];
+    }
+
+    #[DataProvider('invalidDsnProvider')]
+    public function testInvalidDsn(string $dsn, array $options, string $expectedMessage)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        Connection::buildConfiguration($dsn, $options);
+    }
+
+    public static function invalidDsnProvider(): iterable
+    {
+        yield 'invalid scheme' => [
+            'doctrine://default',
+            [],
+            'The given MongoDB Messenger DSN is invalid. Expecting "mongodb://" or "mongodb+srv://".',
+        ];
+
+        yield 'missing database' => [
+            'mongodb://localhost:27017',
+            [],
+            'The MongoDB Messenger transport requires a "database", provide it in the DSN path or as an option.',
+        ];
+
+        yield 'unknown option' => [
+            'mongodb://localhost:27017/db',
+            ['foo' => 'bar'],
+            'Unknown option found: [foo]. Allowed options are [database, collection_name, queue_name, redeliver_timeout].',
+        ];
+
+        yield 'invalid redeliver_timeout' => [
+            'mongodb://localhost:27017/db',
+            ['redeliver_timeout' => 'invalid'],
+            'The "redeliver_timeout" option must be an integer, "string" given.',
+        ];
+    }
+
+    public function testGet()
+    {
+        $collection = $this->createMock(Collection::class);
+
+        $clock = new MockClock();
+        $connection = new Connection($collection, 'foobar', 100, $clock);
+        $document = $this->createDocumentDeliveredTo($connection->getUniqueId());
+
+        $collection->expects($this->once())
+            ->method('findOneAndUpdate')
+            ->with(
+                $this->equalTo([
+                    '$or' => [
+                        ['deliveredAt' => null],
+                        ['deliveredAt' => [
+                            '$lt' => new UTCDateTime($clock->now()->modify('-100 seconds')),
+                        ]],
+                    ],
+                    'availableAt' => ['$lte' => new UTCDateTime($clock->now())],
+                    'queueName' => 'foobar',
+                ]),
+                $this->equalTo([
+                    '$set' => [
+                        'deliveredTo' => $connection->getUniqueId(),
+                        'deliveredAt' => new UTCDateTime($clock->now()),
+                    ],
+                ]),
+                $this->equalTo([
+                    'writeConcern' => new WriteConcern(WriteConcern::MAJORITY),
+                    'returnDocument' => FindOneAndUpdate::RETURN_DOCUMENT_AFTER,
+                    'sort' => ['availableAt' => 1],
+                    'typeMap' => ['root' => BSONDocument::class],
+                ])
+            )
+            ->willReturn($document);
+
+        $this->assertSame($document, $connection->get());
+    }
+
+    public function testGetWrapsMongoExceptions()
+    {
+        $collection = $this->createStub(Collection::class);
+        $collection->method('findOneAndUpdate')
+            ->willThrowException(new RuntimeException('Foo bar baz'));
+
+        $connection = new Connection($collection, 'queueName', 100);
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('Foo bar baz');
+
+        $connection->get();
+    }
+
+    public function testGetWithEmptyCollection()
+    {
+        $collection = $this->createMock(Collection::class);
+        $collection
+            ->expects($this->once())
+            ->method('findOneAndUpdate')
+            ->willReturn(null);
+        $connection = new Connection($collection, 'default', 3_600);
+
+        $this->assertNull($connection->get());
+    }
+
+    public function testGetWithUnmatchedDeliveredAt()
+    {
+        $collection = $this->createMock(Collection::class);
+        $collection->expects($this->once())
+            ->method('findOneAndUpdate')
+            ->willReturn($this->createDocumentDeliveredTo('someoneElse'));
+        $connection = new Connection($collection, 'default', 3_600);
+
+        $this->assertNull($connection->get());
+    }
+
+    public function testSend()
+    {
+        $insertOneResult = $this->createStub(InsertOneResult::class);
+        $objectId = new ObjectId();
+        $insertOneResult->method('getInsertedId')
+            ->willReturn($objectId);
+
+        $clock = new MockClock();
+        $collection = $this->createMock(Collection::class);
+        $collection->expects($this->once())
+            ->method('insertOne')
+            ->with(
+                $this->callback(static function ($document) use ($clock): bool {
+                    self::assertInstanceOf(BSONDocument::class, $document);
+                    self::assertSame('serializedEnvelope', $document->body);
+                    self::assertEquals(new BSONDocument(['type' => 'foo']), $document->headers);
+                    self::assertSame('foobar', $document->queueName);
+                    self::assertEquals(new UTCDateTime($clock->now()), $document->createdAt);
+                    self::assertEquals(new UTCDateTime($clock->now()), $document->availableAt);
+
+                    return true;
+                }),
+                ['writeConcern' => new WriteConcern(WriteConcern::MAJORITY)]
+            )
+            ->willReturn($insertOneResult);
+
+        $connection = new Connection($collection, 'foobar', 3_600, $clock);
+
+        $this->assertSame($objectId, $connection->send('serializedEnvelope', ['type' => 'foo']));
+    }
+
+    public function testSendWithDelay()
+    {
+        $insertOneResult = $this->createStub(InsertOneResult::class);
+        $objectId = new ObjectId();
+        $insertOneResult->method('getInsertedId')
+            ->willReturn($objectId);
+
+        $clock = new MockClock();
+        $collection = $this->createMock(Collection::class);
+        $collection->expects($this->once())
+            ->method('insertOne')
+            ->with(
+                $this->callback(static function ($document) use ($clock): bool {
+                    self::assertInstanceOf(BSONDocument::class, $document);
+                    self::assertEquals(new UTCDateTime($clock->now()), $document->createdAt);
+                    self::assertEquals(new UTCDateTime($clock->now()->modify('+100 seconds')), $document->availableAt);
+
+                    return true;
+                }),
+                ['writeConcern' => new WriteConcern(WriteConcern::MAJORITY)]
+            )
+            ->willReturn($insertOneResult);
+
+        $connection = new Connection($collection, 'foobar', 3_600, $clock);
+
+        $this->assertSame($objectId, $connection->send('serializedEnvelope', [], 100_000));
+    }
+
+    public function testSendWrapsMongoExceptions()
+    {
+        $collection = $this->createStub(Collection::class);
+        $collection->method('insertOne')
+            ->willThrowException(new RuntimeException('Foo bar baz'));
+
+        $connection = new Connection($collection, 'queueName', 100);
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('Foo bar baz');
+
+        $connection->send('body');
+    }
+
+    /**
+     * @return array{int, bool}[]
+     */
+    public static function deleteCountProvider(): array
+    {
+        return [
+            [2, true],
+            [1, true],
+            [0, false],
+        ];
+    }
+
+    #[DataProvider('deleteCountProvider')]
+    public function testAck(int $deletedCount, bool $expectedResult)
+    {
+        $collection = $this->createMock(Collection::class);
+        $objectId = new ObjectId();
+        $deleteResult = $this->createStub(DeleteResult::class);
+        $deleteResult->method('getDeletedCount')
+            ->willReturn($deletedCount);
+        $collection->expects($this->once())
+            ->method('deleteOne')
+            ->with($this->equalTo(['_id' => $objectId]), $this->anything())
+            ->willReturn($deleteResult);
+
+        $connection = new Connection($collection, 'queueName', 100);
+
+        $this->assertSame($expectedResult, $connection->ack((string) $objectId));
+    }
+
+    public function testAckWrapsMongoExceptions()
+    {
+        $collection = $this->createStub(Collection::class);
+        $collection->method('deleteOne')
+            ->willThrowException(new RuntimeException('Foo bar baz'));
+
+        $connection = new Connection($collection, 'queueName', 100);
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('Foo bar baz');
+
+        $connection->ack((string) new ObjectId());
+    }
+
+    #[DataProvider('deleteCountProvider')]
+    public function testReject(int $deletedCount, bool $expectedResult)
+    {
+        $collection = $this->createMock(Collection::class);
+        $objectId = new ObjectId();
+        $deleteResult = $this->createStub(DeleteResult::class);
+        $deleteResult->method('getDeletedCount')
+            ->willReturn($deletedCount);
+        $collection->expects($this->once())
+            ->method('deleteOne')
+            ->with($this->equalTo(['_id' => $objectId]), $this->anything())
+            ->willReturn($deleteResult);
+
+        $connection = new Connection($collection, 'queueName', 100);
+
+        $this->assertSame($expectedResult, $connection->reject((string) $objectId));
+    }
+
+    public function testGetMessageCount()
+    {
+        $collection = $this->createMock(Collection::class);
+        $collection->expects($this->once())
+            ->method('countDocuments')
+            ->willReturn(7);
+
+        $connection = new Connection($collection, 'queueName', 100);
+
+        $this->assertSame(7, $connection->getMessageCount());
+    }
+
+    public function testFind()
+    {
+        $document = new BSONDocument();
+        $objectId = new ObjectId();
+        $collection = $this->createMock(Collection::class);
+        $collection->expects($this->once())
+            ->method('findOne')
+            ->with(
+                $this->equalTo(['_id' => $objectId]),
+                ['typeMap' => ['root' => BSONDocument::class]]
+            )
+            ->willReturn($document);
+
+        $connection = new Connection($collection, 'queueName', 100);
+
+        $this->assertSame($document, $connection->find((string) $objectId));
+    }
+
+    public function testFindAll()
+    {
+        $cursor = $this->createStub(CursorInterface::class);
+        $collection = $this->createMock(Collection::class);
+        $collection->expects($this->once())
+            ->method('find')
+            ->with($this->anything(), $this->callback(static function (array $options): bool {
+                self::assertSame(50, $options['limit']);
+                self::assertSame(['root' => BSONDocument::class], $options['typeMap']);
+
+                return true;
+            }))
+            ->willReturn($cursor);
+
+        $connection = new Connection($collection, 'queueName', 100);
+
+        $this->assertSame($cursor, $connection->findAll(50));
+    }
+
+    public function testDeleteAll()
+    {
+        $collection = $this->createMock(Collection::class);
+        $collection->expects($this->once())
+            ->method('deleteMany')
+            ->with(['queueName' => 'queueName']);
+
+        $connection = new Connection($collection, 'queueName', 100);
+
+        $connection->deleteAll();
+    }
+
+    public function testSetup()
+    {
+        $collection = $this->createMock(Collection::class);
+        $collection->expects($this->once())
+            ->method('createIndex')
+            ->with([
+                'availableAt' => 1,
+                'queueName' => 1,
+                'deliveredAt' => 1,
+            ]);
+
+        $connection = new Connection($collection, 'queueName', 100);
+
+        $connection->setup();
+    }
+
+    private function createDocumentDeliveredTo(string $deliveredTo): BSONDocument
+    {
+        $document = new BSONDocument();
+        $document->deliveredTo = $deliveredTo;
+
+        return $document;
+    }
+}

--- a/src/Symfony/Component/Messenger/Bridge/MongoDb/Tests/Transport/MongoDbReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/MongoDb/Tests/Transport/MongoDbReceiverTest.php
@@ -1,0 +1,172 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\MongoDb\Tests\Transport;
+
+require_once __DIR__.'/../Stubs/mongodb.php';
+
+use MongoDB\BSON\ObjectId;
+use MongoDB\Model\BSONDocument;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Bridge\MongoDb\Stamp\MongoDbReceivedStamp;
+use Symfony\Component\Messenger\Bridge\MongoDb\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Bridge\MongoDb\Transport\Connection;
+use Symfony\Component\Messenger\Bridge\MongoDb\Transport\MongoDbReceiver;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\LogicException;
+use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
+use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
+use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
+use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
+
+class MongoDbReceiverTest extends TestCase
+{
+    public function testItReturnsTheDecodedMessageToTheHandler()
+    {
+        $serializer = new PhpSerializer();
+        $document = $this->createDocument($serializer->encode(new Envelope(new DummyMessage('Hi'))));
+
+        $connection = $this->createStub(Connection::class);
+        $connection->method('get')->willReturn($document);
+
+        $receiver = new MongoDbReceiver($connection, $serializer);
+        $envelopes = $receiver->get();
+        $this->assertCount(1, $envelopes);
+
+        $envelope = $envelopes[0];
+        $message = $envelope->getMessage();
+        $this->assertInstanceOf(DummyMessage::class, $message);
+        $this->assertSame('Hi', $message->getMessage());
+        $this->assertSame((string) $document->_id, $envelope->last(MongoDbReceivedStamp::class)->getId());
+        $this->assertSame((string) $document->_id, $envelope->last(TransportMessageIdStamp::class)->getId());
+    }
+
+    public function testItReturnsEmptyWhenThereAreNoMessages()
+    {
+        $connection = $this->createStub(Connection::class);
+        $connection->method('get')->willReturn(null);
+
+        $receiver = new MongoDbReceiver($connection, $this->createStub(SerializerInterface::class));
+
+        $this->assertSame([], $receiver->get());
+    }
+
+    public function testItRejectsTheMessageIfItCannotBeDecoded()
+    {
+        $document = $this->createDocument(['body' => 'foo']);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('get')->willReturn($document);
+        $connection->expects($this->once())->method('reject')->with((string) $document->_id);
+
+        $serializer = $this->createStub(SerializerInterface::class);
+        $serializer->method('decode')->willThrowException(new MessageDecodingFailedException());
+
+        $receiver = new MongoDbReceiver($connection, $serializer);
+
+        $this->expectException(MessageDecodingFailedException::class);
+
+        $receiver->get();
+    }
+
+    public function testAck()
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())->method('ack')->with('some_id');
+
+        $receiver = new MongoDbReceiver($connection, $this->createStub(SerializerInterface::class));
+        $receiver->ack(new Envelope(new DummyMessage('Hi'), [new MongoDbReceivedStamp('some_id')]));
+    }
+
+    public function testAckThrowsWithoutStamp()
+    {
+        $receiver = new MongoDbReceiver($this->createStub(Connection::class), $this->createStub(SerializerInterface::class));
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('No MongoDbReceivedStamp found on the Envelope.');
+
+        $receiver->ack(new Envelope(new DummyMessage('Hi')));
+    }
+
+    public function testReject()
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())->method('reject')->with('some_id');
+
+        $receiver = new MongoDbReceiver($connection, $this->createStub(SerializerInterface::class));
+        $receiver->reject(new Envelope(new DummyMessage('Hi'), [new MongoDbReceivedStamp('some_id')]));
+    }
+
+    public function testAll()
+    {
+        $serializer = new PhpSerializer();
+        $documents = [
+            $this->createDocument($serializer->encode(new Envelope(new DummyMessage('Hi')))),
+            $this->createDocument($serializer->encode(new Envelope(new DummyMessage('Ho')))),
+        ];
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())->method('findAll')->with(50)->willReturn($documents);
+
+        $receiver = new MongoDbReceiver($connection, $serializer);
+        $envelopes = iterator_to_array($receiver->all(50));
+
+        $this->assertCount(2, $envelopes);
+        $this->assertSame('Hi', $envelopes[0]->getMessage()->getMessage());
+        $this->assertSame('Ho', $envelopes[1]->getMessage()->getMessage());
+    }
+
+    public function testFind()
+    {
+        $serializer = new PhpSerializer();
+        $document = $this->createDocument($serializer->encode(new Envelope(new DummyMessage('Hi'))));
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())->method('find')->with((string) $document->_id)->willReturn($document);
+
+        $receiver = new MongoDbReceiver($connection, $serializer);
+
+        $this->assertSame('Hi', $receiver->find((string) $document->_id)->getMessage()->getMessage());
+    }
+
+    public function testFindReturnsNullWhenThereIsNoMatch()
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())->method('find')->willReturn(null);
+
+        $receiver = new MongoDbReceiver($connection, $this->createStub(SerializerInterface::class));
+
+        $this->assertNull($receiver->find((string) new ObjectId()));
+    }
+
+    public function testGetMessageCount()
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())->method('getMessageCount')->willReturn(3);
+
+        $receiver = new MongoDbReceiver($connection, $this->createStub(SerializerInterface::class));
+
+        $this->assertSame(3, $receiver->getMessageCount());
+    }
+
+    /**
+     * @param array{body: string, headers?: array<string, string>} $encodedEnvelope
+     */
+    private function createDocument(array $encodedEnvelope): BSONDocument
+    {
+        $document = new BSONDocument();
+        $document->_id = new ObjectId();
+        $document->body = $encodedEnvelope['body'];
+        $document->headers = (object) ($encodedEnvelope['headers'] ?? []);
+
+        return $document;
+    }
+}

--- a/src/Symfony/Component/Messenger/Bridge/MongoDb/Tests/Transport/MongoDbSenderTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/MongoDb/Tests/Transport/MongoDbSenderTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\MongoDb\Tests\Transport;
+
+require_once __DIR__.'/../Stubs/mongodb.php';
+
+use MongoDB\BSON\ObjectId;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Bridge\MongoDb\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Bridge\MongoDb\Transport\Connection;
+use Symfony\Component\Messenger\Bridge\MongoDb\Transport\MongoDbSender;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
+use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
+use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
+
+class MongoDbSenderTest extends TestCase
+{
+    public function testSend()
+    {
+        $envelope = new Envelope(new DummyMessage('Oy'));
+        $encoded = ['body' => '...', 'headers' => ['type' => DummyMessage::class]];
+        $objectId = new ObjectId();
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())
+            ->method('send')
+            ->with('...', ['type' => DummyMessage::class], 0, null)
+            ->willReturn($objectId);
+
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->expects($this->once())->method('encode')->with($envelope)->willReturn($encoded);
+
+        $sender = new MongoDbSender($connection, $serializer);
+        $envelope = $sender->send($envelope);
+
+        $this->assertSame((string) $objectId, $envelope->last(TransportMessageIdStamp::class)->getId());
+    }
+
+    public function testSendWithDelay()
+    {
+        $envelope = new Envelope(new DummyMessage('Oy'), [new DelayStamp(500)]);
+        $encoded = ['body' => '...', 'headers' => ['type' => DummyMessage::class]];
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())
+            ->method('send')
+            ->with('...', ['type' => DummyMessage::class], 500, null)
+            ->willReturn(new ObjectId());
+
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->expects($this->once())->method('encode')->with($envelope)->willReturn($encoded);
+
+        $sender = new MongoDbSender($connection, $serializer);
+        $sender->send($envelope);
+    }
+
+    public function testSendWithoutHeaders()
+    {
+        $envelope = new Envelope(new DummyMessage('Oy'));
+        $encoded = ['body' => '...'];
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())
+            ->method('send')
+            ->with('...', [], 0, null)
+            ->willReturn(new ObjectId());
+
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->expects($this->once())->method('encode')->with($envelope)->willReturn($encoded);
+
+        $sender = new MongoDbSender($connection, $serializer);
+        $sender->send($envelope);
+    }
+}

--- a/src/Symfony/Component/Messenger/Bridge/MongoDb/Tests/Transport/MongoDbTransportFactoryTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/MongoDb/Tests/Transport/MongoDbTransportFactoryTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\MongoDb\Tests\Transport;
+
+require_once __DIR__.'/../Stubs/mongodb.php';
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Bridge\MongoDb\Transport\MongoDbTransport;
+use Symfony\Component\Messenger\Bridge\MongoDb\Transport\MongoDbTransportFactory;
+use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
+
+class MongoDbTransportFactoryTest extends TestCase
+{
+    public function testSupports()
+    {
+        $factory = new MongoDbTransportFactory();
+
+        $this->assertTrue($factory->supports('mongodb://localhost:27017/db', []));
+        $this->assertTrue($factory->supports('mongodb+srv://cluster.example.com/db', []));
+        $this->assertFalse($factory->supports('doctrine://default', []));
+        $this->assertFalse($factory->supports('redis://localhost', []));
+    }
+
+    public function testCreateTransport()
+    {
+        $factory = new MongoDbTransportFactory();
+        $transport = $factory->createTransport('mongodb://localhost:27017/db', ['transport_name' => 'mongo'], $this->createStub(SerializerInterface::class));
+
+        $this->assertInstanceOf(MongoDbTransport::class, $transport);
+    }
+}

--- a/src/Symfony/Component/Messenger/Bridge/MongoDb/Tests/Transport/MongoDbTransportIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/MongoDb/Tests/Transport/MongoDbTransportIntegrationTest.php
@@ -1,0 +1,156 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\MongoDb\Tests\Transport;
+
+use MongoDB\Client;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Bridge\MongoDb\Stamp\MongoDbSessionStamp;
+use Symfony\Component\Messenger\Bridge\MongoDb\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Bridge\MongoDb\Transport\Connection;
+use Symfony\Component\Messenger\Bridge\MongoDb\Transport\MongoDbTransport;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
+use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
+use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
+
+#[RequiresPhpExtension('mongodb')]
+#[Group('integration')]
+class MongoDbTransportIntegrationTest extends TestCase
+{
+    private const DATABASE = 'messenger_tests';
+
+    private Client $client;
+    private Connection $connection;
+    private MongoDbTransport $transport;
+
+    protected function setUp(): void
+    {
+        if (!class_exists(Client::class)) {
+            $this->markTestSkipped('The "mongodb/mongodb" package is required.');
+        }
+
+        $clientClass = new \ReflectionClass(Client::class);
+        if ($clientClass->isAbstract()) {
+            self::fail(\sprintf('MongoDB\Client is shadowed by the test stub "%s".', $clientClass->getFileName()));
+        }
+
+        $this->client = new Client(getenv('MONGODB_URI') ?: 'mongodb://localhost:27017', ['serverSelectionTimeoutMS' => 3000]);
+
+        try {
+            $this->client->getDatabase(self::DATABASE)->command(['ping' => 1]);
+        } catch (\Throwable) {
+            $this->markTestSkipped('MongoDB server not found.');
+        }
+
+        $this->connection = Connection::fromDsn('mongodb://localhost/'.self::DATABASE, [], $this->client);
+        $this->connection->deleteAll();
+        $this->transport = new MongoDbTransport($this->connection, new PhpSerializer());
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->connection)) {
+            $this->connection->deleteAll();
+        }
+    }
+
+    public function testSendGetAckRoundtrip()
+    {
+        $sentEnvelope = $this->transport->send(new Envelope(new DummyMessage('Hi')));
+        $this->assertNotNull($sentEnvelope->last(TransportMessageIdStamp::class));
+        $this->assertSame(1, $this->transport->getMessageCount());
+
+        $envelopes = $this->transport->get();
+        $this->assertCount(1, $envelopes);
+        $message = $envelopes[0]->getMessage();
+        $this->assertInstanceOf(DummyMessage::class, $message);
+        $this->assertSame('Hi', $message->getMessage());
+
+        // the message is locked for other consumers while it is handled
+        $this->assertSame([], $this->transport->get());
+
+        $this->transport->ack($envelopes[0]);
+        $this->assertSame(0, $this->transport->getMessageCount());
+    }
+
+    public function testReject()
+    {
+        $this->transport->send(new Envelope(new DummyMessage('Hi')));
+
+        $envelopes = $this->transport->get();
+        $this->assertCount(1, $envelopes);
+
+        $this->transport->reject($envelopes[0]);
+        $this->assertSame(0, $this->transport->getMessageCount());
+    }
+
+    public function testSendWithDelay()
+    {
+        $this->transport->send(new Envelope(new DummyMessage('Later'), [new DelayStamp(60000)]));
+
+        $this->assertSame(0, $this->transport->getMessageCount());
+        $this->assertSame([], $this->transport->get());
+    }
+
+    public function testMessageIsRedeliveredAfterTheRedeliverTimeout()
+    {
+        $this->transport->send(new Envelope(new DummyMessage('Hi')));
+
+        $this->assertCount(1, $this->transport->get());
+        $this->assertSame([], $this->transport->get());
+
+        $impatientConnection = Connection::fromDsn('mongodb://localhost/'.self::DATABASE, ['redeliver_timeout' => 0], $this->client);
+        $impatientTransport = new MongoDbTransport($impatientConnection, new PhpSerializer());
+
+        usleep(2000);
+        $this->assertCount(1, $impatientTransport->get());
+    }
+
+    public function testAllAndFind()
+    {
+        $this->transport->send(new Envelope(new DummyMessage('First')));
+        $sentEnvelope = $this->transport->send(new Envelope(new DummyMessage('Second')));
+
+        $envelopes = iterator_to_array($this->transport->all());
+        $this->assertCount(2, $envelopes);
+        $this->assertSame(['First', 'Second'], array_map(static fn (Envelope $envelope) => $envelope->getMessage()->getMessage(), $envelopes));
+
+        $this->assertCount(1, iterator_to_array($this->transport->all(1)));
+
+        $foundEnvelope = $this->transport->find($sentEnvelope->last(TransportMessageIdStamp::class)->getId());
+        $this->assertNotNull($foundEnvelope);
+        $this->assertSame('Second', $foundEnvelope->getMessage()->getMessage());
+    }
+
+    public function testSendWithSession()
+    {
+        $envelope = new Envelope(new DummyMessage('Hi'), [new MongoDbSessionStamp($this->client->startSession())]);
+
+        $this->transport->send($envelope);
+
+        $this->assertSame(1, $this->transport->getMessageCount());
+    }
+
+    public function testSetupCreatesTheIndex()
+    {
+        $this->transport->setup();
+
+        $indexKeys = [];
+        foreach ($this->client->getCollection(self::DATABASE, 'messenger_messages')->listIndexes() as $index) {
+            $indexKeys[] = $index->getKey();
+        }
+
+        $this->assertContainsEquals(['availableAt' => 1, 'queueName' => 1, 'deliveredAt' => 1], $indexKeys);
+    }
+}

--- a/src/Symfony/Component/Messenger/Bridge/MongoDb/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/MongoDb/Transport/Connection.php
@@ -1,0 +1,357 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\MongoDb\Transport;
+
+use MongoDB\BSON\ObjectId;
+use MongoDB\BSON\UTCDateTime;
+use MongoDB\Client;
+use MongoDB\Collection;
+use MongoDB\Driver\Exception\Exception as MongoDriverException;
+use MongoDB\Driver\Session;
+use MongoDB\Driver\WriteConcern;
+use MongoDB\Model\BSONDocument;
+use MongoDB\Operation\FindOneAndUpdate;
+use Psr\Clock\ClockInterface;
+use Symfony\Component\Messenger\Exception\InvalidArgumentException;
+use Symfony\Component\Messenger\Exception\TransportException;
+
+/**
+ * @internal
+ *
+ * @author Alessandro Lai <alessandro.lai85@gmail.com>
+ */
+class Connection
+{
+    private const DEFAULT_OPTIONS = [
+        'database' => null,
+        'collection_name' => 'messenger_messages',
+        'queue_name' => 'default',
+        'redeliver_timeout' => 3600,
+    ];
+
+    private string $uniqueId;
+
+    public function __construct(
+        private readonly Collection $collection,
+        private readonly string $queueName = 'default',
+        private readonly int $redeliverTimeout = 3600,
+        private readonly ?ClockInterface $clock = null,
+    ) {
+        $this->uniqueId = uniqid('consumer_', true);
+    }
+
+    public static function fromDsn(#[\SensitiveParameter] string $dsn, array $options = [], ?Client $client = null, ?ClockInterface $clock = null): self
+    {
+        [$configuration, $uri] = self::buildConfiguration($dsn, $options);
+
+        $client ??= new Client($uri);
+        $collection = $client->getCollection($configuration['database'], $configuration['collection_name']);
+
+        return new self($collection, $configuration['queue_name'], $configuration['redeliver_timeout'], $clock);
+    }
+
+    /**
+     * Extracts the transport configuration from the DSN and the options, and
+     * returns it along with the DSN stripped from the transport-specific
+     * query parameters, ready to be passed to the MongoDB client.
+     *
+     * The database is read from the DSN path, the other settings from the
+     * DSN query string or from the options, the latter taking precedence.
+     * Query parameters that are not transport settings are kept and passed
+     * to the MongoDB driver.
+     *
+     * @return array{0: array{database: string, collection_name: string, queue_name: string, redeliver_timeout: int}, 1: string}
+     */
+    public static function buildConfiguration(#[\SensitiveParameter] string $dsn, array $options = []): array
+    {
+        if (!str_starts_with($dsn, 'mongodb://') && !str_starts_with($dsn, 'mongodb+srv://')) {
+            throw new InvalidArgumentException('The given MongoDB Messenger DSN is invalid. Expecting "mongodb://" or "mongodb+srv://".');
+        }
+
+        if (false === $components = parse_url($dsn)) {
+            throw new InvalidArgumentException('The given MongoDB Messenger DSN is invalid.');
+        }
+
+        $query = [];
+        if (isset($components['query'])) {
+            parse_str($components['query'], $query);
+        }
+
+        if ($invalidOptions = array_diff(array_keys($options), array_keys(self::DEFAULT_OPTIONS))) {
+            throw new InvalidArgumentException(\sprintf('Unknown option found: [%s]. Allowed options are [%s].', implode(', ', $invalidOptions), implode(', ', array_keys(self::DEFAULT_OPTIONS))));
+        }
+
+        $configuration = $options + array_intersect_key($query, self::DEFAULT_OPTIONS) + self::DEFAULT_OPTIONS;
+        $configuration['database'] ??= ltrim($components['path'] ?? '', '/') ?: null;
+
+        if (null === $configuration['database']) {
+            throw new InvalidArgumentException('The MongoDB Messenger transport requires a "database", provide it in the DSN path or as an option.');
+        }
+
+        if (!is_numeric($configuration['redeliver_timeout'])) {
+            throw new InvalidArgumentException(\sprintf('The "redeliver_timeout" option must be an integer, "%s" given.', get_debug_type($configuration['redeliver_timeout'])));
+        }
+        $configuration['redeliver_timeout'] = (int) $configuration['redeliver_timeout'];
+
+        foreach (array_keys(self::DEFAULT_OPTIONS) as $option) {
+            $dsn = self::removeUriOption($dsn, $option);
+        }
+
+        return [$configuration, $dsn];
+    }
+
+    public function getUniqueId(): string
+    {
+        return $this->uniqueId;
+    }
+
+    /**
+     * @throws TransportException
+     */
+    public function get(): ?BSONDocument
+    {
+        $options = $this->getWriteOptions();
+        $options['returnDocument'] = FindOneAndUpdate::RETURN_DOCUMENT_AFTER;
+        $options['sort'] = [
+            'availableAt' => 1,
+        ];
+        $options = $this->setTypeMapOption($options);
+
+        $updateStatement = [
+            '$set' => [
+                'deliveredTo' => $this->uniqueId,
+                'deliveredAt' => new UTCDateTime($this->now()),
+            ],
+        ];
+
+        try {
+            $updatedDocument = $this->collection->findOneAndUpdate($this->createAvailableMessagesQuery(), $updateStatement, $options);
+        } catch (MongoDriverException $exception) {
+            throw new TransportException($exception->getMessage(), 0, $exception);
+        }
+
+        if (!$updatedDocument instanceof BSONDocument) {
+            return null;
+        }
+
+        if ($updatedDocument['deliveredTo'] !== $this->uniqueId) {
+            // concurrency issue - some other consumer got to this message while we were updating it
+            return null;
+        }
+
+        return $updatedDocument;
+    }
+
+    /**
+     * @param array<string, string> $headers
+     * @param int                   $delay   The delay in milliseconds
+     *
+     * @return ObjectId The inserted id
+     *
+     * @throws TransportException
+     */
+    public function send(string $body, array $headers = [], int $delay = 0, ?Session $session = null): ObjectId
+    {
+        $now = $this->now();
+        $availableAt = $now->modify(\sprintf('+%d milliseconds', $delay));
+
+        $document = new BSONDocument();
+        $document['body'] = $body;
+        $document['headers'] = new BSONDocument($headers);
+        $document['queueName'] = $this->queueName;
+        $document['createdAt'] = new UTCDateTime($now);
+        $document['availableAt'] = new UTCDateTime($availableAt);
+
+        try {
+            $insertResult = $this->collection->insertOne($document, $this->getWriteOptions($session));
+        } catch (MongoDriverException $exception) {
+            throw new TransportException($exception->getMessage(), 0, $exception);
+        }
+
+        return $insertResult->getInsertedId();
+    }
+
+    /**
+     * @param string $id The ID of the message to ack; the corresponding document will be removed from the collection
+     *
+     * @return bool Returns true if the document has been deleted
+     *
+     * @throws TransportException
+     */
+    public function ack(string $id): bool
+    {
+        try {
+            $deleteResult = $this->collection->deleteOne(['_id' => new ObjectId($id)], $this->getWriteOptions());
+        } catch (MongoDriverException $exception) {
+            throw new TransportException($exception->getMessage(), 0, $exception);
+        }
+
+        return $deleteResult->getDeletedCount() > 0;
+    }
+
+    /**
+     * @param string $id The ID of the message to reject; the corresponding document will be removed from the collection
+     *
+     * @return bool Returns true if the document has been deleted
+     *
+     * @throws TransportException
+     */
+    public function reject(string $id): bool
+    {
+        try {
+            $deleteResult = $this->collection->deleteOne(['_id' => new ObjectId($id)], $this->getWriteOptions());
+        } catch (MongoDriverException $exception) {
+            throw new TransportException($exception->getMessage(), 0, $exception);
+        }
+
+        return $deleteResult->getDeletedCount() > 0;
+    }
+
+    /**
+     * @throws TransportException
+     */
+    public function getMessageCount(): int
+    {
+        try {
+            return $this->collection->countDocuments($this->createAvailableMessagesQuery());
+        } catch (MongoDriverException $exception) {
+            throw new TransportException($exception->getMessage(), 0, $exception);
+        }
+    }
+
+    /**
+     * @throws TransportException
+     */
+    public function find(string $id): ?BSONDocument
+    {
+        try {
+            $document = $this->collection->findOne(['_id' => new ObjectId($id)], $this->setTypeMapOption());
+        } catch (MongoDriverException $exception) {
+            throw new TransportException($exception->getMessage(), 0, $exception);
+        }
+
+        return $document instanceof BSONDocument ? $document : null;
+    }
+
+    /**
+     * @return iterable<BSONDocument>
+     *
+     * @throws TransportException
+     */
+    public function findAll(?int $limit = null): iterable
+    {
+        $options = [];
+        if (null !== $limit) {
+            $options['limit'] = $limit;
+        }
+
+        try {
+            return $this->collection->find($this->createAvailableMessagesQuery(), $this->setTypeMapOption($options));
+        } catch (MongoDriverException $exception) {
+            throw new TransportException($exception->getMessage(), 0, $exception);
+        }
+    }
+
+    public function deleteAll(): void
+    {
+        try {
+            $this->collection->deleteMany(['queueName' => $this->queueName]);
+        } catch (MongoDriverException $exception) {
+            throw new TransportException($exception->getMessage(), 0, $exception);
+        }
+    }
+
+    /**
+     * Creates a compound index including the queueName, availableAt and
+     * deliveredAt fields, to speed up the polling query.
+     */
+    public function setup(): void
+    {
+        try {
+            $this->collection->createIndex([
+                'availableAt' => 1,
+                'queueName' => 1,
+                'deliveredAt' => 1,
+            ]);
+        } catch (MongoDriverException $exception) {
+            throw new TransportException($exception->getMessage(), 0, $exception);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function createAvailableMessagesQuery(): array
+    {
+        $now = $this->now();
+        $redeliverLimit = $now->modify(\sprintf('-%d seconds', $this->redeliverTimeout));
+
+        return [
+            '$or' => [
+                ['deliveredAt' => null],
+                ['deliveredAt' => [
+                    '$lt' => new UTCDateTime($redeliverLimit),
+                ]],
+            ],
+            'availableAt' => ['$lte' => new UTCDateTime($now)],
+            'queueName' => $this->queueName,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getWriteOptions(?Session $session = null): array
+    {
+        if (null === $session) {
+            return ['writeConcern' => new WriteConcern(WriteConcern::MAJORITY)];
+        }
+
+        if ($session->isInTransaction()) {
+            return ['session' => $session];
+        }
+
+        return ['session' => $session, 'writeConcern' => new WriteConcern(WriteConcern::MAJORITY)];
+    }
+
+    /**
+     * @param array<string, mixed> $readOptions
+     *
+     * @return array<string, mixed>
+     */
+    private function setTypeMapOption(array $readOptions = []): array
+    {
+        $readOptions['typeMap'] = [
+            'root' => BSONDocument::class,
+        ];
+
+        return $readOptions;
+    }
+
+    private function now(): \DateTimeImmutable
+    {
+        return $this->clock?->now() ?? new \DateTimeImmutable();
+    }
+
+    private static function removeUriOption(string $uri, string $option): string
+    {
+        if (preg_match('/^(.*[?&])'.$option.'=[^&#]*&?(([^#]*).*)$/', $uri, $matches)) {
+            $prefix = $matches[1];
+            if ('' === $matches[3]) {
+                $prefix = substr($prefix, 0, -1);
+            }
+            $uri = $prefix.$matches[2];
+        }
+
+        return $uri;
+    }
+}

--- a/src/Symfony/Component/Messenger/Bridge/MongoDb/Transport/MongoDbReceiver.php
+++ b/src/Symfony/Component/Messenger/Bridge/MongoDb/Transport/MongoDbReceiver.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\MongoDb\Transport;
+
+use MongoDB\Model\BSONDocument;
+use Symfony\Component\Messenger\Bridge\MongoDb\Stamp\MongoDbReceivedStamp;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\LogicException;
+use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
+use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
+use Symfony\Component\Messenger\Transport\Receiver\ListableReceiverInterface;
+use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
+use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
+
+/**
+ * @author Alessandro Lai <alessandro.lai85@gmail.com>
+ */
+class MongoDbReceiver implements MessageCountAwareInterface, ListableReceiverInterface
+{
+    public function __construct(
+        private Connection $connection,
+        private SerializerInterface $serializer,
+    ) {
+    }
+
+    /**
+     * @param int $fetchSize
+     *
+     * @return Envelope[]
+     */
+    public function get(/* int $fetchSize = 1 */): iterable
+    {
+        $fetchSize = \func_num_args() > 0 ? max(1, func_get_arg(0)) : 1;
+
+        $envelopes = [];
+        while ($fetchSize-- > 0 && null !== $document = $this->connection->get()) {
+            $envelopes[] = $this->createEnvelope($document);
+        }
+
+        return $envelopes;
+    }
+
+    public function ack(Envelope $envelope): void
+    {
+        $this->connection->ack($this->findReceivedStamp($envelope)->getId());
+    }
+
+    public function reject(Envelope $envelope): void
+    {
+        $this->connection->reject($this->findReceivedStamp($envelope)->getId());
+    }
+
+    /**
+     * @return iterable<Envelope>
+     */
+    public function all(?int $limit = null): iterable
+    {
+        foreach ($this->connection->findAll($limit) as $document) {
+            yield $this->createEnvelope($document);
+        }
+    }
+
+    public function find(mixed $id): ?Envelope
+    {
+        $document = $this->connection->find((string) $id);
+
+        if (!$document instanceof BSONDocument) {
+            return null;
+        }
+
+        return $this->createEnvelope($document);
+    }
+
+    public function getMessageCount(): int
+    {
+        return $this->connection->getMessageCount();
+    }
+
+    private function findReceivedStamp(Envelope $envelope): MongoDbReceivedStamp
+    {
+        return $envelope->last(MongoDbReceivedStamp::class) ?? throw new LogicException('No MongoDbReceivedStamp found on the Envelope.');
+    }
+
+    private function createEnvelope(BSONDocument $document): Envelope
+    {
+        $documentId = (string) $document['_id'];
+
+        if (($document['headers'] ?? null) instanceof \stdClass) {
+            $headers = (array) $document['headers'];
+        } else {
+            $headers = null;
+        }
+
+        try {
+            $envelope = $this->serializer->decode([
+                'body' => $document['body'] ?? null,
+                'headers' => $headers,
+            ]);
+        } catch (MessageDecodingFailedException $exception) {
+            $this->connection->reject($documentId);
+
+            throw $exception;
+        }
+
+        return $envelope->with(
+            new MongoDbReceivedStamp($documentId),
+            new TransportMessageIdStamp($documentId)
+        );
+    }
+}

--- a/src/Symfony/Component/Messenger/Bridge/MongoDb/Transport/MongoDbSender.php
+++ b/src/Symfony/Component/Messenger/Bridge/MongoDb/Transport/MongoDbSender.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\MongoDb\Transport;
+
+use Symfony\Component\Messenger\Bridge\MongoDb\Stamp\MongoDbSessionStamp;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
+use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
+use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
+use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
+
+/**
+ * @author Alessandro Lai <alessandro.lai85@gmail.com>
+ */
+class MongoDbSender implements SenderInterface
+{
+    public function __construct(
+        private Connection $connection,
+        private SerializerInterface $serializer,
+    ) {
+    }
+
+    public function send(Envelope $envelope): Envelope
+    {
+        $encodedMessage = $this->serializer->encode($envelope);
+
+        $delay = $envelope->last(DelayStamp::class)?->getDelay() ?? 0;
+        $session = $envelope->last(MongoDbSessionStamp::class)?->getSession();
+
+        $id = $this->connection->send($encodedMessage['body'], $encodedMessage['headers'] ?? [], $delay, $session);
+
+        return $envelope->with(new TransportMessageIdStamp((string) $id));
+    }
+}

--- a/src/Symfony/Component/Messenger/Bridge/MongoDb/Transport/MongoDbTransport.php
+++ b/src/Symfony/Component/Messenger/Bridge/MongoDb/Transport/MongoDbTransport.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\MongoDb\Transport;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Transport\Receiver\ListableReceiverInterface;
+use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
+use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
+use Symfony\Component\Messenger\Transport\SetupableTransportInterface;
+use Symfony\Component\Messenger\Transport\TransportInterface;
+
+/**
+ * @author Alessandro Lai <alessandro.lai85@gmail.com>
+ */
+class MongoDbTransport implements TransportInterface, SetupableTransportInterface, MessageCountAwareInterface, ListableReceiverInterface
+{
+    private MongoDbReceiver $receiver;
+    private MongoDbSender $sender;
+
+    public function __construct(
+        private Connection $connection,
+        private SerializerInterface $serializer,
+    ) {
+    }
+
+    /**
+     * @param int $fetchSize
+     *
+     * @return Envelope[]
+     */
+    public function get(/* int $fetchSize = 1 */): iterable
+    {
+        return $this->getReceiver()->get(\func_num_args() > 0 ? func_get_arg(0) : 1);
+    }
+
+    public function ack(Envelope $envelope): void
+    {
+        $this->getReceiver()->ack($envelope);
+    }
+
+    public function reject(Envelope $envelope): void
+    {
+        $this->getReceiver()->reject($envelope);
+    }
+
+    public function send(Envelope $envelope): Envelope
+    {
+        return $this->getSender()->send($envelope);
+    }
+
+    /**
+     * @return iterable<Envelope>
+     */
+    public function all(?int $limit = null): iterable
+    {
+        return $this->getReceiver()->all($limit);
+    }
+
+    public function find(mixed $id): ?Envelope
+    {
+        return $this->getReceiver()->find($id);
+    }
+
+    public function getMessageCount(): int
+    {
+        return $this->getReceiver()->getMessageCount();
+    }
+
+    public function setup(): void
+    {
+        $this->connection->setup();
+    }
+
+    private function getReceiver(): MongoDbReceiver
+    {
+        return $this->receiver ??= new MongoDbReceiver($this->connection, $this->serializer);
+    }
+
+    private function getSender(): MongoDbSender
+    {
+        return $this->sender ??= new MongoDbSender($this->connection, $this->serializer);
+    }
+}

--- a/src/Symfony/Component/Messenger/Bridge/MongoDb/Transport/MongoDbTransportFactory.php
+++ b/src/Symfony/Component/Messenger/Bridge/MongoDb/Transport/MongoDbTransportFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\MongoDb\Transport;
+
+use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
+use Symfony\Component\Messenger\Transport\TransportFactoryInterface;
+
+/**
+ * @author Alessandro Lai <alessandro.lai85@gmail.com>
+ *
+ * @implements TransportFactoryInterface<MongoDbTransport>
+ */
+class MongoDbTransportFactory implements TransportFactoryInterface
+{
+    public function createTransport(#[\SensitiveParameter] string $dsn, array $options, SerializerInterface $serializer): MongoDbTransport
+    {
+        unset($options['transport_name']);
+
+        return new MongoDbTransport(Connection::fromDsn($dsn, $options), $serializer);
+    }
+
+    public function supports(#[\SensitiveParameter] string $dsn, array $options): bool
+    {
+        return str_starts_with($dsn, 'mongodb://') || str_starts_with($dsn, 'mongodb+srv://');
+    }
+}

--- a/src/Symfony/Component/Messenger/Bridge/MongoDb/composer.json
+++ b/src/Symfony/Component/Messenger/Bridge/MongoDb/composer.json
@@ -1,0 +1,35 @@
+{
+    "name": "symfony/mongodb-messenger",
+    "type": "symfony-messenger-bridge",
+    "description": "Symfony MongoDB Messenger Bridge",
+    "keywords": [],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Alessandro Lai",
+            "email": "alessandro.lai85@gmail.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=8.4.1",
+        "ext-mongodb": "^1.21|^2.0",
+        "mongodb/mongodb": "^1.21|^2.0",
+        "psr/clock": "^1.0",
+        "symfony/messenger": "^8.2"
+    },
+    "require-dev": {
+        "symfony/clock": "^7.4|^8.0"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Component\\Messenger\\Bridge\\MongoDb\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev"
+}

--- a/src/Symfony/Component/Messenger/Bridge/MongoDb/phpunit.xml.dist
+++ b/src/Symfony/Component/Messenger/Bridge/MongoDb/phpunit.xml.dist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/13.1/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnDeprecation="true"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+        <env name="MONGODB_URI" value="mongodb://localhost:27017" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony MongoDB Messenger Component Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <source ignoreSuppressionOfDeprecations="true">
+        <include>
+            <directory>./</directory>
+        </include>
+        <exclude>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </source>
+
+    <extensions>
+        <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension" />
+    </extensions>
+</phpunit>

--- a/src/Symfony/Component/Messenger/Transport/TransportFactory.php
+++ b/src/Symfony/Component/Messenger/Transport/TransportFactory.php
@@ -51,6 +51,8 @@ class TransportFactory implements TransportFactoryInterface
             $packageSuggestion = ' Run "composer require symfony/amazon-sqs-messenger" to install Amazon SQS transport.';
         } elseif (str_starts_with($dsn, 'beanstalkd://')) {
             $packageSuggestion = ' Run "composer require symfony/beanstalkd-messenger" to install Beanstalkd transport.';
+        } elseif (str_starts_with($dsn, 'mongodb://') || str_starts_with($dsn, 'mongodb+srv://')) {
+            $packageSuggestion = ' Run "composer require symfony/mongodb-messenger" to install MongoDB transport.';
         }
 
         if ($dsn = $this->santitizeDsn($dsn)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | https://github.com/facile-it/mongodb-messenger-transport/issues/37
| License       | MIT

This imports [facile-it/mongodb-messenger-transport](https://github.com/facile-it/mongodb-messenger-transport) into the monorepo as a new Messenger bridge: `symfony/mongodb-messenger`.

The transport stores messages as documents in a MongoDB collection. Delivery relies on an atomic `findOneAndUpdate` that stamps the consumer id and the delivery time, so concurrent consumers never get the same message twice. A message that stays claimed longer than `redeliver_timeout` is handed out again, which covers crashed consumers.

```env
MESSENGER_TRANSPORT_DSN=mongodb://user:pass@host:27017/db_name?collection_name=messenger_messages&queue_name=default
```

- The database is read from the DSN path, or from the `database` option.
- The other settings can be set in the DSN query string or in the transport's `options` (options take precedence): `collection_name` (default `messenger_messages`), `queue_name` (default `default`), `redeliver_timeout` (default 3600 seconds).
- Any other query parameter is passed through to the MongoDB driver, so driver options such as `replicaSet` or `authSource` keep working. `mongodb+srv://` DSNs are supported.
- The transport implements `ListableReceiverInterface` and `MessageCountAwareInterface`, so `messenger:failed:*` style tooling works. It is setupable: `messenger:setup-transports` creates an index for the polling query; the collection itself is created by MongoDB on first insert, so setup is recommended but not required.
- `MongoDbSessionStamp` allows sending a message inside a MongoDB transaction, by passing the driver session the transaction runs in.
- Requirements: `ext-mongodb` and `mongodb/mongodb`, both `^1.21|^2.0`.

Points for the documentation PR:
- DSN format and the option table with defaults, as above;
- the database is required, the collection is not;
- redelivery semantics of `redeliver_timeout`;
- `messenger:setup-transports` creates the index;
- sending within a transaction via `MongoDbSessionStamp`.
