### PR TITLE
[Yaml] Fix parsing of unquoted multiline scalars with comments or blank lines

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -762,11 +762,20 @@ class Parser
                     $lines = [];
 
                     while ($this->moveToNextLine()) {
+                        if ($this->isCurrentLineBlank()) {
+                            $lines[] = '';
+                            continue;
+                        }
+
                         // unquoted strings end before the first unindented line
                         if (0 === $this->getCurrentLineIndentation()) {
                             $this->moveToPreviousLine();
 
                             break;
+                        }
+
+                        if ($this->isCurrentLineComment()) {
+                            continue;
                         }
 
                         $lines[] = trim($this->currentLine);

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -1752,6 +1752,73 @@ EOT;
     }
 
     /**
+     * @dataProvider getUnquotedMultilineScalarIgnoresCommentsData
+     */
+    public function testUnquotedMultilineScalarIgnoresComments(string $yaml, array $expected)
+    {
+        $this->assertSame($expected, $this->parser->parse($yaml));
+    }
+
+    public static function getUnquotedMultilineScalarIgnoresCommentsData()
+    {
+        yield 'comments interspersed' => [
+            <<<YAML
+                key: unquoted
+                  # this comment should be ignored
+                  next line
+                  # another comment
+                  final line
+                another_key: works
+                YAML,
+            [
+                'key' => 'unquoted next line final line',
+                'another_key' => 'works',
+            ],
+        ];
+
+        yield 'only comments' => [
+            <<<YAML
+                key: unquoted
+                  # this comment should be ignored
+                  # another comment
+                another_key: works
+                YAML,
+            [
+                'key' => 'unquoted',
+                'another_key' => 'works',
+            ],
+        ];
+
+        yield 'blank lines and comments' => [
+            <<<YAML
+                key: unquoted
+                  next line
+
+                  # this comment should be ignored
+                  final line
+                another_key: works
+                YAML,
+            [
+                'key' => "unquoted next line\nfinal line",
+                'another_key' => 'works',
+            ],
+        ];
+
+        yield 'comment at end' => [
+            <<<YAML
+                key: unquoted
+                  next line
+                  # comment at end
+                another_key: works
+                YAML,
+            [
+                'key' => 'unquoted next line',
+                'another_key' => 'works',
+            ],
+        ];
+    }
+
+    /**
      * @dataProvider unquotedStringWithTrailingComment
      */
     public function testParseMultiLineUnquotedStringWithTrailingComment(string $yaml, array $expected)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR fixes two bugs when parsing unquoted multiline scalars:

1.  **Indented comment lines** were incorrectly treated as empty strings, adding unwanted spaces to the final value.
2.  **Indented blank lines** were incorrectly detected as having 0 indentation, causing the parser to stop early and throw a `ParseException`.

For example, the following YAML would previously fail or parse incorrectly:

```yaml
key: unquoted scalar
  next line
  # this comment added an unwanted space (Bug 1)
  
  final line # The blank line above caused a ParseException (Bug 2)
another_key: value