### PR TITLE
[Scheduler] Implement lock per message/run to scale

### DIFF
--- a/src/Symfony/Component/Scheduler/Generator/MessageGenerator.php
+++ b/src/Symfony/Component/Scheduler/Generator/MessageGenerator.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\Scheduler\Generator;
 
 use Psr\Clock\ClockInterface;
 use Symfony\Component\Clock\Clock;
+use Symfony\Component\Lock\LockInterface;
+use Symfony\Component\Scheduler\Messenger\ServiceCallMessage;
 use Symfony\Component\Scheduler\RecurringMessage;
 use Symfony\Component\Scheduler\Schedule;
 use Symfony\Component\Scheduler\ScheduleProviderInterface;
@@ -23,6 +25,9 @@ final class MessageGenerator implements MessageGeneratorInterface
     private ?Schedule $schedule = null;
     private TriggerHeap $triggerHeap;
     private ?\DateTimeImmutable $waitUntil;
+
+    /** @var LockInterface[] */
+    private array $locks = [];
 
     public function __construct(
         private readonly ScheduleProviderInterface $scheduleProvider,
@@ -86,10 +91,27 @@ final class MessageGenerator implements MessageGeneratorInterface
                 $heap->insert([$nextTime, $index, $recurringMessage]);
             }
 
