### PR TITLE
[HttpClient] Make Amp clients comparable to fix DynamoDbLock tests

### DIFF
--- a/src/Symfony/Component/HttpClient/Internal/AmpClientState.php
+++ b/src/Symfony/Component/HttpClient/Internal/AmpClientState.php
@@ -50,13 +50,15 @@ final class AmpClientState extends ClientState
     private array $clients = [];
     private \Closure $clientConfigurator;
 
+    private static \Closure $defaultClientConfigurator;
+
     public function __construct(
         ?callable $clientConfigurator,
         private int $maxHostConnections,
         private int $maxPendingPushes,
         private ?LoggerInterface &$logger,
     ) {
-        $clientConfigurator ??= static fn (PooledHttpClient $client) => new InterceptedHttpClient($client, new RetryRequests(2), []);
+        $clientConfigurator ??= self::$defaultClientConfigurator ??= static fn (PooledHttpClient $client) => new InterceptedHttpClient($client, new RetryRequests(2), []);
         $this->clientConfigurator = $clientConfigurator(...);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Try to fix the job [x86 / minimal-exts / lowest-php](https://github.com/symfony/symfony/actions/runs/18802577388/job/53652067798#logs) on branch 8.0.

The issue it that [`DynamoDbStoreTest`](https://github.com/symfony/symfony/blob/7.4/src/Symfony/Component/Lock/Bridge/DynamoDb/Tests/Store/DynamoDbStoreTest.php) tests use `assertEquals` on `AmpHttpClient` instances. But should be better to rewrite this tests.

```
1) Symfony\Component\Lock\Bridge\DynamoDb\Tests\Store\DynamoDbStoreTest::testFromDsn
Failed asserting that two objects are equal.
--- Expected
+++ Actual
@@ @@
                     'responseCount' => 0
                     'pushedResponses' => []
                     'clients' => []
-                    'clientConfigurator' => Closure Object #3716 ()
+                    'clientConfigurator' => Closure Object #3709 ()
                     'maxHostConnections' => 6
                     'maxPendingPushes' => 50
                     'logger' => null

D:\a\symfony\symfony\src\Symfony\Component\Lock\Bridge\DynamoDb\Tests\Store\DynamoDbStoreTest.php:52

2) Symfony\Component\Lock\Bridge\DynamoDb\Tests\Store\DynamoDbStoreTest::testDsnPrecedence
Failed asserting that two objects are equal.
--- Expected
+++ Actual
@@ @@
                     'responseCount' => 0
                     'pushedResponses' => []
                     'clients' => []
-                    'clientConfigurator' => Closure Object #3722 ()
+                    'clientConfigurator' => Closure Object #472 ()
                     'maxHostConnections' => 6
                     'maxPendingPushes' => 50
                     'logger' => null

D:\a\symfony\symfony\src\Symfony\Component\Lock\Bridge\DynamoDb\Tests\Store\DynamoDbStoreTest.php:60

3) Symfony\Component\Lock\Bridge\DynamoDb\Tests\Store\DynamoDbStoreTest::testFromDsnWithRegion
Failed asserting that two objects are equal.
--- Expected
+++ Actual
@@ @@
                     'responseCount' => 0
                     'pushedResponses' => []
                     'clients' => []
-                    'clientConfigurator' => Closure Object #3685 ()
+                    'clientConfigurator' => Closure Object #3980 ()
                     'maxHostConnections' => 6
                     'maxPendingPushes' => 50
                     'logger' => null

D:\a\symfony\symfony\src\Symfony\Component\Lock\Bridge\DynamoDb\Tests\Store\DynamoDbStoreTest.php:68

4) Symfony\Component\Lock\Bridge\DynamoDb\Tests\Store\DynamoDbStoreTest::testFromDsnWithCustomEndpoint
Failed asserting that two objects are equal.
--- Expected
+++ Actual
@@ @@
                     'responseCount' => 0
                     'pushedResponses' => []
                     'clients' => []
-                    'clientConfigurator' => Closure Object #3727 ()
+                    'clientConfigurator' => Closure Object #3732 ()
                     'maxHostConnections' => 6
                     'maxPendingPushes' => 50
                     'logger' => null

D:\a\symfony\symfony\src\Symfony\Component\Lock\Bridge\DynamoDb\Tests\Store\DynamoDbStoreTest.php:76

5) Symfony\Component\Lock\Bridge\DynamoDb\Tests\Store\DynamoDbStoreTest::testFromDsnWithSslMode
Failed asserting that two objects are equal.
--- Expected
+++ Actual
@@ @@
                     'responseCount' => 0
                     'pushedResponses' => []
                     'clients' => []
-                    'clientConfigurator' => Closure Object #381 ()
+                    'clientConfigurator' => Closure Object #3744 ()
                     'maxHostConnections' => 6
                     'maxPendingPushes' => 50
                     'logger' => null

D:\a\symfony\symfony\src\Symfony\Component\Lock\Bridge\DynamoDb\Tests\Store\DynamoDbStoreTest.php:84

6) Symfony\Component\Lock\Bridge\DynamoDb\Tests\Store\DynamoDbStoreTest::testFromDsnWithSslModeOnDefault
Failed asserting that two objects are equal.
--- Expected
+++ Actual
@@ @@
                     'responseCount' => 0
                     'pushedResponses' => []
                     'clients' => []
-                    'clientConfigurator' => Closure Object #4002 ()
+                    'clientConfigurator' => Closure Object #3755 ()
                     'maxHostConnections' => 6
                     'maxPendingPushes' => 50
                     'logger' => null

D:\a\symfony\symfony\src\Symfony\Component\Lock\Bridge\DynamoDb\Tests\Store\DynamoDbStoreTest.php:92

7) Symfony\Component\Lock\Bridge\DynamoDb\Tests\Store\DynamoDbStoreTest::testFromDsnWithCustomEndpointAndPort
Failed asserting that two objects are equal.
--- Expected
+++ Actual
@@ @@
                     'responseCount' => 0
                     'pushedResponses' => []
                     'clients' => []
-                    'clientConfigurator' => Closure Object #4007 ()
+                    'clientConfigurator' => Closure Object #3766 ()
                     'maxHostConnections' => 6
                     'maxPendingPushes' => 50
                     'logger' => null

D:\a\symfony\symfony\src\Symfony\Component\Lock\Bridge\DynamoDb\Tests\Store\DynamoDbStoreTest.php:100

8) Symfony\Component\Lock\Bridge\DynamoDb\Tests\Store\DynamoDbStoreTest::testFromDsnWithQueryOptions
Failed asserting that two objects are equal.
--- Expected
+++ Actual
@@ @@
                     'responseCount' => 0
                     'pushedResponses' => []
                     'clients' => []
-                    'clientConfigurator' => Closure Object #3706 ()
+                    'clientConfigurator' => Closure Object #3777 ()
                     'maxHostConnections' => 6
                     'maxPendingPushes' => 50
                     'logger' => null

D:\a\symfony\symfony\src\Symfony\Component\Lock\Bridge\DynamoDb\Tests\Store\DynamoDbStoreTest.php:108

9) Symfony\Component\Lock\Bridge\DynamoDb\Tests\Store\DynamoDbStoreTest::testFromDsnWithTableNameOption
Failed asserting that two objects are equal.
--- Expected
+++ Actual
@@ @@
                     'responseCount' => 0
                     'pushedResponses' => []
                     'clients' => []
-                    'clientConfigurator' => Closure Object #3718 ()
+                    'clientConfigurator' => Closure Object #3788 ()
                     'maxHostConnections' => 6
                     'maxPendingPushes' => 50
                     'logger' => null

```