### PR TITLE
[OptionsResolver] Allow deprecations to be overridden with an empty s…

### DIFF
--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -447,6 +447,8 @@ class OptionsResolver implements Options
 
         // ignore if empty string
         if ('' === $message) {
+            unset($this->deprecated[$option]);
+
             return $this;
         }
 

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -2566,4 +2566,42 @@ class OptionsResolverTest extends TestCase
 
         $this->assertSame($expectedOptions, $actualOptions);
     }
+
+    public function testDeprecationCanBeOverriddenWithEmptyString()
+    {
+        // 1. Base configuration (e.g., parent class) deprecates "hostname"
+        $this->resolver
+            ->setDefined(['hostname', 'host'])
+            ->setDeprecated(
+                'hostname',
+                'acme/package',
+                '1.2',
+                'The option "%name%" is deprecated, use "host" instead.'
+            );
+
+        // 2. Child configuration cancel this deprecation
+        $this->resolver
+            ->setDeprecated('hostname', 'acme/package', '1.3', '');
+
+        $this->assertFalse($this->resolver->isDeprecated('hostname'));
+
+        $count = 0;
+        set_error_handler(function (int $type) use (&$count) {
+            if (\E_USER_DEPRECATED === $type) {
+                ++$count;
+            }
+
+            return false;
+        });
+        $e = error_reporting(0);
+
+        try {
+            $this->resolver->resolve(['hostname' => 'localhost']);
+        } finally {
+            error_reporting($e);
+            restore_error_handler();
+        }
+
+        $this->assertSame(0, $count, 'No \E_USER_DEPRECATED error should have been triggered.');
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR fixes a bug that prevented a previously set deprecation from being cancelled. If `setDeprecated()` was called with an empty string, it would return `void` without removing the existing deprecation entry.

This made it impossible for child classes or subsequent configurations to override and disable a deprecation set by a parent configuration.

The fix ensures that calling `setDeprecated('...', '')` actively `unset()`s the deprecation from the internal array, restoring the expected override behavior.

**Example:**

Given a base configuration (e.g., a parent class) that deprecates the `hostname` option, based on the documentation's example:

```php
// In parent class:
$resolver
    ->setDefined(['hostname', 'host'])
    ->setDeprecated(
        'hostname',
        'acme/package',
        '1.2',
        'The option "%name%" is deprecated, use "host" instead.'
    );
```

A child configuration attempts to *annul* this deprecation:

```php
// In child class:
$resolver
    ->setDeprecated('hostname', 'acme/package', '1.3', '');
```

**Before (The Bug):**
The `isDeprecated('hostname')` method still returned `true`, and resolving `['hostname' => '...']` would incorrectly trigger an `E_USER_DEPRECATED` error.

**After (The Fix):**
The deprecation is correctly removed. `isDeprecated('hostname')` now returns `false`, and no deprecation error is triggered when resolving the option.