### PR TITLE
[Serializer][Validator] Attribute metadata no longer requires `container.excluded` tags

### DIFF
--- a/src/Symfony/Component/Serializer/DependencyInjection/AttributeMetadataPass.php
+++ b/src/Symfony/Component/Serializer/DependencyInjection/AttributeMetadataPass.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Serializer\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Exception\MappingException;
 
 /**
@@ -32,9 +31,6 @@ final class AttributeMetadataPass implements CompilerPassInterface
         foreach ($container->getDefinitions() as $id => $definition) {
             if (!$definition->hasTag('serializer.attribute_metadata')) {
                 continue;
-            }
-            if (!$definition->hasTag('container.excluded')) {
-                throw new InvalidArgumentException(\sprintf('The resource "%s" tagged "serializer.attribute_metadata" is missing the "container.excluded" tag.', $id));
             }
             $class = $resolve($definition->getClass());
             foreach ($definition->getTag('serializer.attribute_metadata') as $attributes) {

--- a/src/Symfony/Component/Serializer/Tests/DependencyInjection/AttributeMetadataPassTest.php
+++ b/src/Symfony/Component/Serializer/Tests/DependencyInjection/AttributeMetadataPassTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Serializer\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\DependencyInjection\AttributeMetadataPass;
 use Symfony\Component\Serializer\Exception\MappingException;
 use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
@@ -52,18 +51,14 @@ class AttributeMetadataPassTest extends TestCase
             ->setArguments([false, []]);
 
         $container->register('service1', '%user_entity.class%')
-            ->addTag('serializer.attribute_metadata')
-            ->addTag('container.excluded');
+            ->addTag('serializer.attribute_metadata');
         $container->register('service2', 'App\Entity\Product')
-            ->addTag('serializer.attribute_metadata')
-            ->addTag('container.excluded');
+            ->addTag('serializer.attribute_metadata');
         $container->register('service3', 'App\Entity\Order')
-            ->addTag('serializer.attribute_metadata')
-            ->addTag('container.excluded');
+            ->addTag('serializer.attribute_metadata');
         // Classes should be deduplicated
         $container->register('service4', 'App\Entity\Order')
-            ->addTag('serializer.attribute_metadata')
-            ->addTag('container.excluded');
+            ->addTag('serializer.attribute_metadata');
 
         (new AttributeMetadataPass())->process($container);
 
@@ -78,18 +73,6 @@ class AttributeMetadataPassTest extends TestCase
         $this->assertSame([false, $expectedClasses], $arguments);
     }
 
-    public function testThrowsWhenMissingExcludedTag()
-    {
-        $container = new ContainerBuilder();
-        $container->register('serializer.mapping.attribute_loader');
-
-        $container->register('service_without_excluded', 'App\\Entity\\User')
-            ->addTag('serializer.attribute_metadata');
-
-        $this->expectException(InvalidArgumentException::class);
-        (new AttributeMetadataPass())->process($container);
-    }
-
     public function testProcessWithForOptionAndMatchingMembers()
     {
         $sourceClass = _AttrMeta_Source::class;
@@ -100,8 +83,7 @@ class AttributeMetadataPassTest extends TestCase
             ->setArguments([false, []]);
 
         $container->register('service.source', $sourceClass)
-            ->addTag('serializer.attribute_metadata', ['for' => $targetClass])
-            ->addTag('container.excluded');
+            ->addTag('serializer.attribute_metadata', ['for' => $targetClass]);
 
         (new AttributeMetadataPass())->process($container);
 
@@ -119,8 +101,7 @@ class AttributeMetadataPassTest extends TestCase
             ->setArguments([false, []]);
 
         $container->register('service.source', $sourceClass)
-            ->addTag('serializer.attribute_metadata', ['for' => $targetClass])
-            ->addTag('container.excluded');
+            ->addTag('serializer.attribute_metadata', ['for' => $targetClass]);
 
         $this->expectException(MappingException::class);
         (new AttributeMetadataPass())->process($container);

--- a/src/Symfony/Component/Validator/DependencyInjection/AttributeMetadataPass.php
+++ b/src/Symfony/Component/Validator/DependencyInjection/AttributeMetadataPass.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Validator\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\Validator\Exception\MappingException;
 
 /**
@@ -32,9 +31,6 @@ final class AttributeMetadataPass implements CompilerPassInterface
         foreach ($container->getDefinitions() as $id => $definition) {
             if (!$definition->hasTag('validator.attribute_metadata')) {
                 continue;
-            }
-            if (!$definition->hasTag('container.excluded')) {
-                throw new InvalidArgumentException(\sprintf('The resource "%s" tagged "validator.attribute_metadata" is missing the "container.excluded" tag.', $id));
             }
             $class = $resolve($definition->getClass());
             foreach ($definition->getTag('validator.attribute_metadata') as $attributes) {

--- a/src/Symfony/Component/Validator/Tests/DependencyInjection/AttributeMetadataPassTest.php
+++ b/src/Symfony/Component/Validator/Tests/DependencyInjection/AttributeMetadataPassTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Validator\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\Validator\DependencyInjection\AttributeMetadataPass;
 use Symfony\Component\Validator\Exception\MappingException;
 
@@ -49,18 +48,14 @@ class AttributeMetadataPassTest extends TestCase
             ->addMethodCall('addAttributeMappings', [[]]);
 
         $container->register('service1', '%user_entity.class%')
-            ->addTag('validator.attribute_metadata')
-            ->addTag('container.excluded');
+            ->addTag('validator.attribute_metadata');
         $container->register('service2', 'App\Entity\Product')
-            ->addTag('validator.attribute_metadata')
-            ->addTag('container.excluded');
+            ->addTag('validator.attribute_metadata');
         $container->register('service3', 'App\Entity\Order')
-            ->addTag('validator.attribute_metadata')
-            ->addTag('container.excluded');
+            ->addTag('validator.attribute_metadata');
         // Classes should be deduplicated
         $container->register('service4', 'App\Entity\Order')
-            ->addTag('validator.attribute_metadata')
-            ->addTag('container.excluded');
+            ->addTag('validator.attribute_metadata');
 
         (new AttributeMetadataPass())->process($container);
 
@@ -77,18 +72,6 @@ class AttributeMetadataPassTest extends TestCase
         $this->assertEquals([$expectedClasses], $methodCalls[1][1]);
     }
 
-    public function testThrowsWhenMissingExcludedTag()
-    {
-        $container = new ContainerBuilder();
-        $container->register('validator.builder');
-
-        $container->register('service_without_excluded', 'App\\Entity\\User')
-            ->addTag('validator.attribute_metadata');
-
-        $this->expectException(InvalidArgumentException::class);
-        (new AttributeMetadataPass())->process($container);
-    }
-
     public function testProcessWithForOptionAndMatchingMembers()
     {
         $sourceClass = _AttrMeta_Source::class;
@@ -98,8 +81,7 @@ class AttributeMetadataPassTest extends TestCase
         $container->register('validator.builder');
 
         $container->register('service.source', $sourceClass)
-            ->addTag('validator.attribute_metadata', ['for' => $targetClass])
-            ->addTag('container.excluded');
+            ->addTag('validator.attribute_metadata', ['for' => $targetClass]);
 
         (new AttributeMetadataPass())->process($container);
 
@@ -118,8 +100,7 @@ class AttributeMetadataPassTest extends TestCase
         $container->register('validator.builder');
 
         $container->register('service.source', $sourceClass)
-            ->addTag('validator.attribute_metadata', ['for' => $targetClass])
-            ->addTag('container.excluded');
+            ->addTag('validator.attribute_metadata', ['for' => $targetClass]);
 
         $this->expectException(MappingException::class);
         (new AttributeMetadataPass())->process($container);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62687
| License       | MIT

Unfortunately, #62647 broke container complitation:

>   The resource "\<FQCN\>" tagged "validator.attribute_metadata" is missing the "container.excluded" tag.  

