### PR TITLE
[HttpKernel] Make Kernel::getShareDir() nullable

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
@@ -82,7 +82,7 @@ class AboutCommand extends Command
             ['Charset', $kernel->getCharset()],
             ['Cache directory', self::formatPath($kernel->getCacheDir(), $kernel->getProjectDir()).' (<comment>'.self::formatFileSize($kernel->getCacheDir()).'</>)'],
             ['Build directory', self::formatPath($buildDir, $kernel->getProjectDir()).' (<comment>'.self::formatFileSize($buildDir).'</>)'],
-            ['Share directory', self::formatPath($shareDir, $kernel->getProjectDir()).' (<comment>'.self::formatFileSize($shareDir).'</>)'],
+            ['Share directory', null === $shareDir ? 'none' : self::formatPath($shareDir, $kernel->getProjectDir()).' (<comment>'.self::formatFileSize($shareDir).'</>)'],
             ['Log directory', self::formatPath($kernel->getLogDir(), $kernel->getProjectDir()).' (<comment>'.self::formatFileSize($kernel->getLogDir()).'</>)'],
             new TableSeparator(),
             ['<info>PHP</>'],

--- a/src/Symfony/Bundle/FrameworkBundle/HttpCache/HttpCache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/HttpCache/HttpCache.php
@@ -83,6 +83,6 @@ class HttpCache extends BaseHttpCache
 
     protected function createStore(): StoreInterface
     {
-        return $this->store ?? new Store($this->cacheDir ?: $this->kernel->getShareDir().'/http_cache');
+        return $this->store ?? new Store($this->cacheDir ?: ($this->kernel->getShareDir() ?? $this->kernel->getCacheDir()).'/http_cache');
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
@@ -124,10 +124,15 @@ trait MicroKernelTrait
         return parent::getBuildDir();
     }
 
-    public function getShareDir(): string
+    public function getShareDir(): ?string
     {
         if (isset($_SERVER['APP_SHARE_DIR'])) {
-            return $_SERVER['APP_SHARE_DIR'].'/'.$this->environment;
+            if (false === $dir = filter_var($_SERVER['APP_SHARE_DIR'], \FILTER_VALIDATE_BOOL, \FILTER_NULL_ON_FAILURE) ?? $_SERVER['APP_SHARE_DIR']) {
+                return null;
+            }
+            if (\is_string($dir)) {
+                return $dir.'/'.$this->environment;
+            }
         }
 
         return parent::getShareDir();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
@@ -46,6 +46,49 @@ class MicroKernelTraitTest extends TestCase
         }
     }
 
+    public function testGetShareDirDisabledByEnv()
+    {
+        $previous = $_SERVER['APP_SHARE_DIR'] ?? null;
+        $_SERVER['APP_SHARE_DIR'] = 'false';
+
+        try {
+            $kernel = $this->kernel = new ConcreteMicroKernel('test', false);
+
+            $this->assertNull($kernel->getShareDir());
+
+            $parameters = $kernel->getKernelParameters();
+            $this->assertArrayNotHasKey('kernel.share_dir', $parameters);
+        } finally {
+            if (null === $previous) {
+                unset($_SERVER['APP_SHARE_DIR']);
+            } else {
+                $_SERVER['APP_SHARE_DIR'] = $previous;
+            }
+        }
+    }
+
+    public function testGetShareDirCustomPathFromEnv()
+    {
+        $previous = $_SERVER['APP_SHARE_DIR'] ?? null;
+        $_SERVER['APP_SHARE_DIR'] = sys_get_temp_dir();
+
+        try {
+            $kernel = $this->kernel = new ConcreteMicroKernel('test', false);
+
+            $expected = rtrim(sys_get_temp_dir(), '/').'/test';
+            $this->assertSame($expected, $kernel->getShareDir());
+
+            $parameters = $kernel->getKernelParameters();
+            $this->assertSame($expected, $parameters['kernel.share_dir'] ?? null);
+        } finally {
+            if (null === $previous) {
+                unset($_SERVER['APP_SHARE_DIR']);
+            } else {
+                $_SERVER['APP_SHARE_DIR'] = $previous;
+            }
+        }
+    }
+
     public function test()
     {
         $kernel = $this->kernel = new ConcreteMicroKernel('test', false);

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -303,7 +303,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
         return $this->getCacheDir();
     }
 
-    public function getShareDir(): string
+    public function getShareDir(): ?string
     {
         // Returns $this->getCacheDir() for backward compatibility
         return $this->getCacheDir();
@@ -586,13 +586,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
             'kernel.debug' => $this->debug,
             'kernel.build_dir' => realpath($dir = $this->warmupDir ?: $this->getBuildDir()) ?: $dir,
             'kernel.cache_dir' => realpath($dir = ($this->getCacheDir() === $this->getBuildDir() ? ($this->warmupDir ?: $this->getCacheDir()) : $this->getCacheDir())) ?: $dir,
-            'kernel.share_dir' => realpath($dir = $this->getShareDir()) ?: $dir,
             'kernel.logs_dir' => realpath($dir = $this->getLogDir()) ?: $dir,
             'kernel.bundles' => $bundles,
             'kernel.bundles_metadata' => $bundlesMetadata,
             'kernel.charset' => $this->getCharset(),
             'kernel.container_class' => $this->getContainerClass(),
-        ];
+        ] + (null !== ($dir = $this->getShareDir()) ? ['kernel.share_dir' => realpath($dir) ?: $dir] : []);
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/KernelInterface.php
+++ b/src/Symfony/Component/HttpKernel/KernelInterface.php
@@ -20,9 +20,9 @@ use Symfony\Component\HttpKernel\Bundle\BundleInterface;
  *
  * It manages an environment made of application kernel and bundles.
  *
- * @method string getShareDir() Returns the share directory - not implementing it is deprecated since Symfony 7.4.
- *                              This directory should be used to store data that is shared between all front-end servers.
- *                              This typically fits application caches.
+ * @method string|null getShareDir() Returns the share directory - not implementing it is deprecated since Symfony 7.4.
+ *                                   This directory should be used to store data that is shared between all front-end servers; this typically fits application caches.
+ *                                   `null` should be returned if the application shall not use a share directory.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | #62202
| License       | MIT

This allows specifying explicitly when the app has no share dir.

If the method returns `null`, the `kernel.share_dir` parameter is not defined.
This gives a nice way to spot where references to this parameter remain with `You have requested a non-existent parameter "kernel.share_dir"` exceptions as a hint.

Setting the `APP_SHARE_DIR` env var to any falsy value (`off`, `false`, `0`, etc as supported by `filter_var()`) will lead to configuring the app with no share dir.