### PR TITLE
[ErrorHandler] Improve PHPDoc precision in SerializerErrorRenderer

### DIFF
--- a/src/Symfony/Component/ErrorHandler/ErrorRenderer/SerializerErrorRenderer.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorRenderer/SerializerErrorRenderer.php
@@ -29,9 +29,9 @@ class SerializerErrorRenderer implements ErrorRendererInterface
     private bool|\Closure $debug;
 
     /**
-     * @param string|callable(FlattenException) $format The format as a string or a callable that should return it
-     *                                                  formats not supported by Request::getMimeTypes() should be given as mime types
-     * @param bool|callable                     $debug  The debugging mode as a boolean or a callable that should return it
+     * @param string|callable(FlattenException): string $format The format as a string or a callable that should return it
+     *                                                          formats not supported by Request::getMimeTypes() should be given as mime types
+     * @param bool|callable                             $debug  The debugging mode as a boolean or a callable that should return it
      */
     public function __construct(
         private SerializerInterface $serializer,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR adjusts the PHPDoc for the `$format` parameter in `SerializerErrorRenderer` to include the `callable`'s return type (`:string`).

This provides better precision for static analysis tools.