### PR TITLE
 verify spanish translations with state needs-review-translation

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.es.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.es.xlf
@@ -472,87 +472,87 @@
             </trans-unit>
             <trans-unit id="122">
                 <source>This file is not a valid video.</source>
-                <target state="needs-review-translation">Este archivo no es un video válido.</target>
+                <target>Este archivo no es un vídeo válido.</target>
             </trans-unit>
             <trans-unit id="123">
                 <source>The size of the video could not be detected.</source>
-                <target state="needs-review-translation">No se pudo detectar el tamaño del video.</target>
+                <target>No se pudo detectar el tamaño del vídeo.</target>
             </trans-unit>
             <trans-unit id="124">
                 <source>The video width is too big ({{ width }}px). Allowed maximum width is {{ max_width }}px.</source>
-                <target state="needs-review-translation">El ancho del vídeo es demasiado grande ({{ width }}px). El ancho máximo permitido es {{ max_width }}px.</target>
+                <target>El ancho del vídeo es demasiado grande ({{ width }}px). El ancho máximo permitido es de {{ max_width }}px.</target>
             </trans-unit>
             <trans-unit id="125">
                 <source>The video width is too small ({{ width }}px). Minimum width expected is {{ min_width }}px.</source>
-                <target state="needs-review-translation">El ancho del video es demasiado pequeño ({{ width }}px). El ancho mínimo esperado es {{ min_width }}px.</target>
+                <target>El ancho del vídeo es demasiado pequeño ({{ width }}px). El ancho mínimo requerido es {{ min_width }}px.</target>
             </trans-unit>
             <trans-unit id="126">
                 <source>The video height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px.</source>
-                <target state="needs-review-translation">La altura del video es demasiado grande ({{ height }}px). La altura máxima permitida es {{ max_height }}px.</target>
+                <target>La altura del vídeo es demasiado grande ({{ height }}px). La altura máxima permitida es de {{ max_height }}px.</target>
             </trans-unit>
             <trans-unit id="127">
                 <source>The video height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px.</source>
-                <target state="needs-review-translation">La altura del video es demasiado pequeña ({{ height }}px). La altura mínima esperada es {{ min_height }}px.</target>
+                <target>La altura del vídeo es demasiado pequeña ({{ height }}px). La altura mínima requerida es de {{ min_height }}px.</target>
             </trans-unit>
             <trans-unit id="128">
                 <source>The video has too few pixels ({{ pixels }} pixels). Minimum amount expected is {{ min_pixels }} pixels.</source>
-                <target state="needs-review-translation">El vídeo tiene muy pocos píxeles ({{ pixels }}). La cantidad mínima esperada es {{ min_pixels }}.</target>
+                <target>El vídeo tiene muy pocos píxeles ({{ pixels }}). La cantidad mínima requerida es {{ min_pixels }}.</target>
             </trans-unit>
             <trans-unit id="129">
                 <source>The video has too many pixels ({{ pixels }} pixels). Maximum amount expected is {{ max_pixels }} pixels.</source>
-                <target state="needs-review-translation">El vídeo tiene demasiados píxeles ({{ pixels }}). La cantidad máxima esperada es {{ max_pixels }}.</target>
+                <target>El vídeo tiene demasiados píxeles ({{ pixels }}). La cantidad máxima permitida es {{ max_pixels }}.</target>
             </trans-unit>
             <trans-unit id="130">
                 <source>The video ratio is too big ({{ ratio }}). Allowed maximum ratio is {{ max_ratio }}.</source>
-                <target state="needs-review-translation">La relación del video es demasiado grande ({{ ratio }}). La relación máxima permitida es {{ max_ratio }}.</target>
+                <target>La proporción del vídeo es demasiado grande ({{ ratio }}). La máxima proporción permitida es {{ max_ratio }}.</target>
             </trans-unit>
             <trans-unit id="131">
                 <source>The video ratio is too small ({{ ratio }}). Minimum ratio expected is {{ min_ratio }}.</source>
-                <target state="needs-review-translation">La relación del video es demasiado pequeña ({{ ratio }}). La relación mínima esperada es {{ min_ratio }}.</target>
+                <target>La proporción del vídeo es demasiado pequeña ({{ ratio }}). La mínima proporción permitida es {{ min_ratio }}.</target>
             </trans-unit>
             <trans-unit id="132">
                 <source>The video is square ({{ width }}x{{ height }}px). Square videos are not allowed.</source>
