### PR TITLE
[Form] Clean up wrong method docblocks in data transformers

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/DataTransformer/CollectionToArrayTransformer.php
+++ b/src/Symfony/Bridge/Doctrine/Form/DataTransformer/CollectionToArrayTransformer.php
@@ -24,41 +24,33 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
  */
 class CollectionToArrayTransformer implements DataTransformerInterface
 {
-    /**
-     * Transforms a collection into an array.
-     *
-     * @throws TransformationFailedException
-     */
-    public function transform(mixed $collection): mixed
+    public function transform(mixed $value): mixed
     {
-        if (null === $collection) {
+        if (null === $value) {
             return [];
         }
 
         // For cases when the collection getter returns $collection->toArray()
         // in order to prevent modifications of the returned collection
-        if (\is_array($collection)) {
-            return $collection;
+        if (\is_array($value)) {
+            return $value;
         }
 
-        if (!$collection instanceof ReadableCollection) {
+        if (!$value instanceof ReadableCollection) {
             throw new TransformationFailedException(\sprintf('Expected a "%s" object.', ReadableCollection::class));
         }
 
-        return $collection->toArray();
+        return $value->toArray();
     }
 
-    /**
-     * Transforms an array into a collection.
-     */
-    public function reverseTransform(mixed $array): Collection
+    public function reverseTransform(mixed $value): Collection
     {
-        if ('' === $array || null === $array) {
-            $array = [];
+        if ('' === $value || null === $value) {
+            $value = [];
         } else {
-            $array = (array) $array;
+            $value = (array) $value;
         }
 
-        return new ArrayCollection($array);
+        return new ArrayCollection($value);
     }
 }

--- a/src/Symfony/Component/Form/CallbackTransformer.php
+++ b/src/Symfony/Component/Form/CallbackTransformer.php
@@ -22,13 +22,13 @@ class CallbackTransformer implements DataTransformerInterface
         $this->reverseTransform = $reverseTransform(...);
     }
 
-    public function transform(mixed $data): mixed
+    public function transform(mixed $value): mixed
     {
-        return ($this->transform)($data);
+        return ($this->transform)($value);
     }
 
-    public function reverseTransform(mixed $data): mixed
+    public function reverseTransform(mixed $value): mixed
     {
-        return ($this->reverseTransform)($data);
+        return ($this->reverseTransform)($value);
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ArrayToPartsTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ArrayToPartsTransformer.php
@@ -26,28 +26,28 @@ class ArrayToPartsTransformer implements DataTransformerInterface
     ) {
     }
 
-    public function transform(mixed $array): mixed
+    public function transform(mixed $value): mixed
     {
-        if (!\is_array($array ??= [])) {
+        if (!\is_array($value ??= [])) {
             throw new TransformationFailedException('Expected an array.');
         }
 
         $result = [];
 
         foreach ($this->partMapping as $partKey => $originalKeys) {
-            if (!$array) {
+            if (!$value) {
                 $result[$partKey] = null;
             } else {
-                $result[$partKey] = array_intersect_key($array, array_flip($originalKeys));
+                $result[$partKey] = array_intersect_key($value, array_flip($originalKeys));
             }
         }
 
         return $result;
     }
 
-    public function reverseTransform(mixed $array): mixed
+    public function reverseTransform(mixed $value): mixed
     {
-        if (!\is_array($array)) {
+        if (!\is_array($value)) {
             throw new TransformationFailedException('Expected an array.');
         }
 
@@ -55,10 +55,10 @@ class ArrayToPartsTransformer implements DataTransformerInterface
         $emptyKeys = [];
 
         foreach ($this->partMapping as $partKey => $originalKeys) {
-            if (!empty($array[$partKey])) {
+            if (!empty($value[$partKey])) {
                 foreach ($originalKeys as $originalKey) {
-                    if (isset($array[$partKey][$originalKey])) {
-                        $result[$originalKey] = $array[$partKey][$originalKey];
+                    if (isset($value[$partKey][$originalKey])) {
+                        $result[$originalKey] = $value[$partKey][$originalKey];
                     }
                 }
             } else {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/BooleanToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/BooleanToStringTransformer.php
@@ -37,13 +37,6 @@ class BooleanToStringTransformer implements DataTransformerInterface
         }
     }
 
-    /**
-     * Transforms a Boolean into a string.
-     *
-     * @param bool $value Boolean value
-     *
-     * @throws TransformationFailedException if the given value is not a Boolean
-     */
     public function transform(mixed $value): ?string
     {
         if (null === $value) {
@@ -57,13 +50,6 @@ class BooleanToStringTransformer implements DataTransformerInterface
         return $value ? $this->trueValue : null;
     }
 
-    /**
-     * Transforms a string into a Boolean.
-     *
-     * @param string $value String value
-     *
-     * @throws TransformationFailedException if the given value is not a string
-     */
     public function reverseTransform(mixed $value): bool
     {
         if (\in_array($value, $this->falseValues, true)) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoiceToValueTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoiceToValueTransformer.php
@@ -27,9 +27,9 @@ class ChoiceToValueTransformer implements DataTransformerInterface
     ) {
     }
 
-    public function transform(mixed $choice): mixed
+    public function transform(mixed $value): mixed
     {
-        return (string) current($this->choiceList->getValuesForChoices([$choice]));
+        return (string) current($this->choiceList->getValuesForChoices([$value]));
     }
 
     public function reverseTransform(mixed $value): mixed

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoicesToValuesTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoicesToValuesTransformer.php
@@ -27,40 +27,32 @@ class ChoicesToValuesTransformer implements DataTransformerInterface
     ) {
     }
 
-    /**
-     * @throws TransformationFailedException if the given value is not an array
-     */
-    public function transform(mixed $array): array
+    public function transform(mixed $value): array
     {
-        if (null === $array) {
+        if (null === $value) {
             return [];
         }
 
-        if (!\is_array($array)) {
+        if (!\is_array($value)) {
             throw new TransformationFailedException('Expected an array.');
         }
 
-        return $this->choiceList->getValuesForChoices($array);
+        return $this->choiceList->getValuesForChoices($value);
     }
 
-    /**
-     * @throws TransformationFailedException if the given value is not an array
-     *                                       or if no matching choice could be
-     *                                       found for some given value
-     */
-    public function reverseTransform(mixed $array): array
+    public function reverseTransform(mixed $value): array
     {
-        if (null === $array) {
+        if (null === $value) {
             return [];
         }
 
-        if (!\is_array($array)) {
+        if (!\is_array($value)) {
             throw new TransformationFailedException('Expected an array.');
         }
 
-        $choices = $this->choiceList->getChoicesForValues($array);
+        $choices = $this->choiceList->getChoicesForValues($value);
 
-        if (\count($choices) !== \count($array)) {
+        if (\count($choices) !== \count($value)) {
             throw new TransformationFailedException('Could not find all matching choices for the given values.');
         }
 

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DataTransformerChain.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DataTransformerChain.php
@@ -31,18 +31,6 @@ class DataTransformerChain implements DataTransformerInterface
     ) {
     }
 
-    /**
-     * Passes the value through the transform() method of all nested transformers.
-     *
-     * The transformers receive the value in the same order as they were passed
-     * to the constructor. Each transformer receives the result of the previous
-     * transformer as input. The output of the last transformer is returned
-     * by this method.
-     *
-     * @param mixed $value The original value
-     *
-     * @throws TransformationFailedException
-     */
     public function transform(mixed $value): mixed
     {
         foreach ($this->transformers as $transformer) {
@@ -52,19 +40,6 @@ class DataTransformerChain implements DataTransformerInterface
         return $value;
     }
 
-    /**
-     * Passes the value through the reverseTransform() method of all nested
-     * transformers.
-     *
-     * The transformers receive the value in the reverse order as they were passed
-     * to the constructor. Each transformer receives the result of the previous
-     * transformer as input. The output of the last transformer is returned
-     * by this method.
-     *
-     * @param mixed $value The transformed value
-     *
-     * @throws TransformationFailedException
-     */
     public function reverseTransform(mixed $value): mixed
     {
         for ($i = \count($this->transformers) - 1; $i >= 0; --$i) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateIntervalToArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateIntervalToArrayTransformer.php
@@ -54,16 +54,9 @@ class DateIntervalToArrayTransformer implements DataTransformerInterface
         $this->fields = $fields ?? ['years', 'months', 'days', 'hours', 'minutes', 'seconds', 'invert'];
     }
 
-    /**
-     * Transforms a normalized date interval into an interval array.
-     *
-     * @param \DateInterval $dateInterval Normalized date interval
-     *
-     * @throws UnexpectedTypeException if the given value is not a \DateInterval instance
-     */
-    public function transform(mixed $dateInterval): array
+    public function transform(mixed $value): array
     {
-        if (null === $dateInterval) {
+        if (null === $value) {
             return array_intersect_key(
                 [
                     'years' => '',
@@ -78,12 +71,12 @@ class DateIntervalToArrayTransformer implements DataTransformerInterface
                 array_flip($this->fields)
             );
         }
-        if (!$dateInterval instanceof \DateInterval) {
-            throw new UnexpectedTypeException($dateInterval, \DateInterval::class);
+        if (!$value instanceof \DateInterval) {
+            throw new UnexpectedTypeException($value, \DateInterval::class);
         }
         $result = [];
         foreach (self::AVAILABLE_FIELDS as $field => $char) {
-            $result[$field] = $dateInterval->format('%'.($this->pad ? strtoupper($char) : $char));
+            $result[$field] = $value->format('%'.($this->pad ? strtoupper($char) : $char));
         }
         if (\in_array('weeks', $this->fields, true)) {
             $result['weeks'] = '0';
@@ -97,14 +90,6 @@ class DateIntervalToArrayTransformer implements DataTransformerInterface
         return array_intersect_key($result, array_flip($this->fields));
     }
 
-    /**
-     * Transforms an interval array into a normalized date interval.
-     *
-     * @param array $value Interval array
-     *
-     * @throws UnexpectedTypeException       if the given value is not an array
-     * @throws TransformationFailedException if the value could not be transformed
-     */
     public function reverseTransform(mixed $value): ?\DateInterval
     {
         if (null === $value) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateIntervalToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateIntervalToStringTransformer.php
@@ -36,13 +36,6 @@ class DateIntervalToStringTransformer implements DataTransformerInterface
     ) {
     }
 
-    /**
-     * Transforms a DateInterval object into a date string with the configured format.
-     *
-     * @param \DateInterval|null $value A DateInterval object
-     *
-     * @throws UnexpectedTypeException if the given value is not a \DateInterval instance
-     */
     public function transform(mixed $value): string
     {
         if (null === $value) {
@@ -55,14 +48,6 @@ class DateIntervalToStringTransformer implements DataTransformerInterface
         return $value->format($this->format);
     }
 
-    /**
-     * Transforms a date string in the configured format into a DateInterval object.
-     *
-     * @param string $value An ISO 8601 or date string like date interval presentation
-     *
-     * @throws UnexpectedTypeException       if the given value is not a string
-     * @throws TransformationFailedException if the date interval could not be parsed
-     */
     public function reverseTransform(mixed $value): ?\DateInterval
     {
         if (null === $value) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DatePointToDateTimeTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DatePointToDateTimeTransformer.php
@@ -22,13 +22,6 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
  */
 final class DatePointToDateTimeTransformer implements DataTransformerInterface
 {
-    /**
-     * Transforms a DatePoint into a DateTime object.
-     *
-     * @param DatePoint|null $value A DatePoint object
-     *
-     * @throws TransformationFailedException If the given value is not a DatePoint
-     */
     public function transform(mixed $value): ?\DateTime
     {
         if (null === $value) {
@@ -42,13 +35,6 @@ final class DatePointToDateTimeTransformer implements DataTransformerInterface
         return \DateTime::createFromImmutable($value);
     }
 
-    /**
-     * Transforms a DateTime object into a DatePoint object.
-     *
-     * @param \DateTime|null $value A DateTime object
-     *
-     * @throws TransformationFailedException If the given value is not a \DateTime
-     */
     public function reverseTransform(mixed $value): ?DatePoint
     {
         if (null === $value) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeImmutableToDateTimeTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeImmutableToDateTimeTransformer.php
@@ -23,13 +23,6 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
  */
 final class DateTimeImmutableToDateTimeTransformer implements DataTransformerInterface
 {
-    /**
-     * Transforms a DateTimeImmutable into a DateTime object.
-     *
-     * @param \DateTimeImmutable|null $value A DateTimeImmutable object
-     *
-     * @throws TransformationFailedException If the given value is not a \DateTimeImmutable
-     */
     public function transform(mixed $value): ?\DateTime
     {
         if (null === $value) {
@@ -43,13 +36,6 @@ final class DateTimeImmutableToDateTimeTransformer implements DataTransformerInt
         return \DateTime::createFromImmutable($value);
     }
 
-    /**
-     * Transforms a DateTime object into a DateTimeImmutable object.
-     *
-     * @param \DateTime|null $value A DateTime object
-     *
-     * @throws TransformationFailedException If the given value is not a \DateTime
-     */
     public function reverseTransform(mixed $value): ?\DateTimeImmutable
     {
         if (null === $value) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
@@ -45,16 +45,9 @@ class DateTimeToArrayTransformer extends BaseDateTimeTransformer
         $this->referenceDate = $referenceDate ?? new \DateTimeImmutable('1970-01-01 00:00:00');
     }
 
-    /**
-     * Transforms a normalized date into a localized date.
-     *
-     * @param \DateTimeInterface $dateTime A DateTimeInterface object
-     *
-     * @throws TransformationFailedException If the given value is not a \DateTimeInterface
-     */
-    public function transform(mixed $dateTime): array
+    public function transform(mixed $value): array
     {
-        if (null === $dateTime) {
+        if (null === $value) {
             return array_intersect_key([
                 'year' => '',
                 'month' => '',
@@ -65,22 +58,22 @@ class DateTimeToArrayTransformer extends BaseDateTimeTransformer
             ], array_flip($this->fields));
         }
 
-        if (!$dateTime instanceof \DateTimeInterface) {
+        if (!$value instanceof \DateTimeInterface) {
             throw new TransformationFailedException('Expected a \DateTimeInterface.');
         }
 
         if ($this->inputTimezone !== $this->outputTimezone) {
-            $dateTime = \DateTimeImmutable::createFromInterface($dateTime);
-            $dateTime = $dateTime->setTimezone(new \DateTimeZone($this->outputTimezone));
+            $value = \DateTimeImmutable::createFromInterface($value);
+            $value = $value->setTimezone(new \DateTimeZone($this->outputTimezone));
         }
 
         $result = array_intersect_key([
-            'year' => $dateTime->format('Y'),
-            'month' => $dateTime->format('m'),
-            'day' => $dateTime->format('d'),
-            'hour' => $dateTime->format('H'),
-            'minute' => $dateTime->format('i'),
-            'second' => $dateTime->format('s'),
+            'year' => $value->format('Y'),
+            'month' => $value->format('m'),
+            'day' => $value->format('d'),
+            'hour' => $value->format('H'),
+            'minute' => $value->format('i'),
+            'second' => $value->format('s'),
         ], array_flip($this->fields));
 
         if (!$this->pad) {
@@ -95,14 +88,6 @@ class DateTimeToArrayTransformer extends BaseDateTimeTransformer
         return $result;
     }
 
-    /**
-     * Transforms a localized date into a normalized date.
-     *
-     * @param array $value Localized date
-     *
-     * @throws TransformationFailedException If the given value is not an array,
-     *                                       if the value could not be transformed
-     */
     public function reverseTransform(mixed $value): ?\DateTime
     {
         if (null === $value) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToHtml5LocalDateTimeTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToHtml5LocalDateTimeTransformer.php
@@ -37,59 +37,47 @@ class DateTimeToHtml5LocalDateTimeTransformer extends BaseDateTimeTransformer
      * input is an RFC3339 date followed by 'T', followed by an RFC3339 time.
      * https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#valid-local-date-and-time-string
      *
-     * @param \DateTimeInterface $dateTime
+     * @param \DateTimeInterface $value
      *
      * @throws TransformationFailedException If the given value is not an
      *                                       instance of \DateTime or \DateTimeInterface
      */
-    public function transform(mixed $dateTime): string
+    public function transform(mixed $value): string
     {
-        if (null === $dateTime) {
+        if (null === $value) {
             return '';
         }
 
-        if (!$dateTime instanceof \DateTimeInterface) {
+        if (!$value instanceof \DateTimeInterface) {
             throw new TransformationFailedException('Expected a \DateTimeInterface.');
         }
 
         if ($this->inputTimezone !== $this->outputTimezone) {
-            $dateTime = \DateTimeImmutable::createFromInterface($dateTime);
-            $dateTime = $dateTime->setTimezone(new \DateTimeZone($this->outputTimezone));
+            $value = \DateTimeImmutable::createFromInterface($value);
+            $value = $value->setTimezone(new \DateTimeZone($this->outputTimezone));
         }
 
-        return $dateTime->format($this->withSeconds ? self::HTML5_FORMAT : self::HTML5_FORMAT_NO_SECONDS);
+        return $value->format($this->withSeconds ? self::HTML5_FORMAT : self::HTML5_FORMAT_NO_SECONDS);
     }
 
-    /**
-     * Transforms a local date and time string into a \DateTime.
-     *
-     * When transforming back to DateTime the regex is slightly laxer, taking into
-     * account rules for parsing a local date and time string
-     * https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#parse-a-local-date-and-time-string
-     *
-     * @param string $dateTimeLocal Formatted string
-     *
-     * @throws TransformationFailedException If the given value is not a string,
-     *                                       if the value could not be transformed
-     */
-    public function reverseTransform(mixed $dateTimeLocal): ?\DateTime
+    public function reverseTransform(mixed $value): ?\DateTime
     {
-        if (!\is_string($dateTimeLocal)) {
+        if (!\is_string($value)) {
             throw new TransformationFailedException('Expected a string.');
         }
 
-        if ('' === $dateTimeLocal) {
+        if ('' === $value) {
             return null;
         }
 
         // to maintain backwards compatibility we do not strictly validate the submitted date
         // see https://github.com/symfony/symfony/issues/28699
-        if (!preg_match('/^(\d{4})-(\d{2})-(\d{2})[T ]\d{2}:\d{2}(?::\d{2})?/', $dateTimeLocal, $matches)) {
-            throw new TransformationFailedException(\sprintf('The date "%s" is not a valid date.', $dateTimeLocal));
+        if (!preg_match('/^(\d{4})-(\d{2})-(\d{2})[T ]\d{2}:\d{2}(?::\d{2})?/', $value, $matches)) {
+            throw new TransformationFailedException(\sprintf('The date "%s" is not a valid date.', $value));
         }
 
         try {
-            $dateTime = new \DateTime($dateTimeLocal, new \DateTimeZone($this->outputTimezone));
+            $dateTime = new \DateTime($value, new \DateTimeZone($this->outputTimezone));
         } catch (\Exception $e) {
             throw new TransformationFailedException($e->getMessage(), $e->getCode(), $e);
         }

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
@@ -69,25 +69,17 @@ class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
         $this->timeFormat = $timeFormat;
     }
 
-    /**
-     * Transforms a normalized date into a localized date string/array.
-     *
-     * @param \DateTimeInterface $dateTime A DateTimeInterface object
-     *
-     * @throws TransformationFailedException if the given value is not a \DateTimeInterface
-     *                                       or if the date could not be transformed
-     */
-    public function transform(mixed $dateTime): string
+    public function transform(mixed $value): string
     {
-        if (null === $dateTime) {
+        if (null === $value) {
             return '';
         }
 
-        if (!$dateTime instanceof \DateTimeInterface) {
+        if (!$value instanceof \DateTimeInterface) {
             throw new TransformationFailedException('Expected a \DateTimeInterface.');
         }
 
-        $value = $this->getIntlDateFormatter()->format($dateTime->getTimestamp());
+        $value = $this->getIntlDateFormatter()->format($value->getTimestamp());
 
         if (0 != intl_get_error_code()) {
             throw new TransformationFailedException(intl_get_error_message());
@@ -96,14 +88,6 @@ class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
         return $value;
     }
 
-    /**
-     * Transforms a localized date string/array into a normalized date.
-     *
-     * @param string $value Localized date string
-     *
-     * @throws TransformationFailedException if the given value is not a string,
-     *                                       if the date could not be parsed
-     */
     public function reverseTransform(mixed $value): ?\DateTime
     {
         if (!\is_string($value)) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToRfc3339Transformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToRfc3339Transformer.php
@@ -20,55 +20,40 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
  */
 class DateTimeToRfc3339Transformer extends BaseDateTimeTransformer
 {
-    /**
-     * Transforms a normalized date into a localized date.
-     *
-     * @param \DateTimeInterface $dateTime A DateTimeInterface object
-     *
-     * @throws TransformationFailedException If the given value is not a \DateTimeInterface
-     */
-    public function transform(mixed $dateTime): string
+    public function transform(mixed $value): string
     {
-        if (null === $dateTime) {
+        if (null === $value) {
             return '';
         }
 
-        if (!$dateTime instanceof \DateTimeInterface) {
+        if (!$value instanceof \DateTimeInterface) {
             throw new TransformationFailedException('Expected a \DateTimeInterface.');
         }
 
         if ($this->inputTimezone !== $this->outputTimezone) {
-            $dateTime = \DateTimeImmutable::createFromInterface($dateTime);
-            $dateTime = $dateTime->setTimezone(new \DateTimeZone($this->outputTimezone));
+            $value = \DateTimeImmutable::createFromInterface($value);
+            $value = $value->setTimezone(new \DateTimeZone($this->outputTimezone));
         }
 
-        return preg_replace('/\+00:00$/', 'Z', $dateTime->format('c'));
+        return preg_replace('/\+00:00$/', 'Z', $value->format('c'));
     }
 
-    /**
-     * Transforms a formatted string following RFC 3339 into a normalized date.
-     *
-     * @param string $rfc3339 Formatted string
-     *
-     * @throws TransformationFailedException If the given value is not a string,
-     *                                       if the value could not be transformed
-     */
-    public function reverseTransform(mixed $rfc3339): ?\DateTime
+    public function reverseTransform(mixed $value): ?\DateTime
     {
-        if (!\is_string($rfc3339)) {
+        if (!\is_string($value)) {
             throw new TransformationFailedException('Expected a string.');
         }
 
-        if ('' === $rfc3339) {
+        if ('' === $value) {
             return null;
         }
 
-        if (!preg_match('/^(\d{4})-(\d{2})-(\d{2})T\d{2}:\d{2}(?::\d{2})?(?:\.\d+)?(?:Z|(?:(?:\+|-)\d{2}:\d{2}))$/', $rfc3339, $matches)) {
-            throw new TransformationFailedException(\sprintf('The date "%s" is not a valid date.', $rfc3339));
+        if (!preg_match('/^(\d{4})-(\d{2})-(\d{2})T\d{2}:\d{2}(?::\d{2})?(?:\.\d+)?(?:Z|(?:(?:\+|-)\d{2}:\d{2}))$/', $value, $matches)) {
+            throw new TransformationFailedException(\sprintf('The date "%s" is not a valid date.', $value));
         }
 
         try {
-            $dateTime = new \DateTime($rfc3339);
+            $dateTime = new \DateTime($value);
         } catch (\Exception $e) {
             throw new TransformationFailedException($e->getMessage(), $e->getCode(), $e);
         }

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
@@ -67,38 +67,22 @@ class DateTimeToStringTransformer extends BaseDateTimeTransformer
         }
     }
 
-    /**
-     * Transforms a DateTime object into a date string with the configured format
-     * and timezone.
-     *
-     * @param \DateTimeInterface $dateTime A DateTimeInterface object
-     *
-     * @throws TransformationFailedException If the given value is not a \DateTimeInterface
-     */
-    public function transform(mixed $dateTime): string
+    public function transform(mixed $value): string
     {
-        if (null === $dateTime) {
+        if (null === $value) {
             return '';
         }
 
-        if (!$dateTime instanceof \DateTimeInterface) {
+        if (!$value instanceof \DateTimeInterface) {
             throw new TransformationFailedException('Expected a \DateTimeInterface.');
         }
 
-        $dateTime = \DateTimeImmutable::createFromInterface($dateTime);
-        $dateTime = $dateTime->setTimezone(new \DateTimeZone($this->outputTimezone));
+        $value = \DateTimeImmutable::createFromInterface($value);
+        $value = $value->setTimezone(new \DateTimeZone($this->outputTimezone));
 
-        return $dateTime->format($this->generateFormat);
+        return $value->format($this->generateFormat);
     }
 
-    /**
-     * Transforms a date string in the configured timezone into a DateTime object.
-     *
-     * @param string $value A value as produced by PHP's date() function
-     *
-     * @throws TransformationFailedException If the given value is not a string,
-     *                                       or could not be transformed
-     */
     public function reverseTransform(mixed $value): ?\DateTime
     {
         if (!$value) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToTimestampTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToTimestampTransformer.php
@@ -23,34 +23,19 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
  */
 class DateTimeToTimestampTransformer extends BaseDateTimeTransformer
 {
-    /**
-     * Transforms a DateTime object into a timestamp in the configured timezone.
-     *
-     * @param \DateTimeInterface $dateTime A DateTimeInterface object
-     *
-     * @throws TransformationFailedException If the given value is not a \DateTimeInterface
-     */
-    public function transform(mixed $dateTime): ?int
+    public function transform(mixed $value): ?int
     {
-        if (null === $dateTime) {
+        if (null === $value) {
             return null;
         }
 
-        if (!$dateTime instanceof \DateTimeInterface) {
+        if (!$value instanceof \DateTimeInterface) {
             throw new TransformationFailedException('Expected a \DateTimeInterface.');
         }
 
-        return $dateTime->getTimestamp();
+        return $value->getTimestamp();
     }
 
-    /**
-     * Transforms a timestamp in the configured timezone into a DateTime object.
-     *
-     * @param string $value A timestamp
-     *
-     * @throws TransformationFailedException If the given value is not a timestamp
-     *                                       or if the given timestamp is invalid
-     */
     public function reverseTransform(mixed $value): ?\DateTime
     {
         if (null === $value) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeZoneToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeZoneToStringTransformer.php
@@ -28,25 +28,25 @@ class DateTimeZoneToStringTransformer implements DataTransformerInterface
     ) {
     }
 
-    public function transform(mixed $dateTimeZone): mixed
+    public function transform(mixed $value): mixed
     {
-        if (null === $dateTimeZone) {
+        if (null === $value) {
             return null;
         }
 
         if ($this->multiple) {
-            if (!\is_array($dateTimeZone)) {
+            if (!\is_array($value)) {
                 throw new TransformationFailedException('Expected an array of \DateTimeZone objects.');
             }
 
-            return array_map([new self(), 'transform'], $dateTimeZone);
+            return array_map([new self(), 'transform'], $value);
         }
 
-        if (!$dateTimeZone instanceof \DateTimeZone) {
+        if (!$value instanceof \DateTimeZone) {
             throw new TransformationFailedException('Expected a \DateTimeZone object.');
         }
 
-        return $dateTimeZone->getName();
+        return $value->getName();
     }
 
     public function reverseTransform(mixed $value): mixed

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/IntlTimeZoneToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/IntlTimeZoneToStringTransformer.php
@@ -28,25 +28,25 @@ class IntlTimeZoneToStringTransformer implements DataTransformerInterface
     ) {
     }
 
-    public function transform(mixed $intlTimeZone): mixed
+    public function transform(mixed $value): mixed
     {
-        if (null === $intlTimeZone) {
+        if (null === $value) {
             return null;
         }
 
         if ($this->multiple) {
-            if (!\is_array($intlTimeZone)) {
+            if (!\is_array($value)) {
                 throw new TransformationFailedException('Expected an array of \IntlTimeZone objects.');
             }
 
-            return array_map([new self(), 'transform'], $intlTimeZone);
+            return array_map([new self(), 'transform'], $value);
         }
 
-        if (!$intlTimeZone instanceof \IntlTimeZone) {
+        if (!$value instanceof \IntlTimeZone) {
             throw new TransformationFailedException('Expected a \IntlTimeZone object.');
         }
 
-        return $intlTimeZone->getID();
+        return $value->getID();
     }
 
     public function reverseTransform(mixed $value): mixed

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformer.php
@@ -36,14 +36,6 @@ class MoneyToLocalizedStringTransformer extends NumberToLocalizedStringTransform
         $this->divisor = $divisor ?? 1;
     }
 
-    /**
-     * Transforms a normalized format into a localized money string.
-     *
-     * @param int|float|string|null $value Normalized number
-     *
-     * @throws TransformationFailedException if the given value is not numeric or
-     *                                       if the value cannot be transformed
-     */
     public function transform(mixed $value): string
     {
         if (null !== $value && '' !== $value && 1 !== $this->divisor) {
@@ -56,14 +48,6 @@ class MoneyToLocalizedStringTransformer extends NumberToLocalizedStringTransform
         return parent::transform($value);
     }
 
-    /**
-     * Transforms a localized money string into a normalized format.
-     *
-     * @param string $value Localized money string
-     *
-     * @throws TransformationFailedException if the given value is not a string
-     *                                       or if the value cannot be transformed
-     */
     public function reverseTransform(mixed $value): int|float|null
     {
         $value = parent::reverseTransform($value);

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php
@@ -38,14 +38,6 @@ class NumberToLocalizedStringTransformer implements DataTransformerInterface
         $this->roundingMode = $roundingMode ?? \NumberFormatter::ROUND_HALFUP;
     }
 
-    /**
-     * Transforms a number type into localized number.
-     *
-     * @param int|float|string|null $value Number value
-     *
-     * @throws TransformationFailedException if the given value is not numeric
-     *                                       or if the value cannot be transformed
-     */
     public function transform(mixed $value): string
     {
         if (null === $value || '' === $value) {
@@ -67,14 +59,6 @@ class NumberToLocalizedStringTransformer implements DataTransformerInterface
         return str_replace(["\xc2\xa0", "\xe2\x80\xaf"], ' ', $value);
     }
 
-    /**
-     * Transforms a localized number into an integer or float.
-     *
-     * @param string $value The localized value
-     *
-     * @throws TransformationFailedException if the given value is not a string
-     *                                       or if the value cannot be transformed
-     */
     public function reverseTransform(mixed $value): int|float|null
     {
         if (null !== $value && !\is_string($value)) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/PercentToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/PercentToLocalizedStringTransformer.php
@@ -60,14 +60,6 @@ class PercentToLocalizedStringTransformer implements DataTransformerInterface
         $this->scale = $scale ?? 0;
     }
 
-    /**
-     * Transforms between a normalized format (integer or float) into a percentage value.
-     *
-     * @param int|float $value Normalized value
-     *
-     * @throws TransformationFailedException if the given value is not numeric or
-     *                                       if the value could not be transformed
-     */
     public function transform(mixed $value): string
     {
         if (null === $value) {
@@ -93,14 +85,6 @@ class PercentToLocalizedStringTransformer implements DataTransformerInterface
         return $value;
     }
 
-    /**
-     * Transforms between a percentage value into a normalized format (integer or float).
-     *
-     * @param string $value Percentage value
-     *
-     * @throws TransformationFailedException if the given value is not a string or
-     *                                       if the value could not be transformed
-     */
     public function reverseTransform(mixed $value): int|float|null
     {
         if (!\is_string($value)) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/UlidToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/UlidToStringTransformer.php
@@ -24,13 +24,6 @@ use Symfony\Component\Uid\Ulid;
  */
 class UlidToStringTransformer implements DataTransformerInterface
 {
-    /**
-     * Transforms a Ulid object into a string.
-     *
-     * @param Ulid $value A Ulid object
-     *
-     * @throws TransformationFailedException If the given value is not a Ulid object
-     */
     public function transform(mixed $value): ?string
     {
         if (null === $value) {
@@ -44,14 +37,6 @@ class UlidToStringTransformer implements DataTransformerInterface
         return (string) $value;
     }
 
-    /**
-     * Transforms a ULID string into a Ulid object.
-     *
-     * @param string $value A ULID string
-     *
-     * @throws TransformationFailedException If the given value is not a string,
-     *                                       or could not be transformed
-     */
     public function reverseTransform(mixed $value): ?Ulid
     {
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/UuidToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/UuidToStringTransformer.php
@@ -24,13 +24,6 @@ use Symfony\Component\Uid\Uuid;
  */
 class UuidToStringTransformer implements DataTransformerInterface
 {
-    /**
-     * Transforms a Uuid object into a string.
-     *
-     * @param Uuid $value A Uuid object
-     *
-     * @throws TransformationFailedException If the given value is not a Uuid object
-     */
     public function transform(mixed $value): ?string
     {
         if (null === $value) {
@@ -44,14 +37,6 @@ class UuidToStringTransformer implements DataTransformerInterface
         return (string) $value;
     }
 
-    /**
-     * Transforms a UUID string into a Uuid object.
-     *
-     * @param string $value A UUID string
-     *
-     * @throws TransformationFailedException If the given value is not a string,
-     *                                       or could not be transformed
-     */
     public function reverseTransform(mixed $value): ?Uuid
     {
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValueToDuplicatesTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValueToDuplicatesTransformer.php
@@ -26,9 +26,6 @@ class ValueToDuplicatesTransformer implements DataTransformerInterface
     ) {
     }
 
-    /**
-     * Duplicates the given value through the array.
-     */
     public function transform(mixed $value): array
     {
         $result = [];
@@ -40,24 +37,18 @@ class ValueToDuplicatesTransformer implements DataTransformerInterface
         return $result;
     }
 
-    /**
-     * Extracts the duplicated value from an array.
-     *
-     * @throws TransformationFailedException if the given value is not an array or
-     *                                       if the given array cannot be transformed
-     */
-    public function reverseTransform(mixed $array): mixed
+    public function reverseTransform(mixed $value): mixed
     {
-        if (!\is_array($array)) {
+        if (!\is_array($value)) {
             throw new TransformationFailedException('Expected an array.');
         }
 
-        $result = current($array);
+        $result = current($value);
         $emptyKeys = [];
 
         foreach ($this->keys as $key) {
-            if (isset($array[$key]) && false !== $array[$key] && [] !== $array[$key]) {
-                if ($array[$key] !== $result) {
+            if (isset($value[$key]) && false !== $value[$key] && [] !== $value[$key]) {
+                if ($value[$key] !== $result) {
                     throw new TransformationFailedException('All values in the array should be the same.');
                 }
             } else {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/WeekToArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/WeekToArrayTransformer.php
@@ -23,16 +23,6 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
  */
 class WeekToArrayTransformer implements DataTransformerInterface
 {
-    /**
-     * Transforms a string containing an ISO 8601 week date into an array.
-     *
-     * @param string|null $value A week date string
-     *
-     * @return array{year: int|null, week: int|null}
-     *
-     * @throws TransformationFailedException If the given value is not a string,
-     *                                       or if the given value does not follow the right format
-     */
     public function transform(mixed $value): array
     {
         if (null === $value) {
@@ -53,16 +43,6 @@ class WeekToArrayTransformer implements DataTransformerInterface
         ];
     }
 
-    /**
-     * Transforms an array into a week date string.
-     *
-     * @param array{year: int|null, week: int|null} $value
-     *
-     * @return string|null A week date string following the format Y-\WW
-     *
-     * @throws TransformationFailedException If the given value cannot be merged in a valid week date string,
-     *                                       or if the obtained week date does not exists
-     */
     public function reverseTransform(mixed $value): ?string
     {
         if (null === $value || [] === $value) {

--- a/src/Symfony/Component/Form/Extension/Core/Type/TextType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TextType.php
@@ -42,14 +42,14 @@ class TextType extends AbstractType implements DataTransformerInterface
         return 'text';
     }
 
-    public function transform(mixed $data): mixed
+    public function transform(mixed $value): mixed
     {
         // Model data should not be transformed
-        return $data;
+        return $value;
     }
 
-    public function reverseTransform(mixed $data): mixed
+    public function reverseTransform(mixed $value): mixed
     {
-        return $data ?? '';
+        return $value ?? '';
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

This PR removes the redundant and often incorrect docblocks from transform() and reverseTransform() methods in data transformers. These PHPDocs duplicate the interface, break generics, and add unnecessary noise.
Additionally, parameter names are updated to match those defined in DataTransformerInterface, ensuring consistency across all implementations.