### PR TITLE
[DependencyInjection] Handle recursive factory reentry for shared services in `PhpDumper`

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -458,7 +458,7 @@ EOF;
         foreach ($edges as $edge) {
             $node = $edge->getDestNode();
             $id = $node->getId();
-            if ($sourceId === $id || !$node->getValue() instanceof Definition || $edge->isWeak()) {
+            if (($sourceId === $id && !$edge->isLazy()) || !$node->getValue() instanceof Definition || $edge->isWeak()) {
                 continue;
             }
 
@@ -699,7 +699,6 @@ EOF;
 
         $asGhostObject = false;
         $isProxyCandidate = $this->isProxyCandidate($definition, $asGhostObject, $id);
-        $instantiation = '';
 
         $lastWitherIndex = null;
         foreach ($definition->getMethodCalls() as $k => $call) {
@@ -708,20 +707,26 @@ EOF;
             }
         }
 
-        if (!$isProxyCandidate && $definition->isShared() && !isset($this->singleUsePrivateIds[$id]) && null === $lastWitherIndex) {
-            $instantiation = \sprintf('$container->%s[%s] = %s', $this->container->getDefinition($id)->isPublic() ? 'services' : 'privates', $this->doExport($id), $isSimpleInstance ? '' : '$instance');
-        } elseif (!$isSimpleInstance) {
-            $instantiation = '$instance';
+        $shouldShareInline = !$isProxyCandidate && $definition->isShared() && !isset($this->singleUsePrivateIds[$id]) && null === $lastWitherIndex;
+        $serviceAccessor = \sprintf('$container->%s[%s]', $this->container->getDefinition($id)->isPublic() ? 'services' : 'privates', $this->doExport($id));
+        $return = match (true) {
+            $shouldShareInline && !isset($this->circularReferences[$id]) && $isSimpleInstance=> 'return '.$serviceAccessor.' = ',
+            $shouldShareInline && !isset($this->circularReferences[$id]) => $serviceAccessor.' = $instance = ',
+            $shouldShareInline || !$isSimpleInstance => '$instance = ',
+            default => 'return ',
+        };
+
+        $code = $this->addNewInstance($definition, '        '.$return, $id, $asGhostObject);
+
+        if ($shouldShareInline && isset($this->circularReferences[$id])) {
+            $code .= \sprintf(
+                "\n        if (isset(%s)) {\n            return %1\$s;\n        }\n\n        %s%1\$s = \$instance;\n",
+                $serviceAccessor,
+                $isSimpleInstance ? 'return ' : ''
+            );
         }
 
-        $return = '';
-        if ($isSimpleInstance) {
-            $return = 'return ';
-        } else {
-            $instantiation .= ' = ';
-        }
-
-        return $this->addNewInstance($definition, '        '.$return.$instantiation, $id, $asGhostObject);
+        return $code;
     }
 
     private function isTrivialInstance(Definition $definition): bool
@@ -1055,7 +1060,7 @@ EOTXT
         $code = '';
 
         if ($isSimpleInstance = $isRootInstance = null === $inlineDef) {
-            foreach ($this->serviceCalls as $targetId => [$callCount, $behavior, $byConstructor]) {
+            foreach ($this->serviceCalls as $targetId => [, , $byConstructor]) {
                 if ($byConstructor && isset($this->circularReferences[$id][$targetId]) && !$this->circularReferences[$id][$targetId] && !($this->hasProxyDumper && $definition->isLazy())) {
                     $code .= $this->addInlineReference($id, $definition, $targetId, $forConstructor);
                 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/lazy_autowire_attribute_with_intersection.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/lazy_autowire_attribute_with_intersection.php
@@ -61,7 +61,13 @@ class ProjectServiceContainer extends Container
             return $container->services['foo'];
         }
 
-        return $container->services['foo'] = new \Symfony\Component\DependencyInjection\Tests\Compiler\AAndIInterfaceConsumer($a);
+        $instance = new \Symfony\Component\DependencyInjection\Tests\Compiler\AAndIInterfaceConsumer($a);
+
+        if (isset($container->services['foo'])) {
+            return $container->services['foo'];
+        }
+
+        return $container->services['foo'] = $instance;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/legacy_lazy_autowire_attribute_with_intersection.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/legacy_lazy_autowire_attribute_with_intersection.php
@@ -61,7 +61,13 @@ class ProjectServiceContainer extends Container
             return $container->services['foo'];
         }
 
-        return $container->services['foo'] = new \Symfony\Component\DependencyInjection\Tests\Compiler\AAndIInterfaceConsumer($a);
+        $instance = new \Symfony\Component\DependencyInjection\Tests\Compiler\AAndIInterfaceConsumer($a);
+
+        if (isset($container->services['foo'])) {
+            return $container->services['foo'];
+        }
+
+        return $container->services['foo'] = $instance;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_as_files.txt
@@ -117,7 +117,13 @@ class getBazService extends ProjectServiceContainer
      */
     public static function do($container, $lazyLoad = true)
     {
-        $container->services['baz'] = $instance = new \Baz();
+        $instance = new \Baz();
+
+        if (isset($container->services['baz'])) {
+            return $container->services['baz'];
+        }
+
+        $container->services['baz'] = $instance;
 
         $instance->setFoo(($container->services['foo_with_inline'] ?? $container->load('getFooWithInlineService')));
 
@@ -339,7 +345,13 @@ class getFooWithInlineService extends ProjectServiceContainer
      */
     public static function do($container, $lazyLoad = true)
     {
-        $container->services['foo_with_inline'] = $instance = new \Foo();
+        $instance = new \Foo();
+
+        if (isset($container->services['foo_with_inline'])) {
+            return $container->services['foo_with_inline'];
+        }
+
+        $container->services['foo_with_inline'] = $instance;
 
         $a = new \Bar();
         $a->pub = 'pub';

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -162,7 +162,13 @@ class ProjectServiceContainer extends Container
      */
     protected static function getBazService($container)
     {
-        $container->services['baz'] = $instance = new \Baz();
+        $instance = new \Baz();
+
+        if (isset($container->services['baz'])) {
+            return $container->services['baz'];
+        }
+
+        $container->services['baz'] = $instance;
 
         $instance->setFoo(($container->services['foo_with_inline'] ?? self::getFooWithInlineService($container)));
 
@@ -310,7 +316,13 @@ class ProjectServiceContainer extends Container
      */
     protected static function getFooWithInlineService($container)
     {
-        $container->services['foo_with_inline'] = $instance = new \Foo();
+        $instance = new \Foo();
+
+        if (isset($container->services['foo_with_inline'])) {
+            return $container->services['foo_with_inline'];
+        }
+
+        $container->services['foo_with_inline'] = $instance;
 
         $a = new \Bar();
         $a->pub = 'pub';

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_inlined_factories.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_inlined_factories.txt
@@ -181,7 +181,13 @@ class ProjectServiceContainer extends Container
      */
     protected static function getBazService($container)
     {
-        $container->services['baz'] = $instance = new \Baz();
+        $instance = new \Baz();
+
+        if (isset($container->services['baz'])) {
+            return $container->services['baz'];
+        }
+
+        $container->services['baz'] = $instance;
 
         $instance->setFoo(($container->services['foo_with_inline'] ?? self::getFooWithInlineService($container)));
 
@@ -331,7 +337,13 @@ class ProjectServiceContainer extends Container
      */
     protected static function getFooWithInlineService($container)
     {
-        $container->services['foo_with_inline'] = $instance = new \Foo();
+        $instance = new \Foo();
+
+        if (isset($container->services['foo_with_inline'])) {
+            return $container->services['foo_with_inline'];
+        }
+
+        $container->services['foo_with_inline'] = $instance;
 
         $a = new \Bar();
         $a->pub = 'pub';

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_adawson.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_adawson.php
@@ -78,7 +78,13 @@ class ProjectServiceContainer extends Container
      */
     protected static function getDbService($container)
     {
-        $container->services['App\\Db'] = $instance = new \App\Db();
+        $instance = new \App\Db();
+
+        if (isset($container->services['App\\Db'])) {
+            return $container->services['App\\Db'];
+        }
+
+        $container->services['App\\Db'] = $instance;
 
         $instance->schema = ($container->privates['App\\Schema'] ?? self::getSchemaService($container));
 
@@ -98,6 +104,12 @@ class ProjectServiceContainer extends Container
             return $container->privates['App\\Schema'];
         }
 
-        return $container->privates['App\\Schema'] = new \App\Schema($a);
+        $instance = new \App\Schema($a);
+
+        if (isset($container->privates['App\\Schema'])) {
+            return $container->privates['App\\Schema'];
+        }
+
+        return $container->privates['App\\Schema'] = $instance;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_private.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_private.php
@@ -106,7 +106,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
      */
     protected static function getBar2Service($container)
     {
-        $container->services['bar2'] = $instance = new \BarCircular();
+        $instance = new \BarCircular();
+
+        if (isset($container->services['bar2'])) {
+            return $container->services['bar2'];
+        }
+
+        $container->services['bar2'] = $instance;
 
         $instance->addFoobar(new \FoobarCircular(($container->services['foo2'] ?? self::getFoo2Service($container))));
 
@@ -154,7 +160,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
 
         $b = new \stdClass();
 
-        $container->services['connection'] = $instance = new \stdClass($a, $b);
+        $instance = new \stdClass($a, $b);
+
+        if (isset($container->services['connection'])) {
+            return $container->services['connection'];
+        }
+
+        $container->services['connection'] = $instance;
 
         $b->logger = ($container->services['logger'] ?? self::getLoggerService($container));
 
@@ -174,7 +186,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
 
         $b = new \stdClass();
 
-        $container->services['connection2'] = $instance = new \stdClass($a, $b);
+        $instance = new \stdClass($a, $b);
+
+        if (isset($container->services['connection2'])) {
+            return $container->services['connection2'];
+        }
+
+        $container->services['connection2'] = $instance;
 
         $c = new \stdClass($instance);
 
@@ -202,7 +220,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
         }, 1));
         $a->flag = 'ok';
 
-        return $container->services['doctrine.entity_manager'] = \FactoryChecker::create($a);
+        $instance = \FactoryChecker::create($a);
+
+        if (isset($container->services['doctrine.entity_manager'])) {
+            return $container->services['doctrine.entity_manager'];
+        }
+
+        return $container->services['doctrine.entity_manager'] = $instance;
     }
 
     /**
@@ -234,7 +258,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
             return $container->services['foo2'];
         }
 
-        return $container->services['foo2'] = new \FooCircular($a);
+        $instance = new \FooCircular($a);
+
+        if (isset($container->services['foo2'])) {
+            return $container->services['foo2'];
+        }
+
+        return $container->services['foo2'] = $instance;
     }
 
     /**
@@ -261,7 +291,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
      */
     protected static function getFoo6Service($container)
     {
-        $container->services['foo6'] = $instance = new \stdClass();
+        $instance = new \stdClass();
+
+        if (isset($container->services['foo6'])) {
+            return $container->services['foo6'];
+        }
+
+        $container->services['foo6'] = $instance;
 
         $instance->bar6 = ($container->privates['bar6'] ?? self::getBar6Service($container));
 
@@ -291,7 +327,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
      */
     protected static function getListener3Service($container)
     {
-        $container->services['listener3'] = $instance = new \stdClass();
+        $instance = new \stdClass();
+
+        if (isset($container->services['listener3'])) {
+            return $container->services['listener3'];
+        }
+
+        $container->services['listener3'] = $instance;
 
         $instance->manager = ($container->services['manager3'] ?? self::getManager3Service($container));
 
@@ -311,7 +353,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
             return $container->services['listener4'];
         }
 
-        return $container->services['listener4'] = new \stdClass($a);
+        $instance = new \stdClass($a);
+
+        if (isset($container->services['listener4'])) {
+            return $container->services['listener4'];
+        }
+
+        return $container->services['listener4'] = $instance;
     }
 
     /**
@@ -327,7 +375,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
             return $container->services['logger'];
         }
 
-        $container->services['logger'] = $instance = new \stdClass($a);
+        $instance = new \stdClass($a);
+
+        if (isset($container->services['logger'])) {
+            return $container->services['logger'];
+        }
+
+        $container->services['logger'] = $instance;
 
         $instance->handler = new \stdClass(($container->services['manager'] ?? self::getManagerService($container)));
 
@@ -347,7 +401,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
             return $container->services['manager'];
         }
 
-        return $container->services['manager'] = new \stdClass($a);
+        $instance = new \stdClass($a);
+
+        if (isset($container->services['manager'])) {
+            return $container->services['manager'];
+        }
+
+        return $container->services['manager'] = $instance;
     }
 
     /**
@@ -363,7 +423,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
             return $container->services['manager2'];
         }
 
-        return $container->services['manager2'] = new \stdClass($a);
+        $instance = new \stdClass($a);
+
+        if (isset($container->services['manager2'])) {
+            return $container->services['manager2'];
+        }
+
+        return $container->services['manager2'] = $instance;
     }
 
     /**
@@ -379,7 +445,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
             return $container->services['manager3'];
         }
 
-        return $container->services['manager3'] = new \stdClass($a);
+        $instance = new \stdClass($a);
+
+        if (isset($container->services['manager3'])) {
+            return $container->services['manager3'];
+        }
+
+        return $container->services['manager3'] = $instance;
     }
 
     /**
@@ -424,7 +496,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
         }
         $b = new \stdClass();
 
-        $container->services['pA'] = $instance = new \stdClass($b, $a);
+        $instance = new \stdClass($b, $a);
+
+        if (isset($container->services['pA'])) {
+            return $container->services['pA'];
+        }
+
+        $container->services['pA'] = $instance;
 
         $b->d = ($container->privates['pD'] ?? self::getPDService($container));
 
@@ -460,7 +538,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
             return $container->services['subscriber'];
         }
 
-        return $container->services['subscriber'] = new \stdClass($a);
+        $instance = new \stdClass($a);
+
+        if (isset($container->services['subscriber'])) {
+            return $container->services['subscriber'];
+        }
+
+        return $container->services['subscriber'] = $instance;
     }
 
     /**
@@ -476,7 +560,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
             return $container->privates['bar6'];
         }
 
-        return $container->privates['bar6'] = new \stdClass($a);
+        $instance = new \stdClass($a);
+
+        if (isset($container->privates['bar6'])) {
+            return $container->privates['bar6'];
+        }
+
+        return $container->privates['bar6'] = $instance;
     }
 
     /**
@@ -486,7 +576,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
      */
     protected static function getConnection3Service($container)
     {
-        $container->privates['connection3'] = $instance = new \stdClass();
+        $instance = new \stdClass();
+
+        if (isset($container->privates['connection3'])) {
+            return $container->privates['connection3'];
+        }
+
+        $container->privates['connection3'] = $instance;
 
         $instance->listener = [($container->services['listener3'] ?? self::getListener3Service($container))];
 
@@ -500,7 +596,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
      */
     protected static function getConnection4Service($container)
     {
-        $container->privates['connection4'] = $instance = new \stdClass();
+        $instance = new \stdClass();
+
+        if (isset($container->privates['connection4'])) {
+            return $container->privates['connection4'];
+        }
+
+        $container->privates['connection4'] = $instance;
 
         $instance->listener = [($container->services['listener4'] ?? self::getListener4Service($container))];
 
@@ -520,7 +622,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
             return $container->privates['doctrine.listener'];
         }
 
-        return $container->privates['doctrine.listener'] = new \stdClass($a);
+        $instance = new \stdClass($a);
+
+        if (isset($container->privates['doctrine.listener'])) {
+            return $container->privates['doctrine.listener'];
+        }
+
+        return $container->privates['doctrine.listener'] = $instance;
     }
 
     /**
@@ -546,10 +654,16 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
      */
     protected static function getMailer_TransportService($container)
     {
-        return $container->privates['mailer.transport'] = (new \FactoryCircular(new RewindableGenerator(function () use ($container) {
+        $instance = (new \FactoryCircular(new RewindableGenerator(function () use ($container) {
             yield 0 => ($container->privates['mailer.transport_factory.amazon'] ?? self::getMailer_TransportFactory_AmazonService($container));
             yield 1 => self::getMailerInline_TransportFactory_AmazonService($container);
         }, 2)))->create();
+
+        if (isset($container->privates['mailer.transport'])) {
+            return $container->privates['mailer.transport'];
+        }
+
+        return $container->privates['mailer.transport'] = $instance;
     }
 
     /**
@@ -561,7 +675,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
     {
         $a = new \stdClass();
 
-        $container->privates['mailer.transport_factory.amazon'] = $instance = new \stdClass($a);
+        $instance = new \stdClass($a);
+
+        if (isset($container->privates['mailer.transport_factory.amazon'])) {
+            return $container->privates['mailer.transport_factory.amazon'];
+        }
+
+        $container->privates['mailer.transport_factory.amazon'] = $instance;
 
         $a->handler = ($container->privates['mailer.transport'] ?? self::getMailer_TransportService($container));
 
@@ -604,7 +724,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
             return $container->privates['manager4'];
         }
 
-        return $container->privates['manager4'] = new \stdClass($a);
+        $instance = new \stdClass($a);
+
+        if (isset($container->privates['manager4'])) {
+            return $container->privates['manager4'];
+        }
+
+        return $container->privates['manager4'] = $instance;
     }
 
     /**
@@ -614,7 +740,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
      */
     protected static function getPCService($container, $lazyLoad = true)
     {
-        $container->privates['pC'] = $instance = new \stdClass();
+        $instance = new \stdClass();
+
+        if (isset($container->privates['pC'])) {
+            return $container->privates['pC'];
+        }
+
+        $container->privates['pC'] = $instance;
 
         $instance->d = ($container->privates['pD'] ?? self::getPDService($container));
 
@@ -634,6 +766,12 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
             return $container->privates['pD'];
         }
 
-        return $container->privates['pD'] = new \stdClass($a);
+        $instance = new \stdClass($a);
+
+        if (isset($container->privates['pD'])) {
+            return $container->privates['pD'];
+        }
+
+        return $container->privates['pD'] = $instance;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_public.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_public.php
@@ -106,7 +106,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected static function getBarService($container)
     {
-        $container->services['bar'] = $instance = new \BarCircular();
+        $instance = new \BarCircular();
+
+        if (isset($container->services['bar'])) {
+            return $container->services['bar'];
+        }
+
+        $container->services['bar'] = $instance;
 
         $instance->addFoobar(($container->services['foobar'] ?? self::getFoobarService($container)));
 
@@ -142,7 +148,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
             return $container->services['bar5'];
         }
 
-        $container->services['bar5'] = $instance = new \stdClass($a);
+        $instance = new \stdClass($a);
+
+        if (isset($container->services['bar5'])) {
+            return $container->services['bar5'];
+        }
+
+        $container->services['bar5'] = $instance;
 
         $instance->foo = $a;
 
@@ -177,7 +189,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
         }
         $b = new \stdClass();
 
-        $container->services['connection'] = $instance = new \stdClass($a, $b);
+        $instance = new \stdClass($a, $b);
+
+        if (isset($container->services['connection'])) {
+            return $container->services['connection'];
+        }
+
+        $container->services['connection'] = $instance;
 
         $b->logger = ($container->services['logger'] ?? self::getLoggerService($container));
 
@@ -198,7 +216,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
         }
         $b = new \stdClass();
 
-        $container->services['connection2'] = $instance = new \stdClass($a, $b);
+        $instance = new \stdClass($a, $b);
+
+        if (isset($container->services['connection2'])) {
+            return $container->services['connection2'];
+        }
+
+        $container->services['connection2'] = $instance;
 
         $c = new \stdClass($instance);
         $c->handler2 = new \stdClass(($container->services['manager2'] ?? self::getManager2Service($container)));
@@ -215,7 +239,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected static function getConnection3Service($container)
     {
-        $container->services['connection3'] = $instance = new \stdClass();
+        $instance = new \stdClass();
+
+        if (isset($container->services['connection3'])) {
+            return $container->services['connection3'];
+        }
+
+        $container->services['connection3'] = $instance;
 
         $instance->listener = [($container->services['listener3'] ?? self::getListener3Service($container))];
 
@@ -229,7 +259,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected static function getConnection4Service($container)
     {
-        $container->services['connection4'] = $instance = new \stdClass();
+        $instance = new \stdClass();
+
+        if (isset($container->services['connection4'])) {
+            return $container->services['connection4'];
+        }
+
+        $container->services['connection4'] = $instance;
 
         $instance->listener = [($container->services['listener4'] ?? self::getListener4Service($container))];
 
@@ -243,7 +279,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected static function getDispatcherService($container, $lazyLoad = true)
     {
-        $container->services['dispatcher'] = $instance = new \stdClass();
+        $instance = new \stdClass();
+
+        if (isset($container->services['dispatcher'])) {
+            return $container->services['dispatcher'];
+        }
+
+        $container->services['dispatcher'] = $instance;
 
         $instance->subscriber = ($container->services['subscriber'] ?? self::getSubscriberService($container));
 
@@ -257,7 +299,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected static function getDispatcher2Service($container, $lazyLoad = true)
     {
-        $container->services['dispatcher2'] = $instance = new \stdClass();
+        $instance = new \stdClass();
+
+        if (isset($container->services['dispatcher2'])) {
+            return $container->services['dispatcher2'];
+        }
+
+        $container->services['dispatcher2'] = $instance;
 
         $instance->subscriber2 = ($container->privates['subscriber2'] ?? self::getSubscriber2Service($container));
 
@@ -271,9 +319,15 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected static function getDoctrine_EntityListenerResolverService($container)
     {
-        return $container->services['doctrine.entity_listener_resolver'] = new \stdClass(new RewindableGenerator(function () use ($container) {
+        $instance = new \stdClass(new RewindableGenerator(function () use ($container) {
             yield 0 => ($container->services['doctrine.listener'] ?? self::getDoctrine_ListenerService($container));
         }, 1));
+
+        if (isset($container->services['doctrine.entity_listener_resolver'])) {
+            return $container->services['doctrine.entity_listener_resolver'];
+        }
+
+        return $container->services['doctrine.entity_listener_resolver'] = $instance;
     }
 
     /**
@@ -292,7 +346,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
         $b->resolver = $a;
         $b->flag = 'ok';
 
-        return $container->services['doctrine.entity_manager'] = \FactoryChecker::create($b);
+        $instance = \FactoryChecker::create($b);
+
+        if (isset($container->services['doctrine.entity_manager'])) {
+            return $container->services['doctrine.entity_manager'];
+        }
+
+        return $container->services['doctrine.entity_manager'] = $instance;
     }
 
     /**
@@ -308,7 +368,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
             return $container->services['doctrine.listener'];
         }
 
-        return $container->services['doctrine.listener'] = new \stdClass($a);
+        $instance = new \stdClass($a);
+
+        if (isset($container->services['doctrine.listener'])) {
+            return $container->services['doctrine.listener'];
+        }
+
+        return $container->services['doctrine.listener'] = $instance;
     }
 
     /**
@@ -324,7 +390,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
             return $container->services['foo'];
         }
 
-        return $container->services['foo'] = new \FooCircular($a);
+        $instance = new \FooCircular($a);
+
+        if (isset($container->services['foo'])) {
+            return $container->services['foo'];
+        }
+
+        return $container->services['foo'] = $instance;
     }
 
     /**
@@ -336,7 +408,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
     {
         $a = new \BarCircular();
 
-        $container->services['foo2'] = $instance = new \FooCircular($a);
+        $instance = new \FooCircular($a);
+
+        if (isset($container->services['foo2'])) {
+            return $container->services['foo2'];
+        }
+
+        $container->services['foo2'] = $instance;
 
         $a->addFoobar(($container->services['foobar2'] ?? self::getFoobar2Service($container)));
 
@@ -368,7 +446,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected static function getFoo5Service($container)
     {
-        $container->services['foo5'] = $instance = new \stdClass();
+        $instance = new \stdClass();
+
+        if (isset($container->services['foo5'])) {
+            return $container->services['foo5'];
+        }
+
+        $container->services['foo5'] = $instance;
 
         $instance->bar = ($container->services['bar5'] ?? self::getBar5Service($container));
 
@@ -382,7 +466,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected static function getFoo6Service($container)
     {
-        $container->services['foo6'] = $instance = new \stdClass();
+        $instance = new \stdClass();
+
+        if (isset($container->services['foo6'])) {
+            return $container->services['foo6'];
+        }
+
+        $container->services['foo6'] = $instance;
 
         $instance->bar6 = ($container->privates['bar6'] ?? self::getBar6Service($container));
 
@@ -402,7 +492,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
             return $container->services['foobar'];
         }
 
-        return $container->services['foobar'] = new \FoobarCircular($a);
+        $instance = new \FoobarCircular($a);
+
+        if (isset($container->services['foobar'])) {
+            return $container->services['foobar'];
+        }
+
+        return $container->services['foobar'] = $instance;
     }
 
     /**
@@ -418,7 +514,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
             return $container->services['foobar2'];
         }
 
-        return $container->services['foobar2'] = new \FoobarCircular($a);
+        $instance = new \FoobarCircular($a);
+
+        if (isset($container->services['foobar2'])) {
+            return $container->services['foobar2'];
+        }
+
+        return $container->services['foobar2'] = $instance;
     }
 
     /**
@@ -454,7 +556,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected static function getListener3Service($container)
     {
-        $container->services['listener3'] = $instance = new \stdClass();
+        $instance = new \stdClass();
+
+        if (isset($container->services['listener3'])) {
+            return $container->services['listener3'];
+        }
+
+        $container->services['listener3'] = $instance;
 
         $instance->manager = ($container->services['manager3'] ?? self::getManager3Service($container));
 
@@ -474,7 +582,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
             return $container->services['listener4'];
         }
 
-        return $container->services['listener4'] = new \stdClass($a);
+        $instance = new \stdClass($a);
+
+        if (isset($container->services['listener4'])) {
+            return $container->services['listener4'];
+        }
+
+        return $container->services['listener4'] = $instance;
     }
 
     /**
@@ -490,7 +604,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
             return $container->services['logger'];
         }
 
-        $container->services['logger'] = $instance = new \stdClass($a);
+        $instance = new \stdClass($a);
+
+        if (isset($container->services['logger'])) {
+            return $container->services['logger'];
+        }
+
+        $container->services['logger'] = $instance;
 
         $instance->handler = new \stdClass(($container->services['manager'] ?? self::getManagerService($container)));
 
@@ -510,7 +630,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
             return $container->services['mailer.transport'];
         }
 
-        return $container->services['mailer.transport'] = $a->create();
+        $instance = $a->create();
+
+        if (isset($container->services['mailer.transport'])) {
+            return $container->services['mailer.transport'];
+        }
+
+        return $container->services['mailer.transport'] = $instance;
     }
 
     /**
@@ -520,10 +646,16 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected static function getMailer_TransportFactoryService($container)
     {
-        return $container->services['mailer.transport_factory'] = new \FactoryCircular(new RewindableGenerator(function () use ($container) {
+        $instance = new \FactoryCircular(new RewindableGenerator(function () use ($container) {
             yield 0 => ($container->services['mailer.transport_factory.amazon'] ?? self::getMailer_TransportFactory_AmazonService($container));
             yield 1 => ($container->services['mailer_inline.transport_factory.amazon'] ?? self::getMailerInline_TransportFactory_AmazonService($container));
         }, 2));
+
+        if (isset($container->services['mailer.transport_factory'])) {
+            return $container->services['mailer.transport_factory'];
+        }
+
+        return $container->services['mailer.transport_factory'] = $instance;
     }
 
     /**
@@ -539,7 +671,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
             return $container->services['mailer.transport_factory.amazon'];
         }
 
-        return $container->services['mailer.transport_factory.amazon'] = new \stdClass($a);
+        $instance = new \stdClass($a);
+
+        if (isset($container->services['mailer.transport_factory.amazon'])) {
+            return $container->services['mailer.transport_factory.amazon'];
+        }
+
+        return $container->services['mailer.transport_factory.amazon'] = $instance;
     }
 
     /**
@@ -575,7 +713,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
             return $container->services['manager'];
         }
 
-        return $container->services['manager'] = new \stdClass($a);
+        $instance = new \stdClass($a);
+
+        if (isset($container->services['manager'])) {
+            return $container->services['manager'];
+        }
+
+        return $container->services['manager'] = $instance;
     }
 
     /**
@@ -591,7 +735,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
             return $container->services['manager2'];
         }
 
-        return $container->services['manager2'] = new \stdClass($a);
+        $instance = new \stdClass($a);
+
+        if (isset($container->services['manager2'])) {
+            return $container->services['manager2'];
+        }
+
+        return $container->services['manager2'] = $instance;
     }
 
     /**
@@ -607,7 +757,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
             return $container->services['manager3'];
         }
 
-        return $container->services['manager3'] = new \stdClass($a);
+        $instance = new \stdClass($a);
+
+        if (isset($container->services['manager3'])) {
+            return $container->services['manager3'];
+        }
+
+        return $container->services['manager3'] = $instance;
     }
 
     /**
@@ -631,7 +787,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected static function getMonolog_Logger2Service($container)
     {
-        $container->services['monolog.logger_2'] = $instance = new \stdClass();
+        $instance = new \stdClass();
+
+        if (isset($container->services['monolog.logger_2'])) {
+            return $container->services['monolog.logger_2'];
+        }
+
+        $container->services['monolog.logger_2'] = $instance;
 
         $instance->handler = ($container->services['mailer.transport'] ?? self::getMailer_TransportService($container));
 
@@ -684,7 +846,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
             return $container->services['pA'];
         }
 
-        return $container->services['pA'] = new \stdClass($a, $b);
+        $instance = new \stdClass($a, $b);
+
+        if (isset($container->services['pA'])) {
+            return $container->services['pA'];
+        }
+
+        return $container->services['pA'] = $instance;
     }
 
     /**
@@ -694,7 +862,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected static function getPBService($container)
     {
-        $container->services['pB'] = $instance = new \stdClass();
+        $instance = new \stdClass();
+
+        if (isset($container->services['pB'])) {
+            return $container->services['pB'];
+        }
+
+        $container->services['pB'] = $instance;
 
         $instance->d = ($container->services['pD'] ?? self::getPDService($container));
 
@@ -708,7 +882,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected static function getPCService($container, $lazyLoad = true)
     {
-        $container->services['pC'] = $instance = new \stdClass();
+        $instance = new \stdClass();
+
+        if (isset($container->services['pC'])) {
+            return $container->services['pC'];
+        }
+
+        $container->services['pC'] = $instance;
 
         $instance->d = ($container->services['pD'] ?? self::getPDService($container));
 
@@ -728,7 +908,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
             return $container->services['pD'];
         }
 
-        return $container->services['pD'] = new \stdClass($a);
+        $instance = new \stdClass($a);
+
+        if (isset($container->services['pD'])) {
+            return $container->services['pD'];
+        }
+
+        return $container->services['pD'] = $instance;
     }
 
     /**
@@ -760,7 +946,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
             return $container->services['subscriber'];
         }
 
-        return $container->services['subscriber'] = new \stdClass($a);
+        $instance = new \stdClass($a);
+
+        if (isset($container->services['subscriber'])) {
+            return $container->services['subscriber'];
+        }
+
+        return $container->services['subscriber'] = $instance;
     }
 
     /**
@@ -776,7 +968,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
             return $container->privates['bar6'];
         }
 
-        return $container->privates['bar6'] = new \stdClass($a);
+        $instance = new \stdClass($a);
+
+        if (isset($container->privates['bar6'])) {
+            return $container->privates['bar6'];
+        }
+
+        return $container->privates['bar6'] = $instance;
     }
 
     /**
@@ -818,7 +1016,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
             return $container->privates['manager4'];
         }
 
-        return $container->privates['manager4'] = new \stdClass($a);
+        $instance = new \stdClass($a);
+
+        if (isset($container->privates['manager4'])) {
+            return $container->privates['manager4'];
+        }
+
+        return $container->privates['manager4'] = $instance;
     }
 
     /**
@@ -834,6 +1038,12 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
             return $container->privates['subscriber2'];
         }
 
-        return $container->privates['subscriber2'] = new \stdClass($a);
+        $instance = new \stdClass($a);
+
+        if (isset($container->privates['subscriber2'])) {
+            return $container->privates['subscriber2'];
+        }
+
+        return $container->privates['subscriber2'] = $instance;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_deep_graph.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_deep_graph.php
@@ -50,7 +50,13 @@ class Symfony_DI_PhpDumper_Test_Deep_Graph extends Container
      */
     protected static function getBarService($container)
     {
-        $container->services['bar'] = $instance = new \stdClass();
+        $instance = new \stdClass();
+
+        if (isset($container->services['bar'])) {
+            return $container->services['bar'];
+        }
+
+        $container->services['bar'] = $instance;
 
         $instance->p5 = new \stdClass(($container->services['foo'] ?? self::getFooService($container)));
 
@@ -76,6 +82,12 @@ class Symfony_DI_PhpDumper_Test_Deep_Graph extends Container
 
         $b->p2 = $c;
 
-        return $container->services['foo'] = new \Symfony\Component\DependencyInjection\Tests\Dumper\FooForDeepGraph($a, $b);
+        $instance = new \Symfony\Component\DependencyInjection\Tests\Dumper\FooForDeepGraph($a, $b);
+
+        if (isset($container->services['foo'])) {
+            return $container->services['foo'];
+        }
+
+        return $container->services['foo'] = $instance;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_errored_definition.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_errored_definition.php
@@ -162,7 +162,13 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
      */
     protected static function getBazService($container)
     {
-        $container->services['baz'] = $instance = new \Baz();
+        $instance = new \Baz();
+
+        if (isset($container->services['baz'])) {
+            return $container->services['baz'];
+        }
+
+        $container->services['baz'] = $instance;
 
         $instance->setFoo(($container->services['foo_with_inline'] ?? self::getFooWithInlineService($container)));
 
@@ -310,7 +316,13 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
      */
     protected static function getFooWithInlineService($container)
     {
-        $container->services['foo_with_inline'] = $instance = new \Foo();
+        $instance = new \Foo();
+
+        if (isset($container->services['foo_with_inline'])) {
+            return $container->services['foo_with_inline'];
+        }
+
+        $container->services['foo_with_inline'] = $instance;
 
         $a = new \Bar();
         $a->pub = 'pub';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #49591
| License       | MIT

It took me a while to figure this out.
As with some other non-trivial circular loops, it's possible that a service factory is called twice for the same shared service, but in the end, only one instance should be used and shared.
