### PR TITLE
[Finder] Fix converting unanchored glob patterns to regex

### DIFF
--- a/src/Symfony/Component/Finder/Glob.php
+++ b/src/Symfony/Component/Finder/Glob.php
@@ -44,6 +44,9 @@ class Glob
         $escaping = false;
         $inCurlies = 0;
         $regex = '';
+        if ($unanchored = str_starts_with($glob, '**/')) {
+            $glob = '/'.$glob;
+        }
         $sizeGlob = \strlen($glob);
         for ($i = 0; $i < $sizeGlob; ++$i) {
             $car = $glob[$i];
@@ -102,6 +105,10 @@ class Glob
                 $regex .= $car;
             }
             $escaping = false;
+        }
+
+        if ($unanchored) {
+            $regex = substr_replace($regex, '?', 1 + ('/' === $delimiter) + ($strictLeadingDot ? \strlen('(?=[^\.])') : 0), 0);
         }
 
         return $delimiter.'^'.$regex.'$'.$delimiter;

--- a/src/Symfony/Component/Finder/Tests/GlobTest.php
+++ b/src/Symfony/Component/Finder/Tests/GlobTest.php
@@ -92,4 +92,24 @@ class GlobTest extends TestCase
 
         $this->assertSame(['one/.dot', 'one/a', 'one/b', 'one/b/c.neon', 'one/b/d.neon'], $match);
     }
+
+    public function testGlobToRegexDoubleStarMatchesRootFiles()
+    {
+        $regex = Glob::toRegex('**/*.txt');
+
+        $this->assertSame(1, preg_match($regex, 'file.txt'));
+        $this->assertSame(1, preg_match($regex, 'foo/file.txt'));
+        $this->assertSame(1, preg_match($regex, 'foo/bar/baz.txt'));
+        $this->assertSame(1, preg_match($regex, '/foo/bar.txt'));
+        $this->assertSame(0, preg_match($regex, './foo/bar.txt'));
+        $this->assertSame(0, preg_match($regex, 'foo/.bar/bar.txt'));
+        $this->assertSame(0, preg_match($regex, '.file.txt'));
+        $this->assertSame(0, preg_match($regex, 'foo/bar/baz.php'));
+
+        $regex = Glob::toRegex('**/*.txt', false);
+
+        $this->assertSame(1, preg_match($regex, './foo/bar.txt'));
+        $this->assertSame(1, preg_match($regex, 'foo/.bar/bar.txt'));
+        $this->assertSame(1, preg_match($regex, '.file.txt'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62737
| License       | MIT
