### PR TITLE
[Console] Fix profile invokable command

### DIFF
--- a/src/Symfony/Component/Console/Command/TraceableCommand.php
+++ b/src/Symfony/Component/Console/Command/TraceableCommand.php
@@ -169,9 +169,9 @@ final class TraceableCommand extends Command
     public function setCode(callable $code): static
     {
         if ($code instanceof InvokableCommand) {
-            $r = new \ReflectionFunction(\Closure::bind(function () {
-                return $this->code;
-            }, $code, InvokableCommand::class)());
+            $r = \Closure::bind(function () {
+                return $this->invokable;
+            }, $code, InvokableCommand::class)();
 
             $this->invokableCommandInfo = [
                 'class' => $r->getClosureScopeClass()->name,

--- a/src/Symfony/Component/Console/Tests/Command/TraceableCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/TraceableCommandTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\TraceableCommand;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Console\Tests\Fixtures\InvokableTestCommand;
 use Symfony\Component\Console\Tests\Fixtures\LoopExampleCommand;
 use Symfony\Component\Stopwatch\Stopwatch;
 
@@ -26,6 +27,7 @@ class TraceableCommandTest extends TestCase
     {
         $this->application = new Application();
         $this->application->addCommand(new LoopExampleCommand());
+        $this->application->addCommand(new InvokableTestCommand());
     }
 
     public function testRunIsOverriddenWithoutProfile()
@@ -55,6 +57,16 @@ class TraceableCommandTest extends TestCase
 
         $output = $commandTester->getDisplay();
         $this->assertLoopOutputCorrectness($output);
+    }
+
+    public function testRunOnInvokableCommand()
+    {
+        $command = $this->application->find('invokable:test');
+        $traceableCommand = new TraceableCommand($command, new Stopwatch());
+
+        $commandTester = new CommandTester($traceableCommand);
+        $commandTester->execute([]);
+        $commandTester->assertCommandIsSuccessful();
     }
 
     public function assertLoopOutputCorrectness(string $output)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT


Hello, 

I noticed that, when I try to profile an invokable command on 7.4, it raise the following exception : 

```
[critical] Uncaught Error: ReflectionFunction::__construct(): Argument #1 ($function) must be of type Closure|string, App\Command\MyAwesomeCommand given
TypeError {#199
  #message: "ReflectionFunction::__construct(): Argument #1 ($function) must be of type Closure|string, App\Command\MyAwesomeCommand given"
  #code: 0
  #file: "./vendor/symfony/console/Command/TraceableCommand.php"
  #line: 172
  trace: {
    ./vendor/symfony/console/Command/TraceableCommand.php:172 { …}
    ./vendor/symfony/console/Command/TraceableCommand.php:71 { …}
    ./vendor/symfony/framework-bundle/Console/Application.php:115 { …}
    ./vendor/symfony/console/Application.php:356 { …}
    ./vendor/symfony/framework-bundle/Console/Application.php:77 { …}
    ./vendor/symfony/console/Application.php:195 { …}
    ./vendor/symfony/runtime/Runner/Symfony/ConsoleApplicationRunner.php:49 { …}
    ./vendor/autoload_runtime.php:32 { …}
    ./bin/console:15 {
```

The invokableCommand class changed, the code attribute doesn't longer contains the closure to code.
Let's use the $invokableCommand->invokable instead that contains the reflectionFunction needed.
