### PR TITLE
[SecurityBundle] refresh JWKS on kid mismatch during OIDC discovery

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/OidcTokenHandlerFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/OidcTokenHandlerFactory.php
@@ -67,6 +67,10 @@ class OidcTokenHandlerFactory implements TokenHandlerFactoryInterface
         $tokenHandlerDefinition->replaceArgument(1, (new ChildDefinition('security.access_token_handler.oidc.jwkset'))
             ->replaceArgument(0, $config['keyset']));
 
+        if (!empty($config['refresh_jwks_on_kid_mismatch'])) {
+            $tokenHandlerDefinition->addMethodCall('enableRefreshJwksOnKidMismatch', [true]);
+        }
+
         if ($config['encryption']['enabled']) {
             $algorithmManager = (new ChildDefinition('security.access_token_handler.oidc.encryption'))
                 ->replaceArgument(0, $config['encryption']['algorithms']);
@@ -204,6 +208,10 @@ class OidcTokenHandlerFactory implements TokenHandlerFactoryInterface
                     ->end()
                     ->scalarNode('keyset')
                         ->info('JSON-encoded JWKSet used to sign the token (must contain a list of valid public keys).')
+                    ->end()
+                    ->booleanNode('refresh_jwks_on_kid_mismatch')
+                        ->info('When true, automatically refreshes the JWKS if the token\'s key ID (kid) is not found in the cached set.')
+                        ->defaultFalse()
                     ->end()
                     ->arrayNode('encryption')
                         ->canBeEnabled()

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/schema/security-1.0.xsd
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/schema/security-1.0.xsd
@@ -341,6 +341,7 @@
         <xsd:attribute name="algorithm" type="xsd:string" />
         <xsd:attribute name="key" type="xsd:string" />
         <xsd:attribute name="keyset" type="xsd:string" />
+        <xsd:attribute name="refresh-jwks-on-kid-mismatch" type="xsd:boolean" />
     </xsd:complexType>
 
     <xsd:complexType name="oidc_encryption">

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/access_token_oidc_encryption.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/access_token_oidc_encryption.php
@@ -16,6 +16,7 @@ $container->loadFromExtension('security', [
                         'issuers' => ['https://www.example.com'],
                         'audience' => 'audience',
                         'keyset' => '{"keys":[{"kty":"RSA","n":"abc","e":"AQAB"}]}',
+                        'refresh_jwks_on_kid_mismatch' => true,
                         'encryption' => [
                             'enabled' => true,
                             'keyset' => '{"keys":[{"kty":"RSA","n":"abc","e":"AQAB","d":"def"}]}',

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/access_token_oidc.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/access_token_oidc.xml
@@ -13,7 +13,7 @@
         <firewall name="firewall1" provider="default">
             <access-token>
                 <token-handler>
-                    <oidc audience="audience" keyset='{"keys":[{"kty":"RSA","n":"abc","e":"AQAB"}]}' >
+                    <oidc audience="audience" keyset='{"keys":[{"kty":"RSA","n":"abc","e":"AQAB"}]}' refresh-jwks-on-kid-mismatch="true">
                         <issuer>https://www.example.com</issuer>
                         <algorithm>RS256</algorithm>
                     </oidc>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/access_token_oidc_encryption.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/access_token_oidc_encryption.xml
@@ -13,7 +13,7 @@
         <firewall name="firewall1" provider="default">
             <access-token>
                 <token-handler>
-                    <oidc audience="audience" keyset='{"keys":[{"kty":"RSA","n":"abc","e":"AQAB"}]}' >
+                    <oidc audience="audience" keyset='{"keys":[{"kty":"RSA","n":"abc","e":"AQAB"}]}' refresh-jwks-on-kid-mismatch="true">
                         <issuer>https://www.example.com</issuer>
                         <algorithm>RS256</algorithm>
                         <encryption enforce="true" keyset='{"keys":[{"kty":"RSA","n":"abc","e":"AQAB","d":"def"}]}' >

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/access_token_oidc.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/access_token_oidc.yml
@@ -13,4 +13,5 @@ security:
                         issuers: ['https://www.example.com']
                         audience: 'audience'
                         keyset: '{"keys":[{"kty":"RSA","n":"abc","e":"AQAB"}]}'
+                        refresh_jwks_on_kid_mismatch: true
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/access_token_oidc_encryption.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/access_token_oidc_encryption.yml
@@ -13,6 +13,7 @@ security:
                         issuers: ['https://www.example.com']
                         audience: 'audience'
                         keyset: '{"keys":[{"kty":"RSA","n":"abc","e":"AQAB"}]}'
+                        refresh_jwks_on_kid_mismatch: true
                         encryption:
                             enabled: true
                             keyset: '{"keys":[{"kty":"RSA","n":"abc","e":"AQAB","d":"def"}]}'

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AccessTokenFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AccessTokenFactoryTest.php
@@ -559,6 +559,31 @@ class AccessTokenFactoryTest extends TestCase
         $this->assertEquals($expectedCalls, $container->getDefinition('security.access_token_handler.firewall1')->getMethodCalls());
     }
 
+    public function testOidcTokenHandlerConfigurationWithRefreshJwksOnKidMismatch()
+    {
+        $container = new ContainerBuilder();
+        $config = [
+            'token_handler' => [
+                'oidc' => [
+                    'algorithms' => ['RS256'],
+                    'issuers' => ['https://www.example.com'],
+                    'audience' => 'audience',
+                    'keyset' => '{"keys":[{"kty":"RSA","n":"abc","e":"AQAB"}]}',
+                    'refresh_jwks_on_kid_mismatch' => true,
+                ],
+            ],
+        ];
+        $factory = new AccessTokenFactory($this->createTokenHandlerFactories());
+        $finalizedConfig = $this->processConfig($config, $factory);
+        $factory->createAuthenticator($container, 'firewall1', $finalizedConfig, 'userprovider');
+        $def = $container->getDefinition('security.access_token_handler.firewall1');
+        $calls = $def->getMethodCalls();
+        $this->assertTrue(
+            \in_array(['enableRefreshJwksOnKidMismatch', [true]], $calls, true),
+            'Expected enableRefreshJwksOnKidMismatch(true) to be called when refresh_jwks_on_kid_mismatch is enabled.'
+        );
+    }
+
     public function testMultipleTokenHandlersSet()
     {
         $config = [

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_oidc.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_oidc.yml
@@ -27,6 +27,7 @@ security:
                         algorithms: [ 'ES256' ]
                         # tip: use https://mkjwk.org/ to generate a JWK
                         keyset: '{"keys":[{"kty":"EC","d":"iA_TV2zvftni_9aFAQwFO_9aypfJFCSpcCyevDvz220","crv":"P-256","x":"0QEAsI1wGI-dmYatdUZoWSRWggLEpyzopuhwk-YUnA4","y":"KYl-qyZ26HobuYwlQh-r0iHX61thfP82qqEku7i0woo"}]}'
+                        refresh_jwks_on_kid_mismatch: true
                         encryption:
                             enabled: true
                             algorithms: ['ECDH-ES', 'A128GCM']

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_oidc_jwe.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_oidc_jwe.yml
@@ -27,6 +27,7 @@ security:
                         algorithm: 'ES256'
                         # tip: use https://mkjwk.org/ to generate a JWK
                         keyset: '{"keys":[{"kty":"EC","d":"iA_TV2zvftni_9aFAQwFO_9aypfJFCSpcCyevDvz220","crv":"P-256","x":"0QEAsI1wGI-dmYatdUZoWSRWggLEpyzopuhwk-YUnA4","y":"KYl-qyZ26HobuYwlQh-r0iHX61thfP82qqEku7i0woo"}]}'
+                        refresh_jwks_on_kid_mismatch: true
                         encryption:
                             enabled: true
                             enforce: true

--- a/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenHandler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenHandler.php
@@ -55,6 +55,8 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface
      */
     private array $discoveryClients = [];
 
+    private bool $refreshJwksOnKidMismatch = false;
+
     public function __construct(
         private Algorithm|AlgorithmManager $signatureAlgorithm,
         private JWK|JWKSet|null $signatureKeyset,
@@ -79,6 +81,11 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface
         $this->decryptionKeyset = $decryptionKeyset;
         $this->decryptionAlgorithms = $decryptionAlgorithms;
         $this->enforceEncryption = $enforceEncryption;
+    }
+
+    public function enableRefreshJwksOnKidMismatch(bool $refreshJwksOnKidMismatch): void
+    {
+        $this->refreshJwksOnKidMismatch = $refreshJwksOnKidMismatch;
     }
 
     /**
@@ -107,42 +114,8 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface
 
         $jwkset = $this->signatureKeyset;
         if ($this->discoveryClients) {
-            $clients = $this->discoveryClients;
-            $logger = $this->logger;
-            $keys = $this->discoveryCache->get($this->oidcConfigurationCacheKey, static function () use ($clients, $logger): array {
-                try {
-                    $configResponses = [];
-                    foreach ($clients as $client) {
-                        $configResponses[] = $client->request('GET', '.well-known/openid-configuration', [
-                            'user_data' => $client,
-                        ]);
-                    }
-
-                    $jwkSetResponses = [];
-                    foreach ($client->stream($configResponses) as $response => $chunk) {
-                        if ($chunk->isLast()) {
-                            $jwkSetResponses[] = $response->getInfo('user_data')->request('GET', $response->toArray()['jwks_uri']);
-                        }
-                    }
-
-                    $keys = [];
-                    foreach ($jwkSetResponses as $response) {
-                        foreach ($response->toArray()['keys'] as $key) {
-                            if ('sig' === $key['use']) {
-                                $keys[] = $key;
-                            }
-                        }
-                    }
-
-                    return $keys;
-                } catch (\Exception $e) {
-                    $logger?->error('An error occurred while requesting OIDC certs.', [
-                        'error' => $e->getMessage(),
-                        'trace' => $e->getTraceAsString(),
-                    ]);
-
-                    throw new BadCredentialsException('Invalid credentials.', $e->getCode(), $e);
-                }
+            $keys = $this->discoveryCache->get($this->oidcConfigurationCacheKey, function () {
+                return $this->doFetchOidcSigningKeys();
             });
 
             $jwkset = JWKSet::createFromKeyData(['keys' => $keys]);
@@ -180,7 +153,18 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface
         $serializerManager = new JWSSerializerManager([new JwsCompactSerializer()]);
         $jws = $serializerManager->unserialize($accessToken);
 
-        // Verify the signature
+        // Rotation-safe: if discovery and kid verification are enabled, ensure the token's kid exists in the current JWK set.
+        if ($this->refreshJwksOnKidMismatch && $this->discoveryCache && $this->discoveryClients) {
+            $kid = $jws->getSignature(0)->getProtectedHeader()['kid'] ?? null;
+            if (null !== $kid && !$this->jwksetHasKid($jwkset, $kid)) {
+                $this->discoveryCache->delete($this->oidcConfigurationCacheKey);
+                $freshKeys = $this->discoveryCache->get($this->oidcConfigurationCacheKey, function () {
+                    return $this->doFetchOidcSigningKeys();
+                });
+                $jwkset = JWKSet::createFromKeyData(['keys' => $freshKeys]);
+            }
+        }
+
         if (!$jwsVerifier->verifyWithKeySet($jws, $jwkset, 0)) {
             throw new InvalidSignatureException();
         }
@@ -258,6 +242,60 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface
             $this->logger?->debug('The token decryption failed. Skipping as not mandatory.');
 
             return $accessToken;
+        }
+    }
+
+    private function jwksetHasKid(JWKSet $set, string $kid): bool
+    {
+        foreach ($set->all() as $jwk) {
+            if (($jwk->has('kid') ? $jwk->get('kid') : null) === $kid) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array<int,array<string,mixed>>
+     */
+    private function doFetchOidcSigningKeys(): array
+    {
+        $clients = $this->discoveryClients;
+        $logger = $this->logger;
+
+        try {
+            $configResponses = [];
+            foreach ($clients as $client) {
+                $configResponses[] = $client->request('GET', '.well-known/openid-configuration', [
+                    'user_data' => $client,
+                ]);
+            }
+
+            $jwkSetResponses = [];
+            foreach ($client->stream($configResponses) as $response => $chunk) {
+                if ($chunk->isLast()) {
+                    $jwkSetResponses[] = $response->getInfo('user_data')->request('GET', $response->toArray()['jwks_uri']);
+                }
+            }
+
+            $keys = [];
+            foreach ($jwkSetResponses as $response) {
+                foreach ($response->toArray()['keys'] as $key) {
+                    if ('sig' === ($key['use'] ?? null)) {
+                        $keys[] = $key;
+                    }
+                }
+            }
+
+            return $keys;
+        } catch (\Exception $e) {
+            $logger?->error('An error occurred while requesting OIDC certs.', [
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
+
+            throw new BadCredentialsException('Invalid credentials.', $e->getCode(), $e);
         }
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcTokenHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcTokenHandlerTest.php
@@ -301,14 +301,72 @@ class OidcTokenHandlerTest extends TestCase
         $this->assertTrue($cache->hasItem('oidc_config'));
     }
 
-    private static function buildJWSWithKey(string $payload, JWK $jwk): string
+    private static function buildJWSWithKey(string $payload, JWK $jwk, ?string $kid = null): string
     {
+        $header = ['alg' => 'ES256'];
+        if ($kid) {
+            $header['kid'] = $kid;
+        }
+
         return (new CompactSerializer())->serialize((new JWSBuilder(new AlgorithmManager([
             new ES256(),
         ])))->create()
             ->withPayload($payload)
-            ->addSignature($jwk, ['alg' => 'ES256'])
+            ->addSignature($jwk, $header)
             ->build()
         );
+    }
+
+    public function testRefreshesJwksOnKidMismatch()
+    {
+        $time = time();
+        // Simulate an old JWK (cached) and a new JWK (rotated)
+        $oldKey = array_merge(self::getJWK()->all(), ['use' => 'sig', 'kid' => 'old-key']);
+        $newKey = array_merge(self::getSecondJWK()->all(), ['use' => 'sig', 'kid' => 'new-key']);
+
+        // Mock sequential responses: discovery config, old keyset, then refreshed keyset
+        $httpClient = new MockHttpClient(function ($method, $url) use ($oldKey, $newKey) {
+            static $callCount = 0;
+            ++$callCount;
+
+            return match ($callCount) {
+                1 => new JsonMockResponse(['jwks_uri' => 'https://www.example.com/.well-known/jwks.json']),
+                2 => new JsonMockResponse(['keys' => [$oldKey]]),
+                3 => new JsonMockResponse(['jwks_uri' => 'https://www.example.com/.well-known/jwks.json']),
+                4 => new JsonMockResponse(['keys' => [$newKey]]),
+                default => throw new \RuntimeException('Unexpected call #'.$callCount),
+            };
+        });
+
+        $cache = new ArrayAdapter();
+        $handler = new OidcTokenHandler(
+            new AlgorithmManager([new ES256()]),
+            null,
+            self::AUDIENCE,
+            ['https://www.example.com']
+        );
+
+        $handler->enableDiscovery($cache, $httpClient, 'oidc_config');
+        $handler->enableRefreshJwksOnKidMismatch(true);
+
+        // Token signed with the new key (not present in cache)
+        $claims = [
+            'iat' => $time,
+            'nbf' => $time,
+            'exp' => $time + 3600,
+            'iss' => 'https://www.example.com',
+            'aud' => self::AUDIENCE,
+            'sub' => 'user-rotated',
+            'email' => 'user@example.com',
+        ];
+        $token = self::buildJWSWithKey(json_encode($claims), self::getSecondJWK(), 'new-key');
+
+        $userBadge = $handler->getUserBadgeFrom($token);
+
+        $this->assertInstanceOf(UserBadge::class, $userBadge);
+        $this->assertSame('user-rotated', $userBadge->getUserIdentifier());
+
+        $cachedKeys = $cache->getItem('oidc_config')->get();
+        $this->assertSame('new-key', $cachedKeys[0]['kid']);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #62340
| License       | MIT

This PR adds an optional refresh_jwks_on_kid_mismatch option to the OIDC discovery mechanism.
When enabled, Symfony will automatically refresh the JWKS if the kid (Key ID) in the JWT header
is not found in the cached key set.

This prevents token validation failures in cases where the OIDC provider’s signing keys
have changed while the cached key set has not yet expired.

**Example configuration:**

```yaml
oidc:
    claim: email
    algorithms: ['ES256', 'RS256']
    audience: 'api-example'
    issuers: ['https://oidc.example.com']
    discovery:
        base_uri: https://www.example.com/realms/demo/
        refresh_jwks_on_kid_mismatch: true
