### PR TITLE
[Translation] Make the extractor alias optional

### DIFF
--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 7.4
 ---
 
+ * Make the extractor alias optional
  * Deprecate `TranslatableMessage::__toString`
  * Add `Symfony\Component\Translation\StaticMessage`
 

--- a/src/Symfony/Component/Translation/DependencyInjection/TranslationExtractorPass.php
+++ b/src/Symfony/Component/Translation/DependencyInjection/TranslationExtractorPass.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Translation\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
@@ -30,11 +29,7 @@ class TranslationExtractorPass implements CompilerPassInterface
         $definition = $container->getDefinition('translation.extractor');
 
         foreach ($container->findTaggedServiceIds('translation.extractor', true) as $id => $attributes) {
-            if (!isset($attributes[0]['alias'])) {
-                throw new RuntimeException(\sprintf('The alias for the tag "translation.extractor" of service "%s" must be set.', $id));
-            }
-
-            $definition->addMethodCall('addExtractor', [$attributes[0]['alias'], new Reference($id)]);
+            $definition->addMethodCall('addExtractor', [$attributes[0]['alias'] ?? $id, new Reference($id)]);
         }
     }
 }

--- a/src/Symfony/Component/Translation/Tests/DependencyInjection/TranslationExtractorPassTest.php
+++ b/src/Symfony/Component/Translation/Tests/DependencyInjection/TranslationExtractorPassTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Translation\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Translation\DependencyInjection\TranslationExtractorPass;
 
@@ -50,15 +49,13 @@ class TranslationExtractorPassTest extends TestCase
     public function testProcessMissingAlias()
     {
         $container = new ContainerBuilder();
-        $container->register('translation.extractor');
+        $extractorDefinition = $container->register('translation.extractor');
         $container->register('foo.id')
             ->addTag('translation.extractor', []);
 
         $translationDumperPass = new TranslationExtractorPass();
-
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The alias for the tag "translation.extractor" of service "foo.id" must be set.');
-
         $translationDumperPass->process($container);
+
+        $this->assertEquals([['addExtractor', ['foo.id', new Reference('foo.id')]]], $extractorDefinition->getMethodCalls());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | DX enhancement
| Deprecations? | no
| Issues        | N/A
| License       | MIT

This PR modifies the `TranslationExtractorPass` to make the alias attribute optional for services tagged with `translation.extractor`.                                                                            
                                                                                                                                                                                                                
Previously, a `RuntimeException` was thrown if the alias was not explicitly set. With this change, if the alias is omitted, the service's ID is used as the alias by default. This provides more flexibility and reduces unnecessary configuration for developers.

The corresponding unit test (`TranslationExtractorPassTest`) has been updated to reflect this new behavior and ensure the fallback to the service ID is working as expected.

Since a tag alias can still be provided, this change does not break current behaviour, only allows easier integration of third-party code.

### Background story

I wanted to implement an extension that automatically registers all subclasses of `SomeTranslationExtractor` as translation extractors:
```php
class SomeTranslationExtractorExtension extends Extension
{
    public function load(array $configs, ContainerBuilder $container): void
    {
        // Auto-tag all SomeTranslationExtractor subclasses
        $container->registerForAutoconfiguration(SomeTranslationExtractor::class)
            ->addTag('translation.extractor');
    }
}
```
This is currently not (easily) possible because of the required tag alias for each translation extractor instance.