### PR TITLE
[ExpressionLanguage] Compile numbers with var_export in Compiler::repr for thread-safety

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Compiler.php
+++ b/src/Symfony/Component/ExpressionLanguage/Compiler.php
@@ -114,15 +114,7 @@ class Compiler implements ResetInterface
     public function repr(mixed $value): static
     {
         if (\is_int($value) || \is_float($value)) {
-            if (false !== $locale = setlocale(\LC_NUMERIC, 0)) {
-                setlocale(\LC_NUMERIC, 'C');
-            }
-
-            $this->raw($value);
-
-            if (false !== $locale) {
-                setlocale(\LC_NUMERIC, $locale);
-            }
+            $this->raw(var_export($value, true));
         } elseif (null === $value) {
             $this->raw('null');
         } elseif (\is_bool($value)) {

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/ConstantNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/ConstantNodeTest.php
@@ -31,13 +31,40 @@ class ConstantNodeTest extends AbstractNodeTestCase
     public static function getCompileData(): array
     {
         return [
+            // Booleans
             ['false', new ConstantNode(false)],
             ['true', new ConstantNode(true)],
+
+            // Null
             ['null', new ConstantNode(null)],
+
+            // Integers
             ['3', new ConstantNode(3)],
+            ['-10', new ConstantNode(-10)],
+            ['0', new ConstantNode(0)],
+
+            // Floats
             ['3.3', new ConstantNode(3.3)],
+            ['42.0', new ConstantNode(42.0)],
+            ['-1.23', new ConstantNode(-1.23)],
+            ['0.1', new ConstantNode(0.1)],
+            ['1.0', new ConstantNode(1.0)],
+            ['1.0E-6', new ConstantNode(1.0e-6)],
+            ['1.23456789E+20', new ConstantNode(1.23456789e+20)],
+            ['3.3', new ConstantNode(3.2999999999999998)],
+            ['0.30000000000000004', new ConstantNode(0.1 + 0.2)],
+            ['INF', new ConstantNode(\INF)],
+            ['-INF', new ConstantNode(-\INF)],
+            ['NAN', new ConstantNode(\NAN)],
+
+            // Strings
             ['"foo"', new ConstantNode('foo')],
+            ['""', new ConstantNode('')],
+            ['"a\\"b"', new ConstantNode('a"b')],
+
+            // Arrays
             ['[0 => 1, "b" => "a"]', new ConstantNode([1, 'b' => 'a'])],
+            ['[]', new ConstantNode([])],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR suggests replacing the `setlocale()` logic in `Compiler::repr()` with `var_export()` when compiling numbers.

The current use of `setlocale()` is not thread-safe and can cause race conditions in concurrent environments (e.g., Swoole, RoadRunner).

`var_export()` is locale-independent, thread-safe, and correctly handles all required float formats (`3.3`, `42.0`, `1.0E-6`, `INF`, `NAN`), as confirmed by the expanded test suite.