### PR TITLE
[Clock] Align MockClock::sleep() behavior with NativeClock for negative values

### DIFF
--- a/src/Symfony/Component/Clock/MockClock.php
+++ b/src/Symfony/Component/Clock/MockClock.php
@@ -54,6 +54,10 @@ final class MockClock implements ClockInterface
 
     public function sleep(float|int $seconds): void
     {
+        if (0 >= $seconds) {
+            return;
+        }
+
         $now = (float) $this->now->format('Uu') + $seconds * 1e6;
         $now = substr_replace(\sprintf('@%07.0F', $now), '.', -6, 0);
         $timezone = $this->now->getTimezone();

--- a/src/Symfony/Component/Clock/Tests/MockClockTest.php
+++ b/src/Symfony/Component/Clock/Tests/MockClockTest.php
@@ -117,4 +117,14 @@ class MockClockTest extends TestCase
         $this->assertNotSame($clock, $utcClock);
         $this->assertSame('UTC', $utcClock->now()->getTimezone()->getName());
     }
+
+    public function testSleepWithNegativeValueDoesNothing()
+    {
+        $initialTime = new \DateTimeImmutable('2000-01-01 12:00:00 UTC');
+
+        $clock = new MockClock($initialTime);
+        $clock->sleep(-10.5);
+
+        $this->assertEquals($initialTime, $clock->now());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT


This PR fixes a behavioral inconsistency between `NativeClock` and `MockClock` when handling negative sleep durations.

**The Problem:**

  * `NativeClock::sleep(-10)`: Silently does nothing. The time does not change.
  * `MockClock::sleep(-10)`: **Travels backward in time** by 10 seconds.

This inconsistency can lead to unreliable tests, as the mock does not accurately represent the real implementation's behavior for this edge case.

**The Fix:**
This fix adds a guard clause to `MockClock::sleep()` to ignore any duration less than or equal to zero, perfectly matching the behavior of `NativeClock`.

**Before (The Bug):**

```php
$clock = new MockClock('2000-01-01 12:00:00');
$clock->sleep(-10);
// $clock->now() is '2000-01-01 11:59:50'
```

**After (The Fix):**

```php
$clock = new MockClock('2000-01-01 12:00:00');
$clock->sleep(-10);
// $clock->now() is '2000-01-01 12:00:00'
```