### PR TITLE
[Routing] Align routing.schema.json with YamlFileLoader behavior

### DIFF
--- a/src/Symfony/Component/Routing/Loader/schema/routing.schema.json
+++ b/src/Symfony/Component/Routing/Loader/schema/routing.schema.json
@@ -62,7 +62,17 @@
         "locale": { "type": "string" },
         "format": { "type": "string" },
         "utf8": { "type": "boolean" },
-        "stateless": { "type": "boolean" }
+        "stateless": { "type": "boolean" },
+        "deprecated": {
+          "type": "object",
+          "properties": {
+            "package": { "type": "string" },
+            "version": { "type": "string" },
+            "message": { "type": "string" }
+          },
+          "required": ["package", "version"],
+          "additionalProperties": false
+        }
       },
       "required": ["path"],
       "additionalProperties": false
@@ -70,7 +80,22 @@
     "routeImport": {
       "type": "object",
       "properties": {
-        "resource": { "type": "string", "description": "Path to the resource to import." },
+        "resource": {
+          "description": "Path to the resource to import (commonly a string or {path, namespace}), array of paths, or custom value for loaders (additional properties allowed for extensions).",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } },
+            {
+              "type": "object",
+              "properties": {
+                "path": { "type": "string", "description": "The directory path to the resource." },
+                "namespace": { "type": "string", "description": "The namespace of the controllers in the imported resource (e.g., 'App\\Availability\\UserInterface\\Api')." }
+              },
+              "required": ["path"],
+              "additionalProperties": true
+            }
+          ]
+        },
         "type": {
           "type": "string",
           "description": "The type of the resource (e.g., 'attribute', 'annotation', 'yaml')."
@@ -78,7 +103,7 @@
         "prefix": {
           "oneOf": [
             { "type": "string" },
-            { "type": "object", "patternProperties": { "^.+$": { "type": "string" } } }
+            { "type": "object", "patternProperties": { "^.+$": { "type": "string" } }, "additionalProperties": false }
           ],
           "description": "A URL prefix to apply to all routes from the imported resource."
         },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fixes #62387
| License       | MIT

This fix implements two changes to align the schema with the `YamlFileLoader`'s behavior and the official XSD:

1.  **Fixes `resource` key:** Allows `resource` in an import to be either a `string` (for file paths) or a strict `{ path, namespace }` object (for PSR-4 imports), setting `additionalProperties: false`.
2.  **Adds `deprecated` key:** Adds the `deprecated` property to `routeDefinition` to be consistent with `routeAlias` and the official XSD.

This resolves schema validation errors in IDEs for standard import patterns:

<img width="816" height="431" alt="CleanShot 2025-11-13 at 17 30 50" src="https://github.com/user-attachments/assets/13056058-367f-4029-8704-1d8ac3a5b949" />