### PR TITLE
[Lock][DynamoDB] Enable `http_client` injection and fix tests using AmpV5 client

### DIFF
--- a/src/Symfony/Component/Lock/Bridge/DynamoDb/Store/DynamoDbStore.php
+++ b/src/Symfony/Component/Lock/Bridge/DynamoDb/Store/DynamoDbStore.php
@@ -47,6 +47,7 @@ class DynamoDbStore implements PersistingStoreInterface
         'write_capacity_units' => 20,
         'sslmode' => null,
         'debug' => null,
+        'http_client' => null,
     ];
 
     private DynamoDbClient $client;
@@ -119,7 +120,7 @@ class DynamoDbStore implements PersistingStoreInterface
                 $options['table_name'] = $tableName;
             }
 
-            $this->client = new DynamoDbClient($clientConfiguration);
+            $this->client = new DynamoDbClient($clientConfiguration, null, $options['http_client']);
         }
 
         $this->tableName = $options['table_name'] ?? self::DEFAULT_OPTIONS['table_name'];

--- a/src/Symfony/Component/Lock/Bridge/DynamoDb/Tests/Store/DynamoDbStoreTest.php
+++ b/src/Symfony/Component/Lock/Bridge/DynamoDb/Tests/Store/DynamoDbStoreTest.php
@@ -12,11 +12,22 @@
 namespace Symfony\Component\Lock\Bridge\DynamoDb\Tests\Store;
 
 use AsyncAws\DynamoDb\DynamoDbClient;
