### PR TITLE
[ObjectMapper] merge nested properties when targeting the same class

### DIFF
--- a/src/Symfony/Component/ObjectMapper/CHANGELOG.md
+++ b/src/Symfony/Component/ObjectMapper/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add reverse class-map based on Map attribute
+ * Merge nested properties when targeting the same class
 
 7.4
 ---

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMapping/NestedBankDataDto.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMapping/NestedBankDataDto.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMapping;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: NestedBankDataResource::class)]
+class NestedBankDataDto
+{
+    public string $iban;
+    public NestedBankDto $bank;
+}
+

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMapping/NestedBankDataResource.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMapping/NestedBankDataResource.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMapping;
+
+class NestedBankDataResource
+{
+    public string $iban;
+    public string $bic;
+    public string $bankCode;
+    public string $bankName;
+}
+

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMapping/NestedBankDto.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMapping/NestedBankDto.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMapping;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: NestedBankDataResource::class)]
+class NestedBankDto
+{
+    public string $bic;
+    #[Map(target: 'bankCode')]
+    public string $code;
+    #[Map(target: 'bankName')]
+    public string $name;
+}
+

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -72,6 +72,9 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty\C as Mu
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargets\A as MultipleTargetsA;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargets\C as MultipleTargetsC;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MyProxy;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMapping\NestedBankDataDto;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMapping\NestedBankDataResource;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMapping\NestedBankDto;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\PartialInput\FinalInput;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\PartialInput\PartialInput;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\PromotedConstructor\Source as PromotedConstructorSource;
@@ -731,5 +734,26 @@ final class ObjectMapperTest extends TestCase
         $source = new MultipleTargetPropertyA();
         $mapper = new ObjectMapper();
         $mapper->map($source);
+    }
+
+    public function testNestedBankDataMapping()
+    {
+        $bankDto = new NestedBankDto();
+        $bankDto->bic = 'BIC123';
+        $bankDto->code = 'BANK001';
+        $bankDto->name = 'Test Bank';
+
+        $bankDataDto = new NestedBankDataDto();
+        $bankDataDto->iban = 'IBAN12345';
+        $bankDataDto->bank = $bankDto;
+
+        $mapper = new ObjectMapper();
+        $bankDataResource = $mapper->map($bankDataDto, NestedBankDataResource::class);
+
+        $this->assertInstanceOf(NestedBankDataResource::class, $bankDataResource);
+        $this->assertSame('IBAN12345', $bankDataResource->iban);
+        $this->assertSame('BIC123', $bankDataResource->bic);
+        $this->assertSame('BANK001', $bankDataResource->bankCode);
+        $this->assertSame('Test Bank', $bankDataResource->bankName);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #62357
| License       | MIT

Replacement for https://github.com/symfony/symfony/pull/62377 

## Mapping Nested Objects to the Same Target

When a property of the source object contains another object that maps to the
same target class as the parent, the properties of that nested object are
merged into the current target instance. This is useful for flattening nested
DTO structures into a single resource.

Consider the following example where `BankDataDto` contains a `BankDto`,
and both map to `BankDataResource`:

```php
// src/Dto/BankDataDto.php
namespace App\Dto;

use App\Api\BankDataResource;
use Symfony\Component\ObjectMapper\Attribute\Map;

#[Map(target: BankDataResource::class)]
class BankDataDto
{
    public string $iban;
    public BankDto $bank;
}

// src/Dto/BankDto.php
namespace App\Dto;

use App\Api\BankDataResource;
use Symfony\Component\ObjectMapper\Attribute\Map;

#[Map(target: BankDataResource::class)]
class BankDto
{
    #[Map(target: 'bic')]
    public string $bic;

    #[Map(target: 'bankCode')]
    public string $code;

    #[Map(target: 'bankName')]
    public string $name;
}

// src/Entity/BankDataResource.php
namespace App\Api;

class BankDataResource
{
    public string $iban;
    public string $bic;
    public string $bankCode;
    public string $bankName;
}
```

When mapping `BankDataDto`, the mapper will automatically process the `$bank`
property and map its fields (`bic`, `code`, `name`) to the same
`BankDataResource` instance created for the parent:

```php
$bankDto = new BankDto();
$bankDto->bic = 'BIC123';
$bankDto->code = 'BANK001';
$bankDto->name = 'Test Bank';

$dto = new BankDataDto();
$dto->iban = 'IBAN12345';
$dto->bank = $bankDto;

$mapper = new ObjectMapper();
$resource = $mapper->map($dto, BankDataResource::class);

// $resource->iban === 'IBAN12345'
// $resource->bic === 'BIC123' (mapped from the nested BankDto)
// $resource->bankCode === 'BANK001'
// $resource->bankName === 'Test Bank'
```