### PR TITLE
[Messenger][Redis] Add missing auth for Redis Sentinel

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -91,7 +91,7 @@ jobs:
           REDIS_MASTER_HOST: redis-authenticated
           REDIS_MASTER_PASSWORD: "$tr0ngPassword"
           REDIS_MASTER_SET: redis_sentinel
-          REDIS_SENTINEL_PASSWORD: "$tr0ngPassword"
+          REDIS_SENTINEL_PASSWORD: "$tr0ngSentinelPassword"
           REDIS_SENTINEL_QUORUM: 1
       redis-primary:
         image: bitnamilegacy/redis:latest
@@ -274,7 +274,7 @@ jobs:
           REDIS_SENTINEL_HOSTS: 'unreachable-host:26379 localhost:26379 localhost:26379'
           REDIS_SENTINEL_AUTHENTICATED_HOSTS: 'localhost:26380 localhost:26380'
           REDIS_SENTINEL_SERVICE: redis_sentinel
-          REDIS_SENTINEL_PASSWORD: "$tr0ngPassword"
+          REDIS_SENTINEL_PASSWORD: "$tr0ngSentinelPassword"
           REDIS_REPLICATION_HOSTS: 'localhost:16382 localhost:16381'
           MESSENGER_REDIS_DSN: redis://127.0.0.1:7006/messages
           MESSENGER_REDIS_SENTINEL_MASTER: redis_sentinel

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -52,15 +52,17 @@ jobs:
         volumes:
           - ./:/hostmount
       redis:
-        image: redis:6.2.8
+        image: bitnamilegacy/redis:6.2.8
         ports:
           - 16379:6379
+        env:
+          ALLOW_EMPTY_PASSWORD: "yes"
       redis-authenticated:
-        image: redis:6.2.8
+        image: bitnamilegacy/redis:6.2.8
         ports:
           - 16380:6379
         env:
-          REDIS_ARGS: "--requirepass p@ssword"
+          REDIS_PASSWORD: "$tr0ngPassword"
       redis-cluster:
         image: grokzen/redis-cluster:6.2.8
         ports:
@@ -80,6 +82,16 @@ jobs:
         env:
           REDIS_MASTER_HOST: redis
           REDIS_MASTER_SET: redis_sentinel
+          REDIS_SENTINEL_QUORUM: 1
+      redis-sentinel-authenticated:
+        image: bitnamilegacy/redis-sentinel:6.2.8
+        ports:
+          - 26380:26379
+        env:
+          REDIS_MASTER_HOST: redis-authenticated
+          REDIS_MASTER_PASSWORD: "$tr0ngPassword"
+          REDIS_MASTER_SET: redis_sentinel
+          REDIS_SENTINEL_PASSWORD: "$tr0ngPassword"
           REDIS_SENTINEL_QUORUM: 1
       redis-primary:
         image: bitnamilegacy/redis:latest
@@ -257,9 +269,12 @@ jobs:
           LOCK_DYNAMODB_DSN: "dynamodb://localhost:4566/lock_keys?sslmode=disable"
           REDIS_HOST: 'localhost:16379'
           REDIS_AUTHENTICATED_HOST: 'localhost:16380'
+          REDIS_PASSWORD: "$tr0ngPassword"
           REDIS_CLUSTER_HOSTS: 'localhost:7000 localhost:7001 localhost:7002 localhost:7003 localhost:7004 localhost:7005'
           REDIS_SENTINEL_HOSTS: 'unreachable-host:26379 localhost:26379 localhost:26379'
+          REDIS_SENTINEL_AUTHENTICATED_HOSTS: 'localhost:26380 localhost:26380'
           REDIS_SENTINEL_SERVICE: redis_sentinel
+          REDIS_SENTINEL_PASSWORD: "$tr0ngPassword"
           REDIS_REPLICATION_HOSTS: 'localhost:16382 localhost:16381'
           MESSENGER_REDIS_DSN: redis://127.0.0.1:7006/messages
           MESSENGER_REDIS_SENTINEL_MASTER: redis_sentinel

