### PR TITLE
[HttpFoundation] Fix Expires response header for EventStream

### DIFF
--- a/src/Symfony/Component/HttpFoundation/EventStreamResponse.php
+++ b/src/Symfony/Component/HttpFoundation/EventStreamResponse.php
@@ -48,7 +48,7 @@ class EventStreamResponse extends StreamedResponse
             'Cache-Control' => 'private, no-cache, no-store, must-revalidate, max-age=0',
             'X-Accel-Buffering' => 'no',
             'Pragma' => 'no-cache',
-            'Expire' => '0',
+            'Expires' => '0',
         ];
 
         parent::__construct($callback, $status, $headers);

--- a/src/Symfony/Component/HttpFoundation/Tests/EventStreamResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/EventStreamResponseTest.php
@@ -29,6 +29,14 @@ class EventStreamResponseTest extends TestCase
         $this->assertNull($response->getRetry());
     }
 
+    public function testPresentOfExpiresHeader()
+    {
+        $response = new EventStreamResponse();
+
+        $this->assertTrue($response->headers->has('Expires'));
+        $this->assertSame('0', $response->headers->get('Expires'));
+    }
+
     public function testStreamSingleEvent()
     {
         $response = new EventStreamResponse(function () {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  |no
| Deprecations? |no
| Issues        | -
| License       | MIT

This PR fixes name of the HTTP response header 'Expires' for Event Stream Response, which is currently missing an 's'. Because of the typo, a server may assume that the 'Expires' header is not set and add its own one.  

There may be an old agents that do not check Cache-Control and only use value of Expires header, leading into incorrect caching of the response. Some servers tend to set Expires value to a future.

This fix is applicable to 7.3, 7.4, 8.x. The SSE has not been implemented before 7.3 and is not present in 6.x.

One of the responses when using SSE (notice the expire and the expires headers):
```
HTTP/2 200 
cache-control: max-age=0, must-revalidate, no-cache, no-store, private
x-accel-buffering: no
pragma: no-cache
expire: 0
date: Mon, 24 Nov 2025 17:01:30 GMT
cache-control: max-age=604800
expires: Mon, 01 Dec 2025 17:01:29 GMT
content-type: text/event-stream; charset=UTF-8
server: Apache
...
```

*WIP: Missing tests*