### PR TITLE
[Clock] Removes redundant timezone check

### DIFF
--- a/src/Symfony/Component/Clock/MockClock.php
+++ b/src/Symfony/Component/Clock/MockClock.php
@@ -70,12 +70,6 @@ final class MockClock implements ClockInterface
     {
         if (\is_string($timezone)) {
             $timezone = new \DateTimeZone($timezone);
-        } elseif (\is_string($timezone)) {
-            try {
-                $timezone = new \DateTimeZone($timezone);
-            } catch (\Exception $e) {
-                throw new \DateInvalidTimeZoneException($e->getMessage(), $e->getCode(), $e);
-            }
         }
 
         $clone = clone $this;


### PR DESCRIPTION
| Q | A
|---|---
| Branch? | 8.0
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Issues | n/a
| License | MIT

This PR removes unused code in `MockClock::withTimeZone()`.

This change cleans up the legacy branching logic, similar to the cleanup performed in other components (See #60666 on [this line](https://github.com/symfony/symfony/pull/60666/files#diff-4f259654aa1664031ca46e2710b790a0d01b5f5e0e92455a21eca48241988773L31))