### PR TITLE
[Config] Use the empty string instead of null as an array offset

### DIFF
--- a/src/Symfony/Component/Config/Definition/Dumper/YamlReferenceDumper.php
+++ b/src/Symfony/Component/Config/Definition/Dumper/YamlReferenceDumper.php
@@ -249,6 +249,6 @@ class YamlReferenceDumper
         }
         $keyNode->setInfo($info);
 
-        return [$key => $keyNode];
+        return [$key ?? '' => $keyNode];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

For reference https://github.com/symfony/symfony/pull/61662


[Deprecation in CI](https://github.com/symfony/symfony/actions/runs/19001446632/job/54268718284?pr=62266#step:8:3293)


<img width="854" height="312" alt="Screenshot from 2025-11-01 16-53-54" src="https://github.com/user-attachments/assets/946e5fa5-8300-40b3-b443-080119700e6f" />
