### PR TITLE
[DependencyInjection] Deprecate invalid options when using `from_callable`

### DIFF
--- a/UPGRADE-8.1.md
+++ b/UPGRADE-8.1.md
@@ -1,0 +1,7 @@
+UPGRADE FROM 8.0 to 8.1
+=======================
+
+DependencyInjection
+-------------------
+
+ * Deprecate configuring options `alias`, `parent`, `synthetic`, `file`, `arguments`, `properties`, `configurator` or `calls` when using `from_callable`

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Deprecate configuring options `alias`, `parent`, `synthetic`, `file`, `arguments`, `properties`, `configurator` or `calls` when using `from_callable`
+
 8.0
 ---
 

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -412,6 +412,10 @@ class YamlFileLoader extends FileLoader
                 if (isset($service['factory'])) {
                     throw new InvalidArgumentException(\sprintf('The configuration key "%s" is unsupported for the service "%s" when using "from_callable" in "%s".', $key, $id, $file));
                 }
+
+                if (isset($service[$key])) {
+                    trigger_deprecation('symfony/dependency-injection', '8.1', 'Configuring the "%s" key for the service "%s" when using "from_callable" is deprecated and will throw an "InvalidArgumentException" in 9.0.', $key, $id);
+                }
             }
 
             if ('Closure' !== $service['class'] ??= 'Closure') {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | yes
| Issues        | -
| License       | MIT

I'm not sure if this is a bug or the desired behavior, but when using `from_callable` in YAML configuration, keys such as `properties` or `arguments` should be forbidden/ignored.

Introduced here #49632 on [YamlFileLoader.php:401](https://github.com/symfony/symfony/pull/49632/files#diff-942ccd0095dbe8010523f440b62cc19bc9b56357ea3a6f78b5a9e86faf56be38R401)