### PR TITLE
[Messenger] Fix commands writing to `STDERR` instead of `STDOUT`

### DIFF
--- a/src/Symfony/Component/Messenger/Command/AbstractFailedMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/AbstractFailedMessagesCommand.php
@@ -72,8 +72,10 @@ abstract class AbstractFailedMessagesCommand extends Command
         return $stamp?->getId();
     }
 
-    protected function displaySingleMessage(Envelope $envelope, SymfonyStyle $io): void
+    protected function displaySingleMessage(Envelope $envelope, SymfonyStyle $io, ?SymfonyStyle $errorIo = null): void
     {
+        $errorIo ??= $io->getErrorStyle();
+
         $io->title('Failed Message Details');
 
         /** @var SentToFailureTransportStamp|null $sentToFailureTransportStamp */
@@ -94,7 +96,7 @@ abstract class AbstractFailedMessagesCommand extends Command
         }
 
         if (null === $sentToFailureTransportStamp) {
-            $io->warning('Message does not appear to have been sent to this transport after failing');
+            $errorIo->warning('Message does not appear to have been sent to this transport after failing');
         } else {
             $failedAt = '';
             $errorMessage = '';
@@ -133,7 +135,7 @@ abstract class AbstractFailedMessagesCommand extends Command
         if ($io->isVeryVerbose()) {
             $io->title('Message:');
             if (null !== $lastMessageDecodingFailedStamp) {
-                $io->error('The message could not be decoded. See below an APPROXIMATIVE representation of the class.');
+                $errorIo->error('The message could not be decoded. See below an APPROXIMATIVE representation of the class.');
             }
             $dump = new Dumper($io, null, $this->createCloner());
             $io->writeln($dump($envelope->getMessage()));
@@ -142,7 +144,7 @@ abstract class AbstractFailedMessagesCommand extends Command
             $io->writeln(null === $flattenException ? '(no data)' : $dump($flattenException));
         } else {
             if (null !== $lastMessageDecodingFailedStamp) {
-                $io->error('The message could not be decoded.');
+                $errorIo->error('The message could not be decoded.');
             }
             $io->writeln(' Re-run command with <info>-vv</info> to see more message & error details.');
         }

--- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
@@ -23,7 +23,6 @@ use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -133,7 +132,7 @@ EOF
      */
     protected function interact(InputInterface $input, OutputInterface $output)
     {
-        $io = new SymfonyStyle($input, $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output);
+        $io = new SymfonyStyle($input, $output);
 
         if ($this->receiverNames && !$input->getArgument('receivers')) {
             if (1 === \count($this->receiverNames)) {
@@ -215,19 +214,20 @@ EOF
 
         $stopsWhen[] = 'received a stop signal via the messenger:stop-workers command';
 
-        $io = new SymfonyStyle($input, $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output);
+        $io = new SymfonyStyle($input, $output);
+        $errorIo = $io->getErrorStyle();
         $io->success(\sprintf('Consuming messages from transport%s "%s".', \count($receivers) > 1 ? 's' : '', implode(', ', $receiverNames)));
 
         if ($stopsWhen) {
             $last = array_pop($stopsWhen);
             $stopsWhen = ($stopsWhen ? implode(', ', $stopsWhen).' or ' : '').$last;
-            $io->comment("The worker will automatically exit once it has {$stopsWhen}.");
+            $errorIo->comment("The worker will automatically exit once it has {$stopsWhen}.");
         }
 
-        $io->comment('Quit the worker with CONTROL-C.');
+        $errorIo->comment('Quit the worker with CONTROL-C.');
 
         if (OutputInterface::VERBOSITY_VERBOSE > $output->getVerbosity()) {
-            $io->comment('Re-run the command with a -vv option to see logs about consumed messages.');
+            $errorIo->comment('Re-run the command with a -vv option to see logs about consumed messages.');
         }
 
         $bus = $input->getOption('bus') ? $this->routableBus->getMessageBus($input->getOption('bus')) : $this->routableBus;

--- a/src/Symfony/Component/Messenger/Command/StatsCommand.php
+++ b/src/Symfony/Component/Messenger/Command/StatsCommand.php
@@ -16,7 +16,6 @@ use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
@@ -60,7 +59,8 @@ EOF
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $io = new SymfonyStyle($input, $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output);
+        $io = new SymfonyStyle($input, $output);
+        $errorIo = $io->getErrorStyle();
 
         $transportNames = $this->transportNames;
         if ($input->getArgument('transport_names')) {
@@ -71,7 +71,7 @@ EOF
         $uncountableTransports = [];
         foreach ($transportNames as $transportName) {
             if (!$this->transportLocator->has($transportName)) {
-                $io->warning(\sprintf('The "%s" transport does not exist.', $transportName));
+                $errorIo->warning(\sprintf('The "%s" transport does not exist.', $transportName));
 
                 continue;
             }
@@ -87,7 +87,7 @@ EOF
         $io->table(['Transport', 'Count'], $outputTable);
 
         if ($uncountableTransports) {
-            $io->note(\sprintf('Unable to get message count for the following transports: "%s".', implode('", "', $uncountableTransports)));
+            $errorIo->note(\sprintf('Unable to get message count for the following transports: "%s".', implode('", "', $uncountableTransports)));
         }
 
         return 0;

--- a/src/Symfony/Component/Messenger/Command/StopWorkersCommand.php
+++ b/src/Symfony/Component/Messenger/Command/StopWorkersCommand.php
@@ -15,7 +15,6 @@ use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnRestartSignalListener;
@@ -54,7 +53,7 @@ EOF
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $io = new SymfonyStyle($input, $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output);
+        $io = new SymfonyStyle($input, $output);
 
         $cacheItem = $this->restartSignalCachePool->getItem(StopWorkerOnRestartSignalListener::RESTART_REQUESTED_TIMESTAMP_KEY);
         $cacheItem->set(microtime(true));

--- a/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
@@ -280,4 +280,74 @@ class ConsumeMessagesCommandTest extends TestCase
         yield 'receiver (no repeat)' => [['async', ''], ['async_high', 'failed']];
         yield 'option --bus' => [['--bus', ''], ['messenger.bus.default']];
     }
+
+    public function testSuccessMessageGoesToStdout()
+    {
+        $envelope = new Envelope(new \stdClass(), [new BusNameStamp('dummy-bus')]);
+
+        $receiver = $this->createMock(ReceiverInterface::class);
+        $receiver->expects($this->once())->method('get')->willReturn([$envelope]);
+
+        $receiverLocator = $this->createMock(ContainerInterface::class);
+        $receiverLocator->expects($this->once())->method('has')->with('dummy-receiver')->willReturn(true);
+        $receiverLocator->expects($this->once())->method('get')->with('dummy-receiver')->willReturn($receiver);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->once())->method('dispatch');
+
+        $busLocator = $this->createMock(ContainerInterface::class);
+        $busLocator->expects($this->once())->method('has')->with('dummy-bus')->willReturn(true);
+        $busLocator->expects($this->once())->method('get')->with('dummy-bus')->willReturn($bus);
+
+        $command = new ConsumeMessagesCommand(new RoutableMessageBus($busLocator), $receiverLocator, new EventDispatcher());
+
+        $application = new Application();
+        $application->add($command);
+        $tester = new CommandTester($application->get('messenger:consume'));
+        $tester->execute([
+            'receivers' => ['dummy-receiver'],
+            '--limit' => 1,
+        ], ['capture_stderr_separately' => true]);
+
+        $stdout = $tester->getDisplay();
+        $stderr = $tester->getErrorOutput();
+
+        $this->assertStringContainsString('Consuming messages from transport', $stdout);
+        $this->assertStringNotContainsString('Consuming messages from transport', $stderr);
+    }
+
+    public function testCommentsGoToStderr()
+    {
+        $envelope = new Envelope(new \stdClass(), [new BusNameStamp('dummy-bus')]);
+
+        $receiver = $this->createMock(ReceiverInterface::class);
+        $receiver->expects($this->once())->method('get')->willReturn([$envelope]);
+
+        $receiverLocator = $this->createMock(ContainerInterface::class);
+        $receiverLocator->expects($this->once())->method('has')->with('dummy-receiver')->willReturn(true);
+        $receiverLocator->expects($this->once())->method('get')->with('dummy-receiver')->willReturn($receiver);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->once())->method('dispatch');
+
+        $busLocator = $this->createMock(ContainerInterface::class);
+        $busLocator->expects($this->once())->method('has')->with('dummy-bus')->willReturn(true);
+        $busLocator->expects($this->once())->method('get')->with('dummy-bus')->willReturn($bus);
+
+        $command = new ConsumeMessagesCommand(new RoutableMessageBus($busLocator), $receiverLocator, new EventDispatcher());
+
+        $application = new Application();
+        $application->add($command);
+        $tester = new CommandTester($application->get('messenger:consume'));
+        $tester->execute([
+            'receivers' => ['dummy-receiver'],
+            '--limit' => 1,
+        ], ['capture_stderr_separately' => true]);
+
+        $stdout = $tester->getDisplay();
+        $stderr = $tester->getErrorOutput();
+
+        $this->assertStringNotContainsString('Quit the worker with CONTROL-C', $stdout);
+        $this->assertStringContainsString('Quit the worker with CONTROL-C', $stderr);
+    }
 }

--- a/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesRemoveCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesRemoveCommandTest.php
@@ -351,4 +351,73 @@ class FailedMessagesRemoveCommandTest extends TestCase
         $this->assertStringContainsString('Failed Message Details', $tester->getDisplay());
         $this->assertStringContainsString('4 messages were removed.', $tester->getDisplay());
     }
+
+    public function testSuccessMessageGoesToStdout()
+    {
+        $globalFailureReceiverName = 'failure_receiver';
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+
+        $envelope = new Envelope(new \stdClass(), [new TransportMessageIdStamp('some_id')]);
+        $receiver->method('find')->with('some_id')->willReturn($envelope);
+
+        $serviceLocator = $this->createMock(ServiceLocator::class);
+        $serviceLocator->method('has')->willReturn(true);
+        $serviceLocator->method('get')->willReturn($receiver);
+
+        $command = new FailedMessagesRemoveCommand($globalFailureReceiverName, $serviceLocator);
+        $tester = new CommandTester($command);
+        $tester->execute(['id' => ['some_id'], '--force' => true], ['capture_stderr_separately' => true]);
+
+        $stdout = $tester->getDisplay();
+        $stderr = $tester->getErrorOutput();
+
+        $this->assertStringContainsString('Message with id some_id removed', $stdout);
+        $this->assertStringNotContainsString('Message with id some_id removed', $stderr);
+    }
+
+    public function testErrorMessageGoesToStderr()
+    {
+        $globalFailureReceiverName = 'failure_receiver';
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+
+        $receiver->method('find')->with('not_found')->willReturn(null);
+
+        $serviceLocator = $this->createMock(ServiceLocator::class);
+        $serviceLocator->method('has')->willReturn(true);
+        $serviceLocator->method('get')->willReturn($receiver);
+
+        $command = new FailedMessagesRemoveCommand($globalFailureReceiverName, $serviceLocator);
+        $tester = new CommandTester($command);
+        $tester->execute(['id' => ['not_found']], ['capture_stderr_separately' => true]);
+
+        $stdout = $tester->getDisplay();
+        $stderr = $tester->getErrorOutput();
+
+        $this->assertStringNotContainsString('[ERROR]', $stdout);
+        $this->assertStringContainsString('The message with id "not_found" was not found', $stderr);
+    }
+
+    public function testNoteMessageGoesToStderr()
+    {
+        $globalFailureReceiverName = 'failure_receiver';
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+
+        $envelope = new Envelope(new \stdClass(), [new TransportMessageIdStamp('some_id')]);
+        $receiver->method('find')->with('some_id')->willReturn($envelope);
+
+        $serviceLocator = $this->createMock(ServiceLocator::class);
+        $serviceLocator->method('has')->willReturn(true);
+        $serviceLocator->method('get')->willReturn($receiver);
+
+        $command = new FailedMessagesRemoveCommand($globalFailureReceiverName, $serviceLocator);
+        $tester = new CommandTester($command);
+        $tester->setInputs(['no']);
+        $tester->execute(['id' => ['some_id']], ['capture_stderr_separately' => true]);
+
+        $stdout = $tester->getDisplay();
+        $stderr = $tester->getErrorOutput();
+
+        $this->assertStringNotContainsString('[NOTE]', $stdout);
+        $this->assertStringContainsString('Message with id some_id not removed', $stderr);
+    }
 }

