### PR TITLE
[HttpKernel] Restructure Share Dir for using kernel.share_dir without environment specific directory

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1385,7 +1385,7 @@ class Configuration implements ConfigurationInterface
                             ->info('System related cache pools configuration.')
                             ->defaultValue('cache.adapter.system')
                         ->end()
-                        ->scalarNode('directory')->defaultValue('%kernel.share_dir%/pools/app')->end()
+                        ->scalarNode('directory')->defaultValue('%kernel.share_dir%/cache/%kernel.environment%/pools/app')->end()
                         ->scalarNode('default_psr6_provider')->end()
                         ->scalarNode('default_redis_provider')->defaultValue('redis://localhost')->end()
                         ->scalarNode('default_valkey_provider')->defaultValue('valkey://localhost')->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1385,7 +1385,7 @@ class Configuration implements ConfigurationInterface
                             ->info('System related cache pools configuration.')
                             ->defaultValue('cache.adapter.system')
                         ->end()
-                        ->scalarNode('directory')->defaultValue('%kernel.share_dir%/cache/%kernel.environment%/pools/app')->end()
+                        ->scalarNode('directory')->defaultValue('%kernel.share_dir%/app_cache/%kernel.environment%')->end()
                         ->scalarNode('default_psr6_provider')->end()
                         ->scalarNode('default_redis_provider')->defaultValue('redis://localhost')->end()
                         ->scalarNode('default_valkey_provider')->defaultValue('valkey://localhost')->end()

