### PR TITLE
[Finder] Make method calls explicit in ExcludeDirectoryFilterIterator

### DIFF
--- a/src/Symfony/Component/Finder/Iterator/ExcludeDirectoryFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/ExcludeDirectoryFilterIterator.php
@@ -72,12 +72,12 @@ class ExcludeDirectoryFilterIterator extends \FilterIterator implements \Recursi
      */
     public function accept(): bool
     {
-        if ($this->isRecursive && isset($this->excludedDirs[$this->getFilename()]) && $this->isDir()) {
+        if ($this->isRecursive && isset($this->excludedDirs[$this->current()->getFilename()]) && $this->current()->isDir()) {
             return false;
         }
 
         if ($this->excludedPattern) {
-            $path = $this->isDir() ? $this->current()->getRelativePathname() : $this->current()->getRelativePath();
+            $path = $this->current()->isDir() ? $this->current()->getRelativePathname() : $this->current()->getRelativePath();
             $path = str_replace('\\', '/', $path);
 
             return !preg_match($this->excludedPattern, $path);


### PR DESCRIPTION
| Q | A
|---|---
| Branch? | 7.4
| Bug fix? | no
| New feature? | no
| Deprecations? | no
| Issues | n/a
| License | MIT

This PR refactors `ExcludeDirectoryFilterIterator` to use explicit method calls on `$this->current()` (e.g., `$this->current()->getFilename()`).

This replaces magic `__call` behavior (e.g., `$this->getFilename()`) that confuses IDEs with "`Method not found`" false positives.

The change makes the code clearer and more consistent with other methods in the same class.