### PR TITLE
[Form] Fix EnumType choice_label logic for grouped choices

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/EnumType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/EnumType.php
@@ -31,8 +31,21 @@ final class EnumType extends AbstractType
             ->setAllowedValues('class', enum_exists(...))
             ->setDefault('choices', static fn (Options $options): array => $options['class']::cases())
             ->setDefault('choice_label', static function (Options $options) {
-                if (\is_array($options['choices']) && !array_is_list($options['choices'])) {
-                    return null;
+                $choices = $options['choices'];
+
+                if (\is_array($choices) && !array_is_list($choices)) {
+                    // Check for grouped choices
+                    $isGrouped = false;
+                    foreach ($choices as $value) {
+                        if (\is_array($value)) {
+                            $isGrouped = true;
+                            break;
+                        }
+                    }
+                    if (!$isGrouped) {
+                        // Associative array = custom labels
+                        return null;
+                    }
                 }
 
                 return static fn (\UnitEnum $choice) => $choice instanceof TranslatableInterface ? $choice : $choice->name;

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/EnumTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/EnumTypeTest.php
@@ -311,6 +311,41 @@ class EnumTypeTest extends BaseTypeTestCase
         $this->assertSame('no', $view->children[1]->vars['label']);
     }
 
+    public function testGroupedEnumChoices()
+    {
+        $form = $this->factory->create($this->getTestedType(), null, [
+            'multiple' => false,
+            'expanded' => true,
+            'class' => Answer::class,
+            'choices' => [
+                'Group 1' => [Answer::Yes, Answer::No],
+                'Group 2' => [Answer::FourtyTwo],
+            ],
+        ]);
+        $view = $form->createView();
+        $this->assertCount(2, $view->vars['choices']['Group 1']->choices);
+        $this->assertSame('Yes', $view->vars['choices']['Group 1']->choices[0]->label);
+        $this->assertSame('No', $view->vars['choices']['Group 1']->choices[1]->label);
+        $this->assertCount(1, $view->vars['choices']['Group 2']->choices);
+        $this->assertSame('FourtyTwo', $view->vars['choices']['Group 2']->choices[2]->label);
+    }
+
+    public function testEnumChoicesWithCustomLabels()
+    {
+        $form = $this->factory->create($this->getTestedType(), null, [
+            'multiple' => false,
+            'expanded' => true,
+            'class' => Answer::class,
+            'choices' => [
+                'Custom Yes' => Answer::Yes,
+                'Custom No' => Answer::No,
+            ],
+        ]);
+        $view = $form->createView();
+        $this->assertSame('Custom Yes', $view->children[0]->vars['label']);
+        $this->assertSame('Custom No', $view->children[1]->vars['label']);
+    }
+
     protected function getTestOptions(): array
     {
         return ['class' => Suit::class];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | n/a
| License       | MIT

This PR fixes a regression in the `EnumType`'s default `choice_label` logic.

The previous logic checked `!array_is_list($options['choices'])` to determine if custom labels were provided. If so, it would `return null` to disable the default enum labeler (i.e., `$choice->name`).

However, this check incorrectly matched **grouped choices** (e.g., `['Group 1' => [Answer::Yes]]`), which are also associative arrays. This caused the default labels for enums within groups to break (they became empty).

This fix adds a check to see if the associative array is actually for grouping (by detecting if any value `is_array`) before returning `null`.

Tests are added to cover both:
1.  Grouped choices (verifying the fix).
2.  Custom-labeled choices (verifying no new regression).