### PR TITLE
[HttpClient] Fix sharing CurlClientState between clones of CurlHttpClient instances

### DIFF
--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -51,9 +51,6 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
 
     private ?LoggerInterface $logger = null;
 
-    private int $maxHostConnections;
-    private int $maxPendingPushes;
-
     /**
      * An internal object to share state between the client and its responses.
      */
@@ -72,22 +69,18 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
             throw new \LogicException('You cannot use the "Symfony\Component\HttpClient\CurlHttpClient" as the "curl" extension is not installed.');
         }
 
-        $this->maxHostConnections = $maxHostConnections;
-        $this->maxPendingPushes = $maxPendingPushes;
-
         $this->defaultOptions['buffer'] ??= self::shouldBuffer(...);
 
         if ($defaultOptions) {
             [, $this->defaultOptions] = self::prepareRequest(null, null, $defaultOptions, $this->defaultOptions);
         }
+
+        $this->multi = new CurlClientState($maxHostConnections, $maxPendingPushes);
     }
 
     public function setLogger(LoggerInterface $logger): void
     {
-        $this->logger = $logger;
-        if (isset($this->multi)) {
-            $this->multi->logger = $logger;
-        }
+        $this->logger = $this->multi->logger = $logger;
     }
 
     /**
@@ -95,8 +88,6 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
      */
     public function request(string $method, string $url, array $options = []): ResponseInterface
     {
-        $multi = $this->ensureState();
-
         [$url, $options] = self::prepareRequest($method, $url, $options, $this->defaultOptions);
         $scheme = $url['scheme'];
         $authority = $url['authority'];
@@ -174,24 +165,24 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
         }
 
         // curl's resolve feature varies by host:port but ours varies by host only, let's handle this with our own DNS map
