### PR TITLE
[Form] Removes legacy error messages flag

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.php
@@ -141,7 +141,6 @@ return static function (ContainerConfigurator $container) {
         ->set('form.type_extension.form.validator', FormTypeValidatorExtension::class)
             ->args([
                 service('validator'),
-                false,
                 service('twig.form.renderer')->ignoreOnInvalid(),
                 service('translator')->ignoreOnInvalid(),
             ])

--- a/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
@@ -31,7 +31,6 @@ class FormTypeValidatorExtension extends BaseValidatorExtension
 
     public function __construct(
         private ValidatorInterface $validator,
-        private bool $legacyErrorMessages = true,
         ?FormRendererInterface $formRenderer = null,
         ?TranslatorInterface $translator = null,
     ) {

--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
@@ -29,7 +29,6 @@ class ValidatorExtension extends AbstractExtension
 {
     public function __construct(
         private ValidatorInterface $validator,
-        private bool $legacyErrorMessages = true,
         private ?FormRendererInterface $formRenderer = null,
         private ?TranslatorInterface $translator = null,
     ) {
@@ -53,7 +52,7 @@ class ValidatorExtension extends AbstractExtension
     protected function loadTypeExtensions(): array
     {
         return [
-            new Type\FormTypeValidatorExtension($this->validator, $this->legacyErrorMessages, $this->formRenderer, $this->translator),
+            new Type\FormTypeValidatorExtension($this->validator, $this->formRenderer, $this->translator),
             new Type\RepeatedTypeValidatorExtension(),
             new Type\SubmitTypeValidatorExtension(),
         ];

--- a/src/Symfony/Component/Form/Test/Traits/ValidatorExtensionTrait.php
+++ b/src/Symfony/Component/Form/Test/Traits/ValidatorExtensionTrait.php
@@ -36,6 +36,6 @@ trait ValidatorExtensionTrait
         $this->validator->expects($this->any())->method('getMetadataFor')->willReturn($metadata);
         $this->validator->expects($this->any())->method('validate')->willReturn(new ConstraintViolationList());
 
-        return new ValidatorExtension($this->validator, false);
+        return new ValidatorExtension($this->validator);
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorPerformanceTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorPerformanceTest.php
@@ -24,7 +24,7 @@ class FormValidatorPerformanceTest extends FormPerformanceTestCase
     protected function getExtensions(): array
     {
         return [
-            new ValidatorExtension(Validation::createValidator(), false),
+            new ValidatorExtension(Validation::createValidator()),
         ];
     }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
@@ -79,7 +79,7 @@ class FormTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
     public function testGroupSequenceWithConstraintsOption()
     {
         $form = Forms::createFormFactoryBuilder()
-            ->addExtension(new ValidatorExtension(Validation::createValidator(), false))
+            ->addExtension(new ValidatorExtension(Validation::createValidator()))
             ->getFormFactory()
             ->create(FormTypeTest::TESTED_TYPE, null, ['validation_groups' => new GroupSequence(['First', 'Second'])])
             ->add('field', TextTypeTest::TESTED_TYPE, [

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorExtensionTest.php
@@ -35,7 +35,7 @@ class ValidatorExtensionTest extends TestCase
             ->setMetadataFactory($metadataFactory)
             ->getValidator();
 
-        $extension = new ValidatorExtension($validator, false);
+        $extension = new ValidatorExtension($validator);
 
         $this->assertInstanceOf(ValidatorTypeGuesser::class, $extension->loadTypeGuesser());
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR removes the `$legacyErrorMessages` flag from the validator extension and form type validator extension.

This flag was introduced to handle legacy error messages but is no longer needed.

The usage of this property was removed by [PR #42916](https://github.com/symfony/symfony/pull/42916), but its declaration remained as unused code.