### PR TITLE
[OptionsResolver] Fix missing prototype key in nested error paths

### DIFF
--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -964,6 +964,11 @@ class OptionsResolver implements Options
                 $resolver = new self();
                 $resolver->prototype = false;
                 $resolver->parentsOptions = $this->parentsOptions;
+
+                if ($this->prototype && null !== $this->prototypeIndex && null !== ($parentOptionKey = array_key_last($resolver->parentsOptions))) {
+                    $resolver->parentsOptions[$parentOptionKey] .= \sprintf('[%s]', $this->prototypeIndex);
+                }
+
                 $resolver->parentsOptions[] = $option;
                 foreach ($this->nested[$option] as $closure) {
                     $closure($resolver, $this);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR fixes a bug where `MissingOptionsException` error messages for nested prototypes generated an incomplete path. When an option was missing inside a prototype that was *itself* nested inside another prototype, the key of the parent prototype was omitted from the error message.

The fix ensures the parent's prototype index is correctly tracked and prepended when resolving nested options, providing a full and accurate path for easier debugging.

**Example:**

Given the following nested prototype setup:

```php
$resolver->setOptions('connections', static function (OptionsResolver $connResolver) {
    $connResolver->setPrototype(true); // Parent prototype
    // ...
    $connResolver->setOptions('replicas', static function (OptionsResolver $replicaResolver) {
        $replicaResolver->setPrototype(true); // Nested prototype
        $replicaResolver->setRequired(['host']);
    });
});
```

And this configuration, which is missing a `host` in `main_db`'s second replica:

```php
$options = [
    'connections' => [
        'main_db' => [
            // ...
            'replicas' => [
                ['host' => 'replica-01.local'],
                [], // Missing 'host' here
            ],
        ],
    ],
];
$resolver->resolve($options);
```

**Before (The Bug):**
The exception message was incorrect, missing the `main_db` key:
`The required option "connections[replicas][1][host]" is missing.`

**After (The Fix):**
The exception message is now correct and includes the full path:
`The required option "connections[main_db][replicas][1][host]" is missing.`

A test case (`testNestedPrototypeErrorPathHasFullContext`) has been added to cover this scenario and prevent regressions.