### PR TITLE
[HttpFoundation] Deprecate null $format argument to Request::setFormat()

### DIFF
--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -96,6 +96,7 @@ HttpFoundation
  * Deprecate using `Request::sendHeaders()` after headers have already been sent; use a `StreamedResponse` instead
  * Deprecate method `Request::get()`, use properties `->attributes`, `query` or `request` directly instead
  * Deprecate HTTP method override for methods GET, HEAD, CONNECT and TRACE; it will be ignored in Symfony 8.0
+ * Deprecate accepting null `$format` argument to `Request::setFormat()`
 
 HttpKernel
 ----------

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
  * Deprecate method `Request::get()`, use properties `->attributes`, `query` or `request` directly instead
  * Make `Request::createFromGlobals()` parse the body of PUT, DELETE, PATCH and QUERY requests
  * Deprecate HTTP method override for methods GET, HEAD, CONNECT and TRACE; it will be ignored in Symfony 8.0
+ * Deprecate accepting null `$format` argument to `Request::setFormat()`
 
 7.3
 ---

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1369,15 +1369,21 @@ class Request
     /**
      * Associates a format with mime types.
      *
+     * @param string          $format    The format to set
      * @param string|string[] $mimeTypes The associated mime types (the preferred one must be the first as it will be used as the content type)
      */
     public function setFormat(?string $format, string|array $mimeTypes): void
     {
+        if (null === $format) {
+            trigger_deprecation('symfony/http-foundation', '7.4', 'Passing "null" as the first argument of "%s()" is deprecated. The argument will be non-nullable in Symfony 8.0.', __METHOD__);
+            $format = '';
+        }
+
         if (null === static::$formats) {
             static::initializeFormats();
         }
 
-        static::$formats[$format ?? ''] = (array) $mimeTypes;
+        static::$formats[$format] = (array) $mimeTypes;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | no
| License       | MIT

Deprecates null `$format` argument to `Request::setFormat()` - as discovered in #62246 it makes no sense for this argument to be nullable.
