### PR TITLE
[TwigBridge] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Bridge/Twig/Test/FormLayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Test/FormLayoutTestCase.php
@@ -17,7 +17,7 @@ use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\Form\FormRendererInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\Test\FormIntegrationTestCase;
-use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+use Symfony\Component\Security\Csrf\CsrfTokenManager;
 use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
 
@@ -44,7 +44,7 @@ abstract class FormLayoutTestCase extends FormIntegrationTestCase
         }
 
         $rendererEngine = new TwigRendererEngine($this->getThemes(), $environment);
-        $this->renderer = new FormRenderer($rendererEngine, $this->createMock(CsrfTokenManagerInterface::class));
+        $this->renderer = new FormRenderer($rendererEngine, new CsrfTokenManager());
         $this->registerTwigRuntimeLoader($environment, $this->renderer);
     }
 

--- a/src/Symfony/Bridge/Twig/Test/Traits/RuntimeLoaderProvider.php
+++ b/src/Symfony/Bridge/Twig/Test/Traits/RuntimeLoaderProvider.php
@@ -11,18 +11,17 @@
 
 namespace Symfony\Bridge\Twig\Test\Traits;
 
+use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\Form\FormRenderer;
 use Twig\Environment;
-use Twig\RuntimeLoader\RuntimeLoaderInterface;
+use Twig\RuntimeLoader\ContainerRuntimeLoader;
 
 trait RuntimeLoaderProvider
 {
     protected function registerTwigRuntimeLoader(Environment $environment, FormRenderer $renderer)
     {
-        $loader = $this->createMock(RuntimeLoaderInterface::class);
-        $loader->expects($this->any())->method('load')->willReturnMap([
-            ['Symfony\Component\Form\FormRenderer', $renderer],
-        ]);
-        $environment->addRuntimeLoader($loader);
+        $environment->addRuntimeLoader(new ContainerRuntimeLoader(new ServiceLocator([
+            FormRenderer::class => fn () => $renderer,
+        ])));
     }
 }

--- a/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
@@ -15,11 +15,12 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Twig\AppVariable;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
 use Symfony\Component\HttpFoundation\Session\Session;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\Security\Core\Authentication\Token\NullToken;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Translation\LocaleSwitcher;
 
 class AppVariableTest extends TestCase
@@ -61,9 +62,9 @@ class AppVariableTest extends TestCase
      */
     public function testGetSession()
     {
-        $request = $this->createMock(Request::class);
-        $request->method('hasSession')->willReturn(true);
-        $request->method('getSession')->willReturn($session = new Session());
+        $session = new Session();
+        $request = new Request();
+        $request->setSession($session);
 
         $this->setRequestStack($request);
 
@@ -86,28 +87,25 @@ class AppVariableTest extends TestCase
 
     public function testGetToken()
     {
-        $tokenStorage = $this->createMock(TokenStorageInterface::class);
+        $tokenStorage = new TokenStorage();
         $this->appVariable->setTokenStorage($tokenStorage);
 
-        $token = $this->createMock(TokenInterface::class);
-        $tokenStorage->method('getToken')->willReturn($token);
+        $token = new NullToken();
+        $tokenStorage->setToken($token);
 
         $this->assertEquals($token, $this->appVariable->getToken());
     }
 
     public function testGetUser()
     {
-        $this->setTokenStorage($user = $this->createMock(UserInterface::class));
+        $this->setTokenStorage($user = new InMemoryUser('john', 'password'));
 
         $this->assertEquals($user, $this->appVariable->getUser());
     }
 
     public function testGetLocale()
     {
-        $localeSwitcher = $this->createMock(LocaleSwitcher::class);
-        $this->appVariable->setLocaleSwitcher($localeSwitcher);
-
-        $localeSwitcher->method('getLocale')->willReturn('fr');
+        $this->appVariable->setLocaleSwitcher(new LocaleSwitcher('fr', []));
 
         self::assertEquals('fr', $this->appVariable->getLocale());
     }
@@ -121,16 +119,14 @@ class AppVariableTest extends TestCase
 
     public function testGetTokenWithNoToken()
     {
-        $tokenStorage = $this->createMock(TokenStorageInterface::class);
-        $this->appVariable->setTokenStorage($tokenStorage);
+        $this->appVariable->setTokenStorage(new TokenStorage());
 
         $this->assertNull($this->appVariable->getToken());
     }
 
     public function testGetUserWithNoToken()
     {
-        $tokenStorage = $this->createMock(TokenStorageInterface::class);
-        $this->appVariable->setTokenStorage($tokenStorage);
+        $this->appVariable->setTokenStorage(new TokenStorage());
 
         $this->assertNull($this->appVariable->getUser());
     }
@@ -301,13 +297,11 @@ class AppVariableTest extends TestCase
 
     protected function setTokenStorage($user)
     {
-        $tokenStorage = $this->createMock(TokenStorageInterface::class);
+        $tokenStorage = new TokenStorage();
         $this->appVariable->setTokenStorage($tokenStorage);
 
-        $token = $this->createMock(TokenInterface::class);
-        $tokenStorage->method('getToken')->willReturn($token);
-
-        $token->method('getUser')->willReturn($user);
+        $token = new UsernamePasswordToken($user, 'main');
+        $tokenStorage->setToken($token);
     }
 
     private function setFlashMessages($sessionHasStarted = true)
@@ -317,16 +311,19 @@ class AppVariableTest extends TestCase
             'warning' => ['Warning #1 message'],
             'error' => ['Error #1 message', 'Error #2 message'],
         ];
