### PR TITLE
[Cache] Fix NullAdapter must set taggable

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/NullAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/NullAdapter.php
@@ -28,6 +28,7 @@ class NullAdapter implements AdapterInterface, CacheInterface, NamespacedPoolInt
         self::$createCacheItem ??= \Closure::bind(
             static function ($key) {
                 $item = new CacheItem();
+                $item->isTaggable = true;
                 $item->key = $key;
                 $item->isHit = false;
 

--- a/src/Symfony/Component/Cache/Tests/Adapter/NullAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/NullAdapterTest.php
@@ -138,6 +138,15 @@ class NullAdapterTest extends TestCase
         $this->assertTrue($this->createCachePool()->commit());
     }
 
+    public function testTaggable()
+    {
+        $this->expectNotToPerformAssertions();
+        $adapter = $this->createCachePool();
+        $item = $adapter->getItem('any_item');
+        // No error triggered 'Cache item "%s" comes from a non tag-aware pool: you cannot tag it.'
+        $item->tag(['tag1']);
+    }
+
     public function testInvalidateTags()
     {
         $adapter = $this->createCachePool();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

After PR #61127 merged NullAdapter still doesn't work as taggable. After tagging there is an error 
```
Cache item "tag1" comes from a non tag-aware pool: you cannot tag it.
```

Psalm must fail here same as https://github.com/symfony/symfony/blob/8.1/src/Symfony/Component/Cache/Adapter/AbstractTagAwareAdapter.php#L69
<img width="1896" height="137" alt="image" src="https://github.com/user-attachments/assets/33fb59d4-b048-495d-950c-005dbbaa3ea0" />