--- a/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesRetryCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesRetryCommandTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
 use Symfony\Component\Messenger\Transport\Receiver\ListableReceiverInterface;
+use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
 
 class FailedMessagesRetryCommandTest extends TestCase
 {
@@ -222,5 +223,116 @@ EOF;
         $suggestions = $tester->complete(['--transport', $anotherFailureReceiverName, ' ']);
 
         $this->assertSame(['2ab50dfa1fbf', '78c2da843723'], $suggestions);
+    }
+
+    public function testSuccessMessageGoesToStdout()
+    {
+        $envelope = new Envelope(new \stdClass(), [new TransportMessageIdStamp('some_id')]);
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->method('find')->with('some_id')->willReturn($envelope);
+
+        $serviceLocator = $this->createMock(ServiceLocator::class);
+        $serviceLocator->method('has')->willReturn(true);
+        $serviceLocator->method('get')->willReturn($receiver);
+
+        $command = new FailedMessagesRetryCommand(
+            'failure_receiver',
+            $serviceLocator,
+            $this->createMock(MessageBusInterface::class),
+            new EventDispatcher()
+        );
+
+        $tester = new CommandTester($command);
+        $tester->setInputs(['retry']);
+        $tester->execute(['id' => ['some_id']], ['capture_stderr_separately' => true]);
+
+        $stdout = $tester->getDisplay();
+        $stderr = $tester->getErrorOutput();
+
+        $this->assertStringContainsString('All done!', $stdout);
+        $this->assertStringNotContainsString('All done!', $stderr);
+    }
+
+    public function testCommentsGoToStderr()
+    {
+        $envelope = new Envelope(new \stdClass(), [new TransportMessageIdStamp('some_id')]);
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->method('find')->with('some_id')->willReturn($envelope);
+
+        $serviceLocator = $this->createMock(ServiceLocator::class);
+        $serviceLocator->method('has')->willReturn(true);
+        $serviceLocator->method('get')->willReturn($receiver);
+
+        $command = new FailedMessagesRetryCommand(
+            'failure_receiver',
+            $serviceLocator,
+            $this->createMock(MessageBusInterface::class),
+            new EventDispatcher()
+        );
+
+        $tester = new CommandTester($command);
+        $tester->setInputs(['retry']);
+        $tester->execute(['id' => ['some_id']], ['capture_stderr_separately' => true]);
+
+        $stdout = $tester->getDisplay();
+        $stderr = $tester->getErrorOutput();
+
+        $this->assertStringContainsString('Quit this command with CONTROL-C', $stderr);
+        $this->assertStringNotContainsString('Quit this command with CONTROL-C', $stdout);
+    }
+
+    public function testPendingMessageCountGoesToStdout()
+    {
+        $receiver = new class implements ListableReceiverInterface, MessageCountAwareInterface {
+            public function get(): iterable
+            {
+                return [];
+            }
+
+            public function ack(Envelope $envelope): void
+            {
+            }
+
+            public function reject(Envelope $envelope): void
+            {
+            }
+
+            public function find(mixed $id): ?Envelope
+            {
+                return null;
+            }
+
+            public function all(?int $limit = null): iterable
+            {
+                return [];
+            }
+
+            public function getMessageCount(): int
+            {
+                return 5;
+            }
+        };
+
+        $serviceLocator = $this->createMock(ServiceLocator::class);
+        $serviceLocator->method('has')->willReturn(true);
+        $serviceLocator->method('get')->willReturn($receiver);
+
+        $command = new FailedMessagesRetryCommand(
+            'failure_receiver',
+            $serviceLocator,
+            $this->createMock(MessageBusInterface::class),
+            new EventDispatcher()
+        );
+
+        $tester = new CommandTester($command);
+        $tester->execute(['--force' => true], ['capture_stderr_separately' => true]);
+
+        $stdout = $tester->getDisplay();
+        $stderr = $tester->getErrorOutput();
+
+        $this->assertStringContainsString('There are', $stdout);
+        $this->assertStringContainsString('5', $stdout);
+        $this->assertStringContainsString('messages pending', $stdout);
+        $this->assertStringNotContainsString('messages pending', $stderr);
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Command/StatsCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/StatsCommandTest.php
@@ -116,4 +116,33 @@ class StatsCommandTest extends TestCase
         $this->assertStringNotContainsString('another_message_countable', $display);
         $this->assertStringNotContainsString('! [NOTE] Unable to get message count for the following transports: "simple".', $display);
     }
