### PR TITLE
[Workflow] Fix empty string condition for place name

### DIFF
--- a/src/Symfony/Component/Workflow/Arc.php
+++ b/src/Symfony/Component/Workflow/Arc.php
@@ -23,7 +23,7 @@ final class Arc
         if ($weight < 1) {
             throw new \InvalidArgumentException(\sprintf('The weight must be greater than 0, %d given.', $weight));
         }
-        if (!$place) {
+        if ('' === $place) {
             throw new \InvalidArgumentException('The place name cannot be empty.');
         }
     }

--- a/src/Symfony/Component/Workflow/Tests/ArcTest.php
+++ b/src/Symfony/Component/Workflow/Tests/ArcTest.php
@@ -31,4 +31,10 @@ class ArcTest extends TestCase
 
         new Arc('not empty', 0);
     }
+
+    public function testConstructorWithZeroPlaceName()
+    {
+        $arc = new Arc('0', 1);
+        $this->assertEquals('0', $arc->place);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| License       | MIT

Since 7.4 it is not possible to set "0" as name which is a thing when using constants. This fixes the empty string condition for the place name. 

Simple example

```yaml
framework:
    workflows:
        blog_publishing:
            type: 'state_machine'
            # ...
            places:
                - '0' # const draft
                - '1' # const reviewed
                - '2' # const rejected
                - '3' # const published
            transitions:
                to_review:
                    from: '0'
                    to: '1'
                publish:
                    from: '1'
                    to: '3'
                reject:
                    from: '1'
                    to: '2'
```

Would throw 
> The place name cannot be empty.
