### PR TITLE
 Fix argument syntax for callable and lazy initialization of inline service

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.php
@@ -221,7 +221,7 @@ return static function (ContainerConfigurator $container) {
                     ->args([service('request_stack')]),
                 inline_service(ErrorRendererInterface::class)
                     ->factory([\Closure::class, 'fromCallable'])
-                    ->args([service('error_renderer.default'), 'render'])
+                    ->args([[service('error_renderer.default'), 'render']])
                     ->lazy(),
                 inline_service()
                     ->factory([HtmlErrorRenderer::class, 'isDebug'])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Fix tests from https://github.com/symfony/symfony/pull/60033