### PR TITLE
[DependencyInjection] Reset resolved state when setting a parameter

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
@@ -112,6 +112,7 @@ class ParameterBag implements ParameterBagInterface
         }
 
         $this->parameters[$name] = $value;
+        $this->resolved = false;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/ParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/ParameterBagTest.php
@@ -356,4 +356,21 @@ class ParameterBagTest extends TestCase
             ['50% is less than 100%', '50% is less than 100%', 'Text between % signs is allowed, if there are spaces.'],
         ];
     }
+
+    public function testAddParametersAfterResolveBreaksConsistency()
+    {
+        $bag = new ParameterBag(['kernel.project_dir' => '/var/www/my_project']);
+        $bag->resolve();
+
+        $this->assertTrue($bag->isResolved());
+
+        $bag->set('app.uploads_dir', '%kernel.project_dir%/public/uploads');
+        $bag->resolve();
+
+        $this->assertSame(
+            '/var/www/my_project/public/uploads',
+            $bag->get('app.uploads_dir'),
+            'ParameterBag failed to resolve new parameters added after initial resolution.'
+        );
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Adding a parameter containing placeholders to an already resolved bag resulted in the bag remaining marked as resolved, preventing the new parameter from being resolved.

This PR ensures that `ParameterBag` marks itself as unresolved when a new parameter is set.

```php
$bag = new ParameterBag(['kernel.project_dir' => '/var/www/app']);
$bag->resolve();

$bag->set('app.uploads_dir', '%kernel.project_dir%/public/uploads');
$bag->resolve();

// before: '%kernel.project_dir%/public/uploads'
// after:  '/var/www/app/public/uploads' 
```