### PR TITLE
[Validator] Remove deprecated array type from Expression constructor PHPDoc

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Expression.php
+++ b/src/Symfony/Component/Validator/Constraints/Expression.php
@@ -41,10 +41,10 @@ class Expression extends Constraint
     public bool $negate = true;
 
     /**
-     * @param string|ExpressionObject|array<string,mixed>|null $expression The expression to evaluate
-     * @param array<string,mixed>|null                         $values     The values of the custom variables used in the expression (defaults to an empty array)
-     * @param string[]|null                                    $groups
-     * @param bool|null                                        $negate     Whether to fail if the expression evaluates to true (defaults to false)
+     * @param string|ExpressionObject|null $expression The expression to evaluate
+     * @param array<string,mixed>|null     $values     The values of the custom variables used in the expression (defaults to an empty array)
+     * @param string[]|null                $groups
+     * @param bool|null                    $negate     Whether to fail if the expression evaluates to true (defaults to false)
      */
     public function __construct(
         string|ExpressionObject|null $expression,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | n/a
| License       | MIT


Passing an `array` for the `$expression` argument was deprecated in 7.3 and removed in 8.0. This commit updates the `@param` docblock to match the actual method signature