### PR TITLE
[HttpFoundation] Adjust iterator key to array-key

### DIFF
--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -185,7 +185,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
         try {
             return $class::from($value);
         } catch (\ValueError|\TypeError $e) {
-            throw new UnexpectedValueException(\sprintf('Parameter "%s" cannot be converted to enum: %s.', $key, $e->getMessage()), $e->getCode(), $e);
+            throw new UnexpectedValueException(\sprintf('Parameter "%s" cannot be converted to enum: "%s".', $key, $e->getMessage()), $e->getCode(), $e);
         }
     }
 

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpFoundation\Exception\UnexpectedValueException;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  *
- * @implements \IteratorAggregate<string, mixed>
+ * @implements \IteratorAggregate<array-key, mixed>
  */
 class ParameterBag implements \IteratorAggregate, \Countable
 {
@@ -241,7 +241,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
     /**
      * Returns an iterator for parameters.
      *
-     * @return \ArrayIterator<string, mixed>
+     * @return \ArrayIterator<array-key, mixed>
      */
     public function getIterator(): \ArrayIterator
     {

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -379,4 +379,13 @@ class ParameterBagTest extends TestCase
 
         $this->assertNull($bag->getEnum('invalid-value', FooEnum::class));
     }
+
+    public function testIteratorCanHandleNumericKeysAsInteger()
+    {
+        $bag = new ParameterBag(['0' => 'foo', '1' => 'bar', '80' => 'lux']);
+
+        foreach ($bag as $key => $val) {
+            $this->assertIsInt($key);
+        }
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60411 
| License       | MIT

The typehint for the `ParameterBag` iterator is not correct. The iterator will return `int` keys in the unlikely case where users provide an integer key in their query parameter.

That might look as follows:
```
https://mock.api.com/users?0=username&1=fields
```

The iterator will in this instance have the following representation:

```php
object(ArrayIterator)#1 (1) {
  ["storage":"ArrayIterator":private]=>
  array(2) {
    [0]=> // integer
    string(3) "username"
    [1]=>
    string(3) "fields"
  }
}
```