-        $flashBag = new FlashBag();
-        $flashBag->initialize($flashMessages);
 
-        $session = $this->createMock(Session::class);
-        $session->method('isStarted')->willReturn($sessionHasStarted);
-        $session->method('getFlashBag')->willReturn($flashBag);
+        $storage = new MockArraySessionStorage();
+        $storage->setSessionData([
+            '_symfony_flashes' => $flashMessages,
+        ]);
+        $session = new Session($storage);
 
-        $request = $this->createMock(Request::class);
-        $request->method('hasSession')->willReturn(true);
-        $request->method('getSession')->willReturn($session);
+        if ($sessionHasStarted) {
+            $session->start();
+        }
+
+        $request = new Request();
+        $request->setSession($session);
         $this->setRequestStack($request);
 
         return $flashMessages;

--- a/src/Symfony/Bridge/Twig/Tests/ErrorRenderer/TwigErrorRendererTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/ErrorRenderer/TwigErrorRendererTest.php
@@ -25,7 +25,6 @@ class TwigErrorRendererTest extends TestCase
     {
         $exception = new \Exception();
 
-        $twig = $this->createMock(Environment::class);
         $nativeRenderer = $this->createMock(HtmlErrorRenderer::class);
         $nativeRenderer
             ->expects($this->once())
@@ -33,7 +32,7 @@ class TwigErrorRendererTest extends TestCase
             ->with($exception)
         ;
 
-        (new TwigErrorRenderer($twig, $nativeRenderer, true))->render(new \Exception());
+        (new TwigErrorRenderer(new Environment(new ArrayLoader()), $nativeRenderer, true))->render(new \Exception());
     }
 
     public function testFallbackToNativeRendererIfCustomTemplateNotFound()

--- a/src/Symfony/Bridge/Twig/Tests/EventListener/TemplateAttributeListenerTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/EventListener/TemplateAttributeListenerTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
 use Symfony\Component\HttpKernel\Event\ViewEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Twig\Environment;
