### PR TITLE
[Messenger] Use clock in `DelayStamp` and `RedeliveryStamp` instead of native time classes and methods

### DIFF
--- a/src/Symfony/Component/Messenger/Stamp/DelayStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/DelayStamp.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Messenger\Stamp;
 
+use Symfony\Component\Clock\Clock;
+
 /**
  * Apply this stamp to delay delivery of your message on a transport.
  */
@@ -31,7 +33,7 @@ final class DelayStamp implements StampInterface
 
     public static function delayFor(\DateInterval $interval): self
     {
-        $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+        $now = Clock::get()->withTimeZone(new \DateTimeZone('UTC'))->now();
         $end = $now->add($interval);
 
         return new self(($end->getTimestamp() - $now->getTimestamp()) * 1000);
@@ -39,6 +41,6 @@ final class DelayStamp implements StampInterface
 
     public static function delayUntil(\DateTimeInterface $dateTime): self
     {
-        return new self(($dateTime->getTimestamp() - time()) * 1000);
+        return new self(($dateTime->getTimestamp() - Clock::get()->now()->getTimestamp()) * 1000);
     }
 }

--- a/src/Symfony/Component/Messenger/Stamp/RedeliveryStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/RedeliveryStamp.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Messenger\Stamp;
 
+use Symfony\Component\Clock\Clock;
 use Symfony\Component\Messenger\Envelope;
 
 /**
@@ -24,7 +25,7 @@ final class RedeliveryStamp implements StampInterface
         private int $retryCount,
         ?\DateTimeInterface $redeliveredAt = null,
     ) {
-        $this->redeliveredAt = $redeliveredAt ?? new \DateTimeImmutable();
+        $this->redeliveredAt = $redeliveredAt ?? Clock::get()->now();
     }
 
     public static function getRetryCountFromEnvelope(Envelope $envelope): int


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #62548
| License       | MIT

This PR changes DelayStamp of Messenger component by replacing native `time()` and `DateTimeImmutable` usages with Clock component to make it easier to test. 
Related to the issue #62548

