### PR TITLE
[JsonStreamer] fix invalid json output for list of self

### DIFF
--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Model/DummyWithNestedDictDummies.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Model/DummyWithNestedDictDummies.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Fixtures\Model;
+
+namespace Symfony\Component\JsonStreamer\Tests\Fixtures\Model;
+
+class DummyWithNestedDictDummies
+{
+    /** @var array<string, DummyWithNestedDictDummies>  */
+    public array $dummies = [];
+}

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Model/DummyWithNestedListDummies.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Model/DummyWithNestedListDummies.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Fixtures\Model;
+
+namespace Symfony\Component\JsonStreamer\Tests\Fixtures\Model;
+
+class DummyWithNestedListDummies
+{
+    /** @var DummyWithNestedListDummies[] */
+    public array $dummies = [];
+}

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Model/SelfReferencingDummyDict.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Model/SelfReferencingDummyDict.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\JsonStreamer\Tests\Fixtures\Model;
+
+class SelfReferencingDummyDict
+{
+    /**
+     * @var array<string, self>
+     */
+    public array $items = [];
+}

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Model/SelfReferencingDummyList.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Model/SelfReferencingDummyList.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\JsonStreamer\Tests\Fixtures\Model;
+
+class SelfReferencingDummyList
+{
+    /**
+     * @var self[]
+     */
+    public array $items = [];
+}

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_nested_dict_self.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_nested_dict_self.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @param Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNestedDictDummies $data
+ */
+return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
+    $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNestedDictDummies'] = static function ($data, $depth) use ($valueTransformers, $options, &$generators) {
+        if ($depth >= 512) {
+            throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException('Maximum stack depth exceeded');
+        }
+        $prefix1 = '';
+        yield "{{$prefix1}\"dummies\":";
+        yield "{";
+        $prefix2 = '';
+        foreach ($data->dummies as $key1 => $value1) {
+            $key1 = \substr(\json_encode($key1), 1, -1);
+            yield "{$prefix2}\"{$key1}\":";
+            yield from $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNestedDictDummies']($value1, $depth + 1);
+            $prefix2 = ',';
+        }
+        yield "}}";
+    };
+    try {
+        yield from $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNestedDictDummies']($data, 0);
+    } catch (\JsonException $e) {
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+    }
+};

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_nested_list_self.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_nested_list_self.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @param Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNestedListDummies $data
+ */
+return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
+    $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNestedListDummies'] = static function ($data, $depth) use ($valueTransformers, $options, &$generators) {
+        if ($depth >= 512) {
+            throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException('Maximum stack depth exceeded');
+        }
+        $prefix1 = '';
+        yield "{{$prefix1}\"dummies\":";
+        yield "[";
+        $prefix2 = '';
+        foreach ($data->dummies as $value1) {
+            yield "{$prefix2}";
+            yield from $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNestedListDummies']($value1, $depth + 1);
+            $prefix2 = ',';
+        }
+        yield "]}";
+    };
+    try {
+        yield from $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNestedListDummies']($data, 0);
+    } catch (\JsonException $e) {
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+    }
+};

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/self_referencing_object_dict.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/self_referencing_object_dict.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @param Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummyDict $data
+ */
+return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
+    $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummyDict'] = static function ($data, $depth) use ($valueTransformers, $options, &$generators) {
+        if ($depth >= 512) {
+            throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException('Maximum stack depth exceeded');
+        }
+        $prefix1 = '';
+        yield "{{$prefix1}\"items\":";
+        yield "{";
+        $prefix2 = '';
+        foreach ($data->items as $key1 => $value1) {
+            $key1 = \substr(\json_encode($key1), 1, -1);
+            yield "{$prefix2}\"{$key1}\":";
+            yield from $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummyDict']($value1, $depth + 1);
+            $prefix2 = ',';
+        }
+        yield "}}";
+    };
+    try {
+        yield from $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummyDict']($data, 0);
+    } catch (\JsonException $e) {
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+    }
+};

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/self_referencing_object_list.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/self_referencing_object_list.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @param Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummyList $data
+ */
+return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
+    $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummyList'] = static function ($data, $depth) use ($valueTransformers, $options, &$generators) {
+        if ($depth >= 512) {
+            throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException('Maximum stack depth exceeded');
+        }
+        $prefix1 = '';
+        yield "{{$prefix1}\"items\":";
+        yield "[";
+        $prefix2 = '';
+        foreach ($data->items as $value1) {
+            yield "{$prefix2}";
+            yield from $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummyList']($value1, $depth + 1);
+            $prefix2 = ',';
+        }
+        yield "]}";
+    };
+    try {
+        yield from $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummyList']($data, 0);
+    } catch (\JsonException $e) {
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+    }
+};

