### PR TITLE
[PropertyInfo] `ConstructorExtractor` can read from promoted properties

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SerializerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SerializerTest.php
@@ -21,19 +21,26 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class SerializerTest extends AbstractWebTestCase
 {
-    public function testDeserializeArrayOfObject()
+    /**
+     * @dataProvider provideDeserializeArrayOfObjectData
+     */
+    public function testDeserializeArrayOfObject(string $expectedClass, bool $usePromotedProperties, bool $withConstructorExtractor)
     {
-        static::bootKernel(['test_case' => 'Serializer']);
+        static::bootKernel(['test_case' => 'Serializer', 'root_config' => $withConstructorExtractor ? 'config.yml' : 'config_without_constructor_extractor.yml']);
 
-        $result = static::getContainer()->get('serializer.alias')->deserialize('{"bars": [{"id": 1}, {"id": 2}]}', Foo::class, 'json');
+        $result = static::getContainer()->get('serializer.alias')->deserialize('{"bars": [{"id": 1}, {"id": 2}]}', $expectedClass, 'json');
 
         $bar1 = new Bar();
         $bar1->id = 1;
         $bar2 = new Bar();
         $bar2->id = 2;
 
-        $expected = new Foo();
-        $expected->bars = [$bar1, $bar2];
+        if ($usePromotedProperties) {
+            $expected = new ($expectedClass)([$bar1, $bar2]);
+        } else {
+            $expected = new $expectedClass();
+            $expected->bars = [$bar1, $bar2];
+        }
 
         $this->assertEquals($expected, $result);
     }
@@ -63,6 +70,18 @@ class SerializerTest extends AbstractWebTestCase
     protected static function getKernelClass(): string
     {
         return SerializerKernel::class;
+    }
+
+    public function provideDeserializeArrayOfObjectData(): array
+    {
+        return [
+            ['expectedClass' => Foo::class, 'usePromotedProperties' => false, 'withConstructorExtractor' => false],
+            ['expectedClass' => FooVar::class, 'usePromotedProperties' => true, 'withConstructorExtractor' => false],
+            ['expectedClass' => FooParam::class, 'usePromotedProperties' => true, 'withConstructorExtractor' => false],
+            ['expectedClass' => Foo::class, 'usePromotedProperties' => false, 'withConstructorExtractor' => true],
+            ['expectedClass' => FooVar::class, 'usePromotedProperties' => true, 'withConstructorExtractor' => true],
+            ['expectedClass' => FooParam::class, 'usePromotedProperties' => true, 'withConstructorExtractor' => true],
+        ];
     }
 }
 
@@ -116,4 +135,26 @@ class Bar
      * @var int
      */
     public $id;
+}
+
+class FooVar
+{
+    public function __construct(
+        /**
+         * @var Bar[]
+         */
+        public array $bars,
+    ) {
+    }
+}
+
+class FooParam
+{
+    /**
+     * @param Bar[] $bars
+     */
+    public function __construct(
+        public array $bars,
+    ) {
+    }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Serializer/config_without_constructor_extractor.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Serializer/config_without_constructor_extractor.yml
@@ -1,0 +1,24 @@
+imports:
+    - { resource: ../config/default.yml }
+
+framework:
+    http_method_override: false
+    translator: true
+    serializer:
+        enabled: true
+        circular_reference_handler: Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Serializer\CircularReferenceHandler
+        max_depth_handler: Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Serializer\MaxDepthHandler
+        default_context:
+            enable_max_depth: true
+    property_info:
+        enabled: true
+        with_constructor_extractor: false
+
+services:
+    serializer.alias:
+        alias: serializer
+        public: true
+
+    Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Serializer\CircularReferenceHandler: ~
+
+    Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Serializer\MaxDepthHandler: ~

--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -186,12 +186,20 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
         $docBlock = $this->getDocBlockFromConstructor($class, $property);
 
         if (!$docBlock) {
-            return null;
+            // If no @param found in constructor docblock, try the promoted property's @var docblock
+            if (!$docBlock = $this->getDocBlockFromPromotedProperty($class, $property)) {
+                return null;
+            }
+
+            // For promoted properties, use @var tag instead of @param
+            $tags = $docBlock->getTagsByName('var');
+        } else {
+            $tags = $docBlock->getTagsByName('param');
         }
 
         $types = [];
         /** @var DocBlock\Tags\Var_|DocBlock\Tags\Return_|DocBlock\Tags\Param $tag */
-        foreach ($docBlock->getTagsByName('param') as $tag) {
+        foreach ($tags as $tag) {
             if ($tag && null !== $tag->getType()) {
                 $types[] = $this->phpDocTypeHelper->getTypes($tag->getType());
             }
@@ -266,12 +274,20 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
     public function getTypeFromConstructor(string $class, string $property): ?Type
     {
         if (!$docBlock = $this->getDocBlockFromConstructor($class, $property)) {
-            return null;
+            // If no @param found in constructor docblock, try the promoted property's @var docblock
+            if (!$docBlock = $this->getDocBlockFromPromotedProperty($class, $property)) {
+                return null;
+            }
+
+            // For promoted properties, use @var tag instead of @param
+            $tags = $docBlock->getTagsByName('var');
+        } else {
+            $tags = $docBlock->getTagsByName('param');
         }
 
         $types = [];
         /** @var DocBlock\Tags\Var_|DocBlock\Tags\Return_|DocBlock\Tags\Param $tag */
-        foreach ($docBlock->getTagsByName('param') as $tag) {
+        foreach ($tags as $tag) {
             if ($tag instanceof InvalidTag || !$tagType = $tag->getType()) {
                 continue;
             }
@@ -306,6 +322,25 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
 
             return $this->filterDocBlockParams($docBlock, $property);
         } catch (\InvalidArgumentException) {
+            return null;
+        }
+    }
+
+    private function getDocBlockFromPromotedProperty(string $class, string $property): ?DocBlock
+    {
+        try {
+            $reflectionProperty = new \ReflectionProperty($class, $property);
+        } catch (\ReflectionException) {
+            return null;
+        }
+
+        if (!$reflectionProperty->isPromoted()) {
+            return null;
+        }
+
+        try {
+            return $this->docBlockFactory->create($reflectionProperty, $this->createFromReflector($reflectionProperty->getDeclaringClass()));
+        } catch (\InvalidArgumentException|\RuntimeException) {
             return null;
         }
     }

--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -184,9 +184,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
         trigger_deprecation('symfony/property-info', '7.3', 'The "%s()" method is deprecated, use "%s::getTypeFromConstructor()" instead.', __METHOD__, self::class);
 
         // Give priority to @var declarations, fallback on @param on constructor if not found
-        $docBlock = $this->getDocBlockFromPromotedProperty($class, $property);
-
-        if (!$docBlock) {
+        if (!$docBlock = $this->getDocBlockFromPromotedProperty($class, $property)) {
             if (!$docBlock = $this->getDocBlockFromConstructor($class, $property)) {
                 return null;
             }

--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -183,18 +183,17 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
     {
         trigger_deprecation('symfony/property-info', '7.3', 'The "%s()" method is deprecated, use "%s::getTypeFromConstructor()" instead.', __METHOD__, self::class);
 
-        $docBlock = $this->getDocBlockFromConstructor($class, $property);
+        // Give priority to @var declarations, fallback on @param on constructor if not found
+        $docBlock = $this->getDocBlockFromPromotedProperty($class, $property);
 
         if (!$docBlock) {
-            // If no @param found in constructor docblock, try the promoted property's @var docblock
-            if (!$docBlock = $this->getDocBlockFromPromotedProperty($class, $property)) {
+            if (!$docBlock = $this->getDocBlockFromConstructor($class, $property)) {
                 return null;
             }
 
-            // For promoted properties, use @var tag instead of @param
-            $tags = $docBlock->getTagsByName('var');
-        } else {
             $tags = $docBlock->getTagsByName('param');
+        } else {
+            $tags = $docBlock->getTagsByName('var');
         }
 
         $types = [];
@@ -273,16 +272,15 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
 
     public function getTypeFromConstructor(string $class, string $property): ?Type
     {
-        if (!$docBlock = $this->getDocBlockFromConstructor($class, $property)) {
-            // If no @param found in constructor docblock, try the promoted property's @var docblock
-            if (!$docBlock = $this->getDocBlockFromPromotedProperty($class, $property)) {
+        // Give priority to @var declarations, fallback on @param if not found
+        if (!$docBlock = $this->getDocBlockFromPromotedProperty($class, $property)) {
+            if (!$docBlock = $this->getDocBlockFromConstructor($class, $property)) {
                 return null;
             }
 
-            // For promoted properties, use @var tag instead of @param
-            $tags = $docBlock->getTagsByName('var');
-        } else {
             $tags = $docBlock->getTagsByName('param');
+        } else {
+            $tags = $docBlock->getTagsByName('var');
         }
 
         $types = [];

--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
@@ -181,9 +181,9 @@ final class PhpStanExtractor implements PropertyDescriptionExtractorInterface, P
     {
         trigger_deprecation('symfony/property-info', '7.3', 'The "%s()" method is deprecated, use "%s::getTypeFromConstructor()" instead.', __METHOD__, self::class);
 
-        if (null === $tagDocNode = $this->getDocBlockFromConstructor($class, $property)) {
-            // If no @param found in constructor docblock, try the promoted property's @var docblock
-            if (null === $tagDocNode = $this->getDocBlockFromPromotedProperty($class, $property)) {
+        // Give priority to @var declarations, fallback on @param if not found
+        if (null === $tagDocNode = $this->getDocBlockFromPromotedProperty($class, $property)) {
+            if (null === $tagDocNode = $this->getDocBlockFromConstructor($class, $property)) {
                 return null;
             }
         }
@@ -249,9 +249,10 @@ final class PhpStanExtractor implements PropertyDescriptionExtractorInterface, P
     public function getTypeFromConstructor(string $class, string $property): ?Type
     {
         $declaringClass = $class;
-        if (!$tagDocNode = $this->getDocBlockFromConstructor($declaringClass, $property)) {
-            // If no @param found in constructor docblock, try the promoted property's @var docblock
-            if (!$tagDocNode = $this->getDocBlockFromPromotedProperty($class, $property)) {
+
+        // Give priority to @var declarations, fallback on @param if not found
+        if (!$tagDocNode = $this->getDocBlockFromPromotedProperty($declaringClass, $property)) {
+            if (!$tagDocNode = $this->getDocBlockFromConstructor($declaringClass, $property)) {
                 return null;
             }
         }
@@ -414,7 +415,7 @@ final class PhpStanExtractor implements PropertyDescriptionExtractorInterface, P
         return $tags[0]->value;
     }
 
-    private function getDocBlockFromPromotedProperty(string $class, string $property): ?VarTagValueNode
+    private function getDocBlockFromPromotedProperty(string &$class, string $property): ?VarTagValueNode
     {
         try {
             $reflectionProperty = new \ReflectionProperty($class, $property);
@@ -436,6 +437,7 @@ final class PhpStanExtractor implements PropertyDescriptionExtractorInterface, P
         }
 
         $phpDocNode = $this->getPhpDocNode($rawDocNode);
+        $class = $reflectionProperty->class;
 
         $tags = array_values(array_filter($phpDocNode->getTagsByName('@var'), fn ($tagNode) => $tagNode->value instanceof VarTagValueNode));
 

--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
@@ -182,10 +182,8 @@ final class PhpStanExtractor implements PropertyDescriptionExtractorInterface, P
         trigger_deprecation('symfony/property-info', '7.3', 'The "%s()" method is deprecated, use "%s::getTypeFromConstructor()" instead.', __METHOD__, self::class);
 
         // Give priority to @var declarations, fallback on @param if not found
-        if (null === $tagDocNode = $this->getDocBlockFromPromotedProperty($class, $property)) {
-            if (null === $tagDocNode = $this->getDocBlockFromConstructor($class, $property)) {
-                return null;
-            }
+        if (!$tagDocNode = $this->getDocBlockFromPromotedProperty($class, $property) ?? $this->getDocBlockFromConstructor($class, $property)) {
+            return null;
         }
 
         $types = [];
@@ -251,10 +249,8 @@ final class PhpStanExtractor implements PropertyDescriptionExtractorInterface, P
         $declaringClass = $class;
 
         // Give priority to @var declarations, fallback on @param if not found
-        if (!$tagDocNode = $this->getDocBlockFromPromotedProperty($declaringClass, $property)) {
-            if (!$tagDocNode = $this->getDocBlockFromConstructor($declaringClass, $property)) {
-                return null;
-            }
+        if (!$tagDocNode = $this->getDocBlockFromPromotedProperty($declaringClass, $property) ?? $this->getDocBlockFromConstructor($declaringClass, $property)) {
+            return null;
         }
 
         $typeContext = $this->typeContextFactory->createFromClassName($class, $declaringClass);
@@ -431,21 +427,16 @@ final class PhpStanExtractor implements PropertyDescriptionExtractorInterface, P
             return null;
         }
 
-        $rawDocNode = $reflectionProperty->getDocComment();
-        if (!$rawDocNode) {
+        if (!$rawDocNode = $reflectionProperty->getDocComment()) {
             return null;
         }
 
         $phpDocNode = $this->getPhpDocNode($rawDocNode);
         $class = $reflectionProperty->class;
 
-        $tags = array_values(array_filter($phpDocNode->getTagsByName('@var'), fn ($tagNode) => $tagNode->value instanceof VarTagValueNode));
+        $tags = array_values(array_filter($phpDocNode->getTagsByName('@var'), static fn ($tagNode) => $tagNode->value instanceof VarTagValueNode));
 
-        if (!$tags) {
-            return null;
-        }
-
-        return $tags[0]->value;
+        return $tags ? $tags[0]->value : null;
     }
 
     /**

--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
@@ -182,7 +182,10 @@ final class PhpStanExtractor implements PropertyDescriptionExtractorInterface, P
         trigger_deprecation('symfony/property-info', '7.3', 'The "%s()" method is deprecated, use "%s::getTypeFromConstructor()" instead.', __METHOD__, self::class);
 
         if (null === $tagDocNode = $this->getDocBlockFromConstructor($class, $property)) {
-            return null;
+            // If no @param found in constructor docblock, try the promoted property's @var docblock
+            if (null === $tagDocNode = $this->getDocBlockFromPromotedProperty($class, $property)) {
+                return null;
+            }
         }
 
         $types = [];
@@ -247,7 +250,10 @@ final class PhpStanExtractor implements PropertyDescriptionExtractorInterface, P
     {
         $declaringClass = $class;
         if (!$tagDocNode = $this->getDocBlockFromConstructor($declaringClass, $property)) {
-            return null;
+            // If no @param found in constructor docblock, try the promoted property's @var docblock
+            if (!$tagDocNode = $this->getDocBlockFromPromotedProperty($class, $property)) {
+                return null;
+            }
         }
 
         $typeContext = $this->typeContextFactory->createFromClassName($class, $declaringClass);
@@ -400,6 +406,38 @@ final class PhpStanExtractor implements PropertyDescriptionExtractorInterface, P
     private function filterDocBlockParams(PhpDocNode $docNode, string $allowedParam): ?ParamTagValueNode
     {
         $tags = array_values(array_filter($docNode->getTagsByName('@param'), fn ($tagNode) => $tagNode instanceof PhpDocTagNode && ('$'.$allowedParam) === $tagNode->value->parameterName));
+
+        if (!$tags) {
+            return null;
+        }
+
+        return $tags[0]->value;
+    }
+
+    private function getDocBlockFromPromotedProperty(string $class, string $property): ?VarTagValueNode
+    {
+        try {
+            $reflectionProperty = new \ReflectionProperty($class, $property);
+        } catch (\ReflectionException) {
+            return null;
+        }
+
+        if (!$reflectionProperty->isPromoted()) {
+            return null;
+        }
+
+        if (!$this->canAccessMemberBasedOnItsVisibility($reflectionProperty)) {
+            return null;
+        }
+
+        $rawDocNode = $reflectionProperty->getDocComment();
+        if (!$rawDocNode) {
+            return null;
+        }
+
+        $phpDocNode = $this->getPhpDocNode($rawDocNode);
+
+        $tags = array_values(array_filter($phpDocNode->getTagsByName('@var'), fn ($tagNode) => $tagNode->value instanceof VarTagValueNode));
 
         if (!$tags) {
             return null;

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyCollection;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\InvalidDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\ParentDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php80Dummy;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\Php80PromotedDummyWithDocblock;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\PseudoTypeDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\PseudoTypesDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\TraitUsage\DummyUsedInTrait;
@@ -885,6 +886,23 @@ class PhpDocExtractorTest extends TestCase
         yield ['dateTime', null];
         yield ['ddd', null];
         yield ['mixed', Type::mixed()];
+    }
+
+    /**
+     * @dataProvider constructorPromotedPropertyWithDocblockProvider
+     */
+    public function testExtractConstructorPromotedPropertyWithDocblock(string $property, ?Type $type)
+    {
+        $this->assertEquals($type, $this->extractor->getTypeFromConstructor(Php80PromotedDummyWithDocblock::class, $property));
+    }
+
+    /**
+     * @return iterable<array{0: string, 1: ?Type}>
+     */
+    public static function constructorPromotedPropertyWithDocblockProvider(): iterable
+    {
+        // Test that promoted properties with @var docblock are recognized
+        yield ['dates', Type::list(Type::object(\DateTimeImmutable::class))];
     }
 
     /**

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
@@ -903,6 +903,7 @@ class PhpDocExtractorTest extends TestCase
     {
         // Test that promoted properties with @var docblock are recognized
         yield ['dates', Type::list(Type::object(\DateTimeImmutable::class))];
+        yield ['datesWithIncoherentDocBlock', Type::list(Type::object(\DateTimeImmutable::class))];
     }
 
     /**

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
@@ -963,6 +963,7 @@ class PhpStanExtractorTest extends TestCase
     {
         // Test that promoted properties with @var docblock are recognized
         yield ['dates', Type::list(Type::object(\DateTimeImmutable::class))];
+        yield ['datesWithIncoherentDocBlock', Type::list(Type::object(\DateTimeImmutable::class))];
     }
 
     /**

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
@@ -35,6 +35,7 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\InvalidDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\ParentDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php80Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php80PromotedDummy;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\Php80PromotedDummyWithDocblock;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\PhpStanPseudoTypesDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\RootDummy\RootDummyItem;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\TraitUsage\AnotherNamespace\DummyInAnotherNamespace;
@@ -945,6 +946,23 @@ class PhpStanExtractorTest extends TestCase
         yield ['dateObject', Type::object(\DateTimeInterface::class)];
         yield ['dateTime', null];
         yield ['ddd', null];
+    }
+
+    /**
+     * @dataProvider constructorPromotedPropertyWithDocblockProvider
+     */
+    public function testExtractConstructorPromotedPropertyWithDocblock(string $property, ?Type $type)
+    {
+        $this->assertEquals($type, $this->extractor->getTypeFromConstructor(Php80PromotedDummyWithDocblock::class, $property));
+    }
+
+    /**
+     * @return iterable<array{0: string, 1: ?Type}>
+     */
+    public static function constructorPromotedPropertyWithDocblockProvider(): iterable
+    {
+        // Test that promoted properties with @var docblock are recognized
+        yield ['dates', Type::list(Type::object(\DateTimeImmutable::class))];
     }
 
     /**

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -30,6 +30,7 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\Php74Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php7Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php7ParentDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php80Dummy;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\Php80PromotedDummyWithDocblock;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php81Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php82Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\SnakeCaseDummy;
@@ -1062,6 +1063,23 @@ class ReflectionExtractorTest extends TestCase
         yield ['dateObject', null];
         yield ['dateTime', Type::object(\DateTimeImmutable::class)];
         yield ['ddd', null];
+    }
+
+    /**
+     * @dataProvider constructorPromotedPropertyWithDocblockProvider
+     */
+    public function testExtractConstructorPromotedPropertyWithDocblock(string $property, ?Type $type)
+    {
+        $this->assertEquals($type, $this->extractor->getTypeFromConstructor(Php80PromotedDummyWithDocblock::class, $property));
+    }
+
+    /**
+     * @return iterable<array{0: string, 1: ?Type}>
+     */
+    public static function constructorPromotedPropertyWithDocblockProvider(): iterable
+    {
+        // ReflectionExtractor can only extract native PHP types, not generic types from docblocks
+        yield ['dates', Type::array()];
     }
 
     /**

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Php80PromotedDummyWithDocblock.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Php80PromotedDummyWithDocblock.php
@@ -13,16 +13,28 @@ namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
 
 class Php80PromotedDummyWithDocblock
 {
+    /**
+     * @param \DateTime[] $datesWithIncoherentDocBlock
+     */
     public function __construct(
         /**
          * @var \DateTimeImmutable[]
          */
         private array $dates,
+        /**
+         * @var \DateTimeImmutable[] $datesWithIncoherentDocBlock
+         */
+        private array $datesWithIncoherentDocBlock,
     ) {
     }
 
     public function getDates(): array
     {
         return $this->dates;
+    }
+
+    public function getDatesWithIncoherentDocBlock(): array
+    {
+        return $this->datesWithIncoherentDocBlock;
     }
 }

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Php80PromotedDummyWithDocblock.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Php80PromotedDummyWithDocblock.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+class Php80PromotedDummyWithDocblock
+{
+    public function __construct(
+        /**
+         * @var \DateTimeImmutable[]
+         */
+        private array $dates,
+    ) {
+    }
+
+    public function getDates(): array
+    {
+        return $this->dates;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Issues        | Fix #60795
| License       | MIT

The issue #60795 and the discussion #62045 describes a BC Break with symfony 7.3 regarding the `ConstructorExtractor`. Old behavior could extract types from promoted properties docblock, while the new behavior only works with the function docblock. As the last `ConstructorExtractor` is `ReflectionExtractor`, the extraction fails to provide an accurate description typed arrays, leading to incorrect deserialization.
This PR adds a fallback to read docblock from promoted properties too, to restore the original behavior.