### PR TITLE
[Twig] Ensure WrappedTemplatedEmail::getReturnPath() returns a string

### DIFF
--- a/src/Symfony/Bridge/Twig/Mime/WrappedTemplatedEmail.php
+++ b/src/Symfony/Bridge/Twig/Mime/WrappedTemplatedEmail.php
@@ -92,7 +92,7 @@ final class WrappedTemplatedEmail
 
     public function getReturnPath(): string
     {
-        return $this->message->getReturnPath();
+        return $this->message->getReturnPath()?->toString() ?? '';
     }
 
     /**

--- a/src/Symfony/Bridge/Twig/Tests/Mime/WrappedTemplatedEmailTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Mime/WrappedTemplatedEmailTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Bridge\Twig\Tests\Mime;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Twig\Mime\BodyRenderer;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Bridge\Twig\Mime\WrappedTemplatedEmail;
 use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
 
@@ -98,5 +99,23 @@ class WrappedTemplatedEmailTest extends TestCase
         $renderer->render($email);
 
         return $email;
+    }
+
+    public function testGetReturnPathWhenNull()
+    {
+        $twig = $this->createMock(Environment::class);
+        $message = new TemplatedEmail();
+        $email = new WrappedTemplatedEmail($twig, $message);
+
+        $this->assertSame('', $email->getReturnPath());
+    }
+
+    public function testGetReturnPathWhenSet()
+    {
+        $twig = $this->createMock(Environment::class);
+        $message = (new TemplatedEmail())->returnPath('test@example.com');
+        $email = new WrappedTemplatedEmail($twig, $message);
+
+        $this->assertSame('test@example.com', $email->getReturnPath());
     }
 }


### PR DESCRIPTION
| Q | A
|---|---
| Branch? | 7.3
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Issues | -
| License | MIT

This PR fixes a return type error in `WrappedTemplatedEmail::getReturnPath()`.

The method is type-hinted to return a `string`, but it was directly returning the result of `$this->message->getReturnPath()`, which is `?Address`. 