### PR TITLE
[TypeInfo] Simple array should be array type

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/PropertyInfoTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/PropertyInfoTest.php
@@ -26,7 +26,7 @@ class PropertyInfoTest extends AbstractWebTestCase
             $this->markTestSkipped();
         }
 
-        $this->assertEquals(Type::list(Type::int()), $propertyInfo->getType(Dummy::class, 'codes'));
+        $this->assertEquals(Type::array(Type::int()), $propertyInfo->getType(Dummy::class, 'codes'));
     }
 
     /**

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Model/DummyWithList.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Model/DummyWithList.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\JsonStreamer\Tests\Fixtures\Model;
+
+class DummyWithList
+{
+    /** @var list<ClassicDummy> */
+    public array $dummies;
+
+    public string $customProperty;
+}

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Model/DummyWithNestedList.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Model/DummyWithNestedList.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\JsonStreamer\Tests\Fixtures\Model;
+
+class DummyWithNestedList
+{
+    /** @var list<DummyWithList> */
+    public array $dummies;
+
+    public string $stringProperty;
+}

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/double_nested_array.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/double_nested_array.php
@@ -1,0 +1,40 @@
+<?php
+
+return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
+    try {
+        yield '[';
+        $prefix = '';
+        foreach ($data as $value1) {
+            yield $prefix;
+            yield '{"dummies":{';
+            $prefix = '';
+            foreach ($value1->dummies as $key2 => $value2) {
+                $key2 = is_int($key2) ? $key2 : \substr(\json_encode($key2), 1, -1);
+                yield "{$prefix}\"{$key2}\":";
+                yield '{"dummies":{';
+                $prefix = '';
+                foreach ($value2->dummies as $key3 => $value3) {
+                    $key3 = is_int($key3) ? $key3 : \substr(\json_encode($key3), 1, -1);
+                    yield "{$prefix}\"{$key3}\":";
+                    yield '{"id":';
+                    yield \json_encode($value3->id, \JSON_THROW_ON_ERROR, 506);
+                    yield ',"name":';
+                    yield \json_encode($value3->name, \JSON_THROW_ON_ERROR, 506);
+                    yield '}';
+                    $prefix = ',';
+                }
+                yield '},"customProperty":';
+                yield \json_encode($value2->customProperty, \JSON_THROW_ON_ERROR, 508);
+                yield '}';
+                $prefix = ',';
+            }
+            yield '},"stringProperty":';
+            yield \json_encode($value1->stringProperty, \JSON_THROW_ON_ERROR, 510);
+            yield '}';
+            $prefix = ',';
+        }
+        yield ']';
+    } catch (\JsonException $e) {
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+    }
+};

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nested_array.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nested_array.php
@@ -1,0 +1,30 @@
+<?php
+
+return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
+    try {
+        yield '[';
+        $prefix = '';
+        foreach ($data as $value1) {
+            yield $prefix;
+            yield '{"dummies":{';
+            $prefix = '';
+            foreach ($value1->dummies as $key2 => $value2) {
+                $key2 = is_int($key2) ? $key2 : \substr(\json_encode($key2), 1, -1);
+                yield "{$prefix}\"{$key2}\":";
+                yield '{"id":';
+                yield \json_encode($value2->id, \JSON_THROW_ON_ERROR, 508);
+                yield ',"name":';
+                yield \json_encode($value2->name, \JSON_THROW_ON_ERROR, 508);
+                yield '}';
+                $prefix = ',';
+            }
+            yield '},"customProperty":';
+            yield \json_encode($value1->customProperty, \JSON_THROW_ON_ERROR, 510);
+            yield '}';
+            $prefix = ',';
+        }
+        yield ']';
+    } catch (\JsonException $e) {
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+    }
+};

--- a/src/Symfony/Component/JsonStreamer/Tests/JsonStreamWriterTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/JsonStreamWriterTest.php
@@ -19,8 +19,10 @@ use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithArray;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDateTimes;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithGenerics;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithList;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNestedArray;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNestedList;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNullableProperties;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithPhpDoc;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithUnionProperties;
@@ -119,7 +121,7 @@ class JsonStreamWriterTest extends TestCase
         $dummyWithArray2->customProperty = 'customProperty2';
 
         $this->assertWritten(
-            '[{"dummies":[{"id":1,"name":"dummy"}],"customProperty":"customProperty1"},{"dummies":[{"id":1,"name":"dummy"}],"customProperty":"customProperty2"}]',
+            '[{"dummies":{"0":{"id":1,"name":"dummy"}},"customProperty":"customProperty1"},{"dummies":{"0":{"id":1,"name":"dummy"}},"customProperty":"customProperty2"}]',
             [$dummyWithArray1, $dummyWithArray2],
             Type::list(Type::object(DummyWithArray::class)),
         );
