### PR TITLE
[FrameworkBundle] Make `APP_*_DIR` relative to the project directory

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\BackupGlobals;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -244,5 +245,34 @@ class MicroKernelTraitTest extends TestCase
             'Symfony\Bundle\FrameworkBundle\FrameworkBundle' => ['all' => true],
             'TestBundle' => ['test' => true, 'dev' => true],
         ], $parameters['.kernel.bundles_definition']);
+    }
+
+    public function testRelativeEnvDirsAreResolvedFromProjectDir()
+    {
+        $_SERVER['APP_CACHE_DIR'] = 'var/custom-cache';
+        $_SERVER['APP_BUILD_DIR'] = 'var/custom-build';
+        $_SERVER['APP_SHARE_DIR'] = 'var/custom-share';
+
+        $projectDir = sys_get_temp_dir().'/sf_env_dir_kernel';
+        $kernel = new EnvDirKernel($projectDir);
+
+        $this->assertSame($projectDir.'/var/custom-cache/test', $kernel->getCacheDir());
+        $this->assertSame($projectDir.'/var/custom-build/test', $kernel->getBuildDir());
+        $this->assertSame($projectDir.'/var/custom-share/test', $kernel->getShareDir());
+    }
+}
+
+class EnvDirKernel extends Kernel
+{
+    use MicroKernelTrait;
+
+    public function __construct(private readonly string $projectDir)
+    {
+        parent::__construct('test', false);
+    }
+
+    public function getProjectDir(): string
+    {
+        return $this->projectDir;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | #62395
| License       | MIT

Relying on `APP_PROJECT_DIR` as introduced in #62190 has issues, like #62395
This PR resolves paths configured via `APP_*_DIR` relatively to the project-directory.
This makes things much more predictable and removes the need to rely on `APP_PROJECT_DIR`.