### PR TITLE
[DependencyInjection] Ensure `Definition::getTags()` contains a list of attributes for each tag

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -426,7 +426,7 @@ class Definition
      */
     public function setTags(array $tags): static
     {
-        $this->tags = $tags;
+        $this->tags = array_map('array_values', $tags);
 
         return $this;
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/DecoratorServicePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/DecoratorServicePassTest.php
@@ -187,18 +187,18 @@ class DecoratorServicePassTest extends TestCase
         $container = new ContainerBuilder();
         $container
             ->register('foo')
-            ->setTags(['bar' => ['attr' => 'baz']])
+            ->setTags(['bar' => [['attr' => 'baz']]])
         ;
         $container
             ->register('baz')
-            ->setTags(['foobar' => ['attr' => 'bar']])
+            ->setTags(['foobar' => [['attr' => 'bar']]])
             ->setDecoratedService('foo')
         ;
 
         $this->process($container);
 
         $this->assertEmpty($container->getDefinition('baz.inner')->getTags());
-        $this->assertEquals(['bar' => ['attr' => 'baz'], 'foobar' => ['attr' => 'bar'], 'container.decorator' => [['id' => 'foo', 'inner' => 'baz.inner']]], $container->getDefinition('baz')->getTags());
+        $this->assertEquals(['bar' => [['attr' => 'baz']], 'foobar' => [['attr' => 'bar']], 'container.decorator' => [['id' => 'foo', 'inner' => 'baz.inner']]], $container->getDefinition('baz')->getTags());
     }
 
     public function testProcessMovesTagsFromDecoratedDefinitionToDecoratingDefinitionMultipleTimes()
@@ -207,7 +207,7 @@ class DecoratorServicePassTest extends TestCase
         $container
             ->register('foo')
             ->setPublic(true)
-            ->setTags(['bar' => ['attr' => 'baz']])
+            ->setTags(['bar' => [['attr' => 'baz']]])
         ;
         $container
             ->register('deco1')
@@ -221,7 +221,7 @@ class DecoratorServicePassTest extends TestCase
         $this->process($container);
 
         $this->assertEmpty($container->getDefinition('deco1')->getTags());
-        $this->assertEquals(['bar' => ['attr' => 'baz'], 'container.decorator' => [['id' => 'foo', 'inner' => 'deco1.inner']]], $container->getDefinition('deco2')->getTags());
+        $this->assertEquals(['bar' => [['attr' => 'baz']], 'container.decorator' => [['id' => 'foo', 'inner' => 'deco1.inner']]], $container->getDefinition('deco2')->getTags());
     }
 
     public function testProcessLeavesServiceLocatorTagOnOriginalDefinition()
@@ -229,18 +229,18 @@ class DecoratorServicePassTest extends TestCase
         $container = new ContainerBuilder();
         $container
             ->register('foo')
-            ->setTags(['container.service_locator' => [0 => []], 'bar' => ['attr' => 'baz']])
+            ->setTags(['container.service_locator' => [0 => []], 'bar' => [['attr' => 'baz']]])
         ;
         $container
             ->register('baz')
-            ->setTags(['foobar' => ['attr' => 'bar']])
+            ->setTags(['foobar' => [['attr' => 'bar']]])
             ->setDecoratedService('foo')
         ;
 
         $this->process($container);
 
         $this->assertEquals(['container.service_locator' => [0 => []]], $container->getDefinition('baz.inner')->getTags());
-        $this->assertEquals(['bar' => ['attr' => 'baz'], 'foobar' => ['attr' => 'bar'], 'container.decorator' => [['id' => 'foo', 'inner' => 'baz.inner']]], $container->getDefinition('baz')->getTags());
+        $this->assertEquals(['bar' => [['attr' => 'baz']], 'foobar' => [['attr' => 'bar']], 'container.decorator' => [['id' => 'foo', 'inner' => 'baz.inner']]], $container->getDefinition('baz')->getTags());
     }
 
     public function testProcessLeavesServiceSubscriberTagOnOriginalDefinition()
@@ -248,18 +248,18 @@ class DecoratorServicePassTest extends TestCase
         $container = new ContainerBuilder();
         $container
             ->register('foo')
-            ->setTags(['container.service_subscriber' => [], 'container.service_subscriber.locator' => [], 'bar' => ['attr' => 'baz']])
+            ->setTags(['container.service_subscriber' => [], 'container.service_subscriber.locator' => [], 'bar' => [['attr' => 'baz']]])
         ;
         $container
             ->register('baz')
