### PR TITLE
[Runtime] SymfonyRuntime supports custom FrankenPHP worker runner

### DIFF
--- a/src/Symfony/Component/Runtime/Runner/FrankenPhpWorkerRunner.php
+++ b/src/Symfony/Component/Runtime/Runner/FrankenPhpWorkerRunner.php
@@ -37,20 +37,7 @@ class FrankenPhpWorkerRunner implements RunnerInterface
         $server = array_filter($_SERVER, static fn (string $key) => !str_starts_with($key, 'HTTP_'), \ARRAY_FILTER_USE_KEY);
         $server['APP_RUNTIME_MODE'] = 'web=1&worker=1';
 
-        $handler = function () use ($server, &$sfRequest, &$sfResponse): void {
-            // Connect to the Xdebug client if it's available
-            if (\extension_loaded('xdebug') && \function_exists('xdebug_connect_to_client')) {
-                xdebug_connect_to_client();
-            }
-
-            // Merge the environment variables coming from DotEnv with the ones tied to the current request
-            $_SERVER += $server;
-
-            $sfRequest = Request::createFromGlobals();
-            $sfResponse = $this->kernel->handle($sfRequest);
-
-            $sfResponse->send();
-        };
+        $handler = $this->getHandler($server, $sfRequest,$sfResponse);
 
         $loops = 0;
         do {
@@ -64,5 +51,23 @@ class FrankenPhpWorkerRunner implements RunnerInterface
         } while ($ret && (0 >= $this->loopMax || ++$loops < $this->loopMax));
 
         return 0;
+    }
+
+    protected function getHandler($server, &$sfRequest, &$sfResponse):callable
+    {
+        return function () use ($server, &$sfRequest, &$sfResponse): void {
+            // Connect to the Xdebug client if it's available
+            if (\extension_loaded('xdebug') && \function_exists('xdebug_connect_to_client')) {
+                xdebug_connect_to_client();
+            }
+
+            // Merge the environment variables coming from DotEnv with the ones tied to the current request
+            $_SERVER += $server;
+
+            $sfRequest = Request::createFromGlobals();
+            $sfResponse = $this->kernel->handle($sfRequest);
+
+            $sfResponse->send();
+        };
     }
 }

--- a/src/Symfony/Component/Runtime/SymfonyRuntime.php
+++ b/src/Symfony/Component/Runtime/SymfonyRuntime.php
@@ -91,6 +91,7 @@ class SymfonyRuntime extends GenericRuntime
      *   dotenv_overload?: ?bool,
      *   dotenv_extra_paths?: ?string[],
      *   worker_loop_max?: int, // Use 0 or a negative integer to never restart the worker. Default: 500
+     *   frankenphp_worker_runner_class?: class-string<FrankenPhpWorkerRunner>,
      * } $options
      */
     public function __construct(array $options = [])
@@ -153,6 +154,13 @@ class SymfonyRuntime extends GenericRuntime
 
         $options['worker_loop_max'] = (int) ($workerLoopMax ?? 500);
 
+        $frankenphpWorkerRunner= $options['frankenphp_worker_runner'] ?? $_SERVER['FRANKENPHP_WORKER_RUNNER'] ?? $_ENV['FRANKENPHP_WORKER_RUNNER'] ?? FrankenPhpWorkerRunner::class;
+
+        if(!is_a($frankenphpWorkerRunner, FrankenPhpWorkerRunner::class, true)) {
+            throw new \LogicException(\sprintf('The "frankenphp_worker_runner" runtime option must be a class-string of "%s", "%s" given.', FrankenPhpWorkerRunner::class, $frankenphpWorkerRunner));
+        }
+        $options['frankenphp_worker_runner'] = $frankenphpWorkerRunner;
+
         parent::__construct($options);
     }
 
@@ -160,7 +168,7 @@ class SymfonyRuntime extends GenericRuntime
     {
         if ($application instanceof HttpKernelInterface) {
             if ($_SERVER['FRANKENPHP_WORKER'] ?? false) {
-                return new FrankenPhpWorkerRunner($application, $this->options['worker_loop_max']);
+                return new $this->options['frankenphp_worker_runner']($application, $this->options['worker_loop_max']);
             }
 
             return new HttpKernelRunner($application, Request::createFromGlobals(), $this->options['debug'] ?? false);

--- a/src/Symfony/Component/Runtime/Tests/Support/FrankenPhpCustomWorkerRunner.php
+++ b/src/Symfony/Component/Runtime/Tests/Support/FrankenPhpCustomWorkerRunner.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Runtime\Tests\Support;
+
+use Symfony\Component\Runtime\Runner\FrankenPhpWorkerRunner;
+
+class FrankenPhpCustomWorkerRunner extends FrankenPhpWorkerRunner
+{
+
+}

--- a/src/Symfony/Component/Runtime/Tests/SymfonyRuntimeTest.php
+++ b/src/Symfony/Component/Runtime/Tests/SymfonyRuntimeTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Runtime\Runner\FrankenPhpWorkerRunner;
 use Symfony\Component\Runtime\SymfonyRuntime;
+use Symfony\Component\Runtime\Tests\Support\FrankenPhpCustomWorkerRunner;
 
 class SymfonyRuntimeTest extends TestCase
 {
@@ -49,5 +50,29 @@ class SymfonyRuntimeTest extends TestCase
         $this->expectExceptionMessage('The "worker_loop_max" runtime option must be an integer, "bool" given.');
 
         new SymfonyRuntime(['worker_loop_max' => false]);
+    }
+
+    public function testWithCustomWorkerRunner(){
+        $application = $this->createStub(HttpKernelInterface::class);
+
+        $runtime = new SymfonyRuntime(['frankenphp_worker_runner'=> FrankenPhpCustomWorkerRunner::class]);
+
+        try {
+            $this->assertInstanceOf(FrankenPhpCustomWorkerRunner::class, $runtime->getRunner($application));
+        } finally {
+            restore_error_handler();
+            restore_exception_handler();
+        }
+
+        $_SERVER['FRANKENPHP_WORKER'] = 1;
+        $_SERVER['FRANKENPHP_WORKER_RUNNER'] = FrankenPhpCustomWorkerRunner::class;
+        $runtime = new SymfonyRuntime();
+
+        try {
+            $this->assertInstanceOf(FrankenPhpCustomWorkerRunner::class, $runtime->getRunner($application));
+        } finally {
+            restore_error_handler();
+            restore_exception_handler();
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

We use tideways in our projects.
When frankenPHP run in worker mode we have to start and stop profiling by our own.

https://support.tideways.com/documentation/setup/installation/frankenphp.html#code-changes-to-frankenphp_handle_request-callback

This PR is a alternativ solution to #62130

I want to use a custom `FrankenPhpWorkerRunner` like:
```php
use Symfony\Component\Runtime\Runner\FrankenPhpWorkerRunner;

class FrankenPhpTidewaysmWorkerRunner extends FrankenPhpWorkerRunner
{
    protected function getHandler($server, &$sfRequest, &$sfResponse): callable
    {
        $handler = parent::getHandler($server, $sfRequest, $sfResponse);
        return static function () use ($handler) {
            \Tideways\Profiler::start();
            try {
                $handler();
            } catch (\Throwable $e) {
                \Tideways\Profiler::logException($e);
                throw $e;
            } finally {
                \Tideways\Profiler::stop();
            }
        };
    }
}
```

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
