### PR TITLE
[DependencyInjection] Fix loop corruption in `CheckTypeDeclarationsPass`

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
@@ -142,13 +142,14 @@ final class CheckTypeDeclarationsPass extends AbstractRecursivePass
             if (!$p->hasType() || $p->isVariadic()) {
                 continue;
             }
+            $key = $i;
             if (\array_key_exists($p->name, $values)) {
-                $i = $p->name;
+                $key = $p->name;
             } elseif (!\array_key_exists($i, $values)) {
                 continue;
             }
 
-            $this->checkType($checkedDefinition, $values[$i], $p, $envPlaceholderUniquePrefix);
+            $this->checkType($checkedDefinition, $values[$key], $p, $envPlaceholderUniquePrefix);
         }
 
         if ($reflectionFunction->isVariadic() && ($lastParameter = end($reflectionParameters))->hasType()) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckTypeDeclarationsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckTypeDeclarationsPassTest.php
@@ -1023,6 +1023,18 @@ class CheckTypeDeclarationsPassTest extends TestCase
 
         $this->addToAssertionCount(1);
     }
+
+    public function testCheckTypeDeclarationsSkipsSubsequentNamedArguments()
+    {
+        $container = new ContainerBuilder();
+        $container->register('service', ServiceWithTwoInts::class)
+            ->setArguments(['a' => 1, 'b' => []]);
+
+        $this->expectException(InvalidParameterTypeException::class);
+        $this->expectExceptionMessage('argument 2 of "Symfony\Component\DependencyInjection\Tests\Compiler\ServiceWithTwoInts::__construct()" accepts "int", "array" passed');
+
+        (new CheckTypeDeclarationsPass(true))->process($container);
+    }
 }
 
 class CallableClass
@@ -1035,6 +1047,13 @@ class CallableClass
 class StaticCallableClass
 {
     public static function __callStatic($name, $arguments)
+    {
+    }
+}
+
+class ServiceWithTwoInts
+{
+    public function __construct(int $a, int $b)
     {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

In `CheckTypeDeclarationsPass`, the loop counter `$i` was incorrectly overwritten with the parameter name when processing **named arguments**.

Comparing a string to an integer [here](https://github.com/yoeunes/symfony/blob/3866ff11d86331d1acf49043f5c86b2a054db60f/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php#L140) (e.g. `'b' < 2`) evaluates to `false`. This caused the loop to terminate early, skipping type validation for all subsequent arguments.