### PR TITLE
 Add missing Path class required for `link` tool

### DIFF
--- a/link
+++ b/link
@@ -14,6 +14,7 @@ require __DIR__.'/src/Symfony/Component/Filesystem/Exception/ExceptionInterface.
 require __DIR__.'/src/Symfony/Component/Filesystem/Exception/IOExceptionInterface.php';
 require __DIR__.'/src/Symfony/Component/Filesystem/Exception/IOException.php';
 require __DIR__.'/src/Symfony/Component/Filesystem/Filesystem.php';
+require __DIR__.'/src/Symfony/Component/Filesystem/Path.php';
 
 use Symfony\Component\Filesystem\Filesystem;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

After https://github.com/symfony/symfony/pull/62283, the `Path` class becomes a new requirement for the `link` tool.

Current error:
```bash
Fatal error: Uncaught Error: Class "Symfony\Component\Filesystem\Path" not found in src/Symfony/Component/Filesystem/Filesystem.php:583
```