### PR TITLE
[PropertyInfo] treat mixed[] the same as array when getting types from docblocks

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Util/PhpDocTypeHelper.php
+++ b/src/Symfony/Component/PropertyInfo/Util/PhpDocTypeHelper.php
@@ -249,6 +249,10 @@ final class PhpDocTypeHelper
     {
         $docTypeString = (string) $docType;
 
+        if ('mixed[]' === $docTypeString) {
+            $docTypeString = 'array';
+        }
+
         if ($docType instanceof Collection) {
             $fqsen = $docType->getFqsen();
             if ($fqsen && 'list' === $fqsen->getName() && !class_exists(List_::class, false) && !class_exists((string) $fqsen)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT
