### PR TITLE
[FrameworkBundle] Fix using `FailedMessages*Command` with `SigningSerializer`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
@@ -201,7 +201,7 @@ return static function (ContainerConfigurator $container) {
                 service('messenger.routable_message_bus'),
                 service('event_dispatcher'),
                 service('logger')->nullOnInvalid(),
-                service('messenger.transport.native_php_serializer')->nullOnInvalid(),
+                service('.messenger.transport.native_php_serializer')->nullOnInvalid(),
                 null,
             ])
             ->tag('console.command')
@@ -211,7 +211,7 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 abstract_arg('Default failure receiver name'),
                 abstract_arg('Receivers'),
-                service('messenger.transport.native_php_serializer')->nullOnInvalid(),
+                service('.messenger.transport.native_php_serializer')->nullOnInvalid(),
             ])
             ->tag('console.command')
 
@@ -219,7 +219,7 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 abstract_arg('Default failure receiver name'),
                 abstract_arg('Receivers'),
-                service('messenger.transport.native_php_serializer')->nullOnInvalid(),
+                service('.messenger.transport.native_php_serializer')->nullOnInvalid(),
             ])
             ->tag('console.command')
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
@@ -78,7 +78,10 @@ return static function (ContainerConfigurator $container) {
         ->set('serializer.normalizer.flatten_exception', FlattenExceptionNormalizer::class)
             ->tag('serializer.normalizer', ['built_in' => true, 'priority' => -880])
 
+        ->set('.messenger.transport.native_php_serializer', PhpSerializer::class)
         ->set('messenger.transport.native_php_serializer', PhpSerializer::class)
+            ->factory('current')
+            ->args([[service('.messenger.transport.native_php_serializer')]])
         ->alias('messenger.default_serializer', 'messenger.transport.native_php_serializer')
         ->alias(SerializerInterface::class, 'messenger.default_serializer')
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62550
| License       | MIT

Happens when the transport is explicitly set to `messenger.transport.native_php_serializer`, eg:

```yaml
transports:
    async:
        dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
        serializer: messenger.transport.native_php_serializer
```