### PR TITLE
 install ext-zstd on PHP 8.5 as well

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -34,8 +34,6 @@ jobs:
           - php: '8.3'
           - php: '8.4'
           - php: '8.5'
-            # to be removed when ext-zstd is ready for PHP 8.5
-            extensions: amqp,apcu,brotli,igbinary,intl,mbstring,memcached,redis,relay
             #mode: experimental
       fail-fast: false
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

basically reverting #61126 as ext-zstd is now installable on PHP 8.5
