### PR TITLE
[Cache][HttpKernel] Fix `#[Cache]` overrides controller no-store directive

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/CacheAttributeListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/CacheAttributeListener.php
@@ -170,6 +170,7 @@ class CacheAttributeListener implements EventSubscriberInterface
         }
 
         $hasPublicOrPrivateCacheControlDirective = $hasCacheControlDirective('public') || $hasCacheControlDirective('private');
+        $hasNoStoreCacheControlDirective = $hasCacheControlDirective('no-store');
 
         foreach ($attributes as $cache) {
             if (true === $cache->public && !$hasPublicOrPrivateCacheControlDirective) {
@@ -184,7 +185,7 @@ class CacheAttributeListener implements EventSubscriberInterface
                 $response->headers->addCacheControlDirective('no-store');
             }
 
-            if (false === $cache->noStore) {
+            if (false === $cache->noStore && !$hasNoStoreCacheControlDirective) {
                 $response->headers->removeCacheControlDirective('no-store');
             }
         }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/CacheAttributeListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/CacheAttributeListenerTest.php
@@ -407,6 +407,17 @@ class CacheAttributeListenerTest extends TestCase
         $this->assertFalse($response->headers->hasCacheControlDirective('private'));
     }
 
+    public function testAttributeNoStoreDoesNotRemoveExplicitNoStore()
+    {
+        $request = $this->createRequest(new Cache(noStore: false));
+        $response = new Response();
+        $response->headers->addCacheControlDirective('no-store');
+
+        $this->listener->onKernelResponse($this->createEventMock($request, $response));
+
+        $this->assertTrue($response->headers->hasCacheControlDirective('no-store'));
+    }
+
     public static function provideVaryHeaderScenarios(): \Traversable
     {
         yield 'no vary headers at all' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Issues        | -
| License       | MIT

Related to #62488 

Using no-store still overrides the controller

```php
#[Cache(noStore: false)]
public function index(): Response
{
    $response = new Response();
    $response->headers->addCacheControlDirective('no-store');
    
    return $response;
}
```
Expected : `Cache-Control : no-store, private`
Result : `Cache-Control : no-cache, private`
