### PR TITLE
[Messenger][WIP] Sending messages in batches

### DIFF
--- a/src/Symfony/Component/Messenger/BatchMessageBusInterface.php
+++ b/src/Symfony/Component/Messenger/BatchMessageBusInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger;
+
+use Symfony\Component\Messenger\Exception\ExceptionInterface;
+use Symfony\Component\Messenger\Stamp\StampInterface;
+
+/**
+ * A message bus that supports batch dispatching.
+ *
+ * @author Joppe De Cuyper <hello@joppe.dev>
+ */
+interface BatchMessageBusInterface extends MessageBusInterface
+{
+    /**
+     * Dispatches multiple messages in a batch, allowing transports to optimize delivery.
+     *
+     * Each message passes through the full middleware chain individually.
+     * The actual transport send is deferred until all messages are processed,
+     * then executed as a single batch operation.
+     *
+     * @param object[]|Envelope[] $messages Messages or pre-wrapped envelopes
+     * @param StampInterface[]    $stamps   Stamps applied to all messages
+     *
+     * @return Envelope[] In same order as input, with TransportMessageIdStamp added
+     *
+     * @throws ExceptionInterface
+     */
+    public function dispatchBatch(array $messages, array $stamps = []): array;
+}

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineIntegrationTest.php
@@ -17,6 +17,8 @@ use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
 use Doctrine\DBAL\Tools\DsnParser;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Doctrine\Middleware\Debug\DebugDataHolder;
+use Symfony\Bridge\Doctrine\Middleware\Debug\Middleware;
 use Symfony\Component\Messenger\Bridge\Doctrine\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Bridge\Doctrine\Transport\Connection;
 
@@ -25,6 +27,7 @@ class DoctrineIntegrationTest extends TestCase
 {
     private \Doctrine\DBAL\Connection $driverConnection;
     private Connection $connection;
+    private DebugDataHolder $debugDataHolder;
 
     protected function setUp(): void
     {
@@ -32,6 +35,9 @@ class DoctrineIntegrationTest extends TestCase
         $params = (new DsnParser())->parse($dsn);
         $config = new Configuration();
         $config->setSchemaManagerFactory(new DefaultSchemaManagerFactory());
+
+        $this->debugDataHolder = new DebugDataHolder();
+        $config->setMiddlewares([new Middleware($this->debugDataHolder, null)]);
 
         $this->driverConnection = DriverManager::getConnection($params, $config);
         $this->connection = new Connection([], $this->driverConnection);
@@ -195,6 +201,72 @@ class DoctrineIntegrationTest extends TestCase
         $this->connection->send('the body', ['my' => 'header']);
         $envelope = $this->connection->get();
         $this->assertEquals('the body', $envelope['body']);
+    }
+
+    public function testSendBatch()
+    {
+        // Setup connection, and reset the debug data holder to only capture the batch insert query
+        $this->connection->setup();
+        $this->debugDataHolder->reset();
+
+        $this->connection->sendBatch([
+            ['body' => '{"message": "First"}', 'headers' => ['type' => DummyMessage::class], 'delay' => 0],
+            ['body' => '{"message": "Second"}', 'headers' => ['type' => DummyMessage::class], 'delay' => 0],
+            ['body' => '{"message": "Third"}', 'headers' => ['type' => DummyMessage::class], 'delay' => 0],
+        ]);
+
+        $queries = $this->debugDataHolder->getData()['default'] ?? [];
+        $this->assertCount(1, $queries, 'Batch insert should execute exactly 1 SQL statement');
+        $this->assertStringStartsWith('INSERT INTO', $queries[0]['sql']);
+        $this->assertSame(3, $this->connection->getMessageCount());
+
+        $first = $this->connection->get();
+        $this->assertEquals('{"message": "First"}', $first['body']);
+        $this->connection->ack($first['id']);
+
+        $second = $this->connection->get();
+        $this->assertEquals('{"message": "Second"}', $second['body']);
+        $this->connection->ack($second['id']);
+
+        $third = $this->connection->get();
+        $this->assertEquals('{"message": "Third"}', $third['body']);
+        $this->connection->ack($third['id']);
+
+        $this->assertSame(0, $this->connection->getMessageCount());
+    }
+
+    public function testSendBatchWithDelay()
+    {
+        $this->connection->sendBatch([
+            ['body' => '{"message": "Immediate"}', 'headers' => ['type' => DummyMessage::class], 'delay' => 0],
+            ['body' => '{"message": "Delayed"}', 'headers' => ['type' => DummyMessage::class], 'delay' => 600000],
+        ]);
+
+        // Only the immediate message should be available
+        $this->assertSame(1, $this->connection->getMessageCount());
+
+        $immediate = $this->connection->get();
+        $this->assertEquals('{"message": "Immediate"}', $immediate['body']);
+    }
+
+    public function testSendBatchEmpty()
+    {
+        $this->connection->setup();
+        $this->connection->sendBatch([]);
+
+        $this->assertSame(0, $this->connection->getMessageCount());
+    }
+
+    public function testSendBatchSingleMessage()
+    {
+        $this->connection->sendBatch([
+            ['body' => '{"message": "Only one"}', 'headers' => ['type' => DummyMessage::class], 'delay' => 0],
+        ]);
+
+        $this->assertSame(1, $this->connection->getMessageCount());
+
+        $message = $this->connection->get();
+        $this->assertEquals('{"message": "Only one"}', $message['body']);
     }
 
     private function formatDateTime(\DateTimeImmutable $dateTime): string

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineSenderTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineSenderTest.php
@@ -56,4 +56,60 @@ class DoctrineSenderTest extends TestCase
         $sender = new DoctrineSender($connection, $serializer);
         $sender->send($envelope);
     }
+
+    public function testSendBatchWithIdsReturned()
+    {
+        $envelope1 = new Envelope(new DummyMessage('First'));
+        $envelope2 = new Envelope(new DummyMessage('Second'));
+        $encoded1 = ['body' => 'body1', 'headers' => ['type' => DummyMessage::class]];
+        $encoded2 = ['body' => 'body2', 'headers' => ['type' => DummyMessage::class]];
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())
+            ->method('sendBatch')
+            ->with([
+                ['body' => 'body1', 'headers' => ['type' => DummyMessage::class], 'delay' => 0],
+                ['body' => 'body2', 'headers' => ['type' => DummyMessage::class], 'delay' => 0],
+            ])
+            ->willReturn(['15', '16']);
+
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->method('encode')->willReturnCallback(fn ($envelope) => $envelope->getMessage()->getMessage() === 'First' ? $encoded1 : $encoded2);
+
+        $sender = new DoctrineSender($connection, $serializer);
+        $result = $sender->sendBatch([$envelope1, $envelope2]);
+
+        $this->assertCount(2, $result);
+
+        $stamp1 = $result[0]->last(TransportMessageIdStamp::class);
+        $this->assertNotNull($stamp1);
+        $this->assertSame('15', $stamp1->getId());
+
+        $stamp2 = $result[1]->last(TransportMessageIdStamp::class);
+        $this->assertNotNull($stamp2);
+        $this->assertSame('16', $stamp2->getId());
+    }
+
+    public function testSendBatchWithoutIdsReturned()
+    {
+        $envelope1 = new Envelope(new DummyMessage('First'));
+        $envelope2 = new Envelope(new DummyMessage('Second'));
+        $encoded1 = ['body' => 'body1', 'headers' => ['type' => DummyMessage::class]];
+        $encoded2 = ['body' => 'body2', 'headers' => ['type' => DummyMessage::class]];
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())
+            ->method('sendBatch')
+            ->willReturn(null);
+
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->method('encode')->willReturnCallback(fn ($envelope) => $envelope->getMessage()->getMessage() === 'First' ? $encoded1 : $encoded2);
+
+        $sender = new DoctrineSender($connection, $serializer);
+        $result = $sender->sendBatch([$envelope1, $envelope2]);
+
+        $this->assertCount(2, $result);
+        $this->assertNull($result[0]->last(TransportMessageIdStamp::class));
+        $this->assertNull($result[1]->last(TransportMessageIdStamp::class));
+    }
 }

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
@@ -163,12 +163,14 @@ class Connection implements ResetInterface
      *
      * @param list<array{body: string, headers: array, delay: int}> $messages
      *
+     * @return list<string>|null The inserted IDs if supported by the platform (PostgreSQL), null otherwise
+     *
      * @throws DBALException
      */
-    public function sendBatch(array $messages): void
+    public function sendBatch(array $messages): ?array
     {
         if ([] === $messages) {
-            return;
+            return [];
         }
 
         $now = new \DateTimeImmutable('UTC');
@@ -214,7 +216,7 @@ class Connection implements ResetInterface
             ? $baseSql
             : $baseSql.', '.implode(', ', $additionalPlaceholders);
 
-        $this->executeBatchInsert($sql, $values, $types);
+        return $this->executeBatchInsert($sql, $values, $types);
     }
 
     public function get(): ?array
@@ -576,11 +578,28 @@ class Connection implements ResetInterface
         return $id;
     }
 
-    private function executeBatchInsert(string $sql, array $parameters = [], array $types = []): void
+    /**
+     * @return list<string>|null The inserted IDs if supported by the platform (PostgreSQL), null otherwise
+     */
+    private function executeBatchInsert(string $sql, array $parameters = [], array $types = []): ?array
     {
+        $isPostgreSql = $this->driverConnection->getDatabasePlatform() instanceof PostgreSQLPlatform;
+
+        if ($isPostgreSql) {
+            $sql .= ' RETURNING id';
+        }
+
         insert:
         try {
+            if ($isPostgreSql) {
+                $ids = $this->driverConnection->fetchFirstColumn($sql, $parameters, $types);
+
+                return array_map(strval(...), $ids);
+            }
+
             $this->driverConnection->executeStatement($sql, $parameters, $types);
+
+            return null;
         } catch (TableNotFoundException $e) {
             if (!$this->autoSetup) {
                 throw $e;

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
@@ -158,6 +158,65 @@ class Connection implements ResetInterface
         ]);
     }
 
+    /**
+     * Sends multiple messages in a single INSERT query.
+     *
+     * @param list<array{body: string, headers: array, delay: int}> $messages
+     *
+     * @throws DBALException
+     */
+    public function sendBatch(array $messages): void
+    {
+        if ([] === $messages) {
+            return;
+        }
+
+        $now = new \DateTimeImmutable('UTC');
+        $queueName = $this->configuration['queue_name'];
+        $queryBuilder = $this->driverConnection->createQueryBuilder()
+            ->insert($this->configuration['table_name'])
+            ->values([
+                'body' => '?',
+                'headers' => '?',
+                'queue_name' => '?',
+                'created_at' => '?',
+                'available_at' => '?',
+            ]);
+
+        $baseSql = $queryBuilder->getSQL();
+
+        $additionalPlaceholders = [];
+        $values = [];
+        $types = [];
+
+        foreach ($messages as $index => $message) {
+            $delay = $message['delay'];
+            $availableAt = $now->modify(\sprintf('%+d seconds', $delay / 1000));
+
+            if ($index > 0) {
+                $additionalPlaceholders[] = '(?, ?, ?, ?, ?)';
+            }
+
+            $values[] = $message['body'];
+            $values[] = json_encode($message['headers']);
+            $values[] = $queueName;
+            $values[] = $now;
+            $values[] = $availableAt;
+
+            $types[] = Types::STRING;
+            $types[] = Types::STRING;
+            $types[] = Types::STRING;
+            $types[] = Types::DATETIME_IMMUTABLE;
+            $types[] = Types::DATETIME_IMMUTABLE;
+        }
+
+        $sql = [] === $additionalPlaceholders
+            ? $baseSql
+            : $baseSql.', '.implode(', ', $additionalPlaceholders);
+
+        $this->executeBatchInsert($sql, $values, $types);
+    }
+
     public function get(): ?array
     {
         if ($this->doMysqlCleanup && $this->driverConnection->getDatabasePlatform() instanceof AbstractMySQLPlatform) {
@@ -515,6 +574,21 @@ class Connection implements ResetInterface
         }
 
         return $id;
+    }
+
+    private function executeBatchInsert(string $sql, array $parameters = [], array $types = []): void
+    {
+        insert:
+        try {
+            $this->driverConnection->executeStatement($sql, $parameters, $types);
+        } catch (TableNotFoundException $e) {
+            if (!$this->autoSetup) {
+                throw $e;
+            }
+
+            $this->setup();
+            goto insert;
+        }
     }
 
     private function getSchema(): Schema

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineSender.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineSender.php
@@ -16,14 +16,14 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Component\Messenger\Stamp\DelayStamp;
 use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
-use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
+use Symfony\Component\Messenger\Transport\Sender\BatchSenderInterface;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
 /**
  * @author Vincent Touzet <vincent.touzet@gmail.com>
  */
