### PR TITLE
[DependencyInjection] Add tag decoration support

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/AsTagDecorator.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/AsTagDecorator.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Attribute;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Declares a class as a decorator of all services with a specific tag.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class AsTagDecorator
+{
+    /**
+     * @param string                          $tag       The tag name to decorate
+     * @param int                             $priority  The priority of this decoration when multiple decorators are declared for the same tag
+     * @param ContainerInterface::*_REFERENCE $onInvalid The behavior to adopt when no services have the tag; must be one of the {@see ContainerInterface} constants
+     */
+    public function __construct(
+        public string $tag,
+        public int $priority = 0,
+        public int $onInvalid = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE,
+    ) {
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.1
 ---
 
+ * Add support for decorating all services with a specific tag using the `container.tag_decorator` resource tag or `#[AsTagDecorator]`
  * Add support for `SOURCE_DATE_EPOCH` environment variable
  * Deprecate configuring options `alias`, `parent`, `synthetic`, `file`, `arguments`, `properties`, `configurator` or `calls` when using `from_callable`
  * Deprecate default index/priority methods when defining tagged locators/iterators; use the `#[AsTaggedItem]` attribute instead

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowireAsDecoratorPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowireAsDecoratorPass.php
@@ -12,11 +12,13 @@
 namespace Symfony\Component\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Attribute\AsDecorator;
+use Symfony\Component\DependencyInjection\Attribute\AsTagDecorator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
 
 /**
- * Reads #[AsDecorator] attributes on definitions that are autowired
+ * Reads #[AsDecorator] and #[AsTagDecorator] attributes on definitions that are autowired
  * and don't have the "container.ignore_attributes" tag.
  */
 final class AutowireAsDecoratorPass implements CompilerPassInterface
@@ -37,23 +39,43 @@ final class AutowireAsDecoratorPass implements CompilerPassInterface
 
     private function processClass(string $id, ContainerBuilder $container, Definition $definition, \ReflectionClass $reflectionClass): void
     {
-        if (!$attributes = $reflectionClass->getAttributes(AsDecorator::class, \ReflectionAttribute::IS_INSTANCEOF)) {
+        $decoratorAttributes = $reflectionClass->getAttributes(AsDecorator::class, \ReflectionAttribute::IS_INSTANCEOF);
+        $tagDecoratorAttributes = $reflectionClass->getAttributes(AsTagDecorator::class, \ReflectionAttribute::IS_INSTANCEOF);
+
+        if (!$decoratorAttributes && !$tagDecoratorAttributes) {
             return;
         }
 
-        if (1 === \count($attributes)) {
-            $attribute = $attributes[0]->newInstance();
+        if (1 === \count($decoratorAttributes) && !$tagDecoratorAttributes) {
+            $attribute = $decoratorAttributes[0]->newInstance();
             $definition->setDecoratedService($attribute->decorates, null, $attribute->priority, $attribute->onInvalid);
 
             return;
         }
 
-        foreach ($attributes as $attribute) {
+        foreach ($decoratorAttributes as $attribute) {
             $attribute = $attribute->newInstance();
 
-            $definition = clone $definition;
-            $definition->setDecoratedService($attribute->decorates, null, $attribute->priority, $attribute->onInvalid);
-            $container->setDefinition(\sprintf('.decorator.%s.%s', $attribute->decorates, $id), $definition);
+            $clonedDefinition = clone $definition;
+            $clonedDefinition->setDecoratedService($attribute->decorates, null, $attribute->priority, $attribute->onInvalid);
+            $container->setDefinition(\sprintf('.decorator.%s.%s', $attribute->decorates, $id), $clonedDefinition);
+        }
+
+        foreach ($tagDecoratorAttributes as $attribute) {
+            $attribute = $attribute->newInstance();
+
+            $clonedDefinition = clone $definition;
+            $tagAttributes = [
+                'decorates_tag' => $attribute->tag,
+                'priority' => $attribute->priority,
+            ];
+
+            if (ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE !== $attribute->onInvalid) {
+                $tagAttributes['on_invalid'] = $attribute->onInvalid;
+            }
+
+            $clonedDefinition->addResourceTag('container.tag_decorator', $tagAttributes);
+            $container->setDefinition(\sprintf('.tag_decorator.%s.%s', $attribute->tag, $id), $clonedDefinition);
         }
 
         $container->removeDefinition($id);

--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -66,6 +66,7 @@ class PassConfig
             new AutowireRequiredPropertiesPass(),
             new ResolveBindingsPass(),
             new ServiceLocatorTagPass(),
+            new TagDecoratorPass(),
             new DecoratorServicePass(),
             new CheckDefinitionValidityPass(),
             new AutowirePass(false),

--- a/src/Symfony/Component/DependencyInjection/Compiler/TagDecoratorPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/TagDecoratorPass.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+
+/**
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ */
+final class TagDecoratorPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        foreach ($container->findTaggedResourceIds('container.tag_decorator', false) as $id => $tags) {
+            $definition = $container->getDefinition($id);
+
+            foreach ($tags as $tag) {
+                if (!$decoratesTag = $tag['decorates_tag'] ?? null) {
+                    continue;
+                }
+
+                $priority = $tag['priority'] ?? 0;
+                $invalidBehavior = $tag['on_invalid'] ?? ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE;
+                $taggedServices = $container->findTaggedServiceIds($decoratesTag);
+
+                if (!$taggedServices) {
+                    if (ContainerInterface::IGNORE_ON_INVALID_REFERENCE === $invalidBehavior) {
+                        continue;
+                    }
+
+                    if (ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE === $invalidBehavior) {
+                        throw new ServiceNotFoundException($decoratesTag, $id);
+                    }
+                }
+
+                foreach ($taggedServices as $taggedServiceId => $_) {
+                    $clonedDefinition = clone $definition;
+                    $clonedDefinition->clearTag('container.tag_decorator');
+                    $clonedDefinition->clearTag('container.excluded');
+                    $clonedDefinition->setDecoratedService($taggedServiceId, null, $priority, $invalidBehavior);
+                    $decoratorId = \sprintf('.decorator.%s.%s', $taggedServiceId, $id);
+                    $container->setDefinition($decoratorId, $clonedDefinition);
+                }
+            }
+
+            $container->removeDefinition($id);
+        }
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/AppReference.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/AppReference.php
@@ -90,6 +90,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
  *     decoration_inner_name?: string,
  *     decoration_priority?: int,
  *     decoration_on_invalid?: 'exception'|'ignore'|null,
+ *     decorates_tag?: string,
  *     autowire?: bool,
  *     autoconfigure?: bool,
  *     bind?: array<string, mixed>,

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/DecorateTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/DecorateTrait.php
@@ -31,4 +31,28 @@ trait DecorateTrait
 
         return $this;
     }
+
+    /**
+     * Sets the tag that this definition is decorating.
+     *
+     * When decorating a tag, this definition acts as a template to create decorator services
+     * for each service that has the specified tag.
+     *
+     * @return $this
+     */
+    final public function decorateTag(string $tag, int $priority = 0, int $invalidBehavior = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE): static
+    {
+        $tagAttributes = [
+            'decorates_tag' => $tag,
+            'priority' => $priority,
+        ];
+
+        if (ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE !== $invalidBehavior) {
+            $tagAttributes['on_invalid'] = $invalidBehavior;
+        }
+
+        $this->definition->addResourceTag('container.tag_decorator', $tagAttributes);
+
+        return $this;
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Loader/ContentLoaderTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/ContentLoaderTrait.php
@@ -55,6 +55,7 @@ trait ContentLoaderTrait
         'decoration_inner_name' => 'decoration_inner_name',
         'decoration_priority' => 'decoration_priority',
         'decoration_on_invalid' => 'decoration_on_invalid',
+        'decorates_tag' => 'decorates_tag',
         'autowire' => 'autowire',
         'autoconfigure' => 'autoconfigure',
         'bind' => 'bind',
@@ -609,6 +610,34 @@ trait ContentLoaderTrait
             $priority = $service['decoration_priority'] ?? 0;
 
             $definition->setDecoratedService($decorates, $renameId, $priority, $invalidBehavior);
+        }
+
+        if (null !== $decoratesTag = $service['decorates_tag'] ?? null) {
+            if (isset($service['decorates'])) {
+                throw new InvalidArgumentException(\sprintf('A service cannot have both "decorates" and "decorates_tag" attributes on service "%s" in "%s".', $id, $file));
+            }
+
+            $priority = $service['decoration_priority'] ?? 0;
+
+            $decorationOnInvalid = \array_key_exists('decoration_on_invalid', $service) ? $service['decoration_on_invalid'] : 'exception';
+            $invalidBehavior = match ($decorationOnInvalid) {
+                'exception', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE => ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE,
+                'ignore', ContainerInterface::IGNORE_ON_INVALID_REFERENCE => ContainerInterface::IGNORE_ON_INVALID_REFERENCE,
+                null, ContainerInterface::NULL_ON_INVALID_REFERENCE => ContainerInterface::NULL_ON_INVALID_REFERENCE,
+                'null' => throw new InvalidArgumentException(\sprintf('Invalid value "%s" for attribute "decoration_on_invalid" on service "%s". Did you mean null (without quotes) in "%s"?', $decorationOnInvalid, $id, $file)),
+                default => throw new InvalidArgumentException(\sprintf('Invalid value "%s" for attribute "decoration_on_invalid" on service "%s". Did you mean "exception", "ignore" or "null" in "%s"?', $decorationOnInvalid, $id, $file)),
+            };
+
+            $tagAttributes = [
+                'decorates_tag' => $decoratesTag,
+                'priority' => $priority,
+            ];
+
+            if (ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE !== $invalidBehavior) {
+                $tagAttributes['on_invalid'] = $invalidBehavior;
+            }
+
+            $definition->addResourceTag('container.tag_decorator', $tagAttributes);
         }
 
         if (isset($service['autowire'])) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -26,6 +26,7 @@ use Symfony\Component\DependencyInjection\Compiler\AutowirePass;
 use Symfony\Component\DependencyInjection\Compiler\AutowireRequiredMethodsPass;
 use Symfony\Component\DependencyInjection\Compiler\DecoratorServicePass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveClassPass;
+use Symfony\Component\DependencyInjection\Compiler\TagDecoratorPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Exception\AutowiringFailedException;
@@ -1350,6 +1351,32 @@ class AutowirePassTest extends TestCase
         $barDecoratorName = '.decorator.'.AsDecoratorMultipleBar::class.'.'.AsDecoratorMultiple::class;
         $this->assertSame($barDecoratorName, (string) $container->getAlias(AsDecoratorMultipleBar::class));
         $this->assertSame($barDecoratorName.'.inner', (string) $container->getDefinition($barDecoratorName)->getArgument(1));
+    }
+
+    public function testAsTagDecoratorAttribute()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register(AsTagDecoratorFoo::class)->addTag('test.tag');
+        $container->register(AsTagDecoratorBar::class)->addTag('test.tag');
+        $container->register(AsTagDecoratorService::class, AsTagDecoratorService::class)->setAutowired(true);
+
+        (new AutowirePass())->process($container);
+        (new AutowireAsDecoratorPass())->process($container);
+        (new TagDecoratorPass())->process($container);
+        (new DecoratorServicePass())->process($container);
+
+        $tagDecoratorTemplate = '.tag_decorator.test.tag.'.AsTagDecoratorService::class;
+        $this->assertFalse($container->has($tagDecoratorTemplate));
+
+        $fooDecorator = '.decorator.'.AsTagDecoratorFoo::class.'.'.$tagDecoratorTemplate;
+        $barDecorator = '.decorator.'.AsTagDecoratorBar::class.'.'.$tagDecoratorTemplate;
+
+        $this->assertTrue($container->has($fooDecorator));
+        $this->assertTrue($container->has($barDecorator));
+
+        $this->assertSame($fooDecorator, (string) $container->getAlias(AsTagDecoratorFoo::class));
+        $this->assertSame($barDecorator, (string) $container->getAlias(AsTagDecoratorBar::class));
     }
 
     public function testTypeSymbolExcluded()

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/TagDecoratorPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/TagDecoratorPassTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Compiler\DecoratorServicePass;
+use Symfony\Component\DependencyInjection\Compiler\TagDecoratorPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+
+class TagDecoratorPassTest extends TestCase
+{
+    public function testDecorateByTag()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('foo', \stdClass::class)->addTag('tag');
+        $container->register('bar', \stdClass::class)->addTag('tag');
+        $container->register('decorator', \stdClass::class)->addResourceTag('container.tag_decorator', ['decorates_tag' => 'tag']);
+
+        $this->process($container);
+
+        $this->assertFalse($container->has('decorator'));
+
+        $this->assertTrue($container->has('.decorator.foo.decorator'));
+        $this->assertTrue($container->has('.decorator.bar.decorator'));
+
+        $this->assertSame('.decorator.foo.decorator', (string) $container->getAlias('foo'));
+        $this->assertSame('.decorator.bar.decorator', (string) $container->getAlias('bar'));
+
+        $this->assertTrue($container->has('.decorator.foo.decorator.inner'));
+        $this->assertTrue($container->has('.decorator.bar.decorator.inner'));
+    }
+
+    public function testDecorateByTagPriority()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('foo', \stdClass::class)->addTag('tag');
+        $container->register('bar', \stdClass::class)->addTag('tag');
+        $container->register('decorator1', \stdClass::class)->addResourceTag('container.tag_decorator', ['decorates_tag' => 'tag', 'priority' => 2]);
+        $container->register('decorator2', \stdClass::class)->addResourceTag('container.tag_decorator', ['decorates_tag' => 'tag', 'priority' => 1]);
+
+        $this->process($container);
+
+        $this->assertFalse($container->has('decorator1'));
+        $this->assertFalse($container->has('decorator2'));
+
+        $this->assertTrue($container->has('.decorator.foo.decorator1'));
+        $this->assertTrue($container->has('.decorator.foo.decorator2'));
+        $this->assertTrue($container->has('.decorator.bar.decorator1'));
+        $this->assertTrue($container->has('.decorator.bar.decorator2'));
+
+        $this->assertSame('.decorator.foo.decorator2', (string) $container->getAlias('foo'));
+        $this->assertSame('.decorator.bar.decorator2', (string) $container->getAlias('bar'));
+
+        $this->assertSame('.decorator.foo.decorator1', (string) $container->getAlias('.decorator.foo.decorator2.inner'));
+        $this->assertSame('.decorator.bar.decorator1', (string) $container->getAlias('.decorator.bar.decorator2.inner'));
+    }
+
+    public function testDecorateByTagIgnoreOnInvalid()
+    {
+        $container = new ContainerBuilder();
+        $container->register('decorator', \stdClass::class)->addResourceTag('container.tag_decorator', [
+            'decorates_tag' => 'non_existent_tag',
+            'on_invalid' => ContainerInterface::IGNORE_ON_INVALID_REFERENCE,
+        ]);
+
+        $this->process($container);
+        $this->assertFalse($container->has('decorator'));
+    }
+
+    public function testDecorateByTagNullOnInvalid()
+    {
+        $container = new ContainerBuilder();
+        $container->register('decorator', \stdClass::class)->addResourceTag('container.tag_decorator', [
+            'decorates_tag' => 'non_existent_tag',
+            'on_invalid' => ContainerInterface::NULL_ON_INVALID_REFERENCE,
+        ]);
+
+        $this->process($container);
+        $this->assertFalse($container->has('decorator'));
+    }
+
+    public function testDecorateByTagExceptionOnInvalid()
+    {
+        $container = new ContainerBuilder();
+        $container->register('decorator', \stdClass::class)->addResourceTag('container.tag_decorator', ['decorates_tag' => 'non_existent_tag']);
+
+        $this->expectException(ServiceNotFoundException::class);
+        $this->process($container);
+    }
+
+    protected function process(ContainerBuilder $container): void
+    {
+        (new TagDecoratorPass())->process($container);
+        (new DecoratorServicePass())->process($container);
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
@@ -3,6 +3,7 @@
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use Symfony\Component\DependencyInjection\Attribute\AsDecorator;
+use Symfony\Component\DependencyInjection\Attribute\AsTagDecorator;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\DependencyInjection\Attribute\AutowireDecorated;
 use Symfony\Component\DependencyInjection\Attribute\AutowireInline;
@@ -248,5 +249,25 @@ class NestedAutowireInlineAttribute
         )]
         public AutowireInlineAttributesBar $inlined,
     ) {
+    }
+}
+
+interface AsTagDecoratorInterface
+{
+}
+
+class AsTagDecoratorFoo implements AsTagDecoratorInterface
+{
+}
+
+class AsTagDecoratorBar implements AsTagDecoratorInterface
+{
+}
+
+#[AsTagDecorator('test.tag')]
+class AsTagDecoratorService implements AsTagDecoratorInterface
+{
+    public function __construct(#[AutowireDecorated] AsTagDecoratorInterface $inner)
+    {
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_decorates_tag.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_decorates_tag.yml
@@ -1,0 +1,14 @@
+services:
+    foo:
+        class: stdClass
+        tags:
+            - { name: my_tag }
+
+    bar:
+        class: stdClass
+        tags:
+            - { name: my_tag }
+
+    tag_decorator:
+        class: stdClass
+        decorates_tag: my_tag

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -26,7 +26,9 @@ use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
+use Symfony\Component\DependencyInjection\Compiler\DecoratorServicePass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveBindingsPass;
+use Symfony\Component\DependencyInjection\Compiler\TagDecoratorPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
@@ -1248,5 +1250,22 @@ class YamlFileLoaderTest extends TestCase
         yield 'properties' => ['properties', ['foo' => 'bar']];
         yield 'configurator' => ['configurator', 'some_configurator'];
         yield 'calls' => ['calls', [['method' => 'setFoo', 'arguments' => ['bar']]]];
+    }
+
+    public function testDecoratesTag()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('services_decorates_tag.yml');
+
+        (new TagDecoratorPass())->process($container);
+        (new DecoratorServicePass())->process($container);
+
+        $this->assertFalse($container->has('tag_decorator'));
+
+        $this->assertTrue($container->hasAlias('foo'));
+        $this->assertTrue($container->hasAlias('bar'));
+
+        $this->assertStringContainsString('.decorator.foo.', (string) $container->getAlias('foo'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

Allow to decorate tags.
When decorating a tag, every service with that tag will be decorated.

Consider the following example:
```yaml
services:
    foo: 
        tags: [ tag ]

    bar: 
        tags: [ tag ]

    tag_decorator:
        class: MyDecorator
        decorates_tag: tag
```
In that case, `foo` and `bar` will be decorated by `tag_decorator`.

This can be useful when you need to decorate several services to trace them, for example.
With this PR, no need to write compiler passes to achieve that.