### PR TITLE
[FrameworkBundle] Update deprecation message for `collect_serializer_data`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1053,7 +1053,7 @@ class FrameworkExtension extends Extension
         }
 
         if (false === $config['collect_serializer_data']) {
-            trigger_deprecation('symfony/framework-bundle', '7.3', 'Setting the "framework.profiler.collect_serializer_data" config option to "false" is deprecated.');
+            trigger_deprecation('symfony/framework-bundle', '7.3', 'Not setting the "framework.profiler.collect_serializer_data" config option to "true" is deprecated.');
         }
 
         if ($this->isInitializedConfigEnabled('serializer') && $config['collect_serializer_data']) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

"false" is the default value. The current deprecation message makes me think I have set `collect_serializer_data: false` in my configuration, but in fact it was not specified. That was the default configuration: https://github.com/symfony/recipes/blob/main/symfony/web-profiler-bundle/6.1/config/packages/web_profiler.yaml#L11

Related to https://github.com/symfony/symfony/pull/60069