### PR TITLE
[ObjectMapper] bypass lazy ghost with class transform

### DIFF
--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -241,8 +241,16 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
             } elseif ($objectMap->offsetExists($value)) {
                 $value = $objectMap[$value];
             } elseif (\PHP_VERSION_ID < 80400) {
+                if ($mapTo->transform) {
+                    return $value;
+                }
+
                 return ($this->objectMapper ?? $this)->map($value, $mapTo->target);
             } else {
+                if ($mapTo->transform) {
+                    return $value;
+                }
+
                 $refl = new \ReflectionClass($mapTo->target);
                 $mapper = $this->objectMapper ?? $this;
 

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ServiceLoadedValue/LoadedValue.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ServiceLoadedValue/LoadedValue.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ServiceLoadedValue;
+
+class LoadedValue
+{
+    public function __construct(public string $name)
+    {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ServiceLoadedValue/LoadedValueService.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ServiceLoadedValue/LoadedValueService.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ServiceLoadedValue;
+
+class LoadedValueService
+{
+    public function __construct(private ?LoadedValue $value = null)
+    {
+    }
+
+    public function load(): void
+    {
+        $this->value = new LoadedValue(name: 'loaded');
+    }
+
+    public function get(): LoadedValue
+    {
+        return $this->value;
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ServiceLoadedValue/LoadedValueTarget.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ServiceLoadedValue/LoadedValueTarget.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ServiceLoadedValue;
+
+class LoadedValueTarget
+{
+    public function __construct(public ?LoadedValue $relation = null)
+    {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ServiceLoadedValue/ServiceLoadedValueTransformer.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ServiceLoadedValue/ServiceLoadedValueTransformer.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ServiceLoadedValue;
+
+use Symfony\Component\ObjectMapper\Metadata\ObjectMapperMetadataFactoryInterface;
+use Symfony\Component\ObjectMapper\TransformCallableInterface;
+
+/**
+ * @implements TransformCallableInterface<object,object>
+ */
+class ServiceLoadedValueTransformer implements TransformCallableInterface
+{
+    public function __construct(private readonly LoadedValueService $serviceLoadedValue, private readonly ObjectMapperMetadataFactoryInterface $metadata)
+    {
+    }
+
+    public function __invoke(mixed $value, object $source, ?object $target): mixed
+    {
+        $metadata = $this->metadata->create($value);
+        \assert(count($metadata) === 1);
+        \assert($metadata[0]->target === LoadedValue::class);
+        return $this->serviceLoadedValue->get();
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ServiceLoadedValue/ValueToMap.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ServiceLoadedValue/ValueToMap.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ServiceLoadedValue;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: LoadedValueTarget::class)]
+final class ValueToMap
+{
+    public ?ValueToMapRelation $relation;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ServiceLoadedValue/ValueToMapRelation.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ServiceLoadedValue/ValueToMapRelation.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ServiceLoadedValue;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: LoadedValue::class, transform: ServiceLoadedValueTransformer::class)]
+class ValueToMapRelation
+{
+    public function __construct(public string $name)
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60610
| License       | MIT

This allows to fix #60610 in a way that you can create the target in a transformer:

```php
#[Map(target: TargetEntity::class, transform: GetTargetEntityReference::class)]
class SourceDto {
	public string $id;
}

class GetTargetEntityReference implements TransformCallableInterface
{
    public function __construct(
        private readonly EntityManager $em,
        private readonly ObjectMapperMetadataFactoryInterface $metadata
    ){
    }

    public function __invoke(mixed $value, object $source, ?object $target): mixed
    {

        $metadata = $this->metadata->create($value);
        \assert(count($metadata) === 1);
        return $this->entityManager->getReference($metadata[0]->target, $value->id);
    }
}

}

```


I consider this a bug fix as otherwise you're stuck with the Lazy Ghost. At least in a transform you can choose whether to map recursively or not (you can inject the ObjectMapper into a transformer to keep the same behavior).
  