### PR TITLE
[ProxyManager] Remove extra space before return‑type colon in `proxy-implem.php`

### DIFF
--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/Fixtures/proxy-implem.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/Fixtures/proxy-implem.php
@@ -210,12 +210,12 @@ class SunnyInterface_%s implements \ProxyManager\Proxy\VirtualProxyInterface, \S
         return $this->initializer%s;
     }
 
-    public function initializeProxy() : bool
+    public function initializeProxy(): bool
     {
         return $this->initializer%s && ($this->initializer%s->__invoke($valueHolder%s, $this, 'initializeProxy', array(), $this->initializer%s) || 1) && $this->valueHolder%s = $valueHolder%s;
     }
 
-    public function isProxyInitialized() : bool
+    public function isProxyInitialized(): bool
     {
         return null !== $this->valueHolder%s;
     }

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/ProxyDumperTest.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/ProxyDumperTest.php
@@ -142,6 +142,8 @@ EOPHP;
 
         $implem = preg_replace('#\n    /\*\*.*?\*/#s', '', $implem);
         $implem = str_replace("array(\n        \n    );", "[\n        \n    ];", $implem);
+        // https://github.com/symfony/symfony/pull/62269#issuecomment-3476843062
+        $implem = str_replace('() : bool', '(): bool', $implem);
 
         $this->assertStringMatchesFormatFile(__DIR__.'/Fixtures/proxy-implem.php', $implem);
         $this->assertStringEqualsFile(__DIR__.'/Fixtures/proxy-factory.php', $factory);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no 
| Deprecations? | no
| Issues        | -
| License       | MIT

For reference [Release](https://github.com/laminas/laminas-code/releases/tag/4.17.0), [PR](https://github.com/laminas/laminas-code/pull/208)  and [Action](https://github.com/symfony/symfony/actions/runs/19001841936/job/54269654430?pr=62267#step:8:2755) failure

Also an image of the failure

<img width="904" height="479" alt="Screenshot from 2025-11-01 17-35-45" src="https://github.com/user-attachments/assets/8a54f522-6a32-4096-b802-f8a8aa05d2fc" />