-            if ($yield) {
+            $lockFactory = $this->schedule->getLockFactory();
+            if ($yield && !$lockFactory) {
                 $context = new MessageContext($this->name, $id, $trigger, $time, $nextTime);
                 try {
                     foreach ($recurringMessage->getMessages($context) as $message) {
+                        yield $context => $message;
+                    }
+                } finally {
+                    $checkpoint->save($time, $index);
+                }
+            } elseif ($yield) {
+                $context = new MessageContext($this->name, $id, $trigger, $time, $nextTime);
+                try {
+                    foreach ($recurringMessage->getMessages($context) as $message) {
+                        $messageKey = $this->getMessageIdAndRun($message, $context);
+                        $key = 'scheduler_lock_'.$this->name.'_'.$messageKey;
+                        // lock for one hour to avoid duplicate message dispatching
+                        $lock = ($this->locks[$key] ??= $lockFactory->createLock($key, 3600, false));
+                        if (!$lock->acquire()) {
+                            continue;
+                        }
                         yield $context => $message;
                     }
                 } finally {
@@ -136,5 +158,14 @@ final class MessageGenerator implements MessageGeneratorInterface
     private function checkpoint(): Checkpoint
     {
         return $this->checkpoint ??= new Checkpoint('scheduler_checkpoint_'.$this->name, $this->getSchedule()->getLock(), $this->getSchedule()->getState());
+    }
+
+    private function getMessageIdAndRun(object $message, MessageContext $contest): string
+    {
+        return match (true) {
+            $message instanceof ServiceCallMessage => $message->__toString().json_encode($message->getArguments()),
+            $message instanceof \Stringable => $message->__toString(),
+            default => $message::class,
+        }.$contest->triggeredAt->format('_YmdHis');
     }
 }

--- a/src/Symfony/Component/Scheduler/Generator/MessageGenerator.php
+++ b/src/Symfony/Component/Scheduler/Generator/MessageGenerator.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\Scheduler\Generator;
 use Psr\Clock\ClockInterface;
 use Symfony\Component\Clock\Clock;
 use Symfony\Component\Lock\LockInterface;
-use Symfony\Component\Scheduler\Messenger\ServiceCallMessage;
 use Symfony\Component\Scheduler\RecurringMessage;
 use Symfony\Component\Scheduler\Schedule;
 use Symfony\Component\Scheduler\ScheduleProviderInterface;
@@ -105,8 +104,7 @@ final class MessageGenerator implements MessageGeneratorInterface
                 $context = new MessageContext($this->name, $id, $trigger, $time, $nextTime);
                 try {
                     foreach ($recurringMessage->getMessages($context) as $message) {
-                        $messageKey = $this->getMessageIdAndRun($message, $context);
-                        $key = 'scheduler_lock_'.$this->name.'_'.$messageKey;
+                        $key = 'scheduler_lock_'.$this->name.'_'.$context->id.$context->triggeredAt->format('_YmdHis');
                         // lock for one hour to avoid duplicate message dispatching
                         $lock = ($this->locks[$key] ??= $lockFactory->createLock($key, 3600, false));
                         if (!$lock->acquire()) {
@@ -158,14 +156,5 @@ final class MessageGenerator implements MessageGeneratorInterface
     private function checkpoint(): Checkpoint
     {
         return $this->checkpoint ??= new Checkpoint('scheduler_checkpoint_'.$this->name, $this->getSchedule()->getLock(), $this->getSchedule()->getState());
-    }
-
-    private function getMessageIdAndRun(object $message, MessageContext $contest): string
-    {
-        return match (true) {
-            $message instanceof ServiceCallMessage => $message->__toString().json_encode($message->getArguments()),
-            $message instanceof \Stringable => $message->__toString(),
-            default => $message::class,
-        }.$contest->triggeredAt->format('_YmdHis');
     }
 }

--- a/src/Symfony/Component/Scheduler/Generator/MessageGenerator.php
+++ b/src/Symfony/Component/Scheduler/Generator/MessageGenerator.php
@@ -104,7 +104,7 @@ final class MessageGenerator implements MessageGeneratorInterface
                 $context = new MessageContext($this->name, $id, $trigger, $time, $nextTime);
                 try {
                     foreach ($recurringMessage->getMessages($context) as $message) {
-                        $key = 'scheduler_lock_'.$this->name.'_'.$context->id.$context->triggeredAt->format('_YmdHis');
+                        $key = 'scheduler_lock_'.$this->name.'_'.$context->id.$context->triggeredAt->format('_YmdHi');
                         // lock for one hour to avoid duplicate message dispatching
                         $lock = ($this->locks[$key] ??= $lockFactory->createLock($key, 3600, false));
                         if (!$lock->acquire()) {

--- a/src/Symfony/Component/Scheduler/Schedule.php
+++ b/src/Symfony/Component/Scheduler/Schedule.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Scheduler;
 
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\LockInterface;
 use Symfony\Component\Scheduler\Event\FailureEvent;
 use Symfony\Component\Scheduler\Event\PostRunEvent;
@@ -24,6 +25,7 @@ final class Schedule implements ScheduleProviderInterface
     /** @var array<string,RecurringMessage> */
     private array $messages = [];
     private ?LockInterface $lock = null;
+    private ?LockFactory $lockFactory = null;
     private ?CacheInterface $state = null;
     private bool $shouldRestart = false;
     private bool $onlyLastMissed = false;
@@ -95,10 +97,16 @@ final class Schedule implements ScheduleProviderInterface
     }
 
     /**
+     * lock to acquire a single lock for the whole schedule run.
+     *
      * @return $this
      */
     public function lock(LockInterface $lock): static
     {
+        if ($this->lockFactory) {
+            throw new LogicException(\sprintf('You cannot set a Lock with "%s" if a LockFactory is already set.', __METHOD__));
+        }
+
         $this->lock = $lock;
 
         return $this;
@@ -107,6 +115,27 @@ final class Schedule implements ScheduleProviderInterface
     public function getLock(): ?LockInterface
     {
         return $this->lock;
+    }
+
+    /**
+     * lock factory to acquire locks per message and run.
+     *
+     * @return $this
+     */
+    public function lockFactory(LockFactory $lockFactory): static
+    {
+        if ($this->lock) {
+            throw new LogicException(\sprintf('You cannot set a LockFactory with "%s" if a Lock is already set.', __METHOD__));
+        }
+
+        $this->lockFactory = $lockFactory;
+
+        return $this;
+    }
+
+    public function getLockFactory(): ?LockFactory
+    {
+        return $this->lockFactory;
     }
 
     /**

--- a/src/Symfony/Component/Scheduler/Tests/Fixtures/SomeMessageStringable.php
+++ b/src/Symfony/Component/Scheduler/Tests/Fixtures/SomeMessageStringable.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Symfony\Component\Scheduler\Tests\Fixtures;
+
+class SomeMessageStringable implements \Stringable
+{
+    public function __construct(public string $id)
+    {
+    }
+
+    public function __toString()
+    {
+        return $this->id;
+    }
+
+}

--- a/src/Symfony/Component/Scheduler/Tests/Generator/MessageGeneratorTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Generator/MessageGeneratorTest.php
@@ -15,12 +15,15 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Clock\MockClock;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\Store\InMemoryStore;
 use Symfony\Component\Scheduler\Generator\Checkpoint;
 use Symfony\Component\Scheduler\Generator\MessageContext;
 use Symfony\Component\Scheduler\Generator\MessageGenerator;
 use Symfony\Component\Scheduler\RecurringMessage;
 use Symfony\Component\Scheduler\Schedule;
 use Symfony\Component\Scheduler\ScheduleProviderInterface;
+use Symfony\Component\Scheduler\Tests\Fixtures\SomeMessageStringable;
 use Symfony\Component\Scheduler\Trigger\TriggerInterface;
 
 class MessageGeneratorTest extends TestCase
@@ -260,6 +263,83 @@ class MessageGeneratorTest extends TestCase
         $this->assertCount(1, iterator_to_array($scheduler->getMessages(), false));
 
         $this->assertEquals(self::makeDateTime('22:23:10'), $clock->now());
+    }
+
+    public function testGranularLockAllowsSequentialAcquisition()
+    {
+        // message class stringable representation is used as lock key
+        $message1 = new SomeMessageStringable('message1');
+        $message2 = new SomeMessageStringable('message2');
+        $message3 = new SomeMessageStringable('message3');
+
+        $clock = new MockClock(self::makeDateTime('22:15:00'));
+
+        $lockFactory = new LockFactory(new InMemoryStore());
+        $cache = new ArrayAdapter();
+        // normally it should be the same cache for both consumers to share state
+        // but here we want to simulate two separate workers with their own state
+        $cache2 = new ArrayAdapter();
+
+        $schedule1 = (new Schedule())
+            ->add(RecurringMessage::every('1 minute', $message1))
+            ->add(RecurringMessage::every('1 minute', $message2))
+            ->add(RecurringMessage::every('1 minute', $message3))
+            ->stateful($cache)
+            ->lockFactory($lockFactory)
+        ;
+
+        // Clone schedule for second consumer with its own lock to simulate two separate workers
+        $schedule2 = (new Schedule())
+            ->add(RecurringMessage::every('1 minute', $message1))
+            ->add(RecurringMessage::every('1 minute', $message2))
+            ->add(RecurringMessage::every('1 minute', $message3))
+            ->stateful($cache2)
+            ->lockFactory($lockFactory)
+        ;
+
+        // First consumer
+        $generator1 = new MessageGenerator(
+            $schedule1,
+            'schedule_1',
+            $clock,
+        );
+
+        // Second consumer
+        $generator2 = new MessageGenerator(
+            $schedule2,
+            'schedule_1',
+            $clock,
+        );
+
+        // Warmup. The first run always returns nothing.
+        $this->assertSame([], iterator_to_array($generator1->getMessages(), false));
+        $this->assertSame([], iterator_to_array($generator2->getMessages(), false));
+        $this->assertEquals(self::makeDateTime('22:15:00'), $clock->now());
+
+        $clock->sleep(60 + 10); // 22:16:10
+        $message1 = $generator1->getMessages()->current();
+        $this->assertSame('message1', $message1->id);
+        $message2 = $generator2->getMessages()->current();
+        $this->assertSame('message2', $message2->id);
+        $message3 = $generator1->getMessages()->current();
+        $this->assertSame('message3', $message3->id);
+        $message4 = $generator2->getMessages()->current();
+        $this->assertNull($message4);
+        $message5 = $generator1->getMessages()->current();
+        $this->assertNull($message5);
+
+        $clock->sleep(60); // 22:17:10
+        $this->assertEquals(self::makeDateTime('22:17:10'), $clock->now());
+        $message1 = $generator2->getMessages()->current();
+        $this->assertSame('message1', $message1->id);
+        $message2 = $generator1->getMessages()->current();
+        $this->assertSame('message2', $message2->id);
+        $message3 = $generator1->getMessages()->current();
+        $this->assertSame('message3', $message3->id);
+        $message4 = $generator2->getMessages()->current();
+        $this->assertNull($message4);
+        $message5 = $generator1->getMessages()->current();
+        $this->assertNull($message5);
     }
 
     public static function messagesProvider(): \Generator

--- a/src/Symfony/Component/Scheduler/Tests/Generator/MessageGeneratorTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Generator/MessageGeneratorTest.php
@@ -342,6 +342,85 @@ class MessageGeneratorTest extends TestCase
         $this->assertNull($message5);
     }
 
+    public function testGranularLockAllowsSequentialAcquisitionWithJitter()
+    {
+        // Run multiple iterations to ensure the test is not flaky due to randomness
+        for ($iteration = 0; $iteration < 100; ++$iteration) {
+            // message class stringable representation is used as lock key
+            $message1 = new SomeMessageStringable('message1');
+            $message2 = new SomeMessageStringable('message2');
+            $message3 = new SomeMessageStringable('message3');
+
+            $clock = new MockClock(self::makeDateTime('22:15:00'));
+
+            $lockFactory = new LockFactory(new InMemoryStore());
+            $cache = new ArrayAdapter();
+            // normally it should be the same cache for both consumers to share state
+            // but here we want to simulate two separate workers with their own state
+            $cache2 = new ArrayAdapter();
+
+            // Use a large interval with small jitter
+            $schedule1 = (new Schedule())
+                ->add(RecurringMessage::every('5 minutes', $message1)->withJitter(15))
+                ->add(RecurringMessage::every('5 minutes', $message2)->withJitter(15))
+                ->add(RecurringMessage::every('5 minutes', $message3)->withJitter(15))
+                ->stateful($cache)
+                ->lockFactory($lockFactory)
+            ;
+
+            // Clone schedule for second consumer with its own cache to simulate two separate workers
+            $schedule2 = (new Schedule())
+                ->add(RecurringMessage::every('5 minutes', $message1)->withJitter(15))
+                ->add(RecurringMessage::every('5 minutes', $message2)->withJitter(15))
+                ->add(RecurringMessage::every('5 minutes', $message3)->withJitter(15))
+                ->stateful($cache2)
+                ->lockFactory($lockFactory)
+            ;
+
+            // First consumer
+            $generator1 = new MessageGenerator(
+                $schedule1,
+                'schedule_1',
+                $clock,
+            );
+
+            // Second consumer
+            $generator2 = new MessageGenerator(
+                $schedule2,
+                'schedule_1',
+                $clock,
+            );
+
+            // Warmup. The first run always returns nothing.
+            $this->assertSame([], iterator_to_array($generator1->getMessages(), false));
+            $this->assertSame([], iterator_to_array($generator2->getMessages(), false));
+
+            // Advance clock well beyond interval + max jitter to ensure all messages are ready
+            $clock->sleep(5 * 60 + 60); // 22:21:00 (5 min + 60 sec, well beyond max 15 sec jitter)
+
+            // With jitter, each generator computes different trigger times due to random_int().
+            // However, the lock key uses the canonical (non-jittered) time, so both workers
+            // compete for the same locks. This ensures each message is processed exactly once.
+            $generator1Messages = iterator_to_array($generator1->getMessages(), false);
+            $generator2Messages = iterator_to_array($generator2->getMessages(), false);
+
+            // Collect all processed message IDs
+            $allProcessedIds = [];
+            foreach ($generator1Messages as $msg) {
+                $allProcessedIds[] = $msg->id;
+            }
+            foreach ($generator2Messages as $msg) {
+                $allProcessedIds[] = $msg->id;
+            }
+
+            // Sort to compare regardless of order
+            sort($allProcessedIds);
+
+            // Each message should be processed exactly once across both generators (no duplicates)
+            $this->assertSame(['message1', 'message2', 'message3'], $allProcessedIds, \sprintf('Iteration %d failed', $iteration));
+        }
+    }
+
     public static function messagesProvider(): \Generator
     {
         $first = (object) ['id' => 'first'];

--- a/src/Symfony/Component/Scheduler/Tests/ScheduleTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/ScheduleTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Scheduler\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\Store\InMemoryStore;
 use Symfony\Component\Scheduler\Exception\LogicException;
 use Symfony\Component\Scheduler\RecurringMessage;
 use Symfony\Component\Scheduler\Schedule;
@@ -26,5 +28,33 @@ class ScheduleTest extends TestCase
         $this->expectException(LogicException::class);
 
         $schedule->add(RecurringMessage::cron('* * * * *', new \stdClass()));
+    }
+
+    public function testThatCannotSetLockAndLockFactoryAtTheSameTime()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('You cannot set a LockFactory with "Symfony\Component\Scheduler\Schedule::lockFactory" if a Lock is already set.');
+
+        $lockFactory = new LockFactory(new InMemoryStore());
+        $lock = $lockFactory->createLock('lock_name');
+
+        $schedule = new Schedule();
+        $schedule->add(RecurringMessage::cron('* * * * *', new \stdClass()))
+            ->lock($lock)
+            ->lockFactory($lockFactory);
+    }
+
+    public function testThatCannotSetLockAndLockFactoryAtTheSameTime2()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('You cannot set a Lock with "Symfony\Component\Scheduler\Schedule::lock" if a LockFactory is already set.');
+
+        $lockFactory = new LockFactory(new InMemoryStore());
+        $lock = $lockFactory->createLock('lock_name');
+
+        $schedule = new Schedule();
+        $schedule->add(RecurringMessage::cron('* * * * *', new \stdClass()))
+            ->lockFactory($lockFactory)
+            ->lock($lock);
     }
 }


### PR DESCRIPTION
| Q             | A |
| ------------- | --- |
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #58444
| License       | MIT

Hello,

This change improves the DX of the Scheduler component.  
It makes the scheduler more scalable by allowing the locking mechanism to be applied per message/run instead of per scheduler.

This introduces a new method on the scheduler to set a `LockFactory` rather than a single lock instance.  
If a `LockFactory` is provided, the `MessageGenerator` will attempt to lock the next run of the message before executing it.  
The lock is kept for 24 hours to prevent duplicate runs when multiple runners process the schedule in parallel.

This is a first version. I targeted the **7.4** branch because I'm not fully sure whether this should be considered a feature or a bugfix. 😉
