### PR TITLE
[Mailer] Fix parsing message ids in SMTP responses

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridSmtpTransport.php
@@ -27,4 +27,13 @@ class SendgridSmtpTransport extends EsmtpTransport
         $this->setUsername('apikey');
         $this->setPassword($key);
     }
+
+    protected function parseMessageId(string $mtaResult): string
+    {
+        if (\preg_match('/250 Ok:? queued as (?P<id>\S+)\r?$/mis', $mtaResult, $matches)) {
+            return $matches['id'];
+        }
+
+        return '';
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

I noticed that the message id from Sendgrid didn't get always parsed properly. Looking into the issue I found that sometimes the format looks like `UM1N3y_WXg6h51oIppcERg` or `X8P9ZIaiT3653-UXj4ljGX` which isn't matched by the current regex at https://github.com/symfony/symfony/blob/7.3/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php#L159-L160
This PR fixes matching all Sendgrid ids.
