### PR TITLE
 Release v7.4.2

### DIFF
--- a/CHANGELOG-7.4.md
+++ b/CHANGELOG-7.4.md
@@ -7,6 +7,11 @@ in 7.4 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v7.4.0...v7.4.1
 
+* 7.4.2 (2025-12-08)
+
+ * bug #62682 [Serializer][Validator] Attribute metadata no longer requires `container.excluded` tags (HypeMC)
+ * bug #62685 [DependencyInjection] Fix `PriorityTaggedServiceTrait` when tag attributes are not a list (GromNaN)
+
 * 7.4.1 (2025-12-07)
 
  * bug #62663 [HttpFoundation] Improve logic in Request::createFromGlobals() (nicolas-grekas)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -74,12 +74,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     private static array $freshCache = [];
 
-    public const VERSION = '7.4.2-DEV';
+    public const VERSION = '7.4.2';
     public const VERSION_ID = 70402;
     public const MAJOR_VERSION = 7;
     public const MINOR_VERSION = 4;
     public const RELEASE_VERSION = 2;
-    public const EXTRA_VERSION = 'DEV';
+    public const EXTRA_VERSION = '';
 
     public const END_OF_MAINTENANCE = '11/2028';
     public const END_OF_LIFE = '11/2029';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v7.4.1...v7.4.2)

 * bug #62682 [Serializer][Validator] Attribute metadata no longer requires `container.excluded` tags (@HypeMC)
 * bug #62685 [DependencyInjection] Fix `PriorityTaggedServiceTrait` when tag attributes are not a list (@GromNaN)