+
+    public function testTableOutputGoesToStdout()
+    {
+        $tester = new CommandTester($this->command);
+        $tester->execute([], ['capture_stderr_separately' => true]);
+
+        $stdout = $tester->getDisplay();
+        $stderr = $tester->getErrorOutput();
+
+        $this->assertStringContainsString('Transport', $stdout);
+        $this->assertStringContainsString('message_countable', $stdout);
+
+        $this->assertStringContainsString('[WARNING]', $stderr);
+        $this->assertStringContainsString('[NOTE]', $stderr);
+        $this->assertStringNotContainsString('Transport', $stderr);
+    }
+
+    public function testWarningsGoToStderrWithSpecificTransport()
+    {
+        $tester = new CommandTester($this->command);
+        $tester->execute(['transport_names' => ['message_countable']], ['capture_stderr_separately' => true]);
+
+        $stdout = $tester->getDisplay();
+        $stderr = $tester->getErrorOutput();
+
+        $this->assertStringContainsString('message_countable', $stdout);
+        $this->assertStringNotContainsString('[WARNING]', $stderr);
+        $this->assertStringNotContainsString('Transport', $stderr);
+    }
 }

--- a/src/Symfony/Component/Messenger/Tests/Command/StopWorkersCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/StopWorkersCommandTest.php
@@ -32,4 +32,24 @@ class StopWorkersCommandTest extends TestCase
         $tester = new CommandTester($command);
         $tester->execute([]);
     }
+
+    public function testSuccessMessageGoesToStdout()
+    {
+        $cachePool = $this->createMock(CacheItemPoolInterface::class);
+        $cacheItem = $this->createMock(CacheItemInterface::class);
+        $cacheItem->method('set');
+        $cachePool->method('getItem')->willReturn($cacheItem);
+        $cachePool->method('save');
+
+        $command = new StopWorkersCommand($cachePool);
+
+        $tester = new CommandTester($command);
+        $tester->execute([], ['capture_stderr_separately' => true]);
+
+        $stdout = $tester->getDisplay();
+        $stderr = $tester->getErrorOutput();
+
+        $this->assertStringContainsString('Signal successfully sent', $stdout);
+        $this->assertStringNotContainsString('Signal successfully sent', $stderr);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60822
| License       | MIT

Fixes Messenger commands incorrectly routing all output to STDERR, preventing proper piping and redirection of structured data.

Updated commands to follow the established Symfony pattern (e.g., `TranslationUpdateCommand`, `ContainerLintCommand`):
- Create `$io = new SymfonyStyle($input, $output)` for primary output → **STDOUT**
- Create `$errorIo = $io->getErrorStyle()` for diagnostics → **STDERR**

**STDOUT** (parseable data):
- Tables (message lists, statistics)
- Counts ("There are X messages pending")
- Success messages
- Structured output

**STDERR** (supplementary info):
- Errors and warnings
- Informational comments/hints
- Interactive prompts and confirmations
