### PR TITLE
 Import all node definition classes to DefinitionConfigurator

### DIFF
--- a/src/Symfony/Component/Config/Definition/Configurator/DefinitionConfigurator.php
+++ b/src/Symfony/Component/Config/Definition/Configurator/DefinitionConfigurator.php
@@ -12,8 +12,15 @@
 namespace Symfony\Component\Config\Definition\Configurator;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\BooleanNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\EnumNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\FloatNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\IntegerNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\Config\Definition\Builder\ScalarNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\StringNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\Builder\VariableNodeDefinition;
 use Symfony\Component\Config\Definition\Loader\DefinitionFileLoader;
 
 /**


### PR DESCRIPTION
Noticed problem on static analysis with `UnknownClass` due to not all`*NodeDefinition` being imported, see https://github.com/symfony/symfony/commit/8099cda627b004df1914f6e8bfe1102684774fcb#commitcomment-171732637

| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Not created
| License       | MIT

The only one `ArrayNodeDefinition` that is imported in file scope is not enough for static analysis tools, so the error on static analysis says class don't exists for `VariableNodeDefinition`, `ScalarNodeDefinition`, `StringNodeDefinition`, `BooleanNodeDefinition`, `IntegerNodeDefinition`, `FloatNodeDefinition` and `EnumNodeDefinition` because they're in different namespace than the `DefinitionConfigurator`.