### PR TITLE
[Console] Remove a redundant local variable in the console Application class.

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -389,10 +389,7 @@ class Application implements ResetInterface
         $this->definition ??= $this->getDefaultInputDefinition();
 
         if ($this->singleCommand) {
-            $inputDefinition = $this->definition;
-            $inputDefinition->setArguments();
-
-            return $inputDefinition;
+            $this->definition->setArguments();
         }
 
         return $this->definition;

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -1480,6 +1480,31 @@ class ApplicationTest extends TestCase
         $this->assertTrue($inputDefinition->hasOption('custom'));
     }
 
+    public function testItRemovesArgumentsFromInputDefinitionOnSingleCommandApplication()
+    {
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->setCatchExceptions(false);
+
+        $application->setDefaultCommand('list', true); // It's a single command application.
+
+        $inputDefinition = $application->getDefinition();
+
+        // $inputDefinition->setArguments() is called to remove default arguments.
+        $this->assertSame(0, $inputDefinition->getArgumentCount());
+        $this->assertFalse($inputDefinition->hasArgument('command'));
+
+        // $inputDefinition->setOptions() is not called to leave default options as they are.
+        $this->assertTrue($inputDefinition->hasOption('help'));
+        $this->assertTrue($inputDefinition->hasOption('quiet'));
+        $this->assertTrue($inputDefinition->hasOption('verbose'));
+        $this->assertTrue($inputDefinition->hasOption('version'));
+        $this->assertTrue($inputDefinition->hasOption('ansi'));
+        $this->assertTrue($inputDefinition->hasNegation('no-ansi'));
+        $this->assertFalse($inputDefinition->hasOption('no-ansi'));
+        $this->assertTrue($inputDefinition->hasOption('no-interaction'));
+    }
+
     public function testRunWithDispatcher()
     {
         $application = new Application();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Let's take a look at the `getDefinition` method of the console Application class.

The definition property (`$this->definition`) is an instanceof `InputDefinition` class, it's an object. Creating and returning the `$inputDefinition` local variable doesn't make any sense because it exactly refers to the definition property.

```php
    public function getDefinition(): InputDefinition
    {
        $this->definition ??= $this->getDefaultInputDefinition();

        if ($this->singleCommand) {
            $inputDefinition = $this->definition;
            $inputDefinition->setArguments();

            return $inputDefinition;
        }

        return $this->definition;
    }
```

Therefore, we just need to call `$this->definition->setArguments()` (if necessary) before `$this->definition` is returned at the end of the method.

```php
    public function getDefinition(): InputDefinition
    {
        $this->definition ??= $this->getDefaultInputDefinition();

        if ($this->singleCommand) {
            $this->definition->setArguments();
        }

        return $this->definition;
    }
```

I've already added one more small test for the current behavior. For a single command application, calling the `getDefinition` method will remove default arguments, but it still keeps default options as they are.

Please see code changes for more details!
