### PR TITLE
[VarExporter] Fixes phpdoc syntax in LazyObjectRegistry

### DIFF
--- a/src/Symfony/Component/VarExporter/Internal/LazyObjectRegistry.php
+++ b/src/Symfony/Component/VarExporter/Internal/LazyObjectRegistry.php
@@ -41,7 +41,7 @@ class LazyObjectRegistry
     public static array $classAccessors = [];
 
     /**
-     * @var array<class-string, int}>
+     * @var array<class-string, int>
      */
     public static array $parentGet = [];
 


### PR DESCRIPTION
| Q | A
|---|---
| Branch? | 8.0
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Issues | n/a
| License | MIT

minor phpdoc syntax error in branch 8.0