### PR TITLE
[DependencyInjection] Ensure deprecation detection does not trigger a PHP error

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveClassPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveClassPass.php
@@ -29,7 +29,7 @@ class ResolveClassPass implements CompilerPassInterface
             ) {
                 continue;
             }
-            if (class_exists($id) || interface_exists($id, false)) {
+            if ($container->getReflectionClass($id, false)) {
                 $definition->setClass($id);
                 continue;
             }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveClassPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveClassPassTest.php
@@ -107,4 +107,28 @@ class ResolveClassPassTest extends TestCase
 
         (new ResolveClassPass())->process($container);
     }
+
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
+    public function testInvalidClassWhoseImplementedInterfaceIsMissingDefinition()
+    {
+        $this->expectUserDeprecationMessage('Since symfony/dependency-injection 7.4: Service id "Acme\ClassImplementsUnavailableInterface" looks like a FQCN but no corresponding class or interface exists. To resolve this ambiguity, please rename this service to a non-FQCN (e.g. using dots), or create the missing class or interface.');
+
+        $autoloader = function (string $class) {
+            if ('Acme\ClassImplementsUnavailableInterface' === $class) {
+                new class implements UnavailableInterface {};
+            }
+        };
+
+        spl_autoload_register($autoloader);
+
+        try {
+            $container = new ContainerBuilder();
+            $container->register('Acme\ClassImplementsUnavailableInterface');
+
+            (new ResolveClassPass())->process($container);
+        } finally {
+            spl_autoload_unregister($autoloader);
+        }
+    }
 }


### PR DESCRIPTION
`Exception Interface "TYPO3\CMS\Reports\StatusProviderInterface" not found`
See https://forge.typo3.org/issues/108349


| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62589
| License       | MIT

The `class_exists` check and the condition `$definition instanceof ChildDefinition` have been swapped with #61215 in order to produce an error if a service is not available.

This error was later relaxed in #61270, but the executing order of the condition kept to be `class_exists` first, then `instanceof`.

That means, if `class_exists` fails with a PHP error (like PHP Fatal Error: Interface "My\Vendor\MyInterface" not found`) affected uses will not see the deprecation, but a fatal error instead.