### PR TITLE
 Version as enum

### DIFF
--- a/src/Symfony/Contracts/CHANGELOG.md
+++ b/src/Symfony/Contracts/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.7
+---
+
+ * Add `PackageVersionInterface` to support version-based deprecation messages
+
 3.6
 ---
 

--- a/src/Symfony/Contracts/Deprecation/PackageVersionInterface.php
+++ b/src/Symfony/Contracts/Deprecation/PackageVersionInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Contracts\Deprecation;
+
+interface PackageVersionInterface extends \StringBackedEnum
+{
+}

--- a/src/Symfony/Contracts/Deprecation/PackageVersionInterface.php
+++ b/src/Symfony/Contracts/Deprecation/PackageVersionInterface.php
@@ -11,6 +11,6 @@
 
 namespace Symfony\Contracts\Deprecation;
 
-interface PackageVersionInterface extends \StringBackedEnum
+interface PackageVersionInterface extends \BackedEnum
 {
 }

--- a/src/Symfony/Contracts/Deprecation/composer.json
+++ b/src/Symfony/Contracts/Deprecation/composer.json
@@ -20,7 +20,8 @@
     "autoload": {
         "files": [
             "function.php"
-        ]
+        ],
+        "psr-4": { "Symfony\\Contracts\\Deprecation\\": "" }
     },
     "minimum-stability": "dev",
     "extra": {

--- a/src/Symfony/Contracts/Deprecation/function.php
+++ b/src/Symfony/Contracts/Deprecation/function.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+use Symfony\Contracts\Deprecation\PackageVersionInterface;
+
 if (!function_exists('trigger_deprecation')) {
     /**
      * Triggers a silenced deprecation notice.
@@ -26,8 +28,4 @@ if (!function_exists('trigger_deprecation')) {
 
         @trigger_error(($package || $version ? "Since $package $version: " : '').($args ? vsprintf($message, $args) : $message), \E_USER_DEPRECATED);
     }
-}
-
-interface PackageVersionInterface extends \StringBackedEnum
-{
 }

--- a/src/Symfony/Contracts/Deprecation/function.php
+++ b/src/Symfony/Contracts/Deprecation/function.php
@@ -15,10 +15,10 @@ if (!function_exists('trigger_deprecation')) {
     /**
      * Triggers a silenced deprecation notice.
      *
-     * @param string $package The name of the Composer package that is triggering the deprecation
+     * @param string                         $package The name of the Composer package that is triggering the deprecation
      * @param PackageVersionInterface|string $version The version of the package that introduced the deprecation
-     * @param string $message The message of the deprecation
-     * @param mixed  ...$args Values to insert in the message using printf() formatting
+     * @param string                         $message The message of the deprecation
+     * @param mixed                          ...$args Values to insert in the message using printf() formatting
      *
      * @author Nicolas Grekas <p@tchwork.com>
      */

--- a/src/Symfony/Contracts/Deprecation/function.php
+++ b/src/Symfony/Contracts/Deprecation/function.php
@@ -14,14 +14,20 @@ if (!function_exists('trigger_deprecation')) {
      * Triggers a silenced deprecation notice.
      *
      * @param string $package The name of the Composer package that is triggering the deprecation
-     * @param string $version The version of the package that introduced the deprecation
+     * @param PackageVersionInterface|string $version The version of the package that introduced the deprecation
      * @param string $message The message of the deprecation
      * @param mixed  ...$args Values to insert in the message using printf() formatting
      *
      * @author Nicolas Grekas <p@tchwork.com>
      */
-    function trigger_deprecation(string $package, string $version, string $message, mixed ...$args): void
+    function trigger_deprecation(string $package, PackageVersionInterface|string $version, string $message, mixed ...$args): void
     {
+        $version = $version instanceof PackageVersionInterface ? $version->value : $version;
+
         @trigger_error(($package || $version ? "Since $package $version: " : '').($args ? vsprintf($message, $args) : $message), \E_USER_DEPRECATED);
     }
+}
+
+interface PackageVersionInterface extends \StringBackedEnum
+{
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

Extend versions as StringBackedEnum for easy finding and configuration of deprecations in the package

```php
enum SomePackageVersion: string implements PackageVersionInterface 
{   
    public const V7_3 = '7.3';
    public const V7_4 = '7.4';
    
}

trigger_deprecation('symfony/deprecation-contracts', SomePackageVersion::V7_3, 'The "%s" is deprecated, use "%s" instead.', 'string', PackageVersionInterface::class);
```
