### PR TITLE
[DependencyInjection] Fix preloading `LazyClosure`

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1208,6 +1208,7 @@ EOTXT
                 || ($callable[0] instanceof Definition && !$this->definitionVariables->offsetExists($callable[0]))
             ))) {
                 $initializer = 'fn () => '.$this->dumpValue($callable[0]);
+                $this->preload[LazyClosure::class] = LazyClosure::class;
 
                 return $return.LazyClosure::getCode($initializer, $callable, $class, $this->container, $id).$tail;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Fixes this PHP warning when preloading a container that uses a lazy-closure:

> Can't preload unlinked class Symfony\Component\DependencyInjection\Argument\LazyClosure@anonymous: Unknown parent Symfony\Component\DependencyInjection\Argument\LazyClosure