### PR TITLE
[FrameworkBundle][Mailer] Add `recipient_fetcher` option that allows fetching global recipients from a service

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add `mailer.envelope.recipient_fetcher` option that allows fetching global recipients from a service
+
 8.0
 ---
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -35,6 +35,7 @@ use Symfony\Component\HttpFoundation\IpUtils;
 use Symfony\Component\JsonStreamer\StreamWriterInterface;
 use Symfony\Component\Lock\Lock;
 use Symfony\Component\Lock\Store\SemaphoreStore;
+use Symfony\Component\Mailer\Envelope\RecipientFetcherInterface;
 use Symfony\Component\Mailer\Mailer;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Notifier\Notifier;
@@ -2305,6 +2306,20 @@ class Configuration implements ConfigurationInterface
                                         ->then(static fn ($v) => array_values(array_filter($v)))
                                     ->end()
                                     ->prototype('scalar')->end()
+                                ->end()
+                                ->scalarNode('recipient_fetcher')
+                                    ->info('A service that fetch the recipients.')
+                                    ->defaultNull()
+                                    ->validate()
+                                        ->ifFalse(static function ($v) {
+                                            if (!$v) {
+                                                return true;
+                                            }
+
+                                            return is_a($v, RecipientFetcherInterface::class, true);
+                                        })
+                                        ->thenInvalid('The %s class must implement the "'.RecipientFetcherInterface::class.'" interface.')
+                                    ->end()
                                 ->end()
                                 ->arrayNode('allowed_recipients', 'allowed_recipient')
                                     ->info('A list of regular expressions that allow recipients when "recipients" option is defined.')

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -114,6 +114,7 @@ use Symfony\Component\Lock\Serializer\LockKeyNormalizer;
 use Symfony\Component\Lock\Store\StoreFactory;
 use Symfony\Component\Mailer\Bridge as MailerBridge;
 use Symfony\Component\Mailer\Command\MailerTestCommand;
+use Symfony\Component\Mailer\Envelope\RecipientFetcherInterface;
 use Symfony\Component\Mailer\Mailer;
 use Symfony\Component\Mercure\HubRegistry;
 use Symfony\Component\Messenger\Attribute\AsMessage;
@@ -2874,6 +2875,8 @@ class FrameworkExtension extends Extension
             throw new LogicException('Mailer support cannot be enabled as the component is not installed. Try running "composer require symfony/mailer".');
         }
 
