### PR TITLE
 Migrate the Security Bundle console commands to use the new invokable feature

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -5,7 +5,6 @@ CHANGELOG
 ---
 
  * Add support for the `clientHints`, `prefetchCache`, and `prerenderCache` `ClearSite-Data` directives
- * Migrate the `Symfony/Bundle/SecurityBundle/Command/DebugFirewallCommand` and `Symfony/Bundle/SecurityBundle/Command/SecurityRoleHierarchyDumpCommand` to the invokable console commands feature
 
 8.0
 ---

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add support for the `clientHints`, `prefetchCache`, and `prerenderCache` `ClearSite-Data` directives
+ * Migrate the `Symfony/Bundle/SecurityBundle/Command/DebugFirewallCommand` and `Symfony/Bundle/SecurityBundle/Command/SecurityRoleHierarchyDumpCommand` to the invokable console commands feature
 
 8.0
 ---

--- a/src/Symfony/Bundle/SecurityBundle/Command/DebugFirewallCommand.php
+++ b/src/Symfony/Bundle/SecurityBundle/Command/DebugFirewallCommand.php
@@ -14,14 +14,11 @@ namespace Symfony\Bundle\SecurityBundle\Command;
 use Psr\Container\ContainerInterface;
 use Symfony\Bundle\SecurityBundle\Security\FirewallContext;
 use Symfony\Bundle\SecurityBundle\Security\LazyFirewallContext;
+use Symfony\Component\Console\Attribute\Argument;
 use Symfony\Component\Console\Attribute\AsCommand;
-use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Attribute\Option;
 use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Completion\CompletionSuggestions;
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
@@ -30,8 +27,28 @@ use Symfony\Component\Security\Http\Authenticator\Debug\TraceableAuthenticator;
 /**
  * @author Timo Bakx <timobakx@gmail.com>
  */
