### PR TITLE
[Notifier] Remove unused $transportName argument in EmailChannel::notify()

### DIFF
--- a/src/Symfony/Component/Notifier/Channel/EmailChannel.php
+++ b/src/Symfony/Component/Notifier/Channel/EmailChannel.php
@@ -54,7 +54,7 @@ class EmailChannel implements ChannelInterface
             $message = $notification->asEmailMessage($recipient, $transportName);
         }
 
-        $message ??= EmailMessage::fromNotification($notification, $recipient, $transportName);
+        $message ??= EmailMessage::fromNotification($notification, $recipient);
         $email = $message->getMessage();
         if ($email instanceof Email) {
             if (!$email->getFrom()) {


### PR DESCRIPTION
| Q | A
|---|---
| Branch? | 7.4
| Bug fix? | no
| New feature? | no
| Deprecations? | no
| Issues | n/a
| License | MIT

This PR removes a redundant `$transportName` argument passed to `EmailMessage::fromNotification()` in `EmailChannel::notify()`.

This third argument has been ignored since PR #35167.

The transport is already correctly set on the subsequent line (78) via `$message->transport($transportName);`, making this argument superfluous. This change simply cleans up the legacy method call.