### PR TITLE
 Make clearer where the cache is stored

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1344,7 +1344,7 @@ class Configuration implements ConfigurationInterface
                             ->info('System related cache pools configuration.')
                             ->defaultValue('cache.adapter.system')
                         ->end()
-                        ->scalarNode('directory')->defaultValue('%kernel.share_dir%/pools/app')->end()
+                        ->scalarNode('directory')->defaultValue('%kernel.share_dir%/cache/pools/app')->end()
                         ->scalarNode('default_psr6_provider')->end()
                         ->scalarNode('default_redis_provider')->defaultValue('redis://localhost')->end()
                         ->scalarNode('default_valkey_provider')->defaultValue('valkey://localhost')->end()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -854,7 +854,7 @@ class ConfigurationTest extends TestCase
                 'pools' => [],
                 'app' => 'cache.adapter.filesystem',
                 'system' => 'cache.adapter.system',
-                'directory' => '%kernel.share_dir%/pools/app',
+                'directory' => '%kernel.share_dir%/cache/pools/app',
                 'default_redis_provider' => 'redis://localhost',
                 'default_valkey_provider' => 'valkey://localhost',
                 'default_memcached_provider' => 'memcached://localhost',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | yes <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? |no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

Related to: https://github.com/symfony/symfony/pull/62170 @nicolas-grekas changes.


I think `var/share/pools` is not very transparent, and would say that `var/share/cache/pools` would make it more transparent for what the directory is used. That `var/share/cache` can then be used to store also other shared caches.

I think it will be kind of common to have maybe a shared directory like:

 - `var/share`
    - `cache`
      - `pools`
      - `http_cache`
      - ...
    - `storage` (flysystem)
    - `db` (sqlite)

    
I'm aware we can not do this change for 7.4 so I would do this in 8.0 and do it as recipe change in `7.4` already, what do you think? This make cache clearings easier as it can be done on `var/share/cache` and `var/cache` dirs.