### PR TITLE
[DependencyInjection] Fix invalid PHP syntax for nullable `TypedReference` in `PhpDumper`

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1844,7 +1844,15 @@ EOF;
 
                     $returnedType = '';
                     if ($value instanceof TypedReference) {
-                        $returnedType = \sprintf(': %s\%s', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE >= $value->getInvalidBehavior() ? '' : '?', str_replace(['|', '&'], ['|\\', '&\\'], $value->getType()));
+                        $type = $value->getType();
+                        $nullable = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE >= $value->getInvalidBehavior() ? '' : '?';
+
+                        if ('?' === ($type[0] ?? '')) {
+                            $type = substr($type, 1);
+                            $nullable = '?';
+                        }
+
+                        $returnedType = \sprintf(': %s\%s', $nullable, str_replace(['|', '&'], ['|\\', '&\\'], $type));
                     }
 
                     $attribute = '';

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -2142,6 +2142,25 @@ EOF
             ],
         ];
     }
+
+    public function testDumpServiceClosureWithNullableTypedReference()
+    {
+        $container = new ContainerBuilder();
+        $container->register('bar', 'stdClass');
+        $container->register('foo', 'stdClass')
+            ->setPublic(true)
+            ->setArguments([
+                new ServiceClosureArgument(new TypedReference('bar', '?stdClass')),
+            ]);
+
+        $container->compile();
+
+        $dumper = new PhpDumper($container);
+        $code = $dumper->dump(['as_files' => false]);
+
+        $this->assertStringNotContainsString(': \?stdClass', $code);
+        $this->assertStringContainsString(': ?\stdClass', $code);
+    }
 }
 
 class Rot13EnvVarProcessor implements EnvVarProcessorInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When dumping a `ServiceClosureArgument` wrapping a nullable `TypedReference` (e.g. `?Foo`), `PhpDumper` generates an invalid return type hint: `: \?Foo`.

This occurs because the dumper prepends `\` to the type string to ensure it is fully qualified.