### PR TITLE
[EventDispatcher][FrameworkBundle] Rework union types on `#[AsEventListener]`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -779,32 +779,13 @@ class FrameworkExtension extends Extension
 
         $container->registerAttributeForAutoconfiguration(AsEventListener::class, static function (ChildDefinition $definition, AsEventListener $attribute, \ReflectionClass|\ReflectionMethod $reflector) {
             $tagAttributes = get_object_vars($attribute);
-
-            if (!$reflector instanceof \ReflectionMethod) {
-                $definition->addTag('kernel.event_listener', $tagAttributes);
-
-                return;
-            }
-
-            if (isset($tagAttributes['method'])) {
-                throw new LogicException(\sprintf('AsEventListener attribute cannot declare a method on "%s::%s()".', $reflector->class, $reflector->name));
-            }
-
-            $tagAttributes['method'] = $reflector->getName();
-
-            if (!$eventArg = $reflector->getParameters()[0] ?? null) {
-                throw new LogicException(\sprintf('AsEventListener attribute requires the first argument of "%s::%s()" to be an event object.', $reflector->class, $reflector->name));
-            }
-
-            $types = ($type = $eventArg->getType() instanceof \ReflectionUnionType ? $eventArg->getType()->getTypes() : [$eventArg->getType()]) ?: [];
-
-            foreach ($types as $type) {
-                if ($type instanceof \ReflectionNamedType && !$type->isBuiltin()) {
-                    $tagAttributes['event'] = $type->getName();
-
-                    $definition->addTag('kernel.event_listener', $tagAttributes);
+            if ($reflector instanceof \ReflectionMethod) {
+                if (isset($tagAttributes['method'])) {
+                    throw new LogicException(\sprintf('AsEventListener attribute cannot declare a method on "%s::%s()".', $reflector->class, $reflector->name));
                 }
+                $tagAttributes['method'] = $reflector->getName();
             }
+            $definition->addTag('kernel.event_listener', $tagAttributes);
         });
         $container->registerAttributeForAutoconfiguration(AsController::class, static function (ChildDefinition $definition, AsController $attribute): void {
             $definition->addTag('controller.service_arguments');

--- a/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php
+++ b/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php
@@ -65,19 +65,27 @@ class RegisterListenersPass implements CompilerPassInterface
         foreach ($container->findTaggedServiceIds('kernel.event_listener', true) as $id => $events) {
             $noPreload = 0;
 
+            $resolvedEvents = [];
             foreach ($events as $event) {
-                $priority = $event['priority'] ?? 0;
-
                 if (!isset($event['event'])) {
                     if ($container->getDefinition($id)->hasTag('kernel.event_subscriber')) {
                         continue;
                     }
 
                     $event['method'] ??= '__invoke';
-                    $event['event'] = $this->getEventFromTypeDeclaration($container, $id, $event['method']);
+                    $eventNames = $this->getEventFromTypeDeclaration($container, $id, $event['method']);
+                } else {
+                    $eventNames = [$event['event']];
                 }
 
-                $event['event'] = $aliases[$event['event']] ?? $event['event'];
+                foreach ($eventNames as $eventName) {
+                    $event['event'] = $aliases[$eventName] ?? $eventName;
+                    $resolvedEvents[] = $event;
+                }
+            }
+
+            foreach ($resolvedEvents as $event) {
+                $priority = $event['priority'] ?? 0;
 
                 if (!isset($event['method'])) {
                     $event['method'] = 'on'.preg_replace_callback([
@@ -167,21 +175,40 @@ class RegisterListenersPass implements CompilerPassInterface
         }
     }
 
-    private function getEventFromTypeDeclaration(ContainerBuilder $container, string $id, string $method): string
+    /**
+     * @return string[]
+     */
+    private function getEventFromTypeDeclaration(ContainerBuilder $container, string $id, string $method): array
     {
         if (
             null === ($class = $container->getDefinition($id)->getClass())
             || !($r = $container->getReflectionClass($class, false))
             || !$r->hasMethod($method)
             || 1 > ($m = $r->getMethod($method))->getNumberOfParameters()
-            || !($type = $m->getParameters()[0]->getType()) instanceof \ReflectionNamedType
-            || $type->isBuiltin()
-            || Event::class === ($name = $type->getName())
+            || !(($type = $m->getParameters()[0]->getType()) instanceof \ReflectionNamedType || $type instanceof \ReflectionUnionType)
         ) {
             throw new InvalidArgumentException(\sprintf('Service "%s" must define the "event" attribute on "kernel.event_listener" tags.', $id));
         }
 
-        return $name;
+        $types = $type instanceof \ReflectionUnionType ? $type->getTypes() : [$type];
+
+        $names = [];
+        foreach ($types as $type) {
+            if (!$type instanceof \ReflectionNamedType
+                || $type->isBuiltin()
+                || Event::class === ($name = $type->getName())
+            ) {
+                continue;
+            }
+
+            $names[] = $name;
+        }
+
+        if (!$names) {
+            throw new InvalidArgumentException(\sprintf('Service "%s" must define the "event" attribute on "kernel.event_listener" tags.', $id));
+        }
+
+        return $names;
     }
 }
 

--- a/src/Symfony/Component/EventDispatcher/Tests/DependencyInjection/RegisterListenersPassTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/DependencyInjection/RegisterListenersPassTest.php
@@ -12,14 +12,13 @@
 namespace Symfony\Component\EventDispatcher\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
-use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\AttributeAutoconfigurationPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveInstanceofConditionalsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\EventDispatcher\DependencyInjection\AddEventAliasesPass;
 use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -275,10 +274,7 @@ class RegisterListenersPassTest extends TestCase
 
     public function testTaggedInvokableEventListener()
     {
-        $container = new ContainerBuilder();
-        $container->registerAttributeForAutoconfiguration(AsEventListener::class, static function (ChildDefinition $definition, AsEventListener $attribute): void {
-            $definition->addTag('kernel.event_listener', get_object_vars($attribute));
-        });
+        $container = $this->createContainerBuilder();
         $container->register('foo', TaggedInvokableListener::class)->setAutoconfigured(true);
         $container->register('event_dispatcher', \stdClass::class);
 
@@ -297,21 +293,12 @@ class RegisterListenersPassTest extends TestCase
                 ],
             ],
         ];
-        $this->assertEquals($expectedCalls, $definition->getMethodCalls());
+        $this->assertEquals($expectedCalls, \array_slice($definition->getMethodCalls(), 0, \count($expectedCalls)));
     }
 
     public function testTaggedMultiEventListener()
     {
-        $container = new ContainerBuilder();
-        $container->registerAttributeForAutoconfiguration(AsEventListener::class,
-            static function (ChildDefinition $definition, AsEventListener $attribute, \ReflectionClass|\ReflectionMethod $reflector): void {
-                $tagAttributes = get_object_vars($attribute);
-                if ($reflector instanceof \ReflectionMethod) {
-                    $tagAttributes['method'] = $reflector->getName();
-                }
-                $definition->addTag('kernel.event_listener', $tagAttributes);
-            }
-        );
+        $container = $this->createContainerBuilder();
 
         $container->register('foo', TaggedMultiListener::class)->setAutoconfigured(true);
         $container->register('event_dispatcher', \stdClass::class);
@@ -355,42 +342,12 @@ class RegisterListenersPassTest extends TestCase
                 ],
             ],
         ];
-        $this->assertEquals($expectedCalls, $definition->getMethodCalls());
+        $this->assertEquals($expectedCalls, \array_slice($definition->getMethodCalls(), 0, \count($expectedCalls)));
     }
 
     public function testTaggedMethodUnionTypeEventListener()
     {
-        $container = new ContainerBuilder();
-        $container->registerAttributeForAutoconfiguration(AsEventListener::class,
-            static function (ChildDefinition $definition, AsEventListener $attribute, \ReflectionClass|\ReflectionMethod $reflector) {
-                $tagAttributes = get_object_vars($attribute);
-
-                if (!$reflector instanceof \ReflectionMethod) {
-                    $definition->addTag('kernel.event_listener', $tagAttributes);
-
-                    return;
-                }
-
-                if (isset($tagAttributes['method'])) {
-                    throw new \LogicException(\sprintf('AsEventListener attribute cannot declare a method on "%s::%s()".', $reflector->class, $reflector->name));
-                }
-
-                $tagAttributes['method'] = $reflector->getName();
-
-                if (!$eventArg = $reflector->getParameters()[0] ?? null) {
-                    throw new \LogicException(\sprintf('AsEventListener attribute requires the first argument of "%s::%s()" to be an event object.', $reflector->class, $reflector->name));
-                }
-
-                $types = ($type = $eventArg->getType() instanceof \ReflectionUnionType ? $eventArg->getType()->getTypes() : [$eventArg->getType()]) ?: [];
-
-                foreach ($types as $type) {
-                    if ($type instanceof \ReflectionNamedType && !$type->isBuiltin()) {
-                        $tagAttributes['event'] = $type->getName();
-
-                        $definition->addTag('kernel.event_listener', $tagAttributes);
-                    }
-                }
-            });
+        $container = $this->createContainerBuilder();
 
         $container->register('foo', TaggedUnionTypeListener::class)->setAutoconfigured(true);
         $container->register('event_dispatcher', \stdClass::class);
@@ -419,7 +376,7 @@ class RegisterListenersPassTest extends TestCase
             ],
         ];
 
