### PR TITLE
[DependencyInjection] Deprecate default index/priority methods when defining tagged locators/iterators

### DIFF
--- a/UPGRADE-8.1.md
+++ b/UPGRADE-8.1.md
@@ -1,10 +1,18 @@
 UPGRADE FROM 8.0 to 8.1
 =======================
 
+Symfony 8.1 is a minor release. According to the Symfony release process, there should be no significant
+backward compatibility breaks. Minor backward compatibility breaks are prefixed in this document with
+`[BC BREAK]`, make sure your code is compatible with these entries before upgrading.
+Read more about this in the [Symfony documentation](https://symfony.com/doc/8.1/setup/upgrade_minor.html).
+
+If you're upgrading from a version below 8.0, follow the [8.0 upgrade guide](UPGRADE-8.0.md) first.
+
 DependencyInjection
 -------------------
 
  * Deprecate configuring options `alias`, `parent`, `synthetic`, `file`, `arguments`, `properties`, `configurator` or `calls` when using `from_callable`
+ * Deprecate default index/priority methods when defining tagged locators/iterators; use the `#[AsTaggedItem]` attribute instead
 
 FrameworkBundle
 ---------------

--- a/src/Symfony/Component/DependencyInjection/Attribute/AutowireIterator.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/AutowireIterator.php
@@ -22,21 +22,31 @@ class AutowireIterator extends Autowire
     /**
      * @see ServiceSubscriberInterface::getSubscribedServices()
      *
-     * @param string               $tag                   A tag name to search for to populate the iterator
-     * @param string|null          $indexAttribute        The name of the attribute that defines the key referencing each service in the tagged collection
-     * @param string|null          $defaultIndexMethod    The static method that should be called to get each service's key when their tag doesn't define the previous attribute
-     * @param string|null          $defaultPriorityMethod The static method that should be called to get each service's priority when their tag doesn't define the "priority" attribute
-     * @param string|array<string> $exclude               A service id or a list of service ids to exclude
-     * @param bool                 $excludeSelf           Whether to automatically exclude the referencing service from the iterator
+     * @param string          $tag            A tag name to search for to populate the iterator
+     * @param string|null     $indexAttribute The name of the attribute that defines the key referencing each service in the tagged collection
+     * @param string|string[] $exclude        A service id or a list of service ids to exclude
+     * @param bool            $excludeSelf    Whether to automatically exclude the referencing service from the iterator
      */
     public function __construct(
         string $tag,
         ?string $indexAttribute = null,
-        ?string $defaultIndexMethod = null,
-        ?string $defaultPriorityMethod = null,
-        string|array $exclude = [],
-        bool $excludeSelf = true,
+        string|array|null $exclude = [],
+        bool|string|null $excludeSelf = true,
+        ...$_,
     ) {
-        parent::__construct(new TaggedIteratorArgument($tag, $indexAttribute, $defaultIndexMethod, false, $defaultPriorityMethod, (array) $exclude, $excludeSelf));
+        if (\func_num_args() > 4 || !\is_bool($excludeSelf) || null === $exclude || (\is_string($exclude) && str_starts_with($exclude, 'get') && !\array_key_exists('defaultIndexMethod', $_))) {
+            [, , $defaultIndexMethod, $defaultPriorityMethod, $exclude, $excludeSelf] = \func_get_args() + [2 => null, null, [], true];
+        } else {
+            $defaultIndexMethod = \array_key_exists('defaultIndexMethod', $_) ? $_['defaultIndexMethod'] : false;
+            $defaultPriorityMethod = \array_key_exists('defaultPriorityMethod', $_) ? $_['defaultPriorityMethod'] : false;
+        }
+
+        if (false !== $defaultIndexMethod || false !== $defaultPriorityMethod) {
+            parent::__construct(new TaggedIteratorArgument($tag, $indexAttribute, $defaultIndexMethod, false, $defaultPriorityMethod, (array) $exclude, $excludeSelf));
+
+            return;
+        }
+
+        parent::__construct(new TaggedIteratorArgument($tag, $indexAttribute, false, (array) $exclude, $excludeSelf));
     }
 }

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Deprecate configuring options `alias`, `parent`, `synthetic`, `file`, `arguments`, `properties`, `configurator` or `calls` when using `from_callable`
+ * Deprecate default index/priority methods when defining tagged locators/iterators; use the `#[AsTaggedItem]` attribute instead
 
 8.0
 ---

--- a/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
@@ -43,9 +43,9 @@ trait PriorityTaggedServiceTrait
 
         if ($tagName instanceof TaggedIteratorArgument) {
             $indexAttribute = $tagName->getIndexAttribute();
-            $defaultIndexMethod = $tagName->getDefaultIndexMethod();
+            $defaultIndexMethod = $tagName->getDefaultIndexMethod(false);
             $needsIndexes = $tagName->needsIndexes();
-            $defaultPriorityMethod = $tagName->getDefaultPriorityMethod() ?? 'getDefaultPriority';
+            $defaultPriorityMethod = $tagName->getDefaultPriorityMethod(false) ?? 'getDefaultPriority';
             $exclude = array_merge($exclude, $tagName->getExclude());
             $tagName = $tagName->getTag();
         }
