### PR TITLE
[Console] Deprecate `Symfony\Component\Console\Command\HelpCommand::setCommand()`

### DIFF
--- a/CHANGELOG-7.4.md
+++ b/CHANGELOG-7.4.md
@@ -7,10 +7,6 @@ in 7.4 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v7.4.0...v7.4.1
 
-* Unreleased
-
- * feature #62419 [Console] Deprecate `Symfony\Component\Console\Command\HelpCommand::setCommand()`
-
 * 7.4.0-RC2 (2025-11-16)
 
  * bug #62411 [HttpKernel] Conflict with symfony/flex < 2.10 (nicolas-grekas)
@@ -268,3 +264,4 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
  * feature #60209 [Notifier] Allow to set block_id/value for SlackActionsBlock and SlackButtonBlockElement (miloszowi)
  * feature #60544 [JsonStreamer] Remove `nikic/php-parser` dependency (mtarld)
  * feature #60420 [WebLink] Add class to parse Link headers from HTTP responses (GromNaN)
+

--- a/CHANGELOG-7.4.md
+++ b/CHANGELOG-7.4.md
@@ -7,6 +7,10 @@ in 7.4 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v7.4.0...v7.4.1
 
+* Unreleased
+
+ * feature #62419 [Console] Deprecate `Symfony\Component\Console\Command\HelpCommand::setCommand()`
+
 * 7.4.0-RC2 (2025-11-16)
 
  * bug #62411 [HttpKernel] Conflict with symfony/flex < 2.10 (nicolas-grekas)
@@ -264,4 +268,3 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
  * feature #60209 [Notifier] Allow to set block_id/value for SlackActionsBlock and SlackButtonBlockElement (miloszowi)
  * feature #60544 [JsonStreamer] Remove `nikic/php-parser` dependency (mtarld)
  * feature #60420 [WebLink] Add class to parse Link headers from HTTP responses (GromNaN)
-

--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -29,6 +29,7 @@ Console
 -------
 
  * Deprecate `Symfony\Component\Console\Application::add()` in favor of `addCommand()`
+ * Deprecate the `$command` property and the`setCommand` method of the `Symfony\Component\Console\Command\HelpCommand` class
 
 DependencyInjection
 -------------------

--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -29,7 +29,7 @@ Console
 -------
 
  * Deprecate `Symfony\Component\Console\Application::add()` in favor of `addCommand()`
- * Deprecate the `$command` property and the`setCommand` method of the `Symfony\Component\Console\Command\HelpCommand` class
+ * Deprecate `Symfony\Component\Console\Command\HelpCommand::setCommand()`, use the `command_name` input argument instead
 
 DependencyInjection
 -------------------

--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -29,7 +29,7 @@ Console
 -------
 
  * Deprecate `Symfony\Component\Console\Application::add()` in favor of `addCommand()`
- * Deprecate the `$command` property and the`setCommand` method of the `Symfony\Component\Console\Command\HelpCommand` class
+ * Deprecate `Symfony\Component\Console\Command\HelpCommand::setCommand()`
 
 DependencyInjection
 -------------------

--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -29,7 +29,7 @@ Console
 -------
 
  * Deprecate `Symfony\Component\Console\Application::add()` in favor of `addCommand()`
- * Deprecate `Symfony\Component\Console\Command\HelpCommand::setCommand()`
+ * Deprecate the `$command` property and the`setCommand` method of the `Symfony\Component\Console\Command\HelpCommand` class
 
 DependencyInjection
 -------------------

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -278,6 +278,7 @@ class Application implements ResetInterface
                 $input = new ArrayInput(['command_name' => $this->defaultCommand]);
             } else {
                 $this->wantHelps = true;
+                $input = new ArrayInput(['command_name' => $name]);
             }
         }
 
@@ -609,18 +610,13 @@ class Application implements ResetInterface
             throw new CommandNotFoundException(\sprintf('The "%s" command cannot be found because it is registered under multiple names. Make sure you don\'t set a different name via constructor or "setName()".', $name));
         }
 
-        $command = $this->commands[$name];
-
         if ($this->wantHelps) {
             $this->wantHelps = false;
 
-            $helpCommand = $this->get('help');
-            $helpCommand->setCommand($command);
-
-            return $helpCommand;
+            return $this->get('help');
         }
 
-        return $command;
+        return $this->commands[$name];
     }
 
     /**

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -15,6 +15,7 @@ CHANGELOG
  * Add optional timeout for interaction in `QuestionHelper`
  * Add support for interactive invokable commands with `#[Interact]` and `#[Ask]` attributes
  * Add support for `Cursor` helper in invokable commands
+ * Deprecate `Symfony\Component\Console\Command\HelpCommand::setCommand()`, use the `command_name` input argument instead
 
 7.3
 ---

--- a/src/Symfony/Component/Console/Command/HelpCommand.php
+++ b/src/Symfony/Component/Console/Command/HelpCommand.php
@@ -25,6 +25,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class HelpCommand extends Command
 {
+    /**
+     * @deprecated since Symfony 7.4, to be removed in Symfony 8.0.
+     */
     private Command $command;
 
     protected function configure(): void

--- a/src/Symfony/Component/Console/Command/HelpCommand.php
+++ b/src/Symfony/Component/Console/Command/HelpCommand.php
@@ -25,9 +25,6 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class HelpCommand extends Command
 {
-    /**
-     * @deprecated since Symfony 7.4, to be removed in Symfony 8.0.
-     */
     private Command $command;
 
     protected function configure(): void
@@ -62,7 +59,7 @@ class HelpCommand extends Command
      */
     public function setCommand(Command $command): void
     {
-        trigger_deprecation('symfony/console', '7.4', 'The "%s()" method is deprecated and will be removed in Symfony 8.0.', __METHOD__);
+        trigger_deprecation('symfony/console', '7.4', 'Method "%s()" is deprecated and will be removed in Symfony 8.0, use the command_name input argument instead', __METHOD__);
 
         $this->command = $command;
     }

--- a/src/Symfony/Component/Console/Command/HelpCommand.php
+++ b/src/Symfony/Component/Console/Command/HelpCommand.php
@@ -25,9 +25,6 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class HelpCommand extends Command
 {
-    /**
-     * @deprecated since Symfony 7.4, to be removed in Symfony 8.0.
-     */
     private Command $command;
 
     protected function configure(): void

--- a/src/Symfony/Component/Console/Command/HelpCommand.php
+++ b/src/Symfony/Component/Console/Command/HelpCommand.php
@@ -25,6 +25,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class HelpCommand extends Command
 {
+    /**
+     * @deprecated since Symfony 7.4, to be removed in Symfony 8.0.
+     */
     private Command $command;
 
     protected function configure(): void
@@ -54,17 +57,22 @@ class HelpCommand extends Command
         ;
     }
 
+    /**
+     * @deprecated since Symfony 7.4, to be removed in Symfony 8.0.
+     */
     public function setCommand(Command $command): void
     {
+        trigger_deprecation('symfony/console', '7.4', 'The "%s()" method is deprecated and will be removed in Symfony 8.0.', __METHOD__);
+
         $this->command = $command;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->command ??= $this->getApplication()->find($input->getArgument('command_name'));
+        $command = $this->command ?? $this->getApplication()->find($input->getArgument('command_name'));
 
         $helper = new DescriptorHelper();
-        $helper->describe($output, $this->command, [
+        $helper->describe($output, $command, [
             'format' => $input->getOption('format'),
             'raw_text' => $input->getOption('raw'),
         ]);

--- a/src/Symfony/Component/Console/Tests/Command/HelpCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/HelpCommandTest.php
@@ -12,8 +12,8 @@
 namespace Symfony\Component\Console\Tests\Command;
 
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\HelpCommand;

--- a/src/Symfony/Component/Console/Tests/Command/HelpCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/HelpCommandTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Console\Tests\Command;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\HelpCommand;
@@ -32,8 +34,12 @@ class HelpCommandTest extends TestCase
         $this->assertStringContainsString('raw', $commandTester->getDisplay(), '->execute() returns a text help for the given command alias');
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testExecuteForCommand()
     {
+        $this->expectUserDeprecationMessage('Since symfony/console 7.4: Method "Symfony\Component\Console\Command\HelpCommand::setCommand()" is deprecated and will be removed in Symfony 8.0, use the command_name input argument instead');
+
         $command = new HelpCommand();
         $commandTester = new CommandTester($command);
         $command->setCommand(new ListCommand());
@@ -43,8 +49,12 @@ class HelpCommandTest extends TestCase
         $this->assertStringContainsString('raw', $commandTester->getDisplay(), '->execute() returns a text help for the given command');
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testExecuteForCommandWithXmlOption()
     {
+        $this->expectUserDeprecationMessage('Since symfony/console 7.4: Method "Symfony\Component\Console\Command\HelpCommand::setCommand()" is deprecated and will be removed in Symfony 8.0, use the command_name input argument instead');
+
         $command = new HelpCommand();
         $commandTester = new CommandTester($command);
         $command->setCommand(new ListCommand());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | N/A
| License       | MIT

## What is the problem?

Inside the `Application::get()` method, when help is requested, it retrieves a `HelpCommand` instance and calls `->setCommand()` on that instance.

However, the return type of `Application::get()` is declared as Command — the abstract base class, not a specific subtype.

As a result, invoking `->setCommand()` appears to be a call to an undefined method on the abstract type. In theory, this violates the Liskov Substitution Principle (LSP), since the method contract promises a Command, but the caller relies on behavior that only exists in a concrete subclass (`HelpCommand`).

I know we currently implicitly assume `Application::get('help')` always return a `HelpCommand` instance. But, I still think it should be explicitly here, instead of some magic stuff.

## Solution

Therefore, I suggest deprecating the `$command` property and the `setCommand()` method on `HelpCommand`, and using the `command_name` input argument consistently.

```php
public function doRun(InputInterface $input, OutputInterface $output): int
{
    // Doing something...
    
    $name = $this->getCommandName($input);

    if (true === $input->hasParameterOption(['--help', '-h'], true)) {
        // E.g. php bin/console --help
        // Set command_name as list (the default one)
        if (!$name) {
            $name = 'help';
            $input = new ArrayInput(['command_name' => $this->defaultCommand]);        
        } else { 
            // E.g. php bin/console hello --help
            // Set command_name as hello (the specific one)
            $this->wantHelps = true;
            $input = new ArrayInput(['command_name' => $name]);
        }
    }

    // Doing something...
}
```

Please see code changes for more details!

## Testing

- All current related tests are still passed.
- There are 4 use cases with the "help" command that still work identically before and after changes.

```bash
php bin/console help # Display help for the "help" command
php bin/console --help # Display help for the "list" command (the default one)

php bin/console hello --help # Display help for the "hello" command
php bin/console help hello # Display help for the "hello" command
```