-        if (isset($multi->dnsCache->hostnames[$host])) {
-            $options['resolve'] += [$host => $multi->dnsCache->hostnames[$host]];
+        if (isset($this->multi->dnsCache->hostnames[$host])) {
+            $options['resolve'] += [$host => $this->multi->dnsCache->hostnames[$host]];
         }
 
-        if ($options['resolve'] || $multi->dnsCache->evictions) {
+        if ($options['resolve'] || $this->multi->dnsCache->evictions) {
             // First reset any old DNS cache entries then add the new ones
-            $resolve = $multi->dnsCache->evictions;
-            $multi->dnsCache->evictions = [];
+            $resolve = $this->multi->dnsCache->evictions;
+            $this->multi->dnsCache->evictions = [];
 
             if ($resolve && 0x072A00 > CurlClientState::$curlVersion['version_number']) {
                 // DNS cache removals require curl 7.42 or higher
-                $multi->reset();
+                $this->multi->reset();
             }
 
             foreach ($options['resolve'] as $resolveHost => $ip) {
                 $resolve[] = null === $ip ? "-$resolveHost:$port" : "$resolveHost:$port:$ip";
-                $multi->dnsCache->hostnames[$resolveHost] = $ip;
-                $multi->dnsCache->removals["-$resolveHost:$port"] = "-$resolveHost:$port";
+                $this->multi->dnsCache->hostnames[$resolveHost] = $ip;
+                $this->multi->dnsCache->removals["-$resolveHost:$port"] = "-$resolveHost:$port";
             }
 
             $curlopts[\CURLOPT_RESOLVE] = $resolve;
@@ -293,8 +284,8 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
             $curlopts += $options['extra']['curl'];
         }
 
-        if ($pushedResponse = $multi->pushedResponses[$url] ?? null) {
-            unset($multi->pushedResponses[$url]);
+        if ($pushedResponse = $this->multi->pushedResponses[$url] ?? null) {
+            unset($this->multi->pushedResponses[$url]);
 
             if (self::acceptPushForRequest($method, $options, $pushedResponse)) {
                 $this->logger?->debug(\sprintf('Accepting pushed response: "%s %s"', $method, $url));
@@ -302,7 +293,7 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
                 // Reinitialize the pushed response with request's options
                 $ch = $pushedResponse->handle;
                 $pushedResponse = $pushedResponse->response;
-                $pushedResponse->__construct($multi, $url, $options, $this->logger);
+                $pushedResponse->__construct($this->multi, $url, $options, $this->logger);
             } else {
                 $this->logger?->debug(\sprintf('Rejecting pushed response: "%s"', $url));
                 $pushedResponse = null;
@@ -312,7 +303,7 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
         if (!$pushedResponse) {
             $ch = curl_init();
             $this->logger?->info(\sprintf('Request: "%s %s"', $method, $url));
-            $curlopts += [\CURLOPT_SHARE => $multi->share];
+            $curlopts += [\CURLOPT_SHARE => $this->multi->share];
         }
 
         foreach ($curlopts as $opt => $value) {
@@ -325,7 +316,7 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
             }
         }
 
-        return $pushedResponse ?? new CurlResponse($multi, $ch, $options, $this->logger, $method, self::createRedirectResolver($options, $authority), CurlClientState::$curlVersion['version_number'], $url);
+        return $pushedResponse ?? new CurlResponse($this->multi, $ch, $options, $this->logger, $method, self::createRedirectResolver($options, $authority), CurlClientState::$curlVersion['version_number'], $url);
     }
 
     public function stream(ResponseInterface|iterable $responses, ?float $timeout = null): ResponseStreamInterface
@@ -334,11 +325,9 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
             $responses = [$responses];
         }
 
-        $multi = $this->ensureState();
-
-        if ($multi->handle instanceof \CurlMultiHandle) {
+        if ($this->multi->handle instanceof \CurlMultiHandle) {
             $active = 0;
-            while (\CURLM_CALL_MULTI_PERFORM === curl_multi_exec($multi->handle, $active)) {
+            while (\CURLM_CALL_MULTI_PERFORM === curl_multi_exec($this->multi->handle, $active)) {
             }
         }
 
@@ -347,9 +336,7 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
 
     public function reset(): void
     {
-        if (isset($this->multi)) {
-            $this->multi->reset();
-        }
+        $this->multi->reset();
     }
 
     /**
@@ -446,16 +433,6 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
 
             return implode('', $url);
         };
-    }
-
-    private function ensureState(): CurlClientState
-    {
-        if (!isset($this->multi)) {
-            $this->multi = new CurlClientState($this->maxHostConnections, $this->maxPendingPushes);
-            $this->multi->logger = $this->logger;
-        }
-
-        return $this->multi;
     }
 
     private function findConstantName(int $opt): ?string

--- a/src/Symfony/Component/HttpClient/Internal/CurlClientState.php
+++ b/src/Symfony/Component/HttpClient/Internal/CurlClientState.php
@@ -37,45 +37,15 @@ final class CurlClientState extends ClientState
 
     public static array $curlVersion;
 
-    public function __construct(int $maxHostConnections, int $maxPendingPushes)
-    {
+    public function __construct(
+        private int $maxHostConnections,
+        private int $maxPendingPushes,
+    ) {
         self::$curlVersion ??= curl_version();
-
-        $this->handle = curl_multi_init();
         $this->dnsCache = new DnsCache();
-        $this->reset();
 
-        // Don't enable HTTP/1.1 pipelining: it forces responses to be sent in order
-        if (\defined('CURLPIPE_MULTIPLEX')) {
-            curl_multi_setopt($this->handle, \CURLMOPT_PIPELINING, \CURLPIPE_MULTIPLEX);
-        }
-        if (\defined('CURLMOPT_MAX_HOST_CONNECTIONS') && 0 < $maxHostConnections) {
-            $maxHostConnections = curl_multi_setopt($this->handle, \CURLMOPT_MAX_HOST_CONNECTIONS, $maxHostConnections) ? min(50 * $maxHostConnections, 4294967295) : $maxHostConnections;
-        }
-        if (\defined('CURLMOPT_MAXCONNECTS') && 0 < $maxHostConnections) {
-            curl_multi_setopt($this->handle, \CURLMOPT_MAXCONNECTS, $maxHostConnections);
-        }
-
-        // Skip configuring HTTP/2 push when it's unsupported or buggy, see https://bugs.php.net/77535
-        if (0 >= $maxPendingPushes) {
-            return;
-        }
-
-        // HTTP/2 push crashes before curl 7.61
-        if (!\defined('CURLMOPT_PUSHFUNCTION') || 0x073D00 > self::$curlVersion['version_number'] || !(\CURL_VERSION_HTTP2 & self::$curlVersion['features'])) {
-            return;
-        }
-
-        // Clone to prevent a circular reference
-        $multi = clone $this;
-        $multi->handle = null;
-        $multi->share = null;
-        $multi->pushedResponses = &$this->pushedResponses;
-        $multi->logger = &$this->logger;
-        $multi->handlesActivity = &$this->handlesActivity;
-        $multi->openHandles = &$this->openHandles;
-
-        curl_multi_setopt($this->handle, \CURLMOPT_PUSHFUNCTION, static fn ($parent, $pushed, array $requestHeaders) => $multi->handlePush($parent, $pushed, $requestHeaders, $maxPendingPushes));
+        // handle and share are initialized lazily in __get()
+        unset($this->handle, $this->share);
     }
 
     public function reset(): void
@@ -89,17 +59,59 @@ final class CurlClientState extends ClientState
         $this->dnsCache->evictions = $this->dnsCache->evictions ?: $this->dnsCache->removals;
         $this->dnsCache->removals = $this->dnsCache->hostnames = [];
 
-        $this->share = curl_share_init();
-
-        curl_share_setopt($this->share, \CURLSHOPT_SHARE, \CURL_LOCK_DATA_DNS);
-        curl_share_setopt($this->share, \CURLSHOPT_SHARE, \CURL_LOCK_DATA_SSL_SESSION);
-
-        if (\defined('CURL_LOCK_DATA_CONNECT')) {
-            curl_share_setopt($this->share, \CURLSHOPT_SHARE, \CURL_LOCK_DATA_CONNECT);
-        }
+        unset($this->share);
     }
 
-    private function handlePush($parent, $pushed, array $requestHeaders, int $maxPendingPushes): int
+    public function __get(string $name): mixed
+    {
+        if ('share' === $name) {
+            $this->share = curl_share_init();
+
+            curl_share_setopt($this->share, \CURLSHOPT_SHARE, \CURL_LOCK_DATA_DNS);
+            curl_share_setopt($this->share, \CURLSHOPT_SHARE, \CURL_LOCK_DATA_SSL_SESSION);
+
+            if (\defined('CURL_LOCK_DATA_CONNECT')) {
+                curl_share_setopt($this->share, \CURLSHOPT_SHARE, \CURL_LOCK_DATA_CONNECT);
+            }
+
+            return $this->share;
+        }
+
+        if ('handle' === $name) {
+            $this->handle = curl_multi_init();
+
+            // Don't enable HTTP/1.1 pipelining: it forces responses to be sent in order
+            if (\defined('CURLPIPE_MULTIPLEX')) {
+                curl_multi_setopt($this->handle, \CURLMOPT_PIPELINING, \CURLPIPE_MULTIPLEX);
+            }
+            if (\defined('CURLMOPT_MAX_HOST_CONNECTIONS') && 0 < $this->maxHostConnections) {
+                $this->maxHostConnections = curl_multi_setopt($this->handle, \CURLMOPT_MAX_HOST_CONNECTIONS, $this->maxHostConnections) ? min(50 * $this->maxHostConnections, 4294967295) : $this->maxHostConnections;
+            }
+            if (\defined('CURLMOPT_MAXCONNECTS') && 0 < $this->maxHostConnections) {
+                curl_multi_setopt($this->handle, \CURLMOPT_MAXCONNECTS, $this->maxHostConnections);
+            }
+
+            // Skip configuring HTTP/2 push when it's unsupported or buggy, see https://bugs.php.net/77535
+            if (0 < $this->maxPendingPushes && (\defined('CURLMOPT_PUSHFUNCTION') && 0x073D00 <= self::$curlVersion['version_number'] && (\CURL_VERSION_HTTP2 & self::$curlVersion['features']))) {
+                // Clone to prevent a circular reference
+                $multi = clone $this;
+                $multi->handle = null;
+                $multi->share = null;
+                $multi->pushedResponses = &$this->pushedResponses;
+                $multi->logger = &$this->logger;
+                $multi->handlesActivity = &$this->handlesActivity;
+                $multi->openHandles = &$this->openHandles;
+
+                curl_multi_setopt($this->handle, \CURLMOPT_PUSHFUNCTION, $multi->handlePush(...));
+            }
+
+            return $this->handle;
+        }
+
+        throw new \LogicException(\sprintf('Unknown property "%s" on "%s".', $name, self::class));
+    }
+
+    private function handlePush($parent, $pushed, array $requestHeaders): int
     {
         $headers = [];
         $origin = curl_getinfo($parent, \CURLINFO_EFFECTIVE_URL);
@@ -127,7 +139,7 @@ final class CurlClientState extends ClientState
             return \CURL_PUSH_DENY;
         }
 
-        if ($maxPendingPushes <= \count($this->pushedResponses)) {
+        if ($this->maxPendingPushes <= \count($this->pushedResponses)) {
             $fifoUrl = key($this->pushedResponses);
             unset($this->pushedResponses[$fifoUrl]);
             $this->logger?->debug(\sprintf('Evicting oldest pushed response: "%s"', $fifoUrl));

--- a/src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php
@@ -48,8 +48,8 @@ class CurlHttpClientTest extends HttpClientTestCase
     {
         $httpClient = $this->getHttpClient(__FUNCTION__);
 
-        $r = new \ReflectionMethod($httpClient, 'ensureState');
-        $clientState = $r->invoke($httpClient);
+        $r = new \ReflectionProperty($httpClient, 'multi');
+        $clientState = $r->getValue($httpClient);
         $initialShareId = $clientState->share;
         $httpClient->reset();
         self::assertNotSame($initialShareId, $clientState->share);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62633
| License       | MIT

PR #54207 fixed descriptor exhaustion for apps that never issued HTTP calls, but it inadvertently broke the sharing of Curl state between cloned/scoped clients. Any place that pre-creates lots of withOptions() variants before the first real request will now instantiate a separate CurlClientState per variant, leaking curl multi handles relative to previous releases. The fix restores state sharing so multiple clones can still point to the same CurlClientState while maintaining the “only allocate when someone actually sends a request” behavior.

That's the only thing I could think of that'd explain #62633

/cc @jwage can you give this a try?