### PR TITLE
[HttpKernel] Fix using MapRequestPayload on nullable arguments

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
@@ -168,6 +168,10 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
 
     private function mapRequestPayload(Request $request, string $type, MapRequestPayload $attribute): ?object
     {
+        if ('' === $data = $request->request->all() ?: $request->getContent()) {
+            return null;
+        }
+
         if (null === $format = $request->getContentTypeFormat()) {
             throw new HttpException(Response::HTTP_UNSUPPORTED_MEDIA_TYPE, 'Unsupported format.');
         }
@@ -176,12 +180,8 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
             throw new HttpException(Response::HTTP_UNSUPPORTED_MEDIA_TYPE, \sprintf('Unsupported format, expects "%s", but "%s" given.', implode('", "', (array) $attribute->acceptFormat), $format));
         }
 
-        if ($data = $request->request->all()) {
+        if (\is_array($data)) {
             return $this->serializer->denormalize($data, $type, 'csv', $attribute->serializationContext + self::CONTEXT_DENORMALIZE);
-        }
-
-        if ('' === $data = $request->getContent()) {
-            return null;
         }
 
         if ('form' === $format) {

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php
@@ -179,6 +179,28 @@ class RequestPayloadValueResolverTest extends TestCase
         }
     }
 
+    public function testRequestPayloadWithoutContentTypeOnNullableArgumentReturnsNull()
+    {
+        $validator = $this->createMock(ValidatorInterface::class);
+        $validator->expects($this->never())
+            ->method('validate');
+
+        $resolver = new RequestPayloadValueResolver(new Serializer(), $validator);
+
+        $argument = new ArgumentMetadata('valid', RequestPayload::class, false, false, null, true, [
+            MapRequestPayload::class => new MapRequestPayload(),
+        ]);
+        $request = Request::create('/', 'POST');
+
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $arguments = $resolver->resolve($request, $argument);
+        $event = new ControllerArgumentsEvent($kernel, fn () => null, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $resolver->onKernelControllerArguments($event);
+
+        $this->assertSame([null], $event->getArguments());
+    }
+
     public function testQueryNullPayloadAndNotDefaultOrNullableArgument()
     {
         $validator = $this->createMock(ValidatorInterface::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

#50029 broke the capacity to use `#[MapRequestPayload]` on a nullable argument of an action accepting for GET/POST verbs.