### PR TITLE
[Messenger] Fix PHP 8.5 deprecation for pgsqlGetNotify() in PostgreSQL transport

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/PostgreSqlConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/PostgreSqlConnectionTest.php
@@ -74,6 +74,13 @@ class PostgreSqlConnectionTest extends TestCase
                 return false;
             }
 
+            public function getNotify()
+            {
+                ++$this->notifyCalls;
+
+                return false;
+            }
+
             public function countNotifyCalls()
             {
                 return $this->notifyCalls;

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/PostgreSqlConnection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/PostgreSqlConnection.php
@@ -26,7 +26,7 @@ final class PostgreSqlConnection extends Connection
 {
     /**
      * * check_delayed_interval: The interval to check for delayed messages, in milliseconds. Set to 0 to disable checks. Default: 60000 (1 minute)
-     * * get_notify_timeout: The length of time to wait for a response when calling PDO::pgsqlGetNotify, in milliseconds. Default: 0.
+     * * get_notify_timeout: The length of time to wait for a response when calling PDO::pgsqlGetNotify (or Pdo\Pgsql::getNotify on PHP 8.4+), in milliseconds. Default: 0.
      */
     protected const DEFAULT_OPTIONS = parent::DEFAULT_OPTIONS + [
         'check_delayed_interval' => 60000,
@@ -74,7 +74,9 @@ final class PostgreSqlConnection extends Connection
             }
         }
 
-        $notification = $wrappedConnection->pgsqlGetNotify(\PDO::FETCH_ASSOC, $this->configuration['get_notify_timeout']);
+        $notification = \PHP_VERSION_ID >= 80500
+            ? $wrappedConnection->getNotify(\PDO::FETCH_ASSOC, $this->configuration['get_notify_timeout'])
+            : $wrappedConnection->pgsqlGetNotify(\PDO::FETCH_ASSOC, $this->configuration['get_notify_timeout']);
         if (
             // no notifications, or for another table or queue
             (false === $notification || $notification['message'] !== $this->configuration['table_name'] || $notification['payload'] !== $this->configuration['queue_name'])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no 
| Deprecations? | no 
| License       | MIT

Fix a PHP 8.5 deprecation warning in the PostgreSQL messenger transport.

  In PHP 8.5, `PDO::pgsqlGetNotify()` is deprecated in favor of the new `Pdo\Pgsql::getNotify()` method. This change uses `instanceof` to detect the `Pdo\Pgsql` class and calls the appropriate method, maintaining backward compatibility with older PHP versions.

