### PR TITLE
[FrameworkBundle][ObjectMapper] Add automatic class-map array based on map attributes

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -137,6 +137,7 @@ use Symfony\Component\Notifier\Notifier;
 use Symfony\Component\Notifier\Recipient\Recipient;
 use Symfony\Component\Notifier\TexterInterface;
 use Symfony\Component\Notifier\Transport\TransportFactoryInterface as NotifierTransportFactoryInterface;
+use Symfony\Component\ObjectMapper\Attribute\Map;
 use Symfony\Component\ObjectMapper\ConditionCallableInterface;
 use Symfony\Component\ObjectMapper\ObjectMapperInterface;
 use Symfony\Component\ObjectMapper\TransformCallableInterface;
@@ -618,6 +619,12 @@ class FrameworkExtension extends Extension
                 ->addTag('object_mapper.transform_callable');
             $container->registerForAutoconfiguration(ConditionCallableInterface::class)
                 ->addTag('object_mapper.condition_callable');
+            $container->registerAttributeForAutoconfiguration(Map::class, static function (ChildDefinition $definition, Map $attribute, \ReflectionClass $reflector): void {
+                $definition->addResourceTag('object_mapper.map', [
+                    'source' => $attribute->source ?? $reflector->name,
+                    'target' => $attribute->target ?? $reflector->name,
+                ]);
+            });
         }
 
         $container->registerForAutoconfiguration(PackageInterface::class)

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -59,6 +59,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\JsonStreamer\DependencyInjection\StreamablePass;
 use Symfony\Component\Messenger\DependencyInjection\MessengerPass;
 use Symfony\Component\Mime\DependencyInjection\AddMimeTypeGuesserPass;
+use Symfony\Component\ObjectMapper\DependencyInjection\ReverseMappingPass;
 use Symfony\Component\PropertyInfo\DependencyInjection\PropertyInfoConstructorPass;
 use Symfony\Component\PropertyInfo\DependencyInjection\PropertyInfoPass;
 use Symfony\Component\Routing\DependencyInjection\AddExpressionLanguageProvidersPass;
@@ -206,6 +207,7 @@ class FrameworkBundle extends Bundle
         $container->addCompilerPass(new VirtualRequestStackPass());
         $container->addCompilerPass(new TranslationUpdateCommandPass(), PassConfig::TYPE_BEFORE_REMOVING);
         $this->addCompilerPassIfExists($container, StreamablePass::class);
