### PR TITLE
[ObjectMapper] skip proxy initialization at given depth

### DIFF
--- a/src/Symfony/Component/ObjectMapper/Attribute/TransformAllProperties.php
+++ b/src/Symfony/Component/ObjectMapper/Attribute/TransformAllProperties.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Attribute;
+
+/**
+ * Applies a transformer to all properties of a class.
+ *
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+final class TransformAllProperties
+{
+    /**
+     * @param (string|callable(mixed, object): mixed)|(string|callable(mixed, object): mixed)[]|null $transform A service id or a callable that transforms the value during mapping
+     */
+    public function __construct(
+        public mixed $transform,
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/CHANGELOG.md
+++ b/src/Symfony/Component/ObjectMapper/CHANGELOG.md
@@ -7,6 +7,11 @@ CHANGELOG
  * The component is not marked as `@experimental` anymore
  * Add `ObjectMapperAwareInterface` to set the owning object mapper instance
  * Add a `MapCollection` transform that calls the Mapper over iterable properties
+ * Add a `DepthAwareInterface` to gather information about the mapping depth
+ * Add a `TransformAllProperties` that applies a transform on all properties of
+   a mapped object
+* Add a `UninitializeProxy` transform that skips proxy initialization for a
+  given depth
 
 7.3
 ---

--- a/src/Symfony/Component/ObjectMapper/DepthAwareInterface.php
+++ b/src/Symfony/Component/ObjectMapper/DepthAwareInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper;
+
+/**
+ * Allows a callable or mapper to be aware of the current mapping depth.
+ *
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ */
+interface DepthAwareInterface
+{
+    public function setDepth(int $depth): void;
+}

--- a/src/Symfony/Component/ObjectMapper/Metadata/ReflectionObjectMapperMetadataFactory.php
+++ b/src/Symfony/Component/ObjectMapper/Metadata/ReflectionObjectMapperMetadataFactory.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\ObjectMapper\Metadata;
 
 use Symfony\Component\ObjectMapper\Attribute\Map;
+use Symfony\Component\ObjectMapper\Attribute\TransformAllProperties;
 use Symfony\Component\ObjectMapper\Exception\MappingException;
 
 /**
@@ -23,6 +24,8 @@ final class ReflectionObjectMapperMetadataFactory implements ObjectMapperMetadat
 {
     private array $reflectionClassCache = [];
     private array $attributesCache = [];
+    /** @var array<class-string, list<string|callable>> */
+    private array $classAttributesCache = [];
 
     public function create(object $object, ?string $property = null, array $context = []): array
     {
@@ -35,15 +38,58 @@ final class ReflectionObjectMapperMetadataFactory implements ObjectMapperMetadat
 
             $refl = $this->reflectionClassCache[$object::class] ??= new \ReflectionClass($object);
             $attributes = ($property ? $refl->getProperty($property) : $refl)->getAttributes(Map::class, \ReflectionAttribute::IS_INSTANCEOF);
+
+            $globalTransforms = null !== $property ? $this->getClassPropertyTransforms($refl) : [];
             $mappings = [];
+
             foreach ($attributes as $attribute) {
                 $map = $attribute->newInstance();
-                $mappings[] = new Mapping($map->target, $map->source, $map->if, $map->transform);
+                $transforms = $map->transform ?? [];
+                if ($transforms && \is_callable($transforms) || !\is_array($transforms)) {
+                    $transforms = [$transforms];
+                }
+
+                $mappings[] = new Mapping($map->target, $map->source, $map->if, [...$globalTransforms, ...$transforms]);
+            }
+
+            if ($globalTransforms && !$mappings) {
+                $mappings[] = new Mapping(null, null, null, $globalTransforms);
             }
 
             return $this->attributesCache[$key] = $mappings;
         } catch (\ReflectionException $e) {
             throw new MappingException($e->getMessage(), $e->getCode(), $e);
         }
+    }
+
+    /**
+     * @return list<string|callable>
+     */
+    private function getClassPropertyTransforms(\ReflectionClass $refl): array
+    {
+        $key = $refl->getName();
+        if (isset($this->classAttributesCache[$key])) {
+            return $this->classAttributesCache[$key];
+        }
+
+        $attributes = $refl->getAttributes(TransformAllProperties::class, \ReflectionAttribute::IS_INSTANCEOF);
+        if (!$attributes) {
+            return $this->classAttributesCache[$key] = [];
+        }
+
+        $globalTransforms = [];
+        foreach ($attributes as $attribute) {
+            if ($t = $attribute->newInstance()->transform ?? []) {
+                if (\is_callable($t) || !\is_array($t)) {
+                    $t = [$t];
+                }
+
+                foreach ($t as $transform) {
+                    $globalTransforms[] = $transform;
+                }
+            }
+        }
+
+        return $this->classAttributesCache[$key] = $globalTransforms;
     }
 }

