### PR TITLE
[Config] Order config types in reference.php

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/PhpConfigReferenceDumpPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/PhpConfigReferenceDumpPass.php
@@ -92,7 +92,7 @@ class PhpConfigReferenceDumpPass implements CompilerPassInterface
         $knownEnvs = array_unique($knownEnvs);
         sort($knownEnvs);
         $extensionsPerEnv = [];
-        $appTypes = '';
+        $configTypes = [];
 
         $anyEnvExtensions = [];
         $registeredExtensions = $container->getExtensions();
@@ -115,7 +115,7 @@ class PhpConfigReferenceDumpPass implements CompilerPassInterface
             }
             $anyEnvExtensions[$extensionAlias] = $extension;
             $type = $this->camelCase($extensionAlias).'Config';
-            $appTypes .= \sprintf("\n * @psalm-type %s = %s", $type, ArrayShapeGenerator::generate($configuration->getConfigTreeBuilder()->buildTree()));
+            $configTypes[$type] = \sprintf("\n * @psalm-type %s = %s", $type, ArrayShapeGenerator::generate($configuration->getConfigTreeBuilder()->buildTree()));
 
             foreach ($knownEnvs as $env) {
                 if ($envs[$env] ?? $envs['all'] ?? false) {
@@ -131,9 +131,12 @@ class PhpConfigReferenceDumpPass implements CompilerPassInterface
             }
             $anyEnvExtensions[$alias] = $extension;
             $type = $this->camelCase($alias).'Config';
-            $appTypes .= \sprintf("\n * @psalm-type %s = %s", $type, ArrayShapeGenerator::generate($configuration->getConfigTreeBuilder()->buildTree()));
+            $configTypes[$type] = \sprintf("\n * @psalm-type %s = %s", $type, ArrayShapeGenerator::generate($configuration->getConfigTreeBuilder()->buildTree()));
         }
+
         krsort($extensionsPerEnv);
+        ksort($configTypes);
+        $appTypes = implode('', $configTypes);
 
         $r = new \ReflectionClass(AppReference::class);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/reference.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/reference.php
@@ -123,6 +123,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
  *     ...<string, DefinitionType|AliasType|PrototypeType|StackType|ArgumentsType|null>
  * }
  * @psalm-type ExtensionType = array<string, mixed>
+ * @psalm-type AppConfig = bool
  * @psalm-type TestConfig = array{
  *     enabled?: scalar|null, // Default: false
  *     options?: array{
@@ -131,7 +132,6 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
  *     },
  *     fromBundle?: bool, // Default: false
  * }
- * @psalm-type AppConfig = bool
  * @psalm-type ConfigType = array{
  *     imports?: ImportsConfig,
  *     parameters?: ParametersConfig,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62521
| License       | MIT

Even if the issue is closed, I'm still getting changes when running tests
```
diff --git a/account/config/reference.php b/account/config/reference.php
index e6b19def..8adbf36b 100644
--- a/account/config/reference.php
+++ b/account/config/reference.php
@@ -1666,10 +1666,11 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
  *     intercept_redirects?: bool, // Default: false
  *     excluded_ajax_paths?: scalar|null, // Default: "^/((index|app(_[\\w]+)?)\\.php/)?_wdt"
  * }
- * @psalm-type MakerConfig = array{
- *     root_namespace?: scalar|null, // Default: "App"
- *     generate_final_classes?: bool, // Default: true
- *     generate_final_entities?: bool, // Default: false
+ * @psalm-type DamaDoctrineTestConfig = array{
+ *     enable_static_connection?: mixed, // Default: true
+ *     enable_static_meta_data_cache?: bool, // Default: true
+ *     enable_static_query_cache?: bool, // Default: true
+ *     connection_keys?: list<mixed>,
  * }
  * @psalm-type MonologConfig = array{
  *     use_microseconds?: scalar|null, // Default: true
(1/2) Stage this hunk [y,n,q,a,d,j,J,g,/,e,p,?]? n
@@ -1876,11 +1877,10 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
  *     skip_translation_on_load?: bool, // Default: false
  *     metadata_cache_pool?: scalar|null, // Default: null
  * }
- * @psalm-type DamaDoctrineTestConfig = array{
- *     enable_static_connection?: mixed, // Default: true
- *     enable_static_meta_data_cache?: bool, // Default: true
- *     enable_static_query_cache?: bool, // Default: true
- *     connection_keys?: list<mixed>,
+ * @psalm-type MakerConfig = array{
+ *     root_namespace?: scalar|null, // Default: "App"
+ *     generate_final_classes?: bool, // Default: true
+ *     generate_final_entities?: bool, // Default: false
  * }
  * @psalm-type ConfigType = array{
  *     imports?: ImportsConfig,
```
Possibly because extension/bundle are not loaded in the same order ?

Anyway, this shouldn't rely on any order and I think a good solution would be to order config type alphabetically.