### PR TITLE
[DependencyInjection] Fix loose validation in `#[Autowire]` attribute

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/Autowire.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/Autowire.php
@@ -52,7 +52,7 @@ class Autowire
             if (null !== $value && null !== $service) {
                 throw new LogicException('#[Autowire] attribute cannot declare $value and $service at the same time.');
             }
-        } elseif (!(null !== $value xor null !== $service xor null !== $expression xor null !== $env xor null !== $param)) {
+        } elseif (1 !== (null !== $value) + (null !== $service) + (null !== $expression) + (null !== $env) + (null !== $param)) {
             throw new LogicException('#[Autowire] attribute must declare exactly one of $service, $expression, $env, $param or $value.');
         }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Attribute/AutowireTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Attribute/AutowireTest.php
@@ -82,4 +82,24 @@ class AutowireTest extends TestCase
 
         yield [['value' => 'some-value', 'expression' => 'expr']];
     }
+
+    /**
+     * @dataProvider provideMutuallyExclusiveOptions
+     */
+    public function testConstructThrowsOnMutuallyExclusiveOptions(array $parameters)
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('#[Autowire] attribute must declare exactly one of $service, $expression, $env, $param or $value.');
+
+        new Autowire(...$parameters);
+    }
+
+    public static function provideMutuallyExclusiveOptions(): iterable
+    {
+        yield [[]];
+        yield [['value' => 'some-value', 'service' => 'id']];
+        yield [['value' => 'some-value', 'service' => 'id', 'expression' => 'expr']];
+        yield [['value' => 'some-value', 'service' => 'id', 'expression' => 'expr', 'env' => 'ENV']];
+        yield [['value' => 'some-value', 'service' => 'id', 'expression' => 'expr', 'env' => 'ENV', 'param' => 'param']];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The `Autowire` attribute uses a chain of `xor` conditions to ensure that only one of `$value`, `$service`, `$expression`, `$env`, or `$param` is passed.

However, `xor` is pairwise associative. If **three** of these arguments are passed, the expression evaluates to `true` (`(true ^ true) ^ true === true`), and the validation passes incorrectly.