### PR TITLE
[HttpClient] Don't store response with authentication headers in shared mode

### DIFF
--- a/src/Symfony/Component/HttpClient/CachingHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CachingHttpClient.php
@@ -687,16 +687,21 @@ class CachingHttpClient implements HttpClientInterface, ResetInterface
             return false;
         }
 
-        if (
-            $this->sharedCache
-            && !isset($cacheControl['public']) && !isset($cacheControl['s-maxage']) && !isset($cacheControl['must-revalidate'])
-            && isset($requestHeaders['authorization'])
-        ) {
-            return false;
-        }
+        if ($this->sharedCache) {
+            if (
+                !isset($cacheControl['public']) && !isset($cacheControl['s-maxage']) && !isset($cacheControl['must-revalidate'])
+                && isset($requestHeaders['authorization'])
+            ) {
+                return false;
+            }
 
-        if ($this->sharedCache && isset($cacheControl['private'])) {
-            return false;
+            if (isset($cacheControl['private'])) {
+                return false;
+            }
+
+            if (isset($responseHeaders['authentication-info']) || isset($responseHeaders['set-cookie']) || isset($responseHeaders['www-authenticate'])) {
+                return false;
+            }
         }
 
         // Conditionals require an explicit expiration


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | 
| License       | MIT

Otherwise, this would bring back [`CVE-2022-24894`](https://symfony.com/blog/cve-2022-24894-prevent-storing-cookie-headers-in-httpcache)