--- a/src/Symfony/Component/JsonStreamer/Tests/Write/StreamWriterGeneratorTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Write/StreamWriterGeneratorTest.php
@@ -27,11 +27,15 @@ use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithArray;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDollarNamedProperties;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNestedArray;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNestedDictDummies;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNestedListDummies;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithOtherDummies;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithSyntheticProperties;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithUnionProperties;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithValueTransformerAttributes;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummy;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummyDict;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummyList;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\ValueTransformer\BooleanToStringValueTransformer;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\ValueTransformer\DoubleIntAndCastToStringValueTransformer;
 use Symfony\Component\JsonStreamer\Tests\ServiceContainer;
@@ -99,6 +103,8 @@ class StreamWriterGeneratorTest extends TestCase
         yield ['nullable_object_list', Type::nullable(Type::list(Type::object(DummyWithNameAttributes::class)))];
         yield ['nested_list', Type::list(Type::object(DummyWithArray::class))];
         yield ['double_nested_list', Type::list(Type::object(DummyWithNestedArray::class))];
+        yield ['object_with_nested_list_self', Type::object(DummyWithNestedListDummies::class)];
+        yield ['object_with_nested_dict_self', Type::object(DummyWithNestedDictDummies::class)];
 
         yield ['dict', Type::dict()];
         yield ['object_dict', Type::dict(Type::object(DummyWithNameAttributes::class))];
@@ -112,6 +118,8 @@ class StreamWriterGeneratorTest extends TestCase
         yield ['object_in_object', Type::object(DummyWithOtherDummies::class)];
         yield ['object_with_value_transformer', Type::object(DummyWithValueTransformerAttributes::class)];
         yield ['self_referencing_object', Type::object(SelfReferencingDummy::class)];
+        yield ['self_referencing_object_list', Type::object(SelfReferencingDummyList::class)];
+        yield ['self_referencing_object_dict', Type::object(SelfReferencingDummyDict::class)];
         yield ['object_with_dollar_named_properties', Type::object(DummyWithDollarNamedProperties::class)];
         yield ['object_with_synthetic_properties', Type::object(DummyWithSyntheticProperties::class), new SyntheticPropertyMetadataLoader()];
 

--- a/src/Symfony/Component/JsonStreamer/Write/PhpGenerator.php
+++ b/src/Symfony/Component/JsonStreamer/Write/PhpGenerator.php
@@ -241,7 +241,8 @@ final class PhpGenerator
             if (isset($context['generated_generators'][$dataModelNode->getIdentifier()]) || $dataModelNode->isMock()) {
                 $depthArgument = ($context['generating_generator'] ?? false) ? '$depth + 1' : (string) $context['depth'];
 
-                return $this->line('yield from $generators[\''.$dataModelNode->getIdentifier().'\']('.$accessor.', '.$depthArgument.');', $context);
+                return $this->flushYieldBuffer($context)
+                    .$this->line('yield from $generators[\''.$dataModelNode->getIdentifier().'\']('.$accessor.', '.$depthArgument.');', $context);
             }
 
             ++$context['depth'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

Using the `symfony/json-streamer` component on an object which contains a list of self (`list<int, self>`, `self[]`) generates invalid JSON.

This happens because the generated code does not yield a comma (`,`) for the first entry in the list and instead outputs an additional comma at the end of the list.

A class like:
```php
class Dummy
{
    /** @var Dummy[] */
    public array $dummies = [];
}
```

Currently outputs invalid JSON:
```json
{"dummies":[{"dummies":[]}{"dummies":[]},{"dummies":[]},]}
```

This PR fixes the above example to output valid JSON:
```json
{"dummies":[{"dummies":[]},{"dummies":[]},{"dummies":[]}]}
```
