### PR TITLE
[Lock][DynamoDB] Allow current symfony/lock

### DIFF
--- a/src/Symfony/Component/Lock/Bridge/DynamoDb/composer.json
+++ b/src/Symfony/Component/Lock/Bridge/DynamoDb/composer.json
@@ -16,10 +16,10 @@
         }
     ],
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.4",
         "async-aws/core": "^1.7",
         "async-aws/dynamo-db": "^3.0",
-        "symfony/lock": "^7.4"
+        "symfony/lock": "^7.4|^8.0"
     },
     "conflict": {
         "symfony/polyfill-uuid": "<1.15"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Fix the version constraint to allow installation of the DynamoDB bridge with the latest Lock component.