+use Twig\Loader\ArrayLoader;
 
 class TemplateAttributeListenerTest extends TestCase
 {
@@ -43,7 +44,7 @@ class TemplateAttributeListenerTest extends TestCase
         ;
 
         $request = new Request();
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $controllerArgumentsEvent = new ControllerArgumentsEvent($kernel, [new TemplateAttributeController(), 'foo'], ['Bar'], $request, null);
         $listener = new TemplateAttributeListener($twig);
 
@@ -68,9 +69,11 @@ class TemplateAttributeListenerTest extends TestCase
     public function testForm()
     {
         $request = new Request();
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $controllerArgumentsEvent = new ControllerArgumentsEvent($kernel, [new TemplateAttributeController(), 'foo'], [], $request, null);
-        $listener = new TemplateAttributeListener($this->createMock(Environment::class));
+        $listener = new TemplateAttributeListener(new Environment(new ArrayLoader([
+            'templates/foo.html.twig' => '',
+        ])));
 
         $form = $this->createMock(FormInterface::class);
         $form->expects($this->once())->method('createView');

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractDivLayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractDivLayoutTestCase.php
@@ -471,7 +471,7 @@ abstract class AbstractDivLayoutTestCase extends AbstractLayoutTestCase
 
     public function testCsrf()
     {
-        $this->csrfTokenManager->expects($this->any())
+        $this->csrfTokenManager
             ->method('getToken')
             ->willReturn(new CsrfToken('token_id', 'foo&bar'));
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractLayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractLayoutTestCase.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bridge\Twig\Tests\Extension;
 
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use Symfony\Bridge\Twig\Test\FormLayoutTestCase;
 use Symfony\Component\Form\Extension\Core\Type\PercentType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
@@ -25,7 +25,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 abstract class AbstractLayoutTestCase extends FormLayoutTestCase
 {
-    protected MockObject&CsrfTokenManagerInterface $csrfTokenManager;
+    protected Stub&CsrfTokenManagerInterface $csrfTokenManager;
     protected array $testableFeatures = [];
 
     private string $defaultLocale;
@@ -39,7 +39,7 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
         $this->defaultLocale = \Locale::getDefault();
         \Locale::setDefault('en');
 
-        $this->csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $this->csrfTokenManager = $this->createStub(CsrfTokenManagerInterface::class);
 
         parent::setUp();
     }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractTableLayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractTableLayoutTestCase.php
@@ -337,7 +337,7 @@ abstract class AbstractTableLayoutTestCase extends AbstractLayoutTestCase
 
     public function testCsrf()
     {
-        $this->csrfTokenManager->expects($this->any())
+        $this->csrfTokenManager
             ->method('getToken')
             ->willReturn(new CsrfToken('token_id', 'foo&bar'));
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/DumpExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/DumpExtensionTest.php
@@ -18,7 +18,6 @@ use Symfony\Component\VarDumper\Dumper\HtmlDumper;
 use Symfony\Component\VarDumper\VarDumper;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
-use Twig\Loader\LoaderInterface;
 
 class DumpExtensionTest extends TestCase
 {
@@ -68,7 +67,7 @@ class DumpExtensionTest extends TestCase
     public function testDump($context, $args, $expectedOutput, $debug = true)
     {
         $extension = new DumpExtension(new VarCloner());
-        $twig = new Environment($this->createMock(LoaderInterface::class), [
+        $twig = new Environment(new ArrayLoader(), [
             'debug' => $debug,
             'cache' => false,
             'optimizations' => 0,
@@ -125,7 +124,7 @@ class DumpExtensionTest extends TestCase
             '</pre><script>Sfdump("%s")</script>'
         );
         $extension = new DumpExtension(new VarCloner(), $dumper);
-        $twig = new Environment($this->createMock(LoaderInterface::class), [
+        $twig = new Environment(new ArrayLoader(), [
             'debug' => true,
             'cache' => false,
             'optimizations' => 0,

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap3LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap3LayoutTest.php
@@ -16,7 +16,7 @@ use Symfony\Bridge\Twig\Extension\TranslationExtension;
 use Symfony\Bridge\Twig\Form\TwigRendererEngine;
 use Symfony\Bridge\Twig\Tests\Extension\Fixtures\StubTranslator;
 use Symfony\Component\Form\FormRenderer;
-use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+use Symfony\Component\Security\Csrf\CsrfTokenManager;
 use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
 
@@ -60,7 +60,7 @@ class FormExtensionBootstrap3LayoutTest extends AbstractBootstrap3LayoutTestCase
             'bootstrap_3_layout.html.twig',
             'custom_widgets.html.twig',
         ], $environment);
-        $this->renderer = new FormRenderer($rendererEngine, $this->createMock(CsrfTokenManagerInterface::class));
+        $this->renderer = new FormRenderer($rendererEngine, new CsrfTokenManager());
         $this->registerTwigRuntimeLoader($environment, $this->renderer);
 
         $view = $this->factory
@@ -72,8 +72,7 @@ class FormExtensionBootstrap3LayoutTest extends AbstractBootstrap3LayoutTestCase
 <div class="input-group">
                             <span class="input-group-addon">&euro; </span>
             <input type="text" id="name" name="name" required="required" inputmode="decimal" class="form-control" />        </div>
-HTML
-            , trim($this->renderWidget($view)));
+HTML, trim($this->renderWidget($view)));
     }
 
     protected function getTemplatePaths(): array

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap4LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap4LayoutTest.php
@@ -16,7 +16,7 @@ use Symfony\Bridge\Twig\Extension\TranslationExtension;
 use Symfony\Bridge\Twig\Form\TwigRendererEngine;
 use Symfony\Bridge\Twig\Tests\Extension\Fixtures\StubTranslator;
 use Symfony\Component\Form\FormRenderer;
-use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+use Symfony\Component\Security\Csrf\CsrfTokenManager;
 use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
 
@@ -65,7 +65,7 @@ class FormExtensionBootstrap4LayoutTest extends AbstractBootstrap4LayoutTestCase
             'bootstrap_4_layout.html.twig',
             'custom_widgets.html.twig',
         ], $environment);
-        $this->renderer = new FormRenderer($rendererEngine, $this->createMock(CsrfTokenManagerInterface::class));
+        $this->renderer = new FormRenderer($rendererEngine, new CsrfTokenManager());
         $this->registerTwigRuntimeLoader($environment, $this->renderer);
 
         $view = $this->factory
@@ -77,8 +77,7 @@ class FormExtensionBootstrap4LayoutTest extends AbstractBootstrap4LayoutTestCase
 <div class="input-group "><div class="input-group-prepend">
                     <span class="input-group-text">&euro; </span>
                 </div><input type="text" id="name" name="name" required="required" inputmode="decimal" class="form-control" /></div>
-HTML
-            , trim($this->renderWidget($view)));
+HTML, trim($this->renderWidget($view)));
     }
 
     protected function getTemplatePaths(): array

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap5LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap5LayoutTest.php
@@ -18,7 +18,7 @@ use Symfony\Bridge\Twig\Tests\Extension\Fixtures\StubTranslator;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
 use Symfony\Component\Form\FormRenderer;
-use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+use Symfony\Component\Security\Csrf\CsrfTokenManager;
 use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
 
@@ -67,7 +67,7 @@ class FormExtensionBootstrap5LayoutTest extends AbstractBootstrap5LayoutTestCase
             'bootstrap_5_layout.html.twig',
             'custom_widgets.html.twig',
         ], $environment);
-        $this->renderer = new FormRenderer($rendererEngine, $this->getMockBuilder(CsrfTokenManagerInterface::class)->getMock());
+        $this->renderer = new FormRenderer($rendererEngine, new CsrfTokenManager());
         $this->registerTwigRuntimeLoader($environment, $this->renderer);
 
         $view = $this->factory
@@ -76,8 +76,7 @@ class FormExtensionBootstrap5LayoutTest extends AbstractBootstrap5LayoutTestCase
 
         self::assertSame(<<<'HTML'
 <div class="input-group "><span class="input-group-text">&euro; </span><input type="text" id="name" name="name" required="required" inputmode="decimal" class="form-control" /></div>
-HTML
-            , trim($this->renderWidget($view)));
+HTML, trim($this->renderWidget($view)));
     }
 
     protected function getTemplatePaths(): array

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
@@ -18,7 +18,7 @@ use Symfony\Bridge\Twig\Tests\Extension\Fixtures\StubTranslator;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\Form\FormView;
-use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+use Symfony\Component\Security\Csrf\CsrfTokenManager;
 use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
 
