### PR TITLE
[HttpFoundation] Fix RequestTest insulation

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/invalid_cookie_name.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/invalid_cookie_name.php
@@ -6,6 +6,6 @@ $r = require __DIR__.'/common.inc';
 
 try {
     $r->headers->setCookie(new Cookie('Hello + world', 'hodor', 0, null, null, null, false, true));
-} catch (\InvalidArgumentException $e) {
+} catch (InvalidArgumentException $e) {
     echo $e->getMessage();
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -31,6 +31,8 @@ class RequestTest extends TestCase
     {
         Request::setTrustedProxies([], -1);
         Request::setTrustedHosts([]);
+        Request::setFactory(null);
+        \Closure::bind(static fn () => self::$formats = null, null, Request::class)();
     }
 
     public function testInitialize()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Missing insulation is how we wrote bad tests in 7.4
Also addressing my patch proposal at
https://github.com/symfony/symfony/pull/62287#issuecomment-3523546436