### PR TITLE
[CssSelector] Fix incorrect return type for Token::getType()

### DIFF
--- a/src/Symfony/Component/CssSelector/Parser/Token.php
+++ b/src/Symfony/Component/CssSelector/Parser/Token.php
@@ -31,6 +31,9 @@ class Token
     public const TYPE_NUMBER = 'number';
     public const TYPE_STRING = 'string';
 
+    /**
+     * @param self::TYPE_*|null $type
+     */
     public function __construct(
         private ?string $type,
         private ?string $value,
@@ -38,7 +41,10 @@ class Token
     ) {
     }
 
-    public function getType(): ?int
+    /**
+     * @return self::TYPE_*|null
+     */
+    public function getType(): ?string
     {
         return $this->type;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | n/a
| License       | MIT

The `Token::getType()` method was declared to return `?int`, but the property it returns (`$type`) is a `?string`.

This PR corrects the method signature to return `?string` to match the property type.
