### PR TITLE
[Routing] Indicate the type of the rejected object in `CompiledUrlMatcherDumper`

### DIFF
--- a/src/Symfony/Component/Routing/Matcher/Dumper/CompiledUrlMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/CompiledUrlMatcherDumper.php
@@ -465,11 +465,10 @@ class CompiledUrlMatcherDumper extends MatcherDumper
         if (null === $value) {
             return 'null';
         }
+        if (\is_object($value)) {
+            throw new \InvalidArgumentException(\sprintf('Symfony\Component\Routing\Route cannot contain objects, but "%s" given.', get_debug_type($value)));
+        }
         if (!\is_array($value)) {
-            if (\is_object($value)) {
-                throw new \InvalidArgumentException('Symfony\Component\Routing\Route cannot contain objects.');
-            }
-
             return str_replace("\n", '\'."\n".\'', var_export($value, true));
         }
         if (!$value) {

--- a/src/Symfony/Component/Routing/Tests/Matcher/Dumper/CompiledUrlMatcherDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/Dumper/CompiledUrlMatcherDumperTest.php
@@ -492,7 +492,7 @@ class CompiledUrlMatcherDumperTest extends TestCase
         $routeCollection->add('_', new Route('/', [new \stdClass()]));
         $dumper = new CompiledUrlMatcherDumper($routeCollection);
 
-        $this->expectExceptionMessage('Symfony\Component\Routing\Route cannot contain objects');
+        $this->expectExceptionMessage('Symfony\Component\Routing\Route cannot contain objects, but "stdClass" given.');
         $this->expectException(\InvalidArgumentException::class);
 
         $dumper->dump();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Using `Symfony\Component\DependencyInjection\Loader\Configurator\param` is not supported *yet* by the router configuration. 

```php
namespace Symfony\Component\Routing\Loader\Configurator;

use function Symfony\Component\DependencyInjection\Loader\Configurator\param;

return Routes::config([
    'homepage' => [
        'path' => '/{_locale}',
        'controller' => 'Symfony\\Bundle\\FrameworkBundle\\Controller\\TemplateController::templateAction',
        'defaults' => [
            'template' => 'default/homepage.html.twig',
            '_locale' => param('app.locale'),
        ],
    ],
]);
```

New exception message: 
> Symfony\Component\Routing\Route cannot contain objects, but "Symfony\Component\Config\Loader\ParamConfigurator" given.