### PR TITLE
[Yaml] Align unquoted multiline scalar parsing with spec for comments

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -775,7 +775,7 @@ class Parser
                         }
 
                         if ($this->isCurrentLineComment()) {
-                            continue;
+                            break;
                         }
 
                         $lines[] = trim($this->currentLine);

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -1752,26 +1752,23 @@ EOT;
     }
 
     /**
-     * @dataProvider getUnquotedMultilineScalarIgnoresCommentsData
+     * @dataProvider getUnquotedMultilineScalarHandlesCommentsAndBlanksData
      */
-    public function testUnquotedMultilineScalarIgnoresComments(string $yaml, array $expected)
+    public function testUnquotedMultilineScalarHandlesCommentsAndBlanks(string $yaml, array $expected)
     {
         $this->assertSame($expected, $this->parser->parse($yaml));
     }
 
-    public static function getUnquotedMultilineScalarIgnoresCommentsData()
+    public static function getUnquotedMultilineScalarHandlesCommentsAndBlanksData()
     {
-        yield 'comments interspersed' => [
+        yield 'comments interspersed stops scalar' => [
             <<<YAML
                 key: unquoted
-                  # this comment should be ignored
-                  next line
-                  # another comment
-                  final line
+                  # this comment terminates
                 another_key: works
                 YAML,
             [
-                'key' => 'unquoted next line final line',
+                'key' => 'unquoted',
                 'another_key' => 'works',
             ],
         ];
@@ -1789,17 +1786,16 @@ EOT;
             ],
         ];
 
-        yield 'blank lines and comments' => [
+        yield 'blank lines are preserved and comment stops scalar' => [
             <<<YAML
                 key: unquoted
                   next line
 
-                  # this comment should be ignored
-                  final line
+                  # this comment terminates the scalar
                 another_key: works
                 YAML,
             [
-                'key' => "unquoted next line\nfinal line",
+                'key' => 'unquoted next line',
                 'another_key' => 'works',
             ],
         ];
@@ -1816,6 +1812,21 @@ EOT;
                 'another_key' => 'works',
             ],
         ];
+    }
+
+    public function testUnquotedMultilineScalarThrowsOnOrphanedLineAfterComment()
+    {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Unable to parse at line 3 (near "  next line")');
+
+        $yaml = <<<YAML
+            key: unquoted
+              # this comment terminates
+              next line
+            another_key: works
+            YAML;
+
+        $this->parser->parse($yaml);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR is a follow-up to [#62359](https://github.com/symfony/symfony/pull/62359#discussion_r2528555551) based on feedback from @xabbuh regarding spec compliance.

My previous PR fixed a `ParseException` on blank lines, but it handled comments incorrectly (it **ignored** them inside the scalar).

This PR aligns the parser with the YAML spec ([3.2.3.3](https://yaml.org/spec/1.2.2/#3233-comments)):

1.  It **keeps the fix** for blank lines (they are correctly preserved).
2.  It **changes comment handling**: instead of ignoring an indented comment, the parser now **terminates** the multiline scalar when it encounters one.
