### PR TITLE
[Validator] Throw ValidatorException when validating non-existent property

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
@@ -41,6 +41,7 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Exception\NoSuchMetadataException;
 use Symfony\Component\Validator\Exception\RuntimeException;
+use Symfony\Component\Validator\Exception\ValidatorException;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Factory\MetadataFactoryInterface;
 use Symfony\Component\Validator\ObjectInitializerInterface;
@@ -999,6 +1000,43 @@ class RecursiveValidatorTest extends TestCase
         $violations = $this->validatePropertyValue($entity, 'lastName', 'foo');
 
         $this->assertCount(0, $violations, '->validatePropertyValue() returns no violations if no constraints have been configured for the property being validated');
+    }
+
+    /**
+     * https://github.com/symfony/symfony/issues/62198.
+     */
+    public function testValidatePropertyThrowsExceptionWhenPropertyDoesNotExist()
+    {
+        $entity = new Entity();
+
+        $this->expectException(ValidatorException::class);
+        $this->expectExceptionMessage('The property "propertyThatDoesNotExist" does not exist.');
+
+        $this->validateProperty($entity, 'propertyThatDoesNotExist');
+    }
+
+    /**
+     * https://github.com/symfony/symfony/issues/62198.
+     */
+    public function testValidatePropertyValueThrowsExceptionWhenPropertyDoesNotExist()
+    {
+        $entity = new Entity();
+
+        $this->expectException(ValidatorException::class);
+        $this->expectExceptionMessage('The property "propertyThatDoesNotExist" does not exist.');
+
+        $this->validatePropertyValue($entity, 'propertyThatDoesNotExist', 'test');
+    }
+
+    /**
+     * https://github.com/symfony/symfony/issues/62198.
+     */
+    public function testValidatePropertyValueThrowsExceptionWhenPropertyDoesNotExistWithClassName()
+    {
+        $this->expectException(ValidatorException::class);
+        $this->expectExceptionMessage('The property "propertyThatDoesNotExist" does not exist.');
+
+        $this->validatePropertyValue(Entity::class, 'propertyThatDoesNotExist', 'test');
     }
 
     public function testValidateObjectOnlyOncePerGroup()

--- a/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
+++ b/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
@@ -166,7 +166,10 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
         }
 
         if (!$classMetadata->hasPropertyMetadata($propertyName)) {
-            throw new ValidatorException(\sprintf('The property "%s" does not exist.', $propertyName));
+            $className = \is_object($object) ? $object::class : $object;
+            if (!property_exists($className, $propertyName) && !method_exists($className, 'get'.ucfirst($propertyName)) && !method_exists($className, 'is'.ucfirst($propertyName)) && !method_exists($className, 'has'.ucfirst($propertyName))) {
+                throw new ValidatorException(\sprintf('The property "%s" does not exist.', $propertyName));
+            }
         }
 
         $propertyMetadatas = $classMetadata->getPropertyMetadata($propertyName);
@@ -211,7 +214,10 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
         }
 
         if (!$classMetadata->hasPropertyMetadata($propertyName)) {
-            throw new ValidatorException(\sprintf('The property "%s" does not exist.', $propertyName));
+            $className = \is_object($objectOrClass) ? $objectOrClass::class : $objectOrClass;
+            if (!property_exists($className, $propertyName) && !method_exists($className, 'get'.ucfirst($propertyName)) && !method_exists($className, 'is'.ucfirst($propertyName)) && !method_exists($className, 'has'.ucfirst($propertyName))) {
+                throw new ValidatorException(\sprintf('The property "%s" does not exist.', $propertyName));
+            }
         }
 
         $propertyMetadatas = $classMetadata->getPropertyMetadata($propertyName);

--- a/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
+++ b/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
@@ -165,6 +165,10 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
             throw new ValidatorException(\sprintf('The metadata factory should return instances of "\Symfony\Component\Validator\Mapping\ClassMetadataInterface", got: "%s".', get_debug_type($classMetadata)));
         }
 
+        if (!$classMetadata->hasPropertyMetadata($propertyName)) {
+            throw new ValidatorException(\sprintf('The property "%s" does not exist.', $propertyName));
+        }
+
         $propertyMetadatas = $classMetadata->getPropertyMetadata($propertyName);
         $groups = $groups ? $this->normalizeGroups($groups) : $this->defaultGroups;
         $cacheKey = $this->generateCacheKey($object);
@@ -204,6 +208,10 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
 
         if (!$classMetadata instanceof ClassMetadataInterface) {
             throw new ValidatorException(\sprintf('The metadata factory should return instances of "\Symfony\Component\Validator\Mapping\ClassMetadataInterface", got: "%s".', get_debug_type($classMetadata)));
+        }
+
+        if (!$classMetadata->hasPropertyMetadata($propertyName)) {
+            throw new ValidatorException(\sprintf('The property "%s" does not exist.', $propertyName));
         }
 
         $propertyMetadatas = $classMetadata->getPropertyMetadata($propertyName);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #62198
| License       | MIT

This fixes issue #62198 by adding validation checks in validateProperty() and validatePropertyValue() methods to ensure the property exists before attempting validation. If a property does not exist, a ValidatorException is thrown with an appropriate error message.

The implementation uses hasPropertyMetadata() to check if the property exists before calling getPropertyMetadata(), which prevents silent failures when properties are removed or renamed.
