### PR TITLE
[HttpClient] Fix caching client decorating scoping client

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -2076,7 +2076,7 @@ class Configuration implements ConfigurationInterface
                                 ->acceptAndWrap(['string'], 'base_uri')
                                 ->validate()
                                     ->ifTrue(static fn () => !class_exists(HttpClient::class))
-                                    ->then(static fn () => 'HttpClient support cannot be enabled as the component is not installed. Try running "composer require symfony/http-client".')
+                                    ->then(static fn () => throw new LogicException('HttpClient support cannot be enabled as the component is not installed. Try running "composer require symfony/http-client".'))
                                 ->end()
                                 ->validate()
                                     ->ifTrue(static fn ($v) => !isset($v['scope']) && !isset($v['base_uri']))

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -2295,15 +2295,18 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->assertFalse($arguments[3]);
         $this->assertSame(2, $arguments[4]);
 
-        $this->assertTrue($container->hasDefinition('bar.caching'));
-        $definition = $container->getDefinition('bar.caching');
+        $this->assertTrue($container->hasDefinition('bar.transport.caching'));
+        $definition = $container->getDefinition('bar.transport.caching');
         $this->assertSame(CachingHttpClient::class, $definition->getClass());
-        $this->assertSame('bar', $definition->getDecoratedService()[0]);
         $arguments = $definition->getArguments();
         $this->assertInstanceOf(Reference::class, $arguments[0]);
-        $this->assertSame('bar.caching.inner', (string) $arguments[0]);
+        $this->assertSame('bar.transport.caching.inner', (string) $arguments[0]);
         $this->assertInstanceOf(Reference::class, $arguments[1]);
         $this->assertSame('baz', (string) $arguments[1]);
+        $scopedClient = $container->getDefinition('bar');
+
+        $this->assertSame('bar.transport', (string) $scopedClient->getArgument(0));
+        $this->assertNull($scopedClient->getDecoratedService());
     }
 
     public function testHttpClientRetry()
@@ -2317,8 +2320,8 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->assertSame(0.3, $container->getDefinition('http_client.retry_strategy')->getArgument(4));
         $this->assertSame(2, $container->getDefinition('http_client.retryable')->getArgument(2));
 
-        $this->assertSame(RetryableHttpClient::class, $container->getDefinition('foo.retryable')->getClass());
-        $this->assertSame(4, $container->getDefinition('foo.retry_strategy')->getArgument(2));
+        $this->assertSame(RetryableHttpClient::class, $container->getDefinition('foo.transport.retryable')->getClass());
+        $this->assertSame(4, $container->getDefinition('foo.transport.retry_strategy')->getArgument(2));
     }
 
     public function testHttpClientWithQueryParameterKey()
@@ -2383,15 +2386,15 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->assertInstanceOf(Reference::class, $arguments[1]);
         $this->assertSame('http_client.throttling.limiter', (string) $arguments[1]);
 
-        $this->assertTrue($container->hasDefinition('foo.throttling'));
-        $definition = $container->getDefinition('foo.throttling');
+        $this->assertTrue($container->hasDefinition('foo.transport.throttling'));
+        $definition = $container->getDefinition('foo.transport.throttling');
         $this->assertSame(ThrottlingHttpClient::class, $definition->getClass());
-        $this->assertSame('foo', $definition->getDecoratedService()[0]);
+        $this->assertSame('foo.transport', $definition->getDecoratedService()[0]);
         $this->assertCount(2, $arguments = $definition->getArguments());
         $this->assertInstanceOf(Reference::class, $arguments[0]);
-        $this->assertSame('foo.throttling.inner', (string) $arguments[0]);
+        $this->assertSame('foo.transport.throttling.inner', (string) $arguments[0]);
         $this->assertInstanceOf(Reference::class, $arguments[1]);
-        $this->assertSame('foo.throttling.limiter', (string) $arguments[1]);
+        $this->assertSame('foo.transport.throttling.limiter', (string) $arguments[1]);
     }
 
     public static function provideMailer(): iterable


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62166
| License       | MIT

When registering a scoped client and enabling caching, the scoping client should decorate the caching one, while currently it's registered the wrong way around. This causes `Invalid URL` exceptions, since the URL is not resolved first by the scoping client
