### PR TITLE
[DependencyInjection] Revert "bug #62541  Reset resolved state when setting a parameter"

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
@@ -112,7 +112,6 @@ class ParameterBag implements ParameterBagInterface
         }
 
         $this->parameters[$name] = $value;
-        $this->resolved = false;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/ParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/ParameterBagTest.php
@@ -356,21 +356,4 @@ class ParameterBagTest extends TestCase
             ['50% is less than 100%', '50% is less than 100%', 'Text between % signs is allowed, if there are spaces.'],
         ];
     }
-
-    public function testAddParametersAfterResolveBreaksConsistency()
-    {
-        $bag = new ParameterBag(['kernel.project_dir' => '/var/www/my_project']);
-        $bag->resolve();
-
-        $this->assertTrue($bag->isResolved());
-
-        $bag->set('app.uploads_dir', '%kernel.project_dir%/public/uploads');
-        $bag->resolve();
-
-        $this->assertSame(
-            '/var/www/my_project/public/uploads',
-            $bag->get('app.uploads_dir'),
-            'ParameterBag failed to resolve new parameters added after initial resolution.'
-        );
-    }
 }


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62541
| License       | MIT

This reverts commit 808365fc5aa2d520e41ab574c1e32dab8540b88d, reversing changes made to 3678f5cc65fcb32f9593ac6ff8423383d0c02ac7.

PR #62541 introduced this. But the change makes the CI red on 7.3.
And looking at the code again, changing the "resolved" state means already resolved parameters are going to be resolved twice.
We could eg resolve immediately when setting a new value inside a resolved bag.
I didn't do it since things were working before so I see no hurry to think about how to fix the fix. I prefer reverting for now.
/cc @yoeunes FYI