### PR TITLE
[ObjectMapper] Enable converting backed enums to their scalar values

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/object_mapper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/object_mapper.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Symfony\Component\ObjectMapper\Metadata\EnumMappingMetadataFactory;
 use Symfony\Component\ObjectMapper\Metadata\ObjectMapperMetadataFactoryInterface;
 use Symfony\Component\ObjectMapper\Metadata\ReflectionObjectMapperMetadataFactory;
 use Symfony\Component\ObjectMapper\Metadata\ReverseClassObjectMapperMetadataFactory;
@@ -27,6 +28,12 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 service('.inner'),
                 abstract_arg('class_map'),
+            ])
+
+        ->set('object_mapper.metadata_factory.enum', EnumMappingMetadataFactory::class)
+            ->decorate('object_mapper.metadata_factory')
+            ->args([
+                service('.inner'),
             ])
 
         ->set('object_mapper', ObjectMapper::class)

--- a/src/Symfony/Component/ObjectMapper/CHANGELOG.md
+++ b/src/Symfony/Component/ObjectMapper/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add automatic conversion between `BackedEnum` and scalar types (both ways)
+
 8.1
 ---
 

--- a/src/Symfony/Component/ObjectMapper/Metadata/EnumMappingMetadataFactory.php
+++ b/src/Symfony/Component/ObjectMapper/Metadata/EnumMappingMetadataFactory.php
@@ -1,0 +1,166 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Metadata;
+
+use Symfony\Component\ObjectMapper\Exception\MappingTransformException;
+use Symfony\Component\ObjectMapper\Transform\MapEnum;
+
+/**
+ * @internal
+ *
+ * @author Julien Robic <nayte91@gmail.com>
+ */
+final class EnumMappingMetadataFactory implements ObjectMapperMetadataFactoryInterface
+{
+    private array $reflectionClassCache = [];
+    private array $backingTypeCache = [];
+
+    public function __construct(private readonly ObjectMapperMetadataFactoryInterface $inner)
+    {
+    }
+
+    public function create(object $object, ?string $property = null, array $context = []): array
+    {
+        $mappings = $this->inner->create($object, $property, $context);
+
+        if (!$property || !isset($context['source'], $context['target'])) {
+            return $mappings;
+        }
+
+        if (!$mappings) {
+            return $this->createEnumMappingIfNeeded($context['source'], $property, $context['target'], $property);
+        }
+
+        foreach ($mappings as $i => $mapping) {
+            if ($this->hasMapEnum($mapping)) {
+                continue;
+            }
+
+            [$sourceProperty, $targetProperty] = ($object::class === $context['source']) ?
+                [$property, $mapping->target ?? $property] :
+                [$mapping->source ?? $property, $property]
+            ;
+
+            $sourceType = $this->getPropertyTypeName($context['source'], $sourceProperty);
+            $targetType = $this->getPropertyTypeName($context['target'], $targetProperty);
+
+            if (!$sourceType || !$targetType) {
+                continue;
+            }
+
+            if (!$mapEnum = $this->detectEnumMapping($sourceType, $targetType)) {
+                continue;
+            }
+
+            $mappings[$i] = $this->injectMapEnum($mapping, $mapEnum);
+        }
+
+        return $mappings;
+    }
+
+    private function createEnumMappingIfNeeded(string $sourceClass, string $sourceProperty, string $targetClass, string $targetProperty): array
+    {
+        $sourceType = $this->getPropertyTypeName($sourceClass, $sourceProperty);
+        $targetType = $this->getPropertyTypeName($targetClass, $targetProperty);
+
+        if (!$sourceType || !$targetType) {
+            return [];
+        }
+
+        $mapEnum = $this->detectEnumMapping($sourceType, $targetType);
+
+        return $mapEnum ? [new Mapping(null, null, null, $mapEnum)] : [];
+    }
+
+    private function detectEnumMapping(string $sourceType, string $targetType): ?MapEnum
+    {
+        $validBackingTypes = ['int', 'string'];
+        $sourceIsEnum = is_a($sourceType, \UnitEnum::class, true);
+        $targetIsEnum = is_a($targetType, \UnitEnum::class, true);
+
+        [$enumType, $scalarType] = match (true) {
+            $sourceIsEnum && \in_array($targetType, $validBackingTypes, true) => [$sourceType, $targetType],
+            $targetIsEnum && \in_array($sourceType, $validBackingTypes, true) => [$targetType, $sourceType],
+            default => [null, null],
+        };
+
+        if (null === $enumType) {
+            return null;
+        }
+
+        $backingType = $this->resolveBackingType($enumType);
+        if (null === $backingType) {
+            throw new MappingTransformException(\sprintf('Cannot convert enum "%s" to/from scalar. Only BackedEnum can be converted.', $enumType));
+        }
+        if ($backingType !== $scalarType) {
+            throw new MappingTransformException(\sprintf('Type mismatch: enum "%s" is backed by "%s", but scalar type is "%s".', $enumType, $backingType, $scalarType));
+        }
+
+        return new MapEnum($targetType);
+    }
+
+    private function resolveBackingType(string $enumClass): ?string
+    {
+        if (\array_key_exists($enumClass, $this->backingTypeCache)) {
+            return $this->backingTypeCache[$enumClass];
+        }
+
+        if (!is_a($enumClass, \BackedEnum::class, true)) {
+            return $this->backingTypeCache[$enumClass] = null;
+        }
+
+        $backingType = (new \ReflectionEnum($enumClass))->getBackingType();
+
+        return $this->backingTypeCache[$enumClass] = $backingType instanceof \ReflectionNamedType ? $backingType->getName() : null;
+    }
+
+    private function hasMapEnum(Mapping $mapping): bool
+    {
+        if (null === $mapping->transform) {
+            return false;
+        }
+
+        $transforms = \is_array($mapping->transform) ? $mapping->transform : [$mapping->transform];
+
+        foreach ($transforms as $transform) {
+            if ($transform instanceof MapEnum) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function injectMapEnum(Mapping $mapping, MapEnum $mapEnum): Mapping
+    {
+        $transforms = match (true) {
+            null === $mapping->transform => $mapEnum,
+            \is_array($mapping->transform) => [$mapEnum, ...$mapping->transform],
+            default => [$mapEnum, $mapping->transform],
+        };
+
+        return new Mapping($mapping->target, $mapping->source, $mapping->if, $transforms);
+    }
+
+    private function getPropertyTypeName(string $class, string $property): ?string
+    {
+        $refl = $this->reflectionClassCache[$class] ??= new \ReflectionClass($class);
+
+        if (!$refl->hasProperty($property)) {
+            return null;
+        }
+
+        $type = $refl->getProperty($property)->getType();
+
+        return $type instanceof \ReflectionNamedType ? $type->getName() : null;
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -140,7 +140,10 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
             }
 
             $propertyName = $property->getName();
-            $mappings = $this->metadataFactory->create($readMetadataFrom, $propertyName);
+            $mappings = $this->metadataFactory->create($readMetadataFrom, $propertyName, [
+                'source' => $source::class,
+                'target' => $targetRefl->getName(),
+            ]);
             $mappings = array_filter($mappings, static fn (Mapping $m): bool => !$m->targetClass || is_a($targetName, $m->targetClass, true));
             foreach ($mappings as $mapping) {
                 $sourcePropertyName = $propertyName;

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/EnumMapping/EnumSource.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/EnumMapping/EnumSource.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\EnumMapping;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: ScalarTarget::class)]
+class EnumSource
+{
+    #[Map]
+    public StringStatus $status;
+    #[Map]
+    public IntPriority $priority;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/EnumMapping/EnumTarget.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/EnumMapping/EnumTarget.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\EnumMapping;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+class EnumTarget
+{
+    #[Map]
+    public StringStatus $status;
+    #[Map]
+    public IntPriority $priority;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/EnumMapping/EnumWithExplicitMapSource.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/EnumMapping/EnumWithExplicitMapSource.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\EnumMapping;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: EnumWithExplicitMapTarget::class)]
+class EnumWithExplicitMapSource
+{
+    #[Map('targetStatus')]
+    public StringStatus $status;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/EnumMapping/EnumWithExplicitMapTarget.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/EnumMapping/EnumWithExplicitMapTarget.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\EnumMapping;
+
+class EnumWithExplicitMapTarget
+{
+    public string $targetStatus;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/EnumMapping/ImplicitEnum.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/EnumMapping/ImplicitEnum.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\EnumMapping;
+
+class ImplicitEnum
+{
+    public StringStatus $status;
+    public IntPriority $priority;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/EnumMapping/ImplicitScalar.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/EnumMapping/ImplicitScalar.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\EnumMapping;
+
+class ImplicitScalar
+{
+    public string $status;
+    public int $priority;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/EnumMapping/IntPriority.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/EnumMapping/IntPriority.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\EnumMapping;
+
+enum IntPriority: int
+{
+    case Low = 1;
+    case High = 2;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/EnumMapping/PureColor.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/EnumMapping/PureColor.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\EnumMapping;
+
+enum PureColor
+{
+    case Red;
+    case Blue;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/EnumMapping/ScalarSource.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/EnumMapping/ScalarSource.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\EnumMapping;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: EnumTarget::class)]
+class ScalarSource
+{
+    #[Map]
+    public string $status;
+    #[Map]
+    public int $priority;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/EnumMapping/ScalarTarget.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/EnumMapping/ScalarTarget.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\EnumMapping;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+class ScalarTarget
+{
+    #[Map]
+    public string $status;
+    #[Map]
+    public int $priority;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/EnumMapping/StringStatus.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/EnumMapping/StringStatus.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\EnumMapping;
+
+enum StringStatus: string
+{
+    case Active = 'active';
+    case Inactive = 'inactive';
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperWithEnumTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperWithEnumTest.php
@@ -1,0 +1,341 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\ObjectMapper\Attribute\Map;
+use Symfony\Component\ObjectMapper\Exception\MappingTransformException;
+use Symfony\Component\ObjectMapper\Metadata\EnumMappingMetadataFactory;
+use Symfony\Component\ObjectMapper\Metadata\ReflectionObjectMapperMetadataFactory;
+use Symfony\Component\ObjectMapper\ObjectMapper;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\EnumMapping\EnumSource;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\EnumMapping\EnumTarget;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\EnumMapping\EnumWithExplicitMapSource;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\EnumMapping\EnumWithExplicitMapTarget;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\EnumMapping\ImplicitEnum;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\EnumMapping\ImplicitScalar;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\EnumMapping\IntPriority;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\EnumMapping\PureColor;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\EnumMapping\ScalarSource;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\EnumMapping\ScalarTarget;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\EnumMapping\StringStatus;
+
+final class ObjectMapperWithEnumTest extends TestCase
+{
+    public function testMapBackedEnumToScalar()
+    {
+        $withSourceMetadata = new EnumSource();
+        $withSourceMetadata->status = StringStatus::Active;
+        $withSourceMetadata->priority = IntPriority::High;
+        $withTargetMetadata = new class {
+            public StringStatus $status;
+            public IntPriority $priority;
+        };
+        $withTargetMetadata->status = StringStatus::Active;
+        $withTargetMetadata->priority = IntPriority::High;
+
+        $viaSource = $this->createMapper()->map($withSourceMetadata);
+        $viaTarget = $this->createMapper()->map($withTargetMetadata, ScalarTarget::class);
+
+        $this->assertSame('active', $viaSource->status);
+        $this->assertSame(2, $viaSource->priority);
+        $this->assertSame('active', $viaTarget->status);
+        $this->assertSame(2, $viaTarget->priority);
+    }
+
+    public function testMapScalarToBackedEnum()
+    {
+        $withSourceMetadata = new ScalarSource();
+        $withSourceMetadata->status = 'active';
+        $withSourceMetadata->priority = 1;
+        $withTargetMetadata = new class {
+            public string $status;
+            public int $priority;
+        };
+        $withTargetMetadata->status = 'active';
+        $withTargetMetadata->priority = 1;
+
+        $viaSource = $this->createMapper()->map($withSourceMetadata);
+        $viaTarget = $this->createMapper()->map($withTargetMetadata, EnumTarget::class);
+
+        $this->assertSame(StringStatus::Active, $viaSource->status);
+        $this->assertSame(IntPriority::Low, $viaSource->priority);
+        $this->assertSame(StringStatus::Active, $viaTarget->status);
+        $this->assertSame(IntPriority::Low, $viaTarget->priority);
+    }
+
+    public function testMapEnumToScalarWithExplicitMapAttribute()
+    {
+        $source = new EnumWithExplicitMapSource();
+        $source->status = StringStatus::Inactive;
+
+        $target = $this->createMapper()->map($source);
+
+        $this->assertInstanceOf(EnumWithExplicitMapTarget::class, $target);
+        $this->assertSame('inactive', $target->targetStatus);
+    }
+
+    public function testMapEnumToScalarWithoutPropertyMapAttribute()
+    {
+        $source = new ImplicitEnum();
+        $source->status = StringStatus::Active;
+        $source->priority = IntPriority::High;
+
+        $target = $this->createMapper()->map($source, ImplicitScalar::class);
+
+        $this->assertInstanceOf(ImplicitScalar::class, $target);
+        $this->assertSame('active', $target->status);
+        $this->assertSame(2, $target->priority);
+    }
+
+    public function testMapScalarToEnumWithoutPropertyMapAttribute()
+    {
+        $source = new ImplicitScalar();
+        $source->status = 'active';
+        $source->priority = 2;
+
+        $target = $this->createMapper()->map($source, ImplicitEnum::class);
+
+        $this->assertInstanceOf(ImplicitEnum::class, $target);
+        $this->assertSame(StringStatus::Active, $target->status);
+        $this->assertSame(IntPriority::High, $target->priority);
+    }
+
+    public function testMapEnumWhenMetadataIsReadFromTarget()
+    {
+        $source = new class {
+            public string $status;
+            public int $priority;
+        };
+        $source->status = 'active';
+        $source->priority = 2;
+
+        $target = $this->createMapper()->map($source, EnumTarget::class);
+
+        $this->assertInstanceOf(EnumTarget::class, $target);
+        $this->assertSame(StringStatus::Active, $target->status);
+        $this->assertSame(IntPriority::High, $target->priority);
+    }
+
+    public function testExplicitMapEnumTransformerIsNotDuplicated()
+    {
+        $source = new EnumSource();
+        $source->status = StringStatus::Active;
+        $source->priority = IntPriority::Low;
+
+        $target = $this->createMapper()->map($source, ScalarTarget::class);
+
+        $this->assertInstanceOf(ScalarTarget::class, $target);
+        $this->assertSame('active', $target->status);
+    }
+
+    public function testMapSameEnumIsUnchanged()
+    {
+        $sameEnumTarget = new class {
+            #[Map]
+            public StringStatus $status;
+        };
+        $withSourceMetadata = new EnumSource();
+        $withSourceMetadata->status = StringStatus::Active;
+        $withSourceMetadata->priority = IntPriority::Low;
+        $withTargetMetadata = new class {
+            public StringStatus $status;
+        };
+        $withTargetMetadata->status = StringStatus::Active;
+
+        $viaSource = $this->createMapper()->map($withSourceMetadata, $sameEnumTarget::class);
+        $viaTarget = $this->createMapper()->map($withTargetMetadata, $sameEnumTarget::class);
+
+        $this->assertSame(StringStatus::Active, $viaSource->status);
+        $this->assertSame(StringStatus::Active, $viaTarget->status);
+    }
+
+    #[DataProvider('invalidEnumMappingProvider')]
+    public function testInvalidEnumMappingThrows(string $exceptionClass, object $withSourceMetadata, ?string $targetForSource, object $withTargetMetadata, string $targetForTarget)
+    {
+        $this->assertMapThrows($exceptionClass, $withSourceMetadata, $targetForSource);
+        $this->assertMapThrows($exceptionClass, $withTargetMetadata, $targetForTarget);
+    }
+
+    public static function invalidEnumMappingProvider(): iterable
+    {
+        yield from self::pureEnumCases();
+        yield from self::backingTypeMismatchCases();
+        yield from self::invalidValueCases();
+        yield from self::enumToEnumCases();
+    }
+
+    private static function pureEnumCases(): iterable
+    {
+        $pureEnumSource = new class {
+            #[Map]
+            public PureColor $color;
+        };
+        $pureEnumSource->color = PureColor::Red;
+        $pureEnumTarget = new class {
+            #[Map]
+            public string $color;
+        };
+        $plainPureEnum = new class {
+            public PureColor $color;
+        };
+        $plainPureEnum->color = PureColor::Red;
+        yield 'pure enum to scalar' => [MappingTransformException::class, $pureEnumSource, $pureEnumTarget::class, $plainPureEnum, $pureEnumTarget::class];
+
+        $scalarToPureEnumSource = new class {
+            #[Map]
+            public string $color;
+        };
+        $scalarToPureEnumSource->color = 'red';
+        $pureEnumTargetForScalar = new class {
+            #[Map]
+            public PureColor $color;
+        };
+        $plainScalarColor = new class {
+            public string $color;
+        };
+        $plainScalarColor->color = 'red';
+        yield 'scalar to pure enum' => [MappingTransformException::class, $scalarToPureEnumSource, $pureEnumTargetForScalar::class, $plainScalarColor, $pureEnumTargetForScalar::class];
+    }
+
+    private static function backingTypeMismatchCases(): iterable
+    {
+        $stringEnumToInt = new EnumSource();
+        $stringEnumToInt->status = StringStatus::Active;
+        $stringEnumToInt->priority = IntPriority::Low;
+        $stringEnumToIntTarget = new class {
+            #[Map]
+            public int $status;
+        };
+        $plainStringEnum = new class {
+            public StringStatus $status;
+        };
+        $plainStringEnum->status = StringStatus::Active;
+        yield 'string-backed enum to int' => [MappingTransformException::class, $stringEnumToInt, $stringEnumToIntTarget::class, $plainStringEnum, $stringEnumToIntTarget::class];
+
+        $stringToIntEnumSource = new class {
+            #[Map]
+            public string $priority;
+        };
+        $stringToIntEnumSource->priority = 'high';
+        $intEnumTarget = new class {
+            #[Map]
+            public IntPriority $priority;
+        };
+        $plainStringPriority = new class {
+            public string $priority;
+        };
+        $plainStringPriority->priority = 'high';
+        yield 'string to int-backed enum' => [MappingTransformException::class, $stringToIntEnumSource, $intEnumTarget::class, $plainStringPriority, $intEnumTarget::class];
+
+        $intToStringEnumSource = new class {
+            #[Map]
+            public int $status;
+        };
+        $intToStringEnumSource->status = 42;
+        $stringEnumTarget = new class {
+            #[Map]
+            public StringStatus $status;
+        };
+        $plainInt = new class {
+            public int $status;
+        };
+        $plainInt->status = 42;
+        yield 'int to string-backed enum' => [MappingTransformException::class, $intToStringEnumSource, $stringEnumTarget::class, $plainInt, $stringEnumTarget::class];
+
+        $intEnumToString = new EnumSource();
+        $intEnumToString->status = StringStatus::Active;
+        $intEnumToString->priority = IntPriority::High;
+        $intEnumToStringTarget = new class {
+            #[Map]
+            public string $priority;
+        };
+        $plainIntEnum = new class {
+            public IntPriority $priority;
+        };
+        $plainIntEnum->priority = IntPriority::High;
+        yield 'int-backed enum to string' => [MappingTransformException::class, $intEnumToString, $intEnumToStringTarget::class, $plainIntEnum, $intEnumToStringTarget::class];
+    }
+
+    private static function invalidValueCases(): iterable
+    {
+        $invalidScalar = new ScalarSource();
+        $invalidScalar->status = 'nonexistent';
+        $invalidScalar->priority = 1;
+        $plainInvalidScalar = new class {
+            public string $status;
+            public int $priority;
+        };
+        $plainInvalidScalar->status = 'nonexistent';
+        $plainInvalidScalar->priority = 1;
+        yield 'invalid string to string-backed enum' => [MappingTransformException::class, $invalidScalar, null, $plainInvalidScalar, EnumTarget::class];
+
+        $invalidInt = new ScalarSource();
+        $invalidInt->status = 'active';
+        $invalidInt->priority = 999;
+        $plainInvalidInt = new class {
+            public string $status;
+            public int $priority;
+        };
+        $plainInvalidInt->status = 'active';
+        $plainInvalidInt->priority = 999;
+        yield 'invalid int to int-backed enum' => [MappingTransformException::class, $invalidInt, null, $plainInvalidInt, EnumTarget::class];
+    }
+
+    private static function enumToEnumCases(): iterable
+    {
+        $enumToOther = new EnumSource();
+        $enumToOther->status = StringStatus::Active;
+        $enumToOther->priority = IntPriority::Low;
+        $otherEnumTarget = new class {
+            #[Map]
+            public IntPriority $status;
+        };
+        $plainEnumToOther = new class {
+            public StringStatus $status;
+        };
+        $plainEnumToOther->status = StringStatus::Active;
+        yield 'enum to other enum' => [\TypeError::class, $enumToOther, $otherEnumTarget::class, $plainEnumToOther, $otherEnumTarget::class];
+    }
+
+    public function testMapEnumToScalarWithExplicitTarget()
+    {
+        $source = new class {
+            public StringStatus $status;
+        };
+        $source->status = StringStatus::Active;
+
+        $plainTarget = new class {
+            public string $status;
+        };
+
+        $target = $this->createMapper()->map($source, $plainTarget::class);
+
+        $this->assertSame('active', $target->status);
+    }
+
+    private function createMapper(): ObjectMapper
+    {
+        return new ObjectMapper(new EnumMappingMetadataFactory(new ReflectionObjectMapperMetadataFactory()));
+    }
+
+    private function assertMapThrows(string $exceptionClass, object $source, ?string $targetClass = null): void
+    {
+        try {
+            $this->createMapper()->map($source, $targetClass);
+            $this->fail(\sprintf('Expected %s to be thrown.', $exceptionClass));
+        } catch (\Throwable $e) {
+            $this->assertInstanceOf($exceptionClass, $e);
+        }
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Transform/MapEnum.php
+++ b/src/Symfony/Component/ObjectMapper/Transform/MapEnum.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Transform;
+
+use Symfony\Component\ObjectMapper\Exception\MappingTransformException;
+use Symfony\Component\ObjectMapper\TransformCallableInterface;
+
+/**
+ * @internal
+ *
+ * @implements TransformCallableInterface<object, object>
+ *
+ * @author Julien Robic <nayte91@gmail.com>
+ */
+final class MapEnum implements TransformCallableInterface
+{
+    /** @param string|class-string<\BackedEnum> $targetType */
+    public function __construct(
+        private readonly string $targetType,
+    ) {
+    }
+
+    public function __invoke(mixed $value, object $source, ?object $target): mixed
+    {
+        if (null === $value) {
+            return null;
+        }
+
+        if ($value instanceof \BackedEnum) {
+            return $value->value;
+        }
+
+        try {
+            return $this->targetType::from($value);
+        } catch (\ValueError $e) {
+            throw new MappingTransformException(\sprintf('Invalid value "%s" for enum "%s": "%s".', $value, $this->targetType, $e->getMessage()), 0, $e);
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #61044
| License       | MIT

Enable the object mapper to convert backed enums (int or string) to their scalar values.
~Examples:~ complete list:
- int → int-backed Enum
- string → string-backed Enum
- string-backed Enum → string
- int-backed Enum → int
- enum → same enum (unchanged behavior)

It still throws an exception if you try another combination.

For now, you have to create 2 Transformers to achieve this:

```php
/** @implements TransformCallableInterface<object, object> */
class ScalarToEnumMapper implements TransformCallableInterface
{
    public function __invoke(mixed $value, object $source, ?object $target): mixed
    {
        if (null === $value) {
            return null;
        }

        return $value->value ?? $value->name;
    }
}

/** @implements TransformCallableInterface<object, object> */
class EnumToScalarMapper implements TransformCallableInterface
{
    public function __invoke(mixed $value, object $source, ?object $target): mixed
    {
        if (null === $value) {
            return null;
        }

        if (is_string($value)) {
            return $value;
        }

        if ($value instanceof \BackedEnum) {
            return $value->value;
        }

        if ($value instanceof \UnitEnum) {
            return $value->name;
        }

        return null;
    }
}
```

This PR aims to replace those out of the box. This is a common use case, for example if you use Symfony Messenger with an Async worker, and you have to send Commands with serialized values:

```php
class CreatePost // This is the source!
{
    public function __construct(
        public ?string $content = null,
        #[Map(transform: ScalarToEnumMapper::class)]
        public ?string $status = null, // You will need to convert it as Status in your Post Entity
    }
}
```

Or, the other way around, if you want to get the scalar versions of your Enums to simplify code in templates for your front devs.

```php
class PostCard // This is the target!
{
    public function __construct(
        public ?string $title= null,
        #[Map(transform: EnumToScalarMapper::class)]
        public ?string $contentType = null, // You will want to display only the Enum.value in Twig
    }
}
```

Now, you just map 2 objects that has the same named property, and Object-Mapper will try to gracefully convert Enum to scalar or scalar to Enum based on their type!