### PR TITLE
[Mailer][Mandrill] Implement the X-MC-Tags header

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+* Add support for specifying tags using the `X-MC-Tags` header
+
 7.4
 ---
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Transport/MandrillApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Transport/MandrillApiTransportTest.php
@@ -81,6 +81,21 @@ class MandrillApiTransportTest extends TestCase
         $this->assertArrayNotHasKey('headers', $payload['message']);
     }
 
+    public function testTagsHeaderIsAddedToPayload()
+    {
+        $email = new Email();
+        $email->getHeaders()->addTextHeader('X-MC-Tags', 'foo,bar');
+        $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
+
+        $transport = new MandrillApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(MandrillApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertArrayHasKey('tags', $payload['message']);
+        $this->assertEquals(['foo', 'bar'], $payload['message']['tags']);
+        $this->assertArrayNotHasKey('headers', $payload['message']);
+    }
+
     public function testSend()
     {
         $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillApiTransport.php
@@ -97,6 +97,10 @@ class MandrillApiTransport extends AbstractApiTransport
             $payload['message']['subaccount'] = $email->getHeaders()->get('X-MC-Subaccount')->getBodyAsString();
         }
 
+        if ($email->getHeaders()->get('X-MC-Tags')) {
+            $payload['message']['tags'] = explode(',', $email->getHeaders()->get('X-MC-Tags')->getBodyAsString());
+        }
+
         if ('' !== $envelope->getSender()->getName()) {
             $payload['message']['from_name'] = $envelope->getSender()->getName();
         }
@@ -122,7 +126,7 @@ class MandrillApiTransport extends AbstractApiTransport
         }
 
         foreach ($email->getHeaders()->all() as $name => $header) {
-            if (\in_array($name, ['from', 'to', 'cc', 'bcc', 'subject', 'content-type', 'x-mc-subaccount'], true)) {
+            if (\in_array($name, ['from', 'to', 'cc', 'bcc', 'subject', 'content-type', 'x-mc-subaccount', 'x-mc-tags'], true)) {
                 continue;
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | N/A
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- Implements Mandrills X-MC-Tags header when sending via the API
- https://mailchimp.com/developer/transactional/docs/tags-metadata/#tags

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
