### PR TITLE
[FrameworkBundle] Deprecate setting `collect_serializer_data`

### DIFF
--- a/UPGRADE-8.1.md
+++ b/UPGRADE-8.1.md
@@ -5,3 +5,8 @@ DependencyInjection
 -------------------
 
  * Deprecate configuring options `alias`, `parent`, `synthetic`, `file`, `arguments`, `properties`, `configurator` or `calls` when using `from_callable`
+
+FrameworkBundle
+---------------
+
+ * Deprecate setting the `framework.profiler.collect_serializer_data` config option

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Deprecate setting the `framework.profiler.collect_serializer_data` config option
+
 8.0
 ---
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -361,7 +361,11 @@ class Configuration implements ConfigurationInterface
                         ->booleanNode('only_exceptions')->defaultFalse()->end()
                         ->booleanNode('only_main_requests')->defaultFalse()->end()
                         ->scalarNode('dsn')->defaultValue('file:%kernel.cache_dir%/profiler')->end()
-                        ->enumNode('collect_serializer_data')->values([true])->defaultTrue()->end() // to be @deprecated in Symfony 8.1
+                        ->enumNode('collect_serializer_data')
+                            ->values([true])
+                            ->defaultTrue()
+                            ->setDeprecated('symfony/framework-bundle', '8.1', 'Setting the "%path%.%node%" configuration option is deprecated. It will be removed in version 9.0.')
+                        ->end()
                     ->end()
                 ->end()
             ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/profiler.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/profiler.php
@@ -3,7 +3,6 @@
 $container->loadFromExtension('framework', [
     'profiler' => [
         'enabled' => true,
-        'collect_serializer_data' => true,
     ],
     'serializer' => [
         'enabled' => true,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/profiler.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/profiler.yml
@@ -1,6 +1,5 @@
 framework:
     profiler:
         enabled: true
-        collect_serializer_data: true
     serializer:
         enabled: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/config/framework.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/config/framework.yml
@@ -13,8 +13,6 @@ framework:
         storage_factory_id: session.storage.factory.mock_file
         cookie_secure: auto
         cookie_samesite: lax
-    profiler:
-        collect_serializer_data: true
 
 services:
     logger: { class: Psr\Log\NullLogger }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/FirewallEntryPoint/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/FirewallEntryPoint/config.yml
@@ -14,7 +14,6 @@ framework:
         cookie_samesite: lax
     profiler:
         only_exceptions: false
-        collect_serializer_data: true
 
 services:
     logger: { class: Psr\Log\NullLogger }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/config/framework.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/config/framework.yml
@@ -15,7 +15,6 @@ framework:
         cookie_samesite: lax
     profiler:
         only_exceptions: false
-        collect_serializer_data: true
 
 services:
     logger: { class: Psr\Log\NullLogger }

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Functional/WebProfilerBundleKernel.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Functional/WebProfilerBundleKernel.php
@@ -52,7 +52,7 @@ class WebProfilerBundleKernel extends Kernel
     {
         $config = [
             'secret' => 'foo-secret',
-            'profiler' => ['only_exceptions' => false, 'collect_serializer_data' => true],
+            'profiler' => ['only_exceptions' => false],
             'session' => ['handler_id' => null, 'storage_factory_id' => 'session.storage.factory.mock_file', 'cookie-secure' => 'auto', 'cookie-samesite' => 'lax'],
             'router' => ['utf8' => true],
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | 
| License       | MIT

Follow-up of https://github.com/symfony/symfony/pull/60069.

Deprecate setting `collect_serializer_data`, as it's not used anymore by `FrameworkBundle`
