### PR TITLE
[Mailer][Mailchimp] Add support for the Mandrill `return_path_domain` parameter

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add support for specifying the return path domain using the `X-MC-ReturnPathDomain` header
+
 7.4
 ---
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Transport/MandrillApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Transport/MandrillApiTransportTest.php
@@ -82,6 +82,21 @@ class MandrillApiTransportTest extends TestCase
         $this->assertArrayNotHasKey('headers', $payload['message']);
     }
 
+    public function testReturnPathDomainHeaderIsAddedToPayload()
+    {
+        $email = new Email();
+        $email->getHeaders()->addTextHeader('X-MC-ReturnPathDomain', 'foo-bar');
+        $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
+
+        $transport = new MandrillApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(MandrillApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertArrayHasKey('return_path_domain', $payload['message']);
+        $this->assertEquals('foo-bar', $payload['message']['return_path_domain']);
+        $this->assertArrayNotHasKey('headers', $payload['message']);
+    }
+
     public function testSend()
     {
         $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillApiTransport.php
@@ -97,6 +97,10 @@ class MandrillApiTransport extends AbstractApiTransport
             $payload['message']['subaccount'] = $email->getHeaders()->get('X-MC-Subaccount')->getBodyAsString();
         }
 
+        if ($email->getHeaders()->get('X-MC-ReturnPathDomain')) {
+            $payload['message']['return_path_domain'] = $email->getHeaders()->get('X-MC-ReturnPathDomain')->getBodyAsString();
+        }
+
         if ('' !== $envelope->getSender()->getName()) {
             $payload['message']['from_name'] = $envelope->getSender()->getName();
         }
@@ -125,7 +129,7 @@ class MandrillApiTransport extends AbstractApiTransport
         }
 
         foreach ($email->getHeaders()->all() as $name => $header) {
-            if (\in_array($name, ['from', 'to', 'cc', 'bcc', 'subject', 'content-type', 'x-mc-subaccount'], true)) {
+            if (\in_array($name, ['from', 'to', 'cc', 'bcc', 'subject', 'content-type', 'x-mc-subaccount', 'x-mc-returnpathdomain'], true)) {
                 continue;
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Adds support for the Mandrill `return_path_domain` parameter, set through the `X-Mc-ReturnPathDomain` header, following the same pattern as the existing `X-MC-Subaccount` support:

```php
$email = (new Email())
    ->from('from@example.com')
    ->to('to@example.com')
    ->text('Hello');

$email->getHeaders()->addTextHeader('X-Mc-ReturnPathDomain', 'mail.example.com');
```

The header is consumed into `message.return_path_domain` in the API payload and excluded from the headers passed through to Mandrill, again like `X-MC-Subaccount`.
