### PR TITLE
[HttpClient] CachingHttpClient must run after UriTemplate and Scoping

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2870,12 +2870,12 @@ class FrameworkExtension extends Extension
             unset($scopeConfig['retry_failed']);
 
             // This "transport" service is decorated in the following order:
-            // 1. ThrottlingHttpClient (30) -> throttles requests
-            // 2. UriTemplateHttpClient (25) -> expands URI templates
-            // 3. ScopingHttpClient (20) -> resolves relative URLs and applies scope configuration
-            // 4. CachingHttpClient (15) -> caches responses
-            // 5. RetryableHttpClient (10) -> retries requests
-            // 6. TraceableHttpClient (5) -> traces requests
+            // 1. ThrottlingHttpClient (5) -> throttles requests
+            // 2. UriTemplateHttpClient (10) -> expands URI templates
+            // 3. ScopingHttpClient (15) -> resolves relative URLs and applies scope configuration
+            // 4. CachingHttpClient (20) -> caches responses
+            // 5. RetryableHttpClient (25) -> retries requests
+            // 6. TraceableHttpClient (100) -> traces requests
             $container->register($name, HttpClientInterface::class)
                 ->setFactory('current')
                 ->setArguments([[new Reference('http_client.transport')]])
@@ -2883,7 +2883,7 @@ class FrameworkExtension extends Extension
             ;
 
             $scopingDefinition = $container->register($name.'.scoping', ScopingHttpClient::class)
-                ->setDecoratedService($name, null, 20)
+                ->setDecoratedService($name, null, 15)
                 ->addTag('kernel.reset', ['method' => 'reset', 'on_invalid' => 'ignore']);
 
             if (null === $scope) {
@@ -2912,7 +2912,7 @@ class FrameworkExtension extends Extension
 
             $container
                 ->register($name.'.uri_template', UriTemplateHttpClient::class)
-                ->setDecoratedService($name, null, 25)
+                ->setDecoratedService($name, null, 10)
                 ->setArguments([
                     new Reference('.inner'),
                     new Reference('http_client.uri_template_expander', ContainerInterface::NULL_ON_INVALID_REFERENCE),
@@ -2951,7 +2951,7 @@ class FrameworkExtension extends Extension
 
         $container
             ->register($name.'.caching', CachingHttpClient::class)
-            ->setDecoratedService($name, null, 15)
+            ->setDecoratedService($name, null, 20)
             ->setArguments([
                 new Reference('.inner'),
                 new Reference($options['cache_pool']),
@@ -2976,7 +2976,7 @@ class FrameworkExtension extends Extension
 
         $container
             ->register($name.'.throttling', ThrottlingHttpClient::class)
-            ->setDecoratedService($name, null, 30)
+            ->setDecoratedService($name, null, 5)
             ->setArguments([new Reference('.inner'), new Reference($name.'.throttling.limiter')]);
     }
 
@@ -3008,7 +3008,7 @@ class FrameworkExtension extends Extension
 
         $container
             ->register($name.'.retryable', RetryableHttpClient::class)
-            ->setDecoratedService($name, null, 10)
+            ->setDecoratedService($name, null, 25)
             ->setArguments([new Reference('.inner'), $retryStrategy, $options['max_retries'], new Reference('logger')])
             ->addTag('monolog.logger', ['channel' => 'http_client']);
     }

--- a/src/Symfony/Component/HttpClient/DependencyInjection/HttpClientPass.php
+++ b/src/Symfony/Component/HttpClient/DependencyInjection/HttpClientPass.php
@@ -27,7 +27,7 @@ final class HttpClientPass implements CompilerPassInterface
 
         foreach ($container->findTaggedServiceIds('http_client.client') as $id => $tags) {
             $container->register('.debug.'.$id, TraceableHttpClient::class)
-                ->setDecoratedService($id, null, 5)
+                ->setDecoratedService($id, null, 100)
                 ->setArguments([new Reference('.inner'), new Reference('debug.stopwatch', ContainerInterface::IGNORE_ON_INVALID_REFERENCE), new Reference('profiler.is_disabled_state_checker', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)])
                 ->addTag('kernel.reset', ['method' => 'reset']);
             $container->getDefinition('data_collector.http_client')

--- a/src/Symfony/Component/HttpClient/Tests/DependencyInjection/HttpClientPassTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/DependencyInjection/HttpClientPassTest.php
@@ -38,7 +38,7 @@ class HttpClientPassTest extends TestCase
         $sut->process($container);
         $this->assertTrue($container->hasDefinition('.debug.foo'));
         $this->assertSame(TraceableHttpClient::class, $container->getDefinition('.debug.foo')->getClass());
-        $this->assertSame(['foo', null, 5], $container->getDefinition('.debug.foo')->getDecoratedService());
+        $this->assertSame(['foo', null, 100], $container->getDefinition('.debug.foo')->getDecoratedService());
     }
 
     public function testItRegistersDebugHttpClientToCollector()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |7.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #62590 <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

CachingHttpClient needs the final resolved URL (base_uri from ScopingHttpClient + expanded URI templates) to compute correct cache keys.
