### PR TITLE
[DependencyInjection] add legacy group to test testing a deprecated feature

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests\Loader;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Exception\FileLocatorFileNotFoundException;
@@ -1220,6 +1221,7 @@ class YamlFileLoaderTest extends TestCase
     }
 
     #[IgnoreDeprecations]
+    #[Group('legacy')]
     #[DataProvider('provideForbiddenKeys')]
     public function testFromCallableTriggersDeprecationOnForbiddenKeys(string $key, mixed $value)
     {

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Routing\Tests\Generator;
 
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

We need this group in the future to properly skip the test in the high deps job once we start the development of Symfony 8.4.

