### PR TITLE
[HttpFoundation] Allow Request::setFormat() to override predefined formats

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1298,13 +1298,20 @@ class Request
             static::initializeFormats();
         }
 
+        $exactFormat = null;
+        $canonicalFormat = null;
+
         foreach (static::$formats as $format => $mimeTypes) {
-            if (\in_array($mimeType, (array) $mimeTypes)) {
-                return $format;
+            if (\in_array($mimeType, $mimeTypes, true)) {
+                $exactFormat = $format;
             }
-            if (null !== $canonicalMimeType && \in_array($canonicalMimeType, (array) $mimeTypes)) {
-                return $format;
+            if (null !== $canonicalMimeType && \in_array($canonicalMimeType, $mimeTypes, true)) {
+                $canonicalFormat = $format;
             }
+        }
+
+        if ($format = $exactFormat ?? $canonicalFormat) {
+            return $format;
         }
 
         return null;
@@ -1323,7 +1330,7 @@ class Request
             static::initializeFormats();
         }
 
-        static::$formats[$format] = \is_array($mimeTypes) ? $mimeTypes : [$mimeTypes];
+        static::$formats[$format ?? ''] = (array) $mimeTypes;
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseFormatSameTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseFormatSameTest.php
@@ -58,4 +58,14 @@ class ResponseFormatSameTest extends TestCase
 
         $this->fail();
     }
+
+    public function testOverriddenFormat()
+    {
+        $request = new Request();
+        $request->setFormat('jsonapi', ['application/vnd.api+json']);
+        $request->setFormat('apijson', ['application/vnd.api+json']);
+
+        $constraint = new ResponseFormatSame($request, 'apijson');
+        $this->assertTrue($constraint->evaluate(new Response('', 200, ['Content-Type' => 'application/vnd.api+json']), '', true));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62226 
| License       | MIT

Since #61267 some additional MIME formats are predefined; in order to override the predefined formats you must explictly deregister them. This PR changes the order so formats added later take precedence.
