### PR TITLE
 Make CacheItem::METADATA_EXPIRY_OFFSET accessible

### DIFF
--- a/src/Symfony/Component/Cache/CacheItem.php
+++ b/src/Symfony/Component/Cache/CacheItem.php
@@ -22,7 +22,7 @@ use Symfony\Contracts\Cache\ItemInterface;
  */
 final class CacheItem implements ItemInterface
 {
-    private const METADATA_EXPIRY_OFFSET = 1527506807;
+    public const METADATA_EXPIRY_OFFSET = 1527506807;
     private const VALUE_WRAPPER = "\xA9";
 
     protected string $key;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | ye
| New feature?  | no
| Deprecations? | no
| Issues        | n/a
| License       | MIT

Fix for PhanAccessClassConstantPrivate [phan issue](https://github.com/phan/phan):
```
src/Symfony/Component/Cache/Adapter/AbstractTagAwareAdapter.php:81 PhanAccessClassConstantPrivate Cannot access private class constant \Symfony\Component\Cache\CacheItem::METADATA_EXPIRY_OFFSET defined at src/Symfony/Component/Cache/CacheItem.php:25
src/Symfony/Component/Cache/Adapter/AbstractTagAwareAdapter.php:116 PhanAccessClassConstantPrivate Cannot access private class constant \Symfony\Component\Cache\CacheItem::METADATA_EXPIRY_OFFSET defined at src/Symfony/Component/Cache/CacheItem.php:25
```

`CacheItem::METADATA_EXPIRY_OFFSET` is used at:
- https://github.com/symfony/symfony/blob/77bd236b8da064c90b19b84a35becfb3e43348db/src/Symfony/Component/Cache/Adapter/AbstractTagAwareAdapter.php#L63C88-L63C110

 - https://github.com/symfony/symfony/blob/77bd236b8da064c90b19b84a35becfb3e43348db/src/Symfony/Component/Cache/Adapter/AbstractTagAwareAdapter.php#L98
