### PR TITLE
[JsonStreamer] Fix the generated PHP code when using array shape

### DIFF
--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/array_shape.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/array_shape.php
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * @return array{'id': int, 'name': string}
+ */
+return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
+    return \Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string);
+};

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/array_shape.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/array_shape.stream.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @return array{'id': int, 'name': string}
+ */
+return static function (mixed $stream, \Psr\Container\ContainerInterface $valueTransformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
+    $providers['array{\'id\': int, \'name\': string}'] = static function ($stream, $offset, $length) use ($options, $valueTransformers, $instantiator, &$providers) {
+        $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitDict($stream, $offset, $length);
+        $iterable = static function ($stream, $data) use ($options, $valueTransformers, $instantiator, &$providers) {
+            foreach ($data as $k => $v) {
+                yield $k => \Symfony\Component\JsonStreamer\Read\Decoder::decodeStream($stream, $v[0], $v[1]);
+            }
+        };
+        return \iterator_to_array($iterable($stream, $data));
+    };
+    return $providers['array{\'id\': int, \'name\': string}']($stream, 0, null);
+};

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_backed_enum.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_backed_enum.php
@@ -14,7 +14,7 @@ return static function (string|\Stringable $string, \Psr\Container\ContainerInte
         if (null === $data) {
             return null;
         }
-        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null".', \get_debug_type($data)));
+        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null'));
     };
     return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_backed_enum.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_backed_enum.stream.php
@@ -15,7 +15,7 @@ return static function (mixed $stream, \Psr\Container\ContainerInterface $valueT
         if (null === $data) {
             return null;
         }
-        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null".', \get_debug_type($data)));
+        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null'));
     };
     return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null']($stream, 0, null);
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object.php
@@ -16,7 +16,7 @@ return static function (string|\Stringable $string, \Psr\Container\ContainerInte
         if (null === $data) {
             return null;
         }
-        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy|null".', \get_debug_type($data)));
+        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy|null'));
     };
     return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy|null'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object.stream.php
@@ -24,7 +24,7 @@ return static function (mixed $stream, \Psr\Container\ContainerInterface $valueT
         if (null === $data) {
             return null;
         }
-        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy|null".', \get_debug_type($data)));
+        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy|null'));
     };
     return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy|null']($stream, 0, null);
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object_dict.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object_dict.php
@@ -24,7 +24,7 @@ return static function (string|\Stringable $string, \Psr\Container\ContainerInte
         if (null === $data) {
             return null;
         }
-        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "array<string, Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null".', \get_debug_type($data)));
+        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'array<string, Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null'));
     };
     return $providers['array<string, Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object_dict.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object_dict.stream.php
@@ -33,7 +33,7 @@ return static function (mixed $stream, \Psr\Container\ContainerInterface $valueT
         if (null === $data) {
             return null;
         }
-        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "array<string, Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null".', \get_debug_type($data)));
+        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'array<string, Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null'));
     };
     return $providers['array<string, Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null']($stream, 0, null);
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object_list.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object_list.php
@@ -24,7 +24,7 @@ return static function (string|\Stringable $string, \Psr\Container\ContainerInte
         if (null === $data) {
             return null;
         }
-        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "list<Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null".', \get_debug_type($data)));
+        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'list<Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null'));
     };
     return $providers['list<Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object_list.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object_list.stream.php
@@ -33,7 +33,7 @@ return static function (mixed $stream, \Psr\Container\ContainerInterface $valueT
         if (null === $data) {
             return null;
         }
-        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "list<Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null".', \get_debug_type($data)));
+        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'list<Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null'));
     };
     return $providers['list<Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null']($stream, 0, null);
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_nullable_properties.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_nullable_properties.php
@@ -19,7 +19,7 @@ return static function (string|\Stringable $string, \Psr\Container\ContainerInte
         if (null === $data) {
             return null;
         }
-        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null".', \get_debug_type($data)));
+        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null'));
     };
     return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNullableProperties'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_nullable_properties.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_nullable_properties.stream.php
@@ -27,7 +27,7 @@ return static function (mixed $stream, \Psr\Container\ContainerInterface $valueT
         if (null === $data) {
             return null;
         }
-        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null".', \get_debug_type($data)));
+        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null'));
     };
     return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNullableProperties']($stream, 0, null);
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_union.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_union.php
@@ -22,7 +22,7 @@ return static function (string|\Stringable $string, \Psr\Container\ContainerInte
         if (\is_string($data)) {
             return $data;
         }
-        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null|string".', \get_debug_type($data)));
+        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null|string'));
     };
     return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithUnionProperties'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_union.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_union.stream.php
@@ -29,7 +29,7 @@ return static function (mixed $stream, \Psr\Container\ContainerInterface $valueT
         if (\is_string($data)) {
             return $data;
         }
-        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null|string".', \get_debug_type($data)));
+        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null|string'));
     };
     return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithUnionProperties']($stream, 0, null);
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/union.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/union.php
@@ -30,7 +30,7 @@ return static function (string|\Stringable $string, \Psr\Container\ContainerInte
         if (\is_int($data)) {
             return $data;
         }
-        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes|int|list<Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>".', \get_debug_type($data)));
+        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes|int|list<Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>'));
     };
     return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes|int|list<Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/union.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/union.stream.php
@@ -39,7 +39,7 @@ return static function (mixed $stream, \Psr\Container\ContainerInterface $valueT
         if (\is_int($data)) {
             return $data;
         }
-        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes|int|list<Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>".', \get_debug_type($data)));
+        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes|int|list<Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>'));
     };
     return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes|int|list<Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>']($stream, 0, null);
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Read/StreamReaderGeneratorTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Read/StreamReaderGeneratorTest.php
@@ -111,6 +111,8 @@ class StreamReaderGeneratorTest extends TestCase
         yield ['object_list', Type::list(Type::object(ClassicDummy::class))];
         yield ['nullable_object_list', Type::nullable(Type::list(Type::object(ClassicDummy::class)))];
 
+        yield ['array_shape', Type::arrayShape(['id' => Type::int(), 'name' => Type::string()])];
+
         yield ['dict', Type::dict()];
         yield ['object_dict', Type::dict(Type::object(ClassicDummy::class))];
         yield ['nullable_object_dict', Type::nullable(Type::dict(Type::object(ClassicDummy::class)))];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | 
| License       | MIT

When using array shapes, the type descriptor is of the form `array{'key': string}`. But, the generated code uses this descriptor as array keys resulting in instructions like `$providers['array{'key': string}']`. This code is broken and this PR tries to fix this by escaping the single quotes.
