### PR TITLE
 Release v7.4.0

### DIFF
--- a/CHANGELOG-7.4.md
+++ b/CHANGELOG-7.4.md
@@ -7,6 +7,25 @@ in 7.4 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v7.4.0...v7.4.1
 
+* 7.4.0 (2025-11-21)
+
+ * bug #62454 [ObjectMapper] mapping of nested classes with promoted read-only properties (soyuka)
+ * bug #62456 [AssetMapper] Fix entrypoint status lost during update (yoeunes)
+ * bug #62416 [Console] Fix completion for global options values (HypeMC)
+ * bug #62455 [ObjectMapper] map to embedded object with property access (soyuka)
+ * bug #62458 [Workflow] Fix `MethodMarkingStore` crash with inherited uninitialized properties (yoeunes)
+ * bug #62459 [Routing] Fix case sensitivity for static host matching in compiled routes (yoeunes)
+ * bug #62461 [Routing] Fix localized prefix updates breaking aliases (yoeunes)
+ * bug #62460 [Routing] Fix addNamePrefix breaking aliases to external routes (yoeunes)
+ * bug #62453 [FrameworkBundle] Make `APP_*_DIR` relative to the project directory (nicolas-grekas)
+ * bug #62447 [Form] Mark FormFlow as finished if the last step is skipped (yceruto)
+ * bug #62436 [FrameworkBundle] Dump all registered extensions’ configuration reference (MatTheCat)
+ * bug #62449 [HttpKernel] Fix using MapRequestPayload on nullable arguments (nicolas-grekas)
+ * bug #62415 [HttpClient] Don't reset unused clients in data collector (HypeMC)
+ * bug #62417 [ObjectMapper] bypass lazy ghost with class transform (soyuka)
+ * bug #62437 [DependencyInjection] Fix preloading `LazyClosure` (nicolas-grekas)
+ * bug #62441 [WebProfilerBundle] fix displaying runner (94noni)
+
 * 7.4.0-RC2 (2025-11-16)
 
  * bug #62411 [HttpKernel] Conflict with symfony/flex < 2.10 (nicolas-grekas)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -73,12 +73,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     private static array $freshCache = [];
 
-    public const VERSION = '7.4.0-DEV';
+    public const VERSION = '7.4.0';
     public const VERSION_ID = 70400;
     public const MAJOR_VERSION = 7;
     public const MINOR_VERSION = 4;
     public const RELEASE_VERSION = 0;
-    public const EXTRA_VERSION = 'DEV';
+    public const EXTRA_VERSION = '';
 
     public const END_OF_MAINTENANCE = '11/2028';
     public const END_OF_LIFE = '11/2029';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v7.4.0-RC2...v7.4.0)

 * bug #62454 [ObjectMapper] mapping of nested classes with promoted read-only properties (@soyuka)
 * bug #62456 [AssetMapper] Fix entrypoint status lost during update (@yoeunes)
 * bug #62416 [Console] Fix completion for global options values (@HypeMC)
 * bug #62455 [ObjectMapper] map to embedded object with property access (@soyuka)
 * bug #62458 [Workflow] Fix `MethodMarkingStore` crash with inherited uninitialized properties (@yoeunes)
 * bug #62459 [Routing] Fix case sensitivity for static host matching in compiled routes (@yoeunes)
 * bug #62461 [Routing] Fix localized prefix updates breaking aliases (@yoeunes)
 * bug #62460 [Routing] Fix addNamePrefix breaking aliases to external routes (@yoeunes)
 * bug #62453 [FrameworkBundle] Make `APP_*_DIR` relative to the project directory (@nicolas-grekas)
 * bug #62447 [Form] Mark FormFlow as finished if the last step is skipped (@yceruto)
 * bug #62436 [FrameworkBundle] Dump all registered extensions’ configuration reference (@MatTheCat)
 * bug #62449 [HttpKernel] Fix using MapRequestPayload on nullable arguments (@nicolas-grekas)
 * bug #62415 [HttpClient] Don't reset unused clients in data collector (@HypeMC)
 * bug #62417 [ObjectMapper] bypass lazy ghost with class transform (@soyuka)
 * bug #62437 [DependencyInjection] Fix preloading `LazyClosure` (@nicolas-grekas)
 * bug #62441 [WebProfilerBundle] fix displaying runner (@94noni)
