### PR TITLE
 Refactor: implements `Stringable` when possible

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/MailerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/MailerTest.php
@@ -40,7 +40,7 @@ class MailerTest extends AbstractWebTestCase
         $eventDispatcher = self::getContainer()->get(EventDispatcherInterface::class);
         $logger = self::getContainer()->get('logger');
 
-        $testTransport = new class($eventDispatcher, $logger, $onDoSend) extends AbstractTransport {
+        $testTransport = new class($eventDispatcher, $logger, $onDoSend) extends AbstractTransport implements \Stringable {
             private \Closure $onDoSend;
 
             public function __construct(EventDispatcherInterface $eventDispatcher, LoggerInterface $logger, \Closure $onDoSend)

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SecurityTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SecurityTest.php
@@ -179,7 +179,7 @@ class SecurityTest extends AbstractWebTestCase
     }
 }
 
-final class UserWithoutEquatable implements UserInterface, PasswordAuthenticatedUserInterface
+final class UserWithoutEquatable implements \Stringable, UserInterface, PasswordAuthenticatedUserInterface
 {
     private ?string $username;
     private ?string $password;

--- a/src/Symfony/Component/BrowserKit/Cookie.php
+++ b/src/Symfony/Component/BrowserKit/Cookie.php
@@ -19,7 +19,7 @@ use Symfony\Component\BrowserKit\Exception\UnexpectedValueException;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class Cookie
+class Cookie implements \Stringable
 {
     /**
      * Handles dates as defined by RFC 2616 section 3.3.1, and also some other

--- a/src/Symfony/Component/BrowserKit/Response.php
+++ b/src/Symfony/Component/BrowserKit/Response.php
@@ -16,7 +16,7 @@ use Symfony\Component\BrowserKit\Exception\JsonException;
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  */
-final class Response
+final class Response implements \Stringable
 {
     private array $jsonData;
 

--- a/src/Symfony/Component/Config/Loader/ParamConfigurator.php
+++ b/src/Symfony/Component/Config/Loader/ParamConfigurator.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\Config\Loader;
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class ParamConfigurator
+class ParamConfigurator implements \Stringable
 {
     public function __construct(
         private string $name,

--- a/src/Symfony/Component/Config/Resource/ClassExistenceResource.php
+++ b/src/Symfony/Component/Config/Resource/ClassExistenceResource.php
@@ -21,7 +21,7 @@ namespace Symfony\Component\Config\Resource;
  *
  * @final
  */
-class ClassExistenceResource implements SelfCheckingResourceInterface
+class ClassExistenceResource implements \Stringable, SelfCheckingResourceInterface
 {
     private ?array $exists = null;
 

--- a/src/Symfony/Component/Config/Resource/ComposerResource.php
+++ b/src/Symfony/Component/Config/Resource/ComposerResource.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Config\Resource;
  *
  * @final
  */
-class ComposerResource implements SelfCheckingResourceInterface
+class ComposerResource implements \Stringable, SelfCheckingResourceInterface
 {
     private array $vendors;
 

--- a/src/Symfony/Component/Config/Resource/DirectoryResource.php
+++ b/src/Symfony/Component/Config/Resource/DirectoryResource.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Config\Resource;
  *
  * @final
  */
-class DirectoryResource implements SelfCheckingResourceInterface
+class DirectoryResource implements \Stringable, SelfCheckingResourceInterface
 {
     private string $resource;
 

--- a/src/Symfony/Component/Config/Resource/FileExistenceResource.php
+++ b/src/Symfony/Component/Config/Resource/FileExistenceResource.php
@@ -21,7 +21,7 @@ namespace Symfony\Component\Config\Resource;
  *
  * @final
  */
-class FileExistenceResource implements SelfCheckingResourceInterface
+class FileExistenceResource implements \Stringable, SelfCheckingResourceInterface
 {
     private bool $exists;
 

--- a/src/Symfony/Component/Config/Resource/FileResource.php
+++ b/src/Symfony/Component/Config/Resource/FileResource.php
@@ -20,7 +20,7 @@ namespace Symfony\Component\Config\Resource;
  *
  * @final
  */
-class FileResource implements SelfCheckingResourceInterface
+class FileResource implements \Stringable, SelfCheckingResourceInterface
 {
     private string $resource;
 

--- a/src/Symfony/Component/Config/Resource/GlobResource.php
+++ b/src/Symfony/Component/Config/Resource/GlobResource.php
@@ -25,7 +25,7 @@ use Symfony\Component\Finder\Glob;
  *
  * @implements \IteratorAggregate<string, \SplFileInfo>
  */
-class GlobResource implements \IteratorAggregate, SelfCheckingResourceInterface
+class GlobResource implements \Stringable, \IteratorAggregate, SelfCheckingResourceInterface
 {
     private string $prefix;
     private string $hash;

--- a/src/Symfony/Component/Config/Resource/ReflectionClassResource.php
+++ b/src/Symfony/Component/Config/Resource/ReflectionClassResource.php
@@ -19,7 +19,7 @@ use Symfony\Contracts\Service\ServiceSubscriberInterface;
  *
  * @final
  */
-class ReflectionClassResource implements SelfCheckingResourceInterface
+class ReflectionClassResource implements \Stringable, SelfCheckingResourceInterface
 {
     private array $files = [];
     private string $className;

--- a/src/Symfony/Component/Config/Tests/Resource/ResourceStub.php
+++ b/src/Symfony/Component/Config/Tests/Resource/ResourceStub.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Config\Tests\Resource;
 
 use Symfony\Component\Config\Resource\SelfCheckingResourceInterface;
 
-class ResourceStub implements SelfCheckingResourceInterface
+class ResourceStub implements \Stringable, SelfCheckingResourceInterface
 {
     private bool $fresh = true;
 

--- a/src/Symfony/Component/Console/Completion/CompletionInput.php
+++ b/src/Symfony/Component/Console/Completion/CompletionInput.php
@@ -24,7 +24,7 @@ use Symfony\Component\Console\Input\InputOption;
  *
  * @author Wouter de Jong <wouter@wouterj.nl>
  */
-final class CompletionInput extends ArgvInput
+final class CompletionInput extends ArgvInput implements \Stringable
 {
     public const TYPE_ARGUMENT_VALUE = 'argument_value';
     public const TYPE_OPTION_VALUE = 'option_value';

--- a/src/Symfony/Component/Console/Helper/TableCell.php
+++ b/src/Symfony/Component/Console/Helper/TableCell.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Exception\InvalidArgumentException;
 /**
  * @author Abdellatif Ait boudad <a.aitboudad@gmail.com>
  */
-class TableCell
+class TableCell implements \Stringable
 {
     private array $options = [
         'rowspan' => 1,

--- a/src/Symfony/Component/Console/Helper/TreeNode.php
+++ b/src/Symfony/Component/Console/Helper/TreeNode.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\Console\Helper;
  *
  * @author Simon André <smn.andre@gmail.com>
  */
-final class TreeNode implements \Countable, \IteratorAggregate
+final class TreeNode implements \Countable, \IteratorAggregate, \Stringable
 {
     /**
      * @var array<TreeNode|callable(): \Generator>

--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -38,7 +38,7 @@ use Symfony\Component\Console\Exception\RuntimeException;
  * @see http://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html
  * @see http://www.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap12.html#tag_12_02
  */
-class ArgvInput extends Input
+class ArgvInput extends Input implements \Stringable
 {
     /** @var list<string> */
     private array $tokens;

--- a/src/Symfony/Component/Console/Input/ArrayInput.php
+++ b/src/Symfony/Component/Console/Input/ArrayInput.php
@@ -23,7 +23,7 @@ use Symfony\Component\Console\Exception\InvalidOptionException;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class ArrayInput extends Input
+class ArrayInput extends Input implements \Stringable
 {
     public function __construct(
         private array $parameters,

--- a/src/Symfony/Component/Console/Tests/EventListener/ErrorListenerTest.php
+++ b/src/Symfony/Component/Console/Tests/EventListener/ErrorListenerTest.php
@@ -113,7 +113,7 @@ class ErrorListenerTest extends TestCase
     }
 }
 
-class NonStringInput extends Input
+class NonStringInput extends Input implements \Stringable
 {
     public function getFirstArgument(): ?string
     {

--- a/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
+++ b/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
@@ -396,7 +396,7 @@ class OutputFormatterTest extends TestCase
     }
 }
 
-class TableCell
+class TableCell implements \Stringable
 {
     public function __toString(): string
     {

--- a/src/Symfony/Component/Console/Tests/Logger/ConsoleLoggerTest.php
+++ b/src/Symfony/Component/Console/Tests/Logger/ConsoleLoggerTest.php
@@ -190,7 +190,7 @@ class ConsoleLoggerTest extends TestCase
     }
 }
 
-class DummyTest
+class DummyTest implements \Stringable
 {
     public function __toString(): string
     {

--- a/src/Symfony/Component/Console/Tests/Question/ChoiceQuestionTest.php
+++ b/src/Symfony/Component/Console/Tests/Question/ChoiceQuestionTest.php
@@ -147,7 +147,7 @@ class ChoiceQuestionTest extends TestCase
     }
 }
 
-class StringChoice
+class StringChoice implements \Stringable
 {
     private string $string;
 

--- a/src/Symfony/Component/CssSelector/Node/AttributeNode.php
+++ b/src/Symfony/Component/CssSelector/Node/AttributeNode.php
@@ -21,7 +21,7 @@ namespace Symfony\Component\CssSelector\Node;
  *
  * @internal
  */
-class AttributeNode extends AbstractNode
+class AttributeNode extends AbstractNode implements \Stringable
 {
     public function __construct(
         private NodeInterface $selector,

--- a/src/Symfony/Component/CssSelector/Node/ClassNode.php
+++ b/src/Symfony/Component/CssSelector/Node/ClassNode.php
@@ -21,7 +21,7 @@ namespace Symfony\Component\CssSelector\Node;
  *
  * @internal
  */
-class ClassNode extends AbstractNode
+class ClassNode extends AbstractNode implements \Stringable
 {
     public function __construct(
         private NodeInterface $selector,

--- a/src/Symfony/Component/CssSelector/Node/CombinedSelectorNode.php
+++ b/src/Symfony/Component/CssSelector/Node/CombinedSelectorNode.php
@@ -21,7 +21,7 @@ namespace Symfony\Component\CssSelector\Node;
  *
  * @internal
  */
-class CombinedSelectorNode extends AbstractNode
+class CombinedSelectorNode extends AbstractNode implements \Stringable
 {
     public function __construct(
         private NodeInterface $selector,

--- a/src/Symfony/Component/CssSelector/Node/ElementNode.php
+++ b/src/Symfony/Component/CssSelector/Node/ElementNode.php
@@ -21,7 +21,7 @@ namespace Symfony\Component\CssSelector\Node;
  *
  * @internal
  */
-class ElementNode extends AbstractNode
+class ElementNode extends AbstractNode implements \Stringable
 {
     public function __construct(
         private ?string $namespace = null,

--- a/src/Symfony/Component/CssSelector/Node/FunctionNode.php
+++ b/src/Symfony/Component/CssSelector/Node/FunctionNode.php
@@ -23,7 +23,7 @@ use Symfony\Component\CssSelector\Parser\Token;
  *
  * @internal
  */
-class FunctionNode extends AbstractNode
+class FunctionNode extends AbstractNode implements \Stringable
 {
     private string $name;
 

--- a/src/Symfony/Component/CssSelector/Node/HashNode.php
+++ b/src/Symfony/Component/CssSelector/Node/HashNode.php
@@ -21,7 +21,7 @@ namespace Symfony\Component\CssSelector\Node;
  *
  * @internal
  */
-class HashNode extends AbstractNode
+class HashNode extends AbstractNode implements \Stringable
 {
     public function __construct(
         private NodeInterface $selector,

--- a/src/Symfony/Component/CssSelector/Node/MatchingNode.php
+++ b/src/Symfony/Component/CssSelector/Node/MatchingNode.php
@@ -21,7 +21,7 @@ namespace Symfony\Component\CssSelector\Node;
  *
  * @internal
  */
-class MatchingNode extends AbstractNode
+class MatchingNode extends AbstractNode implements \Stringable
 {
     /**
      * @param array<NodeInterface> $arguments

--- a/src/Symfony/Component/CssSelector/Node/NegationNode.php
+++ b/src/Symfony/Component/CssSelector/Node/NegationNode.php
@@ -21,7 +21,7 @@ namespace Symfony\Component\CssSelector\Node;
  *
  * @internal
  */
-class NegationNode extends AbstractNode
+class NegationNode extends AbstractNode implements \Stringable
 {
     public function __construct(
         private NodeInterface $selector,

--- a/src/Symfony/Component/CssSelector/Node/PseudoNode.php
+++ b/src/Symfony/Component/CssSelector/Node/PseudoNode.php
@@ -21,7 +21,7 @@ namespace Symfony\Component\CssSelector\Node;
  *
  * @internal
  */
-class PseudoNode extends AbstractNode
+class PseudoNode extends AbstractNode implements \Stringable
 {
     private string $identifier;
 

--- a/src/Symfony/Component/CssSelector/Node/SelectorNode.php
+++ b/src/Symfony/Component/CssSelector/Node/SelectorNode.php
@@ -21,7 +21,7 @@ namespace Symfony\Component\CssSelector\Node;
  *
  * @internal
  */
-class SelectorNode extends AbstractNode
+class SelectorNode extends AbstractNode implements \Stringable
 {
     private ?string $pseudoElement;
 

--- a/src/Symfony/Component/CssSelector/Node/SpecificityAdjustmentNode.php
+++ b/src/Symfony/Component/CssSelector/Node/SpecificityAdjustmentNode.php
@@ -21,7 +21,7 @@ namespace Symfony\Component\CssSelector\Node;
  *
  * @internal
  */
-class SpecificityAdjustmentNode extends AbstractNode
+class SpecificityAdjustmentNode extends AbstractNode implements \Stringable
 {
     /**
      * @param array<NodeInterface> $arguments

--- a/src/Symfony/Component/CssSelector/Parser/Token.php
+++ b/src/Symfony/Component/CssSelector/Parser/Token.php
@@ -21,7 +21,7 @@ namespace Symfony\Component\CssSelector\Parser;
  *
  * @internal
  */
-class Token
+class Token implements \Stringable
 {
     public const TYPE_FILE_END = 'eof';
     public const TYPE_DELIMITER = 'delimiter';

--- a/src/Symfony/Component/CssSelector/XPath/XPathExpr.php
+++ b/src/Symfony/Component/CssSelector/XPath/XPathExpr.php
@@ -21,7 +21,7 @@ namespace Symfony\Component\CssSelector\XPath;
  *
  * @internal
  */
-class XPathExpr
+class XPathExpr implements \Stringable
 {
     public function __construct(
         private string $path = '',

--- a/src/Symfony/Component/DependencyInjection/Alias.php
+++ b/src/Symfony/Component/DependencyInjection/Alias.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 
-class Alias
+class Alias implements \Stringable
 {
     private const DEFAULT_DEPRECATION_TEMPLATE = 'The "%alias_id%" service alias is deprecated. You should stop using it, as it will be removed in the future.';
 

--- a/src/Symfony/Component/DependencyInjection/Config/ContainerParametersResource.php
+++ b/src/Symfony/Component/DependencyInjection/Config/ContainerParametersResource.php
@@ -20,7 +20,7 @@ use Symfony\Component\Config\Resource\ResourceInterface;
  *
  * @final
  */
-class ContainerParametersResource implements ResourceInterface
+class ContainerParametersResource implements \Stringable, ResourceInterface
 {
     /**
      * @param array $parameters The container parameters to track

--- a/src/Symfony/Component/DependencyInjection/Exception/AutowiringFailedException.php
+++ b/src/Symfony/Component/DependencyInjection/Exception/AutowiringFailedException.php
@@ -37,7 +37,7 @@ class AutowiringFailedException extends RuntimeException
         $this->messageCallback = $message;
         parent::__construct('', $code, $previous);
 
-        $this->message = new class($this->message, $this->messageCallback) {
+        $this->message = new class($this->message, $this->messageCallback) implements \Stringable {
             private string|self $message;
             private ?\Closure $messageCallback;
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/EnvConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/EnvConfigurator.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Component\Config\Loader\ParamConfigurator;
 
-class EnvConfigurator extends ParamConfigurator
+class EnvConfigurator extends ParamConfigurator implements \Stringable
 {
     /**
      * @var string[]

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ReferenceConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ReferenceConfigurator.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * @author Nicolas Grekas <p@tchwork.com>
  */
-class ReferenceConfigurator extends AbstractConfigurator
+class ReferenceConfigurator extends AbstractConfigurator implements \Stringable
 {
     /** @internal */
     protected string $id;

--- a/src/Symfony/Component/DependencyInjection/Parameter.php
+++ b/src/Symfony/Component/DependencyInjection/Parameter.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\DependencyInjection;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class Parameter
+class Parameter implements \Stringable
 {
     public function __construct(
         private string $id,

--- a/src/Symfony/Component/DependencyInjection/Reference.php
+++ b/src/Symfony/Component/DependencyInjection/Reference.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\DependencyInjection;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class Reference
+class Reference implements \Stringable
 {
     public function __construct(
         private string $id,

--- a/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
@@ -832,7 +832,7 @@ class EnvVarProcessorTest extends TestCase
                     return [
                         'FOO_ENV_LOADER' => '123',
                         'BAZ_ENV_LOADER' => '',
-                        'LAZY_ENV_LOADER' => new class {
+                        'LAZY_ENV_LOADER' => new class implements \Stringable {
                             public function __toString(): string
                             {
                                 return '';
@@ -849,7 +849,7 @@ class EnvVarProcessorTest extends TestCase
                         'FOO_ENV_LOADER' => '234',
                         'BAR_ENV_LOADER' => '456',
                         'BAZ_ENV_LOADER' => '567',
-                        'LAZY_ENV_LOADER' => new class {
+                        'LAZY_ENV_LOADER' => new class implements \Stringable {
                             public function __toString(): string
                             {
                                 return '678';

--- a/src/Symfony/Component/DependencyInjection/Variable.php
+++ b/src/Symfony/Component/DependencyInjection/Variable.php
@@ -24,7 +24,7 @@ namespace Symfony\Component\DependencyInjection;
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-class Variable
+class Variable implements \Stringable
 {
     public function __construct(
         private string $name,

--- a/src/Symfony/Component/ExpressionLanguage/Expression.php
+++ b/src/Symfony/Component/ExpressionLanguage/Expression.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\ExpressionLanguage;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class Expression
+class Expression implements \Stringable
 {
     public function __construct(
         protected string $expression,

--- a/src/Symfony/Component/ExpressionLanguage/Node/Node.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/Node.php
@@ -18,7 +18,7 @@ use Symfony\Component\ExpressionLanguage\Compiler;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class Node
+class Node implements \Stringable
 {
     public array $nodes = [];
     public array $attributes = [];

--- a/src/Symfony/Component/ExpressionLanguage/Token.php
+++ b/src/Symfony/Component/ExpressionLanguage/Token.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\ExpressionLanguage;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class Token
+class Token implements \Stringable
 {
     public const EOF_TYPE = 'end of expression';
     public const NAME_TYPE = 'name';

--- a/src/Symfony/Component/ExpressionLanguage/TokenStream.php
+++ b/src/Symfony/Component/ExpressionLanguage/TokenStream.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\ExpressionLanguage;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class TokenStream
+class TokenStream implements \Stringable
 {
     public Token $current;
 

--- a/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationPath.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationPath.php
@@ -20,7 +20,7 @@ use Symfony\Component\PropertyAccess\PropertyPathInterface;
  *
  * @implements \IteratorAggregate<int, string>
  */
-class ViolationPath implements \IteratorAggregate, PropertyPathInterface
+class ViolationPath implements \Stringable, \IteratorAggregate, PropertyPathInterface
 {
     /** @var list<string> */
     private array $elements = [];

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Factory/DefaultChoiceListFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Factory/DefaultChoiceListFactoryTest.php
@@ -1015,7 +1015,7 @@ class DefaultChoiceListFactoryTest extends TestCase
     }
 }
 
-class DefaultChoiceListFactoryTest_Castable
+class DefaultChoiceListFactoryTest_Castable implements \Stringable
 {
     private string $property;
 

--- a/src/Symfony/Component/HttpClient/Tests/DataCollector/HttpClientDataCollectorTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/DataCollector/HttpClientDataCollectorTest.php
@@ -268,7 +268,7 @@ class HttpClientDataCollectorTest extends TestCase
                             'fooprop' => 'foopropval',
                             'barprop' => 'barpropval',
                         ],
-                        'tostring' => new class {
+                        'tostring' => new class implements \Stringable {
                             public function __toString(): string
                             {
                                 return 'tostringval';

--- a/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
@@ -519,7 +519,7 @@ class MockHttpClientTest extends HttpClientTestCase
     {
         $client = new MockHttpClient();
 
-        $param = new class {
+        $param = new class implements \Stringable {
             public function __toString(): string
             {
                 return 'bar';

--- a/src/Symfony/Component/HttpFoundation/AcceptHeader.php
+++ b/src/Symfony/Component/HttpFoundation/AcceptHeader.php
@@ -22,7 +22,7 @@ class_exists(AcceptHeaderItem::class);
  *
  * @author Jean-François Simon <contact@jfsimon.fr>
  */
-class AcceptHeader
+class AcceptHeader implements \Stringable
 {
     /**
      * @var array<string, AcceptHeaderItem>

--- a/src/Symfony/Component/HttpFoundation/AcceptHeaderItem.php
+++ b/src/Symfony/Component/HttpFoundation/AcceptHeaderItem.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\HttpFoundation;
  *
  * @author Jean-François Simon <contact@jfsimon.fr>
  */
-class AcceptHeaderItem
+class AcceptHeaderItem implements \Stringable
 {
     private float $quality = 1.0;
     private int $index = 0;

--- a/src/Symfony/Component/HttpFoundation/Cookie.php
+++ b/src/Symfony/Component/HttpFoundation/Cookie.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\HttpFoundation;
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-class Cookie
+class Cookie implements \Stringable
 {
     public const SAMESITE_NONE = 'none';
     public const SAMESITE_LAX = 'lax';

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -40,7 +40,7 @@ class_exists(ServerBag::class);
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class Request
+class Request implements \Stringable
 {
     public const HEADER_FORWARDED = 0b000001; // When using RFC 7239
     public const HEADER_X_FORWARDED_FOR = 0b000010;

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -19,7 +19,7 @@ class_exists(ResponseHeaderBag::class);
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class Response
+class Response implements \Stringable
 {
     public const HTTP_CONTINUE = 100;
     public const HTTP_SWITCHING_PROTOCOLS = 101;

--- a/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
@@ -171,7 +171,7 @@ class JsonResponseTest extends TestCase
 
     public function testConstructorWithObjectWithToStringMethod()
     {
-        $class = new class {
+        $class = new class implements \Stringable {
             public function __toString(): string
             {
                 return '{}';

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
@@ -1149,7 +1149,7 @@ class ResponseTest extends ResponseTestCase
     }
 }
 
-class StringableObject
+class StringableObject implements \Stringable
 {
     public function __toString(): string
     {

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
@@ -259,7 +259,7 @@ function some_controller_function($foo, $foobar)
 {
 }
 
-class ControllerTest
+class ControllerTest implements \Stringable
 {
     public function __construct()
     {

--- a/src/Symfony/Component/HttpKernel/Tests/Log/LoggerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Log/LoggerTest.php
@@ -205,7 +205,7 @@ class LoggerTest extends TestCase
     }
 }
 
-class DummyTest
+class DummyTest implements \Stringable
 {
     public function __toString(): string
     {

--- a/src/Symfony/Component/JsonPath/JsonPath.php
+++ b/src/Symfony/Component/JsonPath/JsonPath.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\JsonPath;
  *
  * @immutable
  */
-final class JsonPath
+final class JsonPath implements \Stringable
 {
     /**
      * @param non-empty-string $path

--- a/src/Symfony/Component/Mailer/Bridge/AhaSend/Transport/AhaSendApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/AhaSend/Transport/AhaSendApiTransport.php
@@ -30,7 +30,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 /**
  * @author Farhad Hedayatifard <farhad@ahasend.com>
  */
-final class AhaSendApiTransport extends AbstractApiTransport
+final class AhaSendApiTransport extends AbstractApiTransport implements \Stringable
 {
     private const HOST = 'send.ahasend.com';
 

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesApiAsyncAwsTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesApiAsyncAwsTransport.php
@@ -26,7 +26,7 @@ use Symfony\Component\Mime\MessageConverter;
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>
  */
-class SesApiAsyncAwsTransport extends SesHttpAsyncAwsTransport
+class SesApiAsyncAwsTransport extends SesHttpAsyncAwsTransport implements \Stringable
 {
     public function __toString(): string
     {

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesHttpAsyncAwsTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesHttpAsyncAwsTransport.php
@@ -26,7 +26,7 @@ use Symfony\Component\Mime\Message;
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>
  */
-class SesHttpAsyncAwsTransport extends AbstractTransport
+class SesHttpAsyncAwsTransport extends AbstractTransport implements \Stringable
 {
     public function __construct(
         protected SesClient $sesClient,

--- a/src/Symfony/Component/Mailer/Bridge/Azure/Transport/AzureApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/Transport/AzureApiTransport.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
-final class AzureApiTransport extends AbstractApiTransport
+final class AzureApiTransport extends AbstractApiTransport implements \Stringable
 {
     private const HOST = '%s.communication.azure.com';
 

--- a/src/Symfony/Component/Mailer/Bridge/Brevo/Transport/BrevoApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/Transport/BrevoApiTransport.php
@@ -30,7 +30,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 /**
  * @author Pierre TANGUY
  */
-final class BrevoApiTransport extends AbstractApiTransport
+final class BrevoApiTransport extends AbstractApiTransport implements \Stringable
 {
     public function __construct(
         #[\SensitiveParameter] private string $key,

--- a/src/Symfony/Component/Mailer/Bridge/Infobip/Transport/InfobipApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Infobip/Transport/InfobipApiTransport.php
@@ -29,7 +29,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 /**
  * @see https://www.infobip.com/docs/api#channels/email/send-email
  */
-final class InfobipApiTransport extends AbstractApiTransport
+final class InfobipApiTransport extends AbstractApiTransport implements \Stringable
 {
     private const API_VERSION = '3';
 

--- a/src/Symfony/Component/Mailer/Bridge/MailPace/Transport/MailPaceApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/MailPace/Transport/MailPaceApiTransport.php
@@ -27,7 +27,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 /**
  * @author Paul Oms <support@mailpace.com>
  */
-final class MailPaceApiTransport extends AbstractApiTransport
+final class MailPaceApiTransport extends AbstractApiTransport implements \Stringable
 {
     private const HOST = 'app.mailpace.com/api/v1';
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillApiTransport.php
@@ -28,7 +28,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 /**
  * @author Kevin Verschaeve
  */
-class MandrillApiTransport extends AbstractApiTransport
+class MandrillApiTransport extends AbstractApiTransport implements \Stringable
 {
     private const HOST = 'mandrillapp.com';
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillHttpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillHttpTransport.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 /**
  * @author Kevin Verschaeve
  */
-class MandrillHttpTransport extends AbstractHttpTransport
+class MandrillHttpTransport extends AbstractHttpTransport implements \Stringable
 {
     use MandrillHeadersTrait;
 

--- a/src/Symfony/Component/Mailer/Bridge/MailerSend/Transport/MailerSendApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/MailerSend/Transport/MailerSendApiTransport.php
@@ -27,7 +27,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 /**
  * @see https://developers.mailersend.com/api/v1/email.html
  */
-final class MailerSendApiTransport extends AbstractApiTransport
+final class MailerSendApiTransport extends AbstractApiTransport implements \Stringable
 {
     public function __construct(
         #[\SensitiveParameter] private string $key,

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunApiTransport.php
@@ -29,7 +29,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 /**
  * @author Kevin Verschaeve
  */
-class MailgunApiTransport extends AbstractApiTransport
+class MailgunApiTransport extends AbstractApiTransport implements \Stringable
 {
     private const HOST = 'api.%region_dot%mailgun.net';
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunHttpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunHttpTransport.php
@@ -26,7 +26,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 /**
  * @author Kevin Verschaeve
  */
-class MailgunHttpTransport extends AbstractHttpTransport
+class MailgunHttpTransport extends AbstractHttpTransport implements \Stringable
 {
     use MailgunHeadersTrait;
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
-class MailjetApiTransport extends AbstractApiTransport
+class MailjetApiTransport extends AbstractApiTransport implements \Stringable
 {
     private const HOST = 'api.mailjet.com';
     private const API_VERSION = '3.1';

--- a/src/Symfony/Component/Mailer/Bridge/Mailomat/Transport/MailomatApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailomat/Transport/MailomatApiTransport.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
-final class MailomatApiTransport extends AbstractApiTransport
+final class MailomatApiTransport extends AbstractApiTransport implements \Stringable
 {
     private const HOST = 'api.mailomat.swiss';
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailtrap/Transport/MailtrapApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailtrap/Transport/MailtrapApiTransport.php
@@ -30,7 +30,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-final class MailtrapApiTransport extends AbstractApiTransport
+final class MailtrapApiTransport extends AbstractApiTransport implements \Stringable
 {
     private const LIVE_API_HOST = 'send.api.mailtrap.io';
     private const SANDBOX_API_HOST = 'sandbox.api.mailtrap.io';

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphApiTransport.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
-class MicrosoftGraphApiTransport extends AbstractApiTransport
+class MicrosoftGraphApiTransport extends AbstractApiTransport implements \Stringable
 {
     private const USER_ENDPOINT = '%s/v1.0/users/%s/sendMail';
 

--- a/src/Symfony/Component/Mailer/Bridge/Postal/Transport/PostalApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postal/Transport/PostalApiTransport.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
-final class PostalApiTransport extends AbstractApiTransport
+final class PostalApiTransport extends AbstractApiTransport implements \Stringable
 {
     public function __construct(
         #[\SensitiveParameter] private string $apiToken,

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkApiTransport.php
@@ -30,7 +30,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 /**
  * @author Kevin Verschaeve
  */
-class PostmarkApiTransport extends AbstractApiTransport
+class PostmarkApiTransport extends AbstractApiTransport implements \Stringable
 {
     private const HOST = 'api.postmarkapp.com';
     private const CODE_INACTIVE_RECIPIENT = 406;

--- a/src/Symfony/Component/Mailer/Bridge/Resend/Transport/ResendApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Resend/Transport/ResendApiTransport.php
@@ -30,7 +30,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 /**
  * @author Mathieu Santostefano <msantostefano@proton.me>
  */
-final class ResendApiTransport extends AbstractApiTransport
+final class ResendApiTransport extends AbstractApiTransport implements \Stringable
 {
     public function __construct(
         #[\SensitiveParameter] private readonly string $apiKey,

--- a/src/Symfony/Component/Mailer/Bridge/Scaleway/Transport/ScalewayApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Scaleway/Transport/ScalewayApiTransport.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
-final class ScalewayApiTransport extends AbstractApiTransport
+final class ScalewayApiTransport extends AbstractApiTransport implements \Stringable
 {
     private const HOST = 'api.scaleway.com';
 

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridApiTransport.php
@@ -31,7 +31,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 /**
  * @author Kevin Verschaeve
  */
-class SendgridApiTransport extends AbstractApiTransport
+class SendgridApiTransport extends AbstractApiTransport implements \Stringable
 {
     private const HOST = 'api.%region_dot%sendgrid.com';
 

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Transport/SweegoApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Transport/SweegoApiTransport.php
@@ -29,7 +29,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 /**
  * @author Mathieu Santostefano <msantostefano@proton.me>
  */
-final class SweegoApiTransport extends AbstractApiTransport
+final class SweegoApiTransport extends AbstractApiTransport implements \Stringable
 {
     public function __construct(
         #[\SensitiveParameter] private readonly string $apiKey,

--- a/src/Symfony/Component/Mailer/Tests/MailerTest.php
+++ b/src/Symfony/Component/Mailer/Tests/MailerTest.php
@@ -92,7 +92,7 @@ class MailerTest extends TestCase
         $dispatcher->addListener(MessageEvent::class, fn (MessageEvent $event) => $event->reject(), 255);
         $dispatcher->addListener(MessageEvent::class, fn () => throw new \RuntimeException('Should never be called.'));
 
-        $transport = new class($dispatcher, $this) extends AbstractTransport {
+        $transport = new class($dispatcher, $this) extends AbstractTransport implements \Stringable {
             public function __construct(EventDispatcherInterface $dispatcher, private TestCase $test)
             {
                 parent::__construct($dispatcher);

--- a/src/Symfony/Component/Mailer/Tests/Transport/AbstractTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/AbstractTransportTest.php
@@ -88,7 +88,7 @@ class AbstractTransportTest extends TestCase
         $dispatcher->addListener(MessageEvent::class, fn (MessageEvent $event) => $event->reject(), 255);
         $dispatcher->addListener(MessageEvent::class, fn () => throw new \RuntimeException('Should never be called.'));
 
-        $transport = new class($dispatcher, $this) extends AbstractTransport {
+        $transport = new class($dispatcher, $this) extends AbstractTransport implements \Stringable {
             public function __construct(EventDispatcherInterface $dispatcher, private TestCase $test)
             {
                 parent::__construct($dispatcher);

--- a/src/Symfony/Component/Mailer/Tests/Transport/SendmailTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/SendmailTransportTest.php
@@ -128,7 +128,7 @@ class SendmailTransportTest extends TestCase
         $transportProperty = new \ReflectionProperty(SendmailTransport::class, 'transport');
 
         // Replace the transport with an anonymous consumer that trigger the stream methods
-        $transportProperty->setValue($sendmailTransport, new class($transportProperty->getValue($sendmailTransport)->getStream()) extends SmtpTransport {
+        $transportProperty->setValue($sendmailTransport, new class($transportProperty->getValue($sendmailTransport)->getStream()) extends SmtpTransport implements \Stringable {
             private $stream;
 
             public function __construct(ProcessStream $stream)

--- a/src/Symfony/Component/Mailer/Tests/TransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/TransportTest.php
@@ -100,7 +100,7 @@ class TransportTest extends TestCase
     }
 }
 
-class DummyTransport implements TransportInterface
+class DummyTransport implements \Stringable, TransportInterface
 {
     private string $host;
 

--- a/src/Symfony/Component/Mailer/Transport/NullTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/NullTransport.php
@@ -18,7 +18,7 @@ use Symfony\Component\Mailer\SentMessage;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-final class NullTransport extends AbstractTransport
+final class NullTransport extends AbstractTransport implements \Stringable
 {
     protected function doSend(SentMessage $message): void
     {

--- a/src/Symfony/Component/Mailer/Transport/RoundRobinTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/RoundRobinTransport.php
@@ -24,7 +24,7 @@ use Symfony\Component\Mime\RawMessage;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class RoundRobinTransport implements TransportInterface
+class RoundRobinTransport implements \Stringable, TransportInterface
 {
     /**
      * @var \SplObjectStorage<TransportInterface, float>

--- a/src/Symfony/Component/Mailer/Transport/SendmailTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/SendmailTransport.php
@@ -31,7 +31,7 @@ use Symfony\Component\Mime\RawMessage;
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Chris Corbyn
  */
-class SendmailTransport extends AbstractTransport
+class SendmailTransport extends AbstractTransport implements \Stringable
 {
     private string $command = '/usr/sbin/sendmail -bs';
     private ProcessStream $stream;

--- a/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
@@ -31,7 +31,7 @@ use Symfony\Component\Mime\RawMessage;
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Chris Corbyn
  */
-class SmtpTransport extends AbstractTransport
+class SmtpTransport extends AbstractTransport implements \Stringable
 {
     private bool $started = false;
     private int $restartThreshold = 100;

--- a/src/Symfony/Component/Mailer/Transport/Transports.php
+++ b/src/Symfony/Component/Mailer/Transport/Transports.php
@@ -21,7 +21,7 @@ use Symfony\Component\Mime\RawMessage;
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  */
-final class Transports implements TransportInterface
+final class Transports implements \Stringable, TransportInterface
 {
     /**
      * @var array<string, TransportInterface>

--- a/src/Symfony/Component/Notifier/Bridge/AllMySms/AllMySmsTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/AllMySms/AllMySmsTransport.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Quentin Dequippe <quentin@dequippe.tech>
  */
-final class AllMySmsTransport extends AbstractTransport
+final class AllMySmsTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'api.allmysms.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/AmazonSns/AmazonSnsTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/AmazonSns/AmazonSnsTransport.php
@@ -26,7 +26,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Adrien Chinour <github@chinour.fr>
  */
-final class AmazonSnsTransport extends AbstractTransport
+final class AmazonSnsTransport extends AbstractTransport implements \Stringable
 {
     public function __construct(
         private SnsClient $snsClient,

--- a/src/Symfony/Component/Notifier/Bridge/Bandwidth/BandwidthTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Bandwidth/BandwidthTransport.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author gnito-org <https://github.com/gnito-org>
  */
-final class BandwidthTransport extends AbstractTransport
+final class BandwidthTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'messaging.bandwidth.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/Bluesky/BlueskyTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Bluesky/BlueskyTransport.php
@@ -31,7 +31,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-final class BlueskyTransport extends AbstractTransport
+final class BlueskyTransport extends AbstractTransport implements \Stringable
 {
     private array $authSession = [];
     private ClockInterface $clock;

--- a/src/Symfony/Component/Notifier/Bridge/Brevo/BrevoTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Brevo/BrevoTransport.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Pierre Tanguy
  */
-final class BrevoTransport extends AbstractTransport
+final class BrevoTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'api.brevo.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/Chatwork/ChatworkTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Chatwork/ChatworkTransport.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Ippei Sumida <ippey.s@gmail.com>
  */
-class ChatworkTransport extends AbstractTransport
+class ChatworkTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'api.chatwork.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/ClickSend/ClickSendTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/ClickSend/ClickSendTransport.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author gnito-org <https://github.com/gnito-org>
  */
-final class ClickSendTransport extends AbstractTransport
+final class ClickSendTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'rest.clicksend.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/Clickatell/ClickatellTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Clickatell/ClickatellTransport.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Kevin Auvinet <k.auvinet@gmail.com>
  */
-final class ClickatellTransport extends AbstractTransport
+final class ClickatellTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'api.clickatell.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/ContactEveryone/ContactEveryoneTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/ContactEveryone/ContactEveryoneTransport.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Franck Ranaivo-Harisoa <franckranaivo@gmail.com>
  */
-final class ContactEveryoneTransport extends AbstractTransport
+final class ContactEveryoneTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'contact-everyone.orange-business.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/Discord/DiscordBotTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/DiscordBotTransport.php
@@ -26,7 +26,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  * @author Mathieu Piot <math.piot@gmail.com>
  * @author Tomas Norkūnas <norkunas.tom@gmail.com>
  */
-final class DiscordBotTransport extends AbstractTransport
+final class DiscordBotTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'discord.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/Discord/DiscordTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/DiscordTransport.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Mathieu Piot <math.piot@gmail.com>
  */
-final class DiscordTransport extends AbstractTransport
+final class DiscordTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'discord.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/Engagespot/EngagespotTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Engagespot/EngagespotTransport.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Daniel GORGAN <https://github.com/danut007ro>
  */
-final class EngagespotTransport extends AbstractTransport
+final class EngagespotTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'api.engagespot.co/2/campaigns';
 

--- a/src/Symfony/Component/Notifier/Bridge/Esendex/EsendexTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Esendex/EsendexTransport.php
@@ -22,7 +22,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
-final class EsendexTransport extends AbstractTransport
+final class EsendexTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'api.esendex.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/Expo/ExpoTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Expo/ExpoTransport.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Imad ZAIRIG <https://github.com/zairigimad>
  */
-final class ExpoTransport extends AbstractTransport
+final class ExpoTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'exp.host/--/api/v2/push/send';
 

--- a/src/Symfony/Component/Notifier/Bridge/FakeChat/FakeChatEmailTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/FakeChat/FakeChatEmailTransport.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>
  */
-final class FakeChatEmailTransport extends AbstractTransport
+final class FakeChatEmailTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'default';
 

--- a/src/Symfony/Component/Notifier/Bridge/FakeChat/FakeChatLoggerTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/FakeChat/FakeChatLoggerTransport.php
@@ -23,7 +23,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Antoine Makdessi <amakdessi@me.com>
  */
-final class FakeChatLoggerTransport extends AbstractTransport
+final class FakeChatLoggerTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'default';
 

--- a/src/Symfony/Component/Notifier/Bridge/FakeSms/FakeSmsEmailTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/FakeSms/FakeSmsEmailTransport.php
@@ -26,7 +26,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  * @author James Hemery <james@yieldstudio.fr>
  * @author Oskar Stark <oskarstark@googlemail.com>
  */
-final class FakeSmsEmailTransport extends AbstractTransport
+final class FakeSmsEmailTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'default';
 

--- a/src/Symfony/Component/Notifier/Bridge/FakeSms/FakeSmsLoggerTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/FakeSms/FakeSmsLoggerTransport.php
@@ -23,7 +23,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Antoine Makdessi <amakdessi@me.com>
  */
-final class FakeSmsLoggerTransport extends AbstractTransport
+final class FakeSmsLoggerTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'default';
 

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/FirebaseTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/FirebaseTransport.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Jeroen Spee <https://github.com/Jeroeny>
  */
-final class FirebaseTransport extends AbstractTransport
+final class FirebaseTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'fcm.googleapis.com/fcm/send';
 

--- a/src/Symfony/Component/Notifier/Bridge/FortySixElks/FortySixElksTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/FortySixElks/FortySixElksTransport.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Jon Gotlin <jon@jon.se>
  */
-final class FortySixElksTransport extends AbstractTransport
+final class FortySixElksTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'api.46elks.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/FreeMobile/FreeMobileTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/FreeMobile/FreeMobileTransport.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Antoine Makdessi <amakdessi@me.com>
  */
-final class FreeMobileTransport extends AbstractTransport
+final class FreeMobileTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'smsapi.free-mobile.fr/sendmsg';
 

--- a/src/Symfony/Component/Notifier/Bridge/GatewayApi/GatewayApiTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/GatewayApi/GatewayApiTransport.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Piergiuseppe Longo <piergiuseppe.longo@gmail.com>
  */
-final class GatewayApiTransport extends AbstractTransport
+final class GatewayApiTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'gatewayapi.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/GoIp/GoIpTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/GoIp/GoIpTransport.php
@@ -29,7 +29,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Ahmed Ghanem <ahmedghanem7361@gmail.com>
  */
-final class GoIpTransport extends AbstractTransport
+final class GoIpTransport extends AbstractTransport implements \Stringable
 {
     public function __construct(
         private readonly string $username,

--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/GoogleChatTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/GoogleChatTransport.php
@@ -26,7 +26,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Jérôme Tamarelle <jerome@tamarelle.net>
  */
-final class GoogleChatTransport extends AbstractTransport
+final class GoogleChatTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'chat.googleapis.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/Infobip/InfobipTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Infobip/InfobipTransport.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Jérémy Romey <jeremy@free-agent.fr>
  */
-final class InfobipTransport extends AbstractTransport
+final class InfobipTransport extends AbstractTransport implements \Stringable
 {
     public function __construct(
         #[\SensitiveParameter] private string $authToken,

--- a/src/Symfony/Component/Notifier/Bridge/Iqsms/IqsmsTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Iqsms/IqsmsTransport.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Oleksandr Barabolia <alexandrbarabolya@gmail.com>
  */
-final class IqsmsTransport extends AbstractTransport
+final class IqsmsTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'api.iqsms.ru';
 

--- a/src/Symfony/Component/Notifier/Bridge/Isendpro/IsendproTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Isendpro/IsendproTransport.php
@@ -22,7 +22,7 @@ use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
-final class IsendproTransport extends AbstractTransport
+final class IsendproTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'apirest.isendpro.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/JoliNotif/JoliNotifTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/JoliNotif/JoliNotifTransport.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 /**
  * @author Ahmed Ghanem <ahmedghanem7361@gmail.com>
  */
-final class JoliNotifTransport extends AbstractTransport
+final class JoliNotifTransport extends AbstractTransport implements \Stringable
 {
     public function __construct(
         private readonly JoliNotifier $joliNotifier,

--- a/src/Symfony/Component/Notifier/Bridge/KazInfoTeh/KazInfoTehTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/KazInfoTeh/KazInfoTehTransport.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Egor Taranov <dev@taranovegor.com>
  */
-class KazInfoTehTransport extends AbstractTransport
+class KazInfoTehTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'kazinfoteh.org';
 

--- a/src/Symfony/Component/Notifier/Bridge/LightSms/LightSmsTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/LightSms/LightSmsTransport.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Vasilij Duško <vasilij@prado.lt>
  */
-final class LightSmsTransport extends AbstractTransport
+final class LightSmsTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'www.lightsms.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/LineBot/LineBotTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/LineBot/LineBotTransport.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Yi-Jyun Pan <me@pan93.com>
  */
-final class LineBotTransport extends AbstractTransport
+final class LineBotTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'api.line.me';
 

--- a/src/Symfony/Component/Notifier/Bridge/LineNotify/LineNotifyTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/LineNotify/LineNotifyTransport.php
@@ -23,7 +23,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Akira Kurozumi <info@a-zumi.net>
  */
-final class LineNotifyTransport extends AbstractTransport
+final class LineNotifyTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'notify-api.line.me';
 

--- a/src/Symfony/Component/Notifier/Bridge/LinkedIn/LinkedInTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/LinkedIn/LinkedInTransport.php
@@ -28,7 +28,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  *
  * @see https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/ugc-post-api#sharecontent
  */
-final class LinkedInTransport extends AbstractTransport
+final class LinkedInTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'api.linkedin.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/Lox24/Lox24Transport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Lox24/Lox24Transport.php
@@ -29,7 +29,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Andrei Lebedev <andrew.lebedev@gmail.com>
  */
-final class Lox24Transport extends AbstractTransport
+final class Lox24Transport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'api.lox24.eu';
 

--- a/src/Symfony/Component/Notifier/Bridge/Mailjet/MailjetTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mailjet/MailjetTransport.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Jérôme Nadaud <jerome@nadaud.io>
  */
-final class MailjetTransport extends AbstractTransport
+final class MailjetTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'api.mailjet.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/Mastodon/MastodonTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mastodon/MastodonTransport.php
@@ -31,7 +31,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  *
  * @see https://docs.joinmastodon.org
  */
-final class MastodonTransport extends AbstractTransport
+final class MastodonTransport extends AbstractTransport implements \Stringable
 {
     public function __construct(
         #[\SensitiveParameter] private readonly string $accessToken,

--- a/src/Symfony/Component/Notifier/Bridge/Matrix/MatrixTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Matrix/MatrixTransport.php
@@ -27,7 +27,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 /**
  * @author Frank Schulze <frank@akiber.de>
  */
-final class MatrixTransport extends AbstractTransport
+final class MatrixTransport extends AbstractTransport implements \Stringable
 {
     // not all Message Types are supported by Matrix API
     private const SUPPORTED_MSG_TYPES_BY_API = ['m.text', 'm.emote', 'm.notice', 'm.image', 'm.file', 'm.audio', 'm.video', 'm.key.verification'];

--- a/src/Symfony/Component/Notifier/Bridge/Mattermost/MattermostTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mattermost/MattermostTransport.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Emanuele Panzeri <thepanz@gmail.com>
  */
-final class MattermostTransport extends AbstractTransport
+final class MattermostTransport extends AbstractTransport implements \Stringable
 {
     public function __construct(
         #[\SensitiveParameter] private string $token,

--- a/src/Symfony/Component/Notifier/Bridge/Mercure/MercureTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mercure/MercureTransport.php
@@ -28,7 +28,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  */
-final class MercureTransport extends AbstractTransport
+final class MercureTransport extends AbstractTransport implements \Stringable
 {
     private string|array $topics;
 

--- a/src/Symfony/Component/Notifier/Bridge/MessageBird/MessageBirdTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/MessageBird/MessageBirdTransport.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Vasilij Duško <vasilij@prado.lt>
  */
-final class MessageBirdTransport extends AbstractTransport
+final class MessageBirdTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'rest.messagebird.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/MessageMedia/MessageMediaTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/MessageMedia/MessageMediaTransport.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Adrian Nguyen <vuphuong87@gmail.com>
  */
-final class MessageMediaTransport extends AbstractTransport
+final class MessageMediaTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'api.messagemedia.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/MicrosoftTeamsTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/MicrosoftTeamsTransport.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  * @author Edouard Lescot <edouard.lescot@gmail.com>
  * @author Oskar Stark <oskarstark@googlemail.com>
  */
-final class MicrosoftTeamsTransport extends AbstractTransport
+final class MicrosoftTeamsTransport extends AbstractTransport implements \Stringable
 {
     protected const ENDPOINT = 'outlook.office.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/MobytTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/MobytTransport.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Basien Durand <bdurand-dev@outlook.com>
  */
-final class MobytTransport extends AbstractTransport
+final class MobytTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'app.mobyt.fr';
 

--- a/src/Symfony/Component/Notifier/Bridge/Novu/NovuTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Novu/NovuTransport.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Wouter van der Loop <woutervdl@toppy.nl>
  */
-class NovuTransport extends AbstractTransport
+class NovuTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'web.novu.co';
 

--- a/src/Symfony/Component/Notifier/Bridge/Ntfy/NtfyTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Ntfy/NtfyTransport.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Mickael Perraud <mikaelkael.fr@gmail.com>
  */
-final class NtfyTransport extends AbstractTransport
+final class NtfyTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'ntfy.sh';
     private ?string $user = null;

--- a/src/Symfony/Component/Notifier/Bridge/Octopush/OctopushTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Octopush/OctopushTransport.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Aurélien Martin <pro@aurelienmartin.com>
  */
-final class OctopushTransport extends AbstractTransport
+final class OctopushTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'www.octopush-dm.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/OneSignal/OneSignalTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/OneSignal/OneSignalTransport.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Tomas Norkūnas <norkunas.tom@gmail.com>
  */
-final class OneSignalTransport extends AbstractTransport
+final class OneSignalTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'onesignal.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/OrangeSms/OrangeSmsTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/OrangeSms/OrangeSmsTransport.php
@@ -20,7 +20,7 @@ use Symfony\Component\Notifier\Transport\AbstractTransport;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
-final class OrangeSmsTransport extends AbstractTransport
+final class OrangeSmsTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'api.orange.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransport.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Thomas Ferney <thomas.ferney@gmail.com>
  */
-final class OvhCloudTransport extends AbstractTransport
+final class OvhCloudTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'eu.api.ovh.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/PagerDuty/PagerDutyTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/PagerDuty/PagerDutyTransport.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Joseph Bielawski <stloyd@gmail.com>
  */
-final class PagerDutyTransport extends AbstractTransport
+final class PagerDutyTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'events.pagerduty.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/Plivo/PlivoTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Plivo/PlivoTransport.php
@@ -26,7 +26,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author gnito-org <https://github.com/gnito-org>
  */
-final class PlivoTransport extends AbstractTransport
+final class PlivoTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'api.plivo.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/Primotexto/PrimotextoTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Primotexto/PrimotextoTransport.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Samaël Tomas <samael.tomas@gmail.com>
  */
-final class PrimotextoTransport extends AbstractTransport
+final class PrimotextoTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'api.primotexto.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/Pushover/PushoverTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Pushover/PushoverTransport.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author mocodo <https://github.com/mocodo>
  */
-final class PushoverTransport extends AbstractTransport
+final class PushoverTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'api.pushover.net';
 

--- a/src/Symfony/Component/Notifier/Bridge/Pushy/PushyTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Pushy/PushyTransport.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Joseph Bielawski <stloyd@gmail.com>
  */
-final class PushyTransport extends AbstractTransport
+final class PushyTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'api.pushy.me';
 

--- a/src/Symfony/Component/Notifier/Bridge/Redlink/RedlinkTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Redlink/RedlinkTransport.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Mateusz Żyła <https://github.com/plotkabytes>
  */
-final class RedlinkTransport extends AbstractTransport
+final class RedlinkTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'api.redlink.pl';
 

--- a/src/Symfony/Component/Notifier/Bridge/RingCentral/RingCentralTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/RingCentral/RingCentralTransport.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author gnito-org <https://github.com/gnito-org>
  */
-final class RingCentralTransport extends AbstractTransport
+final class RingCentralTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'platform.ringcentral.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/RocketChatTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/RocketChatTransport.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Jeroen Spee <https://github.com/Jeroeny>
  */
-final class RocketChatTransport extends AbstractTransport
+final class RocketChatTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'rocketchat.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/Sendberry/SendberryTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sendberry/SendberryTransport.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Vasilij Duško <vasilij@prado.lt>
  */
-final class SendberryTransport extends AbstractTransport
+final class SendberryTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'api.sendberry.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/Sevenio/SevenIoTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sevenio/SevenIoTransport.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Frank Nägler <frank@naegler.hamburg>
  */
-final class SevenIoTransport extends AbstractTransport
+final class SevenIoTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'gateway.seven.io';
 

--- a/src/Symfony/Component/Notifier/Bridge/SimpleTextin/SimpleTextinTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/SimpleTextin/SimpleTextinTransport.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author gnito-org <https://github.com/gnito-org>
  */
-final class SimpleTextinTransport extends AbstractTransport
+final class SimpleTextinTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'api-app2.simpletexting.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/Sinch/SinchTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sinch/SinchTransport.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Iliya Miroslavov Iliev <i.miroslavov@gmail.com>
  */
-final class SinchTransport extends AbstractTransport
+final class SinchTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'sms.api.sinch.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/Sipgate/SipgateTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sipgate/SipgateTransport.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Lukas Kaltenbach <lk@wikanet.de>
  */
-final class SipgateTransport extends AbstractTransport
+final class SipgateTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'api.sipgate.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransport.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  */
-final class SlackTransport extends AbstractTransport
+final class SlackTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'slack.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/Sms77/Sms77Transport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sms77/Sms77Transport.php
@@ -26,7 +26,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  *
  * @deprecated since Symfony 7.3, use the Seven.io bridge instead.
  */
-final class Sms77Transport extends AbstractTransport
+final class Sms77Transport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'gateway.sms77.io';
 

--- a/src/Symfony/Component/Notifier/Bridge/SmsBiuras/SmsBiurasTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/SmsBiuras/SmsBiurasTransport.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Vasilij Duško <vasilij@prado.lt>
  */
-final class SmsBiurasTransport extends AbstractTransport
+final class SmsBiurasTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'savitarna.smsbiuras.lt';
 

--- a/src/Symfony/Component/Notifier/Bridge/SmsFactor/SmsFactorTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/SmsFactor/SmsFactorTransport.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Thibault Buathier <thibault.buathier@gmail.com>
  */
-final class SmsFactorTransport extends AbstractTransport
+final class SmsFactorTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'api.smsfactor.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/SmsSluzba/SmsSluzbaTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/SmsSluzba/SmsSluzbaTransport.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Dennis Fridrich <fridrich.dennis@gmail.com>
  */
-final class SmsSluzbaTransport extends AbstractTransport
+final class SmsSluzbaTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'smsgateapi.sms-sluzba.cz';
 

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/SmsapiTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/SmsapiTransport.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Marcin Szepczynski <szepczynski@gmail.com>
  */
-final class SmsapiTransport extends AbstractTransport
+final class SmsapiTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'api.smsapi.pl';
 

--- a/src/Symfony/Component/Notifier/Bridge/Smsbox/SmsboxTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsbox/SmsboxTransport.php
@@ -28,7 +28,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  * @author Alan Zarli <azarli@smsbox.fr>
  * @author Farid Touil <ftouil@smsbox.fr>
  */
-final class SmsboxTransport extends AbstractTransport
+final class SmsboxTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'api.smsbox.pro';
 

--- a/src/Symfony/Component/Notifier/Bridge/Smsc/SmscTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsc/SmscTransport.php
@@ -26,7 +26,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Valentin Nazarov <i.kozlice@protonmail.com>
  */
-final class SmscTransport extends AbstractTransport
+final class SmscTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'smsc.ru';
 

--- a/src/Symfony/Component/Notifier/Bridge/Smsense/SmsenseTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsense/SmsenseTransport.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Valentin Barbu <jimiero@gmail.com>
  */
-final class SmsenseTransport extends AbstractTransport
+final class SmsenseTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'rest.smsense.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/Smsmode/SmsmodeTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsmode/SmsmodeTransport.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author gnito-org <https://github.com/gnito-org>
  */
-final class SmsmodeTransport extends AbstractTransport
+final class SmsmodeTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'rest.smsmode.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/SpotHit/SpotHitTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/SpotHit/SpotHitTransport.php
@@ -29,7 +29,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author James Hemery <james@yieldstudio.fr>
  */
-final class SpotHitTransport extends AbstractTransport
+final class SpotHitTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'spot-hit.fr';
 

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/SweegoTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/SweegoTransport.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Mathieu Santostefano <msantostefano@protonmail.com>
  */
-final class SweegoTransport extends AbstractTransport
+final class SweegoTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'api.sweego.io';
 

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransport.php
@@ -29,7 +29,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-final class TelegramTransport extends AbstractTransport
+final class TelegramTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'api.telegram.org';
 

--- a/src/Symfony/Component/Notifier/Bridge/Telnyx/TelnyxTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telnyx/TelnyxTransport.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Vasilij Duško <vasilij@prado.lt>
  */
-final class TelnyxTransport extends AbstractTransport
+final class TelnyxTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'api.telnyx.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/Termii/TermiiTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Termii/TermiiTransport.php
@@ -26,7 +26,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author gnito-org <https://github.com/gnito-org>
  */
-final class TermiiTransport extends AbstractTransport
+final class TermiiTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'api.ng.termii.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/TurboSms/TurboSmsTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/TurboSms/TurboSmsTransport.php
@@ -26,7 +26,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  *
  * @see https://turbosms.ua/api.html
  */
-final class TurboSmsTransport extends AbstractTransport
+final class TurboSmsTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'api.turbosms.ua';
 

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/TwilioTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/TwilioTransport.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  */
-final class TwilioTransport extends AbstractTransport
+final class TwilioTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'api.twilio.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/Twitter/TwitterTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Twitter/TwitterTransport.php
@@ -30,7 +30,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 /**
  * @author Nicolas Grekas <p@tchwork.com>
  */
-final class TwitterTransport extends AbstractTransport
+final class TwitterTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'api.twitter.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/Unifonic/UnifonicTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Unifonic/UnifonicTransport.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Farhad Safarov <farhad.safarov@gmail.com>
  */
-final class UnifonicTransport extends AbstractTransport
+final class UnifonicTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'el.cloud.unifonic.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/Vonage/VonageTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Vonage/VonageTransport.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  */
-final class VonageTransport extends AbstractTransport
+final class VonageTransport extends AbstractTransport implements \Stringable
 {
     // see https://developer.vonage.com/messaging/sms/overview
     protected const HOST = 'rest.nexmo.com';

--- a/src/Symfony/Component/Notifier/Bridge/Yunpian/YunpianTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Yunpian/YunpianTransport.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Mathieu Santostefano <msantostefano@protonmail.com>
  */
-class YunpianTransport extends AbstractTransport
+class YunpianTransport extends AbstractTransport implements \Stringable
 {
     protected const HOST = 'sms.yunpian.com';
 

--- a/src/Symfony/Component/Notifier/Bridge/Zendesk/ZendeskTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Zendesk/ZendeskTransport.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Joseph Bielawski <stloyd@gmail.com>
  */
-final class ZendeskTransport extends AbstractTransport
+final class ZendeskTransport extends AbstractTransport implements \Stringable
 {
     public function __construct(
         private string $email,

--- a/src/Symfony/Component/Notifier/Bridge/Zulip/ZulipTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Zulip/ZulipTransport.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Mohammad Emran Hasan <phpfour@gmail.com>
  */
-final class ZulipTransport extends AbstractTransport
+final class ZulipTransport extends AbstractTransport implements \Stringable
 {
     public function __construct(
         private string $email,

--- a/src/Symfony/Component/Notifier/Chatter.php
+++ b/src/Symfony/Component/Notifier/Chatter.php
@@ -21,7 +21,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  */
-final class Chatter implements ChatterInterface
+final class Chatter implements \Stringable, ChatterInterface
 {
     public function __construct(
         private TransportInterface $transport,

--- a/src/Symfony/Component/Notifier/Tests/Event/FailedMessageEventTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Event/FailedMessageEventTest.php
@@ -49,7 +49,7 @@ class FailedMessageEventTest extends TestCase
         $eventDispatcherMock = $this->createMock(EventDispatcherInterface::class);
         $clientMock = $this->createMock(HttpClientInterface::class);
 
-        $transport = new class($clientMock, $eventDispatcherMock) extends AbstractTransport {
+        $transport = new class($clientMock, $eventDispatcherMock) extends AbstractTransport implements \Stringable {
             public NullTransportException $exception;
 
             public function __construct($client, ?EventDispatcherInterface $dispatcher = null)

--- a/src/Symfony/Component/Notifier/Texter.php
+++ b/src/Symfony/Component/Notifier/Texter.php
@@ -21,7 +21,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  */
-final class Texter implements TexterInterface
+final class Texter implements \Stringable, TexterInterface
 {
     public function __construct(
         private TransportInterface $transport,

--- a/src/Symfony/Component/Notifier/Transport/NullTransport.php
+++ b/src/Symfony/Component/Notifier/Transport/NullTransport.php
@@ -21,7 +21,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class NullTransport implements TransportInterface
+class NullTransport implements \Stringable, TransportInterface
 {
     public function __construct(
         private ?EventDispatcherInterface $dispatcher = null,

--- a/src/Symfony/Component/Notifier/Transport/RoundRobinTransport.php
+++ b/src/Symfony/Component/Notifier/Transport/RoundRobinTransport.php
@@ -22,7 +22,7 @@ use Symfony\Component\Notifier\Message\SentMessage;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class RoundRobinTransport implements TransportInterface
+class RoundRobinTransport implements \Stringable, TransportInterface
 {
     /**
      * @var \SplObjectStorage<TransportInterface, float>

--- a/src/Symfony/Component/Notifier/Transport/Transports.php
+++ b/src/Symfony/Component/Notifier/Transport/Transports.php
@@ -19,7 +19,7 @@ use Symfony\Component\Notifier\Message\SentMessage;
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  */
-final class Transports implements TransportInterface
+final class Transports implements \Stringable, TransportInterface
 {
     /**
      * @var array<string, TransportInterface>

--- a/src/Symfony/Component/PropertyAccess/PropertyPath.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyPath.php
@@ -22,7 +22,7 @@ use Symfony\Component\PropertyAccess\Exception\OutOfBoundsException;
  *
  * @implements \IteratorAggregate<int, string>
  */
-class PropertyPath implements \IteratorAggregate, PropertyPathInterface
+class PropertyPath implements \Stringable, \IteratorAggregate, PropertyPathInterface
 {
     /**
      * Character used for separating between plural and singular of an element.

--- a/src/Symfony/Component/PropertyAccess/PropertyPathBuilder.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyPathBuilder.php
@@ -16,7 +16,7 @@ use Symfony\Component\PropertyAccess\Exception\OutOfBoundsException;
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class PropertyPathBuilder
+class PropertyPathBuilder implements \Stringable
 {
     private array $elements = [];
     private array $isIndex = [];

--- a/src/Symfony/Component/RateLimiter/Policy/Rate.php
+++ b/src/Symfony/Component/RateLimiter/Policy/Rate.php
@@ -18,7 +18,7 @@ use Symfony\Component\RateLimiter\Util\TimeUtil;
  *
  * @author Wouter de Jong <wouter@wouterj.nl>
  */
-final class Rate
+final class Rate implements \Stringable
 {
     public function __construct(
         private \DateInterval $refillTime,

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -1133,7 +1133,7 @@ class UrlGeneratorTest extends TestCase
     }
 }
 
-class StringableObject
+class StringableObject implements \Stringable
 {
     public function __toString(): string
     {
@@ -1141,7 +1141,7 @@ class StringableObject
     }
 }
 
-class StringableObjectWithPublicProperty
+class StringableObjectWithPublicProperty implements \Stringable
 {
     public $foo = 'property';
 

--- a/src/Symfony/Component/Scheduler/Messenger/Serializer/Normalizer/SchedulerTriggerNormalizer.php
+++ b/src/Symfony/Component/Scheduler/Messenger/Serializer/Normalizer/SchedulerTriggerNormalizer.php
@@ -40,7 +40,7 @@ final class SchedulerTriggerNormalizer implements DenormalizerInterface, Normali
 
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): TriggerInterface
     {
-        return new class($data) implements TriggerInterface {
+        return new class($data) implements \Stringable, TriggerInterface {
             public function __construct(private readonly string $description)
             {
             }

--- a/src/Symfony/Component/Scheduler/Tests/Generator/MessageGeneratorTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Generator/MessageGeneratorTest.php
@@ -345,7 +345,7 @@ class MessageGeneratorTest extends TestCase
                 '22:12:01' => [],
             ],
             'schedule' => [
-                RecurringMessage::trigger(new class implements TriggerInterface {
+                RecurringMessage::trigger(new class implements \Stringable, TriggerInterface {
                     public function __toString(): string
                     {
                         return 'foo';

--- a/src/Symfony/Component/Scheduler/Trigger/CallbackTrigger.php
+++ b/src/Symfony/Component/Scheduler/Trigger/CallbackTrigger.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Scheduler\Trigger;
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  */
-final class CallbackTrigger implements TriggerInterface
+final class CallbackTrigger implements \Stringable, TriggerInterface
 {
     private \Closure $callback;
     private string $description;

--- a/src/Symfony/Component/Scheduler/Trigger/CronExpressionTrigger.php
+++ b/src/Symfony/Component/Scheduler/Trigger/CronExpressionTrigger.php
@@ -21,7 +21,7 @@ use Symfony\Component\Scheduler\Exception\LogicException;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-final class CronExpressionTrigger implements TriggerInterface
+final class CronExpressionTrigger implements \Stringable, TriggerInterface
 {
     private const HASH_ALIAS_MAP = [
         '#hourly' => '# * * * *',

--- a/src/Symfony/Component/Scheduler/Trigger/ExcludeTimeTrigger.php
+++ b/src/Symfony/Component/Scheduler/Trigger/ExcludeTimeTrigger.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Scheduler\Trigger;
 
-final class ExcludeTimeTrigger extends AbstractDecoratedTrigger
+final class ExcludeTimeTrigger extends AbstractDecoratedTrigger implements \Stringable
 {
     public function __construct(
         private readonly TriggerInterface $inner,

--- a/src/Symfony/Component/Scheduler/Trigger/JitterTrigger.php
+++ b/src/Symfony/Component/Scheduler/Trigger/JitterTrigger.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Scheduler\Trigger;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-final class JitterTrigger extends AbstractDecoratedTrigger
+final class JitterTrigger extends AbstractDecoratedTrigger implements \Stringable
 {
     /**
      * @param positive-int $maxSeconds

--- a/src/Symfony/Component/Scheduler/Trigger/PeriodicalTrigger.php
+++ b/src/Symfony/Component/Scheduler/Trigger/PeriodicalTrigger.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Scheduler\Trigger;
 
 use Symfony\Component\Scheduler\Exception\InvalidArgumentException;
 
-class PeriodicalTrigger implements StatefulTriggerInterface
+class PeriodicalTrigger implements \Stringable, StatefulTriggerInterface
 {
     private float $intervalInSeconds = 0.0;
     private ?\DateTimeImmutable $from;

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -20,7 +20,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-abstract class AbstractToken implements TokenInterface, \Serializable
+abstract class AbstractToken implements \Stringable, TokenInterface, \Serializable
 {
     private ?UserInterface $user = null;
     private array $roleNames;

--- a/src/Symfony/Component/Security/Core/Authentication/Token/NullToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/NullToken.php
@@ -16,7 +16,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 /**
  * @author Wouter de Jong <wouter@wouterj.nl>
  */
-class NullToken implements TokenInterface
+class NullToken implements \Stringable, TokenInterface
 {
     public function __toString(): string
     {

--- a/src/Symfony/Component/Security/Core/Role/Role.php
+++ b/src/Symfony/Component/Security/Core/Role/Role.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\Security\Core\Role;
  *
  * @internal
  */
-class Role
+class Role implements \Stringable
 {
     private $role;
 

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationTrustResolverTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationTrustResolverTest.php
@@ -76,7 +76,7 @@ class AuthenticationTrustResolverTest extends TestCase
     }
 }
 
-class FakeCustomToken implements TokenInterface
+class FakeCustomToken implements \Stringable, TokenInterface
 {
     public function __serialize(): array
     {

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/VoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/VoterTest.php
@@ -126,7 +126,7 @@ class TypeErrorVoterTest_Voter extends Voter
     }
 }
 
-class StringableAttribute
+class StringableAttribute implements \Stringable
 {
     public function __toString(): string
     {

--- a/src/Symfony/Component/Security/Csrf/CsrfToken.php
+++ b/src/Symfony/Component/Security/Csrf/CsrfToken.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\Security\Csrf;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class CsrfToken
+class CsrfToken implements \Stringable
 {
     private string $value;
 

--- a/src/Symfony/Component/Security/Http/LoginLink/LoginLinkDetails.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/LoginLinkDetails.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Security\Http\LoginLink;
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
  */
-class LoginLinkDetails
+class LoginLinkDetails implements \Stringable
 {
     public function __construct(
         private string $url,

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/FormLoginAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/FormLoginAuthenticatorTest.php
@@ -162,7 +162,7 @@ class FormLoginAuthenticatorTest extends TestCase
     #[DataProvider('postOnlyDataProvider')]
     public function testHandleNonStringPasswordWithToString(bool $postOnly)
     {
-        $passwordObject = new class {
+        $passwordObject = new class implements \Stringable {
             public function __toString(): string
             {
                 return 's$cr$t';
@@ -282,7 +282,7 @@ class FormLoginAuthenticatorTest extends TestCase
     }
 }
 
-class DummyUserClass
+class DummyUserClass implements \Stringable
 {
     public function __toString(): string
     {

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
@@ -549,7 +549,7 @@ class SupportingUserProvider implements UserProviderInterface
     }
 }
 
-class CustomToken implements TokenInterface
+class CustomToken implements \Stringable, TokenInterface
 {
     private UserInterface $user;
     private array $roles;

--- a/src/Symfony/Component/Semaphore/Key.php
+++ b/src/Symfony/Component/Semaphore/Key.php
@@ -19,7 +19,7 @@ use Symfony\Component\Semaphore\Exception\InvalidArgumentException;
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  * @author Jérémy Derussé <jeremy@derusse.com>
  */
-final class Key
+final class Key implements \Stringable
 {
     private ?float $expiringTime = null;
     private array $state = [];

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -577,7 +577,7 @@ class AbstractObjectNormalizerTest extends TestCase
      */
     public static function provideInvalidDiscriminatorTypes(): iterable
     {
-        $toStringObject = new class {
+        $toStringObject = new class implements \Stringable {
             public function __toString()
             {
                 return 'first';

--- a/src/Symfony/Component/Stopwatch/StopwatchEvent.php
+++ b/src/Symfony/Component/Stopwatch/StopwatchEvent.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\Stopwatch;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class StopwatchEvent
+class StopwatchEvent implements \Stringable
 {
     /**
      * @var StopwatchPeriod[]

--- a/src/Symfony/Component/Stopwatch/StopwatchPeriod.php
+++ b/src/Symfony/Component/Stopwatch/StopwatchPeriod.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\Stopwatch;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class StopwatchPeriod
+class StopwatchPeriod implements \Stringable
 {
     private int|float $start;
     private int|float $end;

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/CrowdinProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/CrowdinProvider.php
@@ -29,7 +29,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  *  * Identifiers refer to Symfony's translation keys;
  *  * Translations refer to Symfony's translated messages
  */
-final class CrowdinProvider implements ProviderInterface
+final class CrowdinProvider implements \Stringable, ProviderInterface
 {
     public function __construct(
         private HttpClientInterface $client,

--- a/src/Symfony/Component/Translation/Bridge/Loco/LocoProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/LocoProvider.php
@@ -29,7 +29,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  *  * Assets refers to Symfony's translation keys
  *  * Translations refers to Symfony's translated messages
  */
-final class LocoProvider implements ProviderInterface
+final class LocoProvider implements \Stringable, ProviderInterface
 {
     public function __construct(
         private HttpClientInterface $client,

--- a/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProvider.php
@@ -29,7 +29,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  *  * Keys refers to Symfony's translation keys;
  *  * Translations refers to Symfony's translated messages
  */
-final class LokaliseProvider implements ProviderInterface
+final class LokaliseProvider implements \Stringable, ProviderInterface
 {
     private const LOKALISE_GET_KEYS_LIMIT = 5000;
     private const PROJECT_TOO_BIG_STATUS_CODE = 413;

--- a/src/Symfony/Component/Translation/Bridge/Phrase/PhraseProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Phrase/PhraseProvider.php
@@ -27,7 +27,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 /**
  * @author wicliff <wicliff.wolda@gmail.com>
  */
-class PhraseProvider implements ProviderInterface
+class PhraseProvider implements \Stringable, ProviderInterface
 {
     private array $phraseLocales = [];
 

--- a/src/Symfony/Component/Translation/Provider/FilteringProvider.php
+++ b/src/Symfony/Component/Translation/Provider/FilteringProvider.php
@@ -19,7 +19,7 @@ use Symfony\Component\Translation\TranslatorBagInterface;
  *
  * @author Mathieu Santostefano <msantostefano@protonmail.com>
  */
-class FilteringProvider implements ProviderInterface
+class FilteringProvider implements \Stringable, ProviderInterface
 {
     public function __construct(
         private ProviderInterface $provider,

--- a/src/Symfony/Component/Translation/Provider/NullProvider.php
+++ b/src/Symfony/Component/Translation/Provider/NullProvider.php
@@ -17,7 +17,7 @@ use Symfony\Component\Translation\TranslatorBagInterface;
 /**
  * @author Mathieu Santostefano <msantostefano@protonmail.com>
  */
-class NullProvider implements ProviderInterface
+class NullProvider implements \Stringable, ProviderInterface
 {
     public function __toString(): string
     {

--- a/src/Symfony/Component/Translation/Provider/TranslationProviderCollection.php
+++ b/src/Symfony/Component/Translation/Provider/TranslationProviderCollection.php
@@ -16,7 +16,7 @@ use Symfony\Component\Translation\Exception\InvalidArgumentException;
 /**
  * @author Mathieu Santostefano <msantostefano@protonmail.com>
  */
-final class TranslationProviderCollection
+final class TranslationProviderCollection implements \Stringable
 {
     /**
      * @var array<string, ProviderInterface>

--- a/src/Symfony/Component/Translation/Tests/TranslatorCacheTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorCacheTest.php
@@ -315,7 +315,7 @@ class TranslatorCacheTest extends TestCase
     }
 }
 
-class StaleResource implements SelfCheckingResourceInterface
+class StaleResource implements \Stringable, SelfCheckingResourceInterface
 {
     public function isFresh(int $timestamp): bool
     {

--- a/src/Symfony/Component/Translation/Tests/TranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorTest.php
@@ -621,7 +621,7 @@ class TranslatorTest extends TestCase
     }
 }
 
-class StringClass
+class StringClass implements \Stringable
 {
     public function __construct(
         protected string $str,

--- a/src/Symfony/Component/Translation/TranslatableMessage.php
+++ b/src/Symfony/Component/Translation/TranslatableMessage.php
@@ -17,7 +17,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @author Nate Wiebe <nate@northern.co>
  */
-class TranslatableMessage implements TranslatableInterface
+class TranslatableMessage implements \Stringable, TranslatableInterface
 {
     public function __construct(
         private string $message,

--- a/src/Symfony/Component/TypeInfo/Type/ArrayShapeType.php
+++ b/src/Symfony/Component/TypeInfo/Type/ArrayShapeType.php
@@ -22,7 +22,7 @@ use Symfony\Component\TypeInfo\TypeIdentifier;
  *
  * @extends CollectionType<GenericType<BuiltinType<TypeIdentifier::ARRAY>>>
  */
-final class ArrayShapeType extends CollectionType
+final class ArrayShapeType extends CollectionType implements \Stringable
 {
     /**
      * @var array<array{type: Type, optional: bool}>

--- a/src/Symfony/Component/TypeInfo/Type/BuiltinType.php
+++ b/src/Symfony/Component/TypeInfo/Type/BuiltinType.php
@@ -20,7 +20,7 @@ use Symfony\Component\TypeInfo\TypeIdentifier;
  *
  * @template T of TypeIdentifier
  */
-final class BuiltinType extends Type
+final class BuiltinType extends Type implements \Stringable
 {
     /**
      * @param T $typeIdentifier

--- a/src/Symfony/Component/TypeInfo/Type/CollectionType.php
+++ b/src/Symfony/Component/TypeInfo/Type/CollectionType.php
@@ -25,7 +25,7 @@ use Symfony\Component\TypeInfo\TypeIdentifier;
  *
  * @implements WrappingTypeInterface<T>
  */
-class CollectionType extends Type implements WrappingTypeInterface
+class CollectionType extends Type implements \Stringable, WrappingTypeInterface
 {
     /**
      * @param T $type

--- a/src/Symfony/Component/TypeInfo/Type/GenericType.php
+++ b/src/Symfony/Component/TypeInfo/Type/GenericType.php
@@ -25,7 +25,7 @@ use Symfony\Component\TypeInfo\TypeIdentifier;
  *
  * @implements WrappingTypeInterface<T>
  */
-final class GenericType extends Type implements WrappingTypeInterface
+final class GenericType extends Type implements \Stringable, WrappingTypeInterface
 {
     /**
      * @var list<Type>

--- a/src/Symfony/Component/TypeInfo/Type/IntersectionType.php
+++ b/src/Symfony/Component/TypeInfo/Type/IntersectionType.php
@@ -22,7 +22,7 @@ use Symfony\Component\TypeInfo\Type;
  *
  * @implements CompositeTypeInterface<T>
  */
-final class IntersectionType extends Type implements CompositeTypeInterface
+final class IntersectionType extends Type implements \Stringable, CompositeTypeInterface
 {
     /**
      * @var list<T>

--- a/src/Symfony/Component/TypeInfo/Type/ObjectType.php
+++ b/src/Symfony/Component/TypeInfo/Type/ObjectType.php
@@ -20,7 +20,7 @@ use Symfony\Component\TypeInfo\TypeIdentifier;
  *
  * @template T of class-string
  */
-class ObjectType extends Type
+class ObjectType extends Type implements \Stringable
 {
     /**
      * @param T $className

--- a/src/Symfony/Component/TypeInfo/Type/TemplateType.php
+++ b/src/Symfony/Component/TypeInfo/Type/TemplateType.php
@@ -23,7 +23,7 @@ use Symfony\Component\TypeInfo\Type;
  *
  * @implements WrappingTypeInterface<T>
  */
-final class TemplateType extends Type implements WrappingTypeInterface
+final class TemplateType extends Type implements \Stringable, WrappingTypeInterface
 {
     /**
      * @param T $bound

--- a/src/Symfony/Component/TypeInfo/Type/UnionType.php
+++ b/src/Symfony/Component/TypeInfo/Type/UnionType.php
@@ -23,7 +23,7 @@ use Symfony\Component\TypeInfo\TypeIdentifier;
  *
  * @implements CompositeTypeInterface<T>
  */
-class UnionType extends Type implements CompositeTypeInterface
+class UnionType extends Type implements \Stringable, CompositeTypeInterface
 {
     /**
      * @var list<T>

--- a/src/Symfony/Component/Validator/ConstraintViolation.php
+++ b/src/Symfony/Component/Validator/ConstraintViolation.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\Validator;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class ConstraintViolation implements ConstraintViolationInterface
+class ConstraintViolation implements \Stringable, ConstraintViolationInterface
 {
     /**
      * Creates a new constraint violation.

--- a/src/Symfony/Component/Validator/ConstraintViolationList.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationList.php
@@ -20,7 +20,7 @@ use Symfony\Component\Validator\Exception\OutOfBoundsException;
  *
  * @implements \IteratorAggregate<int, ConstraintViolationInterface>
  */
-class ConstraintViolationList implements \IteratorAggregate, ConstraintViolationListInterface
+class ConstraintViolationList implements \Stringable, \IteratorAggregate, ConstraintViolationListInterface
 {
     /**
      * @var list<ConstraintViolationInterface>

--- a/src/Symfony/Component/Validator/Tests/ConstraintValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintValidatorTest.php
@@ -69,7 +69,7 @@ final class TestFormatValueConstraintValidator extends ConstraintValidator
     }
 }
 
-final class TestToStringObject
+final class TestToStringObject implements \Stringable
 {
     public function __toString(): string
     {

--- a/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
@@ -16,7 +16,7 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
-class ComparisonTest_Class
+class ComparisonTest_Class implements \Stringable
 {
     protected $value;
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/BicValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/BicValidatorTest.php
@@ -336,7 +336,7 @@ class BicValidatorTest extends ConstraintValidatorTestCase
     }
 }
 
-class BicComparisonTestClass
+class BicComparisonTestClass implements \Stringable
 {
     protected $value;
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
@@ -325,7 +325,7 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
     }
 }
 
-class EmptyEmailObject
+class EmptyEmailObject implements \Stringable
 {
     public function __toString(): string
     {

--- a/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
@@ -82,7 +82,7 @@ class RegexValidatorTest extends ConstraintValidatorTestCase
             ['0'],
             ['090909'],
             [90909],
-            [new class {
+            [new class implements \Stringable {
                 public function __toString(): string
                 {
                     return '090909';
@@ -141,7 +141,7 @@ class RegexValidatorTest extends ConstraintValidatorTestCase
         return [
             ['abcd'],
             ['090foo'],
-            [new class {
+            [new class implements \Stringable {
                 public function __toString(): string
                 {
                     return 'abcd';

--- a/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
@@ -469,7 +469,7 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
     }
 }
 
-class EmailProvider
+class EmailProvider implements \Stringable
 {
     public function __toString(): string
     {

--- a/src/Symfony/Component/VarDumper/Caster/ConstStub.php
+++ b/src/Symfony/Component/VarDumper/Caster/ConstStub.php
@@ -18,7 +18,7 @@ use Symfony\Component\VarDumper\Cloner\Stub;
  *
  * @author Nicolas Grekas <p@tchwork.com>
  */
-class ConstStub extends Stub
+class ConstStub extends Stub implements \Stringable
 {
     public function __construct(string $name, string|int|float|null $value = null)
     {

--- a/src/Symfony/Component/Workflow/Tests/MarkingStore/MethodMarkingStoreTest.php
+++ b/src/Symfony/Component/Workflow/Tests/MarkingStore/MethodMarkingStoreTest.php
@@ -213,7 +213,7 @@ class MethodMarkingStoreTest extends TestCase
 
     private function createValueObject(string $markingValue): object
     {
-        return new class($markingValue) {
+        return new class($markingValue) implements \Stringable {
             private string $markingValue;
 
             public function __construct(string $markingValue)

--- a/src/Symfony/Component/Workflow/Tests/MarkingStore/PropertiesMarkingStoreTest.php
+++ b/src/Symfony/Component/Workflow/Tests/MarkingStore/PropertiesMarkingStoreTest.php
@@ -144,7 +144,7 @@ class PropertiesMarkingStoreTest extends TestCase
 
     private function createValueObject(string $markingValue): object
     {
-        return new class($markingValue) {
+        return new class($markingValue) implements \Stringable {
             public function __construct(
                 private string $markingValue,
             ) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Reference from the [php manual](https://www.php.net/manual/en/class.stringable.php)

From the manual: "The `Stringable` interface denotes a class as having a [__toString()](https://www.php.net/manual/en/language.oop5.magic.php#object.tostring) method. Unlike most interfaces, `Stringable` is implicitly present on any class that has the magic [__toString()](https://www.php.net/manual/en/language.oop5.magic.php#object.tostring) method defined, although it can and **should be** declared explicitly."

```
php-cs-fixer fix --rules=stringable_for_to_string
```

Also, I want to mention that this change is allowed under the [Backward Compatibility Promise](https://symfony.com/doc/current/contributing/code/bc.html#changing-classes).