### PR TITLE
[Cache] Recognize saveDeferred events as writes in `CacheDataCollector`

### DIFF
--- a/src/Symfony/Component/Cache/DataCollector/CacheDataCollector.php
+++ b/src/Symfony/Component/Cache/DataCollector/CacheDataCollector.php
@@ -143,6 +143,8 @@ class CacheDataCollector extends DataCollector implements LateDataCollectorInter
                     }
                 } elseif ('save' === $call->name) {
                     ++$statistics[$name]['writes'];
+                } elseif ('saveDeferred' === $call->name) {
+                    ++$statistics[$name]['writes'];
                 } elseif ('deleteItem' === $call->name) {
                     ++$statistics[$name]['deletes'];
                 }

--- a/src/Symfony/Component/Cache/Tests/DataCollector/CacheDataCollectorTest.php
+++ b/src/Symfony/Component/Cache/Tests/DataCollector/CacheDataCollectorTest.php
@@ -86,6 +86,46 @@ class CacheDataCollectorTest extends TestCase
         $this->assertEquals($statistics[self::INSTANCE_NAME]['writes'], 1, 'writes');
     }
 
+    public function testSaveDeferredEventWithoutExplicitCommitDataCollector()
+    {
+        $traceableAdapterEvent = new \stdClass();
+        $traceableAdapterEvent->name = 'saveDeferred';
+        $traceableAdapterEvent->start = 0;
+        $traceableAdapterEvent->end = 0;
+
+        $statistics = $this->getCacheDataCollectorStatisticsFromEvents([$traceableAdapterEvent]);
+
+        $this->assertSame(1, $statistics[self::INSTANCE_NAME]['calls'], 'calls');
+        $this->assertSame(0, $statistics[self::INSTANCE_NAME]['reads'], 'reads');
+        $this->assertSame(0, $statistics[self::INSTANCE_NAME]['hits'], 'hits');
+        $this->assertSame(0, $statistics[self::INSTANCE_NAME]['misses'], 'misses');
+        $this->assertSame(1, $statistics[self::INSTANCE_NAME]['writes'], 'writes');
+    }
+
+    public function testSaveDeferredEventWithExplicitCommitDataCollector()
+    {
+        $traceableAdapterSaveDeferredEvent = new \stdClass();
+        $traceableAdapterSaveDeferredEvent->name = 'saveDeferred';
+        $traceableAdapterSaveDeferredEvent->start = 0;
+        $traceableAdapterSaveDeferredEvent->end = 0;
+
+        $traceableAdapterCommitEvent = new \stdClass();
+        $traceableAdapterCommitEvent->name = 'commit';
+        $traceableAdapterCommitEvent->start = 0;
+        $traceableAdapterCommitEvent->end = 0;
+
+        $statistics = $this->getCacheDataCollectorStatisticsFromEvents([
+            $traceableAdapterSaveDeferredEvent,
+            $traceableAdapterCommitEvent,
+        ]);
+
+        $this->assertSame(2, $statistics[self::INSTANCE_NAME]['calls'], 'calls');
+        $this->assertSame(0, $statistics[self::INSTANCE_NAME]['reads'], 'reads');
+        $this->assertSame(0, $statistics[self::INSTANCE_NAME]['hits'], 'hits');
+        $this->assertSame(0, $statistics[self::INSTANCE_NAME]['misses'], 'misses');
+        $this->assertSame(1, $statistics[self::INSTANCE_NAME]['writes'], 'writes');
+    }
+
     public function testCollectBeforeEnd()
     {
         $adapter = new TraceableAdapter(new NullAdapter());


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | none
| License       | MIT

I did not find any issues relating to this change.

Currently, `CacheDataCollector` does not increment any counter on calls to either `CacheItemPoolInterface::saveDeferred()` or `CacheItemPoolInterface::commit()`.

With this PR, we continue to ignore `saveDeferred()`, but now treat each call to `commit()` as one write, regardless of the success or failure of the call, similar to the current behavior with `save()`.

I added a test for the unchanged behavior on `saveDeferred()` to make that behavior explicit.
