### PR TITLE
[AssetMapper] Fix entrypoint status lost during update

### DIFF
--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapManager.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapManager.php
@@ -112,6 +112,8 @@ class ImportMapManager
                     $entry->packageModuleSpecifier,
                     null,
                     $importName,
+                    null,
+                    $entry->isEntrypoint,
                 );
 
                 // remove it: then it will be re-added


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When running `importmap:update`, packages defined as `entrypoint: true` in `importmap.php` lose this status and reset to `false`.

This happens because `ImportMapManager` does not pass the existing `entrypoint` value when creating the update options.
