### PR TITLE
[Yaml] Fix incorrect line number for ParseException when failing to parse YAML

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -761,6 +761,10 @@ class Parser
                 default:
                     $lines = [];
 
+                    $realCurrentLineNb = $this->getRealCurrentLineNb();
+
+                    $hasColonInHead = str_contains($value, ': ');
+
                     while ($this->moveToNextLine()) {
                         if ($this->isCurrentLineBlank()) {
                             $lines[] = '';
@@ -799,14 +803,29 @@ class Parser
                     $parsedValue = Inline::parse($value, $flags, $this->refs);
 
                     if ('mapping' === $context && \is_string($parsedValue) && '"' !== $value[0] && "'" !== $value[0] && '[' !== $value[0] && '{' !== $value[0] && '!' !== $value[0] && str_contains($parsedValue, ': ')) {
-                        throw new ParseException('A colon cannot be used in an unquoted mapping value.', $this->getRealCurrentLineNb() + 1, $value, $this->filename);
+                        $line = $realCurrentLineNb + 1;
+                        $snippet = $value;
+
+                        if (!$hasColonInHead) {
+                            foreach ($lines as $i => $lineContent) {
+                                if (str_contains($lineContent, ': ')) {
+                                    $line += $i + 1;
+                                    $snippet = $lineContent;
+                                    break;
+                                }
+                            }
+                        }
+
+                        throw new ParseException('A colon cannot be used in an unquoted mapping value.', $line, $snippet, $this->filename);
                     }
 
                     return $parsedValue;
             }
         } catch (ParseException $e) {
-            $e->setParsedLine($this->getRealCurrentLineNb() + 1);
-            $e->setSnippet($this->currentLine);
+            if (-1 === $e->getParsedLine()) {
+                $e->setParsedLine($this->getRealCurrentLineNb() + 1);
+                $e->setSnippet($this->currentLine);
+            }
 
             throw $e;
         }

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -1315,8 +1315,7 @@ header
     </body>
 
 footer # comment3
-EOT
-                    ,
+EOT,
                 ],
             ],
         ];
@@ -1343,8 +1342,7 @@ foo
 # bar
 baz
 
-EOT
-            ,
+EOT,
             'collection' => [
                 [
                     'one' => <<<'EOT'
@@ -1352,16 +1350,14 @@ foo
 # bar
 baz
 
-EOT
-                    ,
+EOT,
                 ],
                 [
                     'two' => <<<'EOT'
 foo
 # bar
 baz
-EOT
-                    ,
+EOT,
                 ],
             ],
         ];
@@ -1425,8 +1421,7 @@ EOT;
                 'test' => <<<'EOT'
 <h2>A heading</h2>
 <ul> <li>a list</li> <li>may be a good example</li> </ul>
-EOT
-                ,
+EOT,
             ],
             $this->parser->parse($yaml)
         );
@@ -1452,8 +1447,7 @@ EOT;
   <li>a list</li>
   <li>may be a good example</li>
 </ul>
-EOT
-                ,
+EOT,
             ],
             $this->parser->parse($yaml)
         );
@@ -1510,32 +1504,28 @@ EOT,
                 <<<'EOT'
 data: !!binary |
     SGVsbG8d29ybGQ=
-EOT
-                ,
+EOT,
                 '/The normalized base64 encoded data \(data without whitespace characters\) length must be a multiple of four \(\d+ bytes given\)/',
             ],
             'invalid characters in block scalar' => [
                 <<<'EOT'
 data: !!binary |
     SGVsbG8#d29ybGQ=
-EOT
-                ,
+EOT,
                 '/The base64 encoded data \(.*\) contains invalid characters/',
             ],
             'too many equals characters in block scalar' => [
                 <<<'EOT'
 data: !!binary |
     SGVsbG8gd29yb===
-EOT
-                ,
+EOT,
                 '/The base64 encoded data \(.*\) contains invalid characters/',
             ],
             'misplaced equals character in block scalar' => [
                 <<<'EOT'
 data: !!binary |
     SGVsbG8gd29ybG=Q
-EOT
-                ,
+EOT,
                 '/The base64 encoded data \(.*\) contains invalid characters/',
             ],
         ];
@@ -1909,8 +1899,7 @@ entries:
  - message: 'No emails received before timeout - Address: ''test@testemail.company.com''
        Keyword: ''Your Order confirmation'' ttl: 50'
    outcome: failed
