### PR TITLE
[Form] Add reset button in `NavigatorFlowType`

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add `ResetFlowType` button in `NavigatorFlowType` that you can display with `with_reset` option
+
 8.0
 ---
 

--- a/src/Symfony/Component/Form/Flow/Type/NavigatorFlowType.php
+++ b/src/Symfony/Component/Form/Flow/Type/NavigatorFlowType.php
@@ -27,6 +27,10 @@ class NavigatorFlowType extends AbstractType
         $builder->add('previous', PreviousFlowType::class);
         $builder->add('next', NextFlowType::class);
         $builder->add('finish', FinishFlowType::class);
+
+        if ($options['with_reset']) {
+            $builder->add('reset', ResetFlowType::class);
+        }
     }
 
     public function configureOptions(OptionsResolver $resolver): void
@@ -36,5 +40,10 @@ class NavigatorFlowType extends AbstractType
             'mapped' => false,
             'priority' => -100,
         ]);
+
+        $resolver->define('with_reset')
+            ->allowedTypes('bool')
+            ->default(false)
+            ->info('Whether to add a reset button to restart the flow from the first step');
     }
 }

--- a/src/Symfony/Component/Form/Tests/Fixtures/Flow/LastStepSkippedType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Flow/LastStepSkippedType.php
@@ -24,7 +24,9 @@ class LastStepSkippedType extends AbstractFlowType
         $builder->addStep('step1', TextType::class);
         $builder->addStep('step2', skip: static fn () => true);
 
-        $builder->add('navigator', NavigatorFlowType::class);
+        $builder->add('navigator', NavigatorFlowType::class, [
+            'with_reset' => true,
+        ]);
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/src/Symfony/Component/Form/Tests/Fixtures/Flow/UserSignUpNavigatorType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Flow/UserSignUpNavigatorType.php
@@ -14,8 +14,8 @@ namespace Symfony\Component\Form\Tests\Fixtures\Flow;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Flow\Type\NavigatorFlowType;
 use Symfony\Component\Form\Flow\Type\NextFlowType;
-use Symfony\Component\Form\Flow\Type\ResetFlowType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class UserSignUpNavigatorType extends AbstractType
 {
@@ -25,8 +25,13 @@ class UserSignUpNavigatorType extends AbstractType
             'clear_submission' => true,
             'include_if' => ['professional'],
         ]);
+    }
 
-        $builder->add('reset', ResetFlowType::class);
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'with_reset' => true,
+        ]);
     }
 
     public function getParent(): string

--- a/src/Symfony/Component/Form/Tests/Flow/FormFlowTest.php
+++ b/src/Symfony/Component/Form/Tests/Flow/FormFlowTest.php
@@ -945,8 +945,9 @@ class FormFlowTest extends TestCase
         self::assertTrue($flow->has('navigator'));
 
         $navigatorForm = $flow->get('navigator');
-        self::assertCount(1, $navigatorForm->all());
+        self::assertCount(2, $navigatorForm->all());
         self::assertTrue($navigatorForm->has('next'));
+        self::assertTrue($navigatorForm->has('reset'));
 
         $flow->submit([
             'step1' => 'foo',

--- a/src/Symfony/Component/Form/Tests/Flow/Type/NavigatorFlowTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Flow/Type/NavigatorFlowTypeTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Flow\Type;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\Flow\Type\NavigatorFlowType;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\Forms;
+
+class NavigatorFlowTypeTest extends TestCase
+{
+    private FormFactoryInterface $factory;
+
+    protected function setUp(): void
+    {
+        $this->factory = Forms::createFormFactoryBuilder()->getFormFactory();
+    }
+
+    public function testDefaultOptionsDoNotIncludeReset()
+    {
+        $form = $this->factory->create(NavigatorFlowType::class);
+
+        self::assertTrue($form->has('previous'));
+        self::assertTrue($form->has('next'));
+        self::assertTrue($form->has('finish'));
+        self::assertFalse($form->has('reset'));
+    }
+
+    public function testWithResetOptionAddsResetButton()
+    {
+        $form = $this->factory->create(NavigatorFlowType::class, null, [
+            'with_reset' => true,
+        ]);
+
+        self::assertTrue($form->has('previous'));
+        self::assertTrue($form->has('next'));
+        self::assertTrue($form->has('finish'));
+        self::assertTrue($form->has('reset'));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #62500
| License       | MIT

## Summary

`NavigatorFlowType` is a must-have in a Formflow, as it brings you a bunch of welcomed buttons, like 'previous', 'next' or 'finish'. The FormFlow feature also includes a very convenient `ResetFlowType` that you add separately in your form builder.

Now, `NavigatorFlowType` also bundles the `ResetFlowType`: by adding the 'with_reset' option, you will also display the reset button, saving you a few lines of code and a few headaches.

Technically, this follows the same pattern used by `TimeType` (`with_minutes`, `with_seconds`) and `DateIntervalType` (`with_years`, `with_months`, etc.) for conditional child fields.

## Usage

```php
// Without reset (default behavior)
$builder->add('navigator', NavigatorFlowType::class);

// With reset button
$builder->add('navigator', NavigatorFlowType::class, [
    'with_reset' => true,
]);