### PR TITLE
[FrameworkBundle] Add `config/reference.php` as `ResourceFile`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/PhpConfigReferenceDumpPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/PhpConfigReferenceDumpPass.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\Config\Definition\ArrayShapeGenerator;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ConfigurationExtensionInterface;
@@ -160,8 +161,11 @@ class PhpConfigReferenceDumpPass implements CompilerPassInterface
         ]);
 
         $dir = \dirname($this->referenceFile);
-        if (is_dir($dir) && is_writable($dir) && (!is_file($this->referenceFile) || file_get_contents($this->referenceFile) !== $configReference)) {
-            file_put_contents($this->referenceFile, $configReference);
+        if (is_dir($dir) && is_writable($dir)) {
+            if (!is_file($this->referenceFile) || file_get_contents($this->referenceFile) !== $configReference) {
+                file_put_contents($this->referenceFile, $configReference);
+            }
+            $container->addResource(new FileResource($this->referenceFile));
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/PhpConfigReferenceDumpPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/PhpConfigReferenceDumpPassTest.php
@@ -17,6 +17,7 @@ use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\PhpConfigReferen
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
@@ -58,6 +59,7 @@ class PhpConfigReferenceDumpPassTest extends TestCase
         $this->assertStringContainsString('namespace Symfony\Component\DependencyInjection\Loader\Configurator;', $content);
         $this->assertStringContainsString('final class App extends AppReference', $content);
         $this->assertStringContainsString('public static function config(array $config): array', $content);
+        $this->assertEquals([new FileResource(realpath($this->tempDir).'/reference.php')], $container->getResources());
     }
 
     public function testProcessIgnoresFileWriteErrors()
@@ -79,6 +81,7 @@ class PhpConfigReferenceDumpPassTest extends TestCase
 
         $pass->process($container);
         $this->assertFileDoesNotExist($readOnlyDir.'/reference.php');
+        $this->assertEmpty($container->getResources());
     }
 
     public function testProcessGeneratesExpectedReferenceFile()
@@ -100,6 +103,7 @@ class PhpConfigReferenceDumpPassTest extends TestCase
         }
 
         $this->assertFileEquals(__DIR__.'/../../Fixtures/reference.php', $this->tempDir.'/reference.php');
+        $this->assertEquals([new FileResource(realpath($this->tempDir).'/reference.php')], $container->getResources());
     }
 
     #[TestWith([self::class])]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

We want the `config/reference.php` file to be regenerated automatically if it's modified or deleted. This prevents any intentional or unintentional modifications.

This file can still be duplicated for testing changes. 