### PR TITLE
[FrameworkBundle] fix routing config type information

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/PhpConfigReferenceDumpPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/PhpConfigReferenceDumpPass.php
@@ -35,24 +35,24 @@ class PhpConfigReferenceDumpPass implements CompilerPassInterface
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
         {APP_TYPES}
-        final class App extends AppReference
+        final class App
         {
             {APP_PARAM}
             public static function config(array $config): array
             {
-                return parent::config($config);
+                return AppReference::config($config);
             }
         }
 
         namespace Symfony\Component\Routing\Loader\Configurator;
 
         {ROUTES_TYPES}
-        final class Routes extends RoutesReference
+        final class Routes
         {
             {ROUTES_PARAM}
             public static function config(array $config): array
             {
-                return parent::config($config);
+                return $config;
             }
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/PhpConfigReferenceDumpPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/PhpConfigReferenceDumpPassTest.php
@@ -71,7 +71,7 @@ class PhpConfigReferenceDumpPassTest extends TestCase
 
         $content = file_get_contents($referenceFile);
         $this->assertStringContainsString('namespace Symfony\Component\DependencyInjection\Loader\Configurator;', $content);
-        $this->assertStringContainsString('final class App extends AppReference', $content);
+        $this->assertStringContainsString('final class App', $content);
         $this->assertStringContainsString('public static function config(array $config): array', $content);
         $this->assertEquals([new FileResource(realpath($this->tempDir).'/reference.php')], $container->getResources());
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/reference.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/reference.php
@@ -161,7 +161,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
  *     }>
  * }
  */
-final class App extends AppReference
+final class App
 {
     /**
      * @param ConfigType $config
@@ -170,7 +170,7 @@ final class App extends AppReference
      */
     public static function config(array $config): array
     {
-        return parent::config($config);
+        return AppReference::config($config);
     }
 }
 
@@ -238,7 +238,7 @@ namespace Symfony\Component\Routing\Loader\Configurator;
  *     ...<string, RouteConfig|ImportConfig|AliasConfig>
  * }
  */
-final class Routes extends RoutesReference
+final class Routes
 {
     /**
      * @param RoutesConfig $config
@@ -247,6 +247,6 @@ final class Routes extends RoutesReference
      */
     public static function config(array $config): array
     {
-        return parent::config($config);
+        return $config;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

tackling these issues reported by PHPStan:

```
 ------ --------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   config/reference.php                                                                                                                         
 ------ --------------------------------------------------------------------------------------------------------------------------------------------- 
  1339   Parameter #1 $config (array{'when@dev'?: array<string, array{alias: string, deprecated?: array{package: string, version: string, message?:   
         string}}|array{path: array<string, string>|string, controller?: string, methods?: list<string>|string, requirements?: array<string, string>  
         , defaults?: array<string, mixed>, options?: array<string, mixed>, host?: array<string, string>|string, schemes?: list<string>|string, ...}  
         |array{resource: string, type?: string, exclude?: list<string>|string, prefix?: array<string, string>|string, name_prefix?: string, trailin  
         g_slash_on_root?: bool, controller?: string, methods?: list<string>|string, ...}>, 'when@prod'?: array<string, array{alias: string, depreca  
         ted?: array{package: string, version: string, message?: string}}|array{path: array<string, string>|string, controller?: string, methods?: l  
         ist<string>|string, requirements?: array<string, string>, defaults?: array<string, mixed>, options?: array<string, mixed>, host?: array<str  
         ing, string>|string, schemes?: list<string>|string, ...}|array{resource: string, type?: string, exclude?: list<string>|string, prefix?: arr  
         ay<string, string>|string, name_prefix?: string, trailing_slash_on_root?: bool, controller?: string, methods?: list<string>|string, ...}>,   
         'when@test'?: array<string, array{alias: string, deprecated?: array{package: string, version: string, message?: string}}|array{path: array<  
         string, string>|string, controller?: string, methods?: list<string>|string, requirements?: array<string, string>, defaults?: array<string,   
         mixed>, options?: array<string, mixed>, host?: array<string, string>|string, schemes?: list<string>|string, ...}|array{resource: string, ty  
         pe?: string, exclude?: list<string>|string, prefix?: array<string, string>|string, name_prefix?: string, trailing_slash_on_root?: bool, con  
         troller?: string, methods?: list<string>|string, ...}>}) of method Symfony\Component\Routing\Loader\Configurator\Routes::config() should be  
          contravariant with parameter $config (array<string, array<string, array<int<0, max>|string, mixed>|bool|string>>) of method                 
         Symfony\Component\Routing\Loader\Configurator\RoutesReference::config()                                                                      
         🪪  method.childParameterType                                                                                                                
  1341   Method Symfony\Component\Routing\Loader\Configurator\Routes::config() should return array{'when@dev'?: array<string, array{alias: string,    
         deprecated?: array{package: string, version: string, message?: string}}|array{path: array<string, string>|string, controller?: string, meth  
         ods?: list<string>|string, requirements?: array<string, string>, defaults?: array<string, mixed>, options?: array<string, mixed>, host?: ar  
         ray<string, string>|string, schemes?: list<string>|string, ...}|array{resource: string, type?: string, exclude?: list<string>|string, prefi  
         x?: array<string, string>|string, name_prefix?: string, trailing_slash_on_root?: bool, controller?: string, methods?: list<string>|string,   
         ...}>, 'when@prod'?: array<string, array{alias: string, deprecated?: array{package: string, version: string, message?: string}}|array{path:  
         array<string, string>|string, controller?: string, methods?: list<string>|string, requirements?: array<string, string>, defaults?: array<st  
         ring, mixed>, options?: array<string, mixed>, host?: array<string, string>|string, schemes?: list<string>|string, ...}|array{resource: stri  
         ng, type?: string, exclude?: list<string>|string, prefix?: array<string, string>|string, name_prefix?: string, trailing_slash_on_root?: boo  
         l, controller?: string, methods?: list<string>|string, ...}>, 'when@test'?: array<string, array{alias: string, deprecated?: array{package:   
         string, version: string, message?: string}}|array{path: array<string, string>|string, controller?: string, methods?: list<string>|string, r  
         equirements?: array<string, string>, defaults?: array<string, mixed>, options?: array<string, mixed>, host?: array<string, string>|string,   
         schemes?: list<string>|string, ...}|array{resource: string, type?: string, exclude?: list<string>|string, prefix?: array<string, string>|st  
         ring, name_prefix?: string, trailing_slash_on_root?: bool, controller?: string, methods?: list<string>|string, ...}>} but returns array<str  
         ing, array<string, array<int<0, max>|string, mixed>|bool|string>>.                                                                           
         🪪  return.type                                                                                                                              
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------
 ```
