### PR TITLE
[Routing] Fix localized prefix updates breaking aliases

### DIFF
--- a/src/Symfony/Component/Routing/Loader/Configurator/Traits/PrefixTrait.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/Traits/PrefixTrait.php
@@ -27,10 +27,17 @@ trait PrefixTrait
             foreach ($prefix as $locale => $localePrefix) {
                 $prefix[$locale] = trim(trim($localePrefix), '/');
             }
+            $aliases = [];
+            foreach ($routes->getAliases() as $name => $alias) {
+                $aliases[$alias->getId()][] = $name;
+            }
             foreach ($routes->all() as $name => $route) {
                 if (null === $locale = $route->getDefault('_locale')) {
                     $priority = $routes->getPriority($name) ?? 0;
                     $routes->remove($name);
+                    foreach ($aliases[$name] ?? [] as $aliasName) {
+                        $routes->remove($aliasName);
+                    }
                     foreach ($prefix as $locale => $localePrefix) {
                         $localizedRoute = clone $route;
                         $localizedRoute->setDefault('_locale', $locale);
@@ -38,6 +45,9 @@ trait PrefixTrait
                         $localizedRoute->setDefault('_canonical_route', $name);
                         $localizedRoute->setPath($localePrefix.(!$trailingSlashOnRoot && '/' === $route->getPath() ? '' : $route->getPath()));
                         $routes->add($name.'.'.$locale, $localizedRoute, $priority);
+                        foreach ($aliases[$name] ?? [] as $aliasName) {
+                            $routes->addAlias($aliasName.'.'.$locale, $name.'.'.$locale);
+                        }
                     }
                 } elseif (!isset($prefix[$locale])) {
                     throw new \InvalidArgumentException(\sprintf('Route "%s" with locale "%s" is missing a corresponding prefix in its parent collection.', $name, $locale));

--- a/src/Symfony/Component/Routing/Tests/Loader/Configurator/Traits/PrefixTraitTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/Configurator/Traits/PrefixTraitTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Tests\Loader\Configurator\Traits;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Routing\Loader\Configurator\Traits\PrefixTrait;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+class PrefixTraitTest extends TestCase
+{
+    public function testAddLocalizedPrefixUpdatesAliases()
+    {
+        $collection = new RouteCollection();
+        $collection->add('app_route', new Route('/path'));
+        $collection->addAlias('app_alias', 'app_route');
+
+        $trait = new class {
+            use PrefixTrait;
+
+            public function add(RouteCollection $c, array $p)
+            {
+                $this->addPrefix($c, $p, false);
+            }
+        };
+
+        $trait->add($collection, ['en' => '/en', 'fr' => '/fr']);
+
+        $this->assertNull($collection->get('app_route'));
+
+        $this->assertNotNull($collection->get('app_route.en'));
+        $this->assertNotNull($collection->get('app_route.fr'));
+
+        $this->assertNull($collection->getAlias('app_alias'), 'The original alias should be removed as its target no longer exists');
+
+        $aliasEn = $collection->getAlias('app_alias.en');
+        $this->assertNotNull($aliasEn, 'Localized alias for EN should exist');
+        $this->assertEquals('app_route.en', $aliasEn->getId());
+
+        $aliasFr = $collection->getAlias('app_alias.fr');
+        $this->assertNotNull($aliasFr, 'Localized alias for FR should exist');
+        $this->assertEquals('app_route.fr', $aliasFr->getId());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When importing routes with a localized prefix, the original route is replaced by localized versions and removed. However, existing aliases pointing to that route remain unchanged, resulting in broken links to a non-existent target.

This PR ensures that when a route is localized via prefix, its aliases are also localized accordingly.
