### PR TITLE
[Console] Fix exception message when abbreviation matches multiple hidden commands

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -788,9 +788,9 @@ class Application implements ResetInterface
             }
         }
 
-        $command = $this->get(reset($commands));
+        $command = $commands ? $this->get(reset($commands)) : null;
 
-        if ($command->isHidden()) {
+        if (!$command || $command->isHidden()) {
             throw new CommandNotFoundException(\sprintf('The command "%s" does not exist.', $name));
         }
 

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -2424,6 +2424,21 @@ class ApplicationTest extends TestCase
         $this->assertSame(\SIG_DFL, pcntl_signal_get_handler(\SIGUSR1), 'OS-level handler must remain SIG_DFL after a second run.');
     }
 
+    public function testFindAmbiguousHiddenCommands()
+    {
+        $application = new Application();
+
+        $application->add(new Command('test:foo'));
+        $application->add(new Command('test:foobar'));
+        $application->get('test:foo')->setHidden(true);
+        $application->get('test:foobar')->setHidden(true);
+
+        $this->expectException(CommandNotFoundException::class);
+        $this->expectExceptionMessage('The command "t:f" does not exist.');
+
+        $application->find('t:f');
+    }
+
     /**
      * Reads the private "signalHandlers" property of the SignalRegistry for assertions.
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When an abbreviation ambiguously matches multiple hidden commands, the current logic fails to handle the resolution correctly.

In this scenario, `reset($commands)` returns `false`. Consequently, `$this->get(false)` is called, which leads to a confusing exception message: `The command "" does not exist.`