--- a/src/Symfony/Bundle/FrameworkBundle/HttpCache/HttpCache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/HttpCache/HttpCache.php
@@ -46,7 +46,10 @@ class HttpCache extends BaseHttpCache
         if ($cache instanceof StoreInterface) {
             $this->store = $cache;
         } else {
-            $this->cacheDir = $cache;
+            $this->cacheDir = $cache ?? (match (true) {
+                null !== $this->kernel->getShareDir() => $this->kernel->getShareDir().'/http_cache/'.$this->kernel->getEnvironment(),
+                default => $this->kernel->getCacheDir().'/http_cache',
+            });
         }
 
         if (null === $options && $kernel->isDebug()) {
@@ -83,9 +86,6 @@ class HttpCache extends BaseHttpCache
 
     protected function createStore(): StoreInterface
     {
-        return $this->store ?? new Store($this->cacheDir ?: (match (true) {
-            null !== $this->kernel->getShareDir() => $this->kernel->getShareDir().'/cache/'.$this->kernel->getEnvironment().'/http_cache',
-            default => $this->kernel->getCacheDir().'/http_cache',
-        }));
+        return $this->store ?? new Store($this->cacheDir);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/HttpCache/HttpCache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/HttpCache/HttpCache.php
@@ -46,9 +46,6 @@ class HttpCache extends BaseHttpCache
         if ($cache instanceof StoreInterface) {
             $this->store = $cache;
         } else {
-            $this->cacheDir = $cache ?? (match (true) {
-                null !== $this->kernel->getShareDir() => $this->kernel->getShareDir().'/http_cache/'.$this->kernel->getEnvironment(),
-                default => $this->kernel->getCacheDir().'/http_cache',
             $cache ??= null !== ($dir = $kernel->getShareDir()) ? $dir.'/http_cache/'.$kernel->getEnvironment() : $kernel->getCacheDir().'/http_cache',
             $this->cacheDir = $cache;
         }

--- a/src/Symfony/Bundle/FrameworkBundle/HttpCache/HttpCache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/HttpCache/HttpCache.php
@@ -49,7 +49,8 @@ class HttpCache extends BaseHttpCache
             $this->cacheDir = $cache ?? (match (true) {
                 null !== $this->kernel->getShareDir() => $this->kernel->getShareDir().'/http_cache/'.$this->kernel->getEnvironment(),
                 default => $this->kernel->getCacheDir().'/http_cache',
-            });
+            $cache ??= null !== ($dir = $kernel->getShareDir()) ? $dir.'/http_cache/'.$kernel->getEnvironment() : $kernel->getCacheDir().'/http_cache',
+            $this->cacheDir = $cache;
         }
 
         if (null === $options && $kernel->isDebug()) {

--- a/src/Symfony/Bundle/FrameworkBundle/HttpCache/HttpCache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/HttpCache/HttpCache.php
@@ -46,7 +46,7 @@ class HttpCache extends BaseHttpCache
         if ($cache instanceof StoreInterface) {
             $this->store = $cache;
         } else {
-            $cache ??= null !== ($dir = $kernel->getShareDir()) ? $dir.'/http_cache/'.$kernel->getEnvironment() : $kernel->getCacheDir().'/http_cache',
+            $cache ??= null !== ($dir = $kernel->getShareDir()) ? $dir.'/http_cache/'.$kernel->getEnvironment() : $kernel->getCacheDir().'/http_cache';
             $this->cacheDir = $cache;
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/HttpCache/HttpCache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/HttpCache/HttpCache.php
@@ -83,6 +83,9 @@ class HttpCache extends BaseHttpCache
 
     protected function createStore(): StoreInterface
     {
-        return $this->store ?? new Store($this->cacheDir ?: ($this->kernel->getShareDir() ?? $this->kernel->getCacheDir()).'/http_cache');
+        return $this->store ?? new Store($this->cacheDir ?: (match (true) {
+            null !== $this->kernel->getShareDir() => $this->kernel->getShareDir().'/cache/'.$this->kernel->getEnvironment().'/http_cache',
+            default => $this->kernel->getCacheDir().'/http_cache',
+        }));
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
@@ -131,7 +131,7 @@ trait MicroKernelTrait
                 return null;
             }
             if (\is_string($dir)) {
-                return $dir.'/'.$this->environment;
+                return $dir;
             }
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -936,7 +936,7 @@ class ConfigurationTest extends TestCase
                 'pools' => [],
                 'app' => 'cache.adapter.filesystem',
                 'system' => 'cache.adapter.system',
-                'directory' => '%kernel.share_dir%/cache/%kernel.environment%/pools/app',
+                'directory' => '%kernel.share_dir%/app_cache/%kernel.environment%',
                 'default_redis_provider' => 'redis://localhost',
                 'default_valkey_provider' => 'valkey://localhost',
                 'default_memcached_provider' => 'memcached://localhost',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -936,7 +936,7 @@ class ConfigurationTest extends TestCase
                 'pools' => [],
                 'app' => 'cache.adapter.filesystem',
                 'system' => 'cache.adapter.system',
-                'directory' => '%kernel.share_dir%/pools/app',
+                'directory' => '%kernel.share_dir%/cache/%kernel.environment%/pools/app',
                 'default_redis_provider' => 'redis://localhost',
                 'default_valkey_provider' => 'valkey://localhost',
                 'default_memcached_provider' => 'memcached://localhost',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
@@ -75,7 +75,7 @@ class MicroKernelTraitTest extends TestCase
         try {
             $kernel = $this->kernel = new ConcreteMicroKernel('test', false);
 
-            $expected = rtrim(sys_get_temp_dir(), '/').'/test';
+            $expected = rtrim(sys_get_temp_dir(), '/');
             $this->assertSame($expected, $kernel->getShareDir());
 
             $parameters = $kernel->getKernelParameters();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

If I work on a Sulu project its common sometimes to debug things that I switch between `dev`, `stage` (sulu specific), `prod` envs. And if we put our `storage` and `indexes` directory into `%kernel.share_dir%` that path should not include the `%kernel.environment%`.

So uploads and search index in sulu are stored in `var/share/storage` and `var/share/indexes`, not including the current ENV.

With the change in https://github.com/symfony/symfony/pull/62204/ it make possible to know that and only add `%kernel.environment%` to the caches where its relevant. But we could still use `%kernel.share_dir%/storage` in the cloud template here: 
https://github.com/symfonycorp/cloud-templates/pull/43#discussion_r2480959702

So what changed:

**Before**:

```
 - var/share
    - dev
       - pools
       - http_cache
       - indexes
       - storage
    - stage
       - pools
       - http_cache
       - indexes
       - storage
    - prod
       - pools
       - http_cache
       - indexes
       - storage
```

**Now**:

```
 - var/share
    - app_cache
       - dev
       - stage
       - prod
    - http_cache
       - dev
       - stage
       - prod
    - indexes (none env dir)
    - storage (none env dir)
```

This should not as in https://github.com/symfony/symfony/pull/62187 break something as with #62204 we now know if there is kernel.share_dir configured or not.