-class DoctrineSender implements SenderInterface
+class DoctrineSender implements BatchSenderInterface
 {
     private SerializerInterface $serializer;
 
@@ -49,5 +49,39 @@ class DoctrineSender implements SenderInterface
         }
 
         return $envelope->with(new TransportMessageIdStamp($id));
+    }
+
+    public function getMaxBatchSize(): ?int
+    {
+        return null;
+    }
+
+    public function sendBatch(array $envelopes): array
+    {
+        if ([] === $envelopes) {
+            return [];
+        }
+
+        $messages = [];
+        foreach ($envelopes as $envelope) {
+            $encodedMessage = $this->serializer->encode($envelope);
+
+            /** @var DelayStamp|null $delayStamp */
+            $delayStamp = $envelope->last(DelayStamp::class);
+
+            $messages[] = [
+                'body' => $encodedMessage['body'],
+                'headers' => $encodedMessage['headers'] ?? [],
+                'delay' => null !== $delayStamp ? $delayStamp->getDelay() : 0,
+            ];
+        }
+
+        try {
+            $this->connection->sendBatch($messages);
+        } catch (DBALException $exception) {
+            throw new TransportException($exception->getMessage(), 0, $exception);
+        }
+
+        return $envelopes;
     }
 }

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineSender.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineSender.php
@@ -77,9 +77,15 @@ class DoctrineSender implements BatchSenderInterface
         }
 
         try {
-            $this->connection->sendBatch($messages);
+            $ids = $this->connection->sendBatch($messages);
         } catch (DBALException $exception) {
             throw new TransportException($exception->getMessage(), 0, $exception);
+        }
+
+        if (null !== $ids) {
+            foreach ($envelopes as $index => $envelope) {
+                $envelopes[$index] = $envelope->with(new TransportMessageIdStamp($ids[$index]));
+            }
         }
 
         return $envelopes;

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineTransport.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineTransport.php
@@ -18,6 +18,7 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Transport\Receiver\KeepaliveReceiverInterface;
 use Symfony\Component\Messenger\Transport\Receiver\ListableReceiverInterface;
 use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
+use Symfony\Component\Messenger\Transport\Sender\BatchSenderInterface;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\SetupableTransportInterface;
 use Symfony\Component\Messenger\Transport\TransportInterface;
@@ -25,7 +26,7 @@ use Symfony\Component\Messenger\Transport\TransportInterface;
 /**
  * @author Vincent Touzet <vincent.touzet@gmail.com>
  */
