### PR TITLE
[ProxyManagerBridge] Remove comment that reference github discussion

### DIFF
--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/ProxyDumperTest.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/ProxyDumperTest.php
@@ -142,7 +142,6 @@ EOPHP;
 
         $implem = preg_replace('#\n    /\*\*.*?\*/#s', '', $implem);
         $implem = str_replace("array(\n        \n    );", "[\n        \n    ];", $implem);
-        // https://github.com/symfony/symfony/pull/62269#issuecomment-3476843062
         $implem = str_replace('() : bool', '(): bool', $implem);
 
         $this->assertStringMatchesFormatFile(__DIR__.'/Fixtures/proxy-implem.php', $implem);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Minor: This PR removes a comment referencing a discussion on GitHub that I added yesterday in another PR. Apologies, I wasn’t aware that this is not allowed in the project.

https://github.com/symfony/symfony/pull/62269#discussion_r2484871237