### PR TITLE
[PropertyInfo] Fix `ReflectionExtractor` handling of underscore-only property names

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -757,6 +757,10 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
      */
     private function camelize(string $string): string
     {
+        if ('' === ltrim($string, '_')) {
+            return $string;
+        }
+
         return str_replace(' ', '', ucwords(str_replace('_', ' ', $string)));
     }
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -28,6 +28,7 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\Php7Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php7ParentDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php81Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\SnakeCaseDummy;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\UnderscoreDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\VirtualProperties;
 use Symfony\Component\PropertyInfo\Type;
 
@@ -361,31 +362,31 @@ class ReflectionExtractorTest extends TestCase
     /**
      * @dataProvider getReadableProperties
      */
-    public function testIsReadable($property, $expected)
+    public function testIsReadable(string $class, string $property, bool $expected)
     {
-        $this->assertSame(
-            $expected,
-            $this->extractor->isReadable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', $property, [])
-        );
+        $this->assertSame($expected, $this->extractor->isReadable($class, $property, []));
     }
 
     public static function getReadableProperties()
     {
         return [
-            ['bar', false],
-            ['baz', false],
-            ['parent', true],
-            ['a', true],
-            ['b', false],
-            ['c', true],
-            ['d', true],
-            ['e', false],
-            ['f', false],
-            ['Id', true],
-            ['id', true],
-            ['Guid', true],
-            ['guid', false],
-            ['element', false],
+            [Dummy::class, 'bar', false],
+            [Dummy::class, 'baz', false],
+            [Dummy::class, 'parent', true],
+            [Dummy::class, 'a', true],
+            [Dummy::class, 'b', false],
+            [Dummy::class, 'c', true],
+            [Dummy::class, 'd', true],
+            [Dummy::class, 'e', false],
+            [Dummy::class, 'f', false],
+            [Dummy::class, 'Id', true],
+            [Dummy::class, 'id', true],
+            [Dummy::class, 'Guid', true],
+            [Dummy::class, 'guid', false],
+            [Dummy::class, 'element', false],
+            [UnderscoreDummy::class, '_', true],
+            [UnderscoreDummy::class, '__', true],
+            [UnderscoreDummy::class, '___', false],
         ];
     }
 
@@ -560,6 +561,10 @@ class ReflectionExtractorTest extends TestCase
             [Dummy::class, 'foo', true, PropertyReadInfo::TYPE_PROPERTY, 'foo', PropertyReadInfo::VISIBILITY_PUBLIC, false],
             [Php71Dummy::class, 'foo', true, PropertyReadInfo::TYPE_METHOD, 'getFoo', PropertyReadInfo::VISIBILITY_PUBLIC, false],
             [Php71Dummy::class, 'buz', true, PropertyReadInfo::TYPE_METHOD, 'getBuz', PropertyReadInfo::VISIBILITY_PUBLIC, false],
+            [UnderscoreDummy::class, '_', true, PropertyReadInfo::TYPE_METHOD, 'get_', PropertyReadInfo::VISIBILITY_PUBLIC, false],
+            [UnderscoreDummy::class, '__', true, PropertyReadInfo::TYPE_METHOD, 'get__', PropertyReadInfo::VISIBILITY_PUBLIC, false],
+            [UnderscoreDummy::class, 'foo_bar', false, null, null, null, null],
+            [UnderscoreDummy::class, '_foo_', false, null, null, null, null],
         ];
     }
 
@@ -791,5 +796,36 @@ class ReflectionExtractorTest extends TestCase
         yield ['virtualNoSetHook', PropertyReadInfo::VISIBILITY_PUBLIC, PropertyWriteInfo::VISIBILITY_PRIVATE];
         yield ['virtualSetHookOnly', PropertyReadInfo::VISIBILITY_PUBLIC, PropertyWriteInfo::VISIBILITY_PUBLIC];
         yield ['virtualHook', PropertyReadInfo::VISIBILITY_PUBLIC, PropertyWriteInfo::VISIBILITY_PUBLIC];
+    }
+
+    /**
+     * @dataProvider camelizeProvider
+     */
+    public function testCamelize(string $input, string $expected)
+    {
+        $reflection = new \ReflectionClass($this->extractor);
+        $method = $reflection->getMethod('camelize');
+
+        if (\PHP_VERSION_ID < 80500) {
+            $method->setAccessible(true);
+        }
+
+        $this->assertSame($expected, $method->invoke($this->extractor, $input));
+    }
+
+    public static function camelizeProvider(): iterable
+    {
+        yield 'single underscore' => ['_', '_'];
+        yield 'double underscore' => ['__', '__'];
+        yield 'triple underscore' => ['___', '___'];
+
+        yield 'snake case' => ['foo_bar', 'FooBar'];
+        yield 'double snake case' => ['foo__bar', 'FooBar'];
+        yield 'leading underscore' => ['_foo', 'Foo'];
+        yield 'trailing underscore' => ['foo_', 'Foo'];
+        yield 'leading and trailing' => ['_foo_bar_', 'FooBar'];
+        yield 'empty string' => ['', ''];
+        yield 'no underscore' => ['fooBar', 'FooBar'];
+        yield 'pascal case' => ['FooBar', 'FooBar'];
     }
 }

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/UnderscoreDummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/UnderscoreDummy.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+/**
+ * Fixture class for testing underscore-only properties.
+ */
+class UnderscoreDummy
+{
+    private float $_;
+    private float $__;
+
+    public function get_(): float
+    {
+        return $this->_;
+    }
+
+    public function get__(): float
+    {
+        return $this->__;
+    }
+}


### PR DESCRIPTION
| Q | A
|---|---
| Branch? | 6.4
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Issues | Fixes #61425
| License | MIT

This PR fixes a bug in `ReflectionExtractor::camelize` where property names consisting only of underscores (e.g., `$_`) were incorrectly transformed into an empty string.

This caused `getReadInfo` to fail when finding the corresponding accessor (e.g., `get_()`), preventing the property from being detected, which impacts serialization and other component usages.