### PR TITLE
[Mime] Remove unused  variable in Email::prepareParts

### DIFF
--- a/src/Symfony/Component/Mime/Email.php
+++ b/src/Symfony/Component/Mime/Email.php
@@ -507,7 +507,7 @@ class Email extends Message
                 }
 
                 if ($name !== $part->getContentId()) {
-                    $html = str_replace('cid:'.$name, 'cid:'.$part->getContentId(), $html, $count);
+                    $html = str_replace('cid:'.$name, 'cid:'.$part->getContentId(), $html);
                 }
                 $relatedParts[$name] = $part;
                 $part->setName($part->getContentId())->asInline();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR removes the unused `$count` variable from the `str_replace` call in `Email::prepareParts()`.

The logic that used this variable was removed in PR #47462 ([see this line](https://github.com/symfony/symfony/pull/47462/files#diff-b382f312f7b9933d6b86330d8fb833d008fb3493484e8c01cec37f0199c756fcL521)), but the variable itself was left behind. This is a minor cleanup.