### PR TITLE
[DependencyInjection] Prevent trim processor from corrupting binary secrets

### DIFF
--- a/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
+++ b/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
@@ -356,7 +356,7 @@ class EnvVarProcessor implements EnvVarProcessorInterface
         }
 
         if ('trim' === $prefix) {
-            return trim($env);
+            return trim($env, " \t\n\r\v");
         }
 
         throw new RuntimeException(\sprintf('Unsupported env var prefix "%s" for env name "%s".', $prefix, $name));

--- a/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
@@ -982,4 +982,25 @@ CSV;
         yield 'Null' => [false, fn () => null];
         yield 'Env var not defined' => [false, fn () => throw new EnvNotFoundException()];
     }
+
+    /**
+     * @dataProvider provideTrimScenarios
+     */
+    public function testTrimEnvVarProcessorPreservesNullBytes($input, $expected)
+    {
+        $processor = new EnvVarProcessor(new Container());
+
+        $result = $processor->getEnv('trim', 'APP_SECRET', fn () => $input);
+
+        $this->assertSame($expected, $result);
+    }
+
+    public static function provideTrimScenarios(): iterable
+    {
+        yield 'standard_spaces' => ['  foo  ', 'foo'];
+        yield 'newlines_and_tabs' => ["\n\tbar\r\n", 'bar'];
+        yield 'binary_null_at_end' => ["MySecret\0\n", "MySecret\0"];
+        yield 'binary_null_at_start' => ["\n\0MySecret", "\0MySecret"];
+        yield 'binary_null_inside' => [" \tKey\0Value \n", "Key\0Value"];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The `trim` env processor currently uses PHP's default `trim()`, which removes null bytes (`\0`) in addition to whitespace.

This corrupts binary secrets (like encryption keys) that legitimately contain `\0`, especially when stripping trailing newlines from files (e.g. `%env(trim:file:AES_KEY)%`).

```php
// Input:  "Key\0\n" (Valid key + newline)

// Before: "Key"     (\0 removed)
// After:  "Key\0"   (only \n removed)