### PR TITLE
[Notifier] Fix failing test

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Smsbox/Tests/SmsboxTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsbox/Tests/SmsboxTransportTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Notifier\Bridge\Smsbox\Tests;
 
+use Symfony\Component\Clock\Test\ClockSensitiveTrait;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Notifier\Bridge\Smsbox\Enum\Day;
 use Symfony\Component\Notifier\Bridge\Smsbox\Enum\Encoding;
@@ -28,6 +29,8 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 
 final class SmsboxTransportTest extends TransportTestCase
 {
+    use ClockSensitiveTrait;
+
     public static function createTransport(?HttpClientInterface $client = null): SmsboxTransport
     {
         return new SmsboxTransport('apikey', Mode::Standard, Strategy::Marketing, null, $client ?? new MockHttpClient());
@@ -137,6 +140,8 @@ final class SmsboxTransportTest extends TransportTestCase
 
     public function testQueryDateTime()
     {
+        self::mockTime('2023-12-26');
+
         $message = new SmsMessage('+33612345678', 'Hello!');
         $response = $this->createMock(ResponseInterface::class);
         $response->expects($this->exactly(2))


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

>1) Symfony\Component\Notifier\Bridge\Smsbox\Tests\SmsboxTransportTest::testQueryDateTime
Symfony\Component\Notifier\Exception\InvalidArgumentException: The given DateTime must be greater to the current date.

Started happening cause of line 158:

```php
$dateTime = \DateTimeImmutable::createFromFormat('d/m/Y H:i', '05/12/2025 18:00', new \DateTimeZone('UTC'));
```