### PR TITLE
[FrameworkBundle][HttpKernel] Add configuration option to hide server vars in the profiler

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -354,6 +354,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('collect_parameter')->defaultNull()->info('The name of the parameter to use to enable or disable collection on a per request basis.')->end()
                         ->booleanNode('only_exceptions')->defaultFalse()->end()
                         ->booleanNode('only_main_requests')->defaultFalse()->end()
+                        ->booleanNode('hide_server_vars')->defaultFalse()->end()
                         ->scalarNode('dsn')->defaultValue('file:%kernel.cache_dir%/profiler')->end()
                         ->booleanNode('collect_serializer_data')->info('Enables the serializer data collector and profiler panel.')->defaultFalse()->end()
                     ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1041,6 +1041,11 @@ class FrameworkExtension extends Extension
         if (!class_exists(CommandDataCollector::class)) {
             $container->removeDefinition('.data_collector.command');
         }
+
+        if ($config['hide_server_vars']) {
+            $container->getDefinition('data_collector.request')
+                ->addArgument($config['hide_server_vars']);
+        }
     }
 
     private function registerWorkflowConfiguration(array $config, ContainerBuilder $container, PhpFileLoader $loader): void

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -125,6 +125,7 @@
         <xsd:attribute name="password" type="xsd:string" />
         <xsd:attribute name="lifetime" type="xsd:string" />
         <xsd:attribute name="collect-serializer-data" type="xsd:boolean" />
+        <xsd:attribute name="hide-server-vars" type="xsd:boolean" />
     </xsd:complexType>
 
     <xsd:complexType name="router">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -763,6 +763,7 @@ class ConfigurationTest extends TestCase
                 'enabled' => false,
                 'only_exceptions' => false,
                 'only_main_requests' => false,
+                'hide_server_vars' => false,
                 'dsn' => 'file:%kernel.cache_dir%/profiler',
                 'collect' => true,
                 'collect_parameter' => null,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/profiler.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/profiler.php
@@ -8,6 +8,7 @@ $container->loadFromExtension('framework', [
     'profiler' => [
         'enabled' => true,
         'collect_serializer_data' => true,
+        'hide_server_vars' => true
     ],
     'serializer' => [
         'enabled' => true,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/profiler.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/profiler.xml
@@ -9,7 +9,7 @@
     <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
         <framework:php-errors log="true" />
-        <framework:profiler enabled="true" collect-serializer-data="true" />
+        <framework:profiler enabled="true" collect-serializer-data="true" hide-server-vars="true" />
         <framework:serializer enabled="true" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/profiler.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/profiler.yml
@@ -7,5 +7,6 @@ framework:
     profiler:
         enabled: true
         collect_serializer_data: true
+        hide_server_vars: true
     serializer:
         enabled: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -268,6 +268,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
 
         $this->assertTrue($container->hasDefinition('profiler'), '->registerProfilerConfiguration() loads profiling.xml');
         $this->assertTrue($container->hasDefinition('data_collector.config'), '->registerProfilerConfiguration() loads collectors.xml');
+        $this->assertTrue($container->getDefinition('data_collector.request')->getArgument(1));
     }
 
     public function testDisabledProfiler()

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -39,6 +39,7 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
 
     public function __construct(
         private ?RequestStack $requestStack = null,
+        private bool $hideServerVars = false,
     ) {
         $this->controllers = new \SplObjectStorage();
     }
@@ -97,7 +98,7 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
             'request_request' => $request->request->all(),
             'request_files' => $request->files->all(),
             'request_headers' => $request->headers->all(),
-            'request_server' => $request->server->all(),
+            'request_server' => !$this->hideServerVars ? $request->server->all() : [],
             'request_cookies' => $request->cookies->all(),
             'request_attributes' => $attributes,
             'route' => $route,

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
@@ -467,4 +467,28 @@ class RequestDataCollectorTest extends TestCase
             ['', null],
         ];
     }
+
+    public function testHidingServerVars()
+    {
+        $response = $this->createResponse();
+        $request = Request::create('/', 'GET', [], [], [], ['API_KEY' => 'abcXYZ']);
+
+        $c = new RequestDataCollector();
+        $c->collect($request, $response);
+
+        $refClass = new \ReflectionClass(RequestDataCollector::class);
+        $refProperty = $refClass->getProperty('data');
+        $data = $refProperty->getValue($c);
+
+        $this->assertArrayHasKey('request_server', $data);
+        $this->assertArrayHasKey('API_KEY', $data['request_server']);
+        $this->assertEquals('abcXYZ', $data['request_server']['API_KEY']);
+
+        $c = new RequestDataCollector(null, true);
+        $c->collect($request, $response);
+
+        $data = $refProperty->getValue($c);
+
+        $this->assertArrayNotHasKey('API_KEY', $data['request_server']);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes/no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Adds the ability to hide server vars in the profiler page, to avoid leaking sensitive data when the profiler is enabled.
