### PR TITLE
[Messenger] Add the proper type declarations for the messenger SerializerInterface

### DIFF
--- a/src/Symfony/Component/Messenger/Transport/Serialization/SerializerInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/SerializerInterface.php
@@ -29,6 +29,8 @@ interface SerializerInterface
      * - `body` (string) - the message body
      * - `headers` (string<string>) - a key/value pair of headers
      *
+     * @param array{body: string, headers?: array<string, string>} $encodedEnvelope
+     *
      * @throws MessageDecodingFailedException
      */
     public function decode(array $encodedEnvelope): Envelope;
@@ -43,6 +45,8 @@ interface SerializerInterface
      * The most common keys of the encoded array are:
      * - `body` (string) - the message body
      * - `headers` (string<string>) - a key/value pair of headers
+     *
+     * @return array{body: string, headers?: array<string, string>}
      */
     public function encode(Envelope $envelope): array;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | n/a
| License       | MIT

All transports are expecting the structure with a `body` key and an optional `headers` key, not unknown keys that the serializer might decide to use.
All existing serializer implementation already respect that contract to be compatible with our existing transports. Encoding it in the interface contract makes the expectation clear.
