### PR TITLE
[PropertyInfo] fix `@var` tag support for `PhpStanExtractor`

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
@@ -182,7 +182,7 @@ final class PhpStanExtractor implements PropertyDescriptionExtractorInterface, P
         trigger_deprecation('symfony/property-info', '7.3', 'The "%s()" method is deprecated, use "%s::getTypeFromConstructor()" instead.', __METHOD__, self::class);
 
         if (null === $tagDocNode = $this->getDocBlockFromConstructor($class, $property)) {
-            return null;
+            return $this->getTypes($class, $property);
         }
 
         $types = [];
@@ -247,7 +247,7 @@ final class PhpStanExtractor implements PropertyDescriptionExtractorInterface, P
     {
         $declaringClass = $class;
         if (!$tagDocNode = $this->getDocBlockFromConstructor($declaringClass, $property)) {
-            return null;
+            return $this->getType($class, $property);
         }
 
         $typeContext = $this->typeContextFactory->createFromClassName($class, $declaringClass);

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/ConstructorDummyWithVarTagsDocBlock.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/ConstructorDummyWithVarTagsDocBlock.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+
+class ConstructorDummyWithVarTagsDocBlock
+{
+    public function __construct(
+        public \DateTimeZone $timezone,
+        /** @var int */
+        public $date,
+        /** @var \DateTimeInterface */
+        public $dateObject,
+        public \DateTimeImmutable $dateTime,
+        public $mixed,
+        /** @var ConstructorDummy[] */
+        public array $objectsArray,
+    )
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Issues        | Fix #62712
| License       | MIT

added fallback when no `__construct` PHPDocBlock exists

