### PR TITLE
[PropertyInfo] treat `mixed[]` the same as `array` when getting types from docblocks

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Util/PhpDocTypeHelper.php
+++ b/src/Symfony/Component/PropertyInfo/Util/PhpDocTypeHelper.php
@@ -109,6 +109,10 @@ final class PhpDocTypeHelper
     {
         $docType = (string) $type;
 
+        if ('mixed[]' === $docType) {
+            $docType = 'array';
+        }
+
         if ($type instanceof Collection) {
             $fqsen = $type->getFqsen();
             if ($fqsen && 'list' === $fqsen->getName() && !class_exists(List_::class, false) && !class_exists((string) $fqsen)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | account for phpDocumentor/TypeResolver#237
| License       | MIT

This fixes the PropertyInfo component tests by treating `mixed[]` as an alias of `array` sticking with the current behaviour even if that may technically not be fully correct to avoid unwanted behaviour changes for existing applications (see https://github.com/symfony/symfony/pull/62546#discussion_r2573067178).