### PR TITLE
[Filesystem] Unify logic for isAbsolute() in Path

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -576,17 +576,11 @@ class Filesystem
     }
 
     /**
-     * Returns whether the file path is an absolute path.
+     * Returns whether the given path is absolute.
      */
     public function isAbsolutePath(string $file): bool
     {
-        return '' !== $file && (strspn($file, '/\\', 0, 1)
-            || (\strlen($file) > 3 && ctype_alpha($file[0])
-                && ':' === $file[1]
-                && strspn($file, '/\\', 2, 1)
-            )
-            || null !== parse_url($file, \PHP_URL_SCHEME)
-        );
+        return Path::isAbsolute($file);
     }
 
     /**

--- a/src/Symfony/Component/Filesystem/Path.php
+++ b/src/Symfony/Component/Filesystem/Path.php
@@ -358,38 +358,18 @@ final class Path
         return substr($path, 0, -\strlen($actualExtension)).$extension;
     }
 
+    /**
+     * Returns whether the given path is absolute.
+     */
     public static function isAbsolute(string $path): bool
     {
-        if ('' === $path) {
-            return false;
-        }
-
-        // Strip scheme
-        if (false !== ($schemeSeparatorPosition = strpos($path, '://')) && 1 !== $schemeSeparatorPosition) {
-            $path = substr($path, $schemeSeparatorPosition + 3);
-        }
-
-        $firstCharacter = $path[0];
-
-        // UNIX root "/" or "\" (Windows style)
-        if ('/' === $firstCharacter || '\\' === $firstCharacter) {
-            return true;
-        }
-
-        // Windows root
-        if (\strlen($path) > 1 && ctype_alpha($firstCharacter) && ':' === $path[1]) {
-            // Special case: "C:"
-            if (2 === \strlen($path)) {
-                return true;
-            }
-
-            // Normal case: "C:/ or "C:\"
-            if ('/' === $path[2] || '\\' === $path[2]) {
-                return true;
-            }
-        }
-
-        return false;
+        return '' !== $path && (strspn($path, '/\\', 0, 1)
+            || (\strlen($path) > 3 && ctype_alpha($path[0])
+                && ':' === $path[1]
+                && strspn($path, '/\\', 2, 1)
+            )
+            || null !== parse_url($path, \PHP_URL_SCHEME)
+        );
     }
 
     public static function isRelative(string $path): bool

--- a/src/Symfony/Component/Filesystem/Tests/PathTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/PathTest.php
@@ -364,31 +364,50 @@ class PathTest extends TestCase
 
     public static function provideIsAbsolutePathTests(): \Generator
     {
+        // UNIX-style absolute paths
         yield ['/css/style.css', true];
         yield ['/', true];
         yield ['css/style.css', false];
         yield ['', false];
 
+        // UNIX-style absolute paths with backslashes
         yield ['\\css\\style.css', true];
         yield ['\\', true];
         yield ['css\\style.css', false];
 
+        // Windows-style absolute paths
         yield ['C:/css/style.css', true];
         yield ['D:/', true];
         yield ['C:///windows', true];
         yield ['C://test', true];
 
+        // Windows-style absolute paths with backslashes
         yield ['E:\\css\\style.css', true];
         yield ['F:\\', true];
 
-        yield ['phar:///css/style.css', true];
-        yield ['phar:///', true];
-
-        // Windows special case
+        // Windows special case (drive only)
         yield ['C:', true];
 
-        // Not considered absolute
-        yield ['C:css/style.css', false];
+        // URLs and stream wrappers are considered absolute
+        yield ['phar:///css/style.css', true];
+        yield ['phar:///', true];
+        yield ['http://example.com', true];
+        yield ['ftp://user@server/path', true];
+        yield ['vfs://root/file.txt', true];
+
+        // "C:" without a slash is treated as a scheme by parse_url()
+        yield ['C:css/style.css', true];
+
+        // Relative paths
+        yield ['/var/lib', true];
+        yield ['c:\\\\var\\lib', true]; // c:\\var\lib
+        yield ['\\var\\lib', true];
+        yield ['var/lib', false];
+        yield ['../var/lib', false];
+        yield ['', false];
+
+        // Empty path
+        yield ['', false];
     }
 
     /**


### PR DESCRIPTION
| Q | A
|---|---
| Branch? | 7.3
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Issues | n/a
| License | MIT

This PR fixes a bug and removes duplicated code between `Filesystem::isAbsolutePath()` and `Path::isAbsolute()`.

These two methods had different implementations. The logic in `Path` incorrectly reported stream wrappers (`http://`, `vfs://`) and paths like `C:css/style.css` as being relative.

This PR makes `Path::isAbsolute()` the single source of truth by adopting the more robust logic from `Filesystem`. `Filesystem::isAbsolutePath()` now delegates to it.

### Note on Path Class Scope
This change ensures `isAbsolute()` correctly handles stream wrappers. This is consistent with the component's scope, as other methods like `canonicalize()` already support and preserve schemes (e.g., `phar://`).