### PR TITLE
[DependencyInjection] Fix state corruption in `PhpFileLoader` during recursive imports

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
@@ -57,6 +57,9 @@ class PhpFileLoader extends FileLoader
             return include $path;
         }, $this, ProtectedPhpFileLoader::class);
 
+        $instanceof = $this->instanceof;
+        $this->instanceof = [];
+
         try {
             $callback = $load($path, $this->env);
 
@@ -64,7 +67,7 @@ class PhpFileLoader extends FileLoader
                 $this->executeCallback($callback, new ContainerConfigurator($this->container, $this, $this->instanceof, $path, $resource, $this->env), $path);
             }
         } finally {
-            $this->instanceof = [];
+            $this->instanceof = $instanceof;
             $this->registerAliasesForSinglyImplementedInterfaces();
         }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/instanceof_import_child.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/instanceof_import_child.php
@@ -1,0 +1,5 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return function (ContainerConfigurator $container) {};

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/instanceof_import_parent.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/instanceof_import_parent.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+
+return function (ContainerConfigurator $container, PhpFileLoader $loader) {
+    $services = $container->services();
+
+    $services->instanceof(\stdClass::class)->tag('foo_tag');
+
+    $services->set('service_before', \stdClass::class);
+
+    $loader->import('instanceof_import_child.php');
+
+    $services->set('service_after', \stdClass::class);
+};

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
@@ -236,4 +236,18 @@ class PhpFileLoaderTest extends TestCase
         $values = ['foo' => new Definition(\stdClass::class), 'bar' => new Definition(\stdClass::class)];
         $this->assertEquals([new ServiceLocatorArgument($values)], $container->getDefinition('locator_dependent_inline_service')->getArguments());
     }
+
+    public function testInstanceofStateIsRestoredAfterImport()
+    {
+        $container = new ContainerBuilder();
+
+        $loader = new PhpFileLoader($container, new FileLocator(\dirname(__DIR__).'/Fixtures/config'));
+        $loader->load('instanceof_import_parent.php');
+
+        $conditionalsBefore = $container->getDefinition('service_before')->getInstanceofConditionals();
+        $this->assertArrayHasKey(\stdClass::class, $conditionalsBefore, 'Pre-import definition missing instanceof rule.');
+
+        $conditionalsAfter = $container->getDefinition('service_after')->getInstanceofConditionals();
+        $this->assertArrayHasKey(\stdClass::class, $conditionalsAfter, 'Post-import definition missing instanceof rule (State corruption detected).');
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

I'm not sure if this is a bug or not, the `load()` method resets `$this->instanceof` to an empty array in the `finally` block. Because the loader instance is shared during recursive imports (via `$loader->import()` inside the callback), this wipes the configuration of the parent file when the child file finishes loading.

```php
return function (ContainerConfigurator $container, PhpFileLoader $loader) {
    $services = $container->services();
    $services->instanceof(SomeInterface::class)->tag('my_tag');

    // This import triggers a recursive load() on the same loader instance
    $loader->import('child.php');

    // The instanceof rules above are currently lost here because the 
    // child load() reset the state in its finally block.
    $services->set(MyService::class, MyService::class); 
};
```