+use PHPUnit\Framework\Attributes\Before;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Lock\Bridge\DynamoDb\Store\DynamoDbStore;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class DynamoDbStoreTest extends TestCase
 {
+    private HttpClientInterface $httpClient;
+
+    #[Before]
+    public function createMockHttpClient()
+    {
+        $this->httpClient = new MockHttpClient([]);
+    }
+
     public function testExtraOptions()
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -50,77 +61,77 @@ class DynamoDbStoreTest extends TestCase
     public function testFromDsn()
     {
         $this->assertEquals(
-            new DynamoDbStore(new DynamoDbClient(['region' => null, 'accessKeyId' => null, 'accessKeySecret' => null]), ['table_name' => 'table']),
-            new DynamoDbStore('dynamodb://default/table', [])
+            new DynamoDbStore(new DynamoDbClient(['region' => null, 'accessKeyId' => null, 'accessKeySecret' => null], null, $this->httpClient), ['table_name' => 'table']),
+            new DynamoDbStore('dynamodb://default/table', ['http_client' => $this->httpClient])
         );
     }
 
     public function testDsnPrecedence()
     {
         $this->assertEquals(
-            new DynamoDbStore(new DynamoDbClient(['region' => 'us-east-2', 'accessKeyId' => 'key_dsn', 'accessKeySecret' => 'secret_dsn']), ['table_name' => 'table_dsn']),
-            new DynamoDbStore('dynamodb://key_dsn:secret_dsn@default/table_dsn?region=us-east-2', ['region' => 'eu-west-3', 'table_name' => 'table_options'])
+            new DynamoDbStore(new DynamoDbClient(['region' => 'us-east-2', 'accessKeyId' => 'key_dsn', 'accessKeySecret' => 'secret_dsn'], null, $this->httpClient), ['table_name' => 'table_dsn']),
+            new DynamoDbStore('dynamodb://key_dsn:secret_dsn@default/table_dsn?region=us-east-2', ['region' => 'eu-west-3', 'table_name' => 'table_options', 'http_client' => $this->httpClient])
         );
     }
 
     public function testFromDsnWithRegion()
     {
         $this->assertEquals(
-            new DynamoDbStore(new DynamoDbClient(['region' => 'us-west-2', 'accessKeyId' => null, 'accessKeySecret' => null]), ['table_name' => 'table']),
-            new DynamoDbStore('dynamodb://default/table?region=us-west-2', [])
+            new DynamoDbStore(new DynamoDbClient(['region' => 'us-west-2', 'accessKeyId' => null, 'accessKeySecret' => null], null, $this->httpClient), ['table_name' => 'table']),
+            new DynamoDbStore('dynamodb://default/table?region=us-west-2', ['http_client' => $this->httpClient])
         );
     }
 
     public function testFromDsnWithCustomEndpoint()
     {
         $this->assertEquals(
-            new DynamoDbStore(new DynamoDbClient(['region' => null, 'endpoint' => 'https://localhost', 'accessKeyId' => null, 'accessKeySecret' => null]), ['table_name' => 'table']),
-            new DynamoDbStore('dynamodb://localhost/table', [])
+            new DynamoDbStore(new DynamoDbClient(['region' => null, 'endpoint' => 'https://localhost', 'accessKeyId' => null, 'accessKeySecret' => null], null, $this->httpClient), ['table_name' => 'table']),
+            new DynamoDbStore('dynamodb://localhost/table', ['http_client' => $this->httpClient])
         );
     }
 
     public function testFromDsnWithSslMode()
     {
         $this->assertEquals(
-            new DynamoDbStore(new DynamoDbClient(['region' => null, 'endpoint' => 'http://localhost', 'accessKeyId' => null, 'accessKeySecret' => null]), ['table_name' => 'table']),
-            new DynamoDbStore('dynamodb://localhost/table?sslmode=disable', [])
+            new DynamoDbStore(new DynamoDbClient(['region' => null, 'endpoint' => 'http://localhost', 'accessKeyId' => null, 'accessKeySecret' => null], null, $this->httpClient), ['table_name' => 'table']),
+            new DynamoDbStore('dynamodb://localhost/table?sslmode=disable', ['http_client' => $this->httpClient])
         );
     }
 
     public function testFromDsnWithSslModeOnDefault()
     {
         $this->assertEquals(
-            new DynamoDbStore(new DynamoDbClient(['region' => null, 'accessKeyId' => null, 'accessKeySecret' => null]), ['table_name' => 'table']),
-            new DynamoDbStore('dynamodb://default/table?sslmode=disable', [])
+            new DynamoDbStore(new DynamoDbClient(['region' => null, 'accessKeyId' => null, 'accessKeySecret' => null], null, $this->httpClient), ['table_name' => 'table']),
+            new DynamoDbStore('dynamodb://default/table?sslmode=disable', ['http_client' => $this->httpClient])
         );
     }
 
     public function testFromDsnWithCustomEndpointAndPort()
     {
         $this->assertEquals(
-            new DynamoDbStore(new DynamoDbClient(['region' => null, 'endpoint' => 'https://localhost:1234', 'accessKeyId' => null, 'accessKeySecret' => null]), ['table_name' => 'table']),
-            new DynamoDbStore('dynamodb://localhost:1234/table', [])
+            new DynamoDbStore(new DynamoDbClient(['region' => null, 'endpoint' => 'https://localhost:1234', 'accessKeyId' => null, 'accessKeySecret' => null], null, $this->httpClient), ['table_name' => 'table']),
+            new DynamoDbStore('dynamodb://localhost:1234/table', ['http_client' => $this->httpClient])
         );
     }
 
     public function testFromDsnWithQueryOptions()
     {
         $this->assertEquals(
-            new DynamoDbStore(new DynamoDbClient(['region' => null, 'accessKeyId' => null, 'accessKeySecret' => null]), ['table_name' => 'table', 'id_attr' => 'id_dsn']),
-            new DynamoDbStore('dynamodb://default/table?id_attr=id_dsn', [])
+            new DynamoDbStore(new DynamoDbClient(['region' => null, 'accessKeyId' => null, 'accessKeySecret' => null], null, $this->httpClient), ['table_name' => 'table', 'id_attr' => 'id_dsn']),
+            new DynamoDbStore('dynamodb://default/table?id_attr=id_dsn', ['http_client' => $this->httpClient])
         );
     }
 
     public function testFromDsnWithTableNameOption()
     {
         $this->assertEquals(
-            new DynamoDbStore(new DynamoDbClient(['region' => null, 'accessKeyId' => null, 'accessKeySecret' => null]), ['table_name' => 'table']),
-            new DynamoDbStore('dynamodb://default', ['table_name' => 'table'])
+            new DynamoDbStore(new DynamoDbClient(['region' => null, 'accessKeyId' => null, 'accessKeySecret' => null], null, $this->httpClient), ['table_name' => 'table']),
+            new DynamoDbStore('dynamodb://default', ['table_name' => 'table', 'http_client' => $this->httpClient])
         );
 
         $this->assertEquals(
-            new DynamoDbStore(new DynamoDbClient(['region' => null, 'accessKeyId' => null, 'accessKeySecret' => null]), ['table_name' => 'table']),
-            new DynamoDbStore('dynamodb://default/table', ['table_name' => 'table_ignored'])
+            new DynamoDbStore(new DynamoDbClient(['region' => null, 'accessKeyId' => null, 'accessKeySecret' => null], null, $this->httpClient), ['table_name' => 'table']),
+            new DynamoDbStore('dynamodb://default/table', ['table_name' => 'table_ignored', 'http_client' => $this->httpClient])
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Replace https://github.com/symfony/symfony/pull/62162 to fix the [x86 / minimal-exts / lowest-php](https://github.com/symfony/symfony/actions/runs/18802577388/job/53652067798#logs) job in 8.0

In order to compare instances of `DynamoDbStore`, we need to inject the same `HttpClient` instance.
The `http_client` option is a feature that enables, for example, injecting a client decorated by the profiler to view the HTTP requests made by the store, and still use the DSN for the lock configuration.