-#[AsCommand(name: 'debug:firewall', description: 'Display information about your security firewall(s)')]
-final class DebugFirewallCommand extends Command
+#[AsCommand(
+    name: 'debug:firewall',
+    description: 'Display information about your security firewall(s)',
+    help: <<<EOF
+        The <info>%command.name%</info> command displays the firewalls that are configured
+        in your application:
+
+          <info>php %command.full_name%</info>
+
+        You can pass a firewall name to display more detailed information about
+        a specific firewall:
+
+          <info>php %command.full_name% main</info>
+
+        To include all events and event listeners for a specific firewall, use the
+        <info>events</info> option:
+
+          <info>php %command.full_name% --events main</info>
+
+        EOF
+)]
+final class DebugFirewallCommand
 {
     /**
      * @param string[]                   $firewallNames
@@ -43,44 +60,13 @@ final class DebugFirewallCommand extends Command
         private ContainerInterface $eventDispatchers,
         private array $authenticators,
     ) {
-        parent::__construct();
     }
 
-    protected function configure(): void
-    {
-        $exampleName = $this->getExampleName();
-
-        $this
-            ->setHelp(<<<EOF
-                The <info>%command.name%</info> command displays the firewalls that are configured
-                in your application:
-
-                  <info>php %command.full_name%</info>
-
-                You can pass a firewall name to display more detailed information about
-                a specific firewall:
-
-                  <info>php %command.full_name% $exampleName</info>
-
-                To include all events and event listeners for a specific firewall, use the
-                <info>events</info> option:
-
-                  <info>php %command.full_name% --events $exampleName</info>
-
-                EOF
-            )
-            ->setDefinition([
-                new InputArgument('name', InputArgument::OPTIONAL, \sprintf('A firewall name (for example "%s")', $exampleName)),
-                new InputOption('events', null, InputOption::VALUE_NONE, 'Include a list of event listeners (only available in combination with the "name" argument)'),
-            ]);
-    }
-
-    protected function execute(InputInterface $input, OutputInterface $output): int
-    {
-        $io = new SymfonyStyle($input, $output);
-
-        $name = $input->getArgument('name');
-
+    public function __invoke(
+        SymfonyStyle $io,
+        #[Argument(description: 'A firewall name (for example "main")')] ?string $name = null,
+        #[Option(description: 'Include a list of event listeners (only available in combination with the "name" argument)')] bool $events = false,
+    ): int {
         if (null === $name) {
             $this->displayFirewallList($io);
 
@@ -104,7 +90,7 @@ final class DebugFirewallCommand extends Command
 
         $this->displaySwitchUser($context, $io);
 
-        if ($input->getOption('events')) {
+        if ($events) {
             $this->displayEventListeners($name, $context, $io);
         }
 

--- a/src/Symfony/Bundle/SecurityBundle/Command/SecurityRoleHierarchyDumpCommand.php
+++ b/src/Symfony/Bundle/SecurityBundle/Command/SecurityRoleHierarchyDumpCommand.php
@@ -12,9 +12,7 @@
 namespace Symfony\Bundle\SecurityBundle\Command;
 
 use Symfony\Component\Console\Attribute\AsCommand;
-use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Attribute\Option;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Security\Core\Dumper\MermaidDirection;
@@ -26,55 +24,38 @@ use Symfony\Component\Security\Core\Role\RoleHierarchyInterface;
  *
  * @author Damien Fernandes <damien.fernandes24@gmail.com>
  */
-#[AsCommand(name: 'debug:security:role-hierarchy', description: 'Dump the role hierarchy as a Mermaid flowchart')]
-class SecurityRoleHierarchyDumpCommand extends Command
+#[AsCommand(
+    name: 'debug:security:role-hierarchy',
+    description: 'Dump the role hierarchy as a Mermaid flowchart',
+    help: <<<'USAGE'
+        The <info>%command.name%</info> command dumps the role hierarchy in Mermaid format.
+
+        <info>Mermaid</info>: %command.full_name% > roles.mmd
+        <info>Mermaid with direction</info>: %command.full_name% --direction=BT > roles.mmd
+        USAGE
+)]
+class SecurityRoleHierarchyDumpCommand
 {
     public function __construct(
         private readonly RoleHierarchyInterface $roleHierarchy,
     ) {
-        parent::__construct();
     }
 
-    protected function configure(): void
-    {
-        $this
-            ->setDefinition([
-                new InputOption(
-                    'direction',
-                    'd',
-                    InputOption::VALUE_REQUIRED,
-                    'The direction of the flowchart ['.implode('|', array_column(MermaidDirection::cases(), 'value')).']',
-                    MermaidDirection::TOP_TO_BOTTOM->value,
-                    array_column(MermaidDirection::cases(), 'value')
-                ),
-            ])
-            ->setHelp(<<<'USAGE'
-                The <info>%command.name%</info> command dumps the role hierarchy in Mermaid format.
-
-                <info>Mermaid</info>: %command.full_name% > roles.mmd
-                <info>Mermaid with direction</info>: %command.full_name% --direction=BT > roles.mmd
-                USAGE
-            )
-        ;
-    }
-
-    protected function execute(InputInterface $input, OutputInterface $output): int
-    {
-        $io = new SymfonyStyle($input, $output);
-        $direction = $input->getOption('direction');
-
-        if (!$direction = MermaidDirection::tryFrom($direction)) {
-            $io->getErrorStyle()->writeln(\sprintf('<error>Invalid direction, available options are "%s"</error>', implode('"', array_column(MermaidDirection::cases(), 'value'))));
-
-            return Command::FAILURE;
-        }
-
+    public function __invoke(
+        SymfonyStyle $io,
+        #[Option(description: 'The direction of the flowchart', suggestedValues: [self::class, 'getMermaidDirectionChoices'])] MermaidDirection $direction = MermaidDirection::TOP_TO_BOTTOM,
+    ): int {
         $dumper = new MermaidDumper();
 
         foreach (explode("\n", $dumper->dump($this->roleHierarchy, $direction)) as $line) {
-            $output->writeln($line, OutputInterface::OUTPUT_RAW);
+            $io->writeln($line, OutputInterface::OUTPUT_RAW);
         }
 
-        return Command::SUCCESS;
+        return 0;
+    }
+
+    public static function getMermaidDirectionChoices(): array
+    {
+        return array_column(MermaidDirection::cases(), 'value');
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Command/SecurityRoleHierarchyDumpCommandTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Command/SecurityRoleHierarchyDumpCommandTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\SecurityBundle\Tests\Command;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\SecurityBundle\Command\SecurityRoleHierarchyDumpCommand;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Security\Core\Role\RoleHierarchy;
 
@@ -75,9 +76,9 @@ class SecurityRoleHierarchyDumpCommandTest extends TestCase
         $command = new SecurityRoleHierarchyDumpCommand($roleHierarchy);
         $commandTester = new CommandTester($command);
 
-        $exitCode = $commandTester->execute(['--direction' => 'INVALID']);
+        self::expectException(InvalidOptionException::class);
+        self::expectExceptionMessage('The value "INVALID" is not valid for the "direction" option.');
 
-        $this->assertSame(Command::FAILURE, $exitCode);
-        $this->assertStringContainsString('Invalid direction', $commandTester->getDisplay());
+        $commandTester->execute(['--direction' => 'INVALID']);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | None
| License       | MIT

This PR migrates the Console Commands present in the Security Bundle to use the new invokable command feature introduced in Symfony 7.3.

This PR is targeting the Symfony 8.1 branch as it is removing the `extends Command` syntax and public API.