### PR TITLE
[HttpKernel] Conflict with symfony/flex < 2.10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -181,7 +181,8 @@
         "masterminds/html5": "<2.6",
         "phpdocumentor/reflection-docblock": "<5.2",
         "phpdocumentor/type-resolver": "<1.5.1",
-        "phpunit/phpunit": "<7.5|9.1.2"
+        "phpunit/phpunit": "<7.5|9.1.2",
+        "symfony/flex": "<2.10"
     },
     "config": {
         "allow-plugins": {

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -60,6 +60,7 @@
         "symfony/form": "<6.4",
         "symfony/dependency-injection": "<6.4",
         "symfony/doctrine-bridge": "<6.4",
+        "symfony/flex": "<2.10",
         "symfony/http-client": "<6.4",
         "symfony/http-client-contracts": "<2.5",
         "symfony/mailer": "<6.4",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

https://github.com/symfony/flex/pull/1070 is a mandatory fix to have the new `APP_SHARE_DIR` env var work correctly.
This will also encourage people to change their flex requirement: at the moment, it's very easy to forget to bump to `^2` when your project already has a `^1` constraint. Yet, flex v1 isn't maintained anymore. 