### PR TITLE
 Move readonly keyword from class to properties

### DIFF
--- a/src/Symfony/Component/Console/Interaction/Interaction.php
+++ b/src/Symfony/Component/Console/Interaction/Interaction.php
@@ -19,11 +19,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * @internal
  */
-final readonly class Interaction
+final class Interaction
 {
     public function __construct(
-        private object $owner,
-        private InteractiveAttributeInterface $attribute,
+        private readonly object $owner,
+        private readonly InteractiveAttributeInterface $attribute,
     ) {
     }
 

--- a/src/Symfony/Component/Ldap/Security/AssignDefaultRoles.php
+++ b/src/Symfony/Component/Ldap/Security/AssignDefaultRoles.php
@@ -13,13 +13,13 @@ namespace Symfony\Component\Ldap\Security;
 
 use Symfony\Component\Ldap\Entry;
 
-final readonly class AssignDefaultRoles implements RoleFetcherInterface
+final class AssignDefaultRoles implements RoleFetcherInterface
 {
     /**
      * @param string[] $roles
      */
     public function __construct(
-        private array $roles,
+        private readonly array $roles,
     ) {
     }
 

--- a/src/Symfony/Component/Ldap/Security/MemberOfRoles.php
+++ b/src/Symfony/Component/Ldap/Security/MemberOfRoles.php
@@ -13,15 +13,15 @@ namespace Symfony\Component\Ldap\Security;
 
 use Symfony\Component\Ldap\Entry;
 
-final readonly class MemberOfRoles implements RoleFetcherInterface
+final class MemberOfRoles implements RoleFetcherInterface
 {
     /**
      * @param array<string, string> $mapping
      */
     public function __construct(
-        private array $mapping,
-        private string $attributeName = 'ismemberof',
-        private string $groupNameRegex = '/^CN=(?P<group>[^,]+),ou.*$/i',
+        private readonly array $mapping,
+        private readonly string $attributeName = 'ismemberof',
+        private readonly string $groupNameRegex = '/^CN=(?P<group>[^,]+),ou.*$/i',
     ) {
     }
 

--- a/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Transport/BeanstalkdPriorityStamp.php
+++ b/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Transport/BeanstalkdPriorityStamp.php
@@ -13,10 +13,10 @@ namespace Symfony\Component\Messenger\Bridge\Beanstalkd\Transport;
 
 use Symfony\Component\Messenger\Stamp\StampInterface;
 
-final readonly class BeanstalkdPriorityStamp implements StampInterface
+final class BeanstalkdPriorityStamp implements StampInterface
 {
     public function __construct(
-        public int $priority,
+        public readonly int $priority,
     ) {
     }
 }

--- a/src/Symfony/Component/Serializer/NameConverter/SnakeCaseToCamelCaseNameConverter.php
+++ b/src/Symfony/Component/Serializer/NameConverter/SnakeCaseToCamelCaseNameConverter.php
@@ -18,7 +18,7 @@ use Symfony\Component\Serializer\Exception\UnexpectedPropertyException;
  *
  * @author Kévin Dunglas <kevin@dunglas.dev>
  */
-final readonly class SnakeCaseToCamelCaseNameConverter implements NameConverterInterface
+final class SnakeCaseToCamelCaseNameConverter implements NameConverterInterface
 {
     /**
      * Require all properties to be written in camelCase.
@@ -30,8 +30,8 @@ final readonly class SnakeCaseToCamelCaseNameConverter implements NameConverterI
      * @param bool          $lowerCamelCase Use lowerCamelCase style
      */
     public function __construct(
-        private ?array $attributes = null,
-        private bool $lowerCamelCase = true,
+        private readonly ?array $attributes = null,
+        private readonly bool $lowerCamelCase = true,
     ) {
     }
 

--- a/src/Symfony/Component/TypeInfo/TypeResolver/PhpDocAwareReflectionTypeResolver.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/PhpDocAwareReflectionTypeResolver.php
@@ -30,15 +30,15 @@ use Symfony\Component\TypeInfo\TypeContext\TypeContextFactory;
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  */
-final readonly class PhpDocAwareReflectionTypeResolver implements TypeResolverInterface
+final class PhpDocAwareReflectionTypeResolver implements TypeResolverInterface
 {
-    private PhpDocParser $phpDocParser;
-    private Lexer $lexer;
+    private readonly PhpDocParser $phpDocParser;
+    private readonly Lexer $lexer;
 
     public function __construct(
-        private TypeResolverInterface $reflectionTypeResolver,
-        private TypeResolverInterface $stringTypeResolver,
-        private TypeContextFactory $typeContextFactory,
+        private readonly TypeResolverInterface $reflectionTypeResolver,
+        private readonly TypeResolverInterface $stringTypeResolver,
+        private readonly TypeContextFactory $typeContextFactory,
         ?PhpDocParser $phpDocParser = null,
         ?Lexer $lexer = null,
     ) {

--- a/src/Symfony/Component/TypeInfo/TypeResolver/ReflectionParameterTypeResolver.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/ReflectionParameterTypeResolver.php
@@ -22,11 +22,11 @@ use Symfony\Component\TypeInfo\TypeContext\TypeContextFactory;
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
  */
-final readonly class ReflectionParameterTypeResolver implements TypeResolverInterface
+final class ReflectionParameterTypeResolver implements TypeResolverInterface
 {
     public function __construct(
-        private ReflectionTypeResolver $reflectionTypeResolver,
-        private TypeContextFactory $typeContextFactory,
+        private readonly ReflectionTypeResolver $reflectionTypeResolver,
+        private readonly TypeContextFactory $typeContextFactory,
     ) {
     }
 

--- a/src/Symfony/Component/TypeInfo/TypeResolver/ReflectionPropertyTypeResolver.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/ReflectionPropertyTypeResolver.php
@@ -22,11 +22,11 @@ use Symfony\Component\TypeInfo\TypeContext\TypeContextFactory;
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
  */
-final readonly class ReflectionPropertyTypeResolver implements TypeResolverInterface
+final class ReflectionPropertyTypeResolver implements TypeResolverInterface
 {
     public function __construct(
-        private ReflectionTypeResolver $reflectionTypeResolver,
-        private TypeContextFactory $typeContextFactory,
+        private readonly ReflectionTypeResolver $reflectionTypeResolver,
+        private readonly TypeContextFactory $typeContextFactory,
     ) {
     }
 

--- a/src/Symfony/Component/TypeInfo/TypeResolver/ReflectionReturnTypeResolver.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/ReflectionReturnTypeResolver.php
@@ -22,11 +22,11 @@ use Symfony\Component\TypeInfo\TypeContext\TypeContextFactory;
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
  */
-final readonly class ReflectionReturnTypeResolver implements TypeResolverInterface
+final class ReflectionReturnTypeResolver implements TypeResolverInterface
 {
     public function __construct(
-        private ReflectionTypeResolver $reflectionTypeResolver,
-        private TypeContextFactory $typeContextFactory,
+        private readonly ReflectionTypeResolver $reflectionTypeResolver,
+        private readonly TypeContextFactory $typeContextFactory,
     ) {
     }
 

--- a/src/Symfony/Component/TypeInfo/TypeResolver/TypeResolver.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/TypeResolver.php
@@ -24,13 +24,13 @@ use Symfony\Component\TypeInfo\TypeContext\TypeContextFactory;
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
  */
-final readonly class TypeResolver implements TypeResolverInterface
+final class TypeResolver implements TypeResolverInterface
 {
     /**
      * @param ContainerInterface $resolvers Locator of type resolvers, keyed by supported subject type
      */
     public function __construct(
-        private ContainerInterface $resolvers,
+        private readonly ContainerInterface $resolvers,
     ) {
     }
 

--- a/src/Symfony/Component/Workflow/Arc.php
+++ b/src/Symfony/Component/Workflow/Arc.php
@@ -14,11 +14,11 @@ namespace Symfony\Component\Workflow;
 /**
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  */
-final readonly class Arc
+final class Arc
 {
     public function __construct(
-        public string $place,
-        public int $weight,
+        public readonly string $place,
+        public readonly int $weight,
     ) {
         if ($weight < 1) {
             throw new \InvalidArgumentException(\sprintf('The weight must be greater than 0, %d given.', $weight));

--- a/src/Symfony/Component/Workflow/Debug/ListenerExtractor.php
+++ b/src/Symfony/Component/Workflow/Debug/ListenerExtractor.php
@@ -23,11 +23,11 @@ use Symfony\Component\Workflow\Transition;
  *
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  */
-final readonly class ListenerExtractor
+final class ListenerExtractor
 {
     public function __construct(
-        private ?EventDispatcherInterface $dispatcher = null,
-        private ?FileLinkFormatter $fileLinkFormatter = null,
+        private readonly ?EventDispatcherInterface $dispatcher = null,
+        private readonly ?FileLinkFormatter $fileLinkFormatter = null,
     ) {
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Related to https://github.com/symfony-tools/fabbot/pull/5 and https://github.com/symfony/symfony/pull/62168#issuecomment-3450307615

A few readonly classes remain in fixtures files, but I suppose these should remain as is.