### PR TITLE
[HttpFoundation] Fix issue where ServerEvent with "0" data is not sent

### DIFF
--- a/src/Symfony/Component/HttpFoundation/ServerEvent.php
+++ b/src/Symfony/Component/HttpFoundation/ServerEvent.php
@@ -132,14 +132,12 @@ class ServerEvent implements \IteratorAggregate
         }
         yield $head;
 
-        if ($this->data) {
-            if (is_iterable($this->data)) {
-                foreach ($this->data as $data) {
-                    yield \sprintf('data: %s', $data)."\n";
-                }
-            } else {
-                yield \sprintf('data: %s', $this->data)."\n";
+        if (is_iterable($this->data)) {
+            foreach ($this->data as $data) {
+                yield \sprintf('data: %s', $data)."\n";
             }
+        } elseif ('' !== $this->data) {
+            yield \sprintf('data: %s', $this->data)."\n";
         }
 
         yield "\n";

--- a/src/Symfony/Component/HttpFoundation/Tests/EventStreamResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/EventStreamResponseTest.php
@@ -116,6 +116,28 @@ STR;
         $this->assertSameResponseContent("data: foo\n\n", $response);
     }
 
+    public function testStreamEventWith0Data()
+    {
+        $response = new EventStreamResponse(function () {
+            yield new ServerEvent(
+                data: '0',
+            );
+        });
+
+        $this->assertSameResponseContent("data: 0\n\n", $response);
+    }
+
+    public function testStreamEventEmptyStringIgnored()
+    {
+        $response = new EventStreamResponse(function () {
+            yield new ServerEvent(
+                data: '',
+            );
+        });
+
+        $this->assertSameResponseContent("\n", $response);
+    }
+
     private function assertSameResponseContent(string $expected, EventStreamResponse $response): void
     {
         ob_start();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62151
| License       | MIT


Fixes an issue where data with a string value of '0' was not being sent correctly. This update ensures that the '0' string is handled properly when sending data.