### PR TITLE
[PhpUnitBridge] Fix TestCase patching

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit.php
+++ b/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit.php
@@ -276,6 +276,7 @@ if (!file_exists("$PHPUNIT_DIR/$PHPUNIT_VERSION_DIR/phpunit") || $configurationH
         if ($PHPUNIT_REMOVE_RETURN_TYPEHINT) {
             $alteredCode = preg_replace('/^    ((?:protected|public)(?: static)? function \w+\(\)): void/m', '    $1', $alteredCode);
         }
+        file_put_contents($alteredFile, $alteredCode);
 
         // Mutate Assert code
         $alteredCode = file_get_contents($alteredFile = './src/Framework/Assert.php');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

Removing the `void` return type with `SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT ` no longer works in Symfony 7.4+.

It seems `file_put_contents()` has been removed by accident in #61472.