### PR TITLE
[DependencyInjection] Allow manual bindings on parameters with #[Target]

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveBindingsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveBindingsPass.php
@@ -189,8 +189,7 @@ class ResolveBindingsPass extends AbstractRecursivePass
                 if (
                     $value->isAutowired()
                     && !$value->hasTag('container.ignore_attributes')
-                    && ($parameter->getAttributes(Autowire::class, \ReflectionAttribute::IS_INSTANCEOF)
-                    || $parameter->getAttributes(Target::class, \ReflectionAttribute::IS_INSTANCEOF))
+                    && $parameter->getAttributes(Autowire::class, \ReflectionAttribute::IS_INSTANCEOF)
                 ) {
                     continue;
                 }
@@ -202,13 +201,17 @@ class ResolveBindingsPass extends AbstractRecursivePass
                 if ($typeHint && (
                     \array_key_exists($k = preg_replace('/(^|[(|&])\\\\/', '\1', $typeHint).' $'.$name, $bindings)
                     || \array_key_exists($k = preg_replace('/(^|[(|&])\\\\/', '\1', $typeHint).' $'.$parsedName, $bindings)
+                    || ($name !== $parameter->name && \array_key_exists($k = preg_replace('/(^|[(|&])\\\\/', '\1', $typeHint).' $'.$parameter->name, $bindings))
                 )) {
                     $arguments[$key] = $this->getBindingValue($bindings[$k]);
 
                     continue;
                 }
 
-                if (\array_key_exists($k = '$'.$name, $bindings) || \array_key_exists($k = '$'.$parsedName, $bindings)) {
+                if (\array_key_exists($k = '$'.$name, $bindings)
+                    || \array_key_exists($k = '$'.$parsedName, $bindings)
+                    || ($name !== $parameter->name && \array_key_exists($k = '$'.$parameter->name, $bindings))
+                ) {
                     $arguments[$key] = $this->getBindingValue($bindings[$k]);
 
                     continue;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

PR #60910 added a check in `ResolveBindingsPass` that skips parameters with the `#[Target]` attribute.

This prevents users from manually overriding values via `bind` (or `_defaults`) and causes `"unused binding"` exceptions, even when the binding matches the parameter name.

`Symfony\Component\DependencyInjection\Exception\InvalidArgumentException: A binding is configured for an argument named "$arg" for service "service", but no corresponding argument has been found. It may be unused and should be removed, or it may have a typo.`