### PR TITLE
[Config] Fix array shape generation for backed enums

### DIFF
--- a/src/Symfony/Component/Config/Definition/EnumNode.php
+++ b/src/Symfony/Component/Config/Definition/EnumNode.php
@@ -79,12 +79,18 @@ class EnumNode extends ScalarNode
     public function getPermissibleValues(string $separator, bool $trim = true): string
     {
         if (is_subclass_of($this->enumFqcn, \BackedEnum::class)) {
-            return implode($separator, array_column($this->enumFqcn::cases(), 'value'));
+            if (!$trim) {
+                return 'value-of<\\'.$this->enumFqcn.'>'.$separator.'\\'.$this->enumFqcn;
+            }
+
+            $values = array_column($this->enumFqcn::cases(), 'value');
+
+            return implode($separator, array_map(static fn ($value) => json_encode($value, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE), $values));
         }
 
         return implode($separator, array_unique(array_map(static function ($value) use ($trim) {
             if (!$value instanceof \UnitEnum) {
-                return json_encode($value);
+                return json_encode($value, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE | \JSON_PRESERVE_ZERO_FRACTION);
             }
 
             return $trim ? ltrim(var_export($value, true), '\\') : var_export($value, true);

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/PrimitiveTypes/Symfony/Config/PrimitiveTypesConfig.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/PrimitiveTypes/Symfony/Config/PrimitiveTypesConfig.php
@@ -53,7 +53,7 @@ class PrimitiveTypesConfig implements \Symfony\Component\Config\Builder\ConfigBu
 
     /**
      * @default null
-     * @param ParamConfigurator|\Symfony\Component\Config\Tests\Fixtures\StringBackedTestEnum::Foo|\Symfony\Component\Config\Tests\Fixtures\StringBackedTestEnum::Bar $value
+     * @param ParamConfigurator|\Symfony\Component\Config\Tests\Fixtures\StringBackedTestEnum::Foo|\Symfony\Component\Config\Tests\Fixtures\StringBackedTestEnum::BarBaz $value
      * @return $this
      * @deprecated since Symfony 7.4
      */

--- a/src/Symfony/Component/Config/Tests/Definition/ArrayShapeGeneratorTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/ArrayShapeGeneratorTest.php
@@ -25,6 +25,8 @@ use Symfony\Component\Config\Definition\PrototypedArrayNode;
 use Symfony\Component\Config\Definition\ScalarNode;
 use Symfony\Component\Config\Definition\StringNode;
 use Symfony\Component\Config\Definition\VariableNode;
+use Symfony\Component\Config\Tests\Fixtures\IntegerBackedTestEnum;
+use Symfony\Component\Config\Tests\Fixtures\StringBackedTestEnum;
 
 class ArrayShapeGeneratorTest extends TestCase
 {
@@ -52,6 +54,8 @@ class ArrayShapeGeneratorTest extends TestCase
 
         yield [$nullableBooleanNode, 'bool|null'];
         yield [new EnumNode('node', values: ['a', 'b']), '"a"|"b"'];
+        yield [new EnumNode('node', enumFqcn: StringBackedTestEnum::class), 'value-of<\Symfony\Component\Config\Tests\Fixtures\StringBackedTestEnum>|\Symfony\Component\Config\Tests\Fixtures\StringBackedTestEnum'];
+        yield [new EnumNode('node', enumFqcn: IntegerBackedTestEnum::class), 'value-of<\Symfony\Component\Config\Tests\Fixtures\IntegerBackedTestEnum>|\Symfony\Component\Config\Tests\Fixtures\IntegerBackedTestEnum'];
         yield [new ScalarNode('node'), 'scalar|null'];
         yield [new VariableNode('node'), 'mixed'];
 

--- a/src/Symfony/Component/Config/Tests/Definition/Dumper/XmlReferenceDumperTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Dumper/XmlReferenceDumperTest.php
@@ -42,7 +42,7 @@ class XmlReferenceDumperTest extends TestCase
             <!-- scalar-deprecated-with-message: Deprecated (Since vendor/package 1.1: Deprecation custom message for "scalar_deprecated_with_message" at "acme_root") -->
             <!-- enum-with-default: One of "this"; "that" -->
             <!-- enum: One of "this"; "that"; Symfony\Component\Config\Tests\Fixtures\TestEnum::Ccc -->
-            <!-- enum-with-class: One of foo; bar -->
+            <!-- enum-with-class: One of "foo"; "bar baz" -->
             <!-- unit-enum-with-class: One of Symfony\Component\Config\Tests\Fixtures\TestEnum::Foo; Symfony\Component\Config\Tests\Fixtures\TestEnum::Bar; Symfony\Component\Config\Tests\Fixtures\TestEnum::Ccc -->
             <!-- variable: Example: foo, bar -->
             <config

--- a/src/Symfony/Component/Config/Tests/Definition/Dumper/YamlReferenceDumperTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Dumper/YamlReferenceDumperTest.php
@@ -102,7 +102,7 @@ class YamlReferenceDumperTest extends TestCase
                 node_with_a_looong_name: ~
                 enum_with_default:    this # One of "this"; "that"
                 enum:                 ~ # One of "this"; "that"; Symfony\Component\Config\Tests\Fixtures\TestEnum::Ccc
-                enum_with_class:      ~ # One of foo; bar
+                enum_with_class:      ~ # One of "foo"; "bar baz"
                 unit_enum_with_class: ~ # One of Symfony\Component\Config\Tests\Fixtures\TestEnum::Foo; Symfony\Component\Config\Tests\Fixtures\TestEnum::Bar; Symfony\Component\Config\Tests\Fixtures\TestEnum::Ccc
 
                 # some info

--- a/src/Symfony/Component/Config/Tests/Definition/EnumNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/EnumNodeTest.php
@@ -138,7 +138,7 @@ class EnumNodeTest extends TestCase
         $node = new EnumNode('foo', null, enumFqcn: StringBackedTestEnum::class);
 
         $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessage('The value "qux" is not allowed for path "foo". Permissible values: foo, bar (cases of the "Symfony\Component\Config\Tests\Fixtures\StringBackedTestEnum" enum)');
+        $this->expectExceptionMessage('The value "qux" is not allowed for path "foo". Permissible values: "foo", "bar baz" (cases of the "Symfony\Component\Config\Tests\Fixtures\StringBackedTestEnum" enum)');
 
         $node->finalize('qux');
     }
@@ -148,7 +148,7 @@ class EnumNodeTest extends TestCase
         $node = new EnumNode('foo', null, enumFqcn: StringBackedTestEnum::class);
 
         $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessage('The value 1 is not allowed for path "foo". Permissible values: foo, bar (cases of the "Symfony\Component\Config\Tests\Fixtures\StringBackedTestEnum" enum).');
+        $this->expectExceptionMessage('The value 1 is not allowed for path "foo". Permissible values: "foo", "bar baz" (cases of the "Symfony\Component\Config\Tests\Fixtures\StringBackedTestEnum" enum).');
 
         $node->finalize(1);
     }

--- a/src/Symfony/Component/Config/Tests/Fixtures/StringBackedTestEnum.php
+++ b/src/Symfony/Component/Config/Tests/Fixtures/StringBackedTestEnum.php
@@ -5,5 +5,5 @@ namespace Symfony\Component\Config\Tests\Fixtures;
 enum StringBackedTestEnum: string
 {
     case Foo = 'foo';
-    case Bar = 'bar';
+    case BarBaz = 'bar baz';
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | --
| License       | MIT

Spotted in https://github.com/symfony/ai/pull/1013 ➡️ https://github.com/symfony/ai/actions/runs/19780810683/job/56680686767?pr=1013

It works for `redis`, but not for `postgres`, because `redis` is using `->values(Distance::cases())` and `postgres` is using `->enumFqcn(PostgresDistance::class)`:

### Redis

#### Enum
```php
enum Distance: string
{
    use Comparable;

    case Cosine = 'COSINE';
    case L2 = 'L2';
    case Ip = 'IP';
}
```
#### Config
```php
->enumNode('distance')
    ->info('Distance metric to use for vector similarity search')
    ->values(Distance::cases())
    ->defaultValue(Distance::Cosine)
->end()
```
#### RESULT
```php
 *         redis?: array<string, array{ // Default: []
 *             connection_parameters?: mixed, // see https://github.com/phpredis/phpredis?tab=readme-ov-file#example-1
 *             client?: string, // a service id of a Redis client
 *             index_name: string,
 *             key_prefix?: string, // Default: "vector:"
 *             distance?: \Symfony\AI\Store\Bridge\Redis\Distance::Cosine|\Symfony\AI\Store\Bridge\Redis\Distance::L2|\Symfony\AI\Store\Bridge\Redis\Distance::Ip, // Distance metric to use for vector similarity search // Default: "COSINE"
 *         }>,
```

### Postgres

#### Enum
```php
enum Distance: string
{
    use Comparable;

    case Cosine = 'cosine';
    case InnerProduct = 'inner_product';
    case L1 = 'l1';
    case L2 = 'l2';

    public function getComparisonSign(): string
    {
        return match ($this) {
            self::Cosine => '<=>',
            self::InnerProduct => '<#>',
            self::L1 => '<+>',
            self::L2 => '<->',
        };
    }
}
```
#### Config
```php
->enumNode('distance')
    ->info('Distance metric to use for vector similarity search')
    ->enumFqcn(PostgresDistance::class)
    ->defaultValue(PostgresDistance::L2)
->end()
```
#### RESULT
```php
 *         postgres?: array<string, array{ // Default: []
 *             dsn?: string,
 *             username?: string,
 *             password?: string,
 *             table_name: string,
 *             vector_field?: string,
 *             distance?: cosine|inner_product|l1|l2, // Distance metric to use for vector similarity search // Default: "l2"
 *             dbal_connection?: string,
 *         }>,
```

you can see, that the result is different:
FQCN:
`distance?: \Symfony\AI\Store\Bridge\Redis\Distance::Cosine|\Symfony\AI\Store\Bridge\Redis\Distance::L2|\Symfony\AI\Store\Bridge\Redis\Distance::Ip,`
vs. strings:
`distance?: cosine|inner_product|l1|l2,`

Why?