### PR TITLE
[HttpClient] Fix `ScopingHttpClient` to always pass `base_uri` as `string` instead of parsed `array`

### DIFF
--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -170,13 +170,14 @@ trait HttpClientTrait
             unset($options['auth_basic'], $options['auth_bearer']);
 
             // Parse base URI
-            if (\is_string($options['base_uri'])) {
-                $options['base_uri'] = self::parseUrl($options['base_uri']);
+            if (\is_string($baseUri = $options['base_uri'] ?? null)) {
+                $baseUri = self::parseUrl($baseUri);
             }
+            unset($options['base_uri']);
 
             // Validate and resolve URL
             $url = self::parseUrl($url, $options['query']);
-            $url = self::resolveUrl($url, $options['base_uri'], $defaultOptions['query'] ?? []);
+            $url = self::resolveUrl($url, $baseUri, $defaultOptions['query'] ?? []);
         }
 
         // Finalize normalization of options

--- a/src/Symfony/Component/HttpClient/RetryableHttpClient.php
+++ b/src/Symfony/Component/HttpClient/RetryableHttpClient.php
@@ -201,6 +201,8 @@ class RetryableHttpClient implements HttpClientInterface, ResetInterface
         if ($baseUris) {
             $baseUri = 1 < \count($baseUris) ? array_shift($baseUris) : current($baseUris);
             $options['base_uri'] = \is_array($baseUri) ? $baseUri[array_rand($baseUri)] : $baseUri;
+        } elseif (\is_array($options['base_uri'] ?? null)) {
+            unset($options['base_uri']);
         }
 
         return $options;

--- a/src/Symfony/Component/HttpClient/ScopingHttpClient.php
+++ b/src/Symfony/Component/HttpClient/ScopingHttpClient.php
@@ -56,9 +56,11 @@ class ScopingHttpClient implements HttpClientInterface, ResetInterface, LoggerAw
     {
         $e = null;
         $url = self::parseUrl($url, $options['query'] ?? []);
+        $resolved = false;
 
         if (\is_string($options['base_uri'] ?? null)) {
             $options['base_uri'] = self::parseUrl($options['base_uri']);
+            $resolved = true;
         }
 
         try {
@@ -72,8 +74,13 @@ class ScopingHttpClient implements HttpClientInterface, ResetInterface, LoggerAw
             $options = self::mergeDefaultOptions($options, $defaultOptions, true);
             if (\is_string($options['base_uri'] ?? null)) {
                 $options['base_uri'] = self::parseUrl($options['base_uri']);
+                $resolved = true;
             }
             $url = implode('', self::resolveUrl($url, $options['base_uri'] ?? null, $defaultOptions['query'] ?? []));
+        }
+
+        if ($resolved) {
+            unset($options['base_uri']);
         }
 
         foreach ($this->defaultOptionsByRegexp as $regexp => $defaultOptions) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62697
| License       | MIT

### Problem
* `ScopingHttpClient` parsed the `base_uri` into an `array` (scheme, path, query, etc.).
* When passing this parsed value to a decorated client such as `RetryableHttpClient`, it caused errors.
* According to the `HttpClientInterface` in Symfony Contracts, `base_uri` [must be a string](https://github.com/symfony/symfony/blob/6.4/src/Symfony/Contracts/HttpClient/HttpClientInterface.php#L45)

### Solution
* Updated `ScopingHttpClient` so it always forwards `base_uri` as a `string`, not as a parsed array.
* The change is applied for all decorated clients, not only `RetryableHttpClient`, since sending an `array` was not compliant with the `HttpClientInterface` comment.

### Additional Notes
Originally, the idea was to apply this fix only when the decorated client was `RetryableHttpClient` and later add full support for parsed `base_uri` for `RetryableHttpClient` in version 8.1.
However, after reviewing the `HttpClientInterface`, it became clear that sending a parsed `array` for `base_uri` was incorrect.
Therefore, the behavior is now corrected universally.