### PR TITLE
[PropertyInfo] Fix PseudoType support in PhpDocTypeHelper

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\PropertyInfo\Tests\Extractor;
 
 use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\PseudoTypes\IntMask;
+use phpDocumentor\Reflection\PseudoTypes\IntMaskOf;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\ExpectUserDeprecationMessageTrait;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
@@ -909,6 +911,17 @@ class PhpDocExtractorTest extends TestCase
         yield ['numericString', Type::string()];
         yield ['traitString', Type::string()];
         yield ['positiveInt', Type::int()];
+        yield ['true', Type::true()];
+        yield ['false', Type::false()];
+        yield ['valueOfStrings', null];
+        yield ['valueOfIntegers', null];
+        yield ['keyOfStrings', null];
+        yield ['keyOfIntegers', null];
+        yield ['arrayKey', null];
+        yield ['intMask', class_exists(IntMask::class) ? Type::int() : null];
+        yield ['intMaskOf', class_exists(IntMaskOf::class) ? Type::int() : null];
+        yield ['conditional', null];
+        yield ['offsetAccess', null];
     }
 
     /**

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/PseudoTypesDummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/PseudoTypesDummy.php
@@ -16,6 +16,9 @@ namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
  */
 class PseudoTypesDummy
 {
+    public const STRINGS = ['A' => 'A', 'B' => 'B'];
+    public const INTEGERS = [1, 2];
+
     /** @var class-string */
     public $classString;
 
@@ -45,4 +48,37 @@ class PseudoTypesDummy
 
     /** @var literal-string */
     public $literalString;
+
+    /** @var true */
+    public $true;
+
+    /** @var false */
+    public $false;
+
+    /** @var value-of<self::STRINGS> */
+    public $valueOfStrings;
+
+    /** @var value-of<self::INTEGERS> */
+    public $valueOfIntegers;
+
+    /** @var key-of<self::STRINGS> */
+    public $keyOfStrings;
+
+    /** @var key-of<self::INTEGERS> */
+    public $keyOfIntegers;
+
+    /** @var array-key */
+    public $arrayKey;
+
+    /** @var int-mask<1,2,4> */
+    public $intMask;
+
+    /** @var int-mask-of<1|2|4> */
+    public $intMaskOf;
+
+    /** @var (T is int ? string : int) */
+    public $conditional;
+
+    /** @var self::STRINGS['A'] */
+    public $offsetAccess;
 }

--- a/src/Symfony/Component/PropertyInfo/Util/PhpDocTypeHelper.php
+++ b/src/Symfony/Component/PropertyInfo/Util/PhpDocTypeHelper.php
@@ -300,14 +300,6 @@ final class PhpDocTypeHelper
             return Type::array($collectionValueType, $collectionKeyType);
         }
 
-        if ($docType instanceof PseudoType) {
-            if ($docType->underlyingType() instanceof Integer) {
-                return Type::int();
-            } elseif ($docType->underlyingType() instanceof String_) {
-                return Type::string();
-            }
-        }
-
         $docTypeString = match ($docTypeString) {
             'integer' => 'int',
             'boolean' => 'bool',
@@ -324,7 +316,22 @@ final class PhpDocTypeHelper
             return Type::array();
         }
 
-        return null !== $class ? Type::object($class) : Type::builtin($phpType);
+        if (null === $class) {
+            return Type::builtin($phpType);
+        }
+
+        if ($docType instanceof PseudoType) {
+            if ($docType->underlyingType() instanceof Integer) {
+                return Type::int();
+            } elseif ($docType->underlyingType() instanceof String_) {
+                return Type::string();
+            } else {
+                // It's safer to fall back to other extractors here, as resolving pseudo types correctly is not easy at the moment
+                return null;
+            }
+        }
+
+        return Type::object($class);
     }
 
     private function normalizeType(string $docType): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62636
| License       | MIT

The PR on 6.4 is https://github.com/symfony/symfony/pull/62686

I'm not sure how you want to deal with the merges since there will be conflict when merging up 6.4 into 7.3 so I opened both PR to show the changes