### PR TITLE
Set welcome page status code 404 => 200

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
@@ -169,6 +169,7 @@ class RouterListener implements EventSubscriberInterface
 
         if ($e->getPrevious() instanceof NoConfigurationException) {
             $event->setResponse($this->createWelcomeResponse());
+            $event->allowCustomResponseCode();
         }
     }
 
@@ -190,6 +191,6 @@ class RouterListener implements EventSubscriberInterface
         ob_start();
         include \dirname(__DIR__).'/Resources/welcome.html.php';
 
-        return new Response(ob_get_clean(), Response::HTTP_NOT_FOUND);
+        return new Response(ob_get_clean(), Response::HTTP_OK);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
@@ -188,11 +188,11 @@ class RouterListenerTest extends TestCase
         $request = Request::create('http://localhost/');
 
         $response = $kernel->handle($request);
-        $this->assertSame(404, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertStringContainsString('Welcome', $response->getContent());
 
         $response = $kernel->handle($request);
-        $this->assertSame(404, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertStringContainsString('Welcome', $response->getContent());
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT


The default welcome page of Symfony renders with a 404 status code. This makes sense because there is no root route configured, but not quite welcoming. In addition, using `php bin/console make:user && php bin/console make:security:form-login` to create a simple login form with unit tests, would cause the generated unit tests to fail. This is because the unit tests assert redirection to root, combined with a 200 status code. In case there is not root configured yet, this would cause the test to fail, while it in fact does redirect correctly.

These changes update the status code of the welcome page to 200. This causes the unit tests to pass, and suits the welcome page better.