### PR TITLE
[Form] Mark FormFlow as finished if the last step is skipped

### DIFF
--- a/src/Symfony/Component/Form/Flow/FormFlow.php
+++ b/src/Symfony/Component/Form/Flow/FormFlow.php
@@ -221,6 +221,18 @@ class FormFlow extends Form implements FormFlowInterface
             if (!$this->config->getStep($newStep)->isSkipped($data)) {
                 break;
             }
+
+            if ($cursor->isLastStep()) {
+                $this->finished = true;
+
+                if ($this->config->isAutoReset()) {
+                    $this->reset();
+
+                    return true;
+                }
+
+                break;
+            }
         }
 
         $this->cursor = $cursor;

--- a/src/Symfony/Component/Form/Tests/Fixtures/Flow/LastStepSkippedType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Flow/LastStepSkippedType.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Fixtures\Flow;
+
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Flow\AbstractFlowType;
+use Symfony\Component\Form\Flow\FormFlowBuilderInterface;
+use Symfony\Component\Form\Flow\Type\NavigatorFlowType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class LastStepSkippedType extends AbstractFlowType
+{
+    public function buildFormFlow(FormFlowBuilderInterface $builder, array $options): void
+    {
+        $builder->addStep('step1', TextType::class);
+        $builder->addStep('step2', skip: static fn () => true);
+
+        $builder->add('navigator', NavigatorFlowType::class);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => null,
+            'step_property_path' => '[currentStep]',
+        ]);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62445
| License       | MIT

This fixes cases where the last step can't be reached because it's currently skipped, which should mark the end of the process instead of throwing a runtime exception: `"Cannot determine next step."`

Then `$flow->isFinished()` will return true, but you must call the handler of the clicked button manually before checking `$flow->isFinished()` so this escenario will be covered:
```php
if ($flow->isSubmitted() && $flow->isValid()) {
    // ensure the flow button is handled before checking whether it's finished
    $flow->getClickedButton()->handle();

    if ($flow->isFinished()) {
        // do something with $form->getData()

        return $this->redirectToRoute('some_route');
    }
}
```
For other cases, you can continue using the simplified version of this controller. 