### PR TITLE
[Serializer] Fix BackedEnumNormalizer behavior with partial denormalization

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/Normalizer/BackedEnumNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/BackedEnumNormalizerTest.php
@@ -126,4 +126,30 @@ class BackedEnumNormalizerTest extends TestCase
 
         $this->assertSame(StringBackedEnumDummy::GET, $this->normalizer->denormalize('GET', StringBackedEnumDummy::class, null, [BackedEnumNormalizer::ALLOW_INVALID_VALUES => true]));
     }
+
+    public function testDenormalizeNullWithAllowInvalidAndCollectErrorsThrows()
+    {
+        $this->expectException(NotNormalizableValueException::class);
+        $this->expectExceptionMessage('The data is neither an integer nor a string');
+
+        $context = [
+            BackedEnumNormalizer::ALLOW_INVALID_VALUES => true,
+            'not_normalizable_value_exceptions' => [], // Indicate that we want to collect errors
+        ];
+
+        $this->normalizer->denormalize(null, StringBackedEnumDummy::class, null, $context);
+    }
+
+    public function testDenormalizeInvalidValueWithAllowInvalidAndCollectErrorsThrows()
+    {
+        $this->expectException(NotNormalizableValueException::class);
+        $this->expectExceptionMessage('The data must belong to a backed enumeration of type');
+
+        $context = [
+            BackedEnumNormalizer::ALLOW_INVALID_VALUES => true,
+            'not_normalizable_value_exceptions' => [],
+        ];
+
+        $this->normalizer->denormalize('invalid-value', StringBackedEnumDummy::class, null, $context);
+    }
 }


### PR DESCRIPTION
| Q | A
|---|---
| Branch? | 6.4
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Issues | Fixes #62313
| License | MIT

This PR fixes a bug in `BackedEnumNormalizer` that occurs when using `collect_denormalization_errors` and `allow_invalid_values` at the same time.

When `allow_invalid_values` was set, the normalizer would return `null` for invalid data (like `null`) *before* `NotNormalizableValueException` could be thrown.

This caused the denormalization to fail with a fatal `TypeError` (e.g., `Typed property ... must not be null`) instead of populating a `PartialDenormalizationException` with the expected type errors.

This fix ensures that `NotNormalizableValueException` is still thrown when `collect_denormalization_errors` is active (`not_normalizable_value_exceptions` context key is set), allowing the Serializer to catch it and report the error correctly.