### PR TITLE
[Routing] Fix addNamePrefix breaking aliases to external routes

### DIFF
--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -239,7 +239,13 @@ class RouteCollection implements \IteratorAggregate, \Countable
         }
 
         foreach ($this->aliases as $name => $alias) {
-            $prefixedAliases[$prefix.$name] = $alias->withId($prefix.$alias->getId());
+            $targetId = $alias->getId();
+
+            if (isset($this->routes[$targetId]) || isset($this->aliases[$targetId])) {
+                $targetId = $prefix.$targetId;
+            }
+
+            $prefixedAliases[$prefix.$name] = $alias->withId($targetId);
         }
 
         $this->routes = $prefixedRoutes;

--- a/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
@@ -385,4 +385,18 @@ class RouteCollectionTest extends TestCase
 
         $this->assertSame($expected, $collection3->all());
     }
+
+    public function testAddNamePrefixDoesNotBreakExternalAliases()
+    {
+        $collection = new RouteCollection();
+        $collection->add('local_route', new Route('/local'));
+        $collection->addAlias('alias_to_local', 'local_route');
+        $collection->addAlias('alias_to_external', 'external_route');
+        $collection->addNamePrefix('prefix_');
+
+        $aliases = $collection->getAliases();
+
+        $this->assertEquals('prefix_local_route', $aliases['prefix_alias_to_local']->getId(), 'Alias to local route should have its target prefixed');
+        $this->assertEquals('external_route', $aliases['prefix_alias_to_external']->getId(), 'Alias to external route should NOT have its target prefixed');
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When using `name_prefix` on an import, `RouteCollection::addNamePrefix()` unconditionally prefixes the target of all aliases.
If an alias points to an **external route** (a route not present in the imported collection), the link breaks because the external route name is not actually changed.

This PR ensures we only prefix the alias target if that target exists within the collection being modified.

```yaml
# config/routes.yaml
admin_section:
    resource: routes/admin.yaml
    prefix: /admin
    name_prefix: admin_
```

Inside `routes/admin.yaml`, I have an alias pointing to a global route defined elsewhere (`app_logout`):

```yaml
# config/routes/admin.yaml
logout:
    alias: app_logout
```

**Before:**
`php bin/console cache:clear` fails because the dumper tries to find the prefixed target (`admin_app_logout`) which does not exist:

> In CompiledUrlGeneratorDumper.php line 72:
> Target route "admin\_app\_logout" for alias "admin\_logout" does not exist.

**After:**
The alias correctly points to the original `app_logout` route and the cache warms up successfully:

> [OK] Cache for the "dev" environment (debug=true) was successfully cleared.