### PR TITLE
[Serializer] Improve `NotNormalizableValueException` exception messages in `BackedEnumNormalizer`

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Improve `NotNormalizableValueException` exception messages in `BackedEnumNormalizer` to contain more useful information
+
 8.0
 ---
 

--- a/src/Symfony/Component/Serializer/Normalizer/BackedEnumNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/BackedEnumNormalizer.php
@@ -77,7 +77,21 @@ final class BackedEnumNormalizer implements NormalizerInterface, DenormalizerInt
                 return null;
             }
 
-            throw NotNormalizableValueException::createForUnexpectedDataType('The data must belong to a backed enumeration of type '.$type, $data, ['int', 'string'], $context['deserialization_path'] ?? null, true, 0, $e);
+            $backingType = (new \ReflectionEnum($type))->getBackingType()->getName();
+
+            if ($e instanceof \TypeError || get_debug_type($data) !== $backingType) {
+                throw NotNormalizableValueException::createForUnexpectedDataType('The data must be of type '.$backingType, $data, [$backingType], $context['deserialization_path'] ?? null, true, 0, $e);
+            }
+
+            $expectedValues = array_map(function ($type) {
+                if (\is_string($type->value)) {
+                    return "'{$type->value}'";
+                }
+
+                return $type->value;
+            }, $type::cases());
+
+            throw new NotNormalizableValueException('The data must be one of the following values: '.implode(', ', $expectedValues), 0, $e, $type, null, $context['deserialization_path'] ?? null, true);
         }
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/IntegerBackedEnumDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/IntegerBackedEnumDummy.php
@@ -5,4 +5,5 @@ namespace Symfony\Component\Serializer\Tests\Fixtures;
 enum IntegerBackedEnumDummy: int
 {
     case SUCCESS = 200;
+    case NOT_FOUND = 404;
 }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/StringBackedEnumDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/StringBackedEnumDummy.php
@@ -5,4 +5,5 @@ namespace Symfony\Component\Serializer\Tests\Fixtures;
 enum StringBackedEnumDummy: string
 {
     case GET = 'GET';
+    case OPTIONS = 'OPTIONS';
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/BackedEnumNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/BackedEnumNormalizerTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
@@ -59,36 +60,86 @@ class BackedEnumNormalizerTest extends TestCase
         $this->assertFalse($this->normalizer->supportsDenormalization(null, \stdClass::class));
     }
 
-    public function testDenormalize()
+    #[TestWith([StringBackedEnumDummy::GET, 'GET', StringBackedEnumDummy::class], 'string backed enum')]
+    #[TestWith([IntegerBackedEnumDummy::SUCCESS, 200, IntegerBackedEnumDummy::class], 'int backed enum')]
+    #[TestWith([IntegerBackedEnumDummy::SUCCESS, '200', IntegerBackedEnumDummy::class], 'int backed enum with string value')]
+    public function testDenormalize(mixed $expected, mixed $data, string $type)
     {
-        $this->assertSame(StringBackedEnumDummy::GET, $this->normalizer->denormalize('GET', StringBackedEnumDummy::class));
-        $this->assertSame(IntegerBackedEnumDummy::SUCCESS, $this->normalizer->denormalize(200, IntegerBackedEnumDummy::class));
+        $this->assertSame($expected, $this->normalizer->denormalize($data, $type));
     }
 
     public function testDenormalizeNullValueThrowsException()
     {
         $this->expectException(NotNormalizableValueException::class);
+        $this->expectExceptionMessage('The data is neither an integer nor a string, you should pass an integer or a string');
+
         $this->normalizer->denormalize(null, StringBackedEnumDummy::class);
     }
 
     public function testDenormalizeBooleanValueThrowsException()
     {
         $this->expectException(NotNormalizableValueException::class);
+        $this->expectExceptionMessage('The data is neither an integer nor a string, you should pass an integer or a string');
+
         $this->normalizer->denormalize(true, StringBackedEnumDummy::class);
     }
 
     public function testDenormalizeObjectThrowsException()
     {
         $this->expectException(NotNormalizableValueException::class);
+        $this->expectExceptionMessage('The data is neither an integer nor a string, you should pass an integer or a string');
+
         $this->normalizer->denormalize(new \stdClass(), StringBackedEnumDummy::class);
     }
 
