### PR TITLE
[Runtime] add middleware to frankenPhp runner

### DIFF
--- a/src/Symfony/Component/Runtime/Runner/FrankenPhpWorkerRunner.php
+++ b/src/Symfony/Component/Runtime/Runner/FrankenPhpWorkerRunner.php
@@ -25,8 +25,6 @@ use Symfony\Component\Runtime\RunnerInterface;
 class FrankenPhpWorkerRunner implements RunnerInterface
 {
     /**
-     * @param HttpKernelInterface $kernel
-     * @param int $loopMax
      * @param iterable<MiddlewareInterface> $middlewares
      */
     public function __construct(

--- a/src/Symfony/Component/Runtime/Runner/FrankenPhpWorkerRunner.php
+++ b/src/Symfony/Component/Runtime/Runner/FrankenPhpWorkerRunner.php
@@ -61,7 +61,7 @@ class FrankenPhpWorkerRunner implements RunnerInterface
             if (!$middleware instanceof MiddlewareInterface) {
                 throw new \LogicException(\sprintf('The middleware "%s" must implement the "%s" interface.', \is_object($middleware) ? $middleware::class : \gettype($middleware), MiddlewareInterface::class));
             }
-            $handler = fn () => $middleware->wrap($handler, $server);
+            $handler = fn () => $middleware->handle($handler, $server);
         }
 
         $loops = 0;

--- a/src/Symfony/Component/Runtime/Runner/FrankenPhpWorkerRunner.php
+++ b/src/Symfony/Component/Runtime/Runner/FrankenPhpWorkerRunner.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Runtime\Runner;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\TerminableInterface;
+use Symfony\Component\Runtime\Runner\Middleware\MiddlewareInterface;
 use Symfony\Component\Runtime\RunnerInterface;
 
 /**
@@ -23,9 +24,15 @@ use Symfony\Component\Runtime\RunnerInterface;
  */
 class FrankenPhpWorkerRunner implements RunnerInterface
 {
+    /**
+     * @param HttpKernelInterface $kernel
+     * @param int $loopMax
+     * @param iterable<MiddlewareInterface> $middlewares
+     */
     public function __construct(
         private HttpKernelInterface $kernel,
         private int $loopMax,
+        private iterable $middlewares = [],
     ) {
     }
 
@@ -51,6 +58,13 @@ class FrankenPhpWorkerRunner implements RunnerInterface
 
             $sfResponse->send();
         };
+
+        foreach ($this->middlewares as $middleware) {
+            if (!$middleware instanceof MiddlewareInterface) {
+                throw new \LogicException(\sprintf('The middleware "%s" must implement the "%s" interface.', \is_object($middleware) ? $middleware::class : \gettype($middleware), MiddlewareInterface::class));
+            }
+            $handler = fn () => $middleware->wrap($handler, $server);
+        }
 
         $loops = 0;
         do {

--- a/src/Symfony/Component/Runtime/Runner/Middleware/MiddlewareFactory.php
+++ b/src/Symfony/Component/Runtime/Runner/Middleware/MiddlewareFactory.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *
@@ -15,14 +13,15 @@ namespace Symfony\Component\Runtime\Runner\Middleware;
 
 /**
  * @author Sascha Heilmeier <sascha.heilmeier@netlogix.de>
+ * @internal
  */
-readonly class MiddlewareFactory
+final class MiddlewareFactory
 {
     /**
-     * @param class-string<MiddlewareInterface> ...$middleware
+     * @param class-string<MiddlewareInterface>[] $middleware
      * @return \Generator<MiddlewareInterface>
      */
-    public function create(string ...$middleware): \Generator
+    public function create(array $middleware): \Generator
     {
         foreach ($middleware as $middlewareClass) {
             yield new $middlewareClass();

--- a/src/Symfony/Component/Runtime/Runner/Middleware/MiddlewareFactory.php
+++ b/src/Symfony/Component/Runtime/Runner/Middleware/MiddlewareFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Runtime\Runner\Middleware;
+
+/**
+ * @author Sascha Heilmeier<sascha.heilmeier@netlogix.de>
+ */
+readonly class MiddlewareFactory
+{
+    /**
+     * @param class-string<MiddlewareInterface> ...$middleware
+     * @return \Generator<MiddlewareInterface>
+     */
+    public function create(string ...$middleware): \Generator
+    {
+        foreach ($middleware as $middlewareClass) {
+            yield new $middlewareClass();
+        }
+    }
+}

--- a/src/Symfony/Component/Runtime/Runner/Middleware/MiddlewareFactory.php
+++ b/src/Symfony/Component/Runtime/Runner/Middleware/MiddlewareFactory.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Symfony\Component\Runtime\Runner\Middleware;
 
 /**
- * @author Sascha Heilmeier<sascha.heilmeier@netlogix.de>
+ * @author Sascha Heilmeier <sascha.heilmeier@netlogix.de>
  */
 readonly class MiddlewareFactory
 {

--- a/src/Symfony/Component/Runtime/Runner/Middleware/MiddlewareFactory.php
+++ b/src/Symfony/Component/Runtime/Runner/Middleware/MiddlewareFactory.php
@@ -13,12 +13,14 @@ namespace Symfony\Component\Runtime\Runner\Middleware;
 
 /**
  * @author Sascha Heilmeier <sascha.heilmeier@netlogix.de>
+ *
  * @internal
  */
 final class MiddlewareFactory
 {
     /**
      * @param class-string<MiddlewareInterface>[] $middleware
+     *
      * @return \Generator<MiddlewareInterface>
      */
     public function create(array $middleware): \Generator

--- a/src/Symfony/Component/Runtime/Runner/Middleware/MiddlewareInterface.php
+++ b/src/Symfony/Component/Runtime/Runner/Middleware/MiddlewareInterface.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Symfony/Component/Runtime/Runner/Middleware/MiddlewareInterface.php
+++ b/src/Symfony/Component/Runtime/Runner/Middleware/MiddlewareInterface.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Symfony\Component\Runtime\Runner\Middleware;
 
 /**
- * @author Sascha Heilmeier<sascha.heilmeier@netlogix.de>
+ * @author Sascha Heilmeier <sascha.heilmeier@netlogix.de>
  */
 interface MiddlewareInterface
 {

--- a/src/Symfony/Component/Runtime/Runner/Middleware/MiddlewareInterface.php
+++ b/src/Symfony/Component/Runtime/Runner/Middleware/MiddlewareInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Runtime\Runner\Middleware;
+
+/**
+ * @author Sascha Heilmeier<sascha.heilmeier@netlogix.de>
+ */
+interface MiddlewareInterface
+{
+    public function wrap(callable $handler, array $server): void;
+}

--- a/src/Symfony/Component/Runtime/Runner/Middleware/MiddlewareInterface.php
+++ b/src/Symfony/Component/Runtime/Runner/Middleware/MiddlewareInterface.php
@@ -16,5 +16,9 @@ namespace Symfony\Component\Runtime\Runner\Middleware;
  */
 interface MiddlewareInterface
 {
-    public function wrap(callable $handler, array $server): void;
+    /**
+     * @param callable $handler The request handler, which should be called to process the request
+     * @param array<string, mixed> $server environment variables coming from DotEnv
+     */
+    public function handle(callable $handler, array $server): void;
 }

--- a/src/Symfony/Component/Runtime/Runner/Middleware/MiddlewareInterface.php
+++ b/src/Symfony/Component/Runtime/Runner/Middleware/MiddlewareInterface.php
@@ -17,8 +17,8 @@ namespace Symfony\Component\Runtime\Runner\Middleware;
 interface MiddlewareInterface
 {
     /**
-     * @param callable $handler The request handler, which should be called to process the request
-     * @param array<string, mixed> $server environment variables coming from DotEnv
+     * @param callable             $handler The request handler, which should be called to process the request
+     * @param array<string, mixed> $server  environment variables coming from DotEnv
      */
     public function handle(callable $handler, array $server): void;
 }

--- a/src/Symfony/Component/Runtime/SymfonyRuntime.php
+++ b/src/Symfony/Component/Runtime/SymfonyRuntime.php
@@ -159,7 +159,7 @@ class SymfonyRuntime extends GenericRuntime
         $workerMiddlewares = ($options['worker_middlewares'] ?? $_SERVER['FRANKENPHP_MIDDLEWARES'] ?? $_ENV['FRANKENPHP_MIDDLEWARES'] ?? '');
 
         if (!\is_string($workerMiddlewares)) {
-            throw new \LogicException(\sprintf('The "worker_middlewares" runtime option must be an string, "%s" given.', get_debug_type($workerLoopMax)));
+            throw new \LogicException(\sprintf('The "worker_middlewares" runtime option must be an string, "%s" given.', get_debug_type($workerMiddlewares)));
         }
 
         $workerMiddlewares = array_filter(explode("\n", $workerMiddlewares));

--- a/src/Symfony/Component/Runtime/SymfonyRuntime.php
+++ b/src/Symfony/Component/Runtime/SymfonyRuntime.php
@@ -24,6 +24,8 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Runtime\Internal\MissingDotenv;
 use Symfony\Component\Runtime\Internal\SymfonyErrorHandler;
 use Symfony\Component\Runtime\Runner\FrankenPhpWorkerRunner;
+use Symfony\Component\Runtime\Runner\Middleware\MiddlewareFactory;
+use Symfony\Component\Runtime\Runner\Middleware\MiddlewareInterface;
 use Symfony\Component\Runtime\Runner\Symfony\ConsoleApplicationRunner;
 use Symfony\Component\Runtime\Runner\Symfony\HttpKernelRunner;
 use Symfony\Component\Runtime\Runner\Symfony\ResponseRunner;
@@ -91,6 +93,7 @@ class SymfonyRuntime extends GenericRuntime
      *   dotenv_overload?: ?bool,
      *   dotenv_extra_paths?: ?string[],
      *   worker_loop_max?: int, // Use 0 or a negative integer to never restart the worker. Default: 500
+     *   worker_middlewares?: string
      * } $options
      */
     public function __construct(array $options = [])
@@ -153,6 +156,22 @@ class SymfonyRuntime extends GenericRuntime
 
         $options['worker_loop_max'] = (int) ($workerLoopMax ?? 500);
 
+        $workerMiddlewares = ($options['worker_middlewares'] ?? $_SERVER['FRANKENPHP_MIDDLEWARES'] ?? $_ENV['FRANKENPHP_MIDDLEWARES'] ?? '');
+
+        if (!\is_string($workerMiddlewares)) {
+            throw new \LogicException(\sprintf('The "worker_middlewares" runtime option must be an string, "%s" given.', get_debug_type($workerLoopMax)));
+        }
+
+        $workerMiddlewares = array_filter(explode("\n", $workerMiddlewares));
+
+        foreach ($workerMiddlewares as $workerMiddleware) {
+            if (!is_a($workerMiddleware, MiddlewareInterface::class, true)) {
+                throw new \LogicException(\sprintf('The middleware class "%s" must implement "%s".', $workerMiddleware, MiddlewareInterface::class));
+            }
+        }
+
+        $options['worker_middlewares'] = $workerMiddlewares;
+
         parent::__construct($options);
     }
 
@@ -160,7 +179,8 @@ class SymfonyRuntime extends GenericRuntime
     {
         if ($application instanceof HttpKernelInterface) {
             if ($_SERVER['FRANKENPHP_WORKER'] ?? false) {
-                return new FrankenPhpWorkerRunner($application, $this->options['worker_loop_max']);
+                $middlewareFactory = new MiddlewareFactory();
+                return new FrankenPhpWorkerRunner($application, $this->options['worker_loop_max'], $middlewareFactory->create(...$this->options['worker_middlewares']));
             }
 
             return new HttpKernelRunner($application, Request::createFromGlobals(), $this->options['debug'] ?? false);

--- a/src/Symfony/Component/Runtime/SymfonyRuntime.php
+++ b/src/Symfony/Component/Runtime/SymfonyRuntime.php
@@ -163,7 +163,7 @@ class SymfonyRuntime extends GenericRuntime
         }
 
         $workerMiddlewares = array_filter(
-            is_array($workerMiddlewares) ? $workerMiddlewares : explode("\n", $workerMiddlewares)
+            \is_array($workerMiddlewares) ? $workerMiddlewares : explode("\n", $workerMiddlewares)
         );
 
         foreach ($workerMiddlewares as $workerMiddleware) {
@@ -182,6 +182,7 @@ class SymfonyRuntime extends GenericRuntime
         if ($application instanceof HttpKernelInterface) {
             if ($_SERVER['FRANKENPHP_WORKER'] ?? false) {
                 $middlewareFactory = new MiddlewareFactory();
+
                 return new FrankenPhpWorkerRunner($application, $this->options['worker_loop_max'], $middlewareFactory->create($this->options['worker_middlewares']));
             }
 

--- a/src/Symfony/Component/Runtime/SymfonyRuntime.php
+++ b/src/Symfony/Component/Runtime/SymfonyRuntime.php
@@ -93,7 +93,7 @@ class SymfonyRuntime extends GenericRuntime
      *   dotenv_overload?: ?bool,
      *   dotenv_extra_paths?: ?string[],
      *   worker_loop_max?: int, // Use 0 or a negative integer to never restart the worker. Default: 500
-     *   worker_middlewares?: string
+     *   worker_middlewares?: string|string[],
      * } $options
      */
     public function __construct(array $options = [])
@@ -158,11 +158,13 @@ class SymfonyRuntime extends GenericRuntime
 
         $workerMiddlewares = ($options['worker_middlewares'] ?? $_SERVER['FRANKENPHP_MIDDLEWARES'] ?? $_ENV['FRANKENPHP_MIDDLEWARES'] ?? '');
 
-        if (!\is_string($workerMiddlewares)) {
-            throw new \LogicException(\sprintf('The "worker_middlewares" runtime option must be an string, "%s" given.', get_debug_type($workerMiddlewares)));
+        if (!\is_string($workerMiddlewares) && !\is_array($workerMiddlewares)) {
+            throw new \LogicException(\sprintf('The "worker_middlewares" runtime option must be an array or string, "%s" given.', get_debug_type($workerMiddlewares)));
         }
 
-        $workerMiddlewares = array_filter(explode("\n", $workerMiddlewares));
+        $workerMiddlewares = array_filter(
+            is_array($workerMiddlewares) ? $workerMiddlewares : explode("\n", $workerMiddlewares)
+        );
 
         foreach ($workerMiddlewares as $workerMiddleware) {
             if (!is_a($workerMiddleware, MiddlewareInterface::class, true)) {
@@ -180,7 +182,7 @@ class SymfonyRuntime extends GenericRuntime
         if ($application instanceof HttpKernelInterface) {
             if ($_SERVER['FRANKENPHP_WORKER'] ?? false) {
                 $middlewareFactory = new MiddlewareFactory();
-                return new FrankenPhpWorkerRunner($application, $this->options['worker_loop_max'], $middlewareFactory->create(...$this->options['worker_middlewares']));
+                return new FrankenPhpWorkerRunner($application, $this->options['worker_loop_max'], $middlewareFactory->create($this->options['worker_middlewares']));
             }
 
             return new HttpKernelRunner($application, Request::createFromGlobals(), $this->options['debug'] ?? false);

--- a/src/Symfony/Component/Runtime/Tests/FrankenPhpWorkerRunnerTest.php
+++ b/src/Symfony/Component/Runtime/Tests/FrankenPhpWorkerRunnerTest.php
@@ -13,12 +13,14 @@ namespace Symfony\Component\Runtime\Tests;
 
 require_once __DIR__.'/frankenphp-function-mock.php';
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\TerminableInterface;
 use Symfony\Component\Runtime\Runner\FrankenPhpWorkerRunner;
+use Symfony\Component\Runtime\Runner\Middleware\MiddlewareInterface;
 
 interface TestAppInterface extends HttpKernelInterface, TerminableInterface
 {
@@ -26,8 +28,20 @@ interface TestAppInterface extends HttpKernelInterface, TerminableInterface
 
 class FrankenPhpWorkerRunnerTest extends TestCase
 {
-    public function testRun()
+    public static function runData(): iterable
     {
+        yield 'default' => [];
+
+        yield 'middleware' => [
+            'withMiddleware' => true,
+        ];
+    }
+
+    /**
+     * @param class-string<MiddlewareInterface>|null $middleware
+     */
+    #[DataProvider('runData')]
+    public function testRun(bool $withMiddleware = false) {
         $application = $this->createMock(TestAppInterface::class);
         $application
             ->expects($this->once())
@@ -41,7 +55,30 @@ class FrankenPhpWorkerRunnerTest extends TestCase
 
         $_SERVER['FOO'] = 'bar';
 
-        $runner = new FrankenPhpWorkerRunner($application, 500);
+        if ($withMiddleware) {
+            $middlewareMock = $this->createMock(MiddlewareInterface::class);
+            $middlewareMock
+                ->expects($this->once())
+                ->method('wrap')->willReturnCallback(fn ($handler) => $handler());
+        }
+
+        $runner = new FrankenPhpWorkerRunner($application, 500, array_filter([$middlewareMock ?? null]));
+
         $this->assertSame(0, $runner->run());
+    }
+
+    public function testRunInvalidMiddleware()
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage(
+            \sprintf(
+                'The middleware "%s" must implement the "%s" interface',
+                \stdClass::class,
+                MiddlewareInterface::class
+            )
+        );
+        $application = $this->createMock(TestAppInterface::class);
+        $runner = new FrankenPhpWorkerRunner($application, 500, [new \stdClass]);
+        $runner->run();
     }
 }

--- a/src/Symfony/Component/Runtime/Tests/FrankenPhpWorkerRunnerTest.php
+++ b/src/Symfony/Component/Runtime/Tests/FrankenPhpWorkerRunnerTest.php
@@ -64,7 +64,7 @@ class FrankenPhpWorkerRunnerTest extends TestCase
         $middlewareMock = $this->createMock(MiddlewareInterface::class);
         $middlewareMock
             ->expects($this->once())
-            ->method('wrap')->willReturnCallback(fn ($handler) => $handler());
+            ->method('handle')->willReturnCallback(fn ($handler) => $handler());
 
         $runner = new FrankenPhpWorkerRunner($application, 500, array_filter([$middlewareMock ?? null]));
 

--- a/src/Symfony/Component/Runtime/Tests/FrankenPhpWorkerRunnerTest.php
+++ b/src/Symfony/Component/Runtime/Tests/FrankenPhpWorkerRunnerTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Runtime\Tests;
 
 require_once __DIR__.'/frankenphp-function-mock.php';
 
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -28,7 +27,8 @@ interface TestAppInterface extends HttpKernelInterface, TerminableInterface
 
 class FrankenPhpWorkerRunnerTest extends TestCase
 {
-    public function testRun() {
+    public function testRun()
+    {
         $application = $this->createMock(TestAppInterface::class);
         $application
             ->expects($this->once())
@@ -47,7 +47,8 @@ class FrankenPhpWorkerRunnerTest extends TestCase
         $this->assertSame(0, $runner->run());
     }
 
-    public function testRunWithMiddleware() {
+    public function testRunWithMiddleware()
+    {
         $application = $this->createMock(TestAppInterface::class);
         $application
             ->expects($this->once())
@@ -82,7 +83,7 @@ class FrankenPhpWorkerRunnerTest extends TestCase
             )
         );
         $application = $this->createMock(TestAppInterface::class);
-        $runner = new FrankenPhpWorkerRunner($application, 500, [new \stdClass]);
+        $runner = new FrankenPhpWorkerRunner($application, 500, [new \stdClass()]);
         $runner->run();
     }
 }

--- a/src/Symfony/Component/Runtime/Tests/FrankenPhpWorkerRunnerTest.php
+++ b/src/Symfony/Component/Runtime/Tests/FrankenPhpWorkerRunnerTest.php
@@ -28,20 +28,7 @@ interface TestAppInterface extends HttpKernelInterface, TerminableInterface
 
 class FrankenPhpWorkerRunnerTest extends TestCase
 {
-    public static function runData(): iterable
-    {
-        yield 'default' => [];
-
-        yield 'middleware' => [
-            'withMiddleware' => true,
-        ];
-    }
-
-    /**
-     * @param class-string<MiddlewareInterface>|null $middleware
-     */
-    #[DataProvider('runData')]
-    public function testRun(bool $withMiddleware = false) {
+    public function testRun() {
         $application = $this->createMock(TestAppInterface::class);
         $application
             ->expects($this->once())
@@ -55,12 +42,29 @@ class FrankenPhpWorkerRunnerTest extends TestCase
 
         $_SERVER['FOO'] = 'bar';
 
-        if ($withMiddleware) {
-            $middlewareMock = $this->createMock(MiddlewareInterface::class);
-            $middlewareMock
-                ->expects($this->once())
-                ->method('wrap')->willReturnCallback(fn ($handler) => $handler());
-        }
+        $runner = new FrankenPhpWorkerRunner($application, 500);
+
+        $this->assertSame(0, $runner->run());
+    }
+
+    public function testRunWithMiddleware() {
+        $application = $this->createMock(TestAppInterface::class);
+        $application
+            ->expects($this->once())
+            ->method('handle')
+            ->willReturnCallback(function (Request $request, int $type = HttpKernelInterface::MAIN_REQUEST, bool $catch = true): Response {
+                $this->assertSame('bar', $request->server->get('FOO'));
+
+                return new Response();
+            });
+        $application->expects($this->once())->method('terminate');
+
+        $_SERVER['FOO'] = 'bar';
+
+        $middlewareMock = $this->createMock(MiddlewareInterface::class);
+        $middlewareMock
+            ->expects($this->once())
+            ->method('wrap')->willReturnCallback(fn ($handler) => $handler());
 
         $runner = new FrankenPhpWorkerRunner($application, 500, array_filter([$middlewareMock ?? null]));
 

--- a/src/Symfony/Component/Runtime/Tests/Support/InvalidMiddleware.php
+++ b/src/Symfony/Component/Runtime/Tests/Support/InvalidMiddleware.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Runtime\Tests\Support;
+
+class InvalidMiddleware
+{
+}

--- a/src/Symfony/Component/Runtime/Tests/Support/TestMiddleware.php
+++ b/src/Symfony/Component/Runtime/Tests/Support/TestMiddleware.php
@@ -17,7 +17,7 @@ use Symfony\Component\Runtime\Runner\Middleware\MiddlewareInterface;
 
 class TestMiddleware implements MiddlewareInterface
 {
-    public function wrap(callable $handler, array $server): void
+    public function handle(callable $handler, array $server): void
     {
         $handler();
     }

--- a/src/Symfony/Component/Runtime/Tests/Support/TestMiddleware.php
+++ b/src/Symfony/Component/Runtime/Tests/Support/TestMiddleware.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Runtime\Tests\Support;
+
+use Symfony\Component\Runtime\Runner\Middleware\MiddlewareInterface;
+
+class TestMiddleware implements MiddlewareInterface
+{
+    public function wrap(callable $handler, array $server): void
+    {
+        $handler();
+    }
+}

--- a/src/Symfony/Component/Runtime/Tests/SymfonyRuntimeTest.php
+++ b/src/Symfony/Component/Runtime/Tests/SymfonyRuntimeTest.php
@@ -90,8 +90,14 @@ class SymfonyRuntimeTest extends TestCase
             'expectedWorkerMiddlewares' => [],
         ];
 
-        yield 'valid middleware' => [
+        yield 'valid middleware - string' => [
             'value' => TestMiddleware::class,
+            'expectedWorkerMiddlewares' => [TestMiddleware::class],
+        ];
+
+
+        yield 'valid middleware - array' => [
+            'value' => [TestMiddleware::class],
             'expectedWorkerMiddlewares' => [TestMiddleware::class],
         ];
 
@@ -116,12 +122,12 @@ class SymfonyRuntimeTest extends TestCase
 
         yield 'invalid worker_middlewares option type - bool' => [
             'value' => false,
-            'expectedMessage' => \sprintf('The "worker_middlewares" runtime option must be an string, "%s" given.', 'bool')
+            'expectedMessage' => \sprintf('The "worker_middlewares" runtime option must be an array or string, "%s" given.', 'bool')
         ];
 
         yield 'invalid worker_middlewares option type - int' => [
             'value' => 42,
-            'expectedMessage' => \sprintf('The "worker_middlewares" runtime option must be an string, "%s" given.', 'int')
+            'expectedMessage' => \sprintf('The "worker_middlewares" runtime option must be an array or string, "%s" given.', 'int')
         ];
     }
 
@@ -137,6 +143,28 @@ class SymfonyRuntimeTest extends TestCase
         }
 
         $runtime = new SymfonyRuntime(['worker_middlewares' => $value, 'error_handler' => false]);
+
+        if (null !== $expectedWorkerMiddlewares) {
+            $optionsReflection = new \ReflectionProperty($runtime, 'options');
+            $workerMiddlewares = $optionsReflection->getValue($runtime)['worker_middlewares'] ?? [];
+            $this->assertEquals($expectedWorkerMiddlewares, $workerMiddlewares);
+        }
+    }
+
+    #[DataProvider('workerMiddlewaresOptionData')]
+    public function testWorkerMiddlewaresEnv(
+        mixed $value,
+        ?array $expectedWorkerMiddlewares = null,
+        ?string $expectedMessage = null,
+    ) {
+        if (null !== $expectedMessage) {
+            $this->expectException(\LogicException::class);
+            $this->expectExceptionMessage($expectedMessage);
+        }
+
+        $_ENV['FRANKENPHP_MIDDLEWARES'] = (is_array($value) ? implode("\n", $value) : $value);
+
+        $runtime = new SymfonyRuntime(['error_handler' => false]);
 
         if (null !== $expectedWorkerMiddlewares) {
             $optionsReflection = new \ReflectionProperty($runtime, 'options');

--- a/src/Symfony/Component/Runtime/Tests/SymfonyRuntimeTest.php
+++ b/src/Symfony/Component/Runtime/Tests/SymfonyRuntimeTest.php
@@ -95,7 +95,6 @@ class SymfonyRuntimeTest extends TestCase
             'expectedWorkerMiddlewares' => [TestMiddleware::class],
         ];
 
-
         yield 'valid middleware - array' => [
             'value' => [TestMiddleware::class],
             'expectedWorkerMiddlewares' => [TestMiddleware::class],
@@ -112,8 +111,7 @@ class SymfonyRuntimeTest extends TestCase
 
         yield 'invalid middleware not a class' => [
             'value' => 'unknown',
-            'expectedMessage' =>
-                \sprintf(
+            'expectedMessage' => \sprintf(
                 'The middleware class "%s" must implement "%s"',
                 'unknown',
                 MiddlewareInterface::class
@@ -122,12 +120,12 @@ class SymfonyRuntimeTest extends TestCase
 
         yield 'invalid worker_middlewares option type - bool' => [
             'value' => false,
-            'expectedMessage' => \sprintf('The "worker_middlewares" runtime option must be an array or string, "%s" given.', 'bool')
+            'expectedMessage' => \sprintf('The "worker_middlewares" runtime option must be an array or string, "%s" given.', 'bool'),
         ];
 
         yield 'invalid worker_middlewares option type - int' => [
             'value' => 42,
-            'expectedMessage' => \sprintf('The "worker_middlewares" runtime option must be an array or string, "%s" given.', 'int')
+            'expectedMessage' => \sprintf('The "worker_middlewares" runtime option must be an array or string, "%s" given.', 'int'),
         ];
     }
 
@@ -162,7 +160,7 @@ class SymfonyRuntimeTest extends TestCase
             $this->expectExceptionMessage($expectedMessage);
         }
 
-        $_ENV['FRANKENPHP_MIDDLEWARES'] = (is_array($value) ? implode("\n", $value) : $value);
+        $_ENV['FRANKENPHP_MIDDLEWARES'] = (\is_array($value) ? implode("\n", $value) : $value);
 
         $runtime = new SymfonyRuntime(['error_handler' => false]);
 

--- a/src/Symfony/Component/Runtime/Tests/SymfonyRuntimeTest.php
+++ b/src/Symfony/Component/Runtime/Tests/SymfonyRuntimeTest.php
@@ -58,10 +58,11 @@ class SymfonyRuntimeTest extends TestCase
         } finally {
             restore_error_handler();
             restore_exception_handler();
+            unset($_SERVER['FRANKENPHP_MIDDLEWARES']);
         }
     }
 
-    public function _testStringWorkerMaxLoopThrows()
+    public function testStringWorkerMaxLoopThrows()
     {
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('The "worker_loop_max" runtime option must be an integer, "string" given.');
@@ -69,7 +70,7 @@ class SymfonyRuntimeTest extends TestCase
         new SymfonyRuntime(['worker_loop_max' => 'foo']);
     }
 
-    public function _testBoolWorkerMaxLoopThrows()
+    public function testBoolWorkerMaxLoopThrows()
     {
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('The "worker_loop_max" runtime option must be an integer, "bool" given.');
@@ -79,6 +80,16 @@ class SymfonyRuntimeTest extends TestCase
 
     public static function workerMiddlewaresOptionData(): iterable
     {
+        yield 'empty middleware - null' => [
+            'value' => null,
+            'expectedWorkerMiddlewares' => [],
+        ];
+
+        yield 'empty middleware - empty' => [
+            'value' => '',
+            'expectedWorkerMiddlewares' => [],
+        ];
+
         yield 'valid middleware' => [
             'value' => TestMiddleware::class,
             'expectedWorkerMiddlewares' => [TestMiddleware::class],
@@ -92,10 +103,30 @@ class SymfonyRuntimeTest extends TestCase
                 MiddlewareInterface::class
             ),
         ];
+
+        yield 'invalid middleware not a class' => [
+            'value' => 'unknown',
+            'expectedMessage' =>
+                \sprintf(
+                'The middleware class "%s" must implement "%s"',
+                'unknown',
+                MiddlewareInterface::class
+            ),
+        ];
+
+        yield 'invalid worker_middlewares option type - bool' => [
+            'value' => false,
+            'expectedMessage' => \sprintf('The "worker_middlewares" runtime option must be an string, "%s" given.', 'bool')
+        ];
+
+        yield 'invalid worker_middlewares option type - int' => [
+            'value' => 42,
+            'expectedMessage' => \sprintf('The "worker_middlewares" runtime option must be an string, "%s" given.', 'int')
+        ];
     }
 
     #[DataProvider('workerMiddlewaresOptionData')]
-    public function _testWorkerMiddlewaresOption(
+    public function testWorkerMiddlewaresOption(
         mixed $value,
         ?array $expectedWorkerMiddlewares = null,
         ?string $expectedMessage = null,

--- a/src/Symfony/Component/Runtime/Tests/SymfonyRuntimeTest.php
+++ b/src/Symfony/Component/Runtime/Tests/SymfonyRuntimeTest.php
@@ -11,10 +11,14 @@
 
 namespace Symfony\Component\Runtime\Tests;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Runtime\Runner\FrankenPhpWorkerRunner;
+use Symfony\Component\Runtime\Runner\Middleware\MiddlewareInterface;
 use Symfony\Component\Runtime\SymfonyRuntime;
+use Symfony\Component\Runtime\Tests\Support\InvalidMiddleware;
+use Symfony\Component\Runtime\Tests\Support\TestMiddleware;
 
 class SymfonyRuntimeTest extends TestCase
 {
@@ -35,7 +39,29 @@ class SymfonyRuntimeTest extends TestCase
         }
     }
 
-    public function testStringWorkerMaxLoopThrows()
+    public function testGetRunnerWithMiddleware()
+    {
+        $application = $this->createStub(HttpKernelInterface::class);
+
+        $_SERVER['FRANKENPHP_MIDDLEWARES'] = TestMiddleware::class;
+        $runtime = new SymfonyRuntime();
+
+        try {
+            $_SERVER['FRANKENPHP_WORKER'] = 1;
+            $runner = $runtime->getRunner($application);
+            $this->assertInstanceOf(FrankenPhpWorkerRunner::class, $runner);
+
+            $middlewaresProperty = new \ReflectionProperty($runner, 'middlewares');
+            $middlewares = iterator_to_array($middlewaresProperty->getValue($runner));
+            $this->assertCount(1, $middlewares);
+            $this->assertInstanceOf(TestMiddleware::class, $middlewares[0]);
+        } finally {
+            restore_error_handler();
+            restore_exception_handler();
+        }
+    }
+
+    public function _testStringWorkerMaxLoopThrows()
     {
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('The "worker_loop_max" runtime option must be an integer, "string" given.');
@@ -43,11 +69,48 @@ class SymfonyRuntimeTest extends TestCase
         new SymfonyRuntime(['worker_loop_max' => 'foo']);
     }
 
-    public function testBoolWorkerMaxLoopThrows()
+    public function _testBoolWorkerMaxLoopThrows()
     {
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('The "worker_loop_max" runtime option must be an integer, "bool" given.');
 
         new SymfonyRuntime(['worker_loop_max' => false]);
+    }
+
+    public static function workerMiddlewaresOptionData(): iterable
+    {
+        yield 'valid middleware' => [
+            'value' => TestMiddleware::class,
+            'expectedWorkerMiddlewares' => [TestMiddleware::class],
+        ];
+
+        yield 'invalid middleware' => [
+            'value' => InvalidMiddleware::class,
+            'expectedMessage' => \sprintf(
+                'The middleware class "%s" must implement "%s"',
+                InvalidMiddleware::class,
+                MiddlewareInterface::class
+            ),
+        ];
+    }
+
+    #[DataProvider('workerMiddlewaresOptionData')]
+    public function _testWorkerMiddlewaresOption(
+        mixed $value,
+        ?array $expectedWorkerMiddlewares = null,
+        ?string $expectedMessage = null,
+    ) {
+        if (null !== $expectedMessage) {
+            $this->expectException(\LogicException::class);
+            $this->expectExceptionMessage($expectedMessage);
+        }
+
+        $runtime = new SymfonyRuntime(['worker_middlewares' => $value, 'error_handler' => false]);
+
+        if (null !== $expectedWorkerMiddlewares) {
+            $optionsReflection = new \ReflectionProperty($runtime, 'options');
+            $workerMiddlewares = $optionsReflection->getValue($runtime)['worker_middlewares'] ?? [];
+            $this->assertEquals($expectedWorkerMiddlewares, $workerMiddlewares);
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

Like https://github.com/php-runtime/runtime/pull/183

We use tideways in our projects.
We want to use this middleware to enable the request based profiling.

https://support.tideways.com/documentation/setup/installation/frankenphp.html#code-changes-to-frankenphp_handle_request-callback

I want to use a middleware for tideways like this:
```php
class TidewaysMiddleware implements MiddlewareInterface
{
    public function wrap(callable $handler, array $server): void
    {
        if (!$this->checkTideways()) {
            $handler();
            return;
        }

        \Tideways\Profiler::start();
        try {
            $handler();
        } catch (\Throwable $e) {
            \Tideways\Profiler::logException($e);
            throw $e;
        } finally {
            \Tideways\Profiler::stop();
        }
    }

    private function checkTideways(): bool
    {
        return !class_exists('Tideways\Profiler') && !\Tideways\Profiler::isEnabled();
    }
}
```

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
