### PR TITLE
[DomCrawler] Properly ignore errors when using the native HTML5 parser

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -1112,8 +1112,12 @@ class Crawler implements \Countable, \IteratorAggregate
         $htmlContent = $document->saveXml();
         $charset = $document->inputEncoding;
 
+        $internalErrors = libxml_use_internal_errors(true);
+
         $dom = new \DOMDocument('1.0', $charset);
         $dom->loadXML($htmlContent);
+
+        libxml_use_internal_errors($internalErrors);
 
         // Register id attributes as ID attributes for getElementById to work
         foreach ((new \DOMXPath($dom))->query('//*[@id]') as $element) {

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\DomCrawler\Tests;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\Error\Notice;
 use PHPUnit\Framework\TestCase;
@@ -22,7 +23,8 @@ use Symfony\Component\DomCrawler\Form;
 use Symfony\Component\DomCrawler\Image;
 use Symfony\Component\DomCrawler\Link;
 
-class CrawlerTestCase extends TestCase
+#[RequiresPhp('>=8.4')]
+class CrawlerTest extends TestCase
 {
     public static function getDoctype(): string
     {
@@ -1376,6 +1378,21 @@ class CrawlerTestCase extends TestCase
         yield 'Several comments' => ['<!--c--> <!--cc-->'.$html];
         yield 'Whitespaces' => ['    '.$html];
         yield 'All together' => [$BOM.'  <!--c-->'.$html];
+    }
+
+    public function testAlpineJs()
+    {
+        $crawler = $this->createCrawler();
+        $crawler->addHtmlContent(file_get_contents(__DIR__.'/Fixtures/alpine-js.html'));
+
+        if (\PHP_VERSION_ID < 80400) {
+            $this->assertCount(1, $crawler->filterXPath('//button'));
+            $this->assertCount(3, $crawler->filterXPath('//div'));
+        } else {
+            // Alpine JS is well known for not having valid HTML tags...
+            $this->assertCount(0, $crawler->filterXPath('//button'));
+            $this->assertCount(0, $crawler->filterXPath('//div'));
+        }
     }
 
     protected function createTestCrawler($uri = null)

--- a/src/Symfony/Component/DomCrawler/Tests/Fixtures/alpine-js.html
+++ b/src/Symfony/Component/DomCrawler/Tests/Fixtures/alpine-js.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Alpine.js Test Page</title>
+    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
+</head>
+<body>
+    <div x-data="{ open: false, message: 'Hello Alpine!' }">
+        <!-- Alpine.js shorthand @ for x-on: -->
+        <button @click="open = !open" class="btn">
+            Toggle
+        </button>
+
+        <!-- Alpine.js shorthand : for x-bind: -->
+        <div x-show="open" :class="open ? 'visible' : 'hidden'">
+            <p x-text="message"></p>
+
+            <!-- More Alpine.js directives -->
+            <input
+                type="text"
+                x-model="message"
+                @input="console.log('Input changed')"
+                @keydown.enter="console.log('Enter pressed')"
+                @click.away="open = false"
+                :disabled="!open"
+                :placeholder="message"
+            >
+
+            <!-- Template with x-for -->
+            <template x-for="(item, index) in [1, 2, 3]" :key="index">
+                <div
+                    @click="console.log(item)"
+                    :aria-selected="index === 0"
+                    :style="`color: red`"
+                >
+                    Item: <span x-text="item"></span>
+                </div>
+            </template>
+        </div>
+    </div>
+</body>
+</html>

--- a/src/Symfony/Component/DomCrawler/Tests/LegacyHtml5ParserCrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/LegacyHtml5ParserCrawlerTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\Attributes\RequiresPhp;
 use Symfony\Component\DomCrawler\Crawler;
 
 #[RequiresPhp('<8.4')]
-class LegacyHtml5ParserCrawlerTest extends CrawlerTestCase
+class LegacyHtml5ParserCrawlerTest extends CrawlerTest
 {
     public function testHtml()
     {

--- a/src/Symfony/Component/DomCrawler/Tests/LegacyParserCrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/LegacyParserCrawlerTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\DomCrawler\Tests;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 
 #[RequiresPhp('<8.4')]
-class LegacyParserCrawlerTest extends CrawlerTestCase
+class LegacyParserCrawlerTest extends CrawlerTest
 {
     public static function getDoctype(): string
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

As suggested by @stof in #62176