### PR TITLE
[FrameworkBundle] Fix test on read-only directory on Windows

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/PhpConfigReferenceDumpPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/PhpConfigReferenceDumpPassTest.php
@@ -61,6 +61,10 @@ class PhpConfigReferenceDumpPassTest extends TestCase
 
     public function testProcessIgnoresFileWriteErrors()
     {
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            self::markTestSkipped('Cannot reliably make directory read-only on Windows.');
+        }
+
         // Create a read-only directory to simulate write errors
         $readOnlyDir = $this->tempDir.'/readonly';
         mkdir($readOnlyDir, 0o444, true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

[`mkdir`](https://www.php.net/manual/en/function.mkdir.php)'s permissions is ignored on Windows.

Use a Windows command to make the directory read-only.

Fix the [job](https://github.com/symfony/symfony/actions/runs/18751945876/job/53493659812#step:7:1603):
```
1) Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler\PhpConfigReferenceDumpPassTest::testProcessIgnoresFileWriteErrors
Failed asserting that file "C:\Users\RUNNER~1\AppData\Local\Temp/sf_test_config_reference/readonly/reference.php" does not exist.

D:\a\symfony\symfony\src\Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler\PhpConfigReferenceDumpPassTest.php:76
```