-            ->setTags(['foobar' => ['attr' => 'bar']])
+            ->setTags(['foobar' => [['attr' => 'bar']]])
             ->setDecoratedService('foo')
         ;
 
         $this->process($container);
 
         $this->assertEquals(['container.service_subscriber' => [], 'container.service_subscriber.locator' => []], $container->getDefinition('baz.inner')->getTags());
-        $this->assertEquals(['bar' => ['attr' => 'baz'], 'foobar' => ['attr' => 'bar'], 'container.decorator' => [['id' => 'foo', 'inner' => 'baz.inner']]], $container->getDefinition('baz')->getTags());
+        $this->assertEquals(['bar' => [['attr' => 'baz']], 'foobar' => [['attr' => 'bar']], 'container.decorator' => [['id' => 'foo', 'inner' => 'baz.inner']]], $container->getDefinition('baz')->getTags());
     }
 
     public function testProcessLeavesProxyTagOnOriginalDefinition()
@@ -267,18 +267,18 @@ class DecoratorServicePassTest extends TestCase
         $container = new ContainerBuilder();
         $container
             ->register('foo')
-            ->setTags(['proxy' => 'foo', 'bar' => ['attr' => 'baz']])
+            ->setTags(['proxy' => ['foo'], 'bar' => [['attr' => 'baz']]])
         ;
         $container
             ->register('baz')
-            ->setTags(['foobar' => ['attr' => 'bar']])
+            ->setTags(['foobar' => [['attr' => 'bar']]])
             ->setDecoratedService('foo')
         ;
 
         $this->process($container);
 
-        $this->assertEquals(['proxy' => 'foo'], $container->getDefinition('baz.inner')->getTags());
-        $this->assertEquals(['bar' => ['attr' => 'baz'], 'foobar' => ['attr' => 'bar'], 'container.decorator' => [['id' => 'foo', 'inner' => 'baz.inner']]], $container->getDefinition('baz')->getTags());
+        $this->assertEquals(['proxy' => ['foo']], $container->getDefinition('baz.inner')->getTags());
+        $this->assertEquals(['bar' => [['attr' => 'baz']], 'foobar' => [['attr' => 'bar']], 'container.decorator' => [['id' => 'foo', 'inner' => 'baz.inner']]], $container->getDefinition('baz')->getTags());
     }
 
     public function testCannotDecorateSyntheticService()

--- a/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
@@ -216,6 +216,19 @@ class DefinitionTest extends TestCase
         $this->assertEquals('foo', $def->getConfigurator(), '->getConfigurator() returns the configurator');
     }
 
+    public function testSetTagsAreInList()
+    {
+        $def = new Definition('stdClass');
+        $def->setTags([
+            'tag1' => [5 => ['attr1' => 'value1'], 3 => []],
+            'tag2' => [1 => ['attr2' => 'value2']],
+        ]);
+        $this->assertSame([
+            'tag1' => [['attr1' => 'value1'], []],
+            'tag2' => [['attr2' => 'value2']],
+        ], $def->getTags(), '->setTags() reindex the tags arrays');
+    }
+
     public function testClearTags()
     {
         $def = new Definition('stdClass');

--- a/src/Symfony/Component/Translation/Tests/DependencyInjection/TranslationPathsPassTest.php
+++ b/src/Symfony/Component/Translation/Tests/DependencyInjection/TranslationPathsPassTest.php
@@ -37,7 +37,7 @@ class TranslationPathsPassTest extends TestCase
             ->setArguments([null, null, null, null, null, null, [], []])
         ;
         $container->register(ControllerArguments::class, ControllerArguments::class)
-            ->setTags(['controller.service_arguments'])
+            ->setTags(['controller.service_arguments' => []])
         ;
         $container->register(ServiceArguments::class, ServiceArguments::class)
             ->setArguments([new Reference('translator')])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

In https://github.com/symfony/symfony/pull/62329, we assume that the response of `Definition::getTags()` has the type `array<string, list<array>>`. However, when using `Definition::setTags()`, we can set any `array` value without validation.

In https://github.com/symfony/monolog-bundle/pull/485, the tag attributes are filtered, which generates gaps in the keys. The PR mentioned above causes MonologBundle to fail. This can be fixed by https://github.com/symfony/monolog-bundle/pull/563. However I believe the issue should also be addressed in Symfony.

~This PR targets 7.3 because the bug is in this version, but the patch can be applied in 6.4.~ Switched to 6.4