### PR TITLE
[FrameworkBundle] Make `ConfigDebugCommand` use its container to resolve env vars

### DIFF
--- a/UPGRADE-6.4.md
+++ b/UPGRADE-6.4.md
@@ -96,7 +96,7 @@ DependencyInjection
 DoctrineBridge
 --------------
 
- * [BC Break] Add argument `$buildDir` to `ProxyCacheWarmer::warmUp()` 
+ * [BC Break] Add argument `$buildDir` to `ProxyCacheWarmer::warmUp()`
  * [BC Break] Add return type-hints to `EntityFactory`
  * Deprecate `DbalLogger`, use a middleware instead
  * Deprecate not constructing `DoctrineDataCollector` with an instance of `DebugDataHolder`

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
@@ -124,6 +124,9 @@ return static function (ContainerConfigurator $container) {
             ->tag('console.command')
 
         ->set('console.command.config_debug', ConfigDebugCommand::class)
+            ->args([
+                service('container.env_var_processors_locator'),
+            ])
             ->tag('console.command')
 
         ->set('console.command.config_dump_reference', ConfigDumpReferenceCommand::class)

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/EnvVarLoader/StatefulEnvVarLoader.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/EnvVarLoader/StatefulEnvVarLoader.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\EnvVarLoader;
+
+use Symfony\Component\DependencyInjection\EnvVarLoaderInterface;
+
+/**
+ * Simulates a vault-like env var loader whose secrets are populated via static
+ * state. This allows tests to control what the loader returns and to verify
+ * that the running container's already-initialized processor (with its cached
+ * env var state) is used by ConfigDebugCommand instead of a freshly-built one.
+ */
+class StatefulEnvVarLoader implements EnvVarLoaderInterface
+{
+    private static array $envVars = [];
+
+    public static function setEnvVar(string $name, string $value): void
+    {
+        self::$envVars[$name] = $value;
+    }
+
+    public static function reset(): void
+    {
+        self::$envVars = [];
+    }
+
+    public function loadEnvVars(): array
+    {
+        return self::$envVars;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/EnvVarLoader/VaultEnvVarPrimer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/EnvVarLoader/VaultEnvVarPrimer.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\EnvVarLoader;
+
+/**
+ * A simple service that holds a resolved env var value.
+ * Used in tests to force the application container's env var processor
+ * to resolve and cache a vault-provided env var before the static loader
+ * state is cleared.
+ */
+class VaultEnvVarPrimer
+{
+    public function __construct(public readonly string $value)
+    {
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDebugCommandTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
 use Symfony\Bundle\FrameworkBundle\Command\ConfigDebugCommand;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\EnvVarLoader\StatefulEnvVarLoader;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
@@ -272,6 +273,34 @@ class ConfigDebugCommandTest extends AbstractWebTestCase
 
         $this->assertSame(1, $tester->getStatusCode());
         $this->assertStringContainsString('Unable to find configuration for "framework.secret.foo"', $tester->getDisplay());
+    }
+
+    public function testEnvVarsResolvedFromRunningContainerProcessor()
+    {
+        // This test reproduces the scenario where an env var is only resolvable via a
+        // loader (e.g. SodiumVault) that is already initialized in the running container
+        // but cannot be re-instantiated inside the freshly built container (e.g. because
+        // its secrets dir or decryption key depends on another vault secret – a circular
+        // dependency). StatefulEnvVarLoader simulates such a vault: after its state is
+        // cleared, new instances return nothing, but the already-running processor
+        // retains the value in its $loadedVars cache.
+        StatefulEnvVarLoader::setEnvVar('TEST_VAULT_SECRET', 'from_loader');
+
+        $application = $this->createApplication(true);
+
+        // Accessing the primer service forces the running container's EnvVarProcessor
+        // to call StatefulEnvVarLoader::loadEnvVars() and cache the result.
+        static::$kernel->getContainer()->get('test.vault_env_var_primer');
+
+        // Clear the loader's static state: from this point on, new StatefulEnvVarLoader
+        // instances (as would be created by the freshly compiled container) return [].
+        StatefulEnvVarLoader::reset();
+
+        $tester = new CommandTester($application->find('debug:config'));
+        $ret = $tester->execute(['name' => 'foo', '--resolve-env' => true]);
+
+        $this->assertSame(0, $ret);
+        $this->assertStringContainsString('vault_test_secret: from_loader', $tester->getDisplay());
     }
 
     private function createCommandTester(bool $debug): CommandTester

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AppKernel.php
@@ -119,7 +119,10 @@ class AppKernel extends Kernel implements ExtensionInterface, ConfigurationInter
     {
         $treeBuilder = new TreeBuilder('foo');
         $rootNode = $treeBuilder->getRootNode();
-        $rootNode->children()->scalarNode('foo')->defaultValue('bar')->end()->end();
+        $rootNode->children()
+            ->scalarNode('foo')->defaultValue('bar')->end()
+            ->scalarNode('vault_test_secret')->defaultValue('')->end()
+        ->end();
 
         return $treeBuilder;
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ConfigDump/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ConfigDump/config.yml
@@ -10,8 +10,22 @@ framework:
         storage_factory_id: session.storage.factory.native
         cookie_httponly: '%env(bool:COOKIE_HTTPONLY)%'
 
+foo:
+    vault_test_secret: '%env(TEST_VAULT_SECRET)%'
+
 parameters:
     env(LOCALE): en
     env(COOKIE_HTTPONLY): '1'
+    env(TEST_VAULT_SECRET): ''
     secret: test
     default_config_test_foo: bar
+
+services:
+    Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\EnvVarLoader\StatefulEnvVarLoader:
+        tags:
+            - container.env_var_loader
+
+    test.vault_env_var_primer:
+        class: Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\EnvVarLoader\VaultEnvVarPrimer
+        arguments: ['%env(TEST_VAULT_SECRET)%']
+        public: true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62554
| License       | MIT

The `ConfigDebugCommand` currently cannot use the `SodiumVault` to load env vars because its `$secretsDir` depends on one, so calling it with `--resolve-env-vars` fails if an env var is only present in the vault. I’m not sure if it’s for the same reason but compiling the container with `$resolveEnvPlaceholders` suffers from the same issue.

I didn’t find a way to fix this so this PR works around it by setting the new container’s env var processors as the command’s so that the vault (and anything that could be used to resolve env vars) is correctly initialized.