### PR TITLE
[Routing] Simplify importing routes defined on controller services

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
@@ -79,14 +79,12 @@ trait MicroKernelTrait
         $routes->import($configDir.'/{routes}/'.$this->environment.'/*.{php,yaml}');
         $routes->import($configDir.'/{routes}/*.{php,yaml}');
 
+        $routes->import('routing.controllers');
+
         if (is_file($this->getConfigDir().'/routes.yaml')) {
             $routes->import($configDir.'/routes.yaml');
         } else {
             $routes->import($configDir.'/{routes}.php');
-        }
-
-        if ($fileName = (new \ReflectionObject($this))->getFileName()) {
-            $routes->import($fileName, 'attribute');
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/reference.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/reference.php
@@ -184,8 +184,7 @@ namespace Symfony\Component\Routing\Loader\Configurator;
  *
  *     return Routes::config([
  *         'controllers' => [
- *             'resource' => 'attributes',
- *             'type' => 'tagged_services',
+ *             'resource' => 'routing.controllers',
  *         ],
  *     ]);
  *     ```

--- a/src/Symfony/Component/Routing/Loader/AttributeServicesLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AttributeServicesLoader.php
@@ -42,6 +42,6 @@ final class AttributeServicesLoader extends Loader
 
     public function supports(mixed $resource, ?string $type = null): bool
     {
-        return 'tagged_services' === $type && 'attributes' === $resource;
+        return 'routing.controllers' === $resource;
     }
 }

--- a/src/Symfony/Component/Routing/Loader/Configurator/RoutesReference.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/RoutesReference.php
@@ -26,8 +26,7 @@ namespace Symfony\Component\Routing\Loader\Configurator;
  *
  *     return Routes::config([
  *         'controllers' => [
- *             'resource' => 'attributes',
- *             'type' => 'tagged_services',
+ *             'resource' => 'routing.controllers',
  *         ],
  *     ]);
  *     ```

--- a/src/Symfony/Component/Routing/Tests/Loader/AttributeServicesLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AttributeServicesLoaderTest.php
@@ -26,8 +26,8 @@ class AttributeServicesLoaderTest extends TestCase
 
         $this->assertFalse($loader->supports('attributes', null));
         $this->assertFalse($loader->supports('attributes', 'attribute'));
-        $this->assertFalse($loader->supports('other', 'tagged_services'));
-        $this->assertTrue($loader->supports('attributes', 'tagged_services'));
+        $this->assertFalse($loader->supports('other', 'routing.controllers'));
+        $this->assertTrue($loader->supports('routing.controllers'));
     }
 
     public function testDelegatesToAttributeLoaderAndMergesCollections()
@@ -47,7 +47,7 @@ class AttributeServicesLoaderTest extends TestCase
         $attributeLoader->setResolver($resolver);
         $servicesLoader->setResolver($resolver);
 
-        $collection = $servicesLoader->load('attributes', 'tagged_services');
+        $collection = $servicesLoader->load('routing.controllers');
 
         $this->assertArrayHasKey('action', $collection->all());
         $this->assertArrayHasKey('put', $collection->all());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Fine-tuning #61492

Before:

```yaml
controllers:
    resource: attributes
    type: tagged_services
```


After:

```yaml
controllers:
    resource: routing.controllers
```

And when using `MicroKernelTrait` (the default recipe), there's nothing to configure to have routes loaded from `#[Route]` attributes:

```yaml
#config/routes.yaml
# the file can be just empty from any config, and only have a comment saying what it's for
```

```php
// config/routes.php
return Routes::config([
]);
```

The way to opt-out from this `routing.controllers` import would be to override the `Kernel::configureRoutes()` method.