### PR TITLE
[ObjectMapper] Add `Attribute::TARGET_METHOD` to Map

### DIFF
--- a/src/Symfony/Component/ObjectMapper/Attribute/Map.php
+++ b/src/Symfony/Component/ObjectMapper/Attribute/Map.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\ObjectMapper\Attribute;
  *
  * @author Antoine Bluchet <soyuka@gmail.com>
  */
-#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_PROPERTY | \Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class Map
 {
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

According to the [documentation](https://symfony.com/doc/current/object_mapper.html#custom-mapping-logic), `\Symfony\Component\ObjectMapper\Attribute\Map` can be applied to methods:

```php
namespace App\ObjectMapper;

use App\Dto\LegacyUser;
use App\Dto\UserDto;
use App\ObjectMapper\Metadata\MapStructMapperMetadataFactory;
use Symfony\Component\ObjectMapper\Attribute\Map;
use Symfony\Component\ObjectMapper\ObjectMapper;
use Symfony\Component\ObjectMapper\ObjectMapperInterface;

// define the source-to-target mapping at the class level
#[Map(source: LegacyUser::class, target: UserDto::class)]
class LegacyUserMapper implements ObjectMapperInterface
{
    private readonly ObjectMapperInterface $objectMapper;

    // inject the standard ObjectMapper or necessary dependencies
    public function __construct(?ObjectMapperInterface $objectMapper = null)
    {
        // create an ObjectMapper instance configured with *this* mapper's rules
        $metadataFactory = new MapStructMapperMetadataFactory(self::class);
        $this->objectMapper = $objectMapper ?? new ObjectMapper($metadataFactory);
    }

    // define property-specific mapping rules on the map method
    #[Map(source: 'fullName', target: 'name')] // Map LegacyUser::fullName to UserDto::name
    #[Map(source: 'creationTimestamp', target: 'registeredAt', transform: [\DateTimeImmutable::class, 'createFromFormat'])]
    #[Map(source: 'status', if: false)] // Ignore the 'status' property from LegacyUser
    public function map(object $source, object|string|null $target = null): object
    {
        // delegate the actual mapping to the configured ObjectMapper
        return $this->objectMapper->map($source, $target);
    }
}
```

But it causes an exception:
```
Attribute \"Symfony\\Component\\ObjectMapper\\Attribute\\Map\" cannot target method (allowed targets: class, property)
```

This PR makes `\Symfony\Component\ObjectMapper\Attribute\Map` applicable to methods.