### PR TITLE
[WebProfiler] add cURL copy/paste to request tab

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add error indicator to profiler list view for profiles with errors
+ * Add cURL copy paste button in the Request/Response tab
 
 8.0
 ---

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
@@ -232,6 +232,14 @@
                         <p>No content</p>
                     </div>
                 {% endif %}
+
+                {% if collector.curlCommand != '' %}
+                    <h3>Retry command</h3>
+                    <div class="card">
+                        <button class="btn btn-sm hidden" title="Copy as cURL" data-clipboard-text="{{ collector.curlCommand }}">Copy as cURL</button>
+                        <pre class="break-long-words">{{ collector.curlCommand }}</pre>
+                    </div>
+                {% endif %}
             </div>
         </div>
 

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -22,6 +22,7 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Process\Process;
 use Symfony\Component\VarDumper\Cloner\Data;
 
 /**
@@ -129,6 +130,8 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
         }
 
         $this->data['content'] = $content;
+
+        $this->data['curlCommand'] = $this->computeCurlCommand($request, $content);
 
         foreach ($this->data as $key => $value) {
             if (!\is_array($value)) {
@@ -494,5 +497,62 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
         }
 
         return \is_string($controller) ? $controller : 'n/a';
+    }
+
+    private function computeCurlCommand(Request $request, ?string $content): string
+    {
+        $command = ['curl', '--compressed'];
+
+        $method = $request->getMethod();
+
+        if (Request::METHOD_HEAD === $method) {
+            $command[] = '--head';
+        } elseif (Request::METHOD_GET !== $method) {
+            $command[] = \sprintf('--request %s', $method);
+        }
+
+        $command[] = \sprintf('--url %s', escapeshellarg($request->getUri()));
+
+        foreach ($request->headers->all() as $name => $values) {
+            if (\in_array(strtolower($name), ['host', 'cookie'], true)) {
+                continue;
+            }
+
+            $command[] = '--header '.escapeshellarg(ucwords($name, '-').': '.implode(', ', $values));
+        }
+
+        if ($request->cookies->all()) {
+            $cookies = [];
+            foreach ($request->cookies->all() as $name => $value) {
+                $cookies[] = urlencode($name).'='.urlencode($value);
+            }
+            $command[] = '--cookie '.escapeshellarg(implode('; ', $cookies));
+        }
+
+        if ($content && \in_array($method, [Request::METHOD_POST, Request::METHOD_PUT, Request::METHOD_PATCH, Request::METHOD_DELETE], true)) {
+            $command[] = '--data-raw '.$this->escapePayload($content);
+        }
+
+        return implode(" \\\n  ", $command);
+    }
+
+    public function getCurlCommand(): string
+    {
+        return $this->data['curlCommand'] ?? '';
+    }
+
+    private function escapePayload(string $payload): string
+    {
+        static $useProcess;
+
+        if ($useProcess ??= \function_exists('proc_open') && class_exists(Process::class)) {
+            return substr((new Process(['', $payload]))->getCommandLine(), 3);
+        }
+
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            return '"'.str_replace('"', '""', $payload).'"';
+        }
+
+        return "'".str_replace("'", "'\\''", $payload)."'";
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
@@ -462,4 +462,111 @@ class RequestDataCollectorTest extends TestCase
             ['', null],
         ];
     }
+
+    public function testCurlCommandGet()
+    {
+        $request = Request::create('http://test.com/foo?bar=baz');
+
+        $c = new RequestDataCollector();
+        $c->collect($request, $this->createResponse());
+
+        $curlCommand = $c->getCurlCommand();
+        $this->assertStringStartsWith("curl \\\n  --compressed", $curlCommand);
+        $this->assertStringContainsString("--url 'http://test.com/foo?bar=baz'", $curlCommand);
+        $this->assertStringNotContainsString('--request', $curlCommand);
+    }
+
+    public function testCurlCommandPost()
+    {
+        $request = Request::create('http://test.com/foo', 'POST', [], [], [], [], '{"key":"value"}');
+
+        $c = new RequestDataCollector();
+        $c->collect($request, $this->createResponse());
+
+        $curlCommand = $c->getCurlCommand();
+        $this->assertStringContainsString('--request POST', $curlCommand);
+        $this->assertStringContainsString('--data-raw', $curlCommand);
+        $this->assertStringContainsString('{"key":"value"}', $curlCommand);
+    }
+
+    public function testCurlCommandHead()
+    {
+        $request = Request::create('http://test.com/foo', 'HEAD');
+
+        $c = new RequestDataCollector();
+        $c->collect($request, $this->createResponse());
+
+        $curlCommand = $c->getCurlCommand();
+        $this->assertStringContainsString('--head', $curlCommand);
+        $this->assertStringNotContainsString('--request', $curlCommand);
+    }
+
+    public function testCurlCommandWithHeaders()
+    {
+        $request = Request::create('http://test.com/foo');
+        $request->headers->set('Accept', 'application/json');
+        $request->headers->set('X-Custom-Header', 'custom-value');
+
+        $c = new RequestDataCollector();
+        $c->collect($request, $this->createResponse());
+
+        $curlCommand = $c->getCurlCommand();
+        $this->assertStringContainsString("--header 'Accept: application/json'", $curlCommand);
+        $this->assertStringContainsString("--header 'X-Custom-Header: custom-value'", $curlCommand);
+        $this->assertStringNotContainsString('Host:', $curlCommand);
+    }
+
+    public function testCurlCommandWithCookies()
+    {
+        $request = Request::create('http://test.com/foo', 'GET', [], ['session' => 'abc123', 'lang' => 'en']);
+
+        $c = new RequestDataCollector();
+        $c->collect($request, $this->createResponse());
+
+        $curlCommand = $c->getCurlCommand();
+        $this->assertStringContainsString('--cookie', $curlCommand);
+        $this->assertStringContainsString('session=abc123', $curlCommand);
+        $this->assertStringContainsString('lang=en', $curlCommand);
+    }
+
+    public function testCurlCommandPutWithBody()
+    {
+        $request = Request::create('http://test.com/resource/1', 'PUT', [], [], [], [], 'updated data');
+
+        $c = new RequestDataCollector();
+        $c->collect($request, $this->createResponse());
+
+        $curlCommand = $c->getCurlCommand();
+        $this->assertStringContainsString('--request PUT', $curlCommand);
+        $this->assertStringContainsString('--data-raw', $curlCommand);
+    }
+
+    public function testCurlCommandDoesNotDuplicateQueryString()
+    {
+        $request = Request::create('http://test.com/path?foo=bar&baz=qux');
+
+        $c = new RequestDataCollector();
+        $c->collect($request, $this->createResponse());
+
+        $curlCommand = $c->getCurlCommand();
+        $this->assertSame(1, substr_count($curlCommand, 'foo=bar'));
+        $this->assertSame(1, substr_count($curlCommand, 'baz=qux'));
+    }
+
+    public function testCurlCommandGetWithNoBody()
+    {
+        $request = Request::create('http://test.com/foo', 'GET');
+
+        $c = new RequestDataCollector();
+        $c->collect($request, $this->createResponse());
+
+        $curlCommand = $c->getCurlCommand();
+        $this->assertStringNotContainsString('--data-raw', $curlCommand);
+    }
+
+    public function testCurlCommandIsEmptyStringWhenNotCollected()
+    {
+        $c = new RequestDataCollector();
+        $this->assertSame('', $c->getCurlCommand());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
I often need to replay some requests on my application in dev mode, it's easier to generate it in the profiler Request view, copy it and paste in the terminal. It will generate the command with all given parameters/headers.

Here is a screenshot of this:
<img width="981" height="202" alt="Capture d’écran 2025-11-05 à 20 31 44" src="https://github.com/user-attachments/assets/abbdcd28-e047-464f-b52b-8c688c105642" />

I don't know if it's mandatory to write tests for that, feel free to give some advice about that.