### PR TITLE
[DomCrawler] Handle malformed tags in HTML5 parser

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -1272,7 +1272,11 @@ class Crawler implements \Countable, \IteratorAggregate
                     continue;
                 }
 
-                $element = $target->createElement($source->tagName);
+                try {
+                    $element = $target->createElement($source->tagName);
+                } catch (\DOMException) {
+                    continue;
+                }
 
                 foreach ($source->attributes as $attr) {
                     try {

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -1380,6 +1380,13 @@ class CrawlerTest extends TestCase
         yield 'All together' => [$BOM.'  <!--c-->'.$html];
     }
 
+    public function testHtml5MalformedContent()
+    {
+        $crawler = $this->createCrawler();
+        $crawler->addHtmlContent('<script&>');
+        self::assertEquals('<head></head><body></body>', $crawler->html());
+    }
+
     public function testAlpineJs()
     {
         $crawler = $this->createCrawler();

--- a/src/Symfony/Component/DomCrawler/Tests/LegacyHtml5ParserCrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/LegacyHtml5ParserCrawlerTest.php
@@ -72,6 +72,13 @@ class LegacyHtml5ParserCrawlerTest extends CrawlerTest
         yield 'Text between comments' => ['<!--c--> test <!--cc-->'.$html];
     }
 
+    public function testHtml5MalformedContent()
+    {
+        $crawler = $this->createCrawler();
+        $crawler->addHtmlContent('<script&>');
+        self::assertEquals('<head><script></script></head>', $crawler->html());
+    }
+
     protected function createCrawler($node = null, ?string $uri = null, ?string $baseHref = null)
     {
         return new Crawler($node, $uri, $baseHref, true);

--- a/src/Symfony/Component/DomCrawler/Tests/LegacyParserCrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/LegacyParserCrawlerTest.php
@@ -95,4 +95,11 @@ class LegacyParserCrawlerTest extends CrawlerTest
     public function testHtml5ParserParseContentStartingWithValidHeading(string $content)
     {
     }
+
+    public function testHtml5MalformedContent()
+    {
+        $crawler = $this->createCrawler();
+        $crawler->addHtmlContent('<script&>');
+        self::assertEquals('<head><script></script></head>', $crawler->html());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62236
| License       | MIT

Fixes DomCrawler to not crash if it encounters a malformed HTML tag; however the behaviour is still different from the previous version if I naively catch and ignore the exception, as demonstrated by the test case; it should pass on PHP 8.3 and fail on 8.4.