### PR TITLE
[Yaml] Fix regression handling blank lines in unquoted scalars

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -762,11 +762,6 @@ class Parser
                     $lines = [];
 
                     while ($this->moveToNextLine()) {
-                        if ($this->isCurrentLineBlank()) {
-                            $lines[] = '';
-                            continue;
-                        }
-
                         // unquoted strings end before the first unindented line
                         if (0 === $this->getCurrentLineIndentation()) {
                             $this->moveToPreviousLine();
@@ -776,6 +771,10 @@ class Parser
 
                         if ($this->isCurrentLineComment()) {
                             break;
+                        }
+
+                        if ('mapping' === $context && str_contains($this->currentLine, ': ') && !$this->isCurrentLineComment()) {
+                            throw new ParseException('A colon cannot be used in an unquoted mapping value.', $this->getRealCurrentLineNb() + 1, $this->currentLine, $this->filename);
                         }
 
                         $lines[] = trim($this->currentLine);

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -1829,6 +1829,77 @@ EOT;
         $this->parser->parse($yaml);
     }
 
+    public function testUnquotedMultilineScalarWithBlankLines()
+    {
+        $yaml = <<<YAML
+foo:
+  line 1
+
+  line 2
+YAML;
+        $this->assertSame(['foo' => "line 1\nline 2"], $this->parser->parse($yaml));
+    }
+
+    /**
+     * @dataProvider provideInvalidYamlFiles
+     */
+    public function testLineNumberInException(int $expectedLine, string $yaml, string $message)
+    {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage($message);
+        $this->expectExceptionMessage(\sprintf('at line %d', $expectedLine));
+
+        $this->parser->parse($yaml);
+    }
+
+    public static function provideInvalidYamlFiles(): iterable
+    {
+        yield 'invalid_nested_under_scalar' => [
+            4,
+            <<<YAML
+en:
+  NONAMESPACE: Include Entity without Namespace
+  Invalid: Foo
+    About: 'About us'
+    - Invalid
+YAML,
+            'Unable to parse',
+        ];
+
+        yield 'invalid_nested_under_scalar_with_trailing_newlines' => [
+            4,
+            <<<YAML
+en:
+  NONAMESPACE: Include Entity without Namespace
+  Invalid: Foo
+    About: 'About us'
+    - Invalid
+
+
+YAML,
+            'Unable to parse',
+        ];
+
+        yield 'colon_in_unquoted_value' => [
+            2,
+            <<<YAML
+foo: bar
+  baz: qux
+YAML,
+            'A colon cannot be used in an unquoted mapping value',
+        ];
+
+        yield 'colon_in_unquoted_value_multiline' => [
+            2,
+            <<<YAML
+foo:
+  bar
+  baz: qux
+YAML,
+            'Mapping values are not allowed in multi-line blocks',
+        ];
+    }
+
     /**
      * @dataProvider unquotedStringWithTrailingComment
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62581
| License       | MIT

This PR fixes a regression introduced in #62359 regarding unquoted multiline scalars.

A check for blank lines was incorrectly added, causing the parser to bypass indentation checks and consume trailing newlines. This resulted in incorrect line numbers being reported in exceptions (e.g. when a colon is used in an unquoted value).