### PR TITLE
[PropertyInfo] ReflectionMethod::setAccessible() is no-op since PHP 8.1

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -806,10 +806,6 @@ class ReflectionExtractorTest extends TestCase
         $reflection = new \ReflectionClass($this->extractor);
         $method = $reflection->getMethod('camelize');
 
-        if (\PHP_VERSION_ID < 80500) {
-            $method->setAccessible(true);
-        }
-
         $this->assertSame($expected, $method->invoke($this->extractor, $input));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

added in #62334, this allows to entirely remove it after merging into `7.3` like we did everywhere else
