### PR TITLE
 Postal mailer transport message ID retrieval

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Postal/Tests/Transport/PostalApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postal/Tests/Transport/PostalApiTransportTest.php
@@ -64,7 +64,7 @@ class PostalApiTransportTest extends TestCase
             $this->assertSame(base64_encode('some attachment'), $body['attachments'][0]['data']);
             $this->assertSame('foo@bar.fr', $body['reply_to']);
 
-            return new JsonMockResponse(['message_id' => 'foobar'], [
+            return new JsonMockResponse(['data' => ['message_id' => 'foobar']], [
                 'http_code' => 200,
             ]);
         });

--- a/src/Symfony/Component/Mailer/Bridge/Postal/Transport/PostalApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postal/Transport/PostalApiTransport.php
@@ -64,7 +64,7 @@ final class PostalApiTransport extends AbstractApiTransport
             throw new HttpTransportException('Unable to send an email: '.$result['message'].\sprintf(' (code %d).', $statusCode), $response);
         }
 
-        $sentMessage->setMessageId($result['message_id']);
+        $sentMessage->setMessageId($result['data']['message_id']);
 
         return $response;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60727 
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