@@ -133,9 +135,37 @@ class JsonStreamWriterTest extends TestCase
         $dummyWithNestedArray2->stringProperty = 'stringProperty2';
 
         $this->assertWritten(
-            '[{"dummies":[{"dummies":[{"id":1,"name":"dummy"}],"customProperty":"customProperty1"}],"stringProperty":"stringProperty1"},{"dummies":[{"dummies":[{"id":1,"name":"dummy"}],"customProperty":"customProperty2"}],"stringProperty":"stringProperty2"}]',
+            '[{"dummies":{"0":{"dummies":{"0":{"id":1,"name":"dummy"}},"customProperty":"customProperty1"}},"stringProperty":"stringProperty1"},{"dummies":{"0":{"dummies":{"0":{"id":1,"name":"dummy"}},"customProperty":"customProperty2"}},"stringProperty":"stringProperty2"}]',
             [$dummyWithNestedArray1, $dummyWithNestedArray2],
             Type::list(Type::object(DummyWithNestedArray::class)),
+        );
+
+        $dummyWithList1 = new DummyWithList();
+        $dummyWithList1->dummies = [new ClassicDummy()];
+        $dummyWithList1->customProperty = 'customProperty1';
+
+        $dummyWithList2 = new DummyWithList();
+        $dummyWithList2->dummies = [new ClassicDummy()];
+        $dummyWithList2->customProperty = 'customProperty2';
+
+        $this->assertWritten(
+            '[{"dummies":[{"id":1,"name":"dummy"}],"customProperty":"customProperty1"},{"dummies":[{"id":1,"name":"dummy"}],"customProperty":"customProperty2"}]',
+            [$dummyWithList1, $dummyWithList2],
+            Type::list(Type::object(DummyWithList::class)),
+        );
+
+        $dummyWithNestedList1 = new DummyWithNestedList();
+        $dummyWithNestedList1->dummies = [$dummyWithList1];
+        $dummyWithNestedList1->stringProperty = 'stringProperty1';
+
+        $dummyWithNestedList2 = new DummyWithNestedList();
+        $dummyWithNestedList2->dummies = [$dummyWithList2];
+        $dummyWithNestedList2->stringProperty = 'stringProperty2';
+
+        $this->assertWritten(
+            '[{"dummies":[{"dummies":[{"id":1,"name":"dummy"}],"customProperty":"customProperty1"}],"stringProperty":"stringProperty1"},{"dummies":[{"dummies":[{"id":1,"name":"dummy"}],"customProperty":"customProperty2"}],"stringProperty":"stringProperty2"}]',
+            [$dummyWithNestedList1, $dummyWithNestedList2],
+            Type::list(Type::object(DummyWithNestedList::class)),
         );
     }
 

--- a/src/Symfony/Component/JsonStreamer/Tests/Write/StreamWriterGeneratorTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Write/StreamWriterGeneratorTest.php
@@ -22,8 +22,10 @@ use Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyEnum;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithArray;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithList;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNestedArray;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNestedList;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithOtherDummies;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithUnionProperties;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithValueTransformerAttributes;
@@ -95,8 +97,11 @@ class StreamWriterGeneratorTest extends TestCase
         yield ['null_list', Type::list(Type::null())];
         yield ['object_list', Type::list(Type::object(DummyWithNameAttributes::class))];
         yield ['nullable_object_list', Type::nullable(Type::list(Type::object(DummyWithNameAttributes::class)))];
-        yield ['nested_list', Type::list(Type::object(DummyWithArray::class))];
-        yield ['double_nested_list', Type::list(Type::object(DummyWithNestedArray::class))];
+        yield ['nested_list', Type::list(Type::object(DummyWithList::class))];
+        yield ['double_nested_list', Type::list(Type::object(DummyWithNestedList::class))];
+
+        yield ['nested_array', Type::list(Type::object(DummyWithArray::class))];
+        yield ['double_nested_array', Type::list(Type::object(DummyWithNestedArray::class))];
 
         yield ['dict', Type::dict()];
         yield ['object_dict', Type::dict(Type::object(DummyWithNameAttributes::class))];