@@ -148,7 +148,7 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTestCase
             'form_div_layout.html.twig',
             'custom_widgets.html.twig',
         ], $environment);
-        $this->renderer = new FormRenderer($rendererEngine, $this->createMock(CsrfTokenManagerInterface::class));
+        $this->renderer = new FormRenderer($rendererEngine, new CsrfTokenManager());
         $this->registerTwigRuntimeLoader($environment, $this->renderer);
 
         $view = $this->factory

--- a/src/Symfony/Bridge/Twig/Tests/Extension/ImportMapExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/ImportMapExtensionTest.php
@@ -9,15 +9,16 @@
  * file that was distributed with this source code.
  */
 
-namespace Extension;
+namespace Symfony\Bridge\Twig\Tests\Extension;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Twig\Extension\ImportMapExtension;
 use Symfony\Bridge\Twig\Extension\ImportMapRuntime;
 use Symfony\Component\AssetMapper\ImportMap\ImportMapRenderer;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
-use Twig\RuntimeLoader\RuntimeLoaderInterface;
+use Twig\RuntimeLoader\ContainerRuntimeLoader;
 
 class ImportMapExtensionTest extends TestCase
 {
@@ -35,14 +36,10 @@ class ImportMapExtensionTest extends TestCase
             ->willReturn($expected);
         $runtime = new ImportMapRuntime($importMapRenderer);
 
-        $mockRuntimeLoader = $this->createMock(RuntimeLoaderInterface::class);
-        $mockRuntimeLoader
-            ->method('load')
-            ->willReturnMap([
-                [ImportMapRuntime::class, $runtime],
-            ])
-        ;
-        $twig->addRuntimeLoader($mockRuntimeLoader);
+        $runtimeLoader = new ContainerRuntimeLoader(new ServiceLocator([
+            ImportMapRuntime::class => fn () => $runtime,
+        ]));
+        $twig->addRuntimeLoader($runtimeLoader);
 
         $this->assertSame($expected, $twig->render('template'));
     }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/RoutingExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/RoutingExtensionTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Twig\Extension\RoutingExtension;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig\Environment;
