### PR TITLE
 Release v8.0.2

### DIFF
--- a/CHANGELOG-8.0.md
+++ b/CHANGELOG-8.0.md
@@ -7,6 +7,11 @@ in 8.0 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v8.0.0...v8.0.1
 
+* 8.0.2 (2025-12-08)
+
+ * bug #62682 [Serializer][Validator] Attribute metadata no longer requires `container.excluded` tags (HypeMC)
+ * bug #62685 [DependencyInjection] Fix `PriorityTaggedServiceTrait` when tag attributes are not a list (GromNaN)
+
 * 8.0.1 (2025-12-07)
 
  * bug #62663 [HttpFoundation] Improve logic in Request::createFromGlobals() (nicolas-grekas)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -72,12 +72,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     private static array $freshCache = [];
 
-    public const VERSION = '8.0.2-DEV';
+    public const VERSION = '8.0.2';
     public const VERSION_ID = 80002;
     public const MAJOR_VERSION = 8;
     public const MINOR_VERSION = 0;
     public const RELEASE_VERSION = 2;
-    public const EXTRA_VERSION = 'DEV';
+    public const EXTRA_VERSION = '';
 
     public const END_OF_MAINTENANCE = '07/2026';
     public const END_OF_LIFE = '07/2026';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v8.0.1...v8.0.2)

 * bug #62682 [Serializer][Validator] Attribute metadata no longer requires `container.excluded` tags (@HypeMC)
 * bug #62685 [DependencyInjection] Fix `PriorityTaggedServiceTrait` when tag attributes are not a list (@GromNaN)