+        $this->addCompilerPassIfExists($container, ReverseMappingPass::class);
 
         if ($container->getParameter('kernel.debug')) {
             $container->addCompilerPass(new AddDebugLogProcessorPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 2);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/object_mapper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/object_mapper.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Component\ObjectMapper\Metadata\ObjectMapperMetadataFactoryInterface;
 use Symfony\Component\ObjectMapper\Metadata\ReflectionObjectMapperMetadataFactory;
+use Symfony\Component\ObjectMapper\Metadata\ReverseClassObjectMapperMetadataFactory;
 use Symfony\Component\ObjectMapper\ObjectMapper;
 use Symfony\Component\ObjectMapper\ObjectMapperInterface;
 
@@ -20,6 +21,13 @@ return static function (ContainerConfigurator $container) {
     $container->services()
         ->set('object_mapper.metadata_factory', ReflectionObjectMapperMetadataFactory::class)
         ->alias(ObjectMapperMetadataFactoryInterface::class, 'object_mapper.metadata_factory')
+
+        ->set('object_mapper.metadata_factory.reverse_class', ReverseClassObjectMapperMetadataFactory::class)
+            ->decorate('object_mapper.metadata_factory')
+            ->args([
+                service('.inner'),
+                abstract_arg('class_map'),
+            ])
 
         ->set('object_mapper', ObjectMapper::class)
             ->args([

--- a/src/Symfony/Component/ObjectMapper/CHANGELOG.md
+++ b/src/Symfony/Component/ObjectMapper/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add reverse class-map based on Map attribute
+
 7.4
 ---
 

--- a/src/Symfony/Component/ObjectMapper/DependencyInjection/ReverseMappingPass.php
+++ b/src/Symfony/Component/ObjectMapper/DependencyInjection/ReverseMappingPass.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @author Florent Blaison <florent.blaison@gmail.com>
+ */
+final class ReverseMappingPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('object_mapper.metadata_factory.reverse_class')) {
+            return;
+        }
+
+        $reverseClassObjectMapperMetadataFactory = $container->getDefinition('object_mapper.metadata_factory.reverse_class');
+
+        $classes = [];
+        foreach ($container->findTaggedResourceIds('object_mapper.map') as $tags) {
+            foreach ($tags as $tag) {
+                if (isset($tag['source'], $tag['target'])) {
+                    $classes[$tag['source']] = $tag['target'];
+                }
+            }
+        }
+
+        $reverseClassObjectMapperMetadataFactory->replaceArgument(1, $classes);
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Metadata/ReverseClassObjectMapperMetadataFactory.php
+++ b/src/Symfony/Component/ObjectMapper/Metadata/ReverseClassObjectMapperMetadataFactory.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Metadata;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+/**
+ * Maps classes based on attributes found on the target's properties.
+ *
+ * @author Florent Blaison <florent.blaison@gmail.com>
+ */
+final class ReverseClassObjectMapperMetadataFactory implements ObjectMapperMetadataFactoryInterface
+{
+    /**
+     * @var array<string, list<Mapping>>
+     */
+    private array $attributesCache = [];
+
+    /**
+     * @param array<class-string, class-string> $classMap
+     */
+    public function __construct(
+        private readonly ObjectMapperMetadataFactoryInterface $objectMapperMetadataFactory,
+        private readonly array $classMap,
+    ) {
+    }
+
+    public function create(object $object, ?string $property = null, array $context = []): array
+    {
+        $class = $object::class;
+        $key = $class.($property ? '.'.$property : '');
+
+        if (isset($this->attributesCache[$key])) {
+            return $this->attributesCache[$key];
+        }
+
+        $mappings = $this->objectMapperMetadataFactory->create($object, $property, $context);
+
+        if (!$targetClass = $this->classMap[$class] ?? null) {
+            return $mappings;
+        }
+
+        if (!$property) {
+            $mappings[] = new Mapping($targetClass);
+
+            return $this->attributesCache[$key] = $mappings;
+        }
+
+        $refl = new \ReflectionClass($targetClass);
+        foreach ($refl->getProperties() as $reflProperty) {
+            $attributes = $reflProperty->getAttributes(Map::class, \ReflectionAttribute::IS_INSTANCEOF);
+
+            foreach ($attributes as $attribute) {
+                $map = $attribute->newInstance();
+                // We're forcing the target on a reverse mapping to the property name, doesn't make sense without a source
+                if ($map->source) {
+                    $mappings[] = new Mapping($reflProperty->getName(), $map->source, $map->if, $map->transform);
+                }
+            }
+        }
+
+        return $this->attributesCache[$key] = $mappings;
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/Cost.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/Cost.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap;
+
+final class Cost
+{
+    public function __construct(
+        public int $amount,
+        public int $tax,
+        public ?string $bar = null,
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/CostRequestView.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/CostRequestView.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(source: Cost::class)]
+final class CostRequestView
+{
+    public int $amount;
+
+    public int $tax;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/CostRequestWithSourceView.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/CostRequestWithSourceView.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\Cost;
+
+#[Map(source: Cost::class)]
+final class CostRequestWithSourceView
+{
+    #[Map(source: 'bar')]
+    public ?string $foo = null;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/Quote.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/Quote.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap;
+
+final class Quote
+{
+    public function __construct(
+        public string $id,
+        public Cost $cost,
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/QuoteRequestView.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/QuoteRequestView.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(source: Quote::class)]
+final class QuoteRequestView
+{
+    public string $id;
+
+    public CostRequestView $cost;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #62357
| License       | MIT

Create automatic class map array to allow Hexagonal Architecture and map object from the target class in Infrastructure layer
