### PR TITLE
[Filesystem] account for PHP_ZTS being a boolean value on PHP 8.4+

### DIFF
--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTestCase.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTestCase.php
@@ -144,7 +144,7 @@ class FilesystemTestCase extends TestCase
         }
 
         // https://bugs.php.net/69473
-        if ($relative && '\\' === \DIRECTORY_SEPARATOR && 1 === \PHP_ZTS) {
+        if ($relative && '\\' === \DIRECTORY_SEPARATOR && \PHP_ZTS) {
             $this->markTestSkipped('symlink does not support relative paths on thread safe Windows PHP versions');
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

see php/php-src#13079

This will make the Windows build on the `8.0` and `8.1` branches green by skipping the `FilesystemTest::testMirrorCopiesRelativeLinkedContents()` test again.