-use Twig\Loader\LoaderInterface;
+use Twig\Loader\ArrayLoader;
 use Twig\Node\Expression\FilterExpression;
 use Twig\Source;
 
@@ -26,8 +26,8 @@ class RoutingExtensionTest extends TestCase
      */
     public function testEscaping($template, $mustBeEscaped)
     {
-        $twig = new Environment($this->createMock(LoaderInterface::class), ['debug' => true, 'cache' => false, 'autoescape' => 'html', 'optimizations' => 0]);
-        $twig->addExtension(new RoutingExtension($this->createMock(UrlGeneratorInterface::class)));
+        $twig = new Environment(new ArrayLoader(), ['debug' => true, 'cache' => false, 'autoescape' => 'html', 'optimizations' => 0]);
+        $twig->addExtension(new RoutingExtension($this->createStub(UrlGeneratorInterface::class)));
 
         $nodes = $twig->parse($twig->tokenize(new Source($template, '')));
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/SerializerExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/SerializerExtensionTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Twig\Extension\SerializerExtension;
 use Symfony\Bridge\Twig\Extension\SerializerRuntime;
 use Symfony\Bridge\Twig\Tests\Extension\Fixtures\SerializerModelFixture;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Encoder\YamlEncoder;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
@@ -23,7 +24,7 @@ use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
-use Twig\RuntimeLoader\RuntimeLoaderInterface;
+use Twig\RuntimeLoader\ContainerRuntimeLoader;
 
 /**
  * @author Jesse Rushlow <jr@rushlow.dev>
@@ -52,17 +53,13 @@ class SerializerExtensionTest extends TestCase
         $meta = new ClassMetadataFactory(new AttributeLoader());
         $runtime = new SerializerRuntime(new Serializer([new ObjectNormalizer($meta)], [new JsonEncoder(), new YamlEncoder()]));
 
-        $mockRuntimeLoader = $this->createMock(RuntimeLoaderInterface::class);
-        $mockRuntimeLoader
-            ->method('load')
-            ->willReturnMap([
-                ['Symfony\Bridge\Twig\Extension\SerializerRuntime', $runtime],
-            ])
-        ;
+        $runtimeLoader = new ContainerRuntimeLoader(new ServiceLocator([
+            SerializerRuntime::class => fn () => $runtime,
+        ]));
 
         $twig = new Environment(new ArrayLoader(['template' => $template]));
         $twig->addExtension(new SerializerExtension());
-        $twig->addRuntimeLoader($mockRuntimeLoader);
+        $twig->addRuntimeLoader($runtimeLoader);
 
         return $twig;
     }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/StopwatchExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/StopwatchExtensionTest.php
@@ -77,7 +77,7 @@ class StopwatchExtensionTest extends TestCase
                 $expectedName->evaluate($name);
                 $this->assertSame($expectedCategory, $category);
 
-                return $this->createMock(StopwatchEvent::class);
+                return new StopwatchEvent('1.0');
             })
         ;
 
@@ -88,7 +88,7 @@ class StopwatchExtensionTest extends TestCase
                 [$expectedName] = array_shift($expectedStopCalls);
                 $expectedName->evaluate($name);
 
-                return $this->createMock(StopwatchEvent::class);
+                return new StopwatchEvent('1.0');
             })
         ;
 

--- a/src/Symfony/Bridge/Twig/Tests/Node/DumpNodeTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Node/DumpNodeTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Twig\Node\DumpNode;
 use Twig\Compiler;
 use Twig\Environment;
-use Twig\Loader\LoaderInterface;
+use Twig\Loader\ArrayLoader;
 use Twig\Node\Expression\NameExpression;
 use Twig\Node\Expression\Variable\ContextVariable;
 use Twig\Node\Node;
@@ -27,7 +27,7 @@ class DumpNodeTest extends TestCase
     {
         $node = new DumpNode('bar', null, 7);
 
-        $env = new Environment($this->createMock(LoaderInterface::class));
+        $env = new Environment(new ArrayLoader());
         $compiler = new Compiler($env);
 
         $expected = <<<'EOTXT'
@@ -51,7 +51,7 @@ EOTXT;
     {
         $node = new DumpNode('bar', null, 7);
 
-        $env = new Environment($this->createMock(LoaderInterface::class));
+        $env = new Environment(new ArrayLoader());
         $compiler = new Compiler($env);
 
         $expected = <<<'EOTXT'
@@ -85,7 +85,7 @@ EOTXT;
 
         $node = new DumpNode('bar', $vars, 7);
 
-        $env = new Environment($this->createMock(LoaderInterface::class));
+        $env = new Environment(new ArrayLoader());
         $compiler = new Compiler($env);
 
         $expected = <<<'EOTXT'
@@ -117,7 +117,7 @@ EOTXT;
 
         $node = new DumpNode('bar', $vars, 7);
 
-        $env = new Environment($this->createMock(LoaderInterface::class));
+        $env = new Environment(new ArrayLoader());
         $compiler = new Compiler($env);
 
         $expected = <<<'EOTXT'

--- a/src/Symfony/Bridge/Twig/Tests/Node/FormThemeTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Node/FormThemeTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\Form\FormRendererEngineInterface;
 use Twig\Compiler;
 use Twig\Environment;
-use Twig\Loader\LoaderInterface;
+use Twig\Loader\ArrayLoader;
 use Twig\Node\Expression\ArrayExpression;
 use Twig\Node\Expression\ConstantExpression;
 use Twig\Node\Expression\NameExpression;
@@ -64,8 +64,8 @@ class FormThemeTest extends TestCase
 
         $node = new FormThemeNode($form, $resources, 0);
 
-        $environment = new Environment($this->createMock(LoaderInterface::class));
-        $formRenderer = new FormRenderer($this->createMock(FormRendererEngineInterface::class));
+        $environment = new Environment(new ArrayLoader());
+        $formRenderer = new FormRenderer($this->createStub(FormRendererEngineInterface::class));
         $this->registerTwigRuntimeLoader($environment, $formRenderer);
         $compiler = new Compiler($environment);
 

--- a/src/Symfony/Bridge/Twig/Tests/Node/SearchAndRenderBlockNodeTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Node/SearchAndRenderBlockNodeTest.php
@@ -17,7 +17,7 @@ use Twig\Attribute\FirstClassTwigCallableReady;
 use Twig\Compiler;
 use Twig\Environment;
 use Twig\Extension\CoreExtension;
-use Twig\Loader\LoaderInterface;
+use Twig\Loader\ArrayLoader;
 use Twig\Node\Expression\ArrayExpression;
 use Twig\Node\Expression\ConditionalExpression;
 use Twig\Node\Expression\ConstantExpression;
@@ -48,7 +48,7 @@ class SearchAndRenderBlockNodeTest extends TestCase
             $node = new SearchAndRenderBlockNode('form_widget', $arguments, 0);
         }
 
-        $compiler = new Compiler(new Environment($this->createMock(LoaderInterface::class)));
+        $compiler = new Compiler(new Environment(new ArrayLoader()));
 
         $this->assertEquals(
             \sprintf(
@@ -85,7 +85,7 @@ class SearchAndRenderBlockNodeTest extends TestCase
             $node = new SearchAndRenderBlockNode('form_widget', $arguments, 0);
         }
 
-        $compiler = new Compiler(new Environment($this->createMock(LoaderInterface::class)));
+        $compiler = new Compiler(new Environment(new ArrayLoader()));
 
         $this->assertEquals(
             \sprintf(
@@ -116,7 +116,7 @@ class SearchAndRenderBlockNodeTest extends TestCase
             $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
         }
 
-        $compiler = new Compiler(new Environment($this->createMock(LoaderInterface::class)));
+        $compiler = new Compiler(new Environment(new ArrayLoader()));
 
         $this->assertEquals(
             \sprintf(
@@ -147,7 +147,7 @@ class SearchAndRenderBlockNodeTest extends TestCase
             $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
         }
 
-        $compiler = new Compiler(new Environment($this->createMock(LoaderInterface::class)));
+        $compiler = new Compiler(new Environment(new ArrayLoader()));
 
         // "label" => null must not be included in the output!
         // Otherwise the default label is overwritten with null.
@@ -180,7 +180,7 @@ class SearchAndRenderBlockNodeTest extends TestCase
             $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
         }
 
-        $compiler = new Compiler(new Environment($this->createMock(LoaderInterface::class)));
+        $compiler = new Compiler(new Environment(new ArrayLoader()));
 
         // "label" => null must not be included in the output!
         // Otherwise the default label is overwritten with null.
@@ -211,7 +211,7 @@ class SearchAndRenderBlockNodeTest extends TestCase
             $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
         }
 
-        $compiler = new Compiler(new Environment($this->createMock(LoaderInterface::class)));
+        $compiler = new Compiler(new Environment(new ArrayLoader()));
 
         $this->assertEquals(
             \sprintf(
@@ -250,7 +250,7 @@ class SearchAndRenderBlockNodeTest extends TestCase
             $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
         }
 
-        $compiler = new Compiler(new Environment($this->createMock(LoaderInterface::class)));
+        $compiler = new Compiler(new Environment(new ArrayLoader()));
 
         // "label" => null must not be included in the output!
         // Otherwise the default label is overwritten with null.
@@ -296,7 +296,7 @@ class SearchAndRenderBlockNodeTest extends TestCase
             $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
         }
 
-        $compiler = new Compiler(new Environment($this->createMock(LoaderInterface::class)));
+        $compiler = new Compiler(new Environment(new ArrayLoader()));
 
         $this->assertEquals(
             \sprintf(
@@ -343,7 +343,7 @@ class SearchAndRenderBlockNodeTest extends TestCase
             $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
         }
 
-        $compiler = new Compiler(new Environment($this->createMock(LoaderInterface::class)));
+        $compiler = new Compiler(new Environment(new ArrayLoader()));
 
         // "label" => null must not be included in the output!
         // Otherwise the default label is overwritten with null.
@@ -412,7 +412,7 @@ class SearchAndRenderBlockNodeTest extends TestCase
             $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
         }
 
-        $compiler = new Compiler(new Environment($this->createMock(LoaderInterface::class)));
+        $compiler = new Compiler(new Environment(new ArrayLoader()));
 
         // "label" => null must not be included in the output!
         // Otherwise the default label is overwritten with null.

--- a/src/Symfony/Bridge/Twig/Tests/Node/TransNodeTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Node/TransNodeTest.php
@@ -16,7 +16,7 @@ use Symfony\Bridge\Twig\Node\TransNode;
 use Twig\Attribute\YieldReady;
 use Twig\Compiler;
 use Twig\Environment;
-use Twig\Loader\LoaderInterface;
+use Twig\Loader\ArrayLoader;
 use Twig\Node\Expression\NameExpression;
 use Twig\Node\Expression\Variable\ContextVariable;
 use Twig\Node\TextNode;
@@ -32,7 +32,7 @@ class TransNodeTest extends TestCase
         $vars = class_exists(ContextVariable::class) ? new ContextVariable('foo', 0) : new NameExpression('foo', 0);
         $node = new TransNode($body, null, null, $vars);
 
-        $env = new Environment($this->createMock(LoaderInterface::class), ['strict_variables' => true]);
+        $env = new Environment(new ArrayLoader(), ['strict_variables' => true]);
         $compiler = new Compiler($env);
 
         $this->assertEquals(

--- a/src/Symfony/Bridge/Twig/Tests/NodeVisitor/TranslationDefaultDomainNodeVisitorTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/NodeVisitor/TranslationDefaultDomainNodeVisitorTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Twig\NodeVisitor\TranslationDefaultDomainNodeVisitor;
 use Symfony\Bridge\Twig\NodeVisitor\TranslationNodeVisitor;
 use Twig\Environment;
-use Twig\Loader\LoaderInterface;
+use Twig\Loader\ArrayLoader;
 use Twig\Node\Expression\ArrayExpression;
 use Twig\Node\Node;
 
@@ -27,7 +27,7 @@ class TranslationDefaultDomainNodeVisitorTest extends TestCase
     /** @dataProvider getDefaultDomainAssignmentTestData */
     public function testDefaultDomainAssignment(Node $node)
     {
-        $env = new Environment($this->createMock(LoaderInterface::class), ['cache' => false, 'autoescape' => false, 'optimizations' => 0]);
+        $env = new Environment(new ArrayLoader(), ['cache' => false, 'autoescape' => false, 'optimizations' => 0]);
         $visitor = new TranslationDefaultDomainNodeVisitor();
 
         // visit trans_default_domain tag
@@ -53,7 +53,7 @@ class TranslationDefaultDomainNodeVisitorTest extends TestCase
     /** @dataProvider getDefaultDomainAssignmentTestData */
     public function testNewModuleWithoutDefaultDomainTag(Node $node)
     {
-        $env = new Environment($this->createMock(LoaderInterface::class), ['cache' => false, 'autoescape' => false, 'optimizations' => 0]);
+        $env = new Environment(new ArrayLoader(), ['cache' => false, 'autoescape' => false, 'optimizations' => 0]);
         $visitor = new TranslationDefaultDomainNodeVisitor();
 
         // visit trans_default_domain tag

--- a/src/Symfony/Bridge/Twig/Tests/NodeVisitor/TranslationNodeVisitorTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/NodeVisitor/TranslationNodeVisitorTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Twig\NodeVisitor\TranslationNodeVisitor;
 use Twig\Attribute\FirstClassTwigCallableReady;
 use Twig\Environment;
-use Twig\Loader\LoaderInterface;
+use Twig\Loader\ArrayLoader;
 use Twig\Node\Expression\ArrayExpression;
 use Twig\Node\Expression\ConstantExpression;
 use Twig\Node\Expression\FilterExpression;
@@ -30,7 +30,7 @@ class TranslationNodeVisitorTest extends TestCase
     /** @dataProvider getMessagesExtractionTestData */
     public function testMessagesExtraction(Node $node, array $expectedMessages)
     {
-        $env = new Environment($this->createMock(LoaderInterface::class), ['cache' => false, 'autoescape' => false, 'optimizations' => 0]);
+        $env = new Environment(new ArrayLoader(), ['cache' => false, 'autoescape' => false, 'optimizations' => 0]);
         $visitor = new TranslationNodeVisitor();
         $visitor->enable();
         $visitor->enterNode($node, $env);

--- a/src/Symfony/Bridge/Twig/Tests/TokenParser/FormThemeTokenParserTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/TokenParser/FormThemeTokenParserTest.php
@@ -16,7 +16,7 @@ use Symfony\Bridge\Twig\Node\FormThemeNode;
 use Symfony\Bridge\Twig\TokenParser\FormThemeTokenParser;
 use Twig\Attribute\FirstClassTwigCallableReady;
 use Twig\Environment;
-use Twig\Loader\LoaderInterface;
+use Twig\Loader\ArrayLoader;
 use Twig\Node\Expression\ArrayExpression;
 use Twig\Node\Expression\ConstantExpression;
 use Twig\Node\Expression\NameExpression;
@@ -31,7 +31,7 @@ class FormThemeTokenParserTest extends TestCase
      */
     public function testCompile($source, $expected)
     {
-        $env = new Environment($this->createMock(LoaderInterface::class), ['cache' => false, 'autoescape' => false, 'optimizations' => 0]);
+        $env = new Environment(new ArrayLoader(), ['cache' => false, 'autoescape' => false, 'optimizations' => 0]);
         $env->addTokenParser(new FormThemeTokenParser());
         $source = new Source($source, '');
         $stream = $env->tokenize($source);

--- a/src/Symfony/Bridge/Twig/Tests/Translation/TwigExtractorTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Translation/TwigExtractorTest.php
@@ -14,11 +14,10 @@ namespace Symfony\Bridge\Twig\Tests\Translation;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Twig\Extension\TranslationExtension;
 use Symfony\Bridge\Twig\Translation\TwigExtractor;
+use Symfony\Component\Translation\IdentityTranslator;
 use Symfony\Component\Translation\MessageCatalogue;
-use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
-use Twig\Loader\LoaderInterface;
 
 class TwigExtractorTest extends TestCase
 {
@@ -29,14 +28,13 @@ class TwigExtractorTest extends TestCase
      */
     public function testExtract($template, $messages)
     {
-        $loader = $this->createMock(LoaderInterface::class);
-        $twig = new Environment($loader, [
+        $twig = new Environment(new ArrayLoader(), [
             'strict_variables' => true,
             'debug' => true,
             'cache' => false,
             'autoescape' => false,
         ]);
-        $twig->addExtension(new TranslationExtension($this->createMock(TranslatorInterface::class)));
+        $twig->addExtension(new TranslationExtension(new IdentityTranslator()));
 
         $extractor = new TwigExtractor($twig);
         $extractor->setPrefix('prefix');
@@ -99,8 +97,8 @@ class TwigExtractorTest extends TestCase
      */
     public function testExtractSyntaxError($resources, array $messages)
     {
-        $twig = new Environment($this->createMock(LoaderInterface::class));
-        $twig->addExtension(new TranslationExtension($this->createMock(TranslatorInterface::class)));
+        $twig = new Environment(new ArrayLoader());
+        $twig->addExtension(new TranslationExtension(new IdentityTranslator()));
 
         $extractor = new TwigExtractor($twig);
         $catalogue = new MessageCatalogue('en');
@@ -129,7 +127,7 @@ class TwigExtractorTest extends TestCase
             'cache' => false,
             'autoescape' => false,
         ]);
-        $twig->addExtension(new TranslationExtension($this->createMock(TranslatorInterface::class)));
+        $twig->addExtension(new TranslationExtension(new IdentityTranslator()));
 
         $extractor = new TwigExtractor($twig);
         $catalogue = new MessageCatalogue('en');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | part of #62669
| License       | MIT
