### PR TITLE
[Messenger] Support signing messages per handler

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2556,6 +2556,7 @@ class FrameworkExtension extends Extension
         $senderAliases = [];
         $transportRetryReferences = [];
         $transportRateLimiterReferences = [];
+        $serializerIds = [];
         foreach ($config['transports'] as $name => $transport) {
             $serializerId = $transport['serializer'] ?? 'messenger.default_serializer';
             $tags = [
@@ -2572,6 +2573,7 @@ class FrameworkExtension extends Extension
             ;
             $container->setDefinition($transportId = 'messenger.transport.'.$name, $transportDefinition);
             $senderAliases[$name] = $transportId;
+            $serializerIds[$transportId] = $serializerId;
 
             if (null !== $transport['retry_strategy']['service']) {
                 $transportRetryReferences[$name] = new Reference($transport['retry_strategy']['service']);
@@ -2599,13 +2601,11 @@ class FrameworkExtension extends Extension
         }
 
         $senderReferences = [];
-        // alias => service_id
-        foreach ($senderAliases as $alias => $serviceId) {
-            $senderReferences[$alias] = new Reference($serviceId);
+        foreach ($senderAliases as $alias => $transportId) {
+            $senderReferences[$alias] = new Reference($transportId);
         }
-        // service_id => service_id
-        foreach ($senderAliases as $serviceId) {
-            $senderReferences[$serviceId] = new Reference($serviceId);
+        foreach ($senderAliases as $transportId) {
+            $senderReferences[$transportId] = new Reference($transportId);
         }
 
         foreach ($config['transports'] as $name => $transport) {
@@ -2616,7 +2616,7 @@ class FrameworkExtension extends Extension
             }
         }
 
-        $failureTransportReferencesByTransportName = array_map(fn ($failureTransportName) => $senderReferences[$failureTransportName], $failureTransportsByName);
+        $failureTransportReferencesByTransportName = array_map(static fn ($failureTransportName) => $senderReferences[$failureTransportName], $failureTransportsByName);
 
         $messageToSendersMapping = [];
         foreach ($config['routing'] as $message => $messageConfiguration) {
@@ -2644,6 +2644,18 @@ class FrameworkExtension extends Extension
             ->replaceArgument(0, $messageToSendersMapping)
             ->replaceArgument(1, $sendersServiceLocator)
         ;
+
+        $messageToSerializersMapping = [];
+        foreach ($messageToSendersMapping as $message => $senders) {
+            foreach ($senders as $sender) {
+                $serializerId = $serializerIds[$senderAliases[$sender] ?? $sender];
+                $messageToSerializersMapping[$message][$serializerId] = $serializerId;
+            }
+            $messageToSerializersMapping[$message] = array_keys($messageToSerializersMapping[$message]);
+        }
+
+        $container->getDefinition('messenger.signing_serializer')
+            ->replaceArgument(2, $messageToSerializersMapping);
 
         $container->getDefinition('messenger.retry.send_failed_message_for_retry_listener')
             ->replaceArgument(0, $sendersServiceLocator)
@@ -2943,7 +2955,7 @@ class FrameworkExtension extends Extension
 
         $container
             ->register($name.'.caching', CachingHttpClient::class)
-            ->setDecoratedService($name, null,  15)
+            ->setDecoratedService($name, null, 15)
             ->setArguments([
                 new Reference('.inner'),
                 new Reference($options['cache_pool']),

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
@@ -407,6 +407,6 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 service('console.messenger.application'),
             ])
-            ->tag('messenger.message_handler')
+            ->tag('messenger.message_handler', ['sign' => true])
     ;
 };

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/process.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/process.php
@@ -17,6 +17,6 @@ return static function (ContainerConfigurator $container) {
     $container
         ->services()
             ->set('process.messenger.process_message_handler', RunProcessMessageHandler::class)
-                ->tag('messenger.message_handler')
+                ->tag('messenger.message_handler', ['sign' => true])
     ;
 };

--- a/src/Symfony/Component/Messenger/Attribute/AsMessageHandler.php
+++ b/src/Symfony/Component/Messenger/Attribute/AsMessageHandler.php
@@ -44,6 +44,11 @@ class AsMessageHandler
          * Priority of this handler when multiple handlers can process the same message.
          */
         public int $priority = 0,
+
+        /**
+         * Whether messages should be signed when sent on a transport.
+         */
+        public bool $sign = false,
     ) {
     }
 }

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add `Symfony\Component\Messenger\Middleware\AddDefaultStampsMiddleware` and `Symfony\Component\Messenger\Message\DefaultStampsProviderInterface`
  * Add the possibility to configure exchange to exchange bindings in AMQP transport
  * Add `MessageSentToTransportsEvent` that is dispatched only after the message was sent to at least one transport
+ * Support signing messages per handler
 
 7.3
 ---

--- a/src/Symfony/Component/Messenger/Exception/InvalidMessageSignatureException.php
+++ b/src/Symfony/Component/Messenger/Exception/InvalidMessageSignatureException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Exception;
+
+class InvalidMessageSignatureException extends \RuntimeException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SigningSerializerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SigningSerializerTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Transport\Serialization;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\InvalidMessageSignatureException;
+use Symfony\Component\Messenger\Tests\Fixtures\ChildDummyMessage;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessageInterface;
+use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
+use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
+use Symfony\Component\Messenger\Transport\Serialization\SigningSerializer;
+
+class SigningSerializerTest extends TestCase
+{
+    public function testEncodeAddsSignatureHeadersWhenTypeIsSigned()
+    {
+        $serializer = $this->createSerializer([DummyMessage::class]);
+        $envelope = new Envelope(new DummyMessage('hello'));
+
+        $encoded = $serializer->encode($envelope);
+
+        $this->assertArrayHasKey('headers', $encoded);
+        $this->assertArrayHasKey('Body-Sign', $encoded['headers']);
+        $this->assertArrayHasKey('Sign-Algo', $encoded['headers']);
+        $this->assertSame('sha256', $encoded['headers']['Sign-Algo']);
+        $this->assertNotEmpty($encoded['headers']['Body-Sign']);
+    }
+
+    public function testEncodeDoesNotAddSignatureForUnsignedType()
+    {
+        $serializer = $this->createSerializer([]);
+        $envelope = new Envelope(new DummyMessage('hello'));
+
+        $encoded = $serializer->encode($envelope);
+
+        $this->assertArrayNotHasKey('headers', $encoded);
+    }
+
+    public function testDecodeAcceptsValidSignature()
+    {
+        $serializer = $this->createSerializer([DummyMessage::class]);
+        $envelope = new Envelope(new DummyMessage('hello'));
+        $encoded = $serializer->encode($envelope);
+
+        $decoded = $serializer->decode($encoded);
+        $this->assertInstanceOf(Envelope::class, $decoded);
+        $this->assertInstanceOf(DummyMessage::class, $decoded->getMessage());
+    }
+
+    public function testDecodeRejectsMissingSignature()
+    {
+        $serializer = $this->createSerializer([DummyMessage::class]);
+        $inner = new PhpSerializer();
+        $envelope = new Envelope(new DummyMessage('hello'));
+        $encoded = $inner->encode($envelope);
+
+        $this->expectException(InvalidMessageSignatureException::class);
+        $serializer->decode($encoded);
+    }
+
+    public function testDecodeRejectsInvalidSignature()
+    {
+        $serializer = $this->createSerializer([DummyMessage::class]);
+        $envelope = new Envelope(new DummyMessage('hello'));
+        $encoded = $serializer->encode($envelope);
+        $encoded['headers']['Body-Sign'] = 'tampered';
+
+        $this->expectException(InvalidMessageSignatureException::class);
+        $serializer->decode($encoded);
+    }
+
+    public function testEncodeSignsWhenSignedTypeIsInterfaceImplementedByMessage()
+    {
+        $serializer = $this->createSerializer([DummyMessageInterface::class]);
+        $envelope = new Envelope(new DummyMessage('hello'));
+
+        $encoded = $serializer->encode($envelope);
+
+        $this->assertArrayHasKey('headers', $encoded);
+        $this->assertArrayHasKey('Body-Sign', $encoded['headers']);
+        $this->assertArrayHasKey('Sign-Algo', $encoded['headers']);
+    }
+
+    public function testDecodeVerifiesWhenSignedTypeIsParentClassOfMessage()
+    {
+        $serializer = $this->createSerializer([DummyMessage::class]);
+        $inner = new PhpSerializer();
+
+        // Encode with signature by using the SigningSerializer against a child instance
+        $encoded = $serializer->encode(new Envelope(new ChildDummyMessage('child')));
+
+        // Tamper by removing signature to ensure verification occurs for child type
+        unset($encoded['headers']['Body-Sign']);
+
+        $this->expectException(InvalidMessageSignatureException::class);
+        $serializer->decode($encoded);
+    }
+
+    private function createSerializer(array $signedTypes): SerializerInterface
+    {
+        return new SigningSerializer(new PhpSerializer(), 'secret-key', $signedTypes);
+    }
+}

--- a/src/Symfony/Component/Messenger/Transport/Serialization/SigningSerializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/SigningSerializer.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Transport\Serialization;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\InvalidMessageSignatureException;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+final class SigningSerializer implements SerializerInterface
+{
+    /**
+     * @param list<class-string> $signedMessageTypes
+     */
+    public function __construct(
+        private SerializerInterface $inner,
+        #[\SensitiveParameter] private string|\Stringable $signingKey,
+        private array $signedMessageTypes,
+        private string $algorithm = 'sha256',
+    ) {
+    }
+
+    public function encode(Envelope $envelope): array
+    {
+        $encoded = $this->inner->encode($envelope);
+        $type = $envelope->getMessage()::class;
+
+        if ($this->shouldSign($type)) {
+            $encoded['headers']['Body-Sign'] = hash_hmac($this->algorithm, $encoded['body'] ?? '', $this->signingKey);
+            $encoded['headers']['Sign-Algo'] = $this->algorithm;
+        }
+
+        return $encoded;
+    }
+
+    public function decode(array $encodedEnvelope): Envelope
+    {
+        $envelope = $this->inner->decode($encodedEnvelope);
+        $type = $envelope->getMessage()::class;
+
+        if (!$this->shouldSign($type)) {
+            return $envelope;
+        }
+
+        $headers = $encodedEnvelope['headers'] ?? [];
+
+        if (!$sign = $headers['Body-Sign'] ?? null) {
+            throw new InvalidMessageSignatureException(\sprintf('Message "%s" requires a signature but none was found.', $type));
+        }
+
+        if ($this->algorithm !== $algo = $headers['Sign-Algo'] ?? $this->algorithm) {
+            throw new InvalidMessageSignatureException(\sprintf('Expected "%s" signature algorithm for message "%s", "%s" given.', $this->algorithm, $type, $algo));
+        }
+
+        $expected = hash_hmac($algo, $encodedEnvelope['body'] ?? '', $this->signingKey);
+        if (!hash_equals($sign, $expected)) {
+            throw new InvalidMessageSignatureException(\sprintf('Invalid signature for message "%s".', $type));
+        }
+
+        unset($headers['Body-Sign'], $headers['Sign-Algo']);
+        $encodedEnvelope['headers'] = $headers;
+
+        return $envelope;
+    }
+
+    private function shouldSign(string $type): bool
+    {
+        foreach ($this->signedMessageTypes as $signedType) {
+            if (is_a($type, $signedType, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

At the moment, if one is able to inject a forged payload into a queue, one can trigger any handler via the messenger consumer, including eg `RunProcessHandler`. This is not a security issue in Symfony itself because queues should be protected from arbitrary payload injection. But it'd still be nice to harden this.

This PR adds a new `sign` attribute to the `messenger.message_handler` DI tag (which can be set either via explicit config or via `#[AsMessageHandler]`).

When at least one handler does so, a `SigningSerializer` decorator is added to all transport serializers. This then computes the signature when encoding a message bound to such handlers, and verifies it when decoding one.

The `sign` attribute is enabled for `RunProcessHandler` and `RunCommandHandler`, and can be for any others of yours.

Submitting for 7.4 as having a hardened LTS looks important to me.