### PR TITLE
 Few phan fixes

### DIFF
--- a/src/Symfony/Component/Config/Resource/GlobResource.php
+++ b/src/Symfony/Component/Config/Resource/GlobResource.php
@@ -206,6 +206,7 @@ class GlobResource implements \IteratorAggregate, SelfCheckingResourceInterface
                         }
                     } while ($prefix !== $dirPath && $dirPath !== $normalizedPath = \dirname($dirPath));
                 }
+
                 return true;
             })
             ->sortByName()

--- a/src/Symfony/Component/Config/Resource/GlobResource.php
+++ b/src/Symfony/Component/Config/Resource/GlobResource.php
@@ -194,7 +194,7 @@ class GlobResource implements \IteratorAggregate, SelfCheckingResourceInterface
 
         yield from (new Finder())
             ->followLinks()
-            ->filter(function (\SplFileInfo $info) use ($regex, $prefixLen, $prefix) {
+            ->filter(function (\SplFileInfo $info) use ($regex, $prefixLen, $prefix): bool {
                 $normalizedPath = str_replace('\\', '/', $info->getPathname());
                 if (!preg_match($regex, substr($normalizedPath, $prefixLen)) || !$info->isFile()) {
                     return false;
@@ -206,6 +206,7 @@ class GlobResource implements \IteratorAggregate, SelfCheckingResourceInterface
                         }
                     } while ($prefix !== $dirPath && $dirPath !== $normalizedPath = \dirname($dirPath));
                 }
+                return true;
             })
             ->sortByName()
             ->in($prefix)

--- a/src/Symfony/Component/Console/Output/AnsiColorMode.php
+++ b/src/Symfony/Component/Console/Output/AnsiColorMode.php
@@ -78,7 +78,7 @@ enum AnsiColorMode
 
     private function degradeHexColorToAnsi4(int $r, int $g, int $b): int
     {
-        return round($b / 255) << 2 | (round($g / 255) << 1) | round($r / 255);
+        return round($b / 255) << 2 | (round($g / 255) << 1) | (int) round($r / 255);
     }
 
     /**

--- a/src/Symfony/Component/Console/Output/AnsiColorMode.php
+++ b/src/Symfony/Component/Console/Output/AnsiColorMode.php
@@ -78,7 +78,7 @@ enum AnsiColorMode
 
     private function degradeHexColorToAnsi4(int $r, int $g, int $b): int
     {
-        return round($b / 255) << 2 | (round($g / 255) << 1) | (int) round($r / 255);
+        return (int) round($b / 255) << 2 | (round($g / 255) << 1) | (int) round($r / 255);
     }
 
     /**

--- a/src/Symfony/Component/Console/Output/AnsiColorMode.php
+++ b/src/Symfony/Component/Console/Output/AnsiColorMode.php
@@ -78,7 +78,7 @@ enum AnsiColorMode
 
     private function degradeHexColorToAnsi4(int $r, int $g, int $b): int
     {
-        return (int) round($b / 255) << 2 | (round($g / 255) << 1) | (int) round($r / 255);
+        return (int) round($b / 255) << 2 | ((int) round($g / 255) << 1) | (int) round($r / 255);
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
@@ -173,7 +173,7 @@ class DumpDataCollector extends DataCollector implements DataDumperInterface
             }
         }
 
-        self::__construct($this->stopwatch ?? null, \is_string($fileLinkFormat) || $fileLinkFormat instanceof FileLinkFormatter ? $fileLinkFormat : null, \is_string($charset) ? $charset : null);
+        new self($this->stopwatch ?? null, \is_string($fileLinkFormat) || $fileLinkFormat instanceof FileLinkFormatter ? $fileLinkFormat : null, \is_string($charset) ? $charset : null);
     }
 
     public function getDumpsCount(): int

--- a/src/Symfony/Component/VarDumper/Cloner/Data.php
+++ b/src/Symfony/Component/VarDumper/Cloner/Data.php
@@ -417,8 +417,6 @@ class Data implements \ArrayAccess, \Countable, \IteratorAggregate, \Stringable
 
         $stub = new Stub();
         $stub->type = Stub::TYPE_ARRAY;
-        foreach ($item as $stub->class => $stub->position) {
-        }
         if (isset($item[0])) {
             $stub->cut = $item[0];
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | n/a
| License       | MIT

Similar to https://github.com/symfony/symfony/pull/62216, the latest 7.4 was checked with the [latest phan v6](https://github.com/phan/phan/tree/v6). Attaching all the discovered issues: 
[phan-issues.log](https://github.com/user-attachments/files/23229093/phan-issues.log).

This PR fixes a few random issues that seem to be legit:
```
...
src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php:176 PhanAccessOwnConstructor Accessing own constructor directly via self::__construct
...
src/Symfony/Component/VarDumper/Cloner/Data.php:420 PhanEmptyForeachBody Saw a foreach statement with empty body over array of type non-empty-array<mixed,mixed> (iterating has no side effects)
...
src/Symfony/Component/Config/Resource/GlobResource.php:197 PhanPluginInconsistentReturnFunction Function \closure_a8654210b446 has no return type and will inconsistently return or not return
...
src/Symfony/Component/Console/Output/AnsiColorMode.php:81 PhanTypeInvalidBitwiseBinaryOperator Invalid non-int/non-string operand provided to operator '|' between types int and float
...
src/Symfony/Component/Console/Output/AnsiColorMode.php:81 PhanTypeInvalidLeftOperandOfIntegerOp Invalid operator: left operand of << is float (expected int)
...
```