-                <target state="needs-review-translation">El video es cuadrado ({{ width }}x{{ height }}px). No se permiten videos cuadrados.</target>
+                <target>El vídeo es cuadrado ({{ width }}x{{ height }}px). Los vídeos cuadrados no están permitidos.</target>
             </trans-unit>
             <trans-unit id="133">
                 <source>The video is landscape oriented ({{ width }}x{{ height }}px). Landscape oriented videos are not allowed.</source>
-                <target state="needs-review-translation">El video tiene orientación horizontal ({{ width }}x{{ height }} px). No se permiten videos en formato horizontal.</target>
+                <target>El vídeo está orientado horizontalmente ({{ width }}x{{ height }}px). Los vídeos orientados horizontalmente no están permitidos.</target>
             </trans-unit>
             <trans-unit id="134">
                 <source>The video is portrait oriented ({{ width }}x{{ height }}px). Portrait oriented videos are not allowed.</source>
-                <target state="needs-review-translation">El video tiene orientación vertical ({{ width }}x{{ height }} px). No se permiten videos en orientación vertical.</target>
+                <target>El vídeo está orientado verticalmente ({{ width }}x{{ height }}px). Los vídeos orientados verticalmente no están permitidos.</target>
             </trans-unit>
             <trans-unit id="135">
                 <source>The video file is corrupted.</source>
-                <target state="needs-review-translation">El archivo de video está dañado.</target>
+                <target>El archivo de vídeo está dañado.</target>
             </trans-unit>
             <trans-unit id="136">
                 <source>The video contains multiple streams. Only one stream is allowed.</source>
-                <target state="needs-review-translation">El video contiene múltiples flujos. Solo se permite un flujo.</target>
+                <target>El vídeo contiene múltiples flujos. Solo se permite un flujo.</target>
             </trans-unit>
             <trans-unit id="137">
                 <source>Unsupported video codec "{{ codec }}".</source>
-                <target state="needs-review-translation">Códec de vídeo no compatible «{{ codec }}».</target>
+                <target>Códec de vídeo no compatible "{{ codec }}".</target>
             </trans-unit>
             <trans-unit id="138">
                 <source>Unsupported video container "{{ container }}".</source>
-                <target state="needs-review-translation">Contenedor de vídeo no compatible "{{ container }}".</target>
+                <target>Contenedor de vídeo no compatible "{{ container }}".</target>
             </trans-unit>
             <trans-unit id="139">
                 <source>The image file is corrupted.</source>
-                <target state="needs-review-translation">El archivo de imagen está dañado.</target>
+                <target>El archivo de imagen está dañado.</target>
             </trans-unit>
             <trans-unit id="140">
                 <source>The image has too few pixels ({{ pixels }} pixels). Minimum amount expected is {{ min_pixels }} pixels.</source>
-                <target state="needs-review-translation">La imagen tiene muy pocos píxeles ({{ pixels }}). La cantidad mínima esperada es {{ min_pixels }}.</target>
+                <target>La imagen tiene muy pocos píxeles ({{ pixels }}). La cantidad mínima requerida es {{ min_pixels }}.</target>
             </trans-unit>
             <trans-unit id="141">
                 <source>The image has too many pixels ({{ pixels }} pixels). Maximum amount expected is {{ max_pixels }} pixels.</source>
-                <target state="needs-review-translation">La imagen tiene demasiados píxeles ({{ pixels }}). La cantidad máxima esperada es {{ max_pixels }}.</target>
+                <target>La imagen tiene demasiados píxeles ({{ pixels }}). La cantidad máxima permitida es {{ max_pixels }}.</target>
             </trans-unit>
             <trans-unit id="142">
                 <source>This filename does not match the expected charset.</source>
-                <target state="needs-review-translation">Este nombre de archivo no coincide con el conjunto de caracteres esperado.</target>
+                <target>Este nombre de archivo no coincide con el conjunto de caracteres esperado.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A |
|---------------|---
| Branch?       | 6.4 |
| Bug fix?      | no |
| New feature?  | no |
| Deprecations? | no |
| Issues        | Resolve symfony/symfony#61641 |
| License       | MIT |

This PR verifies the Spanish (es) translations for the Validator component, following the existing style and tone used in other translations.

### Why
The Spanish translation file "validators.es.xlf" contained several strings with state "needs-review-translation" that exist in other languages.

### How
- Updated: "src/Symfony/Component/Validator/Resources/translations/validators.es.xlf"

### Before/After
Before: Unchecked translation entries in "validators.es.xlf"  
After: All validator strings now translated and verified in Spanish.
