### PR TITLE
[Validator] Fix call to undefined getParser() in YamlValidator

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/YamlValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/YamlValidator.php
@@ -39,17 +39,19 @@ class YamlValidator extends ConstraintValidator
 
         $value = (string) $value;
 
+        $parser = new Parser();
+
         /** @see \Symfony\Component\Yaml\Command\LintCommand::validate() */
-        $prevErrorHandler = set_error_handler(function ($level, $message, $file, $line) use (&$prevErrorHandler) {
+        $prevErrorHandler = set_error_handler(static function ($level, $message, $file, $line) use (&$prevErrorHandler, $parser) {
             if (\E_USER_DEPRECATED === $level) {
-                throw new ParseException($message, $this->getParser()->getRealCurrentLineNb() + 1);
+                throw new ParseException($message, $parser->getRealCurrentLineNb() + 1);
             }
 
             return $prevErrorHandler ? $prevErrorHandler($level, $message, $file, $line) : false;
         });
 
         try {
-            (new Parser())->parse($value, $constraint->flags);
+            $parser->parse($value, $constraint->flags);
         } catch (ParseException $e) {
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ error }}', $e->getMessage())

--- a/src/Symfony/Component/Validator/Tests/Constraints/YamlValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/YamlValidatorTest.php
@@ -71,6 +71,27 @@ class YamlValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
+    /**
+     * @dataProvider getDeprecationOnLinesData
+     */
+    public function testDeprecationTriggersParseException(int $yamlLine, string $yamlValue)
+    {
+        $lines = explode("\n", $yamlValue);
+        $errorLine = end($lines);
+        $expectedError = 'This is a simulated deprecation at line '.$yamlLine.' (near "'.$errorLine.'")';
+
+        $constraint = new Yaml(
+            message: 'myMessageTest',
+            flags: YamlParser::PARSE_OBJECT,
+        );
+        $this->validator->validate($yamlValue, $constraint);
+        $this->buildViolation('myMessageTest')
+            ->setParameter('{{ error }}', $expectedError)
+            ->setParameter('{{ line }}', $yamlLine)
+            ->setCode(Yaml::INVALID_YAML_ERROR)
+            ->assertRaised();
+    }
+
     public static function getValidValues()
     {
         return [
@@ -93,5 +114,35 @@ class YamlValidatorTest extends ConstraintValidatorTestCase
             ['{:INVALID]', 'Malformed unquoted YAML string at line 1 (near "{:INVALID]").', 1],
             ["key:\nvalue", 'Unable to parse at line 2 (near "value").', 2],
         ];
+    }
+
+    /**
+     * @return array<string, array{0: int, 1: string}>
+     */
+    public static function getDeprecationOnLinesData(): array
+    {
+        $serialized = serialize(new DeprecatedObjectFixture());
+
+        return [
+            'deprecation at line 1' => [1, "object: !php/object '".$serialized."'"],
+            'deprecation at line 2' => [2, "valid: yaml\nobject: !php/object '".$serialized."'"],
+            'deprecation at line 5' => [5, "line1: value\nline2: value\nline3: value\nline4: value\nobject: !php/object '".$serialized."'"],
+        ];
+    }
+}
+
+/**
+ * Fixture class for triggering deprecation during unserialize.
+ */
+class DeprecatedObjectFixture
+{
+    public function __serialize(): array
+    {
+        return [];
+    }
+
+    public function __unserialize(array $data): void
+    {
+        @trigger_error('This is a simulated deprecation', \E_USER_DEPRECATED);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | n/a
| License       | MIT

The `set_error_handler` closure was calling the non-existent method `getParser()`, which would cause a fatal error if a deprecation were ever triggered during parsing.

The fix instantiates the `Parser` as a local variable and passes it to the closure, resolving the issue and ensuring the validator remains stateless.
