### PR TITLE
 [FrameworkBundle] Allow backed enum to be used in initial_marking workflow configuration

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -463,8 +463,19 @@ class Configuration implements ConfigurationInterface
                                         ->cannotBeEmpty()
                                     ->end()
                                     ->arrayNode('initial_marking')
-                                        ->acceptAndWrap(['string'])
+                                        ->acceptAndWrap(['backed-enum', 'string'])
                                         ->defaultValue([])
+                                        ->beforeNormalization()
+                                            ->ifArray()
+                                            ->then(static function ($markings) {
+                                                $normalizedMarkings = [];
+                                                foreach ($markings as $marking) {
+                                                    $normalizedMarkings[] = $marking instanceof \BackedEnum ? $marking->value : $marking;
+                                                }
+
+                                                return $normalizedMarkings;
+                                            })
+                                        ->end()
                                         ->prototype('scalar')->end()
                                     ->end()
                                     ->arrayNode('events_to_dispatch', 'event_to_dispatch')

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -711,6 +711,7 @@ class ConfigurationTest extends TestCase
                     'enum' => [
                         'supports' => [self::class],
                         'places' => Places::cases(),
+                        'initial_marking' => Places::A,
                         'transitions' => [
                             [
                                 'name' => 'one',
@@ -727,6 +728,8 @@ class ConfigurationTest extends TestCase
                 ],
             ],
         ]]);
+
+        $this->assertSame(['a'], $config['workflows']['workflows']['enum']['initial_marking']);
 
         $transitions = $config['workflows']['workflows']['enum']['transitions'];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT

I've tried using workflows with an enum, following this article: https://symfony.com/blog/new-in-symfony-7-4-misc-features-part-2#enum-support-in-workflows

The `initial_marking` configuration did not support it yet with this error:

```
Invalid type for path "framework.workflows.workflows.comment.initial_marking.0". Expected "scalar", but got "App\Entity\CommentState".
```

This change seems to fix it!