### PR TITLE
[Config] Fix nullable EnumNode with BackedEnum

### DIFF
--- a/src/Symfony/Component/Config/Definition/EnumNode.php
+++ b/src/Symfony/Component/Config/Definition/EnumNode.php
@@ -104,6 +104,10 @@ class EnumNode extends ScalarNode
     {
         $value = parent::finalizeValue($value);
 
+        if (null === $value && $this->enumFqcn) {
+            return null;
+        }
+
         if (!$this->enumFqcn) {
             if (!\in_array($value, $this->values, true)) {
                 throw $this->createInvalidValueException($value);

--- a/src/Symfony/Component/Config/Tests/Definition/EnumNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/EnumNodeTest.php
@@ -222,4 +222,12 @@ class EnumNodeTest extends TestCase
 
         new EnumNode('ccc', null, [...TestEnum::cases(), TestEnum2::Ccc]);
     }
+
+    public function testFinalizeNullableBackedEnum()
+    {
+        $node = new EnumNode('status', null, enumFqcn: StringBackedTestEnum::class);
+        $node->setAllowEmptyValue(true); // Equivalent to ->defaultNull() in the builder
+
+        $this->assertNull($node->finalize(null));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When using `EnumNode` with a `BackedEnum` (via `enumFqcn`) and explicitly allowing null values (e.g. `->defaultNull()`), the finalization logic incorrectly throws an `InvalidConfigurationException`:

> "Only strings and integers can be cast to a case of the "Symfony\Component\Config\Tests\Fixtures\StringBackedTestEnum" enum, got value of type "null""

```php
$rootNode
    ->children()
        ->enumNode('status')
            ->enumFqcn(StringBackedTestEnum::class)
            ->defaultNull() // Now correctly allows null in config
        ->end()
    ->end()
;