### PR TITLE
[HttpClient] Fix PHP deprecation when using `AmpHttpClient`

### DIFF
--- a/src/Symfony/Component/HttpClient/AmpHttpClient.php
+++ b/src/Symfony/Component/HttpClient/AmpHttpClient.php
@@ -133,9 +133,9 @@ final class AmpHttpClient implements HttpClientInterface, LoggerAwareInterface, 
             $request->addHeader($h[0], $h[1]);
         }
 
-        $request->setTcpConnectTimeout(1000 * $options['timeout']);
-        $request->setTlsHandshakeTimeout(1000 * $options['timeout']);
-        $request->setTransferTimeout(1000 * $options['max_duration']);
+        $request->setTcpConnectTimeout(ceil(1000 * $options['timeout']));
+        $request->setTlsHandshakeTimeout(ceil(1000 * $options['timeout']));
+        $request->setTransferTimeout(ceil(1000 * $options['max_duration']));
         if (method_exists($request, 'setInactivityTimeout')) {
             $request->setInactivityTimeout(0);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The deprecation happens when max_duration becomes a float in `AsyncContext::replaceRequest()`.