### PR TITLE
 Fix Belarusian translations (validators.be.xlf entries 141 and 142)

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.be.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.be.xlf
@@ -548,11 +548,11 @@
             </trans-unit>
             <trans-unit id="141">
                 <source>The image has too many pixels ({{ pixels }} pixels). Maximum amount expected is {{ max_pixels }} pixels.</source>
-                <target state="needs-review-translation">Малюнак мае занадта шмат пікселяў ({{ pixels }}). Максімальная дапушчальная колькасць {{ max_pixels }}.</target>
+                <target>Малюнак мае занадта шмат пікселяў ({{ pixels }}). Максімальная дапушчальная колькасць {{ max_pixels }}.</target>
             </trans-unit>
             <trans-unit id="142">
                 <source>This filename does not match the expected charset.</source>
-                <target state="needs-review-translation">Гэта назва файла не адпавядае чаканаму набору знакаў.</target>
+                <target>Гэта назва файла не адпавядае чаканаму набору знакаў.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62349 
| License       | MIT

This PR fixes two Belarusian translations in `validators.be.xlf`.

The translations for entries **141** and **142** were already correct.
This PR removes the `needs-review-translation` state.

- File: `src/Symfony/Component/Validator/Resources/translations/validators.be.xlf`
- Verified that the translations are accurate and stylistically consistent.