--- a/src/Symfony/Component/JsonStreamer/composer.json
+++ b/src/Symfony/Component/JsonStreamer/composer.json
@@ -21,7 +21,7 @@
         "psr/container": "^1.1|^2.0",
         "psr/log": "^1|^2|^3",
         "symfony/filesystem": "^7.2",
-        "symfony/type-info": "^7.3.3",
+        "symfony/type-info": "~7.3.8|^7.4.1",
         "symfony/var-exporter": "^7.2"
     },
     "require-dev": {

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
@@ -691,12 +691,12 @@ class PhpStanExtractorTest extends TestCase
         yield ['foo2', Type::float()];
         yield ['foo3', Type::callable()];
         yield ['foo5', Type::mixed()];
-        yield ['files', Type::union(Type::list(Type::object(\SplFileInfo::class)), Type::resource()), null, null];
+        yield ['files', Type::union(Type::array(Type::object(\SplFileInfo::class)), Type::resource()), null, null];
         yield ['bal', Type::object(\DateTimeImmutable::class)];
         yield ['parent', Type::object(ParentDummy::class)];
-        yield ['collection', Type::list(Type::object(\DateTimeImmutable::class))];
-        yield ['nestedCollection', Type::list(Type::list(Type::string()))];
-        yield ['mixedCollection', Type::list()];
+        yield ['collection', Type::array(Type::object(\DateTimeImmutable::class))];
+        yield ['nestedCollection', Type::array(Type::array(Type::string()))];
+        yield ['mixedCollection', Type::array(Type::mixed())];
         yield ['a', Type::int()];
         yield ['b', Type::nullable(Type::object(ParentDummy::class))];
         yield ['c', Type::nullable(Type::bool())];
@@ -707,7 +707,7 @@ class PhpStanExtractorTest extends TestCase
         yield ['h', Type::nullable(Type::string())];
         yield ['i', Type::union(Type::int(), Type::string(), Type::null())];
         yield ['j', Type::nullable(Type::object(\DateTimeImmutable::class))];
-        yield ['nullableCollectionOfNonNullableElements', Type::nullable(Type::list(Type::int()))];
+        yield ['nullableCollectionOfNonNullableElements', Type::nullable(Type::array(Type::int()))];
         yield ['donotexist', null];
         yield ['staticGetter', null];
         yield ['staticSetter', null];
@@ -716,7 +716,7 @@ class PhpStanExtractorTest extends TestCase
         yield ['arrayOfMixed', Type::dict(Type::mixed())];
         yield ['listOfStrings', Type::list(Type::string())];
         yield ['self', Type::object(Dummy::class)];
-        yield ['rootDummyItems', Type::list(Type::object(RootDummyItem::class))];
+        yield ['rootDummyItems', Type::array(Type::object(RootDummyItem::class))];
         yield ['rootDummyItem', Type::object(RootDummyItem::class)];
         yield ['collectionAsObject', Type::collection(Type::object(DummyCollection::class), Type::string(), Type::int())];
     }
@@ -767,12 +767,12 @@ class PhpStanExtractorTest extends TestCase
         yield ['foo2', Type::float()];
         yield ['foo3', Type::callable()];
         yield ['foo5', Type::mixed()];
-        yield ['files', Type::union(Type::list(Type::object(\SplFileInfo::class)), Type::resource())];
+        yield ['files', Type::union(Type::array(Type::object(\SplFileInfo::class)), Type::resource())];
         yield ['bal', Type::object(\DateTimeImmutable::class)];
         yield ['parent', Type::object(ParentDummy::class)];
-        yield ['collection', Type::list(Type::object(\DateTimeImmutable::class))];
-        yield ['nestedCollection', Type::list(Type::list(Type::string()))];
-        yield ['mixedCollection', Type::list()];
+        yield ['collection', Type::array(Type::object(\DateTimeImmutable::class))];
+        yield ['nestedCollection', Type::array(Type::array(Type::string()))];
+        yield ['mixedCollection', Type::array(Type::mixed())];
         yield ['a', null];
         yield ['b', null];
         yield ['c', null];
@@ -783,7 +783,7 @@ class PhpStanExtractorTest extends TestCase
         yield ['h', Type::nullable(Type::string())];
         yield ['i', Type::union(Type::int(), Type::string(), Type::null())];
         yield ['j', Type::nullable(Type::object(\DateTimeImmutable::class))];
