### PR TITLE
[PropertyInfo] Fix PseudoType support in PhpDocTypeHelper

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\PropertyInfo\Tests\Extractor;
 
+use phpDocumentor\Reflection\PseudoTypes\IntMask;
+use phpDocumentor\Reflection\PseudoTypes\IntMaskOf;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy;
@@ -428,7 +430,7 @@ class PhpDocExtractorTest extends TestCase
     /**
      * @dataProvider pseudoTypesProvider
      */
-    public function testPseudoTypes($property, array $type)
+    public function testPseudoTypes($property, ?array $type)
     {
         $this->assertEquals($type, $this->extractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\PseudoTypesDummy', $property));
     }
@@ -445,6 +447,17 @@ class PhpDocExtractorTest extends TestCase
             ['numericString', [new Type(Type::BUILTIN_TYPE_STRING, false, null)]],
             ['traitString', [new Type(Type::BUILTIN_TYPE_STRING, false, null)]],
             ['positiveInt', [new Type(Type::BUILTIN_TYPE_INT, false, null)]],
+            ['true', [new Type(Type::BUILTIN_TYPE_TRUE, false, null)]],
+            ['false', [new Type(Type::BUILTIN_TYPE_FALSE, false, null)]],
+            ['valueOfStrings', null],
+            ['valueOfIntegers', null],
+            ['keyOfStrings', null],
+            ['keyOfIntegers', null],
+            ['arrayKey', null],
+            ['intMask', class_exists(IntMask::class) ? [new Type(Type::BUILTIN_TYPE_INT, false, null)] : null],
+            ['intMaskOf', class_exists(IntMaskOf::class) ? [new Type(Type::BUILTIN_TYPE_INT, false, null)] : null],
+            ['conditional', null],
+            ['offsetAccess', null],
         ];
     }
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/PseudoTypesDummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/PseudoTypesDummy.php
@@ -45,4 +45,37 @@ class PseudoTypesDummy
 
     /** @var literal-string */
     public $literalString;
+
+    /** @var true */
+    public $true;
+
+    /** @var false */
+    public $false;
+
+    /** @var value-of<self::STRINGS> */
+    public $valueOfStrings;
+
+    /** @var value-of<self::INTEGERS> */
+    public $valueOfIntegers;
+
+    /** @var key-of<self::STRINGS> */
+    public $keyOfStrings;
+
+    /** @var key-of<self::INTEGERS> */
+    public $keyOfIntegers;
+
+    /** @var array-key */
+    public $arrayKey;
+
+    /** @var int-mask<1,2,4> */
+    public $intMask;
+
+    /** @var int-mask-of<1|2|4> */
+    public $intMaskOf;
+
+    /** @var (T is int ? string : int) */
+    public $conditional;
+
+    /** @var self::STRINGS['A'] */
+    public $offsetAccess;
 }

--- a/src/Symfony/Component/PropertyInfo/Util/PhpDocTypeHelper.php
+++ b/src/Symfony/Component/PropertyInfo/Util/PhpDocTypeHelper.php
@@ -156,19 +156,26 @@ final class PhpDocTypeHelper
             return new Type(Type::BUILTIN_TYPE_ARRAY, $nullable, null, true, $collectionKeyTypes, $collectionValueTypes);
         }
 
-        if ($type instanceof PseudoType) {
-            if ($type->underlyingType() instanceof Integer) {
-                return new Type(Type::BUILTIN_TYPE_INT, $nullable, null);
-            } elseif ($type->underlyingType() instanceof String_) {
-                return new Type(Type::BUILTIN_TYPE_STRING, $nullable, null);
-            }
-        }
-
         $docType = $this->normalizeType($docType);
         [$phpType, $class] = $this->getPhpTypeAndClass($docType);
 
         if ('array' === $docType) {
             return new Type(Type::BUILTIN_TYPE_ARRAY, $nullable, null, true, null, null);
+        }
+
+        if (null === $class) {
+            return new Type($phpType, $nullable, $class);
+        }
+
+        if ($type instanceof PseudoType) {
+            if ($type->underlyingType() instanceof Integer) {
+                return new Type(Type::BUILTIN_TYPE_INT, $nullable, null);
+            } elseif ($type->underlyingType() instanceof String_) {
+                return new Type(Type::BUILTIN_TYPE_STRING, $nullable, null);
+            } else {
+                // It's safer to fall back to other extractors here, as resolving pseudo types correctly is not easy at the moment
+                return null;
+            }
         }
 
         return new Type($phpType, $nullable, $class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62636
| License       | MIT

The PR on 7.3 is https://github.com/symfony/symfony/pull/62684

I'm not sure how you want to deal with the merges since there will be conflict when merging up 6.4 into 7.3 so I opened both PR to show the changes