### PR TITLE
[Workflow] Improve PHPDoc precision and syntax

### DIFF
--- a/src/Symfony/Component/Workflow/Arc.php
+++ b/src/Symfony/Component/Workflow/Arc.php
@@ -16,6 +16,10 @@ namespace Symfony\Component\Workflow;
  */
 final class Arc
 {
+    /**
+     * @param non-empty-string $place  The place name
+     * @param int<1, max>      $weight The weight of the arc (must be greater than 0)
+     */
     public function __construct(
         public readonly string $place,
         public readonly int $weight,

--- a/src/Symfony/Component/Workflow/Marking.php
+++ b/src/Symfony/Component/Workflow/Marking.php
@@ -26,7 +26,7 @@ class Marking
     private ?array $context = null;
 
     /**
-     * @param int[] $representation Keys are the place name and values should be superior or equals to 1
+     * @param array<string, int<1, max>> $representation Keys are the place name and values should be superior or equals to 1
      */
     public function __construct(array $representation = [])
     {

--- a/src/Symfony/Component/Workflow/MarkingStore/MethodMarkingStore.php
+++ b/src/Symfony/Component/Workflow/MarkingStore/MethodMarkingStore.php
@@ -33,7 +33,8 @@ final class MethodMarkingStore implements MarkingStoreInterface
 {
     /** @var array<class-string, \Closure(object): mixed> */
     private array $getters = [];
-    /** @var array<class-string, \Closure(object, mixed, array)> */
+
+    /** @var array<class-string, \Closure(object, mixed, array): void> */
     private array $setters = [];
 
     /**
@@ -111,16 +112,18 @@ final class MethodMarkingStore implements MarkingStoreInterface
 
     private static function getType(object $subject, string $property, string $method, ?string &$type = null): MarkingStoreMethod
     {
+        $reflectionType = null;
+
         try {
             if (method_exists($subject, $method) && ($r = new \ReflectionMethod($subject, $method))->isPublic()) {
-                $type = 0 < $r->getNumberOfRequiredParameters() ? $r->getParameters()[0]->getType() : null;
+                $reflectionType = 0 < $r->getNumberOfRequiredParameters() ? $r->getParameters()[0]->getType() : null;
 
                 return MarkingStoreMethod::METHOD;
             }
 
             try {
                 if (($r = new \ReflectionProperty($subject, $property))->isPublic()) {
-                    $type = $r->getType();
+                    $reflectionType = $r->getType();
 
                     return MarkingStoreMethod::PROPERTY;
                 }
@@ -129,7 +132,7 @@ final class MethodMarkingStore implements MarkingStoreInterface
 
             throw new LogicException(\sprintf('Cannot store marking: class "%s" should have either a public method named "%s()" or a public property named "$%s"; none found.', get_debug_type($subject), $method, $property));
         } finally {
-            $type = $type instanceof \ReflectionNamedType && is_subclass_of($type->getName(), \BackedEnum::class) ? $type->getName() : null;
+            $type = $reflectionType instanceof \ReflectionNamedType && is_subclass_of($reflectionType->getName(), \BackedEnum::class) ? $reflectionType->getName() : null;
         }
     }
 }

--- a/src/Symfony/Component/Workflow/Transition.php
+++ b/src/Symfony/Component/Workflow/Transition.php
@@ -28,8 +28,8 @@ class Transition
     private array $toArcs;
 
     /**
-     * @param string|string[]|Arc[] $froms
-     * @param string|string[]|Arc[] $tos
+     * @param string|array<string|Arc> $froms
+     * @param string|array<string|Arc> $tos
      */
     public function __construct(
         private string $name,
@@ -46,7 +46,7 @@ class Transition
     }
 
     /**
-     * @return $asArc is true ? array<Arc> : array<string>
+     * @return ($asArc is true ? array<Arc> : array<string>)
      */
     public function getFroms(bool $asArc = false): array
     {
@@ -58,7 +58,7 @@ class Transition
     }
 
     /**
-     * @return $asArc is true ? array<Arc> : array<string>
+     * @return ($asArc is true ? array<Arc> : array<string>)
      */
     public function getTos(bool $asArc = false): array
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | n/a
| License       | MIT

This PR provides a series of PHPDoc and type-safety improvements for the Workflow component. These changes enhance static analysis accuracy and code clarity without changing runtime behavior.

### `MethodMarkingStore.php`

* **`getType()`:** Refactors the method to fix a static analysis issue. It now uses a local variable (`$reflectionType`) to hold the reflection object instead of incorrectly assigning it to the `?string &$type` by-ref parameter.
* **`$setters`:** Adds a missing `: void` return type to the `Closure` definition in the property's PHPDoc for completeness.

### `Transition.php`

* **Constructor:** Adjusts the `@param` for `$froms`/`$tos` from `string[]|Arc[]` to `array<string|Arc>`. This more accurately reflects that the method handles a *mixed* array of strings and `Arc` objects.
* **`getFroms()` / `getTos()`:** Wraps the conditional `@return` type in parentheses (e.g., `($asArc is true ? ...)`). This fixes PHPDoc parsing for tools that support this syntax.

### `Marking.php`

* **Constructor:** Improves the `@param` for `$representation` from a generic `int[]` to the more precise `array<string, int<1, max>>`, which correctly describes the expected shape (a map of places to a positive token count).

### `Arc.php`

* **Constructor:** Adds a PHPDoc to specify parameter types more precisely (`non-empty-string` for `$place` and `int<1, max>` for `$weight`), matching the existing runtime validation.