### PR TITLE
[FrameworkBundle] Revert auto-import of #[Route] defined on controllers

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
@@ -79,12 +79,14 @@ trait MicroKernelTrait
         $routes->import($configDir.'/{routes}/'.$this->environment.'/*.{php,yaml}');
         $routes->import($configDir.'/{routes}/*.{php,yaml}');
 
-        $routes->import('routing.controllers');
-
         if (is_file($this->getConfigDir().'/routes.yaml')) {
             $routes->import($configDir.'/routes.yaml');
         } else {
             $routes->import($configDir.'/{routes}.php');
+        }
+
+        if ($fileName = (new \ReflectionObject($this))->getFileName()) {
+            $routes->import($fileName, 'attribute');
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62401
| License       | MIT

Something we did in #62302 but that leads to #62401