### PR TITLE
[DependencyInjection] Fix wrong trait usage in ServiceLocatorArgument

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Argument/ServiceLocatorArgument.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/ServiceLocatorArgument.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\DependencyInjection\Argument;
 
-use Symfony\Component\DependencyInjection\Loader\Configurator\Traits\ArgumentTrait;
-
 /**
  * Represents a closure acting as a service locator.
  *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

PR #60597 introduced `ArgumentTrait` to optimize serialization.

However, `ServiceLocatorArgument` accidentally imported `ArgumentTrait` (from `Configurator`).