### PR TITLE
[DependencyInjection] Fix sharing services used only by tagged iterators

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
@@ -41,6 +41,7 @@ class AnalyzeServiceReferencesPass extends AbstractRecursivePass
     private bool $lazy;
     private bool $byConstructor;
     private bool $byFactory;
+    private bool $byMultiUseArgument;
     private array $definitions;
     private array $aliases;
 
@@ -67,6 +68,7 @@ class AnalyzeServiceReferencesPass extends AbstractRecursivePass
         $this->lazy = false;
         $this->byConstructor = false;
         $this->byFactory = false;
+        $this->byMultiUseArgument = false;
         $this->definitions = $container->getDefinitions();
         $this->aliases = $container->getAliases();
 
@@ -89,7 +91,12 @@ class AnalyzeServiceReferencesPass extends AbstractRecursivePass
 
         if ($value instanceof ArgumentInterface) {
             $this->lazy = !$this->byFactory || !$value instanceof IteratorArgument;
+            $byMultiUseArgument = $this->byMultiUseArgument;
+            if ($value instanceof IteratorArgument) {
+                $this->byMultiUseArgument = true;
+            }
             parent::processValue($value->getValues());
+            $this->byMultiUseArgument = $byMultiUseArgument;
             $this->lazy = $lazy;
 
             return $value;
@@ -106,7 +113,8 @@ class AnalyzeServiceReferencesPass extends AbstractRecursivePass
                 $value,
                 $this->lazy || ($this->hasProxyDumper && $targetDefinition?->isLazy()),
                 ContainerInterface::IGNORE_ON_UNINITIALIZED_REFERENCE === $value->getInvalidBehavior(),
-                $this->byConstructor
+                $this->byConstructor,
+                $this->byMultiUseArgument
             );
 
             if ($inExpression) {
@@ -117,7 +125,9 @@ class AnalyzeServiceReferencesPass extends AbstractRecursivePass
                     $targetDefinition,
                     $value,
                     $this->lazy || $targetDefinition?->isLazy(),
-                    true
+                    true,
+                    $this->byConstructor,
+                    $this->byMultiUseArgument
                 );
             }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/ServiceReferenceGraph.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ServiceReferenceGraph.php
@@ -74,7 +74,7 @@ class ServiceReferenceGraph
     /**
      * Connects 2 nodes together in the Graph.
      */
-    public function connect(?string $sourceId, mixed $sourceValue, ?string $destId, mixed $destValue = null, ?Reference $reference = null, bool $lazy = false, bool $weak = false, bool $byConstructor = false): void
+    public function connect(?string $sourceId, mixed $sourceValue, ?string $destId, mixed $destValue = null, ?Reference $reference = null, bool $lazy = false, bool $weak = false, bool $byConstructor = false, bool $byMultiUseArgument = false): void
     {
         if (null === $sourceId || null === $destId) {
             return;
@@ -82,7 +82,7 @@ class ServiceReferenceGraph
 
         $sourceNode = $this->createNode($sourceId, $sourceValue);
         $destNode = $this->createNode($destId, $destValue);
-        $edge = new ServiceReferenceGraphEdge($sourceNode, $destNode, $reference, $lazy, $weak, $byConstructor);
+        $edge = new ServiceReferenceGraphEdge($sourceNode, $destNode, $reference, $lazy, $weak, $byConstructor, $byMultiUseArgument);
 
         $sourceNode->addOutEdge($edge);
         $destNode->addInEdge($edge);

--- a/src/Symfony/Component/DependencyInjection/Compiler/ServiceReferenceGraphEdge.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ServiceReferenceGraphEdge.php
@@ -26,8 +26,9 @@ class ServiceReferenceGraphEdge
     private bool $lazy;
     private bool $weak;
     private bool $byConstructor;
+    private bool $byMultiUseArgument;
 
-    public function __construct(ServiceReferenceGraphNode $sourceNode, ServiceReferenceGraphNode $destNode, mixed $value = null, bool $lazy = false, bool $weak = false, bool $byConstructor = false)
+    public function __construct(ServiceReferenceGraphNode $sourceNode, ServiceReferenceGraphNode $destNode, mixed $value = null, bool $lazy = false, bool $weak = false, bool $byConstructor = false, bool $byMultiUseArgument = false)
     {
         $this->sourceNode = $sourceNode;
         $this->destNode = $destNode;
@@ -35,6 +36,7 @@ class ServiceReferenceGraphEdge
         $this->lazy = $lazy;
         $this->weak = $weak;
         $this->byConstructor = $byConstructor;
+        $this->byMultiUseArgument = $byMultiUseArgument;
     }
 
     /**
@@ -83,5 +85,10 @@ class ServiceReferenceGraphEdge
     public function isReferencedByConstructor(): bool
     {
         return $this->byConstructor;
+    }
+
+    public function isFromMultiUseArgument(): bool
+    {
+        return $this->byMultiUseArgument;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -710,7 +710,7 @@ EOF;
         $shouldShareInline = !$isProxyCandidate && $definition->isShared() && !isset($this->singleUsePrivateIds[$id]) && null === $lastWitherIndex;
         $serviceAccessor = \sprintf('$container->%s[%s]', $this->container->getDefinition($id)->isPublic() ? 'services' : 'privates', $this->doExport($id));
         $return = match (true) {
-            $shouldShareInline && !isset($this->circularReferences[$id]) && $isSimpleInstance=> 'return '.$serviceAccessor.' = ',
+            $shouldShareInline && !isset($this->circularReferences[$id]) && $isSimpleInstance => 'return '.$serviceAccessor.' = ',
             $shouldShareInline && !isset($this->circularReferences[$id]) => $serviceAccessor.' = $instance = ',
             $shouldShareInline || !$isSimpleInstance => '$instance = ',
             default => 'return ',
@@ -2194,7 +2194,7 @@ EOF;
             if (!$value = $edge->getSourceNode()->getValue()) {
                 continue;
             }
-            if ($edge->isLazy() || !$value instanceof Definition || !$value->isShared()) {
+            if ($edge->isLazy() || !$value instanceof Definition || !$value->isShared() || $edge->isFromMultiUseArgument()) {
                 return false;
             }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_private.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_private.php
@@ -656,7 +656,7 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
     {
         $instance = (new \FactoryCircular(new RewindableGenerator(function () use ($container) {
             yield 0 => ($container->privates['mailer.transport_factory.amazon'] ?? self::getMailer_TransportFactory_AmazonService($container));
-            yield 1 => self::getMailerInline_TransportFactory_AmazonService($container);
+            yield 1 => ($container->privates['mailer_inline.transport_factory.amazon'] ?? self::getMailerInline_TransportFactory_AmazonService($container));
         }, 2)))->create();
 
         if (isset($container->privates['mailer.transport'])) {
@@ -708,7 +708,7 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
         $a = new \stdClass();
         $a->handler = ($container->privates['mailer_inline.mailer'] ?? self::getMailerInline_MailerService($container));
 
-        return new \stdClass($a);
+        return $container->privates['mailer_inline.transport_factory.amazon'] = new \stdClass($a);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #51095
| License       | MIT

Because tagged iterators are rewindable, the services they yield must be remembered, even if the iterator is the only consumer of said services. At the moment, there's an optimization in PhpDumper that inlines single-use services into their consumers, but when it's a tagged iterator, this conflicts with the rewindable feature.