### PR TITLE
[FrameworkBundle] work around limitation in `JsonResponse` when the data is `null`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -157,6 +157,10 @@ abstract class AbstractController implements ServiceSubscriberInterface
             return new JsonResponse($json, $status, $headers, true);
         }
 
+        if (null === $data) {
+            return new JsonResponse('null', $status, $headers, true);
+        }
+
         return new JsonResponse($data, $status, $headers);
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
@@ -224,6 +224,37 @@ class AbstractControllerTest extends TestCase
         $this->assertEquals('{}', $response->getContent());
     }
 
+    public function testJsonNull()
+    {
+        $controller = $this->createController();
+        $controller->setContainer(new Container());
+
+        $response = $controller->json(null);
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertSame('null', $response->getContent());
+    }
+
+    public function testJsonNullWithSerializer()
+    {
+        $container = new Container();
+
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer
+            ->expects($this->once())
+            ->method('serialize')
+            ->with(null, 'json', ['json_encode_options' => JsonResponse::DEFAULT_ENCODING_OPTIONS])
+            ->willReturn('null');
+
+        $container->set('serializer', $serializer);
+
+        $controller = $this->createController();
+        $controller->setContainer($container);
+
+        $response = $controller->json(null);
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertSame('null', $response->getContent());
+    }
+
     public function testFile()
     {
         $container = new Container();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62404
| License       | MIT

I did abstain from fixing this in `JsonResponse` since https://github.com/symfony/symfony/blob/6769c4c670736adad5d77fe02c25f313e10971b6/src/Symfony/Component/HttpFoundation/JsonResponse.php#L47 has been there for years since symfony/symfony@2d07a17cbd839b52e547cb80e148f810795c23a1