### PR TITLE
[Console] don't discard existing aliases when constructing Command

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -120,6 +120,12 @@ class Command implements SignalableCommandInterface
                 $name = array_shift($aliases);
             }
 
+            // we must not overwrite existing aliases, combine new ones with existing ones
+            $aliases = array_unique([
+                ...$this->aliases,
+                ...$aliases,
+            ]);
+
             $this->setAliases($aliases);
         }
 

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -199,10 +199,23 @@ class CommandTest extends TestCase
     public function testGetSetAliases()
     {
         $command = new \TestCommand();
-        $this->assertEquals(['name'], $command->getAliases(), '->getAliases() returns the aliases');
         $ret = $command->setAliases(['name1']);
         $this->assertEquals($command, $ret, '->setAliases() implements a fluent interface');
         $this->assertEquals(['name1'], $command->getAliases(), '->setAliases() sets the aliases');
+    }
+
+    public function testAliasesSetBeforeParentConstructorArePreserved()
+    {
+        $command = new class extends Command {
+            public function __construct()
+            {
+                // set aliases before calling parent constructor
+                $this->setAliases(['existingalias']);
+                parent::__construct('foo|newalias');
+            }
+        };
+
+        $this->assertSame(['existingalias', 'newalias'], $command->getAliases(), 'Aliases set before parent::__construct() must be preserved.');
     }
 
     #[TestWith(['name|alias1|alias2', 'name', ['alias1', 'alias2'], false])]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4 
| Bug fix?      | yes
| New feature?  no
| Deprecations? | no 
| Issues        | Fix #62557 
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

The code in #62557 was broken by https://github.com/symfony/console/commit/5e7cd96684d8d229b9478fb0d224c60bf0cb2c3d. Here I combine the new aliases found by pipes in the string with existing ones that may have previously been set.
-->

Contributor guidelines:
- [x] Add tests and ensure they pass
- [x] Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- [x] New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- [x] Do not break backward compatibility:
  https://symfony.com/bc
