### PR TITLE
[Cache] Add missing SQLitePlatform use statement in DoctrineDbalAdapter

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php
@@ -21,6 +21,7 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
 use Doctrine\DBAL\Schema\Name\Identifier;


### PR DESCRIPTION
| Q | A
|---|---
| Branch? | 8.0
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Issues | n/a
| License | MIT

This PR adds the missing `use Doctrine\DBAL\Platforms\SQLitePlatform;` statement in the `DoctrineDbalAdapter`.

The `getPlatformName()` method performs an `instanceof SQLitePlatform` check, but the class was not imported at the top of the file. 