### PR TITLE
[Mailer] Add support of ipPoolId for infobip mailer transport

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Infobip/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Infobip/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add support of `ipPoolId` option
+
 7.2
 ---
 

--- a/src/Symfony/Component/Mailer/Bridge/Infobip/README.md
+++ b/src/Symfony/Component/Mailer/Bridge/Infobip/README.md
@@ -25,8 +25,9 @@ This transport supports the following custom headers:
 | `X-Infobip-MessageId`          | string  | The ID that uniquely identifies the message sent to a recipient.                        |
 | `X-Infobip-Track`              | boolean | Enable or disable open and click tracking.                                              |
 | `X-Infobip-TrackingUrl`        | string  | The URL on your callback server on which the open and click notifications will be sent. |
-| `X-Infobip-TrackClicks`        | boolean | Enable or disable track click feature..                                                 |
+| `X-Infobip-TrackClicks`        | boolean | Enable or disable track click feature.                                                  |
 | `X-Infobip-TrackOpens`         | boolean | Enable or disable open click feature.                                                   |
+| `X-Infobip-IpPoolId`           | string  | The ID of the dedicated IP pool that will be used to deliver the message.               |
 
 Resources
 ---------

--- a/src/Symfony/Component/Mailer/Bridge/Infobip/Tests/Transport/InfobipApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Infobip/Tests/Transport/InfobipApiTransportTest.php
@@ -252,7 +252,8 @@ class InfobipApiTransportTest extends TestCase
             ->addTextHeader('X-Infobip-Track', 'false')
             ->addTextHeader('X-Infobip-TrackingUrl', 'https://bar.foo')
             ->addTextHeader('X-Infobip-TrackClicks', 'true')
-            ->addTextHeader('X-Infobip-TrackOpens', 'true');
+            ->addTextHeader('X-Infobip-TrackOpens', 'true')
+            ->addTextHeader('X-Infobip-IpPoolId', 'pool-123');
 
         $this->transport->send($email);
 
@@ -308,6 +309,12 @@ class InfobipApiTransportTest extends TestCase
             Content-Disposition: form-data; name="trackOpens"
 
             true
+            --%s
+            Content-Type: text/plain; charset=utf-8
+            Content-Transfer-Encoding: 8bit
+            Content-Disposition: form-data; name="ipPoolId"
+
+            pool-123
             --%s--
             TXT,
             $options['body']
@@ -441,7 +448,8 @@ class InfobipApiTransportTest extends TestCase
             ->addTextHeader('X-Infobip-Track', 'false')
             ->addTextHeader('X-Infobip-TrackingUrl', 'https://bar.foo')
             ->addTextHeader('X-Infobip-TrackClicks', 'true')
-            ->addTextHeader('X-Infobip-TrackOpens', 'true');
+            ->addTextHeader('X-Infobip-TrackOpens', 'true')
+            ->addTextHeader('X-Infobip-IpPoolId', 'pool-123');
 
         $sentMessage = $this->transport->send($email);
 
@@ -457,6 +465,7 @@ class InfobipApiTransportTest extends TestCase
                 X-Infobip-TrackingUrl: https://bar.foo
                 X-Infobip-TrackClicks: true
                 X-Infobip-TrackOpens: true
+                X-Infobip-IpPoolId: pool-123
                 %a
                 TXT,
             $sentMessage->toString()

--- a/src/Symfony/Component/Mailer/Bridge/Infobip/Transport/InfobipApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Infobip/Transport/InfobipApiTransport.php
@@ -42,6 +42,7 @@ final class InfobipApiTransport extends AbstractApiTransport
         'X-Infobip-TrackingUrl' => 'trackingUrl',
         'X-Infobip-TrackClicks' => 'trackClicks',
         'X-Infobip-TrackOpens' => 'trackOpens',
+        'X-Infobip-IpPoolId' => 'ipPoolId',
     ];
 
     public function __construct(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

<!--

🛠️ Replace this text with a concise explanation of your change:

- What it does and why it's needed

- A simple example of how it works (include PHP, YAML, etc.)

- If it modifies existing behavior, include a before/after comparison



Contributor guidelines:

- ✅ Add tests and ensure they pass

- 🐞 Bug fixes must target the **lowest maintained** branch where they apply

  https://symfony.com/releases#maintained-symfony-branches

- ✨ New features and deprecations must target the **feature** branch

  and must add an entry to the changelog file of the patched component:

  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry

- 🔒 Do not break backward compatibility:

  https://symfony.com/bc

-->

## What it does

Adds support for the `X-Infobip-IpPoolId` custom header in the Infobip Mailer bridge, allowing users to specify which dedicated IP pool should be used when sending emails through the Infobip API.

## Why it's needed

The Infobip API supports specifying an IP pool ID when sending emails, which is useful for organizations that have multiple dedicated IP pools configured. This feature enables Symfony Mailer users to leverage this capability by setting a custom header on their email messages.

## How it works

Users can now set the `X-Infobip-IpPoolId` header on their email messages, and it will be automatically converted to the `ipPoolId` parameter in the Infobip API request payload.

**Example:**
```php
use Symfony\Component\Mime\Email;

$email = (new Email())
    ->from('[email protected]')
    ->to('[email protected]')
    ->subject('Subject')
    ->text('Text content')
    ->getHeaders()->addTextHeader('X-Infobip-IpPoolId', 'pool-123');

$mailer->send($email);
// The header value will be sent as the `ipPoolId` form field in the multipart/form-data request to the Infobip API endpoint.

```

## Changes

- Added `X-Infobip-IpPoolId` header mapping in `InfobipApiTransport`
- Updated README.md documentation to include the new header
- Added test coverage for the new header in both request payload and sent message verification
- Updated CHANGELOG.md with the new feature entry

This change is backward compatible and does not modify any existing behavior.