### PR TITLE
[Messenger] Fix unreachable catch

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
@@ -166,12 +166,12 @@ class Connection implements ResetInterface
         if ($this->driverConnection->getDatabasePlatform() instanceof MySQLPlatform) {
             try {
                 $this->driverConnection->delete($this->configuration['table_name'], ['delivered_at' => '9999-12-31 23:59:59']);
-            } catch (DriverException $e) {
-                // Ignore the exception
             } catch (TableNotFoundException $e) {
                 if ($this->autoSetup) {
                     $this->setup();
                 }
+            } catch (DriverException $e) {
+                // Ignore the exception
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | n/a
| License       | MIT

Fix for `PhanUnreachableCatch` [phan issues](https://github.com/phan/phan):
```
Catch statement for \Doctrine\DBAL\Exception\TableNotFoundException is unreachable. An earlier catch statement at line 168 caught the ancestor class/interface \Doctrine\DBAL\Driver\Exception
```