### PR TITLE
 [JsonPath] Fix throwing on quoted True/False/Null

### DIFF
--- a/src/Symfony/Component/JsonPath/Tests/Fixtures/cts.json
+++ b/src/Symfony/Component/JsonPath/Tests/Fixtures/cts.json
@@ -4355,6 +4355,58 @@
       ]
     },
     {
+      "name": "filter, quoted True, double quotes",
+      "selector": "$[?@.a==\"True\"]",
+      "document": [
+        {
+          "a": "True"
+        },
+        {
+          "a": true
+        },
+        {
+          "a": "SomethingElse"
+        }
+      ],
+      "result": [
+        {
+          "a": "True"
+        }
+      ],
+      "result_paths": [
+        "$[0]"
+      ],
+      "tags": [
+        "case"
+      ]
+    },
+    {
+      "name": "filter, quoted True, single quotes",
+      "selector": "$[?@.a=='True']",
+      "document": [
+        {
+          "a": "True"
+        },
+        {
+          "a": true
+        },
+        {
+          "a": "SomethingElse"
+        }
+      ],
+      "result": [
+        {
+          "a": "True"
+        }
+      ],
+      "result_paths": [
+        "$[0]"
+      ],
+      "tags": [
+        "case"
+      ]
+    },
+    {
       "name": "filter, false, incorrectly capitalized",
       "selector": "$[?@==False]",
       "invalid_selector": true,
@@ -4363,9 +4415,113 @@
       ]
     },
     {
+      "name": "filter, quoted False, double quotes",
+      "selector": "$[?@.a==\"False\"]",
+      "document": [
+        {
+          "a": "False"
+        },
+        {
+          "a": false
+        },
+        {
+          "a": "SomethingElse"
+        }
+      ],
+      "result": [
+        {
+          "a": "False"
+        }
+      ],
+      "result_paths": [
+        "$[0]"
+      ],
+      "tags": [
+        "case"
+      ]
+    },
+    {
+      "name": "filter, quoted False, single quotes",
+      "selector": "$[?@.a=='False']",
+      "document": [
+        {
+          "a": "False"
+        },
+        {
+          "a": false
+        },
+        {
+          "a": "SomethingElse"
+        }
+      ],
+      "result": [
+        {
+          "a": "False"
+        }
+      ],
+      "result_paths": [
+        "$[0]"
+      ],
+      "tags": [
+        "case"
+      ]
+    },
+    {
       "name": "filter, null, incorrectly capitalized",
       "selector": "$[?@==Null]",
       "invalid_selector": true,
+      "tags": [
+        "case"
+      ]
+    },
+    {
+      "name": "filter, quoted Null, double quotes",
+      "selector": "$[?@.a==\"Null\"]",
+      "document": [
+        {
+          "a": "Null"
+        },
+        {
+          "a": null
+        },
+        {
+          "a": "SomethingElse"
+        }
+      ],
+      "result": [
+        {
+          "a": "Null"
+        }
+      ],
+      "result_paths": [
+        "$[0]"
+      ],
+      "tags": [
+        "case"
+      ]
+    },
+    {
+      "name": "filter, quoted Null, single quotes",
+      "selector": "$[?@.a=='Null']",
+      "document": [
+        {
+          "a": "Null"
+        },
+        {
+          "a": null
+        },
+        {
+          "a": "SomethingElse"
+        }
+      ],
+      "result": [
+        {
+          "a": "Null"
+        }
+      ],
+      "result_paths": [
+        "$[0]"
+      ],
       "tags": [
         "case"
       ]

--- a/src/Symfony/Component/JsonPath/Tests/Tokenizer/JsonPathTokenizerTest.php
+++ b/src/Symfony/Component/JsonPath/Tests/Tokenizer/JsonPathTokenizerTest.php
@@ -360,4 +360,18 @@ class JsonPathTokenizerTest extends TestCase
             'dash sign' => ['-test'],
         ];
     }
+
+    public function testQuotedTrueFalseNullShouldNotThrow()
+    {
+        foreach (['True', 'False', 'Null'] as $value) {
+            JsonPathTokenizer::tokenize(
+                new JsonPath(\sprintf('$[?@.a=="%s"]', $value))
+            );
+            JsonPathTokenizer::tokenize(
+                new JsonPath(\sprintf('$[?@.a==\'%s\']', $value))
+            );
+        }
+
+        $this->expectNotToPerformAssertions();
+    }
 }

--- a/src/Symfony/Component/JsonPath/Tokenizer/JsonPathTokenizer.php
+++ b/src/Symfony/Component/JsonPath/Tokenizer/JsonPathTokenizer.php
@@ -355,7 +355,7 @@ final class JsonPathTokenizer
         $filterExpr = ltrim($expr, '?');
         $filterExpr = trim($filterExpr);
 
-        if (preg_match('/\b(True|False|Null)\b/', $filterExpr)) {
+        if (preg_match('/(?<!["\'])\b(True|False|Null)\b(?!["\'])/', $filterExpr)) {
             throw new InvalidJsonPathException('Incorrectly capitalized literal in filter expression.', $position);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Bumped into this when parsing Kubernetes json output where `"True"` is commonly used and JsonPath threw for this valid expression. Making the regex more strict fixes it.

See also [PR for upstream fixtures](https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/113)