--- a/src/Symfony/Component/Cache/Tests/Traits/RedisTraitTest.php
+++ b/src/Symfony/Component/Cache/Tests/Traits/RedisTraitTest.php
@@ -70,7 +70,7 @@ class RedisTraitTest extends TestCase
 
     public static function provideCreateConnection(): array
     {
-        $hosts = array_map(fn ($host) => \sprintf('host[%s]', $host), explode(' ', getenv('REDIS_CLUSTER_HOSTS') ?: ''));
+        $hosts = array_map(static fn ($host) => \sprintf('host[%s]', $host), explode(' ', getenv('REDIS_CLUSTER_HOSTS') ?: ''));
 
         return [
             [

--- a/src/Symfony/Component/Cache/Tests/Traits/RedisTraitTest.php
+++ b/src/Symfony/Component/Cache/Tests/Traits/RedisTraitTest.php
@@ -54,13 +54,18 @@ class RedisTraitTest extends TestCase
             self::markTestSkipped('REDIS_AUTHENTICATED_HOST env var is not defined.');
         }
 
+        if (!getenv('REDIS_PASSWORD')) {
+            self::markTestSkipped('REDIS_PASSWORD env var is not defined.');
+        }
+
         $mock = new class {
             use RedisTrait;
         };
-        $connection = $mock::createConnection('redis://:p%40ssword@'.getenv('REDIS_AUTHENTICATED_HOST'));
+        $password = getenv('REDIS_PASSWORD');
+        $connection = $mock::createConnection('redis://:'.urlencode($password).'@'.getenv('REDIS_AUTHENTICATED_HOST'));
 
         self::assertInstanceOf(\Redis::class, $connection);
-        self::assertSame('p@ssword', $connection->getAuth());
+        self::assertSame($password, $connection->getAuth());
     }
 
     public static function provideCreateConnection(): array

--- a/src/Symfony/Component/Messenger/Bridge/Redis/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/CHANGELOG.md
@@ -5,7 +5,7 @@ CHANGELOG
 ---
 
  * Bump ext-redis to 6.1 and ext-relay to 0.12 minimum
- * Allow separate passwords for Sentinel and master hosts
+ * Allow separate authenticate for Sentinel and master hosts
 
 7.3
 ---

--- a/src/Symfony/Component/Messenger/Bridge/Redis/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Bump ext-redis to 6.1 and ext-relay to 0.12 minimum
+ * Allow separate passwords for Sentinel and master hosts
 
 7.3
 ---

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
@@ -401,6 +401,56 @@ class ConnectionTest extends TestCase
         yield '100ms delay' => ['/^[A-Z\d\/+]+$/i', 100, 'rawCommand', '1'];
     }
 
+    #[DataProvider('provideDsnWithOptionsForAuthResolution')]
+    public function testFromDsnReturnsConnectionWithCorrectAuthResolution(string $dsn, array $options, mixed $expectedMasterAuth, mixed $expectedSentinelAuth)
+    {
+        $redis = $this->createStub(\Redis::class);
+        $connection = Connection::fromDsn($dsn, ['lazy' => true] + $options, $redis);
+
+        $initializer = (new \ReflectionProperty(Connection::class, 'redisInitializer'))->getValue($connection);
+        $vars = (new \ReflectionFunction($initializer))->getStaticVariables();
+
+        $this->assertSame($expectedMasterAuth, $vars['masterAuth']);
+        $this->assertSame($expectedSentinelAuth, $vars['sentinelAuth']);
+    }
+
+    public static function provideDsnWithOptionsForAuthResolution(): \Generator
+    {
+        yield 'no sentinel: auth from DSN user-info' => [
+            'redis://password@localhost/queue', [],
+            'password', null,
+        ];
+        yield 'no sentinel: auth option wins over DSN user-info' => [
+            'redis://password1@localhost/queue', ['auth' => 'password2'],
+            'password2', null,
+        ];
+        yield 'no sentinel: auth from options only' => [
+            'redis://localhost/queue', ['auth' => 'password'],
+            'password', null,
+        ];
+        yield 'no sentinel: user and password from DSN' => [
+            'redis://user:password@localhost/queue', [],
+            ['user', 'password'], null,
+        ];
+
+        yield 'with sentinel: DSN user-info for master, auth param for sentinel' => [
+            'redis:masterPass@?host[127.0.0.1:26379]&auth=sentinelPass', ['sentinel' => 'myMaster'],
+            'masterPass', 'sentinelPass',
+        ];
+        yield 'with sentinel: same auth for both (only auth param)' => [
+            'redis:?host[127.0.0.1:26379]&auth=sharedPass', ['sentinel' => 'myMaster'],
+            'sharedPass', 'sharedPass',
+        ];
+        yield 'with sentinel: DSN user-info only, no auth param' => [
+            'redis:masterPass@?host[127.0.0.1:26379]', ['sentinel' => 'myMaster'],
+            'masterPass', null,
+        ];
+        yield 'with sentinel: user:pass in DSN, auth param for sentinel' => [
+            'redis:user:masterPass@?host[127.0.0.1:26379]&auth=sentinelPass', ['sentinel' => 'myMaster'],
+            ['user', 'masterPass'], 'sentinelPass',
+        ];
+    }
+
     #[Group('integration')]
     #[DataProvider('successSentinelAuthDsnDataProvider')]
     public function testSentinelSuccessfulAuthentication(string $dsn)
