### PR TITLE
[ObjectMapper] call ObjectMapperAware callables

### DIFF
--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -312,16 +312,26 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
     }
 
     /**
-     * @param (string|callable(mixed $value, object $object): mixed) $fn
+     * @param string|callable(mixed $value, object $object): mixed) $fn
      */
     private function getCallable(string|callable $fn, ?ContainerInterface $locator = null): ?callable
     {
         if (\is_callable($fn)) {
+            if ($fn instanceof ObjectMapperAwareInterface) {
+                $fn = $fn->withObjectMapper($this->objectMapper ?? $this);
+            }
+
             return $fn;
         }
 
         if ($locator?->has($fn)) {
-            return $locator->get($fn);
+            $fn = $locator->get($fn);
+
+            if ($fn instanceof ObjectMapperAwareInterface) {
+                $fn = $fn->withObjectMapper($this->objectMapper ?? $this);
+            }
+
+            return \is_callable($fn) ? $fn : null;
         }
 
         return null;

--- a/src/Symfony/Component/ObjectMapper/Transform/MapCollection.php
+++ b/src/Symfony/Component/ObjectMapper/Transform/MapCollection.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\ObjectMapper\Transform;
 
 use Symfony\Component\ObjectMapper\Exception\MappingException;
 use Symfony\Component\ObjectMapper\ObjectMapper;
+use Symfony\Component\ObjectMapper\ObjectMapperAwareInterface;
 use Symfony\Component\ObjectMapper\ObjectMapperInterface;
 use Symfony\Component\ObjectMapper\TransformCallableInterface;
 
@@ -21,10 +22,10 @@ use Symfony\Component\ObjectMapper\TransformCallableInterface;
  *
  * @implements TransformCallableInterface<object, T>
  */
-class MapCollection implements TransformCallableInterface
+class MapCollection implements TransformCallableInterface, ObjectMapperAwareInterface
 {
     public function __construct(
-        private ObjectMapperInterface $objectMapper = new ObjectMapper(),
+        private ?ObjectMapperInterface $objectMapper = null,
     ) {
     }
 
@@ -40,5 +41,11 @@ class MapCollection implements TransformCallableInterface
         }
 
         return $values;
+    }
+
+    public function withObjectMapper(ObjectMapperInterface $objectMapper): static
+    {
+        $this->objectMapper = $objectMapper;
+        return $this;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

Allows to create transforms that are aware of the current mapper and avoid using dependency injection. 