### PR TITLE
[PropertyInfo] fix `@var` tag support for `PhpStanExtractor`

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
@@ -154,7 +154,7 @@ final class PhpStanExtractor implements PropertyTypeExtractorInterface, Construc
     public function getTypesFromConstructor(string $class, string $property): ?array
     {
         if (null === $tagDocNode = $this->getDocBlockFromConstructor($class, $property)) {
-            return null;
+            return $this->getTypes($class, $property);
         }
 
         $types = [];

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
@@ -370,9 +370,27 @@ class PhpStanExtractorTest extends TestCase
             ['date', [new Type(Type::BUILTIN_TYPE_INT)]],
             ['timezone', [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTimeZone')]],
             ['dateObject', [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTimeInterface')]],
-            ['dateTime', null],
+            ['dateTime', [new Type(Type::BUILTIN_TYPE_INT)]],
             ['ddd', null],
         ];
+    }
+
+    /**
+     * @dataProvider provideConstructorTypesWithOnlyVarTags
+     */
+    public function testExtractConstructorTypesWithOnlyVarTags($property, ?array $type = null)
+    {
+        $this->assertEquals($type, $this->extractor->getTypesFromConstructor('Symfony\Component\PropertyInfo\Tests\Fixtures\ConstructorDummyWithVarTagsDocBlock', $property));
+    }
+
+    public static function provideConstructorTypesWithOnlyVarTags()
+    {
+        yield ['date', [new Type(Type::BUILTIN_TYPE_INT)]];
+        yield ['dateObject', [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTimeInterface')]];
+        yield ['objectsArray', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_OBJECT, false, 'Symfony\Component\PropertyInfo\Tests\Fixtures\ConstructorDummy'))]];
+        yield ['dateTime', null];
+        yield ['mixed', null];
+        yield ['timezone', null];
     }
 
     /**

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/ConstructorDummyWithVarTagsDocBlock.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/ConstructorDummyWithVarTagsDocBlock.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+
+class ConstructorDummyWithVarTagsDocBlock
+{
+    public function __construct(
+        public \DateTimeZone $timezone,
+        /** @var int */
+        public $date,
+        /** @var \DateTimeInterface */
+        public $dateObject,
+        public \DateTimeImmutable $dateTime,
+        public $mixed,
+        /** @var ConstructorDummy[] */
+        public array $objectsArray,
+    )
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62712
| License       | MIT

added fallback when no __construct PHPDocBlock exists

duplicate for https://github.com/symfony/symfony/pull/62713