--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -27,12 +27,13 @@ use Symfony\Component\VarExporter\LazyObjectInterface;
  *
  * @author Antoine Bluchet <soyuka@gmail.com>
  */
-final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInterface
+final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInterface, DepthAwareInterface
 {
     /**
      * Tracks recursive references.
      */
     private ?\SplObjectStorage $objectMap = null;
+    private int $depth = 0;
 
     public function __construct(
         private readonly ObjectMapperMetadataFactoryInterface $metadataFactory = new ReflectionObjectMapperMetadataFactory(),
@@ -41,6 +42,11 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
         private readonly ?ContainerInterface $conditionCallableLocator = null,
         private ?ObjectMapperInterface $objectMapper = null,
     ) {
+    }
+
+    public function setDepth(int $depth): void
+    {
+        $this->depth = $depth;
     }
 
     public function map(object $source, object|string|null $target = null): object
@@ -237,7 +243,11 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
             } elseif ($objectMap->offsetExists($value)) {
                 $value = $objectMap[$value];
             } else {
-                $value = ($this->objectMapper ?? $this)->map($value, $mapTo->target);
+                $mapper = $this->objectMapper ?? $this;
+                if ($mapper instanceof DepthAwareInterface) {
+                    $mapper->setDepth($this->depth + 1);
+                }
+                $value = $mapper->map($value, $mapTo->target);
             }
         }
 
