### PR TITLE
[DependencyInjection] Fix invalid PHPDoc for InstantiatorInterface

### DIFF
--- a/src/Symfony/Component/DependencyInjection/LazyProxy/Instantiator/InstantiatorInterface.php
+++ b/src/Symfony/Component/DependencyInjection/LazyProxy/Instantiator/InstantiatorInterface.php
@@ -25,8 +25,10 @@ interface InstantiatorInterface
     /**
      * Instantiates a proxy object.
      *
-     * @param string            $id               Identifier of the requested service
-     * @param callable(object=) $realInstantiator A callback that is capable of producing the real service instance
+     * @param string                                        $id               Identifier of the requested service
+     * @param (callable(): object)|(callable(object): void) $realInstantiator A callback that creates or initializes the real service instance:
+     *                                                                        - For direct instantiation or value-holder proxies: Called without arguments and returns the service object.
+     *                                                                        - For ghost object proxies (using PHP's lazy objects): Called with the proxy as argument, initializes it in place and returns void.
      */
     public function instantiateProxy(ContainerInterface $container, Definition $definition, string $id, callable $realInstantiator): object;
 }

--- a/src/Symfony/Component/DependencyInjection/LazyProxy/Instantiator/RealServiceInstantiator.php
+++ b/src/Symfony/Component/DependencyInjection/LazyProxy/Instantiator/RealServiceInstantiator.php
@@ -23,6 +23,7 @@ class RealServiceInstantiator implements InstantiatorInterface
 {
     public function instantiateProxy(ContainerInterface $container, Definition $definition, string $id, callable $realInstantiator): object
     {
+        /** @var callable(): object $realInstantiator */
         return $realInstantiator();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | n/a
| License       | MIT

This PR fixes an invalid PHPDoc syntax (`callable(object=)`) in `InstantiatorInterface`

The PHPDoc type is updated to `(callable(): object)|(callable(object): void)` to reflect its two valid signatures:

* `RealServiceInstantiator` (for non-lazy services) expects a factory: `callable(): object`.
* `LazyServiceInstantiator` (for lazy proxies/ghosts) expects an initializer: `callable(object): void`.

The textual description of the parameter is also updated to match this dual nature.

---

As I'm not deeply familiar with the lazy instantiation logic, I'd appreciate a close review