### PR TITLE
[DependencyInjection] Fix `query_string` env processor for URLs without query string

### DIFF
--- a/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
+++ b/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
@@ -325,7 +325,7 @@ class EnvVarProcessor implements EnvVarProcessorInterface
         }
 
         if ('query_string' === $prefix) {
-            $queryString = parse_url($env, \PHP_URL_QUERY) ?: $env;
+            $queryString = parse_url($env, \PHP_URL_QUERY) ?: (parse_url($env, \PHP_URL_SCHEME) ? '' : $env);
             parse_str($queryString, $result);
 
             return $result;

--- a/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
@@ -982,4 +982,24 @@ CSV;
         yield 'Null' => [false, fn () => null];
         yield 'Env var not defined' => [false, fn () => throw new EnvNotFoundException()];
     }
+
+    /**
+     * @dataProvider provideQueryStringScenarios
+     */
+    public function testQueryStringEnvVarProcessor($envValue, $expectedResult)
+    {
+        $processor = new EnvVarProcessor(new Container());
+
+        $result = $processor->getEnv('query_string', 'MY_VAR', fn () => $envValue);
+
+        $this->assertSame($expectedResult, $result);
+    }
+
+    public static function provideQueryStringScenarios(): iterable
+    {
+        yield 'url_without_query' => ['https://example.com', []];
+        yield 'url_with_empty_query' => ['https://example.com?', []];
+        yield 'url_with_query' => ['https://example.com?foo=bar&baz=123', ['foo' => 'bar', 'baz' => '123']];
+        yield 'raw_query_string' => ['foo=bar&test=1', ['foo' => 'bar', 'test' => '1']];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When using `%env(query_string:MY_URL)%` with a URL that has no query string (e.g. `https://example.com`), the processor currently falls back to `parse_str('https://example.com', $result)`.

This PR ensures that `[]` is returned when the input is a valid URL but lacks a query component.