### PR TITLE
[HttpClient] Fix releasing uploaded stream resources

### DIFF
--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -355,6 +355,7 @@ trait HttpClientTrait
                     }
                 }
             });
+            $caster = null;
 
             if ('' === $body = http_build_query($body, '', '&')) {
                 return '';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60506
| License       | MIT

The recursive closure kept $streams (and therefore the original resources) reachable until the GC cycle collector ran, so multipart uploads held file handles even after the request lifecyle ended. Setting $caster = null breaks the cycle immediately, letting the resources be released right after the request.