### PR TITLE
[Routing] Fix handling of named capturing groups in requirements

### DIFF
--- a/src/Symfony/Component/Routing/RouteCompiler.php
+++ b/src/Symfony/Component/Routing/RouteCompiler.php
@@ -318,22 +318,100 @@ class RouteCompiler implements RouteCompilerInterface
 
     private static function transformCapturingGroupsToNonCapturings(string $regexp): string
     {
-        for ($i = 0; $i < \strlen($regexp); ++$i) {
-            if ('\\' === $regexp[$i]) {
+        $new = '';
+        $len = \strlen($regexp);
+        $i = 0;
+
+        while ($i < $len) {
+            $char = $regexp[$i];
+
+            if ('\\' === $char && $i + 1 < $len) {
+                $new .= $char.$regexp[$i + 1];
+                $i += 2;
+                continue;
+            }
+
+            if ('(' !== $char) {
+                $new .= $char;
                 ++$i;
                 continue;
             }
-            if ('(' !== $regexp[$i] || !isset($regexp[$i + 2])) {
-                continue;
+
+            $new .= '(';
+            ++$i;
+
+            if ($i >= $len) {
+                break;
             }
-            if ('*' === $regexp[++$i] || '?' === $regexp[$i]) {
+
+            $next_char = $regexp[$i];
+
+            // Preserve PCRE verbs, e.g., (*FAIL), (*PRUNE)
+            if ('*' === $next_char) {
+                $new .= $next_char;
                 ++$i;
+                while ($i < $len && ctype_alpha($regexp[$i])) {
+                    $new .= $regexp[$i];
+                    ++$i;
+                }
+                if ($i < $len && ')' === $regexp[$i]) {
+                    $new .= ')';
+                    ++$i;
+                }
                 continue;
             }
-            $regexp = substr_replace($regexp, '?:', $i, 0);
+
+            if ('?' !== $next_char) {
+                $new .= '?:';
+                continue;
+            }
+
+            $new .= '?';
+            ++$i;
+
+            if ($i >= $len) {
+                break;
+            }
+
+            $next = $regexp[$i];
+
+            // Preserve special groups (non-capturing, assertions, comments), e.g., (?:), (?=), (?#)
+            if (\in_array($next, [':', '=', '!', '#'], true) || ('<' === $next && $i + 1 < $len && \in_array($regexp[$i + 1], ['=', '!'], true))) {
+                $new .= $next;
+                ++$i;
+                if ('<' === $next && $i < $len) {
+                    $new .= $regexp[$i];
+                    ++$i;
+                }
+                continue;
+            }
+
+            // Neutralize named capturing group (?P<name>, ?<name>, ?'name')
+            if (\in_array($next, ['P', '<', "'"], true)) {
+                $closer = "'" === $next ? "'" : '>';
+                if ('P' === $next) {
+                    ++$i;
+                    if ($i >= $len || '<' !== $regexp[$i]) {
+                        continue;
+                    }
+                }
+                ++$i;
+                while ($i < $len && $regexp[$i] !== $closer) {
+                    ++$i;
+                }
+                if ($i >= $len) {
+                    break;
+                }
+                ++$i;
+                $new .= ':'; // Add ':' to make it non-capturing.
+                continue;
+            }
+
+            // Preserve other modifiers, e.g., (?i) for case-insensitivity.
+            $new .= $next;
             ++$i;
         }
 
-        return $regexp;
+        return $new;
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
@@ -15,6 +15,8 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Routing\Exception\NoConfigurationException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
+use Symfony\Component\Routing\Matcher\CompiledUrlMatcher;
+use Symfony\Component\Routing\Matcher\Dumper\CompiledUrlMatcherDumper;
 use Symfony\Component\Routing\Matcher\UrlMatcher;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\Route;
@@ -1015,6 +1017,99 @@ class UrlMatcherTest extends TestCase
         $result = $matcher->match('/test');
         $this->assertSame('test', $result['_route']);
         $this->assertSame('foo-', $result['foo']);
+    }
+
+    /**
+     * @dataProvider provideRequirementRegexCases
+     */
+    public function testRequirementRegexCompiler(string $fooReq, string $barReq, string $path, ?array $expectedResult, ?string $expectedException = null)
+    {
+        if ($expectedException) {
+            $this->expectException($expectedException);
+        }
+
+        $collection = new RouteCollection();
+        $collection->add('test', new Route('/{foo}/{bar}', [], [
+            'foo' => $fooReq,
+            'bar' => $barReq,
+        ]));
+
+        $matcher = new CompiledUrlMatcher((new CompiledUrlMatcherDumper($collection))->getCompiledRoutes(), new RequestContext());
+        $result = $matcher->match($path);
+
+        if ($expectedResult) {
+            $this->assertEquals($expectedResult, $result);
+        }
+    }
+
+    public static function provideRequirementRegexCases(): \Generator
+    {
+        $successResult = ['_route' => 'test', 'foo' => '1', 'bar' => '2'];
+        $successPath = '/1/2';
+
+        yield 'bug case: duplicate (?P<name>)' => [
+            '(?P<digit>\d+)',
+            '(?P<digit>\d+)',
+            $successPath,
+            $successResult,
+        ];
+
+        yield 'bug case: duplicate (?<name>)' => [
+            '(?<digit>\d+)',
+            '(?<digit>\d+)',
+            $successPath,
+            $successResult,
+        ];
+
+        yield "bug case: duplicate (?'name')" => [
+            "(?'digit'\d+)",
+            "(?'digit'\d+)",
+            $successPath,
+            $successResult,
+        ];
+
+        yield 'non-regression: non-capturing groups (?:)' => [
+            '(?:\d+)',
+            '(?:\d+)',
+            $successPath,
+            $successResult,
+        ];
+
+        yield 'non-regression: lookahead groups (?=)' => [
+            '(?=\d)\d',
+            '\d(?!\w)',
+            $successPath,
+            $successResult,
+        ];
+
+        yield 'non-regression: escaped parentheses' => [
+            '\(\d\)',
+            '\(\d\)',
+            '/(1)/(2)',
+            ['_route' => 'test', 'foo' => '(1)', 'bar' => '(2)'],
+        ];
+
+        yield 'non-regression: parentheses in character class' => [
+            '[(\d)]+',
+            '[(\d)]+',
+            '/(1/(2',
+            ['_route' => 'test', 'foo' => '(1', 'bar' => '(2'],
+        ];
+
+        yield 'non-regression: simple regex' => [
+            '\d+',
+            '\d+',
+            $successPath,
+            $successResult,
+        ];
+
+        yield 'matching failure (proves reqs still work)' => [
+            '\d+',
+            '\d+',
+            '/1/abc',
+            null,
+            'Symfony\Component\Routing\Exception\ResourceNotFoundException',
+        ];
     }
 
     protected function getUrlMatcher(RouteCollection $routes, ?RequestContext $context = null)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | no
| License       | MIT


This PR fixes a bug in the `RouteCompiler`.

The `transformCapturingGroupsToNonCapturings()` method did not correctly handle **named** capturing groups (like `(?P<name>...)`, `(?<name>...)`, or `(?'name'...)`). It incorrectly treated them as non-capturing groups.

This caused two types of failures when duplicate names were used in requirements:

1.  For `(?P<...>)` syntax, it incorrectly added the captured value (e.g., `'digit' => '2'`) to the match results, causing assertion failures.
2.  For `(?<...>)` and `(?'...>)` syntax, it caused a `preg_match()` compilation error ("duplicate subpattern name").
