### PR TITLE
[ObjectMapper] map to embedded object with property access

### DIFF
--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/EmbeddedMapping/Address.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/EmbeddedMapping/Address.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\EmbeddedMapping;
+
+class Address
+{
+    public string $zipcode;
+    public string $city;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/EmbeddedMapping/User.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/EmbeddedMapping/User.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\EmbeddedMapping;
+
+class User
+{
+    public string $name;
+    public Address $address;
+
+    public function __construct()
+    {
+        $this->address = new Address();
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/EmbeddedMapping/UserDto.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/EmbeddedMapping/UserDto.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\EmbeddedMapping;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+class UserDto
+{
+    public function __construct(
+        #[Map(target: 'address.zipcode')]
+        public string $userAddressZipcode,
+        #[Map(target: 'address.city')]
+        public string $userAddressCity,
+        public string $name,
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -37,6 +37,9 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\DefaultLazy\OrderTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\DefaultLazy\UserSource;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\DefaultLazy\UserTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\DefaultValueStdClass\TargetDto;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\EmbeddedMapping\Address;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\EmbeddedMapping\User as UserEmbeddedMapping;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\EmbeddedMapping\UserDto;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\Flatten\TargetUser;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\Flatten\User;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\Flatten\UserProfile;
@@ -610,5 +613,23 @@ final class ObjectMapperTest extends TestCase
 
         $this->assertSame($result->relation, $service->get());
         $this->assertSame($result->relation->name, 'loaded');
+    }
+
+    public function testMapEmbeddedProperties()
+    {
+        $dto = new UserDto(
+            userAddressZipcode: '12345',
+            userAddressCity: 'Test City',
+            name: 'John Doe'
+        );
+
+        $mapper = new ObjectMapper(propertyAccessor: PropertyAccess::createPropertyAccessor());
+        $user = $mapper->map($dto, UserEmbeddedMapping::class);
+
+        $this->assertInstanceOf(UserEmbeddedMapping::class, $user);
+        $this->assertSame('John Doe', $user->name);
+        $this->assertInstanceOf(Address::class, $user->address);
+        $this->assertSame('12345', $user->address->zipcode);
+        $this->assertSame('Test City', $user->address->city);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62439
| License       | MIT

Property access component supports the dot notation for writing to embedded objects but a line checking reflection was preventing that to work. Its been moved later in the code ensuring that one can write using property accessor's functionalities.