-        yield ['nullableCollectionOfNonNullableElements', Type::nullable(Type::list(Type::int()))];
+        yield ['nullableCollectionOfNonNullableElements', Type::nullable(Type::array(Type::int()))];
         yield ['donotexist', null];
         yield ['staticGetter', null];
         yield ['staticSetter', null];
@@ -830,12 +830,12 @@ class PhpStanExtractorTest extends TestCase
         yield ['foo2', Type::float()];
         yield ['foo3', Type::callable()];
         yield ['foo5', Type::mixed()];
-        yield ['files', Type::union(Type::list(Type::object(\SplFileInfo::class)), Type::resource())];
+        yield ['files', Type::union(Type::array(Type::object(\SplFileInfo::class)), Type::resource())];
         yield ['bal', Type::object(\DateTimeImmutable::class)];
         yield ['parent', Type::object(ParentDummy::class)];
-        yield ['collection', Type::list(Type::object(\DateTimeImmutable::class))];
-        yield ['nestedCollection', Type::list(Type::list(Type::string()))];
-        yield ['mixedCollection', Type::list()];
+        yield ['collection', Type::array(Type::object(\DateTimeImmutable::class))];
+        yield ['nestedCollection', Type::array(Type::array(Type::string()))];
+        yield ['mixedCollection', Type::array(Type::mixed())];
         yield ['a', null];
         yield ['b', null];
         yield ['c', Type::nullable(Type::bool())];
@@ -846,7 +846,7 @@ class PhpStanExtractorTest extends TestCase
         yield ['h', Type::nullable(Type::string())];
         yield ['i', Type::union(Type::int(), Type::string(), Type::null())];
         yield ['j', Type::nullable(Type::object(\DateTimeImmutable::class))];
-        yield ['nullableCollectionOfNonNullableElements', Type::nullable(Type::list(Type::int()))];
+        yield ['nullableCollectionOfNonNullableElements', Type::nullable(Type::array(Type::int()))];
         yield ['nonNullableCollectionOfNullableElements', Type::array(Type::nullable(Type::int()))];
         yield ['nullableCollectionOfMultipleNonNullableElementTypes', Type::nullable(Type::array(Type::union(Type::int(), Type::string())))];
         yield ['donotexist', null];
@@ -976,16 +976,16 @@ class PhpStanExtractorTest extends TestCase
     public static function unionTypesProvider(): iterable
     {
         yield ['a', Type::union(Type::string(), Type::int())];
-        yield ['b', Type::list(Type::union(Type::string(), Type::int()))];
+        yield ['b', Type::array(Type::union(Type::string(), Type::int()))];
         yield ['c', Type::array(Type::union(Type::string(), Type::int()))];
         yield ['d', Type::array(Type::array(Type::string()), Type::union(Type::string(), Type::int()))];
         yield ['e', Type::union(
             Type::generic(
                 Type::object(Dummy::class),
-                Type::array(Type::string(), Type::mixed()),
+                Type::array(Type::string()),
                 Type::union(
                     Type::int(),
-                    Type::list(Type::collection(Type::object(\Traversable::class), Type::object(DefaultValue::class))),
+                    Type::array(Type::collection(Type::object(\Traversable::class), Type::object(DefaultValue::class))),
                 ),
             ),
             Type::object(ParentDummy::class),

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyUnionType.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyUnionType.php
@@ -40,7 +40,7 @@ class DummyUnionType
     public $d;
 
     /**
-     * @var (Dummy<array<mixed, string>, (int | (\Traversable<DefaultValue>)[])> | ParentDummy | null)
+     * @var (Dummy<array<string>, (int | (\Traversable<DefaultValue>)[])> | ParentDummy | null)
      */
     public $e;
 

--- a/src/Symfony/Component/PropertyInfo/composer.json
+++ b/src/Symfony/Component/PropertyInfo/composer.json
@@ -26,7 +26,7 @@
         "php": ">=8.2",
         "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/string": "^6.4|^7.0",
-        "symfony/type-info": "^7.3.5"
+        "symfony/type-info": "~7.3.8|^7.4.1"
     },
     "require-dev": {
         "symfony/serializer": "^6.4|^7.0",

--- a/src/Symfony/Component/TypeInfo/Tests/TypeResolver/StringTypeResolverTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeResolver/StringTypeResolverTest.php
@@ -73,7 +73,16 @@ class StringTypeResolverTest extends TestCase
         yield [Type::callable(), 'callable(string, int): mixed'];
 
         // array
-        yield [Type::list(Type::bool()), 'bool[]'];
+        yield [Type::array(Type::bool()), 'bool[]'];
+        yield [Type::array(Type::bool()), 'array<bool>'];
+        yield [Type::array(Type::bool(), Type::int()), 'array<int, bool>'];
+        yield [Type::array(Type::bool(), Type::arrayKey()), 'array<array-key, bool>'];
+        yield [Type::array(Type::bool(), Type::arrayKey()), 'array<int|string, bool>'];
+        yield [Type::array(Type::bool(), Type::arrayKey()), 'non-empty-array<int|string, bool>'];
+
+        // list
+        yield [Type::list(Type::bool()), 'list<bool>'];
+        yield [Type::list(Type::bool()), 'non-empty-list<bool>'];
 
         // array shape
         yield [Type::arrayShape(['foo' => Type::true(), 1 => Type::false()]), 'array{foo: true, 1: false}'];
@@ -252,5 +261,29 @@ class StringTypeResolverTest extends TestCase
     {
         $this->expectException(UnsupportedException::class);
         $this->resolver->resolve('value-of<int>');
+    }
+
+    public function testCannotResolveListWithKeyType()
+    {
+        $this->expectException(UnsupportedException::class);
+        $this->resolver->resolve('list<int, string>');
+    }
+
+    public function testCannotResolveInvalidNonEmptyListWithKeyType()
+    {
+        $this->expectException(UnsupportedException::class);
+        $this->resolver->resolve('non-empty-list<int, string>');
+    }
+
+    public function testCannotResolveInvalidArrayKeyType()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->resolver->resolve('array<mixed, string>');
+    }
+
+    public function testCannotResolveInvalidUnionArrayKeyType()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->resolver->resolve('array<int|mixed, string>');
     }
 }