+        $container->registerForAutoconfiguration(RecipientFetcherInterface::class);
+
         $loader->load('mailer.php');
         $loader->load('mailer_transports.php');
         if (!\count($config['transports']) && null === $config['dsn']) {
@@ -2947,7 +2950,13 @@ class FrameworkExtension extends Extension
 
         $envelopeListener = $container->getDefinition('mailer.envelope_listener');
         $envelopeListener->setArgument(0, $config['envelope']['sender'] ?? null);
-        $envelopeListener->setArgument(1, $config['envelope']['recipients'] ?? null);
+
+        $recipients = $config['envelope']['recipients'] ?? null;
+        if (isset($config['envelope']['recipient_fetcher'])) {
+            $recipients = new Reference($config['envelope']['recipient_fetcher']);
+        }
+
+        $envelopeListener->setArgument(1, $recipients);
         $envelopeListener->setArgument(2, $config['envelope']['allowed_recipients'] ?? []);
 
         if ($config['headers']) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Configuration;
+use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Fixtures\Mailer\InvalidRecipientFetcher;
 use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Fixtures\Workflow\Places;
 use Symfony\Bundle\FullStack;
 use Symfony\Component\AssetMapper\Compressor\CompressorInterface;
@@ -27,6 +28,7 @@ use Symfony\Component\HtmlSanitizer\HtmlSanitizer;
 use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\JsonStreamer\JsonStreamWriter;
 use Symfony\Component\Lock\Store\SemaphoreStore;
+use Symfony\Component\Mailer\Envelope\RecipientFetcherInterface;
 use Symfony\Component\Mailer\Mailer;
 use Symfony\Component\Notifier\Notifier;
 use Symfony\Component\RateLimiter\Policy\TokenBucketLimiter;
@@ -376,6 +378,36 @@ class ConfigurationTest extends TestCase
         yield [['enabled' => false, 'resource' => ['redis://default', ['name' => 'foo', 'value' => 'redis://default']]], ['enabled' => false, 'resources' => ['default' => 'redis://default', 'foo' => 'redis://default']]];
         yield [['enabled' => false, 'resource' => [['name' => 'foo', 'value' => 'redis://default']]], ['enabled' => false, 'resources' => ['foo' => 'redis://default']]];
         yield [['enabled' => false, 'resource' => [['name' => 'foo', 'value' => 'redis://foo'], ['name' => 'bar', 'value' => 'redis://bar']]], ['enabled' => false, 'resources' => ['foo' => 'redis://foo', 'bar' => 'redis://bar']]];
+    }
+
+    #[DataProvider('provideInvalidMailerRecipientFetchers')]
+    public function testInvalidMailerRecipientFetcher(string $class, string $recipientFetcher)
+    {
+        if (!interface_exists(RecipientFetcherInterface::class)) {
+            $this->markTestSkipped('This test requires symfony/mailer 8.1 or superior.');
+        }
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage(\sprintf('Invalid configuration for path "framework.mailer.envelope.recipient_fetcher": The "%s" class must implement the "Symfony\Component\Mailer\Envelope\RecipientFetcherInterface" interface.', $class));
+
+        $processor = new Processor();
+        $configuration = new Configuration(true);
+
+        $processor->processConfiguration($configuration, [
+            'framework' => [
+                'mailer' => [
+                    'envelope' => [
+                        'recipient_fetcher' => $recipientFetcher,
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    public static function provideInvalidMailerRecipientFetchers(): iterable
+    {
+        yield ['invalid', 'invalid'];
+        yield ['Symfony\\\Bundle\\\FrameworkBundle\\\Tests\\\DependencyInjection\\\Fixtures\\\Mailer\\\InvalidRecipientFetcher', InvalidRecipientFetcher::class];
     }
 
     public function testItShowANiceMessageIfTwoMessengerBusesAreConfiguredButNoDefaultBus()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/Mailer/InvalidRecipientFetcher.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/Mailer/InvalidRecipientFetcher.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Fixtures\Mailer;
+
+class InvalidRecipientFetcher
+{
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/Mailer/RecipientFetcher.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/Mailer/RecipientFetcher.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Fixtures\Mailer;
+
+use Symfony\Component\Mailer\Envelope\RecipientFetcherInterface;
+use Symfony\Component\Mime\Address;
+
+class RecipientFetcher implements RecipientFetcherInterface
+{
+    /**
+     * @return array<Address|string>
+     */
+    public function fetchRecipients(): array
+    {
+        return [];
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/mailer_with_recipient_fetcher.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/mailer_with_recipient_fetcher.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Fixtures\Mailer\RecipientFetcher;
+
+return static function (ContainerConfigurator $container) {
+    $container->services()
+        ->set(RecipientFetcher::class)
+        ->public();
+
+    $container->extension('framework', [
+        'http_method_override' => false,
+        'handle_all_throwables' => true,
+        'php_errors' => ['log' => true],
+        'mailer' => [
+            'dsn' => 'smtp://example.com',
+            'envelope' => [
+                'sender' => 'sender@example.org',
+                'recipient_fetcher' => RecipientFetcher::class,
+            ],
+            'headers' => [
+                'from' => 'from@example.org',
+                'bcc' => ['bcc1@example.org', 'bcc2@example.org'],
+                'foo' => 'bar',
+            ],
+        ],
+    ]);
+};

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/mailer_with_recipient_fetcher_and_recipients.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/mailer_with_recipient_fetcher_and_recipients.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Fixtures\Mailer\RecipientFetcher;
+
+return static function (ContainerConfigurator $container) {
+    $container->services()
+        ->set(RecipientFetcher::class)
+        ->public();
+
+    $container->extension('framework', [
+        'http_method_override' => false,
+        'handle_all_throwables' => true,
+        'php_errors' => ['log' => true],
+        'mailer' => [
+            'dsn' => 'smtp://example.com',
+            'envelope' => [
+                'sender' => 'sender@example.org',
+                'recipients' => ['redirected@example.org'],
+                'recipient_fetcher' => RecipientFetcher::class,
+            ],
+            'headers' => [
+                'from' => 'from@example.org',
+                'bcc' => ['bcc1@example.org', 'bcc2@example.org'],
+                'foo' => 'bar',
+            ],
+        ],
+    ]);
+};

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/mailer_with_recipient_fetcher.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/mailer_with_recipient_fetcher.yml
@@ -1,0 +1,18 @@
+services:
+    Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Fixtures\Mailer\RecipientFetcher:
+        public: true
+
+framework:
+    http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
+    mailer:
+        dsn: 'smtp://example.com'
+        envelope:
+            sender: sender@example.org
+            recipient_fetcher: Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Fixtures\Mailer\RecipientFetcher
+        headers:
+            from: from@example.org
+            bcc: [bcc1@example.org, bcc2@example.org]
+            foo: bar

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/mailer_with_recipient_fetcher_and_recipients.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/mailer_with_recipient_fetcher_and_recipients.yml
@@ -1,0 +1,20 @@
+services:
+    Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Fixtures\Mailer\RecipientFetcher:
+        public: true
+
+framework:
+    http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
+    mailer:
+        dsn: 'smtp://example.com'
+        envelope:
+            sender: sender@example.org
+            recipients:
+                - redirected@example.org
+            recipient_fetcher: Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Fixtures\Mailer\RecipientFetcher
+        headers:
+            from: from@example.org
+            bcc: [bcc1@example.org, bcc2@example.org]
+            foo: bar

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -17,6 +17,7 @@ use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LogLevel;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Fixtures\Mailer\RecipientFetcher;
 use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Fixtures\Workflow\Validator\DefinitionValidator;
 use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\DummyMessage;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
@@ -67,6 +68,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 use Symfony\Component\HttpKernel\Fragment\FragmentUriGeneratorInterface;
 use Symfony\Component\Lock\Store\SemaphoreStore;
+use Symfony\Component\Mailer\Envelope\RecipientFetcherInterface;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsTransportFactory;
 use Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpTransportFactory;
 use Symfony\Component\Messenger\Bridge\Beanstalkd\Transport\BeanstalkdTransportFactory;
@@ -2385,10 +2387,25 @@ abstract class FrameworkExtensionTestCase extends TestCase
             ['redirected@example.org', 'redirected1@example.org'],
             ['foobar@example\.org', '.*@example\.com'],
         ];
+
+        if (interface_exists(RecipientFetcherInterface::class)) {
+            yield [
+                'mailer_with_recipient_fetcher',
+                ['main' => 'smtp://example.com'],
+                new Reference(RecipientFetcher::class),
+                [],
+            ];
+            yield [
+                'mailer_with_recipient_fetcher_and_recipients',
+                ['main' => 'smtp://example.com'],
+                new Reference(RecipientFetcher::class),
+                [],
+            ];
+        }
     }
 
     #[DataProvider('provideMailer')]
-    public function testMailer(string $configFile, array $expectedTransports, array $expectedRecipients, array $expectedAllowedRecipients)
+    public function testMailer(string $configFile, array $expectedTransports, Reference|array $expectedRecipients, array $expectedAllowedRecipients)
     {
         $container = $this->createContainerFromFile($configFile);
 
@@ -2399,7 +2416,11 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->assertTrue($container->hasDefinition('mailer.envelope_listener'));
         $l = $container->getDefinition('mailer.envelope_listener');
         $this->assertSame('sender@example.org', $l->getArgument(0));
-        $this->assertSame($expectedRecipients, $l->getArgument(1));
+
+        \is_array($expectedRecipients)
+            ? $this->assertSame($expectedRecipients, $l->getArgument(1))
+            : $this->assertEquals($expectedRecipients, $l->getArgument(1));
+
         $this->assertSame($expectedAllowedRecipients, $l->getArgument(2));
         $this->assertEquals(new Reference('messenger.default_bus', ContainerInterface::NULL_ON_INVALID_REFERENCE), $container->getDefinition('mailer.mailer')->getArgument(1));
 

--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add `mailer.envelope.recipient_fetcher` option that allows fetching global recipients from a service
+
 8.0
 ---
 

--- a/src/Symfony/Component/Mailer/Envelope/AssignRecipients.php
+++ b/src/Symfony/Component/Mailer/Envelope/AssignRecipients.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Envelope;
+
+use Symfony\Component\Mime\Address;
+
+final class AssignRecipients implements RecipientFetcherInterface
+{
+    /**
+     * @param array<Address|string> $recipients
+     */
+    public function __construct(private readonly array $recipients)
+    {
+    }
+
+    /**
+     * @return array<Address|string>
+     */
+    public function fetchRecipients(): array
+    {
+        return $this->recipients;
+    }
+}

--- a/src/Symfony/Component/Mailer/Envelope/RecipientFetcherInterface.php
+++ b/src/Symfony/Component/Mailer/Envelope/RecipientFetcherInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Envelope;
+
+use Symfony\Component\Mime\Address;
+
+interface RecipientFetcherInterface
+{
+    /**
+     * @return array<Address|string> The list of recipients addresses
+     */
+    public function fetchRecipients(): array;
+}

--- a/src/Symfony/Component/Mailer/EventListener/EnvelopeListener.php
+++ b/src/Symfony/Component/Mailer/EventListener/EnvelopeListener.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Mailer\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Mailer\Envelope\AssignRecipients;
+use Symfony\Component\Mailer\Envelope\RecipientFetcherInterface;
 use Symfony\Component\Mailer\Event\MessageEvent;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Message;
@@ -26,10 +28,7 @@ class EnvelopeListener implements EventSubscriberInterface
 {
     private ?Address $sender = null;
 
-    /**
-     * @var Address[]|null
-     */
-    private ?array $recipients = null;
+    private RecipientFetcherInterface $recipientFetcher;
 
     /**
      * @param array<Address|string> $recipients
@@ -37,14 +36,14 @@ class EnvelopeListener implements EventSubscriberInterface
      */
     public function __construct(
         Address|string|null $sender = null,
-        ?array $recipients = null,
+        private RecipientFetcherInterface|array|null $recipients = null,
         private array $allowedRecipients = [],
     ) {
         if (null !== $sender) {
             $this->sender = Address::create($sender);
         }
         if (null !== $recipients) {
-            $this->recipients = Address::createArray($recipients);
+            $this->recipientFetcher = \is_array($recipients) ? new AssignRecipients($recipients) : $recipients;
         }
     }
 
@@ -62,7 +61,7 @@ class EnvelopeListener implements EventSubscriberInterface
         }
 
         if ($this->recipients) {
-            $recipients = $this->recipients;
+            $recipients = Address::createArray($this->recipientFetcher->fetchRecipients());
             if ($this->allowedRecipients) {
                 foreach ($event->getEnvelope()->getRecipients() as $recipient) {
                     foreach ($this->allowedRecipients as $allowedRecipient) {

--- a/src/Symfony/Component/Mailer/Tests/EventListener/EnvelopeListenerTest.php
+++ b/src/Symfony/Component/Mailer/Tests/EventListener/EnvelopeListenerTest.php
@@ -14,15 +14,17 @@ namespace Symfony\Component\Mailer\Tests\EventListener;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\Envelope\RecipientFetcherInterface;
 use Symfony\Component\Mailer\Event\MessageEvent;
 use Symfony\Component\Mailer\EventListener\EnvelopeListener;
+use Symfony\Component\Mailer\Tests\Fixtures\RecipientFetcher;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\RawMessage;
 
 class EnvelopeListenerTest extends TestCase
 {
     #[DataProvider('provideRecipientsTests')]
-    public function testRecipients(array $expected, ?array $recipients = null, array $allowedRecipients = [])
+    public function testRecipients(array $expected, RecipientFetcherInterface|array|null $recipients = null, array $allowedRecipients = [])
     {
         $listener = new EnvelopeListener(null, $recipients, $allowedRecipients);
         $message = new RawMessage('message');
@@ -39,6 +41,7 @@ class EnvelopeListenerTest extends TestCase
     {
         yield [['r1@example.com', 'r2@symfony.com'], null, []];
         yield [['admin@admin.com'], ['admin@admin.com'], []];
+        yield [['fetched@example.com', 'fetched@symfony.com'], new RecipientFetcher()];
         yield [['admin@admin.com', 'r1@example.com'], ['admin@admin.com'], ['.*@example\.com']];
         yield [['admin@admin.com', 'r1@example.com', 'r2@symfony.com'], ['admin@admin.com'], ['.*@example\.com', '.*@symfony\.com']];
         yield [['r1@example.com', 'r2@symfony.com'], ['r1@example.com'], ['.*@example\.com', '.*@symfony\.com']];

--- a/src/Symfony/Component/Mailer/Tests/Fixtures/RecipientFetcher.php
+++ b/src/Symfony/Component/Mailer/Tests/Fixtures/RecipientFetcher.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Tests\Fixtures;
+
+use Symfony\Component\Mailer\Envelope\RecipientFetcherInterface;
+use Symfony\Component\Mime\Address;
+
+class RecipientFetcher implements RecipientFetcherInterface
+{
+    /**
+     * @return array<Address|string>
+     */
+    public function fetchRecipients(): array
+    {
+        return ['fetched@example.com', new Address('fetched@symfony.com')];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

Until now, the `Mailer` component provided two ways to configure recipients globally:
- a `mailer.envelope.recipients` option for static ones,
- a [`MessageEvent`](https://symfony.com/doc/current/mailer.html#messageevent) event for dynamic ones.

As a new developer joining an existing Symfony project and assigned to work with the `Mailer` component, your first action would be to look at the `config/packages/mailer.yaml` file.

However, if the recipients were configured through an `EventListener`, you would need more time to be aware of its existence.

Today, in order to improve the developer experience, I propose to add a `mailer.envelope.recipient_fetcher` option that allows fetching global recipients from a service, and therefore from external sources (database, LDAP, etc.).

# Example

<details>

<summary><code>config/packages/mailer.yaml</code></summary>

```yaml
framework:
    mailer:
        envelope:
            recipients:
                - redirected@example.org
            recipient_fetcher: App\Mailer\AdminRecipientFetcher # Overwrites the "recipients" option's addresses
```
</details>

<details>

<summary><code>src/Mailer/AdminRecipientFetcher.php</code></summary>
 
 ```php
<?php

namespace App\Mailer;

use App\Entity\User;
use App\Repository\UserRepository;
use Symfony\Component\Mailer\Envelope\RecipientFetcherInterface;
use Symfony\Component\Mime\Address;

class AdminRecipientFetcher implements RecipientFetcherInterface
{
    public function __construct(
        private UserRepository $userRepository,
    ) {
    }

    /**
     * @return array<Address|string>
     */
    public function fetchRecipients(): array
    {
        $admins = $this->userRepository->findAdmins();

        return $admins
            ->map(static fn (User $user): Address => new Address($user->getEmail()))
            ->toArray();
    }
}
```
</details>

# Acknowledgements

- @Spomky who inspired me with the idea of a "fetcher" ([pull request](https://github.com/symfony/symfony/pull/52181)),
- @weaverryan who helped me to understand the meaning of the "autowire" and "autoconfigure" options ([SymfonyCasts course](https://symfonycasts.com/screencast/symfony-3.3/defaults-autowire-autoconfigure)),
- `api-platform/core` and `lexik/LexikJWTAuthenticationBundle` which taught me how to check in the configuration if a class implements an interface,
- the [Symfony documentation](https://symfony.com/doc/current/components/config/definition.html#validation-rules) which taught me how the validation rules worked in the configuration.