### PR TITLE
[FrameworkBundle] Skip non-bundle classes in `PhpConfigReferenceDumpPass`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/PhpConfigReferenceDumpPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/PhpConfigReferenceDumpPass.php
@@ -18,6 +18,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ConfigurationExtensionInterface;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\AppReference;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\Routing\Loader\Configurator\RoutesReference;
 
 /**
@@ -94,6 +95,9 @@ class PhpConfigReferenceDumpPass implements CompilerPassInterface
 
         $anyEnvExtensions = [];
         foreach ($this->bundlesDefinition as $bundle => $envs) {
+            if (!is_subclass_of($bundle, BundleInterface::class)) {
+                continue;
+            }
             if (!$extension = (new $bundle())->getContainerExtension()) {
                 continue;
             }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/PhpConfigReferenceDumpPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/PhpConfigReferenceDumpPassTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
 
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\PhpConfigReferenceDumpPass;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
@@ -99,6 +100,22 @@ class PhpConfigReferenceDumpPassTest extends TestCase
         }
 
         $this->assertFileEquals(__DIR__.'/../../Fixtures/reference.php', $this->tempDir.'/reference.php');
+    }
+
+    #[TestWith([self::class])]
+    #[TestWith(['Symfony\\NotARealClass'])]
+    public function testProcessWithInvalidBundleClass(string $invalidClass)
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('.container.known_envs', ['test', 'dev']);
+
+        $pass = new PhpConfigReferenceDumpPass($this->tempDir.'/reference.php', [
+            $invalidClass => ['dev' => true],
+        ]);
+        $pass->process($container);
+
+        $referenceFile = $this->tempDir.'/reference.php';
+        $this->assertFileExists($referenceFile);
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

For the "prod" build, the dev dependencies are not installed, some dev bundles can be missing. These bundle classes must be ignored. This is a case where the `config/reference.php` file will be built only partially.

I also check that the class implements the `BundleInterface`, since we call a method of this interface. This fixes a static analysis issue.