@@ -162,6 +162,8 @@ class PriorityTaggedServiceUtil
         if (!$rm->isPublic()) {
             throw new InvalidArgumentException(implode('be public', $message));
         }
+
+        trigger_deprecation('symfony/dependency-injection', '7.4', 'Calling "%s::%s()" to get the "%s" index is deprecated, use the #[AsTaggedItem] attribute instead.', $class, $defaultMethod, $indexAttribute);
 
         $default = $rm->invoke(null);
 

--- a/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
@@ -308,11 +308,13 @@ class XmlDumper extends Dumper
                 if (null !== $tag->getIndexAttribute()) {
                     $xmlAttr .= \sprintf(' index-by="%s"', $this->encode($tag->getIndexAttribute()));
 
-                    if (null !== $tag->getDefaultIndexMethod()) {
-                        $xmlAttr .= \sprintf(' default-index-method="%s"', $this->encode($tag->getDefaultIndexMethod()));
+                    $defaultPrefix = 'getDefault'.str_replace(' ', '', ucwords(preg_replace('/[^a-zA-Z0-9\x7f-\xff]++/', ' ', $tag->getIndexAttribute())));
+
+                    if ($tag->getDefaultIndexMethod(false) !== $defaultPrefix.'Name') {
+                        $xmlAttr .= \sprintf(' default-index-method="%s"', $this->encode($tag->getDefaultIndexMethod(false)));
                     }
-                    if (null !== $tag->getDefaultPriorityMethod()) {
-                        $xmlAttr .= \sprintf(' default-priority-method="%s"', $this->encode($tag->getDefaultPriorityMethod()));
+                    if ($tag->getDefaultPriorityMethod(false) !== $defaultPrefix.'Priority') {
+                        $xmlAttr .= \sprintf(' default-priority-method="%s"', $this->encode($tag->getDefaultPriorityMethod(false)));
                     }
                 }
                 if (1 === \count($excludes = $tag->getExclude())) {

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -265,11 +265,11 @@ class YamlDumper extends Dumper
                         'index_by' => $tag->getIndexAttribute(),
                     ];
 
-                    if (null !== $tag->getDefaultIndexMethod()) {
-                        $content['default_index_method'] = $tag->getDefaultIndexMethod();
+                    if (null !== $tag->getDefaultIndexMethod(false)) {
+                        $content['default_index_method'] = $tag->getDefaultIndexMethod(false);
                     }
-                    if (null !== $tag->getDefaultPriorityMethod()) {
-                        $content['default_priority_method'] = $tag->getDefaultPriorityMethod();
+                    if (null !== $tag->getDefaultPriorityMethod(false)) {
+                        $content['default_priority_method'] = $tag->getDefaultPriorityMethod(false);
                     }
                 }
                 if ($excludes = $tag->getExclude()) {

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
@@ -143,18 +143,50 @@ function iterator(array $values): IteratorArgument
 
 /**
  * Creates a lazy iterator by tag name.
+ *
+ * @param string          $tag            The name of the tag identifying the target services
+ * @param string|null     $indexAttribute The name of the attribute that defines the key referencing each service in the tagged collection
+ * @param string|string[] $exclude        Services to exclude from the iterator
+ * @param bool            $excludeSelf    Whether to automatically exclude the referencing service from the iterator
  */
-function tagged_iterator(string $tag, ?string $indexAttribute = null, ?string $defaultIndexMethod = null, ?string $defaultPriorityMethod = null, string|array $exclude = [], bool $excludeSelf = true): TaggedIteratorArgument
+function tagged_iterator(string $tag, ?string $indexAttribute = null, string|array|null $exclude = [], bool|string|null $excludeSelf = true, ...$_): TaggedIteratorArgument
 {
-    return new TaggedIteratorArgument($tag, $indexAttribute, $defaultIndexMethod, false, $defaultPriorityMethod, (array) $exclude, $excludeSelf);
+    if (\func_num_args() > 4 || !\is_bool($excludeSelf) || null === $exclude || (\is_string($exclude) && str_starts_with($exclude, 'get') && !\array_key_exists('defaultIndexMethod', $_))) {
+        [, , $defaultIndexMethod, $defaultPriorityMethod, $exclude, $excludeSelf] = \func_get_args() + [2 => null, null, [], true];
+    } else {
+        $defaultIndexMethod = \array_key_exists('defaultIndexMethod', $_) ? $_['defaultIndexMethod'] : false;
+        $defaultPriorityMethod = \array_key_exists('defaultPriorityMethod', $_) ? $_['defaultPriorityMethod'] : false;
+    }
+
+    if (false !== $defaultIndexMethod || false !== $defaultPriorityMethod) {
+        return new TaggedIteratorArgument($tag, $indexAttribute, $defaultIndexMethod, false, $defaultPriorityMethod, (array) $exclude, $excludeSelf);
+    }
+
+    return new TaggedIteratorArgument($tag, $indexAttribute, false, (array) $exclude, $excludeSelf);
 }
 
 /**
  * Creates a service locator by tag name.
+ *
+ * @param string          $tag            The name of the tag identifying the target services
+ * @param string|null     $indexAttribute The name of the attribute that defines the key referencing each service in the tagged collection
+ * @param string|string[] $exclude        Services to exclude from the iterator
+ * @param bool            $excludeSelf    Whether to automatically exclude the referencing service from the iterator
  */
-function tagged_locator(string $tag, ?string $indexAttribute = null, ?string $defaultIndexMethod = null, ?string $defaultPriorityMethod = null, string|array $exclude = [], bool $excludeSelf = true): ServiceLocatorArgument
+function tagged_locator(string $tag, ?string $indexAttribute = null, string|array|null $exclude = [], bool|string|null $excludeSelf = true, ...$_): ServiceLocatorArgument
 {
-    return new ServiceLocatorArgument(new TaggedIteratorArgument($tag, $indexAttribute, $defaultIndexMethod, true, $defaultPriorityMethod, (array) $exclude, $excludeSelf));
+    if (\func_num_args() > 4 || !\is_bool($excludeSelf) || null === $exclude || (\is_string($exclude) && str_starts_with($exclude, 'get') && !\array_key_exists('defaultIndexMethod', $_))) {
+        [, , $defaultIndexMethod, $defaultPriorityMethod, $exclude, $excludeSelf] = \func_get_args() + [2 => null, null, [], true];
+    } else {
+        $defaultIndexMethod = \array_key_exists('defaultIndexMethod', $_) ? $_['defaultIndexMethod'] : false;
+        $defaultPriorityMethod = \array_key_exists('defaultPriorityMethod', $_) ? $_['defaultPriorityMethod'] : false;
+    }
+
+    if (false !== $defaultIndexMethod || false !== $defaultPriorityMethod) {
+        return new ServiceLocatorArgument(new TaggedIteratorArgument($tag, $indexAttribute, $defaultIndexMethod, true, $defaultPriorityMethod, (array) $exclude, $excludeSelf));
+    }
+
+    return new ServiceLocatorArgument(new TaggedIteratorArgument($tag, $indexAttribute, true, (array) $exclude, $excludeSelf));
 }
 
 /**

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -867,7 +867,16 @@ class YamlFileLoader extends FileLoader
                         throw new InvalidArgumentException(\sprintf('"!%s" tag contains unsupported key "%s"; supported ones are "%s".', $value->getTag(), implode('", "', $diff), implode('", "', $supportedKeys)));
                     }
 
-                    $argument = new TaggedIteratorArgument($argument['tag'], $argument['index_by'] ?? null, $argument['default_index_method'] ?? null, $forLocator, $argument['default_priority_method'] ?? null, (array) ($argument['exclude'] ?? null), $argument['exclude_self'] ?? true);
+                    $tag = $argument['tag'];
+                    $indexBy = $argument['index_by'] ?? null;
+                    $exclude = (array) ($argument['exclude'] ?? null);
+                    $excludeSelf = $argument['exclude_self'] ?? true;
+
+                    if (\array_key_exists('default_index_method', $argument) || \array_key_exists('default_priority_method', $argument)) {
+                        $argument = new TaggedIteratorArgument($tag, $indexBy, $argument['default_index_method'] ?? null, $forLocator, $argument['default_priority_method'] ?? null, $exclude, $excludeSelf);
+                    } else {
+                        $argument = new TaggedIteratorArgument($tag, $indexBy, $forLocator, $exclude, $excludeSelf);
+                    }
                 } elseif (\is_string($argument) && $argument) {
                     $argument = new TaggedIteratorArgument($argument, null, null, $forLocator);
                 } else {

--- a/src/Symfony/Component/DependencyInjection/Tests/Argument/TaggedIteratorArgumentTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Argument/TaggedIteratorArgumentTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\DependencyInjection\Tests\Argument;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 
@@ -23,42 +25,44 @@ class TaggedIteratorArgumentTest extends TestCase
 
         $this->assertSame('foo', $taggedIteratorArgument->getTag());
         $this->assertNull($taggedIteratorArgument->getIndexAttribute());
-        $this->assertNull($taggedIteratorArgument->getDefaultIndexMethod());
+        $this->assertNull($taggedIteratorArgument->getDefaultIndexMethod(false));
         $this->assertFalse($taggedIteratorArgument->needsIndexes());
-        $this->assertNull($taggedIteratorArgument->getDefaultPriorityMethod());
+        $this->assertNull($taggedIteratorArgument->getDefaultPriorityMethod(false));
     }
 
     public function testOnlyTagWithNeedsIndexes()
     {
-        $taggedIteratorArgument = new TaggedIteratorArgument('foo', null, null, true);
+        $taggedIteratorArgument = new TaggedIteratorArgument('foo', null, true);
 
         $this->assertSame('foo', $taggedIteratorArgument->getTag());
         $this->assertSame('foo', $taggedIteratorArgument->getIndexAttribute());
-        $this->assertSame('getDefaultFooName', $taggedIteratorArgument->getDefaultIndexMethod());
-        $this->assertSame('getDefaultFooPriority', $taggedIteratorArgument->getDefaultPriorityMethod());
+        $this->assertSame('getDefaultFooName', $taggedIteratorArgument->getDefaultIndexMethod(false));
+        $this->assertSame('getDefaultFooPriority', $taggedIteratorArgument->getDefaultPriorityMethod(false));
     }
 
     public function testOnlyTagWithNeedsIndexesAndDotTag()
     {
-        $taggedIteratorArgument = new TaggedIteratorArgument('foo.bar', null, null, true);
+        $taggedIteratorArgument = new TaggedIteratorArgument('foo.bar', null, true);
 
         $this->assertSame('foo.bar', $taggedIteratorArgument->getTag());
         $this->assertSame('bar', $taggedIteratorArgument->getIndexAttribute());
-        $this->assertSame('getDefaultBarName', $taggedIteratorArgument->getDefaultIndexMethod());
-        $this->assertSame('getDefaultBarPriority', $taggedIteratorArgument->getDefaultPriorityMethod());
+        $this->assertSame('getDefaultBarName', $taggedIteratorArgument->getDefaultIndexMethod(false));
+        $this->assertSame('getDefaultBarPriority', $taggedIteratorArgument->getDefaultPriorityMethod(false));
     }
 
     public function testOnlyTagWithNeedsIndexesAndDotsTag()
     {
-        $taggedIteratorArgument = new TaggedIteratorArgument('foo.bar.baz.qux', null, null, true);
+        $taggedIteratorArgument = new TaggedIteratorArgument('foo.bar.baz.qux', null, true);
 
         $this->assertSame('foo.bar.baz.qux', $taggedIteratorArgument->getTag());
         $this->assertSame('qux', $taggedIteratorArgument->getIndexAttribute());
-        $this->assertSame('getDefaultQuxName', $taggedIteratorArgument->getDefaultIndexMethod());
-        $this->assertSame('getDefaultQuxPriority', $taggedIteratorArgument->getDefaultPriorityMethod());
+        $this->assertSame('getDefaultQuxName', $taggedIteratorArgument->getDefaultIndexMethod(false));
+        $this->assertSame('getDefaultQuxPriority', $taggedIteratorArgument->getDefaultPriorityMethod(false));
     }
 
     #[DataProvider('defaultIndexMethodProvider')]
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testDefaultIndexMethod(?string $indexAttribute, ?string $defaultIndexMethod, ?string $expectedDefaultIndexMethod)
     {
         $taggedIteratorArgument = new TaggedIteratorArgument('foo', $indexAttribute, $defaultIndexMethod);
@@ -106,6 +110,8 @@ class TaggedIteratorArgumentTest extends TestCase
     }
 
     #[DataProvider('defaultPriorityMethodProvider')]
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testDefaultPriorityIndexMethod(?string $indexAttribute, ?string $defaultPriorityMethod, ?string $expectedDefaultPriorityMethod)
     {
         $taggedIteratorArgument = new TaggedIteratorArgument('foo', $indexAttribute, null, false, $defaultPriorityMethod);

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Config\FileLocator;
@@ -343,6 +345,8 @@ class IntegrationTest extends TestCase
         ];
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testTaggedServiceWithIndexAttribute()
     {
         $container = new ContainerBuilder();
@@ -367,6 +371,8 @@ class IntegrationTest extends TestCase
         $this->assertSame(['bar' => $container->get(BarTagClass::class), 'foo_tag_class' => $container->get(FooTagClass::class)], $param);
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testTaggedServiceWithIndexAttributeAndDefaultMethod()
     {
         $container = new ContainerBuilder();
@@ -418,6 +424,8 @@ class IntegrationTest extends TestCase
         self::assertSame('foo', $s->locator->get('subscribed1'));
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testTaggedServiceWithIndexAttributeAndDefaultMethodConfiguredViaAttribute()
     {
         $container = new ContainerBuilder();
@@ -442,6 +450,8 @@ class IntegrationTest extends TestCase
         $this->assertSame(['bar_tab_class_with_defaultmethod' => $container->get(BarTagClass::class), 'foo' => $container->get(FooTagClass::class)], $param);
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testTaggedIteratorWithDefaultIndexMethodConfiguredViaAttribute()
     {
         $container = new ContainerBuilder();
@@ -466,6 +476,8 @@ class IntegrationTest extends TestCase
         $this->assertSame(['bar_tag_class' => $container->get(BarTagClass::class), 'foo_tag_class' => $container->get(FooTagClass::class)], $param);
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testTaggedIteratorWithDefaultPriorityMethodConfiguredViaAttribute()
     {
         $container = new ContainerBuilder();
@@ -490,6 +502,8 @@ class IntegrationTest extends TestCase
         $this->assertSame([0 => $container->get(FooTagClass::class), 1 => $container->get(BarTagClass::class)], $param);
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testTaggedIteratorWithDefaultIndexMethodAndWithDefaultPriorityMethodConfiguredViaAttribute()
     {
         $container = new ContainerBuilder();
@@ -514,6 +528,8 @@ class IntegrationTest extends TestCase
         $this->assertSame(['foo_tag_class' => $container->get(FooTagClass::class), 'bar_tag_class' => $container->get(BarTagClass::class)], $param);
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testTaggedLocatorConfiguredViaAttribute()
     {
         $container = new ContainerBuilder();
@@ -540,6 +556,8 @@ class IntegrationTest extends TestCase
         self::assertSame($container->get(FooTagClass::class), $locator->get('foo'));
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testTaggedLocatorConfiguredViaAttributeWithoutIndex()
     {
         $container = new ContainerBuilder();
@@ -566,6 +584,8 @@ class IntegrationTest extends TestCase
         self::assertSame($container->get(FooTagClass::class), $locator->get(FooTagClass::class));
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testTaggedLocatorWithDefaultIndexMethodConfiguredViaAttribute()
     {
         $container = new ContainerBuilder();
@@ -592,6 +612,8 @@ class IntegrationTest extends TestCase
         self::assertSame($container->get(FooTagClass::class), $locator->get('foo_tag_class'));
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testTaggedLocatorWithDefaultPriorityMethodConfiguredViaAttribute()
     {
         $container = new ContainerBuilder();
@@ -621,6 +643,8 @@ class IntegrationTest extends TestCase
         self::assertSame([FooTagClass::class, BarTagClass::class], array_keys($factories->getValue($locator)));
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testTaggedLocatorWithDefaultIndexMethodAndWithDefaultPriorityMethodConfiguredViaAttribute()
     {
         $container = new ContainerBuilder();
@@ -652,6 +676,8 @@ class IntegrationTest extends TestCase
         self::assertSame($container->get(FooTagClass::class), $locator->get('foo_tag_class'));
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testNestedDefinitionWithAutoconfiguredConstructorArgument()
     {
         $container = new ContainerBuilder();
@@ -699,6 +725,8 @@ class IntegrationTest extends TestCase
         self::assertSame($container->get(FooTagClass::class), $locator->get('my_service'));
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testTaggedServiceWithDefaultPriorityMethod()
     {
         $container = new ContainerBuilder();
@@ -723,6 +751,8 @@ class IntegrationTest extends TestCase
         $this->assertSame([$container->get(FooTagClass::class), $container->get(BarTagClass::class)], $param);
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testTaggedServiceLocatorWithIndexAttribute()
     {
         $container = new ContainerBuilder();
@@ -735,7 +765,7 @@ class IntegrationTest extends TestCase
             ->addTag('foo_bar')
         ;
         $container->register('foo_bar_tagged', FooBarTaggedClass::class)
-            ->addArgument(new ServiceLocatorArgument(new TaggedIteratorArgument('foo_bar', 'foo', null, true)))
+            ->addArgument(new ServiceLocatorArgument(new TaggedIteratorArgument('foo_bar', 'foo', true)))
             ->setPublic(true)
         ;
 
@@ -754,6 +784,8 @@ class IntegrationTest extends TestCase
         $this->assertSame(['bar' => $container->get('bar_tag'), 'foo_tag_class' => $container->get('foo_tag')], $same);
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testTaggedServiceLocatorWithMultipleIndexAttribute()
     {
         $container = new ContainerBuilder();
@@ -768,7 +800,7 @@ class IntegrationTest extends TestCase
             ->addTag('foo_bar')
         ;
         $container->register('foo_bar_tagged', FooBarTaggedClass::class)
-            ->addArgument(new ServiceLocatorArgument(new TaggedIteratorArgument('foo_bar', 'foo', null, true)))
+            ->addArgument(new ServiceLocatorArgument(new TaggedIteratorArgument('foo_bar', 'foo', true)))
             ->setPublic(true)
         ;
 
@@ -788,6 +820,8 @@ class IntegrationTest extends TestCase
         $this->assertSame(['bar' => $container->get('bar_tag'), 'bar_duplicate' => $container->get('bar_tag'), 'foo_tag_class' => $container->get('foo_tag')], $same);
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testTaggedServiceLocatorWithIndexAttributeAndDefaultMethod()
     {
         $container = new ContainerBuilder();
@@ -827,7 +861,7 @@ class IntegrationTest extends TestCase
             ->addTag('foo_bar')
         ;
         $container->register('foo_bar_tagged', FooBarTaggedClass::class)
-            ->addArgument(new ServiceLocatorArgument(new TaggedIteratorArgument('foo_bar', null, null, true)))
+            ->addArgument(new ServiceLocatorArgument(new TaggedIteratorArgument('foo_bar', null, true)))
             ->setPublic(true)
         ;
 
@@ -853,7 +887,7 @@ class IntegrationTest extends TestCase
             ->addTag('app.foo_bar', ['foo_bar' => 'baz'])
         ;
         $container->register('foo_bar_tagged', FooBarTaggedClass::class)
-            ->addArgument(new ServiceLocatorArgument(new TaggedIteratorArgument('app.foo_bar', null, null, true)))
+            ->addArgument(new ServiceLocatorArgument(new TaggedIteratorArgument('app.foo_bar', null, true)))
             ->setPublic(true)
         ;
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/PriorityTaggedServiceTraitTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/PriorityTaggedServiceTraitTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
@@ -115,6 +117,8 @@ class PriorityTaggedServiceTraitTest extends TestCase
         $this->assertEquals($expected, $priorityTaggedServiceTraitImplementation->test('my_custom_tag', $container));
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testOnlyTheIndexedTagsAreListed()
     {
         $container = new ContainerBuilder();
@@ -141,6 +145,8 @@ class PriorityTaggedServiceTraitTest extends TestCase
         $this->assertEquals($expected, $priorityTaggedServiceTraitImplementation->test($tag, $container));
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testTheIndexedTagsByDefaultIndexMethod()
     {
         $container = new ContainerBuilder();
@@ -173,6 +179,8 @@ class PriorityTaggedServiceTraitTest extends TestCase
     }
 
     #[DataProvider('provideInvalidDefaultMethods')]
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testTheIndexedTagsByDefaultIndexMethodFailure(string $defaultIndexMethod, ?string $indexAttribute, string $expectedExceptionMessage)
     {
         $this->expectException(InvalidArgumentException::class);
@@ -198,6 +206,8 @@ class PriorityTaggedServiceTraitTest extends TestCase
         yield ['getMethodShouldBePublicInsteadPrivate', 'foo', \sprintf('Either method "%s::getMethodShouldBePublicInsteadPrivate()" should be public or tag "my_custom_tag" on service "service1" is missing attribute "foo".', FooTaggedForInvalidDefaultMethodClass::class)];
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testTaggedItemAttributes()
     {
         $container = new ContainerBuilder();
@@ -225,7 +235,7 @@ class PriorityTaggedServiceTraitTest extends TestCase
 
         $priorityTaggedServiceTraitImplementation = new PriorityTaggedServiceTraitImplementation();
 
-        $tag = new TaggedIteratorArgument('my_custom_tag', 'foo', 'getFooBar', exclude: ['service4', 'service5']);
+        $tag = new TaggedIteratorArgument('my_custom_tag', 'foo', 'getFooBar', false, null, ['service4', 'service5']);
         $expected = [
             'service3' => new TypedReference('service3', HelloNamedService2::class),
             'multi_hello_2' => new TypedReference('service6', MultiTagHelloNamedService::class),
@@ -240,6 +250,8 @@ class PriorityTaggedServiceTraitTest extends TestCase
         $this->assertEquals($expected, $priorityTaggedServiceTraitImplementation->test($tag, $container));
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testResolveIndexedTags()
     {
         $container = new ContainerBuilder();
@@ -268,6 +280,8 @@ class PriorityTaggedServiceTraitTest extends TestCase
         $this->assertEquals($expected, $priorityTaggedServiceTraitImplementation->test($tag, $container));
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testAttributesAreMergedWithTags()
     {
         $container = new ContainerBuilder();
@@ -293,6 +307,8 @@ class PriorityTaggedServiceTraitTest extends TestCase
         $this->assertEquals($expected, $services);
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testAttributesAreFallbacks()
     {
         $container = new ContainerBuilder();
@@ -310,6 +326,8 @@ class PriorityTaggedServiceTraitTest extends TestCase
         $this->assertEquals(['z' => new TypedReference('service_attr_first', MultiTagHelloNamedService::class)], $services);
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testTaggedIteratorWithDefaultNameMethod()
     {
         $container = new ContainerBuilder();
@@ -322,6 +340,8 @@ class PriorityTaggedServiceTraitTest extends TestCase
         $this->assertEquals([new Reference('service')], $services);
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testIndexedIteratorUsesTagAttributeOverDefaultMethod()
     {
         $container = new ContainerBuilder();
@@ -339,6 +359,8 @@ class PriorityTaggedServiceTraitTest extends TestCase
         $this->assertSame('service.a', (string) $services['from_tag']);
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testIndexedIteratorUsesDefaultMethodAsFallback()
     {
         $container = new ContainerBuilder();
@@ -355,6 +377,8 @@ class PriorityTaggedServiceTraitTest extends TestCase
         $this->assertInstanceOf(TypedReference::class, $services['from_static_method']);
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testIndexedIteratorUsesTagIndexAndDefaultPriorityMethod()
     {
         $container = new ContainerBuilder();
@@ -376,6 +400,8 @@ class PriorityTaggedServiceTraitTest extends TestCase
         $this->assertSame(['tag_index', 'another_index'], array_keys($services));
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testTaggedLocatorWithProvidedIndexAttributeAndNonStaticDefaultIndexMethod()
     {
         $container = new ContainerBuilder();
@@ -389,6 +415,8 @@ class PriorityTaggedServiceTraitTest extends TestCase
         $this->assertEquals(['foo' => new TypedReference('service', NonStaticDefaultIndexClass::class)], $services);
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testTaggedLocatorWithoutIndexAttributeAndNonStaticDefaultIndexMethod()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -420,6 +448,8 @@ class PriorityTaggedServiceTraitTest extends TestCase
         $this->assertEquals(['bar' => new TypedReference('service', AsTaggedItemClassWithBusinessMethod::class)], $services);
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testPriorityFallbackWithoutIndexAndStaticPriorityMethod()
     {
         $container = new ContainerBuilder();
@@ -433,6 +463,8 @@ class PriorityTaggedServiceTraitTest extends TestCase
         $this->assertEquals([new Reference('service')], $services);
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testMultiTagsWithMixedAttributesAndNonStaticDefault()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ServiceLocatorTagPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ServiceLocatorTagPassTest.php
@@ -177,7 +177,7 @@ class ServiceLocatorTagPassTest extends TestCase
         $container->register('baz', TestDefinition2::class)->addTag('test_tag');
 
         $container->register('foo', ServiceLocator::class)
-            ->setArguments([new TaggedIteratorArgument('test_tag', null, null, true)])
+            ->setArguments([new TaggedIteratorArgument('test_tag', null, true)])
             ->addTag('container.service_locator')
         ;
 
@@ -198,7 +198,7 @@ class ServiceLocatorTagPassTest extends TestCase
         $container->register('baz', TestDefinition2::class)->addTag('test_tag', ['index' => 1]);
 
         $container->register('foo', ServiceLocator::class)
-            ->setArguments([new TaggedIteratorArgument('test_tag', 'index', null, true)])
+            ->setArguments([new TaggedIteratorArgument('test_tag', 'index', true)])
             ->addTag('container.service_locator')
         ;
 
@@ -217,7 +217,7 @@ class ServiceLocatorTagPassTest extends TestCase
 
         $locator = new Definition(Locator::class);
         $locator->setPublic(true);
-        $locator->addArgument(new ServiceLocatorArgument(new TaggedIteratorArgument('test_tag', null, null, true)));
+        $locator->addArgument(new ServiceLocatorArgument(new TaggedIteratorArgument('test_tag', null, true)));
 
         $container->setDefinition(Locator::class, $locator);
 

--- a/src/Symfony/Component/DependencyInjection/Tests/CrossCheckTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/CrossCheckTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\DependencyInjection\Tests;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -31,6 +33,8 @@ class CrossCheckTest extends TestCase
     }
 
     #[DataProvider('crossCheckYamlLoadersDumpers')]
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testYamlCrossCheck($fixture)
     {
         $tmp = tempnam(sys_get_temp_dir(), 'sf');

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\DependencyInjection\Tests\Dumper;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
@@ -114,6 +116,8 @@ class YamlDumperTest extends TestCase
         $this->assertStringEqualsGeneratedFile('services_inline.yml', $dumper->dump());
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testTaggedArguments()
     {
         $taggedIterator = new TaggedIteratorArgument('foo', 'barfoo', 'foobar', false, 'getPriority');

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/BarTagClass.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/BarTagClass.php
@@ -2,18 +2,30 @@
 
 namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
 
+use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
+
+#[AsTaggedItem('bar_tag_class')]
 class BarTagClass
 {
+    /**
+     * @deprecated since Symfony 8.1
+     */
     public static function getDefaultFooName()
     {
         return 'bar_tag_class';
     }
 
+    /**
+     * @deprecated since Symfony 8.1
+     */
     public static function getFooBar()
     {
         return 'bar_tab_class_with_defaultmethod';
     }
 
+    /**
+     * @deprecated since Symfony 8.1
+     */
     public static function getPriority(): int
     {
         return 0;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/FooTagClass.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/FooTagClass.php
@@ -2,13 +2,22 @@
 
 namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
 
+use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
+
+#[AsTaggedItem('foo_tag_class')]
 class FooTagClass
 {
+    /**
+     * @deprecated since Symfony 8.1
+     */
     public static function getDefaultFooName()
     {
         return 'foo_tag_class';
     }
 
+    /**
+     * @deprecated since Symfony 8.1
+     */
     public static function getPriority(): int
     {
         // Should be more than BarTagClass. More because this class is after

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedIteratorConsumerWithDefaultIndexMethod.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedIteratorConsumerWithDefaultIndexMethod.php
@@ -4,6 +4,9 @@ namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
 
 use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
+/**
+ * @deprecated since Symfony 8.1
+ */
 final class TaggedIteratorConsumerWithDefaultIndexMethod
 {
     public function __construct(

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedIteratorConsumerWithDefaultIndexMethodAndWithDefaultPriorityMethod.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedIteratorConsumerWithDefaultIndexMethodAndWithDefaultPriorityMethod.php
@@ -4,6 +4,9 @@ namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
 
 use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
+/**
+ * @deprecated since Symfony 8.1
+ */
 final class TaggedIteratorConsumerWithDefaultIndexMethodAndWithDefaultPriorityMethod
 {
     public function __construct(

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedIteratorConsumerWithDefaultPriorityMethod.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedIteratorConsumerWithDefaultPriorityMethod.php
@@ -4,6 +4,9 @@ namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
 
 use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
+/**
+ * @deprecated since Symfony 8.1
+ */
 final class TaggedIteratorConsumerWithDefaultPriorityMethod
 {
     public function __construct(

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedLocatorConsumerWithDefaultIndexMethod.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedLocatorConsumerWithDefaultIndexMethod.php
@@ -5,6 +5,9 @@ namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutowireLocator;
 
+/**
+ * @deprecated since Symfony 8.1
+ */
 final class TaggedLocatorConsumerWithDefaultIndexMethod
 {
     public function __construct(

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedLocatorConsumerWithDefaultIndexMethodAndWithDefaultPriorityMethod.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedLocatorConsumerWithDefaultIndexMethodAndWithDefaultPriorityMethod.php
@@ -5,6 +5,9 @@ namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutowireLocator;
 
+/**
+ * @deprecated since Symfony 8.1
+ */
 final class TaggedLocatorConsumerWithDefaultIndexMethodAndWithDefaultPriorityMethod
 {
     public function __construct(

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedLocatorConsumerWithDefaultPriorityMethod.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedLocatorConsumerWithDefaultPriorityMethod.php
@@ -5,6 +5,9 @@ namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutowireLocator;
 
+/**
+ * @deprecated since Symfony 8.1
+ */
 final class TaggedLocatorConsumerWithDefaultPriorityMethod
 {
     public function __construct(

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/legacy_services_with_tagged_arguments.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/legacy_services_with_tagged_arguments.xml
@@ -12,7 +12,7 @@
       <tag name="foo_tag"/>
     </service>
     <service id="foo_tagged_iterator" class="Bar" public="true">
-      <argument type="tagged_iterator" tag="foo_tag" index-by="barfoo"/>
+      <argument type="tagged_iterator" tag="foo_tag" index-by="barfoo" default-index-method="foobar" default-priority-method="getPriority"/>
     </service>
     <service id="foo2_tagged_iterator" class="Bar" public="true">
       <argument type="tagged_iterator" tag="foo_tag" exclude="baz"/>
@@ -24,7 +24,7 @@
       </argument>
     </service>
     <service id="foo_tagged_locator" class="Bar" public="true">
-      <argument type="tagged_locator" tag="foo_tag" index-by="barfoo"/>
+      <argument type="tagged_locator" tag="foo_tag" index-by="barfoo" default-index-method="foobar" default-priority-method="getPriority"/>
     </service>
     <service id="foo2_tagged_locator" class="Bar" public="true">
       <argument type="tagged_locator" tag="foo_tag" exclude="baz"/>

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -415,6 +415,8 @@ class YamlFileLoaderTest extends TestCase
         }
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testTaggedArgumentsWithIndex()
     {
         $container = new ContainerBuilder();
@@ -528,6 +530,8 @@ class YamlFileLoaderTest extends TestCase
         $loader->load('tag_name_no_string.yml');
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testParsesIteratorArgument()
     {
         $container = new ContainerBuilder();
@@ -994,6 +998,8 @@ class YamlFileLoaderTest extends TestCase
         $this->assertSame([['interface' => 'SomeInterface']], $definition->getTag('proxy'));
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testServiceWithSameNameAsInterfaceAndFactoryIsNotTagged()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | -
| License       | MIT

The is deprecating `getDefaultFooName()` methods and `$defaultIndexMethod` arguments used to build tagged iterators/locators (and alike for priorities).

These have been supersceded by `#[AsTaggedItem]` attributes, which are available since Symfony 5.3.

It was about time. Deprecating these will reduce complexity of the code, and of the doc!

We could also deprecate `#[AsTaggedItem]` in favor of `#[AutoconfigureTag]` at some point but this needs dedicated thoughts.
See #48532 for some background on this idea.