### PR TITLE
[DependencyInjection][FrameworkBundle] fix BC break when dumping container for build/lint commands

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/BuildDebugContainerTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/BuildDebugContainerTrait.php
@@ -64,7 +64,10 @@ trait BuildDebugContainerTrait
                 $dumpedContainer = unserialize(file_get_contents(substr_replace($file, '.ser', -4)));
                 $container->setDefinitions($dumpedContainer->getDefinitions());
                 $container->setAliases($dumpedContainer->getAliases());
-                $container->__construct($dumpedContainer->getParameterBag());
+
+                $parameterBag = $container->getParameterBag();
+                $parameterBag->clear();
+                $parameterBag->add($dumpedContainer->getParameterBag()->all());
             } else {
                 (new XmlFileLoader($container, new FileLocator()))->load($file);
                 $locatorPass = new ServiceLocatorTagPass();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

https://github.com/symfony/symfony/pull/60597 introduced a BC break in that it assumes the `ContainerBuilder` constructor accepts the parameter bag as its first argument. However, in our application, we have a custom version of the `ContainerBuilder`.

Since the container is already built at this state, I understand that calling `__construct()` again is just a hack to re-set the parameter bag. A direct setter function for this case should fix the issue.

PS: `Kernel::buildContainer` must always return an instance of `ContainerBuilder`, so the setter method must always be there (our class inherits from it as well).


Links:
 - Original issue: https://github.com/contao/contao/issues/9058
 - Custom `ContainerBuilder` https://github.com/contao/manager-plugin/blob/main/src/Config/ContainerBuilder.php
