### PR TITLE
[HttpKernel] Add `KernelInterface::getShareDir()`, `APP_SHARE_DIR` and `%kernel.share_dir%`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -20,6 +20,7 @@ CHANGELOG
  * Initialize `router.request_context`'s `_locale` parameter to `%kernel.default_locale%`
  * Deprecate `ConfigBuilderCacheWarmer`, return PHP arrays from your config instead
  * Add support for selecting the appropriate error renderer based on the `APP_RUNTIME_MODE` env var
+ * Add `KernelInterface::getShareDir()`, `APP_SHARE_DIR` and `%kernel.share_dir%` to store application data that are shared between all front-end servers
 
 7.3
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1385,7 +1385,7 @@ class Configuration implements ConfigurationInterface
                             ->info('System related cache pools configuration.')
                             ->defaultValue('cache.adapter.system')
                         ->end()
-                        ->scalarNode('directory')->defaultValue('%kernel.cache_dir%/pools/app')->end()
+                        ->scalarNode('directory')->defaultValue('%kernel.share_dir%/pools/app')->end()
                         ->scalarNode('default_psr6_provider')->end()
                         ->scalarNode('default_redis_provider')->defaultValue('redis://localhost')->end()
                         ->scalarNode('default_valkey_provider')->defaultValue('valkey://localhost')->end()

--- a/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
@@ -124,6 +124,15 @@ trait MicroKernelTrait
         return parent::getBuildDir();
     }
 
+    public function getShareDir(): string
+    {
+        if (isset($_SERVER['APP_SHARE_DIR'])) {
+            return $_SERVER['APP_SHARE_DIR'].'/'.$this->environment;
+        }
+
+        return parent::getShareDir();
+    }
+
     public function getLogDir(): string
     {
         return $_SERVER['APP_LOG_DIR'] ?? parent::getLogDir();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -936,7 +936,7 @@ class ConfigurationTest extends TestCase
                 'pools' => [],
                 'app' => 'cache.adapter.filesystem',
                 'system' => 'cache.adapter.system',
-                'directory' => '%kernel.cache_dir%/pools/app',
+                'directory' => '%kernel.share_dir%/pools/app',
                 'default_redis_provider' => 'redis://localhost',
                 'default_valkey_provider' => 'valkey://localhost',
                 'default_memcached_provider' => 'memcached://localhost',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -2852,6 +2852,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
             'kernel.bundles_metadata' => ['FrameworkBundle' => ['namespace' => 'Symfony\\Bundle\\FrameworkBundle', 'path' => __DIR__.'/../..']],
             'kernel.cache_dir' => __DIR__,
             'kernel.build_dir' => __DIR__,
+            'kernel.share_dir' => __DIR__,
             'kernel.project_dir' => __DIR__,
             'kernel.debug' => false,
             'kernel.environment' => 'test',

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -28,7 +28,7 @@
         "symfony/filesystem": "^7.1|^8.0",
         "symfony/finder": "^6.4|^7.0|^8.0",
         "symfony/http-foundation": "^7.4|^8.0",
-        "symfony/http-kernel": "^7.2|^8.0",
+        "symfony/http-kernel": "^7.4|^8.0",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/polyfill-php85": "^1.32",
         "symfony/routing": "^7.4|^8.0"

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -303,6 +303,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
         return $this->getCacheDir();
     }
 
+    public function getShareDir(): string
+    {
+        // Returns $this->getCacheDir() for backward compatibility
+        return $this->getCacheDir();
+    }
+
     public function getLogDir(): string
     {
         return $this->getProjectDir().'/var/log';
@@ -578,9 +584,10 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
             'kernel.runtime_mode.cli' => '%env(not:default:kernel.runtime_mode.web:)%',
             'kernel.runtime_mode.worker' => '%env(bool:default::key:worker:default:kernel.runtime_mode:)%',
             'kernel.debug' => $this->debug,
-            'kernel.build_dir' => realpath($buildDir = $this->warmupDir ?: $this->getBuildDir()) ?: $buildDir,
-            'kernel.cache_dir' => realpath($cacheDir = ($this->getCacheDir() === $this->getBuildDir() ? ($this->warmupDir ?: $this->getCacheDir()) : $this->getCacheDir())) ?: $cacheDir,
-            'kernel.logs_dir' => realpath($this->getLogDir()) ?: $this->getLogDir(),
+            'kernel.build_dir' => realpath($dir = $this->warmupDir ?: $this->getBuildDir()) ?: $dir,
+            'kernel.cache_dir' => realpath($dir = ($this->getCacheDir() === $this->getBuildDir() ? ($this->warmupDir ?: $this->getCacheDir()) : $this->getCacheDir())) ?: $dir,
+            'kernel.share_dir' => realpath($dir = $this->getShareDir()) ?: $dir,
+            'kernel.logs_dir' => realpath($dir = $this->getLogDir()) ?: $dir,
             'kernel.bundles' => $bundles,
             'kernel.bundles_metadata' => $bundlesMetadata,
             'kernel.charset' => $this->getCharset(),

--- a/src/Symfony/Component/HttpKernel/KernelInterface.php
+++ b/src/Symfony/Component/HttpKernel/KernelInterface.php
@@ -20,6 +20,10 @@ use Symfony\Component\HttpKernel\Bundle\BundleInterface;
  *
  * It manages an environment made of application kernel and bundles.
  *
+ * @method string getShareDir() Returns the share directory - not implementing it is deprecated since Symfony 7.4.
+ *                              This directory should be used to store data that is shared between all front-end servers.
+ *                              This typically fits application caches.
+ *
  * @author Fabien Potencier <fabien@symfony.com>
  */
 interface KernelInterface extends HttpKernelInterface
@@ -123,7 +127,9 @@ interface KernelInterface extends HttpKernelInterface
      * Returns the build directory.
      *
      * This directory should be used to store build artifacts, and can be read-only at runtime.
-     * Caches written at runtime should be stored in the "cache directory" ({@see KernelInterface::getCacheDir()}).
+     * System caches written at runtime should be stored in the "cache directory" ({@see KernelInterface::getCacheDir()}).
+     * Application caches that are shared between all front-end servers should be stored
+     * in the "share directory" ({@see KernelInterface::getShareDir()}).
      */
     public function getBuildDir(): string;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

While deploying Symfony applications to production servers, I realized we badly miss a way to split the "app" cache pools out of the `var/cache` directory.

The reason is that Symfony apps perform at maximum performance when `var/cache` is mounted on a local disk. Yet this locality requirement isn't compatible with "app" cache pools, which have to be shared between all instances of a multi-front setup. Before using another storage than the filesystem for cache pools, it's quite common to use a shared mount for the `var/cache` folder, precisely to accommodate for app pools, at the detriment of performance for local-only artifacts.

I had this feature on my todo since a few months and forgot about it. Having this in 7.4 would be great: it would provide an out-of-the-box way to best-deploy Symfony apps without touching their code.