### PR TITLE
[Notifier] do not use recipient phone numbers as sender e-mail addresses

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/FakeSms/FakeSmsEmailTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/FakeSms/FakeSmsEmailTransport.php
@@ -65,7 +65,7 @@ final class FakeSmsEmailTransport extends AbstractTransport
         }
 
         $email = (new Email())
-            ->from($message->getFrom() ?: $this->from)
+            ->from($this->from)
             ->to($this->to)
             ->subject(\sprintf('New SMS on phone number: %s', $message->getPhone()))
             ->html($message->getSubject())

--- a/src/Symfony/Component/Notifier/Bridge/FakeSms/Mailer/DummyMailer.php
+++ b/src/Symfony/Component/Notifier/Bridge/FakeSms/Mailer/DummyMailer.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\FakeSms\Mailer;
+
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\RawMessage;
+
+class DummyMailer implements MailerInterface
+{
+    public ?RawMessage $sentEmail = null;
+
+    public function send(RawMessage $message, ?Envelope $envelope = null): void
+    {
+        $this->sentEmail = $message;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58535
| License       | MIT