### PR TITLE
[Routing] Fix case sensitivity for static host matching in compiled routes

### DIFF
--- a/src/Symfony/Component/Routing/Matcher/Dumper/CompiledUrlMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/CompiledUrlMatcherDumper.php
@@ -222,7 +222,12 @@ EOF;
         foreach ($staticRoutes as $url => $routes) {
             $compiledRoutes[$url] = [];
             foreach ($routes as $name => [$route, $hasTrailingSlash]) {
-                $compiledRoutes[$url][] = $this->compileRoute($route, $name, (!$route->compile()->getHostVariables() ? $route->getHost() : $route->compile()->getHostRegex()) ?: null, $hasTrailingSlash, false, $conditions);
+                if ($route->compile()->getHostVariables()) {
+                    $host = $route->compile()->getHostRegex();
+                } elseif ($host = $route->getHost()) {
+                    $host = strtolower($host);
+                }
+                $compiledRoutes[$url][] = $this->compileRoute($route, $name, $host ?: null, $hasTrailingSlash, false, $conditions);
             }
         }
 

--- a/src/Symfony/Component/Routing/Tests/Matcher/CompiledUrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/CompiledUrlMatcherTest.php
@@ -13,11 +13,33 @@ namespace Symfony\Component\Routing\Tests\Matcher;
 
 use Symfony\Component\Routing\Matcher\CompiledUrlMatcher;
 use Symfony\Component\Routing\Matcher\Dumper\CompiledUrlMatcherDumper;
+use Symfony\Component\Routing\Matcher\UrlMatcher;
 use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
 class CompiledUrlMatcherTest extends UrlMatcherTest
 {
+    public function testStaticHostIsCaseInsensitive()
+    {
+        $collection = new RouteCollection();
+        $collection->add('static_host_route', new Route('/test', [], [], [], 'API.example.com'));
+
+        $context = new RequestContext('/test', 'GET', 'api.example.com');
+        $matcher = new UrlMatcher($collection, $context);
+
+        $result = $matcher->match('/test');
+        $this->assertEquals('static_host_route', $result['_route'], 'UrlMatcher should match case-insensitive host');
+
+        $dumper = new CompiledUrlMatcherDumper($collection);
+        $compiledRoutes = $dumper->getCompiledRoutes();
+
+        $compiledMatcher = new CompiledUrlMatcher($compiledRoutes, $context);
+
+        $result = $compiledMatcher->match('/test');
+        $this->assertEquals('static_host_route', $result['_route'], 'CompiledUrlMatcher should match case-insensitive host');
+    }
+
     protected function getUrlMatcher(RouteCollection $routes, ?RequestContext $context = null)
     {
         $dumper = new CompiledUrlMatcherDumper($routes);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`CompiledUrlMatcher` uses string comparison for static hosts, but checks lowercased request host against the original route host. This fails if the route host has uppercase letters (e.g., `'api.example.com' !== 'API.example.com'`), throwing `ResourceNotFoundException`.

`UrlMatcher` avoids this via case-insensitive regex.

This PR lowercases static hosts in `CompiledUrlMatcherDumper` for consistency.