### PR TITLE
[Routing] Fix default value not taken if usigng name:entity.attribute

### DIFF
--- a/src/Symfony/Component/Routing/Loader/AttributeClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AttributeClassLoader.php
@@ -219,11 +219,11 @@ abstract class AttributeClassLoader implements LoaderInterface
                 continue;
             }
             foreach ($paths as $locale => $path) {
-                if (preg_match(\sprintf('/\{%s(?:<.*?>)?\}/', preg_quote($param->name)), $path)) {
+                if (preg_match(\sprintf('/\{(?|([^\}:<]++):%s(?:\.[^\}<]++)?|(%1$s))(?:<.*?>)?\}/', preg_quote($param->name)), $path, $matches)) {
                     if (\is_scalar($defaultValue = $param->getDefaultValue()) || null === $defaultValue) {
-                        $defaults[$param->name] = $defaultValue;
+                        $defaults[$matches[1]] = $defaultValue;
                     } elseif ($defaultValue instanceof \BackedEnum) {
-                        $defaults[$param->name] = $defaultValue->value;
+                        $defaults[$matches[1]] = $defaultValue->value;
                     }
                     break;
                 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/DefaultValueController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/DefaultValueController.php
@@ -3,6 +3,7 @@
 namespace Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures;
 
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Routing\Tests\Fixtures\AttributedClasses\BarClass;
 use Symfony\Component\Routing\Tests\Fixtures\Enum\TestIntBackedEnum;
 use Symfony\Component\Routing\Tests\Fixtures\Enum\TestStringBackedEnum;
 
@@ -28,6 +29,16 @@ class DefaultValueController
 
     #[Route(path: '/enum/{default<\d+>}', name: 'int_enum_action')]
     public function intEnumAction(TestIntBackedEnum $default = TestIntBackedEnum::Diamonds)
+    {
+    }
+
+    #[Route(path: '/defaultMappedParam/{libelle:bar}', name: 'defaultMappedParam_default')]
+    public function defaultMappedParam(?BarClass $bar = null)
+    {
+    }
+
+    #[Route(path: '/defaultAdvancedMappedParam/{barLibelle:bar.libelle}', name: 'defaultAdvancedMappedParam_default')]
+    public function defaultAdvancedMappedParam(?BarClass $bar = null)
     {
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Loader/AttributeClassLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AttributeClassLoaderTest.php
@@ -171,12 +171,16 @@ class AttributeClassLoaderTest extends TestCase
     public function testDefaultValuesForMethods()
     {
         $routes = $this->loader->load(DefaultValueController::class);
-        $this->assertCount(5, $routes);
+        $this->assertCount(7, $routes);
         $this->assertEquals('/{default}/path', $routes->get('action')->getPath());
         $this->assertEquals('value', $routes->get('action')->getDefault('default'));
         $this->assertEquals('Symfony', $routes->get('hello_with_default')->getDefault('name'));
         $this->assertEquals('World', $routes->get('hello_without_default')->getDefault('name'));
         $this->assertEquals('diamonds', $routes->get('string_enum_action')->getDefault('default'));
+        $this->assertArrayHasKey('libelle', $routes->get('defaultMappedParam_default')->getDefaults());
+        $this->assertNull($routes->get('defaultMappedParam_default')->getDefault('libelle'));
+        $this->assertArrayHasKey('barLibelle', $routes->get('defaultAdvancedMappedParam_default')->getDefaults());
+        $this->assertNull($routes->get('defaultAdvancedMappedParam_default')->getDefault('barLibelle'));
         $this->assertEquals(20, $routes->get('int_enum_action')->getDefault('default'));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3 
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Issues        | 
| License       | MIT

When using Mapped parameters, default values can't be used : 
```php

    #[Route('/zoom/{vortexLibelle:vortex.libelle}/{libelle:otherVortex}', name: 'zoom', methods: ['GET'])]
    #[AjaxCallOrNot]
    public function zoom(VortexManager $vr, Vortex $vortex, ?Vortex $otherVortex = null): Response
    {
        ...
    }
```
or
```php
    #[Route('/zoom/{vortexLibelle:vortex.libelle}/{otherVortexLibelle:otherVortex.libelle}', name: 'zoom', methods: ['GET'])]
    #[AjaxCallOrNot]
    public function zoom(VortexManager $vr, Vortex $vortex, ?Vortex $otherVortex = null): Response
    {
        ...
    }
```

route was not found if we want to go to : /zoom/myVortex,

with this fix, it's OK