-        $this->assertEquals($expectedCalls, $definition->getMethodCalls());
+        $this->assertEquals($expectedCalls, \array_slice($definition->getMethodCalls(), 0, \count($expectedCalls)));
     }
 
     public function testAliasedEventListener()
@@ -568,6 +525,17 @@ class RegisterListenersPassTest extends TestCase
             ],
         ];
         $this->assertEquals($expectedCalls, $definition->getMethodCalls());
+    }
+
+    private function createContainerBuilder(): ContainerBuilder
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.debug', true);
+        $container->setParameter('kernel.project_dir', __DIR__);
+        $container->setParameter('kernel.container_class', 'testContainer');
+        (new FrameworkExtension())->load([], $container);
+
+        return $container;
     }
 }
 

--- a/src/Symfony/Component/EventDispatcher/composer.json
+++ b/src/Symfony/Component/EventDispatcher/composer.json
@@ -24,6 +24,7 @@
         "symfony/expression-language": "^6.4|^7.0|^8.0",
         "symfony/config": "^6.4|^7.0|^8.0",
         "symfony/error-handler": "^6.4|^7.0|^8.0",
+        "symfony/framework-bundle": "^6.4|^7.0|^8.0",
         "symfony/http-foundation": "^6.4|^7.0|^8.0",
         "symfony/service-contracts": "^2.5|^3",
         "symfony/stopwatch": "^6.4|^7.0|^8.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This is a reimplementation of #61252.
The previous PR introduced a backward compatibility break.

Consider the following listener:

```php
final class TestListener
{
    #[AsEventListener(event: RequestEvent::class)]
    public function onRequestEvent(): void
    {
        // ...
    }
}
```

In earlier versions, this worked fine, but now it throws:

> AsEventListener attribute requires the first argument of "App\EventListener\TestListener::onRequestEvent()" to be an event object.

Interestingly, there *was* a test for this scenario, but since each test method re-defines the `registerAttributeForAutoconfiguration()` closure (which wasn't updated everywhere), the tests still passed.

Additionally, the implementation was added to the `FrameworkExtension`, even though similar logic already existed in `RegisterListenersPass::getEventFromTypeDeclaration()`, resulting in a decentralized implementation.

This PR reverts the changes in `FrameworkExtension` and re-implements the feature in `RegisterListenersPass`.
The tests now reuse the closure from `FrameworkExtension` to make them more robust and consistent with the actual implementation.
