### PR TITLE
[FrameworkBundle] Remove traits from KernelTestCase

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -19,6 +19,7 @@ CHANGELOG
  * Remove the `validation.cache` option
  * Remove `TranslationUpdateCommand` in favor of `TranslationExtractCommand`
  * Remove `ConfigBuilderCacheWarmer`, return PHP arrays from your config instead
+ * Remove `MailerAssertionsTrait` and `NotificationAssertionsTrait` from `KernelTestCase`, use those traits directly when you need them
 
 7.4
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -24,9 +24,6 @@ use Symfony\Contracts\Service\ResetInterface;
  */
 abstract class KernelTestCase extends TestCase
 {
-    use MailerAssertionsTrait;
-    use NotificationAssertionsTrait;
-
     protected static ?string $class = null;
     protected static ?KernelInterface $kernel = null;
     protected static bool $booted = false;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/MailerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/MailerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
 use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\MailerAssertionsTrait;
 use Symfony\Bundle\FullStack;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Mailer\Mailer;
@@ -22,6 +23,8 @@ use Symfony\Component\Mime\Email;
 
 class MailerTest extends AbstractWebTestCase
 {
+    use MailerAssertionsTrait;
+
     public function testEnvelopeListener()
     {
         self::bootKernel(['test_case' => 'Mailer']);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/NotificationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/NotificationTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
 use PHPUnit\Framework\Attributes\RequiresMethod;
+use Symfony\Bundle\FrameworkBundle\Test\NotificationAssertionsTrait;
 use Symfony\Bundle\MercureBundle\MercureBundle;
 
 final class NotificationTest extends AbstractWebTestCase
 {
+    use NotificationAssertionsTrait;
+
     #[RequiresMethod(MercureBundle::class, 'build')]
     public function testNotifierAssertion()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 9.0
| Bug fix?      | no
| New feature?  | yes (BC)
| Deprecations? | no
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

`MailerAssertionsTrait` and `NotificationAssertionsTrait` are rarely used in many tests in a typical Symfony application, yet they come by default in the `KernelTestCase` which unnecessarily bloats the class by adding 34 methods.

In our codebase we duplicated `KernelTestCase` to avoid having methods that are unusable (because we don't use the mailer and the notifier), which is hacky. Unfortunately, PHP provides no way to "unuse" traits.

I propose removing these traits from the test case. It is a BC break (for tests only), but easy for new applications to adapt to, and makes the test case more composable.
