### PR TITLE
[HttpClient] Don't reset unused clients in data collector

### DIFF
--- a/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
+++ b/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
@@ -64,7 +64,9 @@ final class HttpClientDataCollector extends DataCollector implements LateDataCol
             $this->data['error_count'] += $errorCount;
             $this->data['clients'][$name]['error_count'] += $errorCount;
 
-            $client->reset();
+            if ($traces) {
+                $client->reset();
+            }
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The data collector resets all clients on each request. When multiple scoped clients use the throttling feature, every rate limiter is reset each time, causing locks that were never used to be acquired only to be immediately released. Since most of the time only one or none of the clients is used, this behavior is unnecessary and inefficient.

This PR ensures that only clients that were actually used are reset.