### PR TITLE
[HttpKernel] Add support for `SOURCE_DATE_EPOCH` environment variable

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -147,7 +147,7 @@ class PhpDumper extends Dumper
             'inline_class_loader' => null,
             'preload_classes' => [],
             'service_locator_tag' => 'container.service_locator',
-            'build_time' => time(),
+            'build_time' => filter_var($_SERVER['SOURCE_DATE_EPOCH'] ?? null, \FILTER_VALIDATE_INT, \FILTER_NULL_ON_FAILURE) ?? time(),
         ], $options);
 
         $this->addGetService = false;

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add support for bundles as compiler pass
+ * Add support for `SOURCE_DATE_EPOCH` environment variable
 
 8.0
 ---

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -672,6 +672,10 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
             }
         }
 
+        if (null === $buildTime = filter_var($_SERVER['SOURCE_DATE_EPOCH'] ?? null, \FILTER_VALIDATE_INT, \FILTER_NULL_ON_FAILURE)) {
+            $buildTime = time();
+        }
+
         $content = $dumper->dump([
             'class' => $class,
             'base_class' => $baseClass,
@@ -680,7 +684,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
             'debug' => $this->debug,
             'inline_factories' => $buildParameters['.container.dumper.inline_factories'] ?? false,
             'inline_class_loader' => $buildParameters['.container.dumper.inline_class_loader'] ?? $this->debug,
-            'build_time' => $container->hasParameter('kernel.container_build_time') ? $container->getParameter('kernel.container_build_time') : time(),
+            'build_time' => $container->hasParameter('kernel.container_build_time') ? $container->getParameter('kernel.container_build_time') : $buildTime,
             'preload_classes' => array_map('get_class', $this->bundles),
         ]);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

If you care about reproducible builds, you probably already use the [kernel.container_build_time](https://symfony.com/doc/current/reference/configuration/kernel.html#kernel-container-build-time) parameter to "pin" the build date of your service container.

Nevertheless, the [SOURCE_DATE_EPOCH](https://reproducible-builds.org/docs/source-date-epoch/) standardized environment variable provides a better flexibility.

For instance, if you want to use the date of the last commit :

```
export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
bin/console cache:clear
```

This pull request intends to add support for this env var but gives priority to `kernel.container_build_time` if set.