### PR TITLE
[Messenger] Add missing auth for Redis Sentinel

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -81,6 +81,15 @@ jobs:
           REDIS_MASTER_HOST: redis
           REDIS_MASTER_SET: redis_sentinel
           REDIS_SENTINEL_QUORUM: 1
+      redis-sentinel-authenticated:
+        image: bitnamilegacy/redis-sentinel:6.2.8
+        ports:
+          - 26380:26379
+        env:
+          REDIS_MASTER_HOST: redis-authenticated
+          REDIS_MASTER_SET: redis_sentinel
+          REDIS_SENTINEL_PASSWORD: p@ssword
+          REDIS_SENTINEL_QUORUM: 1
       redis-primary:
         image: bitnamilegacy/redis:latest
         ports:
@@ -258,7 +267,9 @@ jobs:
           REDIS_AUTHENTICATED_HOST: 'localhost:16380'
           REDIS_CLUSTER_HOSTS: 'localhost:7000 localhost:7001 localhost:7002 localhost:7003 localhost:7004 localhost:7005'
           REDIS_SENTINEL_HOSTS: 'unreachable-host:26379 localhost:26379 localhost:26379'
+          REDIS_SENTINEL_AUTHENTICATED_HOSTS: 'unreachable-host:26380 localhost:26380 localhost:26380'
           REDIS_SENTINEL_SERVICE: redis_sentinel
+          REDIS_SENTINEL_PASSWORD: p@ssword
           REDIS_REPLICATION_HOSTS: 'localhost:16382 localhost:16381'
           MESSENGER_REDIS_DSN: redis://127.0.0.1:7006/messages
           MESSENGER_REDIS_SENTINEL_MASTER: redis_sentinel

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
@@ -152,6 +152,8 @@ class ConnectionTest extends TestCase
         yield 'User and colon' => ['user', 'redis://user:@localhost/queue'];
         yield 'Colon and password' => ['password', 'redis://:password@localhost/queue'];
         yield 'Colon and falsy password' => ['0', 'redis://:0@localhost/queue'];
+        yield 'Password from auth' => ['password', 'redis://'];
+        $dsn = 'redis:?host['.str_replace(' ', ']&host[', getenv('')).']&auth='.getenv('REDIS_SENTINEL_PASSWORD');
     }
 
     public function testAuthFromOptions()
@@ -402,6 +404,56 @@ class ConnectionTest extends TestCase
         yield 'No delay' => ['/^THE_MESSAGE_ID$/', 0, 'xadd', 'THE_MESSAGE_ID'];
 
         yield '100ms delay' => ['/^[A-Z\d\/+]+$/i', 100, 'rawCommand', '1'];
+    }
+
+    /**
+     * @group integration
+     */
+    public function testSentinelSuccessfulAuthentication()
+    {
+        if (!$hosts = getenv('REDIS_SENTINEL_AUTHENTICATED_HOSTS')) {
+            $this->markTestSkipped('REDIS_SENTINEL_AUTHENTICATED_HOSTS env var is not defined.');
+        }
+
+        if (!$password = getenv('REDIS_SENTINEL_PASSWORD')) {
+            $this->markTestSkipped('REDIS_SENTINEL_PASSWORD env var is not defined.');
+        }
+
+        if (!$master = getenv('MESSENGER_REDIS_SENTINEL_MASTER')) {
+            $this->markTestSkipped('MESSENGER_REDIS_SENTINEL_MASTER env var is not defined.');
+        }
+
+        $hosts = array_map(static fn ($host) => \sprintf('host[%s]', $host), explode(' ', $hosts));
+        $dsn = 'redis://?'.implode('&', $hosts).'&auth='.$password;
+
+        try {
+            Connection::fromDsn($dsn, ['sentinel' => $master, 'lazy' => false]);
+        } catch (\Exception $e) {
+            $this->fail('Failed to Redis Sentinel authentication: '.$e->getMessage());
+        }
+    }
+
+    /**
+     * @group integration
+     */
+    public function testSentinelFailedAuthentication()
+    {
+        if (!$hosts = getenv('REDIS_SENTINEL_AUTHENTICATED_HOSTS')) {
+            $this->markTestSkipped('REDIS_SENTINEL_AUTHENTICATED_HOSTS env var is not defined.');
+        }
+
+        if (!$master = getenv('MESSENGER_REDIS_SENTINEL_MASTER')) {
+            $this->markTestSkipped('MESSENGER_REDIS_SENTINEL_MASTER env var is not defined.');
+        }
+
+        $hosts = array_map(static fn ($host) => \sprintf('host[%s]', $host), explode(' ', $hosts));
+        $password = 'wr0ngpassword';
+        $dsn = 'redis://?'.implode('&', $hosts).'&auth='.$password;
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/Redis connection failed/');
+
+        Connection::fromDsn($dsn, ['sentinel' => $master, 'lazy' => false]);
     }
 
     /**

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -115,6 +115,7 @@ class Connection
                     $sentinelClass = \extension_loaded('redis') ? \RedisSentinel::class : Sentinel::class;
                     $hostIndex = 0;
                     $hosts = \is_array($host) ? $host : [['scheme' => 'tcp', 'host' => $host, 'port' => $port]];
+                    $passAuth = isset($auth) && (!\extension_loaded('redis') || \defined('Redis::OPT_NULL_MULTIBULK_AS_NULL'));
                     do {
                         $host = $hosts[$hostIndex]['host'];
                         $port = $hosts[$hostIndex]['port'] ?? 0;
@@ -136,9 +137,15 @@ class Connection
                                     'readTimeout' => $options['read_timeout'],
                                 ];
 
+                                if ($passAuth) {
+                                    $params['auth'] = $auth;
+                                }
+
                                 $sentinel = @new \RedisSentinel($params);
                             } else {
-                                $sentinel = @new $sentinelClass($host, $port, $options['timeout'], $options['persistent_id'], $options['retry_interval'], $options['read_timeout']);
+                                $extra = $passAuth ? [$auth] : [];
+
+                                $sentinel = @new $sentinelClass($host, $port, $options['timeout'], $options['persistent_id'], $options['retry_interval'], $options['read_timeout'], ...$extra);
                             }
 
                             if ($address = @$sentinel->getMasterAddrByName($sentinelMaster)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

When getting the master server in redis transport via sentinel, auth was omitted. Used code similar to [Cache/Traits/RedisTrait.php#L243](https://github.com/symfony/symfony/blob/7.4/src/Symfony/Component/Cache/Traits/RedisTrait.php#L243)

