### PR TITLE
[Form][Intl] Allow the developer to choose if he want to include/exclude currencies that do not have validity dates.

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -6,7 +6,7 @@ CHANGELOG
 
  * Add `input=date_point` to `DateTimeType`, `DateType` and `TimeType`
  * Add support for guessing form type of enum properties
- * Add `active_at`, `not_active_at` and `legal_tender` options to `CurrencyType`
+ * Add `active_at`, `not_active_at` and `legal_tender`, `include_undated` options to `CurrencyType`
  * Add `FormFlow` for multistep forms management
 
 7.3

--- a/src/Symfony/Component/Intl/Tests/CurrenciesTest.php
+++ b/src/Symfony/Component/Intl/Tests/CurrenciesTest.php
@@ -866,12 +866,14 @@ class CurrenciesTest extends ResourceBundleTestCase
         $this->assertFalse(Currencies::isValidInCountry('CH', 'CHF', false, null));
     }
 
-    public function testCheCurrencyDoesNotHaveValidityDatesInSwitzerland()
+    public function testCheCurrencyIncluded()
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Cannot check whether the currency CHE is active or not in CH because they are no validity dates available.');
+        $this->assertTrue(Currencies::isValidInCountry('CH', 'CHE', false, true, includeUndated: true));
+    }
 
-        Currencies::isValidInCountry('CH', 'CHE', false, false);
+    public function testCheCurrencyExcluded()
+    {
+        $this->assertFalse(Currencies::isValidInCountry('CH', 'CHE', false, true, includeUndated: false));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | #62215 
| License       | MIT

It's not really a bugfix but a correction from the feedback of @javiereguiluz. This PR add a parameter named `include_undated` that allows the user to choose if he wants to include or not the currencies that do not have validity dates available. The advantage from the previous implementation is that the exception is gone.