### PR TITLE
[JsonPath] Remove unused "nothing" property from JsonCrawler

### DIFF
--- a/src/Symfony/Component/JsonPath/JsonCrawler.php
+++ b/src/Symfony/Component/JsonPath/JsonCrawler.php
@@ -32,8 +32,6 @@ use Symfony\Component\JsonStreamer\Read\Splitter;
  */
 final class JsonCrawler implements JsonCrawlerInterface
 {
-    private static \stdClass $nothing;
-
     private const RFC9535_FUNCTIONS = [
         'length' => true,
         'count' => true,
@@ -833,8 +831,8 @@ final class JsonCrawler implements JsonCrawlerInterface
 
     private function compareEquality(mixed $left, mixed $right): bool
     {
-        $leftIsNothing = $left === Nothing::Nothing;
-        $rightIsNothing = $right === Nothing::Nothing;
+        $leftIsNothing = Nothing::Nothing === $left;
+        $rightIsNothing = Nothing::Nothing === $right;
 
         if (
             $leftIsNothing && $rightIsNothing


### PR DESCRIPTION
| Q | A
|---|---
| Branch? | 7.4
| Bug fix? | no
| New feature? | no
| Deprecations? | no
| Issues | n/a
| License | MIT

This PR removes the `private static \stdClass $nothing;` property from `JsonCrawler`, as it is no longer used and has been replaced by the `Nothing::Nothing` enum. See #61749