### PR TITLE
[HttpClient] mark response stale when age equals freshness lifetime

### DIFF
--- a/src/Symfony/Component/HttpClient/CachingHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CachingHttpClient.php
@@ -559,7 +559,7 @@ class CachingHttpClient implements HttpClientInterface, ResetInterface
         $now = time();
         $expires = $data['expires_at'];
 
-        if (null !== $expires && $now <= $expires) {
+        if (null !== $expires && $now < $expires) {
             return Freshness::Fresh;
         }
 

--- a/src/Symfony/Component/HttpClient/Tests/CachingHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/CachingHttpClientTest.php
@@ -172,9 +172,9 @@ class CachingHttpClientTest extends TestCase
         self::assertSame(200, $response->getStatusCode());
         self::assertSame('foo', $response->getContent());
 
-        sleep(5);
+        sleep(4);
 
-        // After 5 seconds, the cached response is still considered valid.
+        // After 4 seconds, the cached response is still considered valid.
         $response = $client->request('GET', 'http://example.com/foo-bar');
         self::assertSame(200, $response->getStatusCode());
         self::assertSame('foo', $response->getContent());
@@ -954,14 +954,14 @@ class CachingHttpClientTest extends TestCase
         self::assertSame('foo', $response->getContent());
 
         // Heuristic: 10% of 3600s = 360s; should be fresh within this time
-        sleep(360); // 5 minutes
+        sleep(359); // 5 minutes
 
         $response = $client->request('GET', 'http://example.com/heuristic');
         self::assertSame(200, $response->getStatusCode());
         self::assertSame('foo', $response->getContent());
 
         // After heuristic expires
-        sleep(1); // Total 361s, past 360s heuristic
+        sleep(2); // Total 361s, past 360s heuristic
 
         $response = $client->request('GET', 'http://example.com/heuristic');
         self::assertSame(200, $response->getStatusCode());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | 
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
