### PR TITLE
[Serializer] Convert the elements of scalar collections

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -578,6 +578,38 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                         $class = $collectionValueBaseType->getClassName().'[]';
                         $context['key_type'] = $collectionKeyType;
                         $context['value_type'] = $collectionValueType;
+                    } elseif (\is_array($data) && $collectionValueBaseType instanceof BuiltinType && \in_array($collectionValueBaseType->getTypeIdentifier(), [TypeIdentifier::BOOL, TypeIdentifier::FLOAT, TypeIdentifier::INT, TypeIdentifier::STRING], true)) {
+                        // elements of a scalar collection are converted with the very same rules as any other value
+                        $result = [];
+                        $childContext = null;
+                        $valueTypeIdentifier = $collectionValueBaseType->getTypeIdentifier();
+                        $valueIsNullable = $collectionValueType->isNullable();
+
+                        foreach ($data as $key => $value) {
+                            // values that already have the expected type are the common case, keep them as is
+                            if (null === $value ? $valueIsNullable : match ($valueTypeIdentifier) {
+                                TypeIdentifier::BOOL => \is_bool($value),
+                                TypeIdentifier::FLOAT => \is_float($value),
+                                TypeIdentifier::INT => \is_int($value),
+                                default => \is_string($value),
+                            }) {
+                                $result[$key] = $value;
+                                continue;
+                            }
+
+                            $childContext ??= $this->createChildContext($context, $attribute, $format);
+                            $childContext['deserialization_path'] = ($context['deserialization_path'] ?? false) ? \sprintf('%s[%s]', $context['deserialization_path'], $key) : "[$key]";
+
+                            try {
+                                // the wrapped type is passed on so that a nullable element type keeps accepting null
+                                $result[$key] = $this->validateAndDenormalize($collectionValueType, $currentClass, $attribute, $value, $format, $childContext);
+                            } catch (NotNormalizableValueException) {
+                                // elements that cannot be converted are left untouched, as they have always been
+                                $result[$key] = $value;
+                            }
+                        }
+
+                        return $result;
                     } elseif ($collectionValueBaseType instanceof BuiltinType && TypeIdentifier::ARRAY === $collectionValueBaseType->getTypeIdentifier()) {
                         // get inner type for any nested array
                         $innerType = $collectionValueType;

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -1439,6 +1439,39 @@ class AbstractObjectNormalizerTest extends TestCase
         $this->assertEquals($expected, $normalizer->denormalize($data, ScalarCollectionDocBlockDummy::class));
     }
 
+    public function testDenormalizeConvertsScalarCollectionElements()
+    {
+        $normalizer = new AbstractObjectNormalizerWithMetadataAndPropertyTypeExtractors();
+
+        $dummy = $normalizer->denormalize([
+            'ints' => ['1', '2'],
+            'floats' => ['1.5', null],
+            'bools' => ['name' => 'true'],
+        ], ScalarCollectionsDummy::class, null, [AbstractObjectNormalizer::ENABLE_TYPE_CONVERSION => true]);
+
+        $this->assertSame([1, 2], $dummy->ints);
+        $this->assertSame([1.5, null], $dummy->floats);
+        $this->assertSame(['name' => true], $dummy->bools);
+    }
+
+    public function testDenormalizeConvertsScalarCollectionElementsDecodedFromXml()
+    {
+        $normalizer = new AbstractObjectNormalizerWithMetadataAndPropertyTypeExtractors();
+
+        $dummy = $normalizer->denormalize(['ints' => ['1', '2']], ScalarCollectionsDummy::class, 'xml');
+
+        $this->assertSame([1, 2], $dummy->ints);
+    }
+
+    public function testDenormalizeLeavesUnconvertibleScalarCollectionElementsUntouched()
+    {
+        $normalizer = new AbstractObjectNormalizerWithMetadataAndPropertyTypeExtractors();
+
+        $dummy = $normalizer->denormalize(['ints' => [1, 'nope', ['a' => 1]]], ScalarCollectionsDummy::class, null, [AbstractObjectNormalizer::ENABLE_TYPE_CONVERSION => true]);
+
+        $this->assertSame([1, 'nope', ['a' => 1]], $dummy->ints);
+    }
+
     public function testDenormalizeCollectionOfUnionTypesPropertyWithPhpDocExtractor()
     {
         $normalizer = new AbstractObjectNormalizerWithMetadataAndPropertyTypeExtractors();
@@ -2202,6 +2235,18 @@ class ScalarCollectionDocBlockDummy
     {
         return $this->values;
     }
+}
+
+class ScalarCollectionsDummy
+{
+    /** @var list<int> */
+    public array $ints = [];
+
+    /** @var list<?float> */
+    public array $floats = [];
+
+    /** @var array<string, bool> */
+    public array $bools = [];
 }
 
 class UnionCollectionDocBlockDummy


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53490
| License       | MIT

`ENABLE_TYPE_CONVERSION` converts a scalar property but skips the elements of a scalar collection, so a declared `int[]` keeps holding strings:

```php
class Dto {
    /** @var int[] */ public array $ids = [];
    public ?int $one = null;
}

$serializer->deserialize('{"ids":["1","2"],"one":"3"}', Dto::class, 'json', [
    AbstractObjectNormalizer::ENABLE_TYPE_CONVERSION => true,
]);

// before: $one === 3, $ids === ['1', '2']
// after:  $one === 3, $ids === [1, 2]
```

The option is on by default for XML and CSV, precisely because every value arrives as a string there, so those two formats are affected without opting in at all.

Elements now go through `validateAndDenormalize()` like every other value, which is what object collections already do, so a single set of conversion rules applies everywhere. Elements that cannot be converted are left untouched, exactly as today, and a test pins that. Whether they should be rejected instead is a separate call, discussed in #65289.

Values that already carry the expected type skip the recursion, which keeps the common case cheap.

Thanks @SamuilovAD for reporting this and for the original patch. The implementation was replaced to reuse the existing denormalization path rather than add a `CAST_SCALAR_COLLECTIONS` option with a second set of casting rules, but the branch history still holds your commit.