-class DoctrineTransport implements TransportInterface, SetupableTransportInterface, MessageCountAwareInterface, ListableReceiverInterface, KeepaliveReceiverInterface
+class DoctrineTransport implements TransportInterface, SetupableTransportInterface, MessageCountAwareInterface, ListableReceiverInterface, KeepaliveReceiverInterface, BatchSenderInterface
 {
     private DoctrineReceiver $receiver;
     private DoctrineSender $sender;
@@ -74,6 +75,16 @@ class DoctrineTransport implements TransportInterface, SetupableTransportInterfa
     public function send(Envelope $envelope): Envelope
     {
         return $this->getSender()->send($envelope);
+    }
+
+    public function getMaxBatchSize(): ?int
+    {
+        return $this->getSender()->getMaxBatchSize();
+    }
+
+    public function sendBatch(array $envelopes): array
+    {
+        return $this->getSender()->sendBatch($envelopes);
     }
 
     public function setup(): void

--- a/src/Symfony/Component/Messenger/Event/BatchSentToTransportsEvent.php
+++ b/src/Symfony/Component/Messenger/Event/BatchSentToTransportsEvent.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Event;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
+
+/**
+ * Event dispatched after a batch of messages has been sent to transports.
+ *
+ * @author Joppe De Cuyper <hello@joppe.dev>
+ */
+final class BatchSentToTransportsEvent
+{
+    /**
+     * @param Envelope[]                     $envelopes
+     * @param array<string, SenderInterface> $senders
+     */
+    public function __construct(
+        private string $batchId,
+        private array $envelopes,
+        private array $senders,
+    ) {
+    }
+
+    public function getBatchId(): string
+    {
+        return $this->batchId;
+    }
+
+    /**
+     * @return Envelope[]
+     */
+    public function getEnvelopes(): array
+    {
+        return $this->envelopes;
+    }
+
+    /**
+     * @return array<string, SenderInterface>
+     */
+    public function getSenders(): array
+    {
+        return $this->senders;
+    }
+}

--- a/src/Symfony/Component/Messenger/Exception/BatchSizeExceededException.php
+++ b/src/Symfony/Component/Messenger/Exception/BatchSizeExceededException.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Exception;
+
+/**
+ * Thrown when a batch dispatch exceeds a transport's maximum batch size.
+ *
+ * @author Joppe De Cuyper <hello@joppe.dev>
+ */
+class BatchSizeExceededException extends LogicException
+{
+    public function __construct(
+        private string $transportName,
+        private int $batchSize,
+        private int $maxBatchSize,
+    ) {
+        parent::__construct(\sprintf(
+            'Transport "%s" supports a maximum batch size of %d, but %d messages were provided.',
+            $transportName,
+            $maxBatchSize,
+            $batchSize,
+        ));
+    }
+
+    public function getTransportName(): string
+    {
+        return $this->transportName;
+    }
+
+    public function getBatchSize(): int
+    {
+        return $this->batchSize;
+    }
+
+    public function getMaxBatchSize(): int
+    {
+        return $this->maxBatchSize;
+    }
+}

--- a/src/Symfony/Component/Messenger/MessageBus.php
+++ b/src/Symfony/Component/Messenger/MessageBus.php
@@ -11,23 +11,31 @@
 
 namespace Symfony\Component\Messenger;
 
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Log\LoggerAwareTrait;
 use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
 use Symfony\Component\Messenger\Middleware\StackMiddleware;
+use Symfony\Component\Messenger\Stamp\BatchStamp;
+use Symfony\Component\Messenger\Transport\Sender\BatchCollector;
 
 /**
  * @author Samuel Roze <samuel.roze@gmail.com>
  * @author Matthias Noback <matthiasnoback@gmail.com>
  * @author Nicolas Grekas <p@tchwork.com>
  */
-class MessageBus implements MessageBusInterface
+class MessageBus implements BatchMessageBusInterface
 {
+    use LoggerAwareTrait;
+
     private \IteratorAggregate $middlewareAggregate;
 
     /**
      * @param iterable<mixed, MiddlewareInterface> $middlewareHandlers
      */
-    public function __construct(iterable $middlewareHandlers = [])
-    {
+    public function __construct(
+        iterable $middlewareHandlers = [],
+        private ?EventDispatcherInterface $eventDispatcher = null,
+    ) {
         if ($middlewareHandlers instanceof \IteratorAggregate) {
             $this->middlewareAggregate = $middlewareHandlers;
         } elseif (\is_array($middlewareHandlers)) {
@@ -67,5 +75,29 @@ class MessageBus implements MessageBusInterface
         $stack = new StackMiddleware($middlewareIterator);
 
         return $middlewareIterator->current()->handle($envelope, $stack);
+    }
+
+    public function dispatchBatch(array $messages, array $stamps = []): array
+    {
+        if ([] === $messages) {
+            return [];
+        }
+
+        $collector = new BatchCollector($this->eventDispatcher);
+        if (null !== $this->logger) {
+            $collector->setLogger($this->logger);
+        }
+
+        $messages = array_values($messages);
+        $batchSize = \count($messages);
+
+        foreach ($messages as $index => $message) {
+            $batchStamp = new BatchStamp($collector->getBatchId(), $index, $batchSize, $collector);
+
+            $envelope = $this->dispatch($message, [...$stamps, $batchStamp]);
+            $collector->trackEnvelope($index, $envelope);
+        }
+
+        return $collector->flush();
     }
 }

--- a/src/Symfony/Component/Messenger/Middleware/SendMessageMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/SendMessageMiddleware.php
@@ -17,6 +17,7 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Event\MessageSentToTransportsEvent;
 use Symfony\Component\Messenger\Event\SendMessageToTransportsEvent;
 use Symfony\Component\Messenger\Exception\NoSenderForMessageException;
+use Symfony\Component\Messenger\Stamp\BatchStamp;
 use Symfony\Component\Messenger\Stamp\ReceivedStamp;
 use Symfony\Component\Messenger\Stamp\SentStamp;
 use Symfony\Component\Messenger\Transport\Sender\SendersLocatorInterface;
@@ -43,6 +44,8 @@ class SendMessageMiddleware implements MiddlewareInterface
         ];
 
         $sender = null;
+        $batchStamp = $envelope->last(BatchStamp::class);
+        $collector = $batchStamp?->getCollector();
 
         if ($envelope->all(ReceivedStamp::class)) {
             // it's a received message, do not send it back
@@ -57,12 +60,22 @@ class SendMessageMiddleware implements MiddlewareInterface
                 $envelope = $event->getEnvelope();
             }
 
-            foreach ($senders as $alias => $sender) {
-                $this->logger?->info('Sending message {class} with {alias} sender using {sender}', $context + ['alias' => $alias, 'sender' => $sender::class]);
-                $envelope = $sender->send($envelope->with(new SentStamp($sender::class, \is_string($alias) ? $alias : null)));
+            if ($collector) {
+                // Batch mode: add to collector instead of sending immediately
+                foreach ($senders as $alias => $sender) {
+                    $this->logger?->info('Batching message {class} with {alias} sender using {sender}', $context + ['alias' => $alias, 'sender' => $sender::class]);
+                    $envelope = $envelope->with(new SentStamp($sender::class, \is_string($alias) ? $alias : null));
+                    $collector->addPendingSend($alias, $sender, $envelope, $batchStamp->getBatchIndex());
+                }
+            } else {
+                // Normal mode: send immediately
+                foreach ($senders as $alias => $sender) {
+                    $this->logger?->info('Sending message {class} with {alias} sender using {sender}', $context + ['alias' => $alias, 'sender' => $sender::class]);
+                    $envelope = $sender->send($envelope->with(new SentStamp($sender::class, \is_string($alias) ? $alias : null)));
+                }
             }
 
-            if (null !== $this->eventDispatcher && $senders) {
+            if (null !== $this->eventDispatcher && $senders && !$collector) {
                 $this->eventDispatcher->dispatch(new MessageSentToTransportsEvent($envelope, $senders));
             }
 

--- a/src/Symfony/Component/Messenger/Stamp/BatchStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/BatchStamp.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Stamp;
+
+use Symfony\Component\Messenger\Transport\Sender\BatchCollector;
+
+/**
+ * Stamp identifying a message as part of a batch dispatch.
+ *
+ * This stamp can be used by event listeners to correlate messages
+ * belonging to the same batch.
+ *
+ * @author Joppe De Cuyper <hello@joppe.dev>
+ */
+final class BatchStamp implements NonSendableStampInterface
+{
+    public function __construct(
+        private string $batchId,
+        private int $batchIndex,
+        private int $batchSize,
+        private ?BatchCollector $collector = null,
+    ) {
+    }
+
+    public function getBatchId(): string
+    {
+        return $this->batchId;
+    }
+
+    public function getBatchIndex(): int
+    {
+        return $this->batchIndex;
+    }
+
+    public function getBatchSize(): int
+    {
+        return $this->batchSize;
+    }
+
+    /**
+     * @internal
+     */
+    public function getCollector(): ?BatchCollector
+    {
+        return $this->collector;
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/MessageBusBatchTest.php
+++ b/src/Symfony/Component/Messenger/Tests/MessageBusBatchTest.php
@@ -1,0 +1,223 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\BatchSentToTransportsEvent;
+use Symfony\Component\Messenger\Event\MessageSentToTransportsEvent;
+use Symfony\Component\Messenger\Event\SendMessageToTransportsEvent;
+use Symfony\Component\Messenger\MessageBus;
+use Symfony\Component\Messenger\Middleware\SendMessageMiddleware;
+use Symfony\Component\Messenger\Stamp\BatchStamp;
+use Symfony\Component\Messenger\Stamp\SentStamp;
+use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Transport\Sender\BatchSenderInterface;
+use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
+use Symfony\Component\Messenger\Transport\Sender\SendersLocator;
+
+class MessageBusBatchTest extends TestCase
+{
+    public function testDispatchBatchWithEmptyArray()
+    {
+        $bus = new MessageBus();
+        $result = $bus->dispatchBatch([]);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testDispatchBatchAddsBatchStampToEachMessage()
+    {
+        $message1 = new DummyMessage('Hello');
+        $message2 = new DummyMessage('World');
+
+        $bus = new MessageBus();
+        $envelopes = $bus->dispatchBatch([$message1, $message2]);
+
+        $this->assertCount(2, $envelopes);
+
+        // Check first envelope
+        $batchStamp1 = $envelopes[0]->last(BatchStamp::class);
+        $this->assertNotNull($batchStamp1);
+        $this->assertSame(0, $batchStamp1->getBatchIndex());
+        $this->assertSame(2, $batchStamp1->getBatchSize());
+
+        // Check second envelope
+        $batchStamp2 = $envelopes[1]->last(BatchStamp::class);
+        $this->assertNotNull($batchStamp2);
+        $this->assertSame(1, $batchStamp2->getBatchIndex());
+        $this->assertSame(2, $batchStamp2->getBatchSize());
+
+        // Both should have the same batch ID
+        $this->assertSame($batchStamp1->getBatchId(), $batchStamp2->getBatchId());
+    }
+
+    public function testDispatchBatchSendsToTransportViaBatchSender()
+    {
+        $message1 = new DummyMessage('Hello');
+        $message2 = new DummyMessage('World');
+
+        $sender = $this->createMock(BatchSenderInterface::class);
+        $sender->expects($this->once())
+            ->method('sendBatch')
+            ->with($this->callback(function (array $envelopes) {
+                return 2 === \count($envelopes)
+                    && $envelopes[0]->getMessage() instanceof DummyMessage
+                    && $envelopes[1]->getMessage() instanceof DummyMessage;
+            }))
+            ->willReturnCallback(function (array $envelopes) {
+                return array_map(fn (Envelope $e) => $e->with(new TransportMessageIdStamp('id-'.spl_object_id($e))), $envelopes);
+            });
+
+        $sendersLocator = $this->createSendersLocator([DummyMessage::class => ['async']], ['async' => $sender]);
+        $middleware = new SendMessageMiddleware($sendersLocator);
+
+        $bus = new MessageBus([$middleware]);
+        $envelopes = $bus->dispatchBatch([$message1, $message2]);
+
+        $this->assertCount(2, $envelopes);
+        $this->assertNotNull($envelopes[0]->last(TransportMessageIdStamp::class));
+        $this->assertNotNull($envelopes[1]->last(TransportMessageIdStamp::class));
+        $this->assertNotNull($envelopes[0]->last(SentStamp::class));
+        $this->assertNotNull($envelopes[1]->last(SentStamp::class));
+    }
+
+    public function testDispatchBatchFallsBackToIndividualSendsForNonBatchSender()
+    {
+        $message1 = new DummyMessage('Hello');
+        $message2 = new DummyMessage('World');
+
+        $sender = $this->createMock(SenderInterface::class);
+        $sender->expects($this->exactly(2))
+            ->method('send')
+            ->willReturnCallback(fn (Envelope $e) => $e->with(new TransportMessageIdStamp('id-'.spl_object_id($e))));
+
+        $sendersLocator = $this->createSendersLocator([DummyMessage::class => ['async']], ['async' => $sender]);
+        $middleware = new SendMessageMiddleware($sendersLocator);
+
+        $bus = new MessageBus([$middleware]);
+        $envelopes = $bus->dispatchBatch([$message1, $message2]);
+
+        $this->assertCount(2, $envelopes);
+        $this->assertNotNull($envelopes[0]->last(TransportMessageIdStamp::class));
+        $this->assertNotNull($envelopes[1]->last(TransportMessageIdStamp::class));
+    }
+
+    public function testDispatchBatchWithMixedMessages()
+    {
+        // Message with sender
+        $message1 = new DummyMessage('Async');
+        // Message without sender (will be handled synchronously)
+        $message2 = new \stdClass();
+
+        $sender = $this->createMock(BatchSenderInterface::class);
+        $sender->expects($this->once())
+            ->method('sendBatch')
+            ->willReturnCallback(fn (array $envelopes) => array_map(
+                fn (Envelope $e) => $e->with(new TransportMessageIdStamp('id')),
+                $envelopes
+            ));
+
+        $sendersLocator = $this->createSendersLocator([DummyMessage::class => ['async']], ['async' => $sender]);
+        $middleware = new SendMessageMiddleware($sendersLocator);
+
+        $bus = new MessageBus([$middleware]);
+        $envelopes = $bus->dispatchBatch([$message1, $message2]);
+
+        $this->assertCount(2, $envelopes);
+
+        // First message should have been sent
+        $this->assertNotNull($envelopes[0]->last(SentStamp::class));
+        $this->assertNotNull($envelopes[0]->last(TransportMessageIdStamp::class));
+
+        // Second message should NOT have been sent (no sender configured)
+        $this->assertNull($envelopes[1]->last(SentStamp::class));
+        $this->assertNull($envelopes[1]->last(TransportMessageIdStamp::class));
+    }
+
+    public function testDispatchBatchDispatchesEvents()
+    {
+        $message1 = new DummyMessage('Hello');
+        $message2 = new DummyMessage('World');
+
+        $sender = $this->createMock(BatchSenderInterface::class);
+        $sender->method('sendBatch')->willReturnArgument(0);
+
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+
+        $dispatchedEvents = [];
+        $dispatcher->method('dispatch')
+            ->willReturnCallback(function (object $event) use (&$dispatchedEvents) {
+                $dispatchedEvents[] = $event::class;
+
+                return $event;
+            });
+
+        $sendersLocator = $this->createSendersLocator([DummyMessage::class => ['async']], ['async' => $sender]);
+        $middleware = new SendMessageMiddleware($sendersLocator, $dispatcher);
+
+        $bus = new MessageBus([$middleware], $dispatcher);
+        $bus->dispatchBatch([$message1, $message2]);
+
+        // Should have SendMessageToTransportsEvent for each message (2x)
+        // MessageSentToTransportsEvent for each sent message (2x)
+        // BatchSentToTransportsEvent once
+        $this->assertContains(SendMessageToTransportsEvent::class, $dispatchedEvents);
+        $this->assertContains(MessageSentToTransportsEvent::class, $dispatchedEvents);
+        $this->assertContains(BatchSentToTransportsEvent::class, $dispatchedEvents);
+    }
+
+    public function testDispatchBatchPreservesMessageOrder()
+    {
+        $messages = [];
+        for ($i = 0; $i < 10; ++$i) {
+            $messages[] = new DummyMessage("Message $i");
+        }
+
+        $sender = $this->createMock(BatchSenderInterface::class);
+        $sender->method('sendBatch')->willReturnCallback(function (array $envelopes) {
+            // Transport must return envelopes in same order (per BatchSenderInterface contract)
+            // Add a stamp to verify they went through
+            return array_map(
+                fn (Envelope $e) => $e->with(new TransportMessageIdStamp('id-'.spl_object_id($e))),
+                $envelopes
+            );
+        });
+
+        $sendersLocator = $this->createSendersLocator([DummyMessage::class => ['async']], ['async' => $sender]);
+        $middleware = new SendMessageMiddleware($sendersLocator);
+
+        $bus = new MessageBus([$middleware]);
+        $envelopes = $bus->dispatchBatch($messages);
+
+        $this->assertCount(10, $envelopes);
+
+        // Verify order matches input
+        for ($i = 0; $i < 10; ++$i) {
+            $this->assertSame("Message $i", $envelopes[$i]->getMessage()->getMessage());
+        }
+    }
+
+    private function createSendersLocator(array $sendersMap, array $senders): SendersLocator
+    {
+        $container = new Container();
+
+        foreach ($senders as $id => $sender) {
+            $container->set($id, $sender);
+        }
+
+        return new SendersLocator($sendersMap, $container);
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/MessageBusBatchTest.php
+++ b/src/Symfony/Component/Messenger/Tests/MessageBusBatchTest.php
@@ -23,6 +23,7 @@ use Symfony\Component\Messenger\Middleware\SendMessageMiddleware;
 use Symfony\Component\Messenger\Stamp\BatchStamp;
 use Symfony\Component\Messenger\Stamp\SentStamp;
 use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
+use Symfony\Component\Messenger\Exception\BatchSizeExceededException;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Transport\Sender\BatchSenderInterface;
 use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
@@ -208,6 +209,112 @@ class MessageBusBatchTest extends TestCase
         for ($i = 0; $i < 10; ++$i) {
             $this->assertSame("Message $i", $envelopes[$i]->getMessage()->getMessage());
         }
+    }
+
+    public function testDispatchBatchThrowsWhenMaxBatchSizeExceeded()
+    {
+        $messages = [];
+        for ($i = 0; $i < 5; ++$i) {
+            $messages[] = new DummyMessage("Message $i");
+        }
+
+        $sender = $this->createMock(BatchSenderInterface::class);
+        $sender->method('getMaxBatchSize')->willReturn(3);
+        $sender->expects($this->never())->method('sendBatch');
+
+        $sendersLocator = $this->createSendersLocator([DummyMessage::class => ['async']], ['async' => $sender]);
+        $middleware = new SendMessageMiddleware($sendersLocator);
+
+        $bus = new MessageBus([$middleware]);
+
+        $this->expectException(BatchSizeExceededException::class);
+        $this->expectExceptionMessage('Transport "async" supports a maximum batch size of 3, but 5 messages were provided.');
+
+        $bus->dispatchBatch($messages);
+    }
+
+    public function testDispatchBatchSucceedsWhenWithinMaxBatchSize()
+    {
+        $messages = [];
+        for ($i = 0; $i < 3; ++$i) {
+            $messages[] = new DummyMessage("Message $i");
+        }
+
+        $sender = $this->createMock(BatchSenderInterface::class);
+        $sender->method('getMaxBatchSize')->willReturn(3);
+        $sender->expects($this->once())
+            ->method('sendBatch')
+            ->willReturnArgument(0);
+
+        $sendersLocator = $this->createSendersLocator([DummyMessage::class => ['async']], ['async' => $sender]);
+        $middleware = new SendMessageMiddleware($sendersLocator);
+
+        $bus = new MessageBus([$middleware]);
+        $envelopes = $bus->dispatchBatch($messages);
+
+        $this->assertCount(3, $envelopes);
+    }
+
+    public function testDispatchBatchWithUnlimitedMaxBatchSize()
+    {
+        $messages = [];
+        for ($i = 0; $i < 100; ++$i) {
+            $messages[] = new DummyMessage("Message $i");
+        }
+
+        $sender = $this->createMock(BatchSenderInterface::class);
+        $sender->method('getMaxBatchSize')->willReturn(null);
+        $sender->expects($this->once())
+            ->method('sendBatch')
+            ->willReturnArgument(0);
+
+        $sendersLocator = $this->createSendersLocator([DummyMessage::class => ['async']], ['async' => $sender]);
+        $middleware = new SendMessageMiddleware($sendersLocator);
+
+        $bus = new MessageBus([$middleware]);
+        $envelopes = $bus->dispatchBatch($messages);
+
+        $this->assertCount(100, $envelopes);
+    }
+
+    public function testDispatchBatchValidatesAllTransportsBeforeSending()
+    {
+        $messages = [];
+        for ($i = 0; $i < 5; ++$i) {
+            $messages[] = new DummyMessage("Message $i");
+        }
+
+        // First transport has no limit
+        $sender1 = $this->createMock(BatchSenderInterface::class);
+        $sender1->method('getMaxBatchSize')->willReturn(null);
+        $sender1->expects($this->never())->method('sendBatch');
+
+        // Second transport has a limit that will be exceeded
+        $sender2 = $this->createMock(BatchSenderInterface::class);
+        $sender2->method('getMaxBatchSize')->willReturn(3);
+        $sender2->expects($this->never())->method('sendBatch');
+
+        $sendersLocator = $this->createSendersLocator(
+            [DummyMessage::class => ['doctrine', 'sqs']],
+            ['doctrine' => $sender1, 'sqs' => $sender2]
+        );
+        $middleware = new SendMessageMiddleware($sendersLocator);
+
+        $bus = new MessageBus([$middleware]);
+
+        $this->expectException(BatchSizeExceededException::class);
+        $this->expectExceptionMessage('Transport "sqs" supports a maximum batch size of 3, but 5 messages were provided.');
+
+        $bus->dispatchBatch($messages);
+    }
+
+    public function testBatchSizeExceededExceptionContainsDetails()
+    {
+        $exception = new BatchSizeExceededException('sqs', 15, 10);
+
+        $this->assertSame('sqs', $exception->getTransportName());
+        $this->assertSame(15, $exception->getBatchSize());
+        $this->assertSame(10, $exception->getMaxBatchSize());
     }
 
     private function createSendersLocator(array $sendersMap, array $senders): SendersLocator

--- a/src/Symfony/Component/Messenger/Transport/Sender/BatchCollector.php
+++ b/src/Symfony/Component/Messenger/Transport/Sender/BatchCollector.php
@@ -16,6 +16,7 @@ use Psr\Log\LoggerAwareTrait;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Event\BatchSentToTransportsEvent;
 use Symfony\Component\Messenger\Event\MessageSentToTransportsEvent;
+use Symfony\Component\Messenger\Exception\BatchSizeExceededException;
 use Symfony\Component\Messenger\Stamp\SentStamp;
 
 /**
@@ -69,52 +70,110 @@ final class BatchCollector
      * Flush all pending sends and return the final envelopes.
      *
      * @return Envelope[]
+     *
+     * @throws BatchSizeExceededException When a transport's max batch size is exceeded
      */
     public function flush(): array
     {
-        /** @var array<string, SenderInterface> $senders */
+        $this->validateBatchSizes();
+
+        $senders = $this->sendToTransports();
+
+        $this->pending = [];
+        ksort($this->envelopes);
+
+        $this->dispatchEvents($senders);
+
+        return $this->envelopes;
+    }
+
+    /**
+     * @return array<string, SenderInterface> Map of alias to sender
+     */
+    private function sendToTransports(): array
+    {
         $senders = [];
 
         foreach ($this->pending as $alias => $data) {
             $sender = $data['sender'];
             $senders[$alias] = $sender;
-            $envelopes = array_column($data['items'], 'envelope');
-            $indices = array_column($data['items'], 'index');
 
-            if ($sender instanceof BatchSenderInterface) {
-                $sent = $sender->sendBatch($envelopes);
-            } else {
-                $this->logger?->warning('Transport "{alias}" does not implement BatchSenderInterface, falling back to individual sends.', [
-                    'alias' => $alias,
-                    'sender' => $sender::class,
-                ]);
-                $sent = array_map(fn (Envelope $envelope) => $sender->send($envelope), $envelopes);
-            }
+            $sent = $this->sendToTransport($alias, $sender, $data['items']);
 
-            // Update tracked envelopes with results from transport
-            foreach ($sent as $i => $envelope) {
-                $this->envelopes[$indices[$i]] = $envelope;
+            foreach ($sent as $index => $envelope) {
+                $this->envelopes[$index] = $envelope;
             }
         }
 
-        $this->pending = [];
+        return $senders;
+    }
 
-        // Sort by index
-        ksort($this->envelopes);
+    /**
+     * @param list<array{envelope: Envelope, index: int}> $items
+     *
+     * @return array<int, Envelope> Map of original index to sent envelope
+     */
+    private function sendToTransport(string $alias, SenderInterface $sender, array $items): array
+    {
+        $envelopes = array_column($items, 'envelope');
+        $indices = array_column($items, 'index');
 
-        // Dispatch events
-        if (null !== $this->eventDispatcher && [] !== $senders) {
-            foreach ($this->envelopes as $envelope) {
-                $envelopeSenders = $this->getSendersForEnvelope($envelope, $senders);
-                if ([] !== $envelopeSenders) {
-                    $this->eventDispatcher->dispatch(new MessageSentToTransportsEvent($envelope, $envelopeSenders));
-                }
-            }
-
-            $this->eventDispatcher->dispatch(new BatchSentToTransportsEvent($this->batchId, $this->envelopes, $senders));
+        if ($sender instanceof BatchSenderInterface) {
+            $sent = $sender->sendBatch($envelopes);
+        } else {
+            $this->logger?->warning('Transport "{alias}" does not implement BatchSenderInterface, falling back to individual sends.', [
+                'alias' => $alias,
+                'sender' => $sender::class,
+            ]);
+            $sent = array_map(static fn (Envelope $envelope) => $sender->send($envelope), $envelopes);
         }
 
-        return $this->envelopes;
+        return array_combine($indices, $sent);
+    }
+
+    /**
+     * @param array<string, SenderInterface> $senders
+     */
+    private function dispatchEvents(array $senders): void
+    {
+        if (null === $this->eventDispatcher || [] === $senders) {
+            return;
+        }
+
+        foreach ($this->envelopes as $envelope) {
+            $envelopeSenders = $this->getSendersForEnvelope($envelope, $senders);
+            if ([] !== $envelopeSenders) {
+                $this->eventDispatcher->dispatch(new MessageSentToTransportsEvent($envelope, $envelopeSenders));
+            }
+        }
+
+        $this->eventDispatcher->dispatch(new BatchSentToTransportsEvent($this->batchId, $this->envelopes, $senders));
+    }
+
+    /**
+     * Validates that no transport's max batch size is exceeded.
+     *
+     * @throws BatchSizeExceededException
+     */
+    private function validateBatchSizes(): void
+    {
+        foreach ($this->pending as $alias => $data) {
+            $sender = $data['sender'];
+
+            if (!$sender instanceof BatchSenderInterface) {
+                continue;
+            }
+
+            $maxBatchSize = $sender->getMaxBatchSize();
+            if (null === $maxBatchSize) {
+                continue;
+            }
+
+            $batchSize = \count($data['items']);
+            if ($batchSize > $maxBatchSize) {
+                throw new BatchSizeExceededException($alias, $batchSize, $maxBatchSize);
+            }
+        }
     }
 
     /**

--- a/src/Symfony/Component/Messenger/Transport/Sender/BatchCollector.php
+++ b/src/Symfony/Component/Messenger/Transport/Sender/BatchCollector.php
@@ -1,0 +1,137 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Transport\Sender;
+
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Log\LoggerAwareTrait;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\BatchSentToTransportsEvent;
+use Symfony\Component\Messenger\Event\MessageSentToTransportsEvent;
+use Symfony\Component\Messenger\Stamp\SentStamp;
+
+/**
+ * Collects envelopes during batch dispatch and flushes them to transports.
+ *
+ * @author Joppe De Cuyper <hello@joppe.dev>
+ *
+ * @internal
+ */
+final class BatchCollector
+{
+    use LoggerAwareTrait;
+
+    private string $batchId;
+
+    /** @var array<int, Envelope> */
+    private array $envelopes = [];
+
+    /** @var array<string, array{sender: SenderInterface, items: list<array{envelope: Envelope, index: int}>}> */
+    private array $pending = [];
+
+    public function __construct(
+        private ?EventDispatcherInterface $eventDispatcher = null,
+    ) {
+        $this->batchId = bin2hex(random_bytes(16));
+    }
+
+    public function getBatchId(): string
+    {
+        return $this->batchId;
+    }
+
+    /**
+     * Track an envelope after it has passed through the middleware chain.
+     */
+    public function trackEnvelope(int $index, Envelope $envelope): void
+    {
+        $this->envelopes[$index] = $envelope;
+    }
+
+    /**
+     * Add an envelope to be sent to a specific transport.
+     */
+    public function addPendingSend(string $alias, SenderInterface $sender, Envelope $envelope, int $index): void
+    {
+        $this->pending[$alias] ??= ['sender' => $sender, 'items' => []];
+        $this->pending[$alias]['items'][] = ['envelope' => $envelope, 'index' => $index];
+    }
+
+    /**
+     * Flush all pending sends and return the final envelopes.
+     *
+     * @return Envelope[]
+     */
+    public function flush(): array
+    {
+        /** @var array<string, SenderInterface> $senders */
+        $senders = [];
+
+        foreach ($this->pending as $alias => $data) {
+            $sender = $data['sender'];
+            $senders[$alias] = $sender;
+            $envelopes = array_column($data['items'], 'envelope');
+            $indices = array_column($data['items'], 'index');
+
+            if ($sender instanceof BatchSenderInterface) {
+                $sent = $sender->sendBatch($envelopes);
+            } else {
+                $this->logger?->warning('Transport "{alias}" does not implement BatchSenderInterface, falling back to individual sends.', [
+                    'alias' => $alias,
+                    'sender' => $sender::class,
+                ]);
+                $sent = array_map(fn (Envelope $envelope) => $sender->send($envelope), $envelopes);
+            }
+
+            // Update tracked envelopes with results from transport
+            foreach ($sent as $i => $envelope) {
+                $this->envelopes[$indices[$i]] = $envelope;
+            }
+        }
+
+        $this->pending = [];
+
+        // Sort by index
+        ksort($this->envelopes);
+
+        // Dispatch events
+        if (null !== $this->eventDispatcher && [] !== $senders) {
+            foreach ($this->envelopes as $envelope) {
+                $envelopeSenders = $this->getSendersForEnvelope($envelope, $senders);
+                if ([] !== $envelopeSenders) {
+                    $this->eventDispatcher->dispatch(new MessageSentToTransportsEvent($envelope, $envelopeSenders));
+                }
+            }
+
+            $this->eventDispatcher->dispatch(new BatchSentToTransportsEvent($this->batchId, $this->envelopes, $senders));
+        }
+
+        return $this->envelopes;
+    }
+
+    /**
+     * @param array<string, SenderInterface> $senders
+     *
+     * @return array<string, SenderInterface>
+     */
+    private function getSendersForEnvelope(Envelope $envelope, array $senders): array
+    {
+        $envelopeSenders = [];
+        foreach ($envelope->all(SentStamp::class) as $sentStamp) {
+            $alias = $sentStamp->getSenderAlias();
+            if (null !== $alias && isset($senders[$alias])) {
+                $envelopeSenders[$alias] = $senders[$alias];
+            }
+        }
+
+        return $envelopeSenders;
+    }
+}

--- a/src/Symfony/Component/Messenger/Transport/Sender/BatchSenderInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/Sender/BatchSenderInterface.php
@@ -37,8 +37,8 @@ interface BatchSenderInterface extends SenderInterface
      * The number of envelopes MUST NOT exceed getMaxBatchSize() if it returns
      * a non-null value.
      *
-     * The returned envelopes should contain a TransportMessageIdStamp and
-     * MUST be in the same order as the input envelopes.
+     * The returned envelopes MUST be in the same order as the input envelopes.
+     * The envelopes may contain a TransportMessageIdStamp if supported by the transport
      *
      * @param Envelope[] $envelopes
      *

--- a/src/Symfony/Component/Messenger/Transport/Sender/BatchSenderInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/Sender/BatchSenderInterface.php
@@ -22,10 +22,20 @@ use Symfony\Component\Messenger\Exception\ExceptionInterface;
 interface BatchSenderInterface extends SenderInterface
 {
     /**
+     * Returns the maximum number of envelopes that can be sent in a single batch.
+     *
+     * @return int|null The maximum batch size, or null if unlimited
+     */
+    public function getMaxBatchSize(): ?int;
+
+    /**
      * Sends multiple envelopes in a single batch operation.
      *
      * This method MUST be atomic: either all messages are sent successfully,
      * or none are sent and an exception is thrown.
+     *
+     * The number of envelopes MUST NOT exceed getMaxBatchSize() if it returns
+     * a non-null value.
      *
      * The returned envelopes should contain a TransportMessageIdStamp and
      * MUST be in the same order as the input envelopes.

--- a/src/Symfony/Component/Messenger/Transport/Sender/BatchSenderInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/Sender/BatchSenderInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Transport\Sender;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\ExceptionInterface;
+
+/**
+ * A sender that supports sending multiple envelopes in a single batch operation.
+ *
+ * @author Joppe De Cuyper <hello@joppe.dev>
+ */
+interface BatchSenderInterface extends SenderInterface
+{
+    /**
+     * Sends multiple envelopes in a single batch operation.
+     *
+     * This method MUST be atomic: either all messages are sent successfully,
+     * or none are sent and an exception is thrown.
+     *
+     * The returned envelopes should contain a TransportMessageIdStamp and
+     * MUST be in the same order as the input envelopes.
+     *
+     * @param Envelope[] $envelopes
+     *
+     * @return Envelope[]
+     *
+     * @throws ExceptionInterface
+     */
+    public function sendBatch(array $envelopes): array;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | Possibly? <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #60748 
| License       | MIT

**Note: This PR is a proof of concept. It is in no way, shape or form supposed to be a final ready for production fix. This PR is supposed to get the conversation going. Please, provide feedback where needed, as this feature turned out to be more complex than i initially imagined 😀 This is also the reason the code is littered with comments**

## Batch Dispatch for Symfony Messenger

Allows dispatching multiple messages in a single batch, enabling transports to optimize delivery (e.g., bulk inserts to a queue). This allows you to optimize message sending (Eg. Single SQS request for 10 messages, where you pay per-request)

### How it works

```$bus->dispatchBatch([new OrderCreated(1), new OrderCreated(2), new OrderCreated(3)]);```

### Step by step:

1. MessageBus::dispatchBatch() creates a BatchCollector and generates a unique batch ID
2. Each message goes through the regular middleware chain individually, with a BatchStamp attached (contains batchId, index, size, and collector reference)
3. SendMessageMiddleware detects the collector in BatchStamp, so it skips sending the message and instead adds it to the collector
4. After all messages are processed, BatchCollector::flush() groups envelopes by transport and calls sendBatch() (or falls back to individual send() calls)
5. Events are dispatched: SendMessageToTransportsEvent per message, MessageSentToTransportsEvent per sent message, BatchSentToTransportsEvent once for the whole batch

### Notes

  1. Error handling - If one transport in a multi-transport batch fails, partial sends may have occurred. But that issue currently also exists for single messages
  2. Batch size limits - I have now blocked this on the collector level, to avoid partial flushes.