### PR TITLE
 Release v7.3.7

### DIFF
--- a/CHANGELOG-7.3.md
+++ b/CHANGELOG-7.3.md
@@ -7,6 +7,11 @@ in 7.3 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v7.3.0...v7.3.1
 
+* 7.3.7 (2025-11-12)
+
+ * security #cve-2025-64500 [HttpFoundation] Fix parsing pathinfo with no leading slash (nicolas-grekas)
+ * bug #62333  Postal mailer transport message ID retrieval (lalcebo)
+
 * 7.3.6 (2025-11-06)
 
  * bug #62324 [HttpFoundation] Fix parsing hosts and schemes in URLs (nicolas-grekas)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -73,12 +73,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     private static array $freshCache = [];
 
-    public const VERSION = '7.3.7-DEV';
+    public const VERSION = '7.3.7';
     public const VERSION_ID = 70307;
     public const MAJOR_VERSION = 7;
     public const MINOR_VERSION = 3;
     public const RELEASE_VERSION = 7;
-    public const EXTRA_VERSION = 'DEV';
+    public const EXTRA_VERSION = '';
 
     public const END_OF_MAINTENANCE = '01/2026';
     public const END_OF_LIFE = '01/2026';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v7.3.6...v7.3.7)

 * security #cve-2025-64500 [HttpFoundation] Fix parsing pathinfo with no leading slash (@nicolas-grekas)
 * bug #62333  Postal mailer transport message ID retrieval (@lalcebo)
