### PR TITLE
[HttpClient] Disable HTTP/2 PUSH by default

### DIFF
--- a/src/Symfony/Component/HttpClient/HttpClient.php
+++ b/src/Symfony/Component/HttpClient/HttpClient.php
@@ -29,7 +29,7 @@ final class HttpClient
      *
      * @see HttpClientInterface::OPTIONS_DEFAULTS for available options
      */
-    public static function create(array $defaultOptions = [], int $maxHostConnections = 6, int $maxPendingPushes = 50): HttpClientInterface
+    public static function create(array $defaultOptions = [], int $maxHostConnections = 6, int $maxPendingPushes = 0): HttpClientInterface
     {
         if ($amp = class_exists(ConnectionLimitingPool::class) && interface_exists(Promise::class)) {
             if (!\extension_loaded('curl')) {
@@ -70,7 +70,7 @@ final class HttpClient
     /**
      * Creates a client that adds options (e.g. authentication headers) only when the request URL matches the provided base URI.
      */
-    public static function createForBaseUri(string $baseUri, array $defaultOptions = [], int $maxHostConnections = 6, int $maxPendingPushes = 50): HttpClientInterface
+    public static function createForBaseUri(string $baseUri, array $defaultOptions = [], int $maxHostConnections = 6, int $maxPendingPushes = 0): HttpClientInterface
     {
         $client = self::create([], $maxHostConnections, $maxPendingPushes);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | #60219 and #60220
| License       | MIT

I propose to disable HTTP/2 PUSH by default on 6.4.

And I propose to remove it altogether from 7.4.

TL;DR, fixing those issues is going to be really difficult and not worth the effort.

If anyone really relies on PUSH, use AmpHttpClient - this one is fine. CurlHttpClient isn't.
