### PR TITLE
[Config] Add default generic to Configuration to TParent generic

### DIFF
--- a/src/Symfony/Component/Config/Definition/Builder/FloatNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/FloatNodeDefinition.php
@@ -16,7 +16,7 @@ use Symfony\Component\Config\Definition\FloatNode;
 /**
  * This class provides a fluent interface for defining a float node.
  *
- * @template TParent of NodeParentInterface|null
+ * @template TParent of NodeParentInterface|null = null
  *
  * @extends NumericNodeDefinition<TParent>
  *

--- a/src/Symfony/Component/Config/Definition/Builder/IntegerNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/IntegerNodeDefinition.php
@@ -16,7 +16,7 @@ use Symfony\Component\Config\Definition\IntegerNode;
 /**
  * This class provides a fluent interface for defining an integer node.
  *
- * @template TParent of NodeParentInterface|null
+ * @template TParent of NodeParentInterface|null = null
  *
  * @extends NumericNodeDefinition<TParent>
  *

--- a/src/Symfony/Component/Config/Definition/Builder/NodeBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NodeBuilder.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Config\Definition\Builder;
 /**
  * This class provides a fluent interface for building a node.
  *
- * @template TParent of (NodeDefinition&ParentNodeDefinitionInterface)|null
+ * @template TParent of (NodeDefinition&ParentNodeDefinitionInterface)|null = null
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */

--- a/src/Symfony/Component/Config/Definition/Builder/NodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NodeDefinition.php
@@ -19,7 +19,7 @@ use Symfony\Component\Config\Definition\NodeInterface;
 /**
  * This class provides a fluent interface for defining a node.
  *
- * @template TParent of NodeParentInterface|null
+ * @template TParent of NodeParentInterface|null = null
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */

--- a/src/Symfony/Component/Config/Definition/Builder/NumericNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NumericNodeDefinition.php
@@ -16,7 +16,7 @@ use Symfony\Component\Config\Definition\Exception\InvalidDefinitionException;
 /**
  * Abstract class that contains common code of integer and float node definitions.
  *
- * @template TParent of NodeParentInterface|null
+ * @template TParent of NodeParentInterface|null = null
  *
  * @extends ScalarNodeDefinition<TParent>
  *

--- a/src/Symfony/Component/Config/Definition/Builder/ScalarNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ScalarNodeDefinition.php
@@ -16,7 +16,7 @@ use Symfony\Component\Config\Definition\ScalarNode;
 /**
  * This class provides a fluent interface for defining a node.
  *
- * @template TParent of NodeParentInterface|null
+ * @template TParent of NodeParentInterface|null = null
  *
  * @extends VariableNodeDefinition<TParent>
  *

--- a/src/Symfony/Component/Config/Definition/Builder/StringNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/StringNodeDefinition.php
@@ -16,7 +16,7 @@ use Symfony\Component\Config\Definition\StringNode;
 /**
  * This class provides a fluent interface for defining a node.
  *
- * @template TParent of NodeParentInterface|null
+ * @template TParent of NodeParentInterface|null = null
  *
  * @extends ScalarNodeDefinition<TParent>
  *

--- a/src/Symfony/Component/Config/Definition/Builder/VariableNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/VariableNodeDefinition.php
@@ -17,7 +17,7 @@ use Symfony\Component\Config\Definition\VariableNode;
 /**
  * This class provides a fluent interface for defining a node.
  *
- * @template TParent of NodeParentInterface|null
+ * @template TParent of NodeParentInterface|null = null
  *
  * @extends NodeDefinition<TParent>
  *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? |no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

Missed in https://github.com/symfony/symfony/pull/62616.

Define all TParent which are nullable as default null.