### PR TITLE
[TypeInfo] Fix template key-type for array

### DIFF
--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyCollection.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyCollection.php
@@ -11,6 +11,10 @@
 
 namespace Symfony\Component\TypeInfo\Tests\Fixtures;
 
+/**
+ * @template TKey of array-key
+ * @template TValue
+ */
 final class DummyCollection implements \IteratorAggregate
 {
     public function getIterator(): \Traversable

--- a/src/Symfony/Component/TypeInfo/Tests/TypeResolver/StringTypeResolverTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeResolver/StringTypeResolverTest.php
@@ -66,6 +66,12 @@ class StringTypeResolverTest extends TestCase
     {
         $typeContextFactory = new TypeContextFactory(new StringTypeResolver());
 
+        /**
+         * @template TFoo of int
+         * @template TBar of string
+         */
+        $dummyTemplateKeyUnion = new class {};
+
         // callable
         yield [Type::callable(), 'callable(string, int): mixed'];
 
@@ -76,10 +82,16 @@ class StringTypeResolverTest extends TestCase
         yield [Type::array(Type::bool(), Type::arrayKey()), 'array<array-key, bool>'];
         yield [Type::array(Type::bool(), Type::arrayKey()), 'array<int|string, bool>'];
         yield [Type::array(Type::bool(), Type::arrayKey()), 'non-empty-array<int|string, bool>'];
+        yield [Type::array(Type::bool(), Type::template('TKey', Type::union(Type::int(), Type::string()))), 'array<TKey, bool>', $typeContextFactory->createFromClassName(DummyCollection::class)];
+        yield [Type::array(Type::template('TValue', Type::mixed()), Type::template('TKey', Type::union(Type::int(), Type::string()))), 'array<TKey, TValue>', $typeContextFactory->createFromClassName(DummyCollection::class)];
+        yield [Type::array(Type::template('TValue', Type::mixed()), Type::arrayKey()), 'array<array-key, TValue>', $typeContextFactory->createFromClassName(DummyCollection::class)];
+        yield [Type::array(Type::bool(), Type::union(Type::template('TFoo', Type::int()), Type::template('TBar', Type::string()))), 'array<TFoo|TBar, bool>', $typeContextFactory->createFromClassName($dummyTemplateKeyUnion::class)];
+        yield [Type::array(Type::bool(), Type::arrayKey()), 'array<'.DummyWithConstants::class.'::DUMMY_STRING_A|'.DummyWithConstants::class.'::DUMMY_INT_A, bool>', $typeContextFactory->createFromClassName(DummyWithConstants::class)];
 
         // list
         yield [Type::list(Type::bool()), 'list<bool>'];
         yield [Type::list(Type::bool()), 'non-empty-list<bool>'];
+        yield [Type::list(Type::template('TValue', Type::mixed())), 'list<TValue>', $typeContextFactory->createFromClassName(DummyCollection::class)];
 
         // array shape
         yield [Type::arrayShape(['foo' => Type::true(), 1 => Type::false()]), 'array{foo: true, 1: false}'];
@@ -289,5 +301,38 @@ class StringTypeResolverTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->resolver->resolve('array<int|mixed, string>');
+    }
+
+    public function testCannotResolveInvalidTemplateKeyType()
+    {
+        /**
+         * @template TKey of mixed
+         */
+        $dummyClass = new class {};
+
+        $typeContextFactory = new TypeContextFactory(new StringTypeResolver());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->resolver->resolve('array<TKey, string>', $typeContextFactory->createFromClassName($dummyClass::class));
+    }
+
+    public function testCannotResolveUnionTemplateKeyTypeWithInvalidBound()
+    {
+        /**
+         * @template TFoo of int
+         * @template TBar of float
+         */
+        $dummyClass = new class {};
+
+        $typeContextFactory = new TypeContextFactory(new StringTypeResolver());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->resolver->resolve('array<TFoo|TBar, string>', $typeContextFactory->createFromClassName($dummyClass::class));
+    }
+
+    public function testCannotResolveInvalidScalarArrayKeyType()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->resolver->resolve('array<scalar, string>');
     }
 }

--- a/src/Symfony/Component/TypeInfo/Type/CollectionType.php
+++ b/src/Symfony/Component/TypeInfo/Type/CollectionType.php
@@ -52,14 +52,33 @@ class CollectionType extends Type implements WrappingTypeInterface
         } elseif ($type instanceof GenericType && $type->getWrappedType() instanceof BuiltinType && TypeIdentifier::ARRAY === $type->getWrappedType()->getTypeIdentifier()) {
             $keyType = $this->getCollectionKeyType();
 
-            $keyTypes = $keyType instanceof UnionType ? $keyType->getTypes() : [$keyType];
-
-            foreach ($keyTypes as $type) {
-                if (!$type instanceof BuiltinType || !\in_array($type->getTypeIdentifier(), [TypeIdentifier::INT, TypeIdentifier::STRING], true)) {
-                    throw new InvalidArgumentException(\sprintf('"%s" is not a valid array key type.', (string) $keyType));
-                }
-            }
+            $this->assertValidArrayKeyType($keyType);
         }
+    }
+
+    private function assertValidArrayKeyType(Type $keyType, ?Type $rootType = null): void
+    {
+        $rootType ??= $keyType;
+
+        if ($keyType instanceof UnionType) {
+            foreach ($keyType->getTypes() as $type) {
+                $this->assertValidArrayKeyType($type, $rootType);
+            }
+
+            return;
+        }
+
+        if ($keyType instanceof TemplateType) {
+            $this->assertValidArrayKeyType($keyType->getBound(), $rootType);
+
+            return;
+        }
+
+        if ($keyType instanceof BuiltinType && \in_array($keyType->getTypeIdentifier(), [TypeIdentifier::INT, TypeIdentifier::STRING], true)) {
+            return;
+        }
+
+        throw new InvalidArgumentException(\sprintf('"%s" is not a valid array key type.', (string) $rootType));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

https://github.com/symfony/symfony/pull/62388 broke type detection for template keys for array:

```php
/**
 * @template TKey of array-key
 * @template TValue
 */
class Collection {
}
```

Above example currently throws an exception `Symfony\Component\TypeInfo\Exception\InvalidArgumentException: "TKey" is not a valid array key type.` even though `TKey` is a type of `array-key` (`int|string`). 

This PR fixes this by getting the wrapped type when dealing with a template type when checking if a valid array key type is provided.
