### PR TITLE
[Workflow] Fix `MethodMarkingStore` crash with inherited uninitialized properties

### DIFF
--- a/src/Symfony/Component/Workflow/MarkingStore/MethodMarkingStore.php
+++ b/src/Symfony/Component/Workflow/MarkingStore/MethodMarkingStore.php
@@ -53,8 +53,7 @@ final class MethodMarkingStore implements MarkingStoreInterface
         try {
             $marking = ($this->getGetter($subject))();
         } catch (\Error $e) {
-            $unInitializedPropertyMessage = \sprintf('Typed property %s::$%s must not be accessed before initialization', get_debug_type($subject), $this->property);
-            if ($e->getMessage() !== $unInitializedPropertyMessage) {
+            if (!str_starts_with($e->getMessage(), 'Typed property ') || !str_ends_with($e->getMessage(), '::$'.$this->property.' must not be accessed before initialization')) {
                 throw $e;
             }
         }

--- a/src/Symfony/Component/Workflow/Tests/MarkingStore/MethodMarkingStoreTest.php
+++ b/src/Symfony/Component/Workflow/Tests/MarkingStore/MethodMarkingStoreTest.php
@@ -107,6 +107,16 @@ class MethodMarkingStoreTest extends TestCase
         $markingStore->getMarking($subject);
     }
 
+    public function testGetMarkingWithUninitializedPropertyInheritance()
+    {
+        $subject = new ChildInheritingProperty();
+
+        $markingStore = new MethodMarkingStore(true, 'place');
+        $marking = $markingStore->getMarking($subject);
+
+        $this->assertCount(0, $marking->getPlaces());
+    }
+
     private function createValueObject(string $markingValue): object
     {
         return new class($markingValue) {
@@ -123,4 +133,13 @@ class MethodMarkingStoreTest extends TestCase
             }
         };
     }
+}
+
+class ParentWithProperty
+{
+    public string $place;
+}
+
+class ChildInheritingProperty extends ParentWithProperty
+{
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When using `MethodMarkingStore` with an uninitialized typed property defined in a parent class, `getMarking()` crashes.

This happens because PHP's internal error message references the declaring class (Parent), but the current code compares it against `get_debug_type($subject)` which returns the instance class (Child).

This PR relaxes the exception message validation to ignore the class name. It now checks if the message starts with `Typed property` and ends with the expected uninitialized property suffix.