@@ -317,11 +327,20 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
     private function getCallable(string|callable $fn, ?ContainerInterface $locator = null): ?callable
     {
         if (\is_callable($fn)) {
+            if ($fn instanceof DepthAwareInterface) {
+                $fn->setDepth($this->depth);
+            }
+
             return $fn;
         }
 
         if ($locator?->has($fn)) {
-            return $locator->get($fn);
+            $callable = $locator->get($fn);
+            if ($callable instanceof DepthAwareInterface) {
+                $callable->setDepth($this->depth);
+            }
+
+            return $callable;
         }
 
         return null;

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/DepthProxy/MockLazyProxy.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/DepthProxy/MockLazyProxy.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\DepthProxy;
+
+use Symfony\Component\VarExporter\LazyObjectInterface;
+
+class MockLazyProxy implements LazyObjectInterface
+{
+    private bool $initialized = false;
+
+    public function __construct(
+        private string $exceptionMessage,
+    ) {
+    }
+
+    public function initializeLazyObject(): object
+    {
+        $this->initialized = true;
+        throw new \RuntimeException($this->exceptionMessage);
+    }
+
+    public function isLazyObjectInitialized(bool $partial = false): bool
+    {
+        return $this->initialized;
+    }
+
+    public function resetLazyObject(): bool
+    {
+        return false;
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/DepthProxy/Post.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/DepthProxy/Post.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\DepthProxy;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+use Symfony\Component\ObjectMapper\Attribute\TransformAllProperties;
+use Symfony\Component\ObjectMapper\Transform\UninitializeProxy;
+
+#[Map(target: PostDto::class)]
+#[TransformAllProperties(transform: new UninitializeProxy(maxDepth: 1))]
+class Post
+{
+    public function __construct(
+        public string $title,
+        public object $comments, // This will be the lazy proxy
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/DepthProxy/PostDto.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/DepthProxy/PostDto.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\DepthProxy;
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+class PostDto
+{
+    public string $title;
+    public ?object $comments = null;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/DepthProxy/User.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/DepthProxy/User.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\DepthProxy;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+use Symfony\Component\ObjectMapper\Attribute\TransformAllProperties;
+use Symfony\Component\ObjectMapper\Transform\UninitializeProxy;
+
+#[Map(target: UserDto::class)]
+#[TransformAllProperties(transform: new UninitializeProxy(maxDepth: 1))]
+class User
+{
+    public function __construct(
+        public string $name,
+        public object $post,
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/DepthProxy/UserDto.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/DepthProxy/UserDto.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\DepthProxy;
+
+class UserDto
+{
+    public string $name;
+    public ?PostDto $post = null;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -35,6 +35,7 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\DeeperRecursion\RecursiveDto;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\DeeperRecursion\Relation;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\DeeperRecursion\RelationDto;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\DefaultValueStdClass\TargetDto;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\DepthProxy;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\Flatten\TargetUser;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\Flatten\User;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\Flatten\UserProfile;
@@ -562,5 +563,28 @@ final class ObjectMapperTest extends TestCase
         $transformed = $mapper->map($u, TransformCollectionB::class);
 
         $this->assertEquals([new TransformCollectionD('a'), new TransformCollectionD('b')], $transformed->foo);
+    }
+
+    public function testTransformAllPropertiesWithDepthStopsRecursion()
+    {
+        $user = new DepthProxy\User(
+            'User',
+            new DepthProxy\Post(
+                'Post',
+                new DepthProxy\MockLazyProxy('Proxy (Comment) should not be initialized')
+            )
+        );
+
+        $container = $this->createMock(ContainerInterface::class);
+
+        $mapper = new ObjectMapper(transformCallableLocator: $container);
+        $dto = $mapper->map($user, DepthProxy\UserDto::class);
+
+        $this->assertInstanceOf(DepthProxy\UserDto::class, $dto);
+        $this->assertSame('User', $dto->name);
+        $this->assertInstanceOf(DepthProxy\PostDto::class, $dto->post);
+        $this->assertSame('Post', $dto->post->title);
+
+        $this->assertNull($dto->post->comments);
     }
 }

--- a/src/Symfony/Component/ObjectMapper/Transform/UninitializeProxy.php
+++ b/src/Symfony/Component/ObjectMapper/Transform/UninitializeProxy.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Transform;
+
+use Doctrine\Persistence\Proxy;
+use Symfony\Component\ObjectMapper\DepthAwareInterface;
+use Symfony\Component\ObjectMapper\TransformCallableInterface;
+use Symfony\Component\VarExporter\LazyObjectInterface;
+
+/**
+ * Transforms an uninitialized proxy into null, optionally based on depth.
+ *
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ *
+ * @implements TransformCallableInterface<object,object>
+ */
+final class UninitializeProxy implements TransformCallableInterface, DepthAwareInterface
+{
+    private int $currentDepth = 0;
+
+    /**
+     * @param int $maxDepth a depth of 0 means it will *always* transform the proxy
+     */
+    public function __construct(
+        private readonly int $maxDepth = 0,
+    ) {
+    }
+
+    public function setDepth(int $depth): void
+    {
+        $this->currentDepth = $depth;
+    }
+
+    public function __invoke(mixed $value, object $source, ?object $target): mixed
+    {
+        if ($this->currentDepth >= $this->maxDepth) {
+            if ($value instanceof LazyObjectInterface && !$value->isLazyObjectInitialized()) {
+                return null;
+            }
+
+            if ($value instanceof Proxy && !$value->__isInitialized()) {
+                return null;
+            }
+        }
+
+        return $value;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no
| Issues        | Fixes #61357
| License       | MIT

See changelog and related issue:

 * Add a `DepthAwareInterface` to gather information about the mapping depth
 * Add a `TransformAllProperties` that applies a transform on all properties of
   a mapped object
* Add a `UninitializeProxy` transform that skips proxy initialization for a
  given depth

