### PR TITLE
[DomCrawler] Fall back to DOMDocument parser to create invalid elements

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -1275,7 +1275,7 @@ class Crawler implements \Countable, \IteratorAggregate
                 try {
                     $element = $target->createElement($source->tagName);
                 } catch (\DOMException) {
-                    $dom = clone $target;
+                    $dom = new \DOMDocument('1.0', $target->encoding);
                     @$dom->loadHTML('<'.$source->tagName.'>');
                     $element = $dom->lastChild->firstChild->firstChild;
                     $element = $target->importNode($element, true);

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -1276,9 +1276,8 @@ class Crawler implements \Countable, \IteratorAggregate
                     $element = $target->createElement($source->tagName);
                 } catch (\DOMException) {
                     $dom = new \DOMDocument('1.0', $target->encoding);
-                    @$dom->loadHTML('<'.$source->tagName.'>');
-                    $element = $dom->lastChild->firstChild->firstChild;
-                    $element = $target->importNode($element, true);
+                    @$dom->loadHTML('<'.$source->tagName.'>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+                    $element = $target->importNode($dom->firstChild);
                 }
 
                 foreach ($source->attributes as $attr) {

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -1111,11 +1111,10 @@ class Crawler implements \Countable, \IteratorAggregate
         $internalErrors = libxml_use_internal_errors(true);
 
         $document = \Dom\HTMLDocument::createFromString($htmlContent, \Dom\HTML_NO_DEFAULT_NS, $charset);
-
-        libxml_use_internal_errors($internalErrors);
-
         $dom = new \DOMDocument('1.0', $document->inputEncoding);
         $this->copyFromHtml5ToDom($document->documentElement, $dom);
+
+        libxml_use_internal_errors($internalErrors);
 
         return $dom;
     }
@@ -1276,7 +1275,7 @@ class Crawler implements \Countable, \IteratorAggregate
                     $element = $target->createElement($source->tagName);
                 } catch (\DOMException) {
                     $dom = new \DOMDocument('1.0', $target->encoding);
-                    @$dom->loadHTML('<'.$source->tagName.'>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+                    $dom->loadHTML('<'.$source->tagName.'>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
                     $element = $target->importNode($dom->firstChild);
                 }
 

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -1275,7 +1275,10 @@ class Crawler implements \Countable, \IteratorAggregate
                 try {
                     $element = $target->createElement($source->tagName);
                 } catch (\DOMException) {
-                    continue;
+                    $dom = clone $target;
+                    @$dom->loadHTML('<'.$source->tagName.'>');
+                    $element = $dom->lastChild->firstChild->firstChild;
+                    $element = $target->importNode($element, true);
                 }
 
                 foreach ($source->attributes as $attr) {

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -1275,7 +1275,7 @@ class Crawler implements \Countable, \IteratorAggregate
                     $element = $target->createElement($source->tagName);
                 } catch (\DOMException) {
                     $dom = new \DOMDocument('1.0', $target->encoding);
-                    $dom->loadHTML('<'.$source->tagName.'>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+                    $dom->loadHTML('<'.$source->tagName.'>', \LIBXML_HTML_NOIMPLIED | \LIBXML_HTML_NODEFDTD);
                     $element = $target->importNode($dom->firstChild);
                 }
 

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -1383,7 +1383,7 @@ class CrawlerTest extends TestCase
     public function testHtml5MalformedContent()
     {
         $crawler = $this->createCrawler();
-        $crawler->addHtmlContent('<script&>');
+        $crawler->addHtmlContent('<html><head></head><body><script&>');
         self::assertEquals('<head></head><body><script></script></body>', $crawler->html());
     }
 

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -1384,7 +1384,7 @@ class CrawlerTest extends TestCase
     {
         $crawler = $this->createCrawler();
         $crawler->addHtmlContent('<script&>');
-        self::assertEquals('<head></head><body></body>', $crawler->html());
+        self::assertEquals('<head></head><body><script></script></body>', $crawler->html());
     }
 
     public function testAlpineJs()

--- a/src/Symfony/Component/DomCrawler/Tests/LegacyHtml5ParserCrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/LegacyHtml5ParserCrawlerTest.php
@@ -72,13 +72,6 @@ class LegacyHtml5ParserCrawlerTest extends CrawlerTest
         yield 'Text between comments' => ['<!--c--> test <!--cc-->'.$html];
     }
 
-    public function testHtml5MalformedContent()
-    {
-        $crawler = $this->createCrawler();
-        $crawler->addHtmlContent('<script&>');
-        self::assertEquals('<head><script></script></head>', $crawler->html());
-    }
-
     protected function createCrawler($node = null, ?string $uri = null, ?string $baseHref = null)
     {
         return new Crawler($node, $uri, $baseHref, true);

--- a/src/Symfony/Component/DomCrawler/Tests/LegacyParserCrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/LegacyParserCrawlerTest.php
@@ -95,11 +95,4 @@ class LegacyParserCrawlerTest extends CrawlerTest
     public function testHtml5ParserParseContentStartingWithValidHeading(string $content)
     {
     }
-
-    public function testHtml5MalformedContent()
-    {
-        $crawler = $this->createCrawler();
-        $crawler->addHtmlContent('<script&>');
-        self::assertEquals('<head><script></script></head>', $crawler->html());
-    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62236
| License       | MIT

Followup to #62240.

Instead of bailing out immediately on error, we now try harder to create an invalid element by passing any malformed tag into `DOMDocument::loadHTML()` for it to parse.
