### PR TITLE
[FrameworkBundle] Fix TypeError when traversing scalar values in debug:config

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
@@ -161,7 +161,7 @@ EOF
         $steps = explode('.', $path);
 
         foreach ($steps as $step) {
-            if (!\array_key_exists($step, $config)) {
+            if (!\is_array($config) || !\array_key_exists($step, $config)) {
                 throw new LogicException(\sprintf('Unable to find configuration for "%s.%s".', $alias, $path));
             }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDebugCommandTest.php
@@ -264,6 +264,16 @@ class ConfigDebugCommandTest extends AbstractWebTestCase
         yield 'option --format, debug' => [true, ['--format', ''], ['yaml', 'json']];
     }
 
+    public function testDumpPathDeepIntoScalar()
+    {
+        $tester = $this->createCommandTester(true);
+
+        $tester->execute(['name' => 'framework', 'path' => 'secret.foo']);
+
+        $this->assertSame(1, $tester->getStatusCode());
+        $this->assertStringContainsString('Unable to find configuration for "framework.secret.foo"', $tester->getDisplay());
+    }
+
     private function createCommandTester(bool $debug): CommandTester
     {
         $command = $this->createApplication($debug)->find('debug:config');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When running `debug:config` with a path that traverses deep into a scalar value (e.g. `debug:config framework secret.foo`), the command crashes instead of reporting that the path does not exist.

before:
```bash
$ php bin/console debug:config framework secret.foo                                                                                                                                                                   14:43:06

In ConfigDebugCommand.php line 164:
                                                                                
  array_key_exists(): Argument #2 ($array) must be of type array, string given  
                                                                                

debug:config [--resolve-env] [--format FORMAT] [--] [<name> [<path>]]
```

after:

```
$ php bin/console debug:config framework secret.foo                                                                                                                                                                  

                                                                                                                        
 [ERROR] Unable to find configuration for "framework.secret.foo".                                                       
                                                                                                                        
```
