### PR TITLE
[FrameworkBundle] Change HttpCache directory to use new getShareDir

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/HttpCache/HttpCache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/HttpCache/HttpCache.php
@@ -83,6 +83,6 @@ class HttpCache extends BaseHttpCache
 
     protected function createStore(): StoreInterface
     {
-        return $this->store ?? new Store($this->cacheDir ?: $this->kernel->getCacheDir().'/http_cache');
+        return $this->store ?? new Store($this->cacheDir ?: $this->kernel->getShareDir().'/http_cache');
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
@@ -116,7 +116,7 @@ return static function (ContainerConfigurator $container) {
 
         ->set('http_cache.store', Store::class)
             ->args([
-                param('kernel.cache_dir').'/http_cache',
+                param('kernel.share_dir').'/http_cache',
             ])
         ->alias(StoreInterface::class, 'http_cache.store')
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

In @sulu we are already using for app caches and http caches a shared directory root directory the last years, because we had a 2 kernel setup (var/cache/admin, var/cache/website) where both caches are shared (var/cache/common) between the application. With 

Symfony also adding similar things in #62170 providing share dir for the app caches I think it make sense to include the http cache there as its also more like an app cache.
