### PR TITLE
[HtmlSanitizer] Remove `srcdoc` from allowed attributes

### DIFF
--- a/src/Symfony/Component/HtmlSanitizer/Reference/W3CReference.php
+++ b/src/Symfony/Component/HtmlSanitizer/Reference/W3CReference.php
@@ -368,7 +368,7 @@ final class W3CReference
         'span' => true,
         'spellcheck' => true,
         'src' => true,
-        'srcdoc' => true,
+        // 'srcdoc' => false, // XSS vector if not properly sandboxed, should be enabled explicitly with ->allowAttribute('srcdoc', 'iframe')->forceAttribute('iframe', 'sandbox', '')
         'srclang' => true,
         'srcset' => true,
         'standby' => true,

--- a/src/Symfony/Component/HtmlSanitizer/Tests/Fixtures/baseline-attribute-allow-list.json
+++ b/src/Symfony/Component/HtmlSanitizer/Tests/Fixtures/baseline-attribute-allow-list.json
@@ -182,7 +182,6 @@
   "span",
   "spellcheck",
   "src",
-  "srcdoc",
   "srclang",
   "srcset",
   "standby",

--- a/src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerAllTest.php
+++ b/src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerAllTest.php
@@ -568,6 +568,23 @@ class HtmlSanitizerAllTest extends TestCase
         }
     }
 
+    public function testIFrameDefaultsAreSafe()
+    {
+        $sanitizer = new HtmlSanitizer((new HtmlSanitizerConfig())
+            ->allowElement('iframe', '*')
+        );
+        $input = '<iframe src="javascript:alert()" onload="alert()" srcdoc="<script>alert()</script>">XSS</iframe>';
+        $this->assertSame('<iframe>XSS</iframe>', $sanitizer->sanitize($input));
+
+        $sanitizer = new HtmlSanitizer((new HtmlSanitizerConfig())
+            ->allowElement('iframe', '*')
+            ->allowAttribute('srcdoc', 'iframe')
+            ->forceAttribute('iframe', 'sandbox', '')
+        );
+        $input = '<iframe src="javascript:alert()" onload="alert()" srcdoc="<script>alert()</script>">XSS-prevented by sandbox</iframe>';
+        $this->assertSame('<iframe srcdoc="&lt;script&gt;alert()&lt;/script&gt;" sandbox>XSS-prevented by sandbox</iframe>', $sanitizer->sanitize($input));
+    }
+
     public function testUnlimitedLength()
     {
         $sanitizer = new HtmlSanitizer((new HtmlSanitizerConfig())->withMaxInputLength(-1));

--- a/src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerConfigTest.php
+++ b/src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerConfigTest.php
@@ -109,7 +109,7 @@ class HtmlSanitizerConfigTest extends TestCase
         $config = new HtmlSanitizerConfig();
         $config = $config->allowElement('div', '*');
         $this->assertSame(['div'], array_keys($config->getAllowedElements()));
-        $this->assertCount(211, $config->getAllowedElements()['div']);
+        $this->assertCount(210, $config->getAllowedElements()['div']);
         $this->assertSame([], $config->getBlockedElements());
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The `srcdoc` attribute is unlisted from the standard attributes to prevent potential misconfiguration. It must now be explicitly enabled, and it is STRONGLY advised to `->forceAttribute('iframe', 'sandbox', '')` when doing so.

Submitting as a bugfix because the current defaults are a foot-gun.
