### PR TITLE
[Serializer] Fix php 8.5 warning unexpected NAN value was coerced to …

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -464,7 +464,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
 
             return $this->selectNodeType($node, $this->serializer->normalize($val, $format, $context), $format, $context);
         } elseif (is_numeric($val)) {
-            return $this->appendText($node, (string) $val);
+            return $this->appendText($node, is_nan($val) ? 'NAN' : (string) $val);
         } elseif (\is_string($val) && $this->needsCdataWrapping($val, $context)) {
             return $this->appendCData($node, $val);
         } elseif (\is_string($val)) {

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -954,6 +954,26 @@ XML;
         $this->assertEquals($expected, $encoder->encode($data, 'xml'));
     }
 
+    public function testEncodeNan()
+    {
+        $value = \NAN;
+
+        $expected = '<?xml version="1.0"?>'."\n".
+            '<response>NAN</response>'."\n";
+
+        $this->assertEquals($expected, $this->encoder->encode($value, 'xml'));
+    }
+
+    public function testEncodeInfinite()
+    {
+        $value = \INF;
+
+        $expected = '<?xml version="1.0"?>'."\n".
+            '<response>INF</response>'."\n";
+
+        $this->assertEquals($expected, $this->encoder->encode($value, 'xml'));
+    }
+
     private function createXmlEncoderWithEnvelopeNormalizer(): XmlEncoder
     {
         $normalizers = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch       | 6.4
| Bug fix      | yes
| New feature  | no 
| Deprecations |no 
| Issues        | Fix #...
| License       | MIT

Fix  php 8.5 warning unexpected NAN value was coerced to string

@see https://wiki.php.net/rfc/warnings-php-8-5#coercing_nan_to_other_types