-YAML
-                ,
+YAML,
                 [
                     'entries' => [
                         [
@@ -1926,8 +1915,7 @@ entries:
  - message: "No emails received before timeout - Address: \"test@testemail.company.com\"
        Keyword: \"Your Order confirmation\" ttl: 50"
    outcome: failed
-YAML
-                ,
+YAML,
                 [
                     'entries' => [
                         [
@@ -2035,8 +2023,7 @@ EOF;
     'foo': 'bar',
     'bar': 'baz'
 }
-YAML
-                ,
+YAML,
             ],
             'mapping with unquoted strings and values' => [
                 ['foo' => 'bar', 'bar' => 'baz'],
@@ -2045,8 +2032,7 @@ YAML
     foo: bar,
     bar: baz
 }
-YAML
-                ,
+YAML,
             ],
             'sequence' => [
                 ['foo', 'bar'],
@@ -2055,8 +2041,7 @@ YAML
     'foo',
     'bar'
 ]
-YAML
-                ,
+YAML,
             ],
             'sequence with unquoted items' => [
                 ['foo', 'bar'],
@@ -2065,8 +2050,7 @@ YAML
     foo,
     bar
 ]
-YAML
-                ,
+YAML,
             ],
             'nested mapping terminating at end of line' => [
                 [
@@ -2077,8 +2061,7 @@ YAML
                 <<<YAML
 { foo: { bar: foobar }
 }
-YAML
-                ,
+YAML,
             ],
             'nested sequence terminating at end of line' => [
                 [
@@ -2112,8 +2095,7 @@ YAML,
     'foo': ['bar', 'foobar'],
     'bar': ['baz']
 }
-YAML
-                ,
+YAML,
             ],
             'sequence spanning multiple lines nested in mapping' => [
                 [
@@ -2128,8 +2110,7 @@ foobar: [foo,
     bar,
     baz
 ]
-YAML
-                ,
+YAML,
             ],
             'sequence spanning multiple lines nested in mapping with a following mapping' => [
                 [
@@ -2162,8 +2143,7 @@ foo: [foobar, [
     bar,
     baz
 ]]
-YAML
-                ,
+YAML,
             ],
             'nested sequence nested in mapping starting on the following line' => [
                 [
@@ -2181,8 +2161,7 @@ foo: [foobar,
         bar,
         baz
 ]]
-YAML
-                ,
+YAML,
             ],
             'mapping nested in sequence' => [
                 ['foo', ['bar' => 'baz']],
@@ -2193,8 +2172,7 @@ YAML
         'bar': 'baz'
     }
 ]
-YAML
-                ,
+YAML,
             ],
             'mapping spanning multiple lines nested in sequence' => [
                 [
@@ -2208,8 +2186,7 @@ YAML
     foo: bar,
     bar: baz
 }
-YAML
-                ,
+YAML,
             ],
             'nested mapping nested in sequence starting on the same line' => [
                 [
@@ -2226,8 +2203,7 @@ YAML
     },
     bar: baz
 }
-YAML
-                ,
+YAML,
             ],
             'nested mapping nested in sequence starting on the following line' => [
                 [
@@ -2245,8 +2221,7 @@ YAML
     },
     bar: baz
 }
-YAML
-                ,
+YAML,
             ],
             'single quoted multi-line string' => [
                 "foo\nbar",
@@ -2254,8 +2229,7 @@ YAML
 'foo
 
 bar'
-YAML
-                ,
+YAML,
             ],
             'double quoted multi-line string' => [
                 "foo\nbar",
@@ -2263,8 +2237,7 @@ YAML
 'foo
 
 bar'
-YAML
-                ,
+YAML,
             ],
             'single-quoted multi-line mapping value' => [
                 ['foo' => "bar\nbaz"],

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -2666,6 +2666,30 @@ YAML;
         $this->parser->parse($yaml);
     }
 
+    /**
+     * @see https://github.com/symfony/symfony/issues/62581
+     */
+    public function testParseExceptionLineNumberForUnquotedMappingValueWithIndentedContent()
+    {
+        $yaml = <<<YAML
+            en:
+                NONAMESPACE: Include Entity without Namespace
+                Invalid: Foo
+                    About: 'About us'
+                    - Invalid
+            YAML;
+
+        try {
+            $this->parser->parse($yaml);
+            $this->fail('A ParseException should have been thrown.');
+        } catch (ParseException $e) {
+            $this->assertSame(4, $e->getParsedLine(), 'The line number is incorrect.');
+            $this->assertStringContainsString('A colon cannot be used in an unquoted mapping value', $e->getMessage());
+            $this->assertStringContainsString('at line 4', $e->getMessage());
+            $this->assertStringContainsString("About: 'About us'", $e->getSnippet(), 'The snippet is incorrect.');
+        }
+    }
+
     public function testPhpConstantTagMappingKey()
     {
         $yaml = <<<YAML


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #62581 <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
