### PR TITLE
[Security] Add `#[AsVoter]` attribute to configure voter priority

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Attribute/AsVoter.php
+++ b/src/Symfony/Bundle/SecurityBundle/Attribute/AsVoter.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Attribute;
+
+/**
+ * Service tag to autoconfigure voters with priority support.
+ *
+ * @author Ayyoub AFW-ALLAH <ayyoub.afwallah@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class AsVoter
+{
+    public function __construct(public int $priority = 0)
+    {
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -26,6 +26,7 @@ CHANGELOG
     }
     ```
  * Deprecate `LazyFirewallContext::__invoke()`
+ * Add `#[AsVoter]` attribute to configure voter priority
 
 7.3
 ---

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\SecurityBundle\DependencyInjection;
 
 use Composer\InstalledVersions;
 use Symfony\Bridge\Twig\Extension\LogoutUrlExtension;
+use Symfony\Bundle\SecurityBundle\Attribute\AsVoter;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AuthenticatorFactoryInterface;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\FirewallListenerFactoryInterface;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\StatelessAuthenticatorFactoryInterface;
@@ -189,6 +190,13 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
         if ($container->hasDefinition('security.role_hierarchy')) {
             $loader->load('security_role_hierarchy_dump_command.php');
         }
+
+        $container->registerAttributeForAutoconfiguration(
+            AsVoter::class,
+            static function (ChildDefinition $definition, AsVoter $attribute): void {
+                $definition->addTag('security.voter', ['priority' => $attribute->priority]);
+            }
+        );
 
         $container->registerForAutoconfiguration(VoterInterface::class)
             ->addTag('security.voter');

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSecurityVotersPassTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSecurityVotersPassTest.php
@@ -12,7 +12,11 @@
 namespace Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Attribute\AsVoter;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\AddSecurityVotersPass;
+use Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Fixtures\Voter\AsVoterDefaultPriority;
+use Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Fixtures\Voter\AsVoterHighPriority;
+use Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Fixtures\Voter\AsVoterMediumPriority;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
@@ -71,6 +75,92 @@ class AddSecurityVotersPassTest extends TestCase
         $this->assertEquals(new Reference('highest_prio_service'), $refs[0]);
         $this->assertEquals(new Reference('lowest_prio_service'), $refs[1]);
         $this->assertCount(4, $refs);
+    }
+
+    public function testThatSecurityVotersWithAsVoterAttributeAreProcessedInPriorityOrder()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.debug', false);
+
+        $container
+            ->register('security.access.decision_manager', AccessDecisionManager::class)
+            ->addArgument([])
+        ;
+
+        // Register voters - attributes are read and applied as tags
+        $this->registerVoterWithAttribute($container, 'attribute_highest_prio', AsVoterHighPriority::class);
+        $this->registerVoterWithAttribute($container, 'attribute_medium_prio', AsVoterMediumPriority::class);
+        $this->registerVoterWithAttribute($container, 'attribute_default_prio', AsVoterDefaultPriority::class);
+
+        // Manual voter with explicit priority tag
+        $container
+            ->register('manual_tag_voter', Voter::class)
+            ->addTag('security.voter', ['priority' => 150])
+        ;
+
+        // Process
+        $compilerPass = new AddSecurityVotersPass();
+        $compilerPass->process($container);
+
+        // Verify order
+        $definition = $container->getDefinition('security.access.decision_manager');
+        $argument = $definition->getArgument(0);
+        $refs = $argument->getValues();
+
+        $this->assertEquals(new Reference('attribute_highest_prio'), $refs[0]);
+        $this->assertEquals(new Reference('manual_tag_voter'), $refs[1]);
+        $this->assertEquals(new Reference('attribute_medium_prio'), $refs[2]);
+        $this->assertEquals(new Reference('attribute_default_prio'), $refs[3]);
+        $this->assertCount(4, $refs);
+    }
+
+    public function testThatAsVoterAttributeOverridesOtherAutoConfigurations()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.debug', false);
+
+        $container
+            ->register('security.access.decision_manager', AccessDecisionManager::class)
+            ->addArgument([])
+        ;
+
+        $this->registerVoterWithAttribute($container, 'voter_with_attribute', AsVoterHighPriority::class);
+
+        $container->register('voter_with_both', AsVoterMediumPriority::class)
+            ->addTag('security.voter', ['priority' => 250]);
+
+        // override the manual tag
+        $this->registerVoterWithAttribute($container, 'voter_with_both', AsVoterMediumPriority::class);
+
+        // Process
+        $compilerPass = new AddSecurityVotersPass();
+        $compilerPass->process($container);
+
+        // Verify order
+        $definition = $container->getDefinition('security.access.decision_manager');
+        $argument = $definition->getArgument(0);
+        $refs = $argument->getValues();
+
+        $this->assertEquals(new Reference('voter_with_attribute'), $refs[0]);
+        $this->assertEquals(new Reference('voter_with_both'), $refs[1]);
+        $this->assertCount(2, $refs);
+    }
+
+    /**
+     * Simulates attribute autoconfiguration
+     * Reads the AsVoter attribute and adds the 'security.voter' tag.
+     */
+    private function registerVoterWithAttribute(ContainerBuilder $container, string $id, string $class): void
+    {
+        $container->register($id, $class);
+
+        $reflectionClass = new \ReflectionClass($class);
+        $attributes = $reflectionClass->getAttributes(AsVoter::class);
+
+        if (!empty($attributes)) {
+            $asVoter = $attributes[0]->newInstance();
+            $container->getDefinition($id)->addTag('security.voter', ['priority' => $asVoter->priority]);
+        }
     }
 
     public function testThatVotersAreTraceableInDebugMode()

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/Voter/AsVoterDefaultPriority.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/Voter/AsVoterDefaultPriority.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Fixtures\Voter;
+
+use Symfony\Bundle\SecurityBundle\Attribute\AsVoter;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+#[AsVoter]
+final class AsVoterDefaultPriority implements VoterInterface
+{
+    public function vote(TokenInterface $token, $subject, array $attributes, ?Vote $vote = null): int
+    {
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/Voter/AsVoterHighPriority.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/Voter/AsVoterHighPriority.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Fixtures\Voter;
+
+use Symfony\Bundle\SecurityBundle\Attribute\AsVoter;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+#[AsVoter(priority: 200)]
+final class AsVoterHighPriority implements VoterInterface
+{
+    public function vote(TokenInterface $token, $subject, array $attributes, ?Vote $vote = null): int
+    {
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/Voter/AsVoterMediumPriority.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/Voter/AsVoterMediumPriority.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Fixtures\Voter;
+
+use Symfony\Bundle\SecurityBundle\Attribute\AsVoter;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+#[AsVoter(priority: 100)]
+final class AsVoterMediumPriority implements VoterInterface
+{
+    public function vote(TokenInterface $token, $subject, array $attributes, ?Vote $vote = null): int
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #43074 
| License       | MIT

## Description

This PR introduces a new `#[AsVoter]` attribute that allows security voters to declare their priority directly within the class, as proposed in issue #43074.

While `#[Autoconfigure]` can technically set voter priority, it requires manually specifying tag names, making the configuration verbose, error-prone, and less intuitive.

The goal of `#[AsVoter]` is to simplify voter configuration and make it explicit, intuitive, and easy to use.

### Behavior

- The attribute can be added once per class
- The `#[AsVoter]` attribute overrides YAML configuration and `#[Autoconfigure]` 

### Before
```php
// config/services.yaml
services:
    App\Security\Voter\PostVoter:
        tags:
            - { name: security.voter, priority: 100 }
```
```php
use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;

#[Autoconfigure('security.voter', ['priority' => 100])]
class PostVoter implements VoterInterface
{
    public function vote(TokenInterface $token, mixed $subject, array $attributes): int
    {
        // ...
    }
}
```
### After
```php
use Symfony\Component\Security\Core\Attribute\AsVoter;

#[AsVoter(priority: 100)]
class PostVoter implements VoterInterface
{
    public function vote(TokenInterface $token, mixed $subject, array $attributes): int
    {
        // ...
    }
}
```
