### PR TITLE
[PHPDoc] Fix various PHPDoc syntax errors

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Middleware/Debug/Query.php
+++ b/src/Symfony/Bridge/Doctrine/Middleware/Debug/Query.php
@@ -79,7 +79,7 @@ class Query
     }
 
     /**
-     * @return array<int, string|int|float}>
+     * @return array<int, string|int|float>
      */
     public function getParams(): array
     {

--- a/src/Symfony/Component/Runtime/GenericRuntime.php
+++ b/src/Symfony/Component/Runtime/GenericRuntime.php
@@ -49,7 +49,7 @@ class GenericRuntime implements RuntimeInterface
     protected array $options;
 
     /**
-     * @param array {
+     * @param array{
      *   debug?: ?bool,
      *   runtimes?: ?array,
      *   error_handler?: string|false,

--- a/src/Symfony/Component/Translation/Command/TranslationLintCommand.php
+++ b/src/Symfony/Component/Translation/Command/TranslationLintCommand.php
@@ -70,7 +70,7 @@ class TranslationLintCommand extends Command
     {
         $locales = $input->getOption('locale');
 
-        /** @var array<string, array<string, array<string, \Throwable>> $errors */
+        /** @var array<string, array<string, array<string, \Throwable>>> $errors */
         $errors = [];
         $domainsByLocales = [];
 


### PR DESCRIPTION
| Q | A
|---|---
| Branch? | 7.4
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Issues | n/a
| License | MIT

This PR fixes several minor PHPDoc syntax errors (typos like an extra `}`, a missing `>`, or invalid `array {` spacing) across various components.

These changes correct parsing errors for static analysis tools and IDEs.