### PR TITLE
[DependencyInjection] Don't add empty `.container.known_envs` in XML loader

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -63,11 +63,10 @@ class XmlFileLoader extends FileLoader
                 $this->loadXml($xml, $path, $root);
             }
         }
-        $knownEnvs = $this->container->hasParameter('.container.known_envs') ? array_flip($this->container->getParameter('.container.known_envs')) : [];
         foreach ($xpath->query('//container:when') ?: [] as $root) {
-            $knownEnvs[$root->getAttribute('env')] = true;
+            $knownEnvs = $this->container->hasParameter('.container.known_envs') ? array_flip($this->container->getParameter('.container.known_envs')) : [];
+            $this->container->setParameter('.container.known_envs', array_keys($knownEnvs + [$root->getAttribute('env') => true]));
         }
-        $this->container->setParameter('.container.known_envs', array_keys($knownEnvs));
 
         return null;
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -154,7 +154,6 @@ class XmlFileLoaderTest extends TestCase
             ],
             'mixedcase' => ['MixedCaseKey' => 'value'],
             'constant' => \PHP_EOL,
-            '.container.known_envs' => [],
         ];
 
         $this->assertEquals($expected, $actual, '->load() converts XML values to PHP ones');
@@ -191,7 +190,6 @@ class XmlFileLoaderTest extends TestCase
             ],
             'mixedcase' => ['MixedCaseKey' => 'value'],
             'constant' => \PHP_EOL,
-            '.container.known_envs' => [],
             'bar' => '%foo%',
             'imported_from_ini' => true,
             'imported_from_yaml' => true,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The XML loader is the only one that creates the `.container.known_envs` parameter even if there is no `<when env="...">` in the file. The PHP and Yaml loaders read and update this parameter only when they find a `when@<env>` key.

https://github.com/symfony/symfony/blob/1aa580f49841d479754c34102e42d334d0ce1a5a/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php#L81-L85
https://github.com/symfony/symfony/blob/1aa580f49841d479754c34102e42d334d0ce1a5a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php#L958-L962

This is causing an issue in [symfony-config-xml-to-php](https://github.com/GromNaN/symfony-config-xml-to-php) when comparing the result of loading equivalent PHP and XML config files. This key is added by the XML loader, not the PHP loader.
