### PR TITLE
[HttpKernel] Don't reset services between fragments redering when using in HttpCache

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -67,6 +67,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
     private ?string $warmupDir = null;
     private int $requestStackSize = 0;
     private bool $resetServices = false;
+    private bool $handlingHttpCache = false;
 
     /**
      * @var array<string, bool>
@@ -98,6 +99,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
         $this->container = null;
         $this->requestStackSize = 0;
         $this->resetServices = false;
+        $this->handlingHttpCache = false;
     }
 
     public function boot(): void
@@ -170,13 +172,22 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
             $container = $this->container ?? $this->preBoot();
 
             if ($container->has('http_cache')) {
-                return $container->get('http_cache')->handle($request, $type, $catch);
+                $this->handlingHttpCache = true;
+
+                try {
+                    return $container->get('http_cache')->handle($request, $type, $catch);
+                } finally {
+                    $this->handlingHttpCache = false;
+                    $this->resetServices = true;
+                }
             }
         }
 
         $this->boot();
         ++$this->requestStackSize;
-        $this->resetServices = true;
+        if (!$this->handlingHttpCache) {
+            $this->resetServices = true;
+        }
 
         try {
             return $this->getHttpKernel()->handle($request, $type, $catch);

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
@@ -30,6 +31,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter;
 use Symfony\Component\HttpKernel\HttpKernel;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\HttpKernel\Tests\Fixtures\KernelWithoutBundles;
 use Symfony\Component\HttpKernel\Tests\Fixtures\ResettableService;
 
@@ -492,6 +494,39 @@ class KernelTest extends TestCase
         $this->assertEquals(1, ResettableService::$counter);
     }
 
+    public function testServicesAreNotResetBetweenHttpCacheFragments()
+    {
+        ResettableService::$counter = 0;
+        $fragmentKernel = new FragmentHandlingKernel();
+
+        $kernel = new CustomProjectDirKernel(function (ContainerBuilder $container) {
+            $container->addCompilerPass(new ResettableServicePass());
+            $container->register('kernel', CustomProjectDirKernel::class)
+                ->setSynthetic(true)
+                ->setPublic(true);
+            $container->register('one', ResettableService::class)
+                ->setPublic(true)
+                ->addTag('kernel.reset', ['method' => 'reset']);
+            $container->register('services_resetter', ServicesResetter::class)->setPublic(true);
+            $container->register('http_cache', FragmentRenderingHttpCache::class)
+                ->setPublic(true)
+                ->addArgument(new Reference('kernel'));
+        }, $fragmentKernel, 'http_cache_fragments');
+
+        $kernel->handle(new Request());
+
+        $this->assertSame([
+            ['/first-fragment', HttpKernelInterface::MAIN_REQUEST],
+            ['/second-fragment', HttpKernelInterface::MAIN_REQUEST],
+        ], $fragmentKernel->handledPaths);
+        $this->assertSame([0, 0], $fragmentKernel->resetCounters);
+        $this->assertSame(0, ResettableService::$counter);
+
+        $kernel->boot();
+
+        $this->assertSame(1, ResettableService::$counter);
+    }
+
     #[Group('time-sensitive')]
     public function testKernelStartTimeIsResetWhileBootingAlreadyBootedKernel()
     {
@@ -729,5 +764,41 @@ class KernelForTestWithLoadClassCache extends KernelForTest
 {
     public function doLoadClassCache(): void
     {
+    }
+}
+
+class FragmentHandlingKernel implements HttpKernelInterface
+{
+    public array $handledPaths = [];
+    public array $resetCounters = [];
+
+    public function handle(Request $request, int $type = self::MAIN_REQUEST, bool $catch = true): Response
+    {
+        $this->handledPaths[] = [$request->getPathInfo(), $type];
+        $this->resetCounters[] = ResettableService::$counter;
+
+        return new Response($request->getPathInfo());
+    }
+}
+
+class FragmentRenderingHttpCache implements HttpKernelInterface
+{
+    public function __construct(
+        private KernelInterface $kernel,
+        private string $trackedServiceId = 'one',
+    ) {
+    }
+
+    public function handle(Request $request, int $type = self::MAIN_REQUEST, bool $catch = true): Response
+    {
+        $this->kernel->boot();
+        $this->kernel->getContainer()->get($this->trackedServiceId);
+
+        $responses = [];
+        foreach (['/first-fragment', '/second-fragment'] as $path) {
+            $responses[] = $this->kernel->handle(Request::create($path), self::MAIN_REQUEST, $catch);
+        }
+
+        return new Response(implode('', array_map(static fn (Response $response) => $response->getContent(), $responses)));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62451
| License       | MIT

