### PR TITLE
[DependencyInjection] Fix repeatable `#[AsTaggedItem]` to avoid double registration and ignoring `container.ignore_attributes`

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
@@ -67,44 +67,43 @@ trait PriorityTaggedServiceTrait
             $reflector = null !== $class ? $container->getReflectionClass($class) : null;
             $checkTaggedItem = !$definition->hasTag($definition->isAutoconfigured() ? 'container.ignore_attributes' : $tagName);
 
-            foreach ($attributes as $attribute) {
-                $index = $priority = null;
+            $asTaggedItemAttributes = $reflector && $checkTaggedItem ? $reflector->getAttributes(AsTaggedItem::class) : [];
 
-                if (isset($attribute['priority'])) {
-                    $priority = $attribute['priority'];
-                } elseif (null === $defaultPriority && $defaultPriorityMethod && $reflector) {
-                    $defaultPriority = PriorityTaggedServiceUtil::getDefault($serviceId, $reflector, $defaultPriorityMethod, $tagName, 'priority', $checkTaggedItem);
-                }
-                $priority ??= $defaultPriority ??= 0;
-
-                if (null === $indexAttribute && !$defaultIndexMethod && !$needsIndexes) {
-                    $services[] = [$priority, ++$i, null, $serviceId, null];
-                    continue 2;
-                }
-
-                if (null !== $indexAttribute && isset($attribute[$indexAttribute])) {
-                    $index = $parameterBag->resolveValue($attribute[$indexAttribute]);
-                }
-                if (null === $index && null === $defaultIndex && $defaultPriorityMethod && $reflector) {
-                    $defaultIndex = PriorityTaggedServiceUtil::getDefault($serviceId, $reflector, $defaultIndexMethod ?? 'getDefaultName', $tagName, $indexAttribute, $checkTaggedItem);
-                }
-                $index ??= $defaultIndex ??= $definition->getTag('container.decorator')[0]['id'] ?? $serviceId;
-
-                $services[] = [$priority, ++$i, $index, $serviceId, $class];
-            }
-
-            if ($reflector) {
-                $attributes = $reflector->getAttributes(AsTaggedItem::class);
-                $attributeCount = \count($attributes);
-
-                foreach ($attributes as $attribute) {
+            if (1 < \count($asTaggedItemAttributes)) {
+                foreach ($asTaggedItemAttributes as $attribute) {
                     $instance = $attribute->newInstance();
 
-                    if (!$instance->index && 1 < $attributeCount) {
+                    if (!$instance->index) {
                         throw new InvalidArgumentException(\sprintf('Attribute "%s" on class "%s" cannot have an empty index when repeated.', AsTaggedItem::class, $class));
                     }
 
-                    $services[] = [$instance->priority ?? 0, ++$i, $instance->index ?? $serviceId, $serviceId, $class];
+                    $services[] = [$instance->priority ?? 0, ++$i, $instance->index, $serviceId, $class];
+                }
+            } else {
+                foreach ($attributes as $attribute) {
+                    $index = $priority = null;
+
+                    if (isset($attribute['priority'])) {
+                        $priority = $attribute['priority'];
+                    } elseif (null === $defaultPriority && $defaultPriorityMethod && $reflector) {
+                        $defaultPriority = PriorityTaggedServiceUtil::getDefault($serviceId, $reflector, $defaultPriorityMethod, $tagName, 'priority', $checkTaggedItem);
+                    }
+                    $priority ??= $defaultPriority ??= 0;
+
+                    if (null === $indexAttribute && !$defaultIndexMethod && !$needsIndexes) {
+                        $services[] = [$priority, ++$i, null, $serviceId, null];
+                        continue 2;
+                    }
+
+                    if (null !== $indexAttribute && isset($attribute[$indexAttribute])) {
+                        $index = $parameterBag->resolveValue($attribute[$indexAttribute]);
+                    }
+                    if (null === $index && null === $defaultIndex && $defaultPriorityMethod && $reflector) {
+                        $defaultIndex = PriorityTaggedServiceUtil::getDefault($serviceId, $reflector, $defaultIndexMethod ?? 'getDefaultName', $tagName, $indexAttribute, $checkTaggedItem);
+                    }
+                    $index ??= $defaultIndex ??= $definition->getTag('container.decorator')[0]['id'] ?? $serviceId;
+
+                    $services[] = [$priority, ++$i, $index, $serviceId, $class];
                 }
             }
         }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/PriorityTaggedServiceTraitTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/PriorityTaggedServiceTraitTest.php
@@ -256,6 +256,46 @@ class PriorityTaggedServiceTraitTest extends TestCase
         (new PriorityTaggedServiceTraitImplementation())->test($tag, $container);
     }
 
+    public function testIgnoreAttributesIsRespected()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('service1', SingleTaggedItemService::class)
+            ->setAutoconfigured(true)
+            ->addTag('my_custom_tag')
+            ->addTag('container.ignore_attributes');
+
+        (new ResolveInstanceofConditionalsPass())->process($container);
+
+        $priorityTaggedServiceTraitImplementation = new PriorityTaggedServiceTraitImplementation();
+        $tag = new TaggedIteratorArgument('my_custom_tag', 'foo', 'getFooBar');
+
+        $services = $priorityTaggedServiceTraitImplementation->test($tag, $container);
+
+        $this->assertArrayHasKey('service1', $services);
+        $this->assertArrayNotHasKey('single_hello', $services);
+        $this->assertCount(1, $services);
+    }
+
+    public function testSingleAsTaggedItemDoesNotDuplicate()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('service1', SingleTaggedItemService::class)
+            ->setAutoconfigured(true)
+            ->addTag('my_custom_tag');
+
+        (new ResolveInstanceofConditionalsPass())->process($container);
+
+        $priorityTaggedServiceTraitImplementation = new PriorityTaggedServiceTraitImplementation();
+        $tag = new TaggedIteratorArgument('my_custom_tag', 'foo', 'getFooBar');
+
+        $services = $priorityTaggedServiceTraitImplementation->test($tag, $container);
+
+        $this->assertArrayHasKey('single_hello', $services);
+        $this->assertCount(1, $services);
+    }
+
     public function testResolveIndexedTags()
     {
         $container = new ContainerBuilder();
@@ -314,6 +354,11 @@ class MultiTagHelloNamedService
 #[AsTaggedItem(priority: 1)]
 #[AsTaggedItem(priority: 2)]
 class MultiNoNameTagHelloNamedService
+{
+}
+
+#[AsTaggedItem(index: 'single_hello', priority: 5)]
+class SingleTaggedItemService
 {
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | https://github.com/symfony/symfony/pull/59088#issuecomment-3493520633
| License       | MIT

More reviewable [without whitespaces](https://github.com/symfony/symfony/pull/62327/files?w=1)