### PR TITLE
 Introduced variables for FormErrors for easier Xdebug debugging.

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -651,7 +651,14 @@ class Form implements \IteratorAggregate, FormInterface, ClearableErrorsInterfac
             return true;
         }
 
-        return 0 === \count($this->getErrors(true));
+        $errors = $this->getErrors(true);
+        $errorCount = \count($errors);
+
+        if (0 === $errorCount) {
+            return true;
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        |  
| License       | MIT

Introduced variables for FormErrors for easier Xdebug debugging. 

For example, you can now place a breakpoint on the `return false;` line and exactly debug which FormError caused the form to not be valid.

Just a simple quality of life tweak in my opinion.


<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