@@ -443,10 +493,8 @@ class ConnectionTest extends TestCase
 
     public static function successSentinelAuthDsnDataProvider(): \Generator
     {
-        yield 'auth via master_auth & sentinel_auth' => ['redis:?{hosts}&master_auth={master_auth}&sentinel_auth={sentinel_auth}'];
-        yield 'auth via master_auth & old auth options' => ['redis:?{hosts}&master_auth={master_auth}&auth={sentinel_auth}'];
-        yield 'auth via old auth param & sentinel_auth' => ['redis:{master_auth}@?{hosts}&sentinel_auth={sentinel_auth}'];
-        yield 'fallback on BC: old auth param & old auth options' => ['redis:{master_auth}@?{hosts}&auth={sentinel_auth}'];
+        yield 'master auth via DSN user-info, sentinel auth via param' => ['redis:{master_auth}@?{hosts}&auth={sentinel_auth}'];
+        yield 'same auth for both (only auth param)' => ['redis:?{hosts}&auth={master_auth}'];
     }
 
     #[Group('integration')]
@@ -465,7 +513,7 @@ class ConnectionTest extends TestCase
 
         $hosts = array_map(static fn ($host) => \sprintf('host[%s]', $host), explode(' ', $hosts));
         $password = 'wr0ngpassword';
-        $dsn = 'redis:?'.implode('&', $hosts).'&sentinel_auth='.urlencode($password);
+        $dsn = 'redis:?'.implode('&', $hosts).'&auth='.urlencode($password);
 
         $redis = $this->createRedisMock();
         $redis->expects($this->never())

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
@@ -402,6 +402,62 @@ class ConnectionTest extends TestCase
     }
 
     #[Group('integration')]
