### PR TITLE
[TwigBundle] Fix unintended BC break for the `exception_controller` twig setting

### DIFF
--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -183,6 +183,11 @@ Translation
 
  * Deprecate `TranslatableMessage::__toString`
 
+TwigBundle
+----------
+
+ * Deprecate setting the `exception_controller` config to `null`. This was a legacy opt-out of a deprecation that is a no-op since Symfony 5.0. Remove that setting entirely instead.
+
 Uid
 ---
 

--- a/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.4
+---
+
+* Deprecate setting the `exception_controller` config to `null`. This was a legacy opt-out of a deprecation that is a no-op since Symfony 5.0. Remove that setting entirely instead.
+
 7.3
 ---
 

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -20,6 +20,7 @@
         "composer-runtime-api": ">=2.1",
         "symfony/config": "^7.4|^8.0",
         "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/twig-bridge": "^7.3|^8.0",
         "symfony/http-foundation": "^6.4|^7.0|^8.0",
         "symfony/http-kernel": "^6.4.13|^7.1.6|^8.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | yes <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | n/a
| License       | MIT

Setting the `exception_controller` setting to `null` was the opt-in for the Symfony 5.0 behavior in TwigBundle 4.4 and so was kept supported as a no-op in 5.0+ to support the migration path, without ever being deprecated.
This setting was removed in 7.4.0 without deprecation, without realizing that it was part of this compat layer. This replaces this removal with a deprecation (reported as if it was introduced in 7.4 from the start) while the removal will be preserved in Symfony 8.0.
