### PR TITLE
[Form] Clean up wrong method docblocks in data transformers

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/DataTransformer/CollectionToArrayTransformer.php
+++ b/src/Symfony/Bridge/Doctrine/Form/DataTransformer/CollectionToArrayTransformer.php
@@ -20,15 +20,10 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
- * @implements DataTransformerInterface<Collection, array>
+ * @implements DataTransformerInterface<Collection|array, array>
  */
 class CollectionToArrayTransformer implements DataTransformerInterface
 {
-    /**
-     * Transforms a collection into an array.
-     *
-     * @throws TransformationFailedException
-     */
     public function transform(mixed $collection): mixed
     {
         if (null === $collection) {
@@ -48,9 +43,6 @@ class CollectionToArrayTransformer implements DataTransformerInterface
         return $collection->toArray();
     }
 
-    /**
-     * Transforms an array into a collection.
-     */
     public function reverseTransform(mixed $array): Collection
     {
         if ('' === $array || null === $array) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/BooleanToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/BooleanToStringTransformer.php
@@ -37,13 +37,6 @@ class BooleanToStringTransformer implements DataTransformerInterface
         }
     }
 
-    /**
-     * Transforms a Boolean into a string.
-     *
-     * @param bool $value Boolean value
-     *
-     * @throws TransformationFailedException if the given value is not a Boolean
-     */
     public function transform(mixed $value): ?string
     {
         if (null === $value) {
@@ -57,13 +50,6 @@ class BooleanToStringTransformer implements DataTransformerInterface
         return $value ? $this->trueValue : null;
     }
 
-    /**
-     * Transforms a string into a Boolean.
-     *
-     * @param string $value String value
-     *
-     * @throws TransformationFailedException if the given value is not a string
-     */
     public function reverseTransform(mixed $value): bool
     {
         if (\in_array($value, $this->falseValues, true)) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoicesToValuesTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoicesToValuesTransformer.php
@@ -27,9 +27,6 @@ class ChoicesToValuesTransformer implements DataTransformerInterface
     ) {
     }
 
-    /**
-     * @throws TransformationFailedException if the given value is not an array
-     */
     public function transform(mixed $array): array
     {
         if (null === $array) {
@@ -43,11 +40,6 @@ class ChoicesToValuesTransformer implements DataTransformerInterface
         return $this->choiceList->getValuesForChoices($array);
     }
 
-    /**
-     * @throws TransformationFailedException if the given value is not an array
-     *                                       or if no matching choice could be
-     *                                       found for some given value
-     */
     public function reverseTransform(mixed $array): array
     {
         if (null === $array) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DataTransformerChain.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DataTransformerChain.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Form\Extension\Core\DataTransformer;
 
 use Symfony\Component\Form\DataTransformerInterface;
-use Symfony\Component\Form\Exception\TransformationFailedException;
 
 /**
  * Passes a value through multiple value transformers.
@@ -31,18 +30,6 @@ class DataTransformerChain implements DataTransformerInterface
     ) {
     }
 
-    /**
-     * Passes the value through the transform() method of all nested transformers.
-     *
-     * The transformers receive the value in the same order as they were passed
-     * to the constructor. Each transformer receives the result of the previous
-     * transformer as input. The output of the last transformer is returned
-     * by this method.
-     *
-     * @param mixed $value The original value
-     *
-     * @throws TransformationFailedException
-     */
     public function transform(mixed $value): mixed
     {
         foreach ($this->transformers as $transformer) {
@@ -52,19 +39,6 @@ class DataTransformerChain implements DataTransformerInterface
         return $value;
     }
 
-    /**
-     * Passes the value through the reverseTransform() method of all nested
-     * transformers.
-     *
-     * The transformers receive the value in the reverse order as they were passed
-     * to the constructor. Each transformer receives the result of the previous
-     * transformer as input. The output of the last transformer is returned
-     * by this method.
-     *
-     * @param mixed $value The transformed value
-     *
-     * @throws TransformationFailedException
-     */
     public function reverseTransform(mixed $value): mixed
     {
         for ($i = \count($this->transformers) - 1; $i >= 0; --$i) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateIntervalToArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateIntervalToArrayTransformer.php
@@ -54,13 +54,6 @@ class DateIntervalToArrayTransformer implements DataTransformerInterface
         $this->fields = $fields ?? ['years', 'months', 'days', 'hours', 'minutes', 'seconds', 'invert'];
     }
 
-    /**
-     * Transforms a normalized date interval into an interval array.
-     *
-     * @param \DateInterval $dateInterval Normalized date interval
-     *
-     * @throws UnexpectedTypeException if the given value is not a \DateInterval instance
-     */
     public function transform(mixed $dateInterval): array
     {
         if (null === $dateInterval) {
@@ -97,14 +90,6 @@ class DateIntervalToArrayTransformer implements DataTransformerInterface
         return array_intersect_key($result, array_flip($this->fields));
     }
 
-    /**
-     * Transforms an interval array into a normalized date interval.
-     *
-     * @param array $value Interval array
-     *
-     * @throws UnexpectedTypeException       if the given value is not an array
-     * @throws TransformationFailedException if the value could not be transformed
-     */
     public function reverseTransform(mixed $value): ?\DateInterval
     {
         if (null === $value) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateIntervalToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateIntervalToStringTransformer.php
@@ -36,13 +36,6 @@ class DateIntervalToStringTransformer implements DataTransformerInterface
     ) {
     }
 
-    /**
-     * Transforms a DateInterval object into a date string with the configured format.
-     *
-     * @param \DateInterval|null $value A DateInterval object
-     *
-     * @throws UnexpectedTypeException if the given value is not a \DateInterval instance
-     */
     public function transform(mixed $value): string
     {
         if (null === $value) {
@@ -55,14 +48,6 @@ class DateIntervalToStringTransformer implements DataTransformerInterface
         return $value->format($this->format);
     }
 
-    /**
-     * Transforms a date string in the configured format into a DateInterval object.
-     *
-     * @param string $value An ISO 8601 or date string like date interval presentation
-     *
-     * @throws UnexpectedTypeException       if the given value is not a string
-     * @throws TransformationFailedException if the date interval could not be parsed
-     */
     public function reverseTransform(mixed $value): ?\DateInterval
     {
         if (null === $value) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DatePointToDateTimeTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DatePointToDateTimeTransformer.php
@@ -22,13 +22,6 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
  */
 final class DatePointToDateTimeTransformer implements DataTransformerInterface
 {
-    /**
-     * Transforms a DatePoint into a DateTime object.
-     *
-     * @param DatePoint|null $value A DatePoint object
-     *
-     * @throws TransformationFailedException If the given value is not a DatePoint
-     */
     public function transform(mixed $value): ?\DateTime
     {
         if (null === $value) {
@@ -42,13 +35,6 @@ final class DatePointToDateTimeTransformer implements DataTransformerInterface
         return \DateTime::createFromImmutable($value);
     }
 
-    /**
-     * Transforms a DateTime object into a DatePoint object.
-     *
-     * @param \DateTime|null $value A DateTime object
-     *
-     * @throws TransformationFailedException If the given value is not a \DateTime
-     */
     public function reverseTransform(mixed $value): ?DatePoint
     {
         if (null === $value) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeImmutableToDateTimeTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeImmutableToDateTimeTransformer.php
@@ -23,13 +23,6 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
  */
 final class DateTimeImmutableToDateTimeTransformer implements DataTransformerInterface
 {
-    /**
-     * Transforms a DateTimeImmutable into a DateTime object.
-     *
-     * @param \DateTimeImmutable|null $value A DateTimeImmutable object
-     *
-     * @throws TransformationFailedException If the given value is not a \DateTimeImmutable
-     */
     public function transform(mixed $value): ?\DateTime
     {
         if (null === $value) {
@@ -43,13 +36,6 @@ final class DateTimeImmutableToDateTimeTransformer implements DataTransformerInt
         return \DateTime::createFromImmutable($value);
     }
 
-    /**
-     * Transforms a DateTime object into a DateTimeImmutable object.
-     *
-     * @param \DateTime|null $value A DateTime object
-     *
-     * @throws TransformationFailedException If the given value is not a \DateTime
-     */
     public function reverseTransform(mixed $value): ?\DateTimeImmutable
     {
         if (null === $value) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
@@ -45,13 +45,6 @@ class DateTimeToArrayTransformer extends BaseDateTimeTransformer
         $this->referenceDate = $referenceDate ?? new \DateTimeImmutable('1970-01-01 00:00:00');
     }
 
-    /**
-     * Transforms a normalized date into a localized date.
-     *
-     * @param \DateTimeInterface $dateTime A DateTimeInterface object
-     *
-     * @throws TransformationFailedException If the given value is not a \DateTimeInterface
-     */
     public function transform(mixed $dateTime): array
     {
         if (null === $dateTime) {
@@ -95,14 +88,6 @@ class DateTimeToArrayTransformer extends BaseDateTimeTransformer
         return $result;
     }
 
-    /**
-     * Transforms a localized date into a normalized date.
-     *
-     * @param array $value Localized date
-     *
-     * @throws TransformationFailedException If the given value is not an array,
-     *                                       if the value could not be transformed
-     */
     public function reverseTransform(mixed $value): ?\DateTime
     {
         if (null === $value) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToHtml5LocalDateTimeTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToHtml5LocalDateTimeTransformer.php
@@ -31,16 +31,11 @@ class DateTimeToHtml5LocalDateTimeTransformer extends BaseDateTimeTransformer
     }
 
     /**
-     * Transforms a \DateTime into a local date and time string.
-     *
      * According to the HTML standard, the input string of a datetime-local
      * input is an RFC3339 date followed by 'T', followed by an RFC3339 time.
-     * https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#valid-local-date-and-time-string
+     * https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#valid-local-date-and-time-string.
      *
-     * @param \DateTimeInterface $dateTime
-     *
-     * @throws TransformationFailedException If the given value is not an
-     *                                       instance of \DateTime or \DateTimeInterface
+     * @throws \DateInvalidTimeZoneException
      */
     public function transform(mixed $dateTime): string
     {
@@ -61,16 +56,11 @@ class DateTimeToHtml5LocalDateTimeTransformer extends BaseDateTimeTransformer
     }
 
     /**
-     * Transforms a local date and time string into a \DateTime.
-     *
      * When transforming back to DateTime the regex is slightly laxer, taking into
      * account rules for parsing a local date and time string
-     * https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#parse-a-local-date-and-time-string
+     * https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#parse-a-local-date-and-time-string.
      *
-     * @param string $dateTimeLocal Formatted string
-     *
-     * @throws TransformationFailedException If the given value is not a string,
-     *                                       if the value could not be transformed
+     * @throws \DateInvalidTimeZoneException
      */
     public function reverseTransform(mixed $dateTimeLocal): ?\DateTime
     {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
@@ -69,14 +69,6 @@ class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
         $this->timeFormat = $timeFormat;
     }
 
-    /**
-     * Transforms a normalized date into a localized date string/array.
-     *
-     * @param \DateTimeInterface $dateTime A DateTimeInterface object
-     *
-     * @throws TransformationFailedException if the given value is not a \DateTimeInterface
-     *                                       or if the date could not be transformed
-     */
     public function transform(mixed $dateTime): string
     {
         if (null === $dateTime) {
@@ -96,14 +88,6 @@ class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
         return $value;
     }
 
-    /**
-     * Transforms a localized date string/array into a normalized date.
-     *
-     * @param string $value Localized date string
-     *
-     * @throws TransformationFailedException if the given value is not a string,
-     *                                       if the date could not be parsed
-     */
     public function reverseTransform(mixed $value): ?\DateTime
     {
         if (!\is_string($value)) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToRfc3339Transformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToRfc3339Transformer.php
@@ -20,14 +20,7 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
  */
 class DateTimeToRfc3339Transformer extends BaseDateTimeTransformer
 {
-    /**
-     * Transforms a normalized date into a localized date.
-     *
-     * @param \DateTimeInterface $dateTime A DateTimeInterface object
-     *
-     * @throws TransformationFailedException If the given value is not a \DateTimeInterface
-     */
-    public function transform(mixed $dateTime): string
+    public function transform(mixed $dateTime): ?string
     {
         if (null === $dateTime) {
             return '';
@@ -45,14 +38,6 @@ class DateTimeToRfc3339Transformer extends BaseDateTimeTransformer
         return preg_replace('/\+00:00$/', 'Z', $dateTime->format('c'));
     }
 
-    /**
-     * Transforms a formatted string following RFC 3339 into a normalized date.
-     *
-     * @param string $rfc3339 Formatted string
-     *
-     * @throws TransformationFailedException If the given value is not a string,
-     *                                       if the value could not be transformed
-     */
     public function reverseTransform(mixed $rfc3339): ?\DateTime
     {
         if (!\is_string($rfc3339)) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
@@ -67,14 +67,6 @@ class DateTimeToStringTransformer extends BaseDateTimeTransformer
         }
     }
 
-    /**
-     * Transforms a DateTime object into a date string with the configured format
-     * and timezone.
-     *
-     * @param \DateTimeInterface $dateTime A DateTimeInterface object
-     *
-     * @throws TransformationFailedException If the given value is not a \DateTimeInterface
-     */
     public function transform(mixed $dateTime): string
     {
         if (null === $dateTime) {
@@ -91,14 +83,6 @@ class DateTimeToStringTransformer extends BaseDateTimeTransformer
         return $dateTime->format($this->generateFormat);
     }
 
-    /**
-     * Transforms a date string in the configured timezone into a DateTime object.
-     *
-     * @param string $value A value as produced by PHP's date() function
-     *
-     * @throws TransformationFailedException If the given value is not a string,
-     *                                       or could not be transformed
-     */
     public function reverseTransform(mixed $value): ?\DateTime
     {
         if (!$value) {
@@ -110,7 +94,7 @@ class DateTimeToStringTransformer extends BaseDateTimeTransformer
         }
 
         if (str_contains($value, "\0")) {
-            throw new TransformationFailedException('Null bytes not allowed');
+            throw new TransformationFailedException('Null bytes not allowed.');
         }
 
         $outputTz = new \DateTimeZone($this->outputTimezone);

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToTimestampTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToTimestampTransformer.php
@@ -23,13 +23,6 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
  */
 class DateTimeToTimestampTransformer extends BaseDateTimeTransformer
 {
-    /**
-     * Transforms a DateTime object into a timestamp in the configured timezone.
-     *
-     * @param \DateTimeInterface $dateTime A DateTimeInterface object
-     *
-     * @throws TransformationFailedException If the given value is not a \DateTimeInterface
-     */
     public function transform(mixed $dateTime): ?int
     {
         if (null === $dateTime) {
@@ -43,14 +36,6 @@ class DateTimeToTimestampTransformer extends BaseDateTimeTransformer
         return $dateTime->getTimestamp();
     }
 
-    /**
-     * Transforms a timestamp in the configured timezone into a DateTime object.
-     *
-     * @param string $value A timestamp
-     *
-     * @throws TransformationFailedException If the given value is not a timestamp
-     *                                       or if the given timestamp is invalid
-     */
     public function reverseTransform(mixed $value): ?\DateTime
     {
         if (null === $value) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformer.php
@@ -36,14 +36,6 @@ class MoneyToLocalizedStringTransformer extends NumberToLocalizedStringTransform
         $this->divisor = $divisor ?? 1;
     }
 
-    /**
-     * Transforms a normalized format into a localized money string.
-     *
-     * @param int|float|string|null $value Normalized number
-     *
-     * @throws TransformationFailedException if the given value is not numeric or
-     *                                       if the value cannot be transformed
-     */
     public function transform(mixed $value): string
     {
         if (null !== $value && '' !== $value && 1 !== $this->divisor) {
@@ -56,14 +48,6 @@ class MoneyToLocalizedStringTransformer extends NumberToLocalizedStringTransform
         return parent::transform($value);
     }
 
-    /**
-     * Transforms a localized money string into a normalized format.
-     *
-     * @param string $value Localized money string
-     *
-     * @throws TransformationFailedException if the given value is not a string
-     *                                       or if the value cannot be transformed
-     */
     public function reverseTransform(mixed $value): int|float|null
     {
         $value = parent::reverseTransform($value);

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php
@@ -38,14 +38,6 @@ class NumberToLocalizedStringTransformer implements DataTransformerInterface
         $this->roundingMode = $roundingMode ?? \NumberFormatter::ROUND_HALFUP;
     }
 
-    /**
-     * Transforms a number type into localized number.
-     *
-     * @param int|float|string|null $value Number value
-     *
-     * @throws TransformationFailedException if the given value is not numeric
-     *                                       or if the value cannot be transformed
-     */
     public function transform(mixed $value): string
     {
         if (null === $value || '' === $value) {
@@ -67,14 +59,6 @@ class NumberToLocalizedStringTransformer implements DataTransformerInterface
         return str_replace(["\xc2\xa0", "\xe2\x80\xaf"], ' ', $value);
     }
 
-    /**
-     * Transforms a localized number into an integer or float.
-     *
-     * @param string $value The localized value
-     *
-     * @throws TransformationFailedException if the given value is not a string
-     *                                       or if the value cannot be transformed
-     */
     public function reverseTransform(mixed $value): int|float|null
     {
         if (null !== $value && !\is_string($value)) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/PercentToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/PercentToLocalizedStringTransformer.php
@@ -60,14 +60,6 @@ class PercentToLocalizedStringTransformer implements DataTransformerInterface
         $this->scale = $scale ?? 0;
     }
 
-    /**
-     * Transforms between a normalized format (integer or float) into a percentage value.
-     *
-     * @param int|float $value Normalized value
-     *
-     * @throws TransformationFailedException if the given value is not numeric or
-     *                                       if the value could not be transformed
-     */
     public function transform(mixed $value): string
     {
         if (null === $value) {
@@ -93,14 +85,6 @@ class PercentToLocalizedStringTransformer implements DataTransformerInterface
         return $value;
     }
 
-    /**
-     * Transforms between a percentage value into a normalized format (integer or float).
-     *
-     * @param string $value Percentage value
-     *
-     * @throws TransformationFailedException if the given value is not a string or
-     *                                       if the value could not be transformed
-     */
     public function reverseTransform(mixed $value): int|float|null
     {
         if (!\is_string($value)) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/UlidToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/UlidToStringTransformer.php
@@ -24,13 +24,6 @@ use Symfony\Component\Uid\Ulid;
  */
 class UlidToStringTransformer implements DataTransformerInterface
 {
-    /**
-     * Transforms a Ulid object into a string.
-     *
-     * @param Ulid $value A Ulid object
-     *
-     * @throws TransformationFailedException If the given value is not a Ulid object
-     */
     public function transform(mixed $value): ?string
     {
         if (null === $value) {
@@ -44,14 +37,6 @@ class UlidToStringTransformer implements DataTransformerInterface
         return (string) $value;
     }
 
-    /**
-     * Transforms a ULID string into a Ulid object.
-     *
-     * @param string $value A ULID string
-     *
-     * @throws TransformationFailedException If the given value is not a string,
-     *                                       or could not be transformed
-     */
     public function reverseTransform(mixed $value): ?Ulid
     {
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/UuidToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/UuidToStringTransformer.php
@@ -24,13 +24,6 @@ use Symfony\Component\Uid\Uuid;
  */
 class UuidToStringTransformer implements DataTransformerInterface
 {
-    /**
-     * Transforms a Uuid object into a string.
-     *
-     * @param Uuid $value A Uuid object
-     *
-     * @throws TransformationFailedException If the given value is not a Uuid object
-     */
     public function transform(mixed $value): ?string
     {
         if (null === $value) {
@@ -44,14 +37,6 @@ class UuidToStringTransformer implements DataTransformerInterface
         return (string) $value;
     }
 
-    /**
-     * Transforms a UUID string into a Uuid object.
-     *
-     * @param string $value A UUID string
-     *
-     * @throws TransformationFailedException If the given value is not a string,
-     *                                       or could not be transformed
-     */
     public function reverseTransform(mixed $value): ?Uuid
     {
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValueToDuplicatesTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValueToDuplicatesTransformer.php
@@ -26,9 +26,6 @@ class ValueToDuplicatesTransformer implements DataTransformerInterface
     ) {
     }
 
-    /**
-     * Duplicates the given value through the array.
-     */
     public function transform(mixed $value): array
     {
         $result = [];
@@ -40,12 +37,6 @@ class ValueToDuplicatesTransformer implements DataTransformerInterface
         return $result;
     }
 
-    /**
-     * Extracts the duplicated value from an array.
-     *
-     * @throws TransformationFailedException if the given value is not an array or
-     *                                       if the given array cannot be transformed
-     */
     public function reverseTransform(mixed $array): mixed
     {
         if (!\is_array($array)) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/WeekToArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/WeekToArrayTransformer.php
@@ -23,16 +23,6 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
  */
 class WeekToArrayTransformer implements DataTransformerInterface
 {
-    /**
-     * Transforms a string containing an ISO 8601 week date into an array.
-     *
-     * @param string|null $value A week date string
-     *
-     * @return array{year: int|null, week: int|null}
-     *
-     * @throws TransformationFailedException If the given value is not a string,
-     *                                       or if the given value does not follow the right format
-     */
     public function transform(mixed $value): array
     {
         if (null === $value) {
@@ -53,16 +43,6 @@ class WeekToArrayTransformer implements DataTransformerInterface
         ];
     }
 
-    /**
-     * Transforms an array into a week date string.
-     *
-     * @param array{year: int|null, week: int|null} $value
-     *
-     * @return string|null A week date string following the format Y-\WW
-     *
-     * @throws TransformationFailedException If the given value cannot be merged in a valid week date string,
-     *                                       or if the obtained week date does not exists
-     */
     public function reverseTransform(mixed $value): ?string
     {
         if (null === $value || [] === $value) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

This PR removes the redundant and often incorrect docblocks from transform() and reverseTransform() methods in data transformers. These PHPDocs duplicate the interface, break generics, and add unnecessary noise.
Additionally, parameter names are updated to match those defined in DataTransformerInterface, ensuring consistency across all implementations.