--- a/src/Symfony/Component/TypeInfo/Type/CollectionType.php
+++ b/src/Symfony/Component/TypeInfo/Type/CollectionType.php
@@ -49,6 +49,16 @@ class CollectionType extends Type implements WrappingTypeInterface
             if (!$keyType instanceof BuiltinType || TypeIdentifier::INT !== $keyType->getTypeIdentifier()) {
                 throw new InvalidArgumentException(\sprintf('"%s" is not a valid list key type.', (string) $keyType));
             }
+        } elseif ($type instanceof GenericType && $type->getWrappedType() instanceof BuiltinType && TypeIdentifier::ARRAY === $type->getWrappedType()->getTypeIdentifier()) {
+            $keyType = $this->getCollectionKeyType();
+
+            $keyTypes = $keyType instanceof UnionType ? $keyType->getTypes() : [$keyType];
+
+            foreach ($keyTypes as $type) {
+                if (!$type instanceof BuiltinType || !\in_array($type->getTypeIdentifier(), [TypeIdentifier::INT, TypeIdentifier::STRING], true)) {
+                    throw new InvalidArgumentException(\sprintf('"%s" is not a valid array key type.', (string) $keyType));
+                }
+            }
         }
     }
 

--- a/src/Symfony/Component/TypeInfo/TypeResolver/StringTypeResolver.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/StringTypeResolver.php
@@ -100,7 +100,7 @@ final class StringTypeResolver implements TypeResolverInterface
         }
 
         if ($node instanceof ArrayTypeNode) {
-            return Type::list($this->getTypeFromNode($node->type, $typeContext));
+            return Type::array($this->getTypeFromNode($node->type, $typeContext));
         }
 
         if ($node instanceof ArrayShapeNode) {
@@ -263,6 +263,10 @@ final class StringTypeResolver implements TypeResolverInterface
                 if (1 === \count($variableTypes)) {
                     return new CollectionType(Type::generic($type, $keyType, $variableTypes[0]), $asList);
                 } elseif (2 === \count($variableTypes)) {
+                    if ($asList) {
+                        throw new \DomainException(\sprintf('"%s" type cannot have a key type defined.', $node->type));
+                    }
+
                     return Type::collection($type, $variableTypes[1], $variableTypes[0], $asList);
                 }
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

While using latest Symfony Live Components we detected that simple array docblocks (`bool[]`) were parsed as list type instead of array type. I couldn't find any documentation on what's officially known as list vs. array, as PHP does not really distinguish between list and array. It is my understanding hower that using `bool[]` means array. PHPstan docs also mentions `Type[]` being array (https://phpstan.org/writing-php-code/phpdoc-types)
I've added a few tests to verify the new behaviour.

I also added an extra check for which key types are supported for arrays (with tests). I'm not sure if these should go in this PR, or if I should add a second PR for this.

