### PR TITLE
[Config] Fix defaultNull() support for IntegerNode and FloatNode

### DIFF
--- a/src/Symfony/Component/Config/Definition/FloatNode.php
+++ b/src/Symfony/Component/Config/Definition/FloatNode.php
@@ -25,6 +25,10 @@ class FloatNode extends NumericNode
      */
     protected function validateType(mixed $value)
     {
+        if (null === $value && $this->hasDefaultValue() && null === $this->getDefaultValue()) {
+            return;
+        }
+
         // Integers are also accepted, we just cast them
         if (\is_int($value)) {
             $value = (float) $value;

--- a/src/Symfony/Component/Config/Definition/IntegerNode.php
+++ b/src/Symfony/Component/Config/Definition/IntegerNode.php
@@ -25,6 +25,10 @@ class IntegerNode extends NumericNode
      */
     protected function validateType(mixed $value)
     {
+        if (null === $value && $this->hasDefaultValue() && null === $this->getDefaultValue()) {
+            return;
+        }
+
         if (!\is_int($value)) {
             $ex = new InvalidTypeException(\sprintf('Invalid type for path "%s". Expected "int", but got "%s".', $this->getPath(), get_debug_type($value)));
             if ($hint = $this->getInfo()) {

--- a/src/Symfony/Component/Config/Tests/Definition/FloatNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/FloatNodeTest.php
@@ -76,4 +76,12 @@ class FloatNodeTest extends TestCase
             [new \stdClass()],
         ];
     }
+
+    public function testFinalizeWithNullAndAllowEmptyValue()
+    {
+        $node = new FloatNode('test');
+        $node->setDefaultValue(null);
+
+        $this->assertNull($node->finalize(null));
+    }
 }

--- a/src/Symfony/Component/Config/Tests/Definition/IntegerNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/IntegerNodeTest.php
@@ -73,4 +73,12 @@ class IntegerNodeTest extends TestCase
             [new \stdClass()],
         ];
     }
+
+    public function testFinalizeWithNullAndAllowEmptyValue()
+    {
+        $node = new IntegerNode('test');
+        $node->setDefaultValue(null);
+
+        $this->assertNull($node->finalize(null));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Currently, `IntegerNode` and `FloatNode` throw an `InvalidTypeException` when `null` is passed, even if `->defaultNull()` (or `allowEmptyValue`) is explicitly configured.

This happens because their `validateType` methods strictly enforce `is_int` / `is_float` checks, ignoring the `allowEmptyValue` property managed by the parent `VariableNode`.

The following error is thrown during finalization:
> Invalid type for path "test". Expected "int", but got "null".

```php
$rootNode
    ->children()
        ->integerNode('port')
            ->defaultNull() // Now correctly allows null instead of throwing InvalidTypeException
        ->end()
        ->floatNode('score')
            ->defaultNull()
        ->end()
    ->end()
;
```

**BC Layer:** Explicitly setting `allowEmptyValue` to `false` in the constructor. because the parent `VariableNode` defaults it to `true`.