-    public function testDenormalizeBadBackingValueThrowsException()
+    public function testDenormalizeInvalidBackedTypeThrowsException()
     {
         $this->expectException(NotNormalizableValueException::class);
-        $this->expectExceptionMessage('The data must belong to a backed enumeration of type '.StringBackedEnumDummy::class);
+        $this->expectExceptionMessage('The data must be of type string');
+
+        $this->normalizer->denormalize(8, StringBackedEnumDummy::class);
+    }
+
+    public function testDenormalizeInvalidIntegerBackedValueThrowsException()
+    {
+        $this->expectException(NotNormalizableValueException::class);
+        $this->expectExceptionMessage('The data must be one of the following values: 200, 404');
+
+        $this->normalizer->denormalize(300, IntegerBackedEnumDummy::class);
+    }
+
+    public function testDenormalizeInvalidStringBackedValueThrowsException()
+    {
+        $this->expectException(NotNormalizableValueException::class);
+        $this->expectExceptionMessage("The data must be one of the following values: 'GET', 'OPTIONS'");
 
         $this->normalizer->denormalize('POST', StringBackedEnumDummy::class);
+    }
+
+    public function testDenormalizeInvalidBackedValueWithAllowInvalidAndCollectErrorsThrows()
+    {
+        $this->expectException(NotNormalizableValueException::class);
+        $this->expectExceptionMessage("The data must be one of the following values: 'GET', 'OPTIONS'");
+
+        $context = [
+            BackedEnumNormalizer::ALLOW_INVALID_VALUES => true,
+            'not_normalizable_value_exceptions' => [],
+        ];
+
+        $this->normalizer->denormalize('invalid-value', StringBackedEnumDummy::class, null, $context);
+    }
+
+    public function testDenormalizeNullWithAllowInvalidAndCollectErrorsThrows()
+    {
+        $this->expectException(NotNormalizableValueException::class);
+        $this->expectExceptionMessage('The data is neither an integer nor a string');
+
+        $context = [
+            BackedEnumNormalizer::ALLOW_INVALID_VALUES => true,
+            'not_normalizable_value_exceptions' => [], // Indicate that we want to collect errors
+        ];
+
+        $this->normalizer->denormalize(null, StringBackedEnumDummy::class, null, $context);
     }
 
     public function testNormalizeShouldThrowExceptionForNonEnumObjects()
@@ -125,31 +176,5 @@ class BackedEnumNormalizerTest extends TestCase
         $this->assertNull($this->normalizer->denormalize(null, StringBackedEnumDummy::class, null, [BackedEnumNormalizer::ALLOW_INVALID_VALUES => true]));
 
         $this->assertSame(StringBackedEnumDummy::GET, $this->normalizer->denormalize('GET', StringBackedEnumDummy::class, null, [BackedEnumNormalizer::ALLOW_INVALID_VALUES => true]));
-    }
-
-    public function testDenormalizeNullWithAllowInvalidAndCollectErrorsThrows()
-    {
-        $this->expectException(NotNormalizableValueException::class);
-        $this->expectExceptionMessage('The data is neither an integer nor a string');
-
-        $context = [
-            BackedEnumNormalizer::ALLOW_INVALID_VALUES => true,
-            'not_normalizable_value_exceptions' => [], // Indicate that we want to collect errors
-        ];
-
-        $this->normalizer->denormalize(null, StringBackedEnumDummy::class, null, $context);
-    }
-
-    public function testDenormalizeInvalidValueWithAllowInvalidAndCollectErrorsThrows()
-    {
-        $this->expectException(NotNormalizableValueException::class);
-        $this->expectExceptionMessage('The data must belong to a backed enumeration of type');
-
-        $context = [
-            BackedEnumNormalizer::ALLOW_INVALID_VALUES => true,
-            'not_normalizable_value_exceptions' => [],
-        ];
-
-        $this->normalizer->denormalize('invalid-value', StringBackedEnumDummy::class, null, $context);
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -80,6 +80,7 @@ use Symfony\Component\Serializer\Tests\Fixtures\ObjectCollectionPropertyDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Php74Full;
 use Symfony\Component\Serializer\Tests\Fixtures\Php80WithOptionalConstructorParameter;
 use Symfony\Component\Serializer\Tests\Fixtures\Php80WithPromotedTypedConstructor;
+use Symfony\Component\Serializer\Tests\Fixtures\StringBackedEnumDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\TraversableDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\TrueBuiltInDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\WithTypedConstructor;
@@ -1548,9 +1549,9 @@ class SerializerTest extends TestCase
 
         $expected = [
             [
-                'currentType' => 'string',
+                'currentType' => StringBackedEnumDummy::class,
                 'useMessageForUser' => true,
-                'message' => 'The data must belong to a backed enumeration of type Symfony\Component\Serializer\Tests\Fixtures\StringBackedEnumDummy',
+                'message' => "The data must be one of the following values: 'GET', 'OPTIONS'",
             ],
         ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->

This PR stems from a discussion I had with @xabbuh following the discussion at #54226 and specifically the [comment](https://github.com/symfony/symfony/pull/54226#issuecomment-3583510204) from @nesl247.

With this PR I would like to propose some changes in the `BackedEnumNormalizer` that give the exception messages a bit more meaning in terms of what data is actually expected.

## Example

### Before

```php
enum StringBackedEnumDummy: string
{
    case GET = 'GET';
    case OPTIONS = 'OPTIONS';
}

$this->normalizer->denormalize('POST', StringBackedEnumDummy::class);

// Throws NotNormalizableValueException with message:
//   The data must belong to a backed enumeration of type StringBackedEnumDummy
```

### After

```php
enum StringBackedEnumDummy: string
{
    case GET = 'GET';
    case OPTIONS = 'OPTIONS';
}

$this->normalizer->denormalize('POST', StringBackedEnumDummy::class);

// Throws NotNormalizableValueException with message:
//   The data must be one of the following values: 'GET', 'OPTIONS'
```