### PR TITLE
 Use `readonly` classes when possible

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Middleware/Debug/Middleware.php
+++ b/src/Symfony/Bridge/Doctrine/Middleware/Debug/Middleware.php
@@ -20,12 +20,12 @@ use Symfony\Component\Stopwatch\Stopwatch;
  *
  * @author Laurent VOULLEMIER <laurent.voullemier@gmail.com>
  */
-final class Middleware implements MiddlewareInterface
+final readonly class Middleware implements MiddlewareInterface
 {
     public function __construct(
-        private readonly DebugDataHolder $debugDataHolder,
-        private readonly ?Stopwatch $stopwatch,
-        private readonly string $connectionName = 'default',
+        private DebugDataHolder $debugDataHolder,
+        private ?Stopwatch $stopwatch,
+        private string $connectionName = 'default',
     ) {
     }
 

--- a/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
@@ -44,10 +44,10 @@ use Symfony\Component\Security\Core\Exception\TokenNotFoundException;
  *
  * (the `class` column is for BC with tables created with before Symfony 8)
  */
-final class DoctrineTokenProvider implements TokenProviderInterface, TokenVerifierInterface
+final readonly class DoctrineTokenProvider implements TokenProviderInterface, TokenVerifierInterface
 {
     public function __construct(
-        private readonly Connection $conn,
+        private Connection $conn,
     ) {
     }
 

--- a/src/Symfony/Bridge/Doctrine/Validator/DoctrineLoader.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/DoctrineLoader.php
@@ -29,13 +29,13 @@ use Symfony\Component\Validator\Mapping\Loader\LoaderInterface;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-final class DoctrineLoader implements LoaderInterface
+final readonly class DoctrineLoader implements LoaderInterface
 {
     use AutoMappingTrait;
 
     public function __construct(
-        private readonly EntityManagerInterface $entityManager,
-        private readonly ?string $classValidatorRegexp = null,
+        private EntityManagerInterface $entityManager,
+        private ?string $classValidatorRegexp = null,
     ) {
     }
 

--- a/src/Symfony/Bridge/PhpUnit/Attribute/DnsSensitive.php
+++ b/src/Symfony/Bridge/PhpUnit/Attribute/DnsSensitive.php
@@ -12,10 +12,10 @@
 namespace Symfony\Bridge\PhpUnit\Attribute;
 
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
-final class DnsSensitive
+final readonly class DnsSensitive
 {
     public function __construct(
-        public readonly ?string $class = null,
+        public ?string $class = null,
     ) {
     }
 }

--- a/src/Symfony/Bridge/PhpUnit/Attribute/TimeSensitive.php
+++ b/src/Symfony/Bridge/PhpUnit/Attribute/TimeSensitive.php
@@ -12,10 +12,10 @@
 namespace Symfony\Bridge\PhpUnit\Attribute;
 
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
-final class TimeSensitive
+final readonly class TimeSensitive
 {
     public function __construct(
-        public readonly ?string $class = null,
+        public ?string $class = null,
     ) {
     }
 }

--- a/src/Symfony/Bridge/PsrHttpMessage/ArgumentValueResolver/PsrServerRequestResolver.php
+++ b/src/Symfony/Bridge/PsrHttpMessage/ArgumentValueResolver/PsrServerRequestResolver.php
@@ -25,7 +25,7 @@ use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
  * @author Iltar van der Berg <kjarli@gmail.com>
  * @author Alexander M. Turek <me@derrabus.de>
  */
-final class PsrServerRequestResolver implements ValueResolverInterface
+final readonly class PsrServerRequestResolver implements ValueResolverInterface
 {
     private const SUPPORTED_TYPES = [
         ServerRequestInterface::class => true,
@@ -34,7 +34,7 @@ final class PsrServerRequestResolver implements ValueResolverInterface
     ];
 
     public function __construct(
-        private readonly HttpMessageFactoryInterface $httpMessageFactory,
+        private HttpMessageFactoryInterface $httpMessageFactory,
     ) {
     }
 

--- a/src/Symfony/Bridge/PsrHttpMessage/EventListener/PsrResponseListener.php
+++ b/src/Symfony/Bridge/PsrHttpMessage/EventListener/PsrResponseListener.php
@@ -24,9 +24,9 @@ use Symfony\Component\HttpKernel\KernelEvents;
  * @author Kévin Dunglas <dunglas@gmail.com>
  * @author Alexander M. Turek <me@derrabus.de>
  */
-final class PsrResponseListener implements EventSubscriberInterface
+final readonly class PsrResponseListener implements EventSubscriberInterface
 {
-    private readonly HttpFoundationFactoryInterface $httpFoundationFactory;
+    private HttpFoundationFactoryInterface $httpFoundationFactory;
 
     public function __construct(?HttpFoundationFactoryInterface $httpFoundationFactory = null)
     {

--- a/src/Symfony/Bundle/SecurityBundle/Routing/LogoutRouteLoader.php
+++ b/src/Symfony/Bundle/SecurityBundle/Routing/LogoutRouteLoader.php
@@ -15,15 +15,15 @@ use Symfony\Component\DependencyInjection\Config\ContainerParametersResource;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
-final class LogoutRouteLoader
+final readonly class LogoutRouteLoader
 {
     /**
      * @param array<string, string> $logoutUris    Logout URIs indexed by the corresponding firewall name
      * @param string                $parameterName Name of the container parameter containing {@see $logoutUris} value
      */
     public function __construct(
-        private readonly array $logoutUris,
-        private readonly string $parameterName,
+        private array $logoutUris,
+        private string $parameterName,
     ) {
     }
 

--- a/src/Symfony/Bundle/SecurityBundle/Security/FirewallConfig.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/FirewallConfig.php
@@ -14,22 +14,22 @@ namespace Symfony\Bundle\SecurityBundle\Security;
 /**
  * @author Robin Chalas <robin.chalas@gmail.com>
  */
-final class FirewallConfig
+final readonly class FirewallConfig
 {
     public function __construct(
-        private readonly string $name,
-        private readonly string $userChecker,
-        private readonly ?string $requestMatcher = null,
-        private readonly bool $securityEnabled = true,
-        private readonly bool $stateless = false,
-        private readonly ?string $provider = null,
-        private readonly ?string $context = null,
-        private readonly ?string $entryPoint = null,
-        private readonly ?string $accessDeniedHandler = null,
-        private readonly ?string $accessDeniedUrl = null,
-        private readonly array $authenticators = [],
-        private readonly ?array $switchUser = null,
-        private readonly ?array $logout = null,
+        private string $name,
+        private string $userChecker,
+        private ?string $requestMatcher = null,
+        private bool $securityEnabled = true,
+        private bool $stateless = false,
+        private ?string $provider = null,
+        private ?string $context = null,
+        private ?string $entryPoint = null,
+        private ?string $accessDeniedHandler = null,
+        private ?string $accessDeniedUrl = null,
+        private array $authenticators = [],
+        private ?array $switchUser = null,
+        private ?array $logout = null,
     ) {
     }
 

--- a/src/Symfony/Component/AssetMapper/Compiler/CssAssetUrlCompiler.php
+++ b/src/Symfony/Component/AssetMapper/Compiler/CssAssetUrlCompiler.php
@@ -22,7 +22,7 @@ use Symfony\Component\Filesystem\Path;
  *
  * Originally sourced from https://github.com/rails/propshaft/blob/main/lib/propshaft/compiler/css_asset_urls.rb
  */
-final class CssAssetUrlCompiler implements AssetCompilerInterface
+final readonly class CssAssetUrlCompiler implements AssetCompilerInterface
 {
     // https://regex101.com/r/BOJ3vG/2
     public const ASSET_URL_PATTERN = <<<'REGEX'
@@ -36,8 +36,8 @@ final class CssAssetUrlCompiler implements AssetCompilerInterface
         REGEX;
 
     public function __construct(
-        private readonly string $missingImportMode = self::MISSING_IMPORT_WARN,
-        private readonly ?LoggerInterface $logger = null,
+        private string $missingImportMode = self::MISSING_IMPORT_WARN,
+        private ?LoggerInterface $logger = null,
     ) {
     }
 

--- a/src/Symfony/Component/AssetMapper/Compiler/JavaScriptImportPathCompiler.php
+++ b/src/Symfony/Component/AssetMapper/Compiler/JavaScriptImportPathCompiler.php
@@ -26,7 +26,7 @@ use Symfony\Component\Filesystem\Path;
  *
  * @author Ryan Weaver <ryan@symfonycasts.com>
  */
-final class JavaScriptImportPathCompiler implements AssetCompilerInterface
+final readonly class JavaScriptImportPathCompiler implements AssetCompilerInterface
 {
     /**
      * @see https://regex101.com/r/1iBAIb/2
@@ -54,9 +54,9 @@ final class JavaScriptImportPathCompiler implements AssetCompilerInterface
     /mxu';
 
     public function __construct(
-        private readonly ImportMapConfigReader $importMapConfigReader,
-        private readonly string $missingImportMode = self::MISSING_IMPORT_WARN,
-        private readonly ?LoggerInterface $logger = null,
+        private ImportMapConfigReader $importMapConfigReader,
+        private string $missingImportMode = self::MISSING_IMPORT_WARN,
+        private ?LoggerInterface $logger = null,
     ) {
     }
 

--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapEntry.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapEntry.php
@@ -16,24 +16,24 @@ namespace Symfony\Component\AssetMapper\ImportMap;
  *
  * @author Ryan Weaver <ryan@symfonycasts.com>
  */
-final class ImportMapEntry
+final readonly class ImportMapEntry
 {
     private function __construct(
-        public readonly string $importName,
-        public readonly ImportMapType $type,
+        public string $importName,
+        public ImportMapType $type,
         /**
          * A logical path, relative path or absolute path to the file.
          */
-        public readonly string $path,
-        public readonly bool $isEntrypoint,
+        public string $path,
+        public bool $isEntrypoint,
         /**
          * The version of the package (remote only).
          */
-        public readonly ?string $version,
+        public ?string $version,
         /**
          * The full "package-name/path" (remote only).
          */
-        public readonly ?string $packageModuleSpecifier,
+        public ?string $packageModuleSpecifier,
     ) {
     }
 

--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapPackageAudit.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapPackageAudit.php
@@ -11,13 +11,13 @@
 
 namespace Symfony\Component\AssetMapper\ImportMap;
 
-final class ImportMapPackageAudit
+final readonly class ImportMapPackageAudit
 {
     public function __construct(
-        public readonly string $package,
-        public readonly ?string $version,
+        public string $package,
+        public ?string $version,
         /** @var array<ImportMapPackageAuditVulnerability> */
-        public readonly array $vulnerabilities = [],
+        public array $vulnerabilities = [],
     ) {
     }
 

--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapPackageAuditVulnerability.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapPackageAuditVulnerability.php
@@ -11,16 +11,16 @@
 
 namespace Symfony\Component\AssetMapper\ImportMap;
 
-final class ImportMapPackageAuditVulnerability
+final readonly class ImportMapPackageAuditVulnerability
 {
     public function __construct(
-        public readonly string $ghsaId,
-        public readonly ?string $cveId,
-        public readonly string $url,
-        public readonly string $summary,
-        public readonly string $severity,
-        public readonly ?string $vulnerableVersionRange,
-        public readonly ?string $firstPatchedVersion,
+        public string $ghsaId,
+        public ?string $cveId,
+        public string $url,
+        public string $summary,
+        public string $severity,
+        public ?string $vulnerableVersionRange,
+        public ?string $firstPatchedVersion,
     ) {
     }
 }

--- a/src/Symfony/Component/AssetMapper/ImportMap/PackageRequireOptions.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/PackageRequireOptions.php
@@ -16,19 +16,19 @@ namespace Symfony\Component\AssetMapper\ImportMap;
  *
  * @author Kévin Dunglas <kevin@dunglas.dev>
  */
-final class PackageRequireOptions
+final readonly class PackageRequireOptions
 {
-    public readonly string $importName;
+    public string $importName;
 
     public function __construct(
         /**
          * The "package-name/path" of the remote package.
          */
-        public readonly string $packageModuleSpecifier,
-        public readonly ?string $versionConstraint = null,
+        public string $packageModuleSpecifier,
+        public ?string $versionConstraint = null,
         ?string $importName = null,
-        public readonly ?string $path = null,
-        public readonly bool $entrypoint = false,
+        public ?string $path = null,
+        public bool $entrypoint = false,
     ) {
         $this->importName = $importName ?: $packageModuleSpecifier;
     }

--- a/src/Symfony/Component/AssetMapper/ImportMap/PackageVersionProblem.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/PackageVersionProblem.php
@@ -11,13 +11,13 @@
 
 namespace Symfony\Component\AssetMapper\ImportMap;
 
-final class PackageVersionProblem
+final readonly class PackageVersionProblem
 {
     public function __construct(
-        public readonly string $packageName,
-        public readonly string $dependencyPackageName,
-        public readonly string $requiredVersionConstraint,
-        public readonly ?string $installedVersion,
+        public string $packageName,
+        public string $dependencyPackageName,
+        public string $requiredVersionConstraint,
+        public ?string $installedVersion,
     ) {
     }
 }

--- a/src/Symfony/Component/AssetMapper/ImportMap/Resolver/ResolvedImportMapPackage.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/Resolver/ResolvedImportMapPackage.php
@@ -14,12 +14,12 @@ namespace Symfony\Component\AssetMapper\ImportMap\Resolver;
 use Symfony\Component\AssetMapper\ImportMap\ImportMapType;
 use Symfony\Component\AssetMapper\ImportMap\PackageRequireOptions;
 
-final class ResolvedImportMapPackage
+final readonly class ResolvedImportMapPackage
 {
     public function __construct(
-        public readonly PackageRequireOptions $requireOptions,
-        public readonly string $version,
-        public readonly ImportMapType $type,
+        public PackageRequireOptions $requireOptions,
+        public string $version,
+        public ImportMapType $type,
     ) {
     }
 }

--- a/src/Symfony/Component/AssetMapper/MapperAwareAssetPackage.php
+++ b/src/Symfony/Component/AssetMapper/MapperAwareAssetPackage.php
@@ -18,11 +18,11 @@ use Symfony\Component\Asset\PackageInterface;
  *
  * @author Ryan Weaver <ryan@symfonycasts.com>
  */
-final class MapperAwareAssetPackage implements PackageInterface
+final readonly class MapperAwareAssetPackage implements PackageInterface
 {
     public function __construct(
-        private readonly PackageInterface $innerPackage,
-        private readonly AssetMapperInterface $assetMapper,
+        private PackageInterface $innerPackage,
+        private AssetMapperInterface $assetMapper,
     ) {
     }
 

--- a/src/Symfony/Component/Console/Helper/TreeStyle.php
+++ b/src/Symfony/Component/Console/Helper/TreeStyle.php
@@ -16,15 +16,15 @@ namespace Symfony\Component\Console\Helper;
  *
  * @author Simon André <smn.andre@gmail.com>
  */
-final class TreeStyle
+final readonly class TreeStyle
 {
     public function __construct(
-        private readonly string $prefixEndHasNext,
-        private readonly string $prefixEndLast,
-        private readonly string $prefixLeft,
-        private readonly string $prefixMidHasNext,
-        private readonly string $prefixMidLast,
-        private readonly string $prefixRight,
+        private string $prefixEndHasNext,
+        private string $prefixEndLast,
+        private string $prefixLeft,
+        private string $prefixMidHasNext,
+        private string $prefixMidLast,
+        private string $prefixRight,
     ) {
     }
 

--- a/src/Symfony/Component/Console/Messenger/RunCommandContext.php
+++ b/src/Symfony/Component/Console/Messenger/RunCommandContext.php
@@ -14,12 +14,12 @@ namespace Symfony\Component\Console\Messenger;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-final class RunCommandContext
+final readonly class RunCommandContext
 {
     public function __construct(
-        public readonly RunCommandMessage $message,
-        public readonly int $exitCode,
-        public readonly string $output,
+        public RunCommandMessage $message,
+        public int $exitCode,
+        public string $output,
     ) {
     }
 }

--- a/src/Symfony/Component/Console/Messenger/RunCommandMessageHandler.php
+++ b/src/Symfony/Component/Console/Messenger/RunCommandMessageHandler.php
@@ -22,10 +22,10 @@ use Symfony\Component\Messenger\Exception\UnrecoverableExceptionInterface;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-final class RunCommandMessageHandler
+final readonly class RunCommandMessageHandler
 {
     public function __construct(
-        private readonly Application $application,
+        private Application $application,
     ) {
     }
 

--- a/src/Symfony/Component/HttpClient/Messenger/PingWebhookMessage.php
+++ b/src/Symfony/Component/HttpClient/Messenger/PingWebhookMessage.php
@@ -14,13 +14,13 @@ namespace Symfony\Component\HttpClient\Messenger;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-final class PingWebhookMessage implements \Stringable
+final readonly class PingWebhookMessage implements \Stringable
 {
     public function __construct(
-        public readonly string $method,
-        public readonly string $url,
-        public readonly array $options = [],
-        public readonly bool $throw = true,
+        public string $method,
+        public string $url,
+        public array $options = [],
+        public bool $throw = true,
     ) {
     }
 

--- a/src/Symfony/Component/HttpKernel/Attribute/IsSignatureValid.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/IsSignatureValid.php
@@ -25,10 +25,10 @@ namespace Symfony\Component\HttpKernel\Attribute;
  * @author Santiago San Martin <sanmartindev@gmail.com>
  */
 #[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_FUNCTION)]
-final class IsSignatureValid
+final readonly class IsSignatureValid
 {
     /** @var string[] */
-    public readonly array $methods;
+    public array $methods;
 
     /**
      * @param string[]|string $methods HTTP methods that require signature validation. An empty array means that no method filtering is done

--- a/src/Symfony/Component/HttpKernel/Attribute/WithLogLevel.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/WithLogLevel.php
@@ -19,12 +19,12 @@ use Psr\Log\LogLevel;
  * @author Dejan Angelov <angelovdejan@protonmail.com>
  */
 #[\Attribute(\Attribute::TARGET_CLASS)]
-final class WithLogLevel
+final readonly class WithLogLevel
 {
     /**
      * @param LogLevel::* $level The level to use to log the exception
      */
-    public function __construct(public readonly string $level)
+    public function __construct(public string $level)
     {
         if (!\defined('Psr\Log\LogLevel::'.strtoupper($this->level))) {
             throw new \InvalidArgumentException(\sprintf('Invalid log level "%s".', $this->level));

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/DateTimeValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/DateTimeValueResolver.php
@@ -24,10 +24,10 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  * @author Benjamin Eberlei <kontakt@beberlei.de>
  * @author Tim Goudriaan <tim@codedmonkey.com>
  */
-final class DateTimeValueResolver implements ValueResolverInterface
+final readonly class DateTimeValueResolver implements ValueResolverInterface
 {
     public function __construct(
-        private readonly ?ClockInterface $clock = null,
+        private ?ClockInterface $clock = null,
     ) {
     }
 

--- a/src/Symfony/Component/JsonPath/JsonPath.php
+++ b/src/Symfony/Component/JsonPath/JsonPath.php
@@ -16,13 +16,13 @@ namespace Symfony\Component\JsonPath;
  *
  * @immutable
  */
-final class JsonPath
+final readonly class JsonPath
 {
     /**
      * @param non-empty-string $path
      */
     public function __construct(
-        private readonly string $path = '$',
+        private string $path = '$',
     ) {
     }
 

--- a/src/Symfony/Component/Mailer/EventListener/SmimeEncryptedMessageListener.php
+++ b/src/Symfony/Component/Mailer/EventListener/SmimeEncryptedMessageListener.php
@@ -21,11 +21,11 @@ use Symfony\Component\Mime\Message;
  *
  * @author Elías Fernández
  */
-final class SmimeEncryptedMessageListener implements EventSubscriberInterface
+final readonly class SmimeEncryptedMessageListener implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly SmimeCertificateRepositoryInterface $smimeRepository,
-        private readonly ?int $cipher = null,
+        private SmimeCertificateRepositoryInterface $smimeRepository,
+        private ?int $cipher = null,
     ) {
     }
 

--- a/src/Symfony/Component/Messenger/Message/RedispatchMessage.php
+++ b/src/Symfony/Component/Messenger/Message/RedispatchMessage.php
@@ -13,15 +13,15 @@ namespace Symfony\Component\Messenger\Message;
 
 use Symfony\Component\Messenger\Envelope;
 
-final class RedispatchMessage implements \Stringable
+final readonly class RedispatchMessage implements \Stringable
 {
     /**
      * @param object|Envelope $envelope       The message or the message pre-wrapped in an envelope
      * @param string[]|string $transportNames Transport names to be used for the message
      */
     public function __construct(
-        public readonly object $envelope,
-        public readonly array|string $transportNames = [],
+        public object $envelope,
+        public array|string $transportNames = [],
     ) {
     }
 

--- a/src/Symfony/Component/Messenger/Stamp/AckStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/AckStamp.php
@@ -16,13 +16,13 @@ use Symfony\Component\Messenger\Envelope;
 /**
  * Marker stamp for messages that can be ack/nack'ed.
  */
-final class AckStamp implements NonSendableStampInterface
+final readonly class AckStamp implements NonSendableStampInterface
 {
     /**
      * @param \Closure(Envelope, \Throwable|null) $ack
      */
     public function __construct(
-        private readonly \Closure $ack,
+        private \Closure $ack,
     ) {
     }
 

--- a/src/Symfony/Component/Messenger/Stamp/SentForRetryStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/SentForRetryStamp.php
@@ -14,10 +14,10 @@ namespace Symfony\Component\Messenger\Stamp;
 /**
  * Stamp indicating whether a failed message has been sent for retry.
  */
-final class SentForRetryStamp implements NonSendableStampInterface
+final readonly class SentForRetryStamp implements NonSendableStampInterface
 {
     public function __construct(
-        public readonly bool $isSent,
+        public bool $isSent,
     ) {
     }
 }

--- a/src/Symfony/Component/ObjectMapper/Condition/TargetClass.php
+++ b/src/Symfony/Component/ObjectMapper/Condition/TargetClass.php
@@ -18,12 +18,12 @@ use Symfony\Component\ObjectMapper\ConditionCallableInterface;
  *
  * @implements ConditionCallableInterface<object, T>
  */
-final class TargetClass implements ConditionCallableInterface
+final readonly class TargetClass implements ConditionCallableInterface
 {
     /**
      * @param class-string<T> $className
      */
-    public function __construct(private readonly string $className)
+    public function __construct(private string $className)
     {
     }
 

--- a/src/Symfony/Component/Process/Messenger/RunProcessContext.php
+++ b/src/Symfony/Component/Process/Messenger/RunProcessContext.php
@@ -16,14 +16,14 @@ use Symfony\Component\Process\Process;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-final class RunProcessContext
+final readonly class RunProcessContext
 {
-    public readonly ?int $exitCode;
-    public readonly ?string $output;
-    public readonly ?string $errorOutput;
+    public ?int $exitCode;
+    public ?string $output;
+    public ?string $errorOutput;
 
     public function __construct(
-        public readonly RunProcessMessage $message,
+        public RunProcessMessage $message,
         Process $process,
     ) {
         $this->exitCode = $process->getExitCode();

--- a/src/Symfony/Component/PropertyInfo/Extractor/ConstructorExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ConstructorExtractor.php
@@ -19,13 +19,13 @@ use Symfony\Component\TypeInfo\Type;
  *
  * @author Dmitrii Poddubnyi <dpoddubny@gmail.com>
  */
-final class ConstructorExtractor implements PropertyTypeExtractorInterface
+final readonly class ConstructorExtractor implements PropertyTypeExtractorInterface
 {
     /**
      * @param iterable<int, ConstructorArgumentTypeExtractorInterface> $extractors
      */
     public function __construct(
-        private readonly iterable $extractors = [],
+        private iterable $extractors = [],
     ) {
     }
 

--- a/src/Symfony/Component/PropertyInfo/PropertyReadInfo.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyReadInfo.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\PropertyInfo;
  *
  * @author Joel Wurtz <jwurtz@jolicode.com>
  */
-final class PropertyReadInfo
+final readonly class PropertyReadInfo
 {
     public const TYPE_METHOD = 'method';
     public const TYPE_PROPERTY = 'property';
@@ -26,11 +26,11 @@ final class PropertyReadInfo
     public const VISIBILITY_PRIVATE = 'private';
 
     public function __construct(
-        private readonly string $type,
-        private readonly string $name,
-        private readonly string $visibility,
-        private readonly bool $static,
-        private readonly bool $byRef,
+        private string $type,
+        private string $name,
+        private string $visibility,
+        private bool $static,
+        private bool $byRef,
     ) {
     }
 

--- a/src/Symfony/Component/Scheduler/Generator/MessageContext.php
+++ b/src/Symfony/Component/Scheduler/Generator/MessageContext.php
@@ -16,14 +16,14 @@ use Symfony\Component\Scheduler\Trigger\TriggerInterface;
 /**
  * @author Tugdual Saunier <tugdual@saunier.tech>
  */
-final class MessageContext
+final readonly class MessageContext
 {
     public function __construct(
-        public readonly string $name,
-        public readonly string $id,
-        public readonly TriggerInterface $trigger,
-        public readonly \DateTimeImmutable $triggeredAt,
-        public readonly ?\DateTimeImmutable $nextTriggerAt = null,
+        public string $name,
+        public string $id,
+        public TriggerInterface $trigger,
+        public \DateTimeImmutable $triggeredAt,
+        public ?\DateTimeImmutable $nextTriggerAt = null,
     ) {
     }
 }

--- a/src/Symfony/Component/Scheduler/Messenger/ScheduledStamp.php
+++ b/src/Symfony/Component/Scheduler/Messenger/ScheduledStamp.php
@@ -14,9 +14,9 @@ namespace Symfony\Component\Scheduler\Messenger;
 use Symfony\Component\Messenger\Stamp\StampInterface;
 use Symfony\Component\Scheduler\Generator\MessageContext;
 
-final class ScheduledStamp implements StampInterface
+final readonly class ScheduledStamp implements StampInterface
 {
-    public function __construct(public readonly MessageContext $messageContext)
+    public function __construct(public MessageContext $messageContext)
     {
     }
 }

--- a/src/Symfony/Component/Scheduler/Trigger/CronExpressionTrigger.php
+++ b/src/Symfony/Component/Scheduler/Trigger/CronExpressionTrigger.php
@@ -21,7 +21,7 @@ use Symfony\Component\Scheduler\Exception\LogicException;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-final class CronExpressionTrigger implements TriggerInterface
+final readonly class CronExpressionTrigger implements TriggerInterface
 {
     private const HASH_ALIAS_MAP = [
         '#hourly' => '# * * * *',
@@ -44,10 +44,10 @@ final class CronExpressionTrigger implements TriggerInterface
         [0, 6],
     ];
 
-    private readonly ?string $timezone;
+    private ?string $timezone;
 
     public function __construct(
-        private readonly CronExpression $expression = new CronExpression('* * * * *'),
+        private CronExpression $expression = new CronExpression('* * * * *'),
         \DateTimeZone|string|null $timezone = null,
     ) {
         $this->timezone = $timezone instanceof \DateTimeZone ? $timezone->getName() : $timezone;

--- a/src/Symfony/Component/Security/Core/User/ChainUserChecker.php
+++ b/src/Symfony/Component/Security/Core/User/ChainUserChecker.php
@@ -13,12 +13,12 @@ namespace Symfony\Component\Security\Core\User;
 
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
-final class ChainUserChecker implements UserCheckerInterface
+final readonly class ChainUserChecker implements UserCheckerInterface
 {
     /**
      * @param iterable<UserCheckerInterface> $checkers
      */
-    public function __construct(private readonly iterable $checkers)
+    public function __construct(private iterable $checkers)
     {
     }
 

--- a/src/Symfony/Component/Security/Http/AccessToken/ChainAccessTokenExtractor.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/ChainAccessTokenExtractor.php
@@ -18,13 +18,13 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Florent Morselli <florent.morselli@spomky-labs.com>
  */
-final class ChainAccessTokenExtractor implements AccessTokenExtractorInterface
+final readonly class ChainAccessTokenExtractor implements AccessTokenExtractorInterface
 {
     /**
      * @param AccessTokenExtractorInterface[] $accessTokenExtractors
      */
     public function __construct(
-        private readonly iterable $accessTokenExtractors,
+        private iterable $accessTokenExtractors,
     ) {
     }
 

--- a/src/Symfony/Component/Security/Http/AccessToken/FormEncodedBodyExtractor.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/FormEncodedBodyExtractor.php
@@ -25,10 +25,10 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @see https://datatracker.ietf.org/doc/html/rfc6750#section-2.2
  */
-final class FormEncodedBodyExtractor implements AccessTokenExtractorInterface
+final readonly class FormEncodedBodyExtractor implements AccessTokenExtractorInterface
 {
     public function __construct(
-        private readonly string $parameter = 'access_token',
+        private string $parameter = 'access_token',
     ) {
     }
 

--- a/src/Symfony/Component/Security/Http/AccessToken/OAuth2/Oauth2TokenHandler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/OAuth2/Oauth2TokenHandler.php
@@ -28,11 +28,11 @@ use function Symfony\Component\String\u;
  *
  * @internal
  */
-final class Oauth2TokenHandler implements AccessTokenHandlerInterface
+final readonly class Oauth2TokenHandler implements AccessTokenHandlerInterface
 {
     public function __construct(
-        private readonly HttpClientInterface $client,
-        private readonly ?LoggerInterface $logger = null,
+        private HttpClientInterface $client,
+        private ?LoggerInterface $logger = null,
     ) {
     }
 

--- a/src/Symfony/Component/Security/Http/AccessToken/QueryAccessTokenExtractor.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/QueryAccessTokenExtractor.php
@@ -26,12 +26,12 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @see https://datatracker.ietf.org/doc/html/rfc6750#section-2.3
  */
-final class QueryAccessTokenExtractor implements AccessTokenExtractorInterface
+final readonly class QueryAccessTokenExtractor implements AccessTokenExtractorInterface
 {
     public const PARAMETER = 'access_token';
 
     public function __construct(
-        private readonly string $parameter = self::PARAMETER,
+        private string $parameter = self::PARAMETER,
     ) {
     }
 

--- a/src/Symfony/Component/Security/Http/Controller/SecurityTokenValueResolver.php
+++ b/src/Symfony/Component/Security/Http/Controller/SecurityTokenValueResolver.php
@@ -22,9 +22,9 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 /**
  * @author Konstantin Myakshin <molodchick@gmail.com>
  */
-final class SecurityTokenValueResolver implements ValueResolverInterface
+final readonly class SecurityTokenValueResolver implements ValueResolverInterface
 {
-    public function __construct(private readonly TokenStorageInterface $tokenStorage)
+    public function __construct(private TokenStorageInterface $tokenStorage)
     {
     }
 

--- a/src/Symfony/Component/Serializer/CacheWarmer/CompiledClassMetadataCacheWarmer.php
+++ b/src/Symfony/Component/Serializer/CacheWarmer/CompiledClassMetadataCacheWarmer.php
@@ -23,13 +23,13 @@ trigger_deprecation('symfony/serializer', '7.3', 'The "%s" class is deprecated.'
  *
  * @deprecated since Symfony 7.3
  */
-final class CompiledClassMetadataCacheWarmer implements CacheWarmerInterface
+final readonly class CompiledClassMetadataCacheWarmer implements CacheWarmerInterface
 {
     public function __construct(
-        private readonly array $classesToCompile,
-        private readonly ClassMetadataFactoryInterface $classMetadataFactory,
-        private readonly ClassMetadataFactoryCompiler $classMetadataFactoryCompiler,
-        private readonly Filesystem $filesystem,
+        private array $classesToCompile,
+        private ClassMetadataFactoryInterface $classMetadataFactory,
+        private ClassMetadataFactoryCompiler $classMetadataFactoryCompiler,
+        private Filesystem $filesystem,
     ) {
     }
 

--- a/src/Symfony/Component/Serializer/Normalizer/ConstraintViolationListNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ConstraintViolationListNormalizer.php
@@ -22,7 +22,7 @@ use Symfony\Component\Validator\ConstraintViolationListInterface;
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-final class ConstraintViolationListNormalizer implements NormalizerInterface
+final readonly class ConstraintViolationListNormalizer implements NormalizerInterface
 {
     public const INSTANCE = 'instance';
     public const STATUS = 'status';
@@ -31,8 +31,8 @@ final class ConstraintViolationListNormalizer implements NormalizerInterface
     public const PAYLOAD_FIELDS = 'payload_fields';
 
     public function __construct(
-        private readonly array $defaultContext = [],
-        private readonly ?NameConverterInterface $nameConverter = null,
+        private array $defaultContext = [],
+        private ?NameConverterInterface $nameConverter = null,
     ) {
     }
 

--- a/src/Symfony/Component/Serializer/Normalizer/DataUriNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DataUriNormalizer.php
@@ -23,7 +23,7 @@ use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-final class DataUriNormalizer implements NormalizerInterface, DenormalizerInterface
+final readonly class DataUriNormalizer implements NormalizerInterface, DenormalizerInterface
 {
     private const SUPPORTED_TYPES = [
         \SplFileInfo::class => true,
@@ -31,7 +31,7 @@ final class DataUriNormalizer implements NormalizerInterface, DenormalizerInterf
         File::class => true,
     ];
 
-    private readonly ?MimeTypeGuesserInterface $mimeTypeGuesser;
+    private ?MimeTypeGuesserInterface $mimeTypeGuesser;
 
     public function __construct(?MimeTypeGuesserInterface $mimeTypeGuesser = null)
     {

--- a/src/Symfony/Component/Webhook/Controller/WebhookController.php
+++ b/src/Symfony/Component/Webhook/Controller/WebhookController.php
@@ -24,12 +24,12 @@ use Symfony\Component\Webhook\Client\RequestParserInterface;
  *
  * @internal
  */
-final class WebhookController
+final readonly class WebhookController
 {
     public function __construct(
         /** @var array<string, array{parser: RequestParserInterface, secret: string}> $parsers */
-        private readonly array $parsers,
-        private readonly MessageBusInterface $bus,
+        private array $parsers,
+        private MessageBusInterface $bus,
     ) {
     }
 

--- a/src/Symfony/Component/Webhook/Server/HeaderSignatureConfigurator.php
+++ b/src/Symfony/Component/Webhook/Server/HeaderSignatureConfigurator.php
@@ -19,11 +19,11 @@ use Symfony\Component\Webhook\Exception\LogicException;
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  */
-final class HeaderSignatureConfigurator implements RequestConfiguratorInterface
+final readonly class HeaderSignatureConfigurator implements RequestConfiguratorInterface
 {
     public function __construct(
-        private readonly string $algo = 'sha256',
-        private readonly string $signatureHeaderName = 'Webhook-Signature',
+        private string $algo = 'sha256',
+        private string $signatureHeaderName = 'Webhook-Signature',
     ) {
     }
 

--- a/src/Symfony/Component/Webhook/Server/HeadersConfigurator.php
+++ b/src/Symfony/Component/Webhook/Server/HeadersConfigurator.php
@@ -17,11 +17,11 @@ use Symfony\Component\RemoteEvent\RemoteEvent;
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  */
-final class HeadersConfigurator implements RequestConfiguratorInterface
+final readonly class HeadersConfigurator implements RequestConfiguratorInterface
 {
     public function __construct(
-        private readonly string $eventHeaderName = 'Webhook-Event',
-        private readonly string $idHeaderName = 'Webhook-Id',
+        private string $eventHeaderName = 'Webhook-Event',
+        private string $idHeaderName = 'Webhook-Id',
     ) {
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #...
| License       | MIT

I used the Rector rule [ReadOnlyClassRector](https://getrector.com/rule-detail/read-only-class-rector)

The `rector.php` file I used.

```php
<?php

use Rector\Config\RectorConfig;
use Rector\Php82\Rector\Class_\ReadOnlyClassRector;

return RectorConfig::configure()
    ->withPaths([
        __DIR__ . '/src',
    ])
    ->withSkip([
        __DIR__ . '/src/*/Tests/*',
    ])
    ->withRules([
        ReadOnlyClassRector::class,
    ]);
```