### PR TITLE
[Config] Define `TreeBuilder` default generic type

### DIFF
--- a/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
@@ -19,7 +19,7 @@ use Symfony\Component\Config\Definition\PrototypedArrayNode;
 /**
  * This class provides a fluent interface for defining an array node.
  *
- * @template TParent of NodeParentInterface|null
+ * @template TParent of NodeParentInterface|null = null
  *
  * @extends NodeDefinition<TParent>
  *

--- a/src/Symfony/Component/Config/Definition/Builder/TreeBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/TreeBuilder.php
@@ -16,7 +16,7 @@ use Symfony\Component\Config\Definition\NodeInterface;
 /**
  * This is the entry class for building a config tree.
  *
- * @template T of 'array'|'variable'|'scalar'|'string'|'boolean'|'integer'|'float'|'enum'
+ * @template T of 'array'|'variable'|'scalar'|'string'|'boolean'|'integer'|'float'|'enum' = 'array'
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */

--- a/src/Symfony/Component/Config/Definition/Configuration.php
+++ b/src/Symfony/Component/Config/Definition/Configuration.php
@@ -31,9 +31,12 @@ class Configuration implements ConfigurationInterface
     ) {
     }
 
+    /**
+     * @return TreeBuilder<'array'>
+     */
     public function getConfigTreeBuilder(): TreeBuilder
     {
-        $treeBuilder = new TreeBuilder($this->alias);
+        $treeBuilder = new TreeBuilder($this->alias, 'array');
         $file = (new \ReflectionObject($this->subject))->getFileName();
         $loader = new DefinitionFileLoader($treeBuilder, new FileLocator(\dirname($file)), $this->container);
         $configurator = new DefinitionConfigurator($treeBuilder, $loader, $file, $file);

--- a/src/Symfony/Component/Config/Definition/ConfigurationInterface.php
+++ b/src/Symfony/Component/Config/Definition/ConfigurationInterface.php
@@ -22,6 +22,8 @@ interface ConfigurationInterface
 {
     /**
      * Generates the configuration tree builder.
+     *
+     * @return TreeBuilder<'array'>
      */
     public function getConfigTreeBuilder(): TreeBuilder;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

The generics make sense internal but are very confusing for all people not knowing about internal behaviours and hard to guess whats corrct so we should provide defaults for them. Similar to https://github.com/symfony/symfony/pull/61805 add some defaults.

Stumbled over this during upgrade StofDoctrineExtensionBundle:

```
  14     Method Stof\DoctrineExtensionsBundle\DependencyInjection\Configuration::getConfigTreeBuilder() return type with generic class Symfony\Component\Config\Definition\Builder\TreeBuilder does not specify its types: T
         🪪  missingType.generics
  40     Method Stof\DoctrineExtensionsBundle\DependencyInjection\Configuration::getVendorNode() return type with generic class Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition does not specify its types: TParent
         🪪  missingType.generics
  67     Method Stof\DoctrineExtensionsBundle\DependencyInjection\Configuration::getClassNode() return type with generic class Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition does not specify its types: TParent
         🪪  missingType.generics
  121    Method Stof\DoctrineExtensionsBundle\DependencyInjection\Configuration::getSoftDeleteableNode() return type with generic class Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition does not specify its types: TParent
         🪪  missingType.generics
  136    Method Stof\DoctrineExtensionsBundle\DependencyInjection\Configuration::getUploadableNode() return type with generic class Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition does not specify its types: TParent
         🪪  missingType.generics
```