### PR TITLE
[Serializer][Validator] make `doLoadClassMetadata()` methods private

### DIFF
--- a/src/Symfony/Component/Serializer/Mapping/Loader/AttributeLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AttributeLoader.php
@@ -77,7 +77,7 @@ class AttributeLoader implements LoaderInterface
         return $success;
     }
 
-    public function doLoadClassMetadata(\ReflectionClass $reflectionClass, ClassMetadataInterface $classMetadata): bool
+    private function doLoadClassMetadata(\ReflectionClass $reflectionClass, ClassMetadataInterface $classMetadata): bool
     {
         $className = $reflectionClass->name;
         $loaded = false;

--- a/src/Symfony/Component/Validator/Mapping/Loader/AttributeLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/AttributeLoader.php
@@ -59,7 +59,7 @@ class AttributeLoader implements LoaderInterface
         return $success;
     }
 
-    public function doLoadClassMetadata(\ReflectionClass $reflClass, ClassMetadata $metadata): bool
+    private function doLoadClassMetadata(\ReflectionClass $reflClass, ClassMetadata $metadata): bool
     {
         $className = $reflClass->name;
         $success = false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

I don't see a good reason to have them callable from the outside. This was probably a mistake in #61545/#61563.