### PR TITLE
[Cache] Remove unset call on undefined variable in PhpArrayAdapter

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/PhpArrayAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/PhpArrayAdapter.php
@@ -324,7 +324,7 @@ class PhpArrayAdapter implements AdapterInterface, CacheInterface, PruneableInte
 
         file_put_contents($tmpFile, $dump);
         @chmod($tmpFile, 0o666 & ~umask());
-        unset($serialized, $value, $dump);
+        unset($value, $dump);
 
         @rename($tmpFile, $this->file);
         unset(self::$valuesCache[$this->file]);


### PR DESCRIPTION
| Q | A
|---|---
| Branch? | 7.4
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Issues | n/a
| License | MIT

This PR removes a call to `unset()` on the undefined `$serialized` variable in `PhpArrayAdapter::warmUp()`.

This variable was removed in PR #28188 (as seen on [this line](https://github.com/symfony/symfony/pull/28188/files#diff-76feb2e3886d3684cd34e6b381e047a40abf5b7894ef7941cc6a2eda0b3abd37L80)), but the `unset()` call was accidentally left behind. This change cleans up the leftover code.