### PR TITLE
[DependencyInjection] Throw when using `$this` or its internal scope from PHP config files

### DIFF
--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -33,10 +33,10 @@ Console
 DependencyInjection
 -------------------
 
+ * [BC BREAK] Throw when using `$this` or its internal scope from PHP config files; use the `$loader` variable instead
  * Add argument `$target` to `ContainerBuilder::registerAliasForArgument()`
  * Add argument `$throwOnAbstract` to `ContainerBuilder::findTaggedResourceIds()`
  * Deprecate registering a service without a class when its id is a non-existing FQCN
- * Deprecate using `$this` or its internal scope from PHP config files; use the `$loader` variable instead
  * Deprecate XML configuration format, use YAML or PHP instead
  * Deprecate `ExtensionInterface::getXsdValidationBasePath()` and `getNamespace()`;
    bundles that need to support older versions of Symfony can keep the methods

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 7.4
 ---
 
+ * [BC BREAK] Throw when using `$this` or its internal scope from PHP config files; use the `$loader` variable instead
  * Allow adding resource tags using any config format
  * Allow `#[AsAlias]` to be extended
  * Parse attributes found on abstract classes for resource definitions
@@ -12,7 +13,6 @@ CHANGELOG
  * Allow multiple `#[AsDecorator]` attributes
  * Handle declaring services using PHP arrays that follow the same shape as corresponding yaml files
  * Add `AppReference` to help writing PHP configs using yaml-like array-shapes
- * Deprecate using `$this` or its internal scope from PHP config files; use the `$loader` variable instead
  * Deprecate XML configuration format, use YAML or PHP instead
  * Deprecate `ExtensionInterface::getXsdValidationBasePath()` and `getNamespace()`
  * Deprecate the fluent PHP format for semantic configuration, use `$container->extension()` or return an array instead

--- a/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
@@ -98,7 +98,7 @@ class PhpFileLoader extends FileLoader
                     $result = null;
                 }
 
-                trigger_deprecation('symfony/dependency-injection', '7.4', 'Using `$this` or its internal scope in config files is deprecated, use the `$loader` variable instead in "%s" on line %d.', $e->getFile(), $e->getLine());
+                throw new LogicException(\sprintf('Using `$this` or its internal scope in config files is not supported anymore, use the `$loader` variable instead in "%s" on line %d.', $e->getFile(), $e->getLine()), $e->getCode(), $e);
             }
 
             if (\is_object($result) && \is_callable($result)) {
@@ -300,11 +300,4 @@ class PhpFileLoader extends FileLoader
 
         return $loader();
     }
-}
-
-/**
- * @internal
- */
-final class ProtectedPhpFileLoader extends PhpFileLoader
-{
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
@@ -331,14 +331,13 @@ class PhpFileLoaderTest extends TestCase
         $this->assertStringEqualsFile(\dirname(__DIR__).'/Fixtures/php/named_closure_compiled.php', $dumper->dump());
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testTriggersDeprecationWhenAccessingLoaderInternalScope()
     {
         $fixtures = realpath(__DIR__.'/../Fixtures');
         $loader = new PhpFileLoader(new ContainerBuilder(), new FileLocator($fixtures.'/config'));
 
-        $this->expectUserDeprecationMessageMatches('{^Since symfony/dependency-injection 7.4: Using \`\$this\` or its internal scope in config files is deprecated, use the \`\$loader\` variable instead in ".+" on line \d+\.$}');
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessageMatches('/^Using \`\$this\` or its internal scope in config files is not supported anymore, use the \`\$loader\` variable instead in ".+" on line \d+\.$/');
 
         $loader->load('legacy_internal_scope.php');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | #62547 
| License       | MIT

The BC layer brought by #61860 doesn't work: as described in #62547, the first call to load() has side effects which can break when the second and fallback call is made.

I don't see any other way. Well, one would be to operate on a clone, and if that works, rerun with the real container builder. But the overhead is going to be high for everybody.

I'm therefor proposing to change this as a BC BREAK. While less than ideal, this happens at compile time, and the fix is trivial and explained in the error message.