### PR TITLE
[Console] Add missing VERBOSITY_SILENT case in CommandDataCollector

### DIFF
--- a/src/Symfony/Component/Console/DataCollector/CommandDataCollector.php
+++ b/src/Symfony/Component/Console/DataCollector/CommandDataCollector.php
@@ -43,6 +43,7 @@ final class CommandDataCollector extends DataCollector
             'duration' => $command->duration,
             'max_memory_usage' => $command->maxMemoryUsage,
             'verbosity_level' => match ($command->output->getVerbosity()) {
+                OutputInterface::VERBOSITY_SILENT => 'silent',
                 OutputInterface::VERBOSITY_QUIET => 'quiet',
                 OutputInterface::VERBOSITY_NORMAL => 'normal',
                 OutputInterface::VERBOSITY_VERBOSE => 'verbose',


### PR DESCRIPTION
| Q | A
|---|---
| Branch? | 7.3
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Issues | -
| License | MIT

This PR fixes a bug in the `CommandDataCollector` that causes a fatal error.

When running a command with both `--profile` and `--silent` (or `-q`), the `CommandDataCollector::collect()` method throws an `UnhandledMatchError` because the `VERBOSITY_SILENT` (value `8`) case is missing from the `match` statement.

This patch adds the missing `OutputInterface::VERBOSITY_SILENT => 'silent'` case to resolve the crash.