### PR TITLE
[Translation] Remove an unused argument passed to parseNode() method

### DIFF
--- a/src/Symfony/Component/Translation/PseudoLocalizationTranslator.php
+++ b/src/Symfony/Component/Translation/PseudoLocalizationTranslator.php
@@ -183,7 +183,7 @@ final class PseudoLocalizationTranslator implements TranslatorInterface, Transla
 
             $parts[] = [false, false, '>'];
 
-            $parts = array_merge($parts, $this->parseNode($childNode, $parts));
+            $parts = array_merge($parts, $this->parseNode($childNode));
 
             $parts[] = [false, false, '</'.$childNode->tagName.'>'];
         }


### PR DESCRIPTION
| Q | A
|---|---
| Branch? | 7.4
| Bug fix? | no
| New feature? | no
| Deprecations? | no
| Issues | n/a
| License | MIT

This PR removes an unused argument from the recursive call to `parseNode()` in `PseudoLocalizationTranslator`.

The call was passing a second argument, but the method's signature only accepts one.