### PR TITLE
[DependencyInjection] Fix `PriorityTaggedServiceTrait` when tag attributes are not a list

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
@@ -81,6 +81,7 @@ trait PriorityTaggedServiceTrait
                 $phpAttributes = [];
             }
 
+            $attributes = array_values($attributes);
             for ($i = 0; $i < \count($attributes); ++$i) {
                 if (!($attribute = $attributes[$i]) && $phpAttributes) {
                     array_splice($attributes, $i--, 1, $phpAttributes);

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/PriorityTaggedServiceTraitTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/PriorityTaggedServiceTraitTest.php
@@ -449,6 +449,21 @@ class PriorityTaggedServiceTraitTest extends TestCase
         $this->assertArrayHasKey('foo', $services);
         $this->assertArrayHasKey('default', $services);
     }
+
+    public function testTagAttributesAreNotAList()
+    {
+        $container = new ContainerBuilder();
+        $container->register('service1')->setTags([
+            'my_custom_tag' => [1 => ['attributes' => 'not_a_list']],
+        ]);
+
+        $priorityTaggedServiceTraitImplementation = new PriorityTaggedServiceTraitImplementation();
+
+        $expected = [
+            new Reference('service1'),
+        ];
+        $this->assertEquals($expected, $priorityTaggedServiceTraitImplementation->test('my_custom_tag', $container));
+    }
 }
 
 class PriorityTaggedServiceTraitImplementation


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Alternative to https://github.com/symfony/symfony/pull/62683

Ensure the attributes of the tag are in a list before iterating on them using sequential indexes.

> In https://github.com/symfony/monolog-bundle/pull/485, the tag attributes are filtered, which generates gaps in the keys. The PR mentioned above causes MonologBundle to fail. This can be fixed by https://github.com/symfony/monolog-bundle/pull/563. However I believe the issue should also be addressed in Symfony.