### PR TITLE
[FrameworkBundle] Don't exclude classes with constraint/serialization attributes from being registered as services

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1855,8 +1855,7 @@ class FrameworkExtension extends Extension
         if (class_exists(ValidatorAttributeMetadataPass::class) && (!($config['enable_attributes'] ?? false) || !$container->getParameter('kernel.debug')) && trait_exists(ArgumentTrait::class)) {
             // The $reflector argument hints at where the attribute could be used
             $container->registerAttributeForAutoconfiguration(Constraint::class, static function (ChildDefinition $definition, Constraint $attribute, \ReflectionClass|\ReflectionMethod|\ReflectionProperty $reflector) {
-                $definition->addTag('validator.attribute_metadata')
-                    ->addTag('container.excluded', ['source' => 'because it\'s a validator constraint extension']);
+                $definition->addTag('validator.attribute_metadata');
             });
         }
 
@@ -2121,15 +2120,13 @@ class FrameworkExtension extends Extension
         if (class_exists(SerializerAttributeMetadataPass::class) && (!($config['enable_attributes'] ?? false) || !$container->getParameter('kernel.debug'))) {
             // The $reflector argument hints at where the attribute could be used
             $configurator = static function (ChildDefinition $definition, object $attribute, \ReflectionClass|\ReflectionMethod|\ReflectionProperty $reflector) {
-                $definition->addTag('serializer.attribute_metadata')
-                    ->addTag('container.excluded', ['source' => 'because it\'s a serializer metadata extension']);
+                $definition->addTag('serializer.attribute_metadata');
             };
             $container->registerAttributeForAutoconfiguration(SerializerMapping\Context::class, $configurator);
             $container->registerAttributeForAutoconfiguration(SerializerMapping\Groups::class, $configurator);
 
             $configurator = static function (ChildDefinition $definition, object $attribute, \ReflectionMethod|\ReflectionProperty $reflector) {
-                $definition->addTag('serializer.attribute_metadata')
-                    ->addTag('container.excluded', ['source' => 'because it\'s a serializer metadata extension']);
+                $definition->addTag('serializer.attribute_metadata');
             };
             $container->registerAttributeForAutoconfiguration(SerializerMapping\Ignore::class, $configurator);
             $container->registerAttributeForAutoconfiguration(SerializerMapping\MaxDepth::class, $configurator);
@@ -2137,8 +2134,7 @@ class FrameworkExtension extends Extension
             $container->registerAttributeForAutoconfiguration(SerializerMapping\SerializedPath::class, $configurator);
 
             $container->registerAttributeForAutoconfiguration(SerializerMapping\DiscriminatorMap::class, static function (ChildDefinition $definition) {
-                $definition->addTag('serializer.attribute_metadata')
-                    ->addTag('container.excluded', ['source' => 'because it\'s a serializer metadata extension']);
+                $definition->addTag('serializer.attribute_metadata');
             });
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62641 and https://github.com/symfony/ux/issues/3194
| License       | MIT

Apparently that breaks some apps, and live components 😓 