### PR TITLE
[FrameworkBundle][Messenger] Add `RetryStrategyStamp`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -142,6 +142,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Middleware\AddDefaultStampsMiddleware;
 use Symfony\Component\Messenger\Middleware\DeduplicateMiddleware;
 use Symfony\Component\Messenger\Middleware\RouterContextMiddleware;
+use Symfony\Component\Messenger\Retry\DynamicRetryStrategy;
 use Symfony\Component\Messenger\Transport\AmqpExt\AmqpTransportFactory;
 use Symfony\Component\Messenger\Transport\RedisExt\RedisTransportFactory;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
@@ -2425,6 +2426,10 @@ class FrameworkExtension extends Extension
 
         $loader->load('messenger.php');
 
+        if (!class_exists(DynamicRetryStrategy::class)) {
+            $container->removeDefinition('messenger.retry.abstract_dynamic_retry_strategy');
+        }
+
         if (!interface_exists(DenormalizerInterface::class)) {
             $container->removeDefinition('serializer.normalizer.flatten_exception');
         }
@@ -2576,7 +2581,7 @@ class FrameworkExtension extends Extension
             $serializerIds[$transportId] = $serializerId;
 
             if (null !== $transport['retry_strategy']['service']) {
-                $transportRetryReferences[$name] = new Reference($transport['retry_strategy']['service']);
+                $retryServiceId = $transport['retry_strategy']['service'];
             } else {
                 $retryServiceId = \sprintf('messenger.retry.multiplier_retry_strategy.%s', $name);
                 $retryDefinition = new ChildDefinition('messenger.retry.abstract_multiplier_retry_strategy');
@@ -2587,7 +2592,11 @@ class FrameworkExtension extends Extension
                     ->replaceArgument(3, $transport['retry_strategy']['max_delay'])
                     ->replaceArgument(4, $transport['retry_strategy']['jitter']);
                 $container->setDefinition($retryServiceId, $retryDefinition);
+            }
 
+            if ($container->hasDefinition('messenger.retry.abstract_dynamic_retry_strategy')) {
+                $transportRetryReferences[$name] = (new ChildDefinition('messenger.retry.abstract_dynamic_retry_strategy'))->setDecoratedService($retryServiceId);
+            } else {
                 $transportRetryReferences[$name] = new Reference($retryServiceId);
             }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
@@ -37,6 +37,7 @@ use Symfony\Component\Messenger\Middleware\RouterContextMiddleware;
 use Symfony\Component\Messenger\Middleware\SendMessageMiddleware;
 use Symfony\Component\Messenger\Middleware\TraceableMiddleware;
 use Symfony\Component\Messenger\Middleware\ValidationMiddleware;
+use Symfony\Component\Messenger\Retry\DynamicRetryStrategy;
 use Symfony\Component\Messenger\Retry\MultiplierRetryStrategy;
 use Symfony\Component\Messenger\RoutableMessageBus;
 use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransportFactory;
@@ -191,6 +192,12 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('multiplier'),
                 abstract_arg('max delay ms'),
                 abstract_arg('jitter'),
+            ])
+
+        ->set('messenger.retry.abstract_dynamic_retry_strategy', DynamicRetryStrategy::class)
+            ->abstract()
+            ->args([
+                abstract_arg('fallback strategy'),
             ])
 
         // rate limiter

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Add the possibility to configure exchange to exchange bindings in AMQP transport
  * Add `MessageSentToTransportsEvent` that is dispatched only after the message was sent to at least one transport
  * Support signing messages per handler
+ * Add `RetryStrategyStamp` to dynamically control retry behavior
 
 7.3
 ---

--- a/src/Symfony/Component/Messenger/Retry/DynamicRetryStrategy.php
+++ b/src/Symfony/Component/Messenger/Retry/DynamicRetryStrategy.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Retry;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Stamp\RetryStrategyStamp;
+
+/**
+ * @author Valtteri R <valtzu@gmail.com>
+ */
+final class DynamicRetryStrategy implements RetryStrategyInterface
+{
+    public function __construct(private RetryStrategyInterface $fallbackStrategy)
+    {
+    }
+
+    public function isRetryable(Envelope $message, ?\Throwable $throwable = null): bool
+    {
+        return $message->last(RetryStrategyStamp::class)?->isRetryable()
+            ?? $this->fallbackStrategy->isRetryable($message, $throwable);
+    }
+
+    public function getWaitingTime(Envelope $message, ?\Throwable $throwable = null): int
+    {
+        return $message->last(RetryStrategyStamp::class)?->getWaitingTime()
+            ?? $this->fallbackStrategy->getWaitingTime($message, $throwable);
+    }
+}

--- a/src/Symfony/Component/Messenger/Stamp/RetryStrategyStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/RetryStrategyStamp.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Stamp;
+
+/**
+ * Override retry behavior for a single message when dispatching.
+ *
+ * @author Valtteri R <valtzu@gmail.com>
+ */
+final class RetryStrategyStamp implements StampInterface
+{
+    public function __construct(
+        private ?bool $retryable = null,
+        private ?int $waitingTime = null,
+    ) {
+    }
+
+    public function isRetryable(): ?bool
+    {
+        return $this->retryable;
+    }
+
+    public function getWaitingTime(): ?int
+    {
+        return $this->waitingTime;
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Retry/DynamicRetryStrategyTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Retry/DynamicRetryStrategyTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Retry;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Retry\DynamicRetryStrategy;
+use Symfony\Component\Messenger\Retry\RetryStrategyInterface;
+use Symfony\Component\Messenger\Stamp\RetryStrategyStamp;
+
+class DynamicRetryStrategyTest extends TestCase
+{
+    public function testIsRetryable()
+    {
+        $strategy = new DynamicRetryStrategy($this->createStub(RetryStrategyInterface::class));
+        $envelope = new Envelope(new \stdClass(), [new RetryStrategyStamp(true)]);
+
+        $this->assertTrue($strategy->isRetryable($envelope));
+    }
+
+    public function testIsNotRetryable()
+    {
+        $strategy = new DynamicRetryStrategy($this->createStub(RetryStrategyInterface::class));
+        $envelope = new Envelope(new \stdClass(), [new RetryStrategyStamp(false)]);
+
+        $this->assertFalse($strategy->isRetryable($envelope));
+    }
+
+    public function testIsRetryableWithNoStamp()
+    {
+        $fallbackStrategy = $this->createMock(RetryStrategyInterface::class);
+        $fallbackStrategy->expects($this->once())->method('isRetryable')->willReturn(true);
+
+        $strategy = new DynamicRetryStrategy($fallbackStrategy);
+        $envelope = new Envelope(new \stdClass());
+
+        $this->assertTrue($strategy->isRetryable($envelope));
+    }
+
+    public function testGetWaitingTime()
+    {
+        $strategy = new DynamicRetryStrategy($this->createStub(RetryStrategyInterface::class));
+        $envelope = new Envelope(new \stdClass(), [new RetryStrategyStamp(null, 123)]);
+
+        $this->assertSame(123, $strategy->getWaitingTime($envelope));
+    }
+
+    public function testGetWaitingTimeWithNoStamp()
+    {
+        $fallbackStrategy = $this->createMock(RetryStrategyInterface::class);
+        $fallbackStrategy->expects($this->once())->method('getWaitingTime')->willReturn(456);
+
+        $strategy = new DynamicRetryStrategy($fallbackStrategy);
+        $envelope = new Envelope(new \stdClass());
+
+        $this->assertSame(456, $strategy->getWaitingTime($envelope));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

Sometimes you only know if a message should be retried or not when dispatching the message, e.g. `RunCommandMessage` with one command should be retried, but not with another command. I'm proposing to add a stamp & decorator strategy to make that possible.

Examples
---

```php
$this->bus->dispatch(new RunCommandMessage('do:not:retry'), [new RetryStrategyStamp(retryable: false)]);
$this->bus->dispatch(new RunCommandMessage('always:retry'), [new RetryStrategyStamp(retryable: true)]);
$this->bus->dispatch(new RunCommandMessage('always:retry:custom-delay'), [new RetryStrategyStamp(retryable: true, waitingTime: 10_000)]);
$this->bus->dispatch(new RunCommandMessage('retry:custom-delay'), [new RetryStrategyStamp(waitingTime: 10_000)]);
```

or e.g. if a single message class should never be retried:

```php
#[AsMessage]
class NeverRetryThisMessage implements DefaultStampsProviderInterface
{
    // ...

    public function getDefaultStamps(): array
    {
        return [new RetryStrategyStamp(retryable: false)];
    }
}
```

---

It is worth noting that `RecoverableMessageInterface` & `UnrecoverableExceptionInterface` would still have higher priority than this stamp.

---

This is somewhat related to #62056 & could be useful for #50462 to allow chain-specific retry behavior.