### PR TITLE
[HttpClient] Fix `Warning: curl_multi_select(): timeout must be positive`

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/TransportResponseTrait.php
+++ b/src/Symfony/Component/HttpClient/Response/TransportResponseTrait.php
@@ -299,7 +299,7 @@ trait TransportResponseTrait
                 continue;
             }
 
-            if (-1 === self::select($multi, min($timeoutMin, $timeoutMax - $elapsedTimeout))) {
+            if (-1 === self::select($multi, min($timeoutMin, max(0, $timeoutMax - $elapsedTimeout)))) {
                 usleep((int) min(500, 1E6 * $timeoutMin));
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| License       | MIT

Full error text: `ErrorException: Warning: curl_multi_select(): timeout must be between 0 and 2147484`

Somehow this timeout is a negative float in some cases. I haven't been able to reproduce it manually. Here's an example:

<img width="979" height="920" alt="image" src="https://github.com/user-attachments/assets/57e44026-cb1a-412c-acb2-b94ec13de48e" />

```
ErrorException: Warning: curl_multi_select(): timeout must be between 0 and 2147484
#0 /vendor/symfony/http-client/Response/CurlResponse.php(342): Symfony\Component\HttpClient\Response\CurlResponse::select
#1 /vendor/symfony/http-client/Response/TransportResponseTrait.php(298): Symfony\Component\HttpClient\Response\CurlResponse::stream
#2 /vendor/symfony/http-client/Response/CommonResponseTrait.php(148): Symfony\Component\HttpClient\Response\CurlResponse::initialize
#3 /vendor/symfony/http-client/Response/TransportResponseTrait.php(130): Symfony\Component\HttpClient\Response\CurlResponse::doDestruct
#4 /vendor/symfony/http-client/Response/CurlResponse.php(242): Symfony\Component\HttpClient\Response\CurlResponse::__destruct
#5 /vendor/sentry/sentry/src/Client.php(177): Sentry\Client::captureEvent
#6 /vendor/sentry/sentry/src/State/Hub.php(155): Sentry\State\Hub::captureEvent
#7 /vendor/sentry/sentry/src/Tracing/Transaction.php(188): Sentry\Tracing\Transaction::finish
#8 /vendor/..redacted(): ...::shutdownHandler
#9 [internal](0)
```

Not sure if this is the place to enforce the `>=0` float or in https://github.com/symfony/symfony/blob/7.4/src/Symfony/Component/HttpClient/Response/CurlResponse.php#L363