+    public function testSentinelSuccessfulAuthentication()
+    {
+        if (!$hosts = getenv('REDIS_SENTINEL_AUTHENTICATED_HOSTS')) {
+            $this->markTestSkipped('REDIS_SENTINEL_AUTHENTICATED_HOSTS env var is not defined.');
+        }
+
+        if (!$password = getenv('REDIS_SENTINEL_PASSWORD')) {
+            $this->markTestSkipped('REDIS_SENTINEL_PASSWORD env var is not defined.');
+        }
+
+        if (!$master = getenv('MESSENGER_REDIS_SENTINEL_MASTER')) {
+            $this->markTestSkipped('MESSENGER_REDIS_SENTINEL_MASTER env var is not defined.');
+        }
+
+        $hosts = array_map(static fn ($host) => \sprintf('host[%s]', $host), explode(' ', $hosts));
+        $dsn = 'redis:?'.implode('&', $hosts).'&auth='.urlencode($password);
+
+        $redis = $this->createRedisMock();
+        $redis->expects($this->once())
+            ->method('auth')
+            ->with($password)
+            ->willReturn(true);
+
+        try {
+            Connection::fromDsn($dsn, ['sentinel' => $master, 'lazy' => false], $redis);
+        } catch (\Exception $e) {
+            $this->fail('Failed to connect to redis sentinel. Reason: '.$e->getMessage());
+        }
+    }
+
+    #[Group('integration')]
+    public function testSentinelFailedAuthentication()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/Failed to retrieve master information from sentinel/');
+
+        if (!$hosts = getenv('REDIS_SENTINEL_AUTHENTICATED_HOSTS')) {
+            $this->markTestSkipped('REDIS_SENTINEL_AUTHENTICATED_HOSTS env var is not defined.');
+        }
+
+        if (!$master = getenv('MESSENGER_REDIS_SENTINEL_MASTER')) {
+            $this->markTestSkipped('MESSENGER_REDIS_SENTINEL_MASTER env var is not defined.');
+        }
+
+        $hosts = array_map(static fn ($host) => \sprintf('host[%s]', $host), explode(' ', $hosts));
+        $password = 'wr0ngpassword';
+        $dsn = 'redis:?'.implode('&', $hosts).'&auth='.urlencode($password);
+
+        $redis = $this->createRedisMock();
+        $redis->expects($this->never())
+            ->method('auth');
+
+        Connection::fromDsn($dsn, ['sentinel' => $master, 'lazy' => false], $redis);
+    }
+
+    #[Group('integration')]
     public function testInvalidSentinelMasterName()
     {
         if (!$hosts = getenv('REDIS_SENTINEL_HOSTS')) {

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
@@ -402,13 +402,18 @@ class ConnectionTest extends TestCase
     }
 
     #[Group('integration')]
-    public function testSentinelSuccessfulAuthentication()
+    #[DataProvider('successSentinelAuthDsnDataProvider')]
+    public function testSentinelSuccessfulAuthentication(string $dsn)
     {
         if (!$hosts = getenv('REDIS_SENTINEL_AUTHENTICATED_HOSTS')) {
             $this->markTestSkipped('REDIS_SENTINEL_AUTHENTICATED_HOSTS env var is not defined.');
         }
 
-        if (!$password = getenv('REDIS_SENTINEL_PASSWORD')) {
+        if (!$masterPassword = getenv('REDIS_MASTER_PASSWORD')) {
+            $this->markTestSkipped('REDIS_MASTER_PASSWORD env var is not defined.');
+        }
+
+        if (!$sentinelPassword = getenv('REDIS_SENTINEL_PASSWORD')) {
             $this->markTestSkipped('REDIS_SENTINEL_PASSWORD env var is not defined.');
         }
 
@@ -417,12 +422,16 @@ class ConnectionTest extends TestCase
         }
 
         $hosts = array_map(static fn ($host) => \sprintf('host[%s]', $host), explode(' ', $hosts));
-        $dsn = 'redis:?'.implode('&', $hosts).'&auth='.urlencode($password);
+        $dsn = strtr($dsn, [
+            '{master_auth}' => urlencode($masterPassword),
+            '{sentinel_auth}' => urlencode($sentinelPassword),
+            '{hosts}' => implode('&', $hosts),
+        ]);
 
         $redis = $this->createRedisMock();
         $redis->expects($this->once())
             ->method('auth')
-            ->with($password)
+            ->with($masterPassword)
             ->willReturn(true);
 
         try {
@@ -430,6 +439,14 @@ class ConnectionTest extends TestCase
         } catch (\Exception $e) {
             $this->fail('Failed to connect to redis sentinel. Reason: '.$e->getMessage());
         }
+    }
+
+    public static function successSentinelAuthDsnDataProvider(): \Generator
+    {
+        yield 'auth via master_auth & sentinel_auth' => ['redis:?{hosts}&master_auth={master_auth}&sentinel_auth={sentinel_auth}'];
+        yield 'auth via master_auth & old auth options' => ['redis:?{hosts}&master_auth={master_auth}&auth={sentinel_auth}'];
+        yield 'auth via old auth param & sentinel_auth' => ['redis:{master_auth}@?{hosts}&sentinel_auth={sentinel_auth}'];
+        yield 'fallback on BC: old auth param & old auth options' => ['redis:{master_auth}@?{hosts}&auth={sentinel_auth}'];
     }
 
     #[Group('integration')]
@@ -448,7 +465,7 @@ class ConnectionTest extends TestCase
 
         $hosts = array_map(static fn ($host) => \sprintf('host[%s]', $host), explode(' ', $hosts));
         $password = 'wr0ngpassword';
-        $dsn = 'redis:?'.implode('&', $hosts).'&auth='.urlencode($password);
+        $dsn = 'redis:?'.implode('&', $hosts).'&sentinel_auth='.urlencode($password);
 
         $redis = $this->createRedisMock();
         $redis->expects($this->never())

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
@@ -515,7 +515,7 @@ class ConnectionTest extends TestCase
         $password = 'wr0ngpassword';
         $dsn = 'redis:?'.implode('&', $hosts).'&auth='.urlencode($password);
 
-        $redis = $this->createRedisMock();
+        $redis = $this->createMock(\Redis::class);
         $redis->expects($this->never())
             ->method('auth');
 

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -235,13 +235,12 @@ class Connection
                 $params['host'] = 'tls://'.$params['host'];
             }
         } else {
-            $dsns = explode(',', $dsn);
-            $paramss = array_map(function ($dsn) use (&$options) {
+            $dsnParams = array_map(function ($dsn) use (&$options) {
                 return self::parseDsn($dsn, $options);
-            }, $dsns);
+            }, explode(',', $dsn));
 
             // Merge all the URLs, the last one overrides the previous ones
-            $params = array_merge(...$paramss);
+            $params = array_merge(...$dsnParams);
             $tls = 'rediss' === $params['scheme'] || 'valkeys' === $params['scheme'];
 
             // Regroup all the hosts in an array interpretable by RedisCluster
@@ -254,7 +253,7 @@ class Connection
                 }
 
                 return $params['host'].':'.($params['port'] ?? 6379);
-            }, $paramss, $dsns);
+            }, $dsnParams);
         }
 
         if (isset($options['sentinel']) && isset($options['redis_sentinel']) && $options['sentinel'] !== $options['redis_sentinel']) {

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -199,7 +199,7 @@ class Connection
         @$redis->{$connect}($host, $port, $params['timeout'], $params['persistent_id'], $params['retry_interval'], $params['read_timeout'], ...(\defined('Redis::SCAN_PREFIX') || \extension_loaded('relay')) ? [$extra] : []);
 
         $error = null;
-        set_error_handler(function ($type, $msg) use (&$error) { $error = $msg; });
+        set_error_handler(static function ($type, $msg) use (&$error) { $error = $msg; });
 
         try {
             $isConnected = $redis->isConnected();
@@ -244,7 +244,7 @@ class Connection
                 $params['host'] = 'tls://'.$params['host'];
             }
         } else {
-            $dsnParams = array_map(function ($dsn) use (&$options) {
+            $dsnParams = array_map(static function ($dsn) use (&$options) {
                 return self::parseDsn($dsn, $options);
             }, explode(',', $dsn));
 
@@ -253,7 +253,7 @@ class Connection
             $tls = 'rediss' === $params['scheme'] || 'valkeys' === $params['scheme'];
 
             // Regroup all the hosts in an array interpretable by RedisCluster
-            $params['host'] = array_map(function ($params) use ($tls) {
+            $params['host'] = array_map(static function ($params) use ($tls) {
                 if (!isset($params['host'])) {
                     throw new InvalidArgumentException('Missing host in DSN, it must be defined when using Redis Cluster.');
                 }
@@ -361,7 +361,7 @@ class Connection
         }
 
         $auth = null;
-        $url = preg_replace_callback('#^'.$scheme.':(//)?(?:(?:(?<user>[^:@]*+):)?(?<password>[^@]*+)@)?#', function ($m) use (&$auth) {
+        $url = preg_replace_callback('#^'.$scheme.':(//)?(?:(?:(?<user>[^:@]*+):)?(?<password>[^@]*+)@)?#', static function ($m) use (&$auth) {
             if (isset($m['password'])) {
                 if (!\in_array($m['user'], ['', 'default'], true)) {
                     $auth['user'] = rawurldecode($m['user']);

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -45,6 +45,8 @@ class Connection
         'claim_interval' => 60000, // Interval by which pending/abandoned messages should be checked
         'lazy' => false,
         'auth' => null,
+        'master_auth' => null, // password for master instance
+        'sentinel_auth' => null, // password for sentinel instances
         'serializer' => 1, // see \Redis::SERIALIZER_PHP,
         'sentinel' => null, // String, master to look for (optional, default is NULL meaning Sentinel support is disabled)
         'timeout' => 0.0, // Float, value in seconds (optional, default is 0 meaning unlimited)
@@ -74,7 +76,8 @@ class Connection
         $options += self::DEFAULT_OPTIONS;
         $host = $options['host'];
         $port = $options['port'];
-        $auth = $options['auth'];
+        $masterAuth = $options['master_auth'] ?? $options['auth'];
+        $sentinelAuth = $options['sentinel_auth'];
 
         $sentinelMaster = $options['sentinel'] ?? $options['redis_sentinel'] ?? $options['sentinel_master'] ?? null;
 
@@ -94,14 +97,14 @@ class Connection
 
         if ((\is_array($host) && null === $sentinelMaster) || $redis instanceof \RedisCluster) {
             $hosts = \is_string($host) ? [$host.':'.$port] : $host; // Always ensure we have an array
-            $this->redisInitializer = static fn () => self::initializeRedisCluster($redis, $hosts, $auth, $options);
+            $this->redisInitializer = static fn () => self::initializeRedisCluster($redis, $hosts, $masterAuth, $options);
         } else {
-            $this->redisInitializer = static function () use ($redis, $sentinelMaster, $host, $port, $options, $auth) {
+            $this->redisInitializer = static function () use ($redis, $sentinelMaster, $host, $port, $options, $masterAuth, $sentinelAuth) {
                 if (null !== $sentinelMaster) {
                     $sentinelClass = \extension_loaded('redis') ? \RedisSentinel::class : Sentinel::class;
                     $hostIndex = 0;
                     $hosts = \is_array($host) ? $host : [['scheme' => 'tcp', 'host' => $host, 'port' => $port]];
-                    $passAuth = isset($auth) && (!\extension_loaded('redis') || \defined('Redis::OPT_NULL_MULTIBULK_AS_NULL'));
+                    $passSentinelAuth = null !== $sentinelAuth && (!\extension_loaded('redis') || \defined('Redis::OPT_NULL_MULTIBULK_AS_NULL'));
                     do {
                         $host = $hosts[$hostIndex]['host'];
                         $port = $hosts[$hostIndex]['port'] ?? 0;
@@ -127,13 +130,13 @@ class Connection
                                     $params['ssl'] = $options['ssl'];
                                 }
 
-                                if ($passAuth) {
-                                    $params['auth'] = $auth;
+                                if ($passSentinelAuth) {
+                                    $params['auth'] = $sentinelAuth;
                                 }
 
                                 $sentinel = @new \RedisSentinel($params);
                             } else {
-                                $extra = $passAuth ? [$auth] : [];
+                                $extra = $passSentinelAuth ? [$sentinelAuth] : [];
 
                                 $sentinel = @new $sentinelClass($host, $port, $options['timeout'], $options['persistent_id'], $options['retry_interval'], $options['read_timeout'], ...$extra);
                             }
@@ -150,7 +153,7 @@ class Connection
                     }
                 }
 
-                return self::initializeRedis($redis ?? (\extension_loaded('redis') ? new \Redis() : new Relay()), $host, $port, $auth, $options);
+                return self::initializeRedis($redis ?? (\extension_loaded('redis') ? new \Redis() : new Relay()), $host, $port, $masterAuth, $options);
             };
         }
 
@@ -177,17 +180,25 @@ class Connection
     }
 
     /**
-     * @param string|string[]|null $auth
+     * @param string|string[]|null $masterAuth
      */
-    private static function initializeRedis(\Redis|Relay $redis, string $host, int $port, string|array|null $auth, array $params): \Redis|Relay
+    private static function initializeRedis(\Redis|Relay $redis, string $host, int $port, string|array|null $masterAuth, array $params): \Redis|Relay
     {
         if ($redis->isConnected()) {
             return $redis;
         }
 
+        $extra = [
+            'stream' => $params['ssl'] ?? null,
+        ];
+
+        if (null !== $masterAuth) {
+            $extra['auth'] = $masterAuth;
+        }
+
         $connect = isset($params['persistent_id']) ? 'pconnect' : 'connect';
 
-        @$redis->{$connect}($host, $port, $params['timeout'], $params['persistent_id'], $params['retry_interval'], $params['read_timeout'], ...(\defined('Redis::SCAN_PREFIX') || \extension_loaded('relay')) ? [['stream' => $params['ssl'] ?? null]] : []);
+        @$redis->{$connect}($host, $port, $params['timeout'], $params['persistent_id'], $params['retry_interval'], $params['read_timeout'], ...(\defined('Redis::SCAN_PREFIX') || \extension_loaded('relay')) ? [$extra] : []);
 
         $error = null;
         set_error_handler(function ($type, $msg) use (&$error) { $error = $msg; });
@@ -204,7 +215,7 @@ class Connection
 
         $redis->setOption($redis instanceof \Redis ? \Redis::OPT_SERIALIZER : Relay::OPT_SERIALIZER, $params['serializer']);
 
-        if (null !== $auth && !$redis->auth($auth)) {
+        if (null !== $masterAuth && !$redis->auth($masterAuth)) {
             throw new InvalidArgumentException('Redis connection failed: '.$redis->getLastError());
         }
 
@@ -216,11 +227,11 @@ class Connection
     }
 
     /**
-     * @param string|string[]|null $auth
+     * @param string|string[]|null $masterAuth
      */
-    private static function initializeRedisCluster(?\RedisCluster $redis, array $hosts, string|array|null $auth, array $params): \RedisCluster
+    private static function initializeRedisCluster(?\RedisCluster $redis, array $hosts, string|array|null $masterAuth, array $params): \RedisCluster
     {
-        $redis ??= new \RedisCluster(null, $hosts, $params['timeout'], $params['read_timeout'], (bool) ($params['persistent'] ?? false), $auth, ...\defined('Redis::SCAN_PREFIX') ? [$params['ssl'] ?? null] : []);
+        $redis ??= new \RedisCluster(null, $hosts, $params['timeout'], $params['read_timeout'], (bool) ($params['persistent'] ?? false), $masterAuth, ...\defined('Redis::SCAN_PREFIX') ? [$params['ssl'] ?? null] : []);
         $redis->setOption(\Redis::OPT_SERIALIZER, $params['serializer']);
 
         return $redis;
@@ -268,6 +279,10 @@ class Connection
             throw new InvalidArgumentException('Cannot use both "redis_sentinel" and "sentinel_master" at the same time.');
         }
 
+        if (isset($options['sentinel_auth']) && isset($options['auth']) && $options['sentinel_auth'] !== $options['auth']) {
+            throw new InvalidArgumentException('Cannot use both "sentinel_auth" and "auth" at the same time.');
+        }
+
         $options['sentinel'] ??= $options['redis_sentinel'] ?? $options['sentinel_master'] ?? null;
         unset($options['redis_sentinel'], $options['sentinel_master']);
 
@@ -285,7 +300,15 @@ class Connection
 
         $pass = '' !== ($params['pass'] ?? '') ? rawurldecode($params['pass']) : null;
         $user = '' !== ($params['user'] ?? '') ? rawurldecode($params['user']) : null;
-        $options['auth'] ??= null !== $pass && null !== $user ? [$user, $pass] : ($pass ?? $user);
+        $masterAuthFromParams = null !== $pass && null !== $user ? [$user, $pass] : ($pass ?? $user);
+
+        if (isset($options['master_auth']) && null !== $masterAuthFromParams && $options['master_auth'] !== $masterAuthFromParams) {
+            throw new InvalidArgumentException('Cannot use both "auth" param and "master_auth" option at the same time.');
+        }
+
+        $options['master_auth'] ??= $masterAuthFromParams ?? $options['auth'];
+        $options['sentinel_auth'] ??= $options['auth'];
+        unset($options['auth']);
 
         if (isset($params['query'])) {
             parse_str($params['query'], $query);
@@ -344,6 +367,7 @@ class Connection
             $url = str_replace($scheme.':', 'file:', $dsn);
         }
 
+        $auth = null;
         $url = preg_replace_callback('#^'.$scheme.':(//)?(?:(?:(?<user>[^:@]*+):)?(?<password>[^@]*+)@)?#', function ($m) use (&$auth) {
             if (isset($m['password'])) {
                 if (!\in_array($m['user'], ['', 'default'], true)) {

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -45,8 +45,6 @@ class Connection
         'claim_interval' => 60000, // Interval by which pending/abandoned messages should be checked
         'lazy' => false,
         'auth' => null,
-        'master_auth' => null, // password for master instance
-        'sentinel_auth' => null, // password for sentinel instances
         'serializer' => 1, // see \Redis::SERIALIZER_PHP,
         'sentinel' => null, // String, master to look for (optional, default is NULL meaning Sentinel support is disabled)
         'timeout' => 0.0, // Float, value in seconds (optional, default is 0 meaning unlimited)
@@ -76,9 +74,9 @@ class Connection
         $options += self::DEFAULT_OPTIONS;
         $host = $options['host'];
         $port = $options['port'];
-        $masterAuth = $options['master_auth'] ?? $options['auth'];
-        $sentinelAuth = $options['sentinel_auth'];
 
+        $masterAuth = $options['master_auth'] ?? $options['auth'] ?? null;
+        $sentinelAuth = $options['sentinel_auth'] ?? null;
         $sentinelMaster = $options['sentinel'] ?? $options['redis_sentinel'] ?? $options['sentinel_master'] ?? null;
 
         if (null !== $sentinelMaster && !class_exists(\RedisSentinel::class) && !class_exists(Sentinel::class)) {
@@ -180,9 +178,9 @@ class Connection
     }
 
     /**
-     * @param string|string[]|null $masterAuth
+     * @param string|string[]|null $auth
      */
-    private static function initializeRedis(\Redis|Relay $redis, string $host, int $port, string|array|null $masterAuth, array $params): \Redis|Relay
+    private static function initializeRedis(\Redis|Relay $redis, string $host, int $port, string|array|null $auth, array $params): \Redis|Relay
     {
         if ($redis->isConnected()) {
             return $redis;
@@ -192,8 +190,8 @@ class Connection
             'stream' => $params['ssl'] ?? null,
         ];
 
-        if (null !== $masterAuth) {
-            $extra['auth'] = $masterAuth;
+        if (null !== $auth) {
+            $extra['auth'] = $auth;
         }
 
         $connect = isset($params['persistent_id']) ? 'pconnect' : 'connect';
@@ -215,7 +213,7 @@ class Connection
 
         $redis->setOption($redis instanceof \Redis ? \Redis::OPT_SERIALIZER : Relay::OPT_SERIALIZER, $params['serializer']);
 
-        if (null !== $masterAuth && !$redis->auth($masterAuth)) {
+        if (null !== $auth && !$redis->auth($auth)) {
             throw new InvalidArgumentException('Redis connection failed: '.$redis->getLastError());
         }
 
@@ -227,11 +225,11 @@ class Connection
     }
 
     /**
-     * @param string|string[]|null $masterAuth
+     * @param string|string[]|null $auth
      */
-    private static function initializeRedisCluster(?\RedisCluster $redis, array $hosts, string|array|null $masterAuth, array $params): \RedisCluster
+    private static function initializeRedisCluster(?\RedisCluster $redis, array $hosts, string|array|null $auth, array $params): \RedisCluster
     {
-        $redis ??= new \RedisCluster(null, $hosts, $params['timeout'], $params['read_timeout'], (bool) ($params['persistent'] ?? false), $masterAuth, ...\defined('Redis::SCAN_PREFIX') ? [$params['ssl'] ?? null] : []);
+        $redis ??= new \RedisCluster(null, $hosts, $params['timeout'], $params['read_timeout'], (bool) ($params['persistent'] ?? false), $auth, ...\defined('Redis::SCAN_PREFIX') ? [$params['ssl'] ?? null] : []);
         $redis->setOption(\Redis::OPT_SERIALIZER, $params['serializer']);
 
         return $redis;
@@ -279,10 +277,6 @@ class Connection
             throw new InvalidArgumentException('Cannot use both "redis_sentinel" and "sentinel_master" at the same time.');
         }
 
-        if (isset($options['sentinel_auth']) && isset($options['auth']) && $options['sentinel_auth'] !== $options['auth']) {
-            throw new InvalidArgumentException('Cannot use both "sentinel_auth" and "auth" at the same time.');
-        }
-
         $options['sentinel'] ??= $options['redis_sentinel'] ?? $options['sentinel_master'] ?? null;
         unset($options['redis_sentinel'], $options['sentinel_master']);
 
@@ -300,15 +294,14 @@ class Connection
 
         $pass = '' !== ($params['pass'] ?? '') ? rawurldecode($params['pass']) : null;
         $user = '' !== ($params['user'] ?? '') ? rawurldecode($params['user']) : null;
-        $masterAuthFromParams = null !== $pass && null !== $user ? [$user, $pass] : ($pass ?? $user);
+        $urlAuth = null !== $pass && null !== $user ? [$user, $pass] : ($pass ?? $user);
 
-        if (isset($options['master_auth']) && null !== $masterAuthFromParams && $options['master_auth'] !== $masterAuthFromParams) {
-            throw new InvalidArgumentException('Cannot use both "auth" param and "master_auth" option at the same time.');
+        if (null !== $options['sentinel']) {
+            $options['sentinel_auth'] = $options['auth'];
+            $options['master_auth'] = $urlAuth ?? $options['auth'];
+        } else {
+            $options['master_auth'] = $options['auth'] ?? $urlAuth;
         }
-
-        $options['master_auth'] ??= $masterAuthFromParams ?? $options['auth'];
-        $options['sentinel_auth'] ??= $options['auth'];
-        unset($options['auth']);
 
         if (isset($params['query'])) {
             parse_str($params['query'], $query);

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -101,6 +101,7 @@ class Connection
                     $sentinelClass = \extension_loaded('redis') ? \RedisSentinel::class : Sentinel::class;
                     $hostIndex = 0;
                     $hosts = \is_array($host) ? $host : [['scheme' => 'tcp', 'host' => $host, 'port' => $port]];
+                    $passAuth = isset($auth) && (!\extension_loaded('redis') || \defined('Redis::OPT_NULL_MULTIBULK_AS_NULL'));
                     do {
                         $host = $hosts[$hostIndex]['host'];
                         $port = $hosts[$hostIndex]['port'] ?? 0;
@@ -126,9 +127,15 @@ class Connection
                                     $params['ssl'] = $options['ssl'];
                                 }
 
+                                if ($passAuth) {
+                                    $params['auth'] = $auth;
+                                }
+
                                 $sentinel = @new \RedisSentinel($params);
                             } else {
-                                $sentinel = @new $sentinelClass($host, $port, $options['timeout'], $options['persistent_id'], $options['retry_interval'], $options['read_timeout']);
+                                $extra = $passAuth ? [$auth] : [];
+
+                                $sentinel = @new $sentinelClass($host, $port, $options['timeout'], $options['persistent_id'], $options['retry_interval'], $options['read_timeout'], ...$extra);
                             }
 
                             if ($address = @$sentinel->getMasterAddrByName($sentinelMaster)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

When getting the master server in redis transport via sentinel, auth was omitted. Used code similar to [Cache/Traits/RedisTrait.php#L243](https://github.com/symfony/symfony/blob/7.4/src/Symfony/Component/Cache/Traits/RedisTrait.php#L243)
This is still not an ideal solution, and to some extent it duplicates the logic from **Symfony/Component/Cache/Traits/RedisTrait.php**, so it would be good to unify this in the future.

To cover the integration test I had to tweak the integration services a bit:
- used one image for all redis services
- correctly pass authorisation settings
