### PR TITLE
[Semaphore] mark test using a Redis connection as an integration test

### DIFF
--- a/src/Symfony/Component/Semaphore/Tests/Store/RelayStoreTest.php
+++ b/src/Symfony/Component/Semaphore/Tests/Store/RelayStoreTest.php
@@ -15,12 +15,18 @@ use Relay\Relay;
 
 /**
  * @requires extension relay
+ *
+ * @group integration
  */
 class RelayStoreTest extends AbstractRedisStoreTestCase
 {
     protected function setUp(): void
     {
-        $this->getRedisConnection()->flushDB();
+        try {
+            $this->getRedisConnection()->flushDB();
+        } catch (\Relay\Exception $e) {
+            self::markTestSkipped($e->getMessage());
+        }
     }
 
     public static function setUpBeforeClass(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT
