### PR TITLE
[Validator] Correct PHPDoc for Collection constructor

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Collection.php
+++ b/src/Symfony/Component/Validator/Constraints/Collection.php
@@ -38,10 +38,10 @@ class Collection extends Composite
     public string $missingFieldsMessage = 'This field is missing.';
 
     /**
-     * @param array<string,Constraint>|null $fields             An associative array defining keys in the collection and their constraints
-     * @param string[]|null                 $groups
-     * @param bool|null                     $allowExtraFields   Whether to allow additional keys not declared in the configured fields (defaults to false)
-     * @param bool|null                     $allowMissingFields Whether to allow the collection to lack some fields declared in the configured fields (defaults to false)
+     * @param array<string,Constraint|list<Constraint>>|null $fields             An associative array defining keys in the collection and their constraints
+     * @param string[]|null                                  $groups
+     * @param bool|null                                      $allowExtraFields   Whether to allow additional keys not declared in the configured fields (defaults to false)
+     * @param bool|null                                      $allowMissingFields Whether to allow the collection to lack some fields declared in the configured fields (defaults to false)
      */
     #[HasNamedArguments]
     public function __construct(mixed $fields = null, ?array $groups = null, mixed $payload = null, ?bool $allowExtraFields = null, ?bool $allowMissingFields = null, ?string $extraFieldsMessage = null, ?string $missingFieldsMessage = null)


### PR DESCRIPTION
| Q | A
| ------------- | ---
| Branch? | 7.4
| Bug fix? | yes
| New feature? | no
| Deprecations? | no
| Issues | 
| License | MIT

This PR fixes the PHPDoc for the `Collection` constraint's constructor.

The current type hint for the `$fields` parameter is `@param array<string,Constraint>|null`, which is too strict. It does not allow the documented and valid use case of passing an array (a `list`) of constraints for a single field.

This causes false-positive errors in static analysis tools like PHPStan when using the constraint as intended.

**Example of valid code that fails PHPStan:**

```php
#[Assert\Collection(
    fields: [
        'my_field' => [new Assert\NotBlank(), new Assert\Length(max: 100)], // PHPStan error
    ]
)]
````

**PHPStan Error:**

```
Parameter $fields of attribute class Symfony\Component\Validator\Constraints\Collection constructor expects array<string, Symfony\Component\Validator\Constraint>|null, array<string, list<...>> given.
```

This PR updates the PHPDoc to `array<string,Constraint|list<Constraint>>|null`, which correctly reflects the component's behavior and fixes the static analysis errors.

**Before:**

```php
* @param array<string,Constraint>|null $fields
```

**After:**

```php
* @param array<string,Constraint|list<Constraint>>|null $fields
```