### PR TITLE
 Use the standard `MONGODB_URI` variable to configure tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,7 +22,7 @@
         <env name="REDIS_SOCKET" value="/var/run/redis/redis-server.sock" />
         <env name="MESSENGER_REDIS_DSN" value="redis://localhost/messages" />
         <env name="MEMCACHED_HOST" value="localhost" />
-        <env name="MONGODB_HOST" value="localhost" />
+        <env name="MONGODB_URI" value="mongodb://localhost:27017" />
         <env name="ZOOKEEPER_HOST" value="localhost" />
         <env name="COUCHBASE_HOST" value="localhost" />
         <env name="COUCHBASE_USER" value="Administrator" />

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
@@ -45,12 +45,12 @@ class MongoDbSessionHandlerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->manager = new Manager('mongodb://'.getenv('MONGODB_HOST'));
+        $this->manager = new Manager(getenv('MONGODB_URI'));
 
         try {
             $this->manager->executeCommand(self::DABASE_NAME, new Command(['ping' => 1]));
         } catch (ConnectionException $e) {
-            $this->markTestSkipped(\sprintf('MongoDB Server "%s" not running: %s', getenv('MONGODB_HOST'), $e->getMessage()));
+            $this->markTestSkipped(\sprintf('MongoDB Server "%s" not running: %s', getenv('MONGODB_URI'), $e->getMessage()));
         }
 
         $this->options = [

--- a/src/Symfony/Component/HttpFoundation/phpunit.xml.dist
+++ b/src/Symfony/Component/HttpFoundation/phpunit.xml.dist
@@ -11,7 +11,7 @@
 >
     <php>
         <ini name="error_reporting" value="-1" />
-        <env name="MONGODB_HOST" value="localhost" />
+        <env name="MONGODB_URI" value="mongodb://localhost:27017" />
     </php>
 
     <testsuites>

--- a/src/Symfony/Component/Lock/Tests/Store/MongoDbStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/MongoDbStoreTest.php
@@ -50,7 +50,7 @@ class MongoDbStoreTest extends AbstractStoreTestCase
 
     private static function getMongoManager(): Manager
     {
-        return new Manager('mongodb://'.getenv('MONGODB_HOST'));
+        return new Manager(getenv('MONGODB_URI'));
     }
 
     protected function getClockDelay(): int

--- a/src/Symfony/Component/Lock/phpunit.xml.dist
+++ b/src/Symfony/Component/Lock/phpunit.xml.dist
@@ -13,7 +13,7 @@
         <ini name="error_reporting" value="-1" />
         <env name="REDIS_HOST" value="localhost" />
         <env name="MEMCACHED_HOST" value="localhost" />
-        <env name="MONGODB_HOST" value="localhost" />
+        <env name="MONGODB_URI" value="mongodb://localhost:27017" />
         <env name="ZOOKEEPER_HOST" value="localhost" />
     </php>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

[MongoDB connection string](https://www.mongodb.com/docs/manual/reference/connection-string/) is more than a host name. In order to be able to test on other server configuration easily (Atlas, replica-set), I need to pass a full `MONGODB_URI`.