### PR TITLE
 Fix the initialization of the phpunit bridge

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/bootstrap.php
+++ b/src/Symfony/Bridge/PhpUnit/bootstrap.php
@@ -13,7 +13,7 @@ use Doctrine\Deprecations\Deprecation;
 use Symfony\Bridge\PhpUnit\DeprecationErrorHandler;
 
 // Skip if we're using PHPUnit >=10
-if (class_exists(PHPUnit\Metadata\Metadata::class, false)) {
+if (class_exists(PHPUnit\Metadata\Metadata::class)) {
     return;
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

When PHPUnit is installed through composer, the bootstrap.php file will be loaded *before* the `Metadata` class is autoloaded by PHPUnit itself. This was breaking the skipping of the initialization, which broke deprecation reporting by mixing the old system and PHPUnit 11 in my case.
Before https://github.com/symfony/symfony/pull/61863, the old checks were triggering autoloading.
