### PR TITLE
[Validator] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
@@ -123,10 +123,10 @@ abstract class ConstraintValidatorTestCase extends TestCase
 
     protected function createContext()
     {
-        $translator = $this->createMock(TranslatorInterface::class);
-        $translator->expects($this->any())->method('trans')->willReturnArgument(0);
-        $validator = $this->createMock(ValidatorInterface::class);
-        $validator->expects($this->any())
+        $translator = $this->createStub(TranslatorInterface::class);
+        $translator->method('trans')->willReturnArgument(0);
+        $validator = $this->createStub(ValidatorInterface::class);
+        $validator
             ->method('validate')
             ->willReturnCallback(fn () => $this->expectedViolations[$this->call++] ?? new ConstraintViolationList());
 
@@ -135,36 +135,47 @@ abstract class ConstraintValidatorTestCase extends TestCase
         $context->setNode($this->value, $this->object, $this->metadata, $this->propertyPath);
         $context->setConstraint($this->constraint);
 
-        $contextualValidatorMockBuilder = $this->getMockBuilder(AssertingContextualValidator::class)
-            ->setConstructorArgs([$context]);
-        $contextualValidatorMethods = [
-            'atPath',
-            'validate',
-            'validateProperty',
-            'validatePropertyValue',
-            'getViolations',
-        ];
+        if (method_exists($this, 'getStubBuilder')) {
+            $contextualValidator = self::getStubBuilder(AssertingContextualValidator::class)
+                ->setConstructorArgs([$context])
+                ->onlyMethods([
+                    'atPath',
+                    'validate',
+                    'validateProperty',
+                    'validatePropertyValue',
+                    'getViolations',
+                ])
+                ->getStub();
+        } else {
+            $contextualValidator = $this->getMockBuilder(AssertingContextualValidator::class)
+                ->setConstructorArgs([$context])
+                ->onlyMethods([
+                    'atPath',
+                    'validate',
+                    'validateProperty',
+                    'validatePropertyValue',
+                    'getViolations',
+                ])
+                ->getMock();
+        }
 
-        $contextualValidatorMockBuilder->onlyMethods($contextualValidatorMethods);
-        $contextualValidator = $contextualValidatorMockBuilder->getMock();
-        $contextualValidator->expects($this->any())
+        $contextualValidator
             ->method('atPath')
             ->willReturnCallback(fn ($path) => $contextualValidator->doAtPath($path));
-        $contextualValidator->expects($this->any())
+        $contextualValidator
             ->method('validate')
             ->willReturnCallback(fn ($value, $constraints = null, $groups = null) => $contextualValidator->doValidate($value, $constraints, $groups));
-        $contextualValidator->expects($this->any())
+        $contextualValidator
             ->method('validateProperty')
             ->willReturnCallback(fn ($object, $propertyName, $groups = null) => $contextualValidator->validateProperty($object, $propertyName, $groups));
-        $contextualValidator->expects($this->any())
+        $contextualValidator
             ->method('validatePropertyValue')
             ->willReturnCallback(fn ($objectOrClass, $propertyName, $value, $groups = null) => $contextualValidator->doValidatePropertyValue($objectOrClass, $propertyName, $value, $groups));
-        $contextualValidator->expects($this->any())
+        $contextualValidator
             ->method('getViolations')
             ->willReturnCallback(fn () => $contextualValidator->doGetViolations());
-        $validator->expects($this->any())
+        $validator
             ->method('inContext')
-            ->with($context)
             ->willReturn($contextualValidator);
 
         return $context;

--- a/src/Symfony/Component/Validator/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Validator/Tests/Command/DebugCommandTest.php
@@ -15,7 +15,6 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Validator\Command\DebugCommand;
 use Symfony\Component\Validator\Mapping\Factory\LazyLoadingMetadataFactory;
-use Symfony\Component\Validator\Mapping\Factory\MetadataFactoryInterface;
 use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 use Symfony\Component\Validator\Tests\Dummy\DummyClassOne;
 
@@ -180,9 +179,7 @@ TXT
 
     public function testOutputWithInvalidClassArgument()
     {
-        $validator = $this->createMock(MetadataFactoryInterface::class);
-
-        $command = new DebugCommand($validator);
+        $command = new DebugCommand(new LazyLoadingMetadataFactory());
 
         $tester = new CommandTester($command);
         $tester->execute(['class' => 'App\\NotFoundResource'], ['decorated' => false]);

--- a/src/Symfony/Component/Validator/Tests/Constraints/ExpressionValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ExpressionValidatorTest.php
@@ -258,7 +258,7 @@ class ExpressionValidatorTest extends ConstraintValidatorTestCase
             'expression' => 'false',
         ]);
 
-        $expressionLanguage = $this->createMock(ExpressionLanguage::class);
+        $expressionLanguage = $this->createStub(ExpressionLanguage::class);
 
         $used = false;
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotCompromisedPasswordValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotCompromisedPasswordValidatorTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Validator\Constraints\Luhn;
 use Symfony\Component\Validator\Constraints\NotCompromisedPassword;
 use Symfony\Component\Validator\Constraints\NotCompromisedPasswordValidator;
@@ -18,9 +20,7 @@ use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
-use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
@@ -204,7 +204,6 @@ class NotCompromisedPasswordValidatorTest extends ConstraintValidatorTestCase
     public function testApiError()
     {
         $this->expectException(ExceptionInterface::class);
-        $this->expectExceptionMessage('Problem contacting the Have I been Pwned API.');
         $this->validator->validate(self::PASSWORD_TRIGGERING_AN_ERROR, new NotCompromisedPassword());
     }
 
@@ -213,8 +212,9 @@ class NotCompromisedPasswordValidatorTest extends ConstraintValidatorTestCase
      */
     public function testApiErrorSkipped(NotCompromisedPassword $constraint)
     {
+        self::expectNotToPerformAssertions();
+
         $this->validator->validate(self::PASSWORD_TRIGGERING_AN_ERROR, $constraint);
-        $this->assertTrue(true); // No exception have been thrown
     }
 
     public static function provideErrorSkippingConstraints(): iterable
@@ -225,44 +225,20 @@ class NotCompromisedPasswordValidatorTest extends ConstraintValidatorTestCase
 
     private function createHttpClientStub(?string $returnValue = null): HttpClientInterface
     {
-        $httpClientStub = $this->createMock(HttpClientInterface::class);
-        $httpClientStub->method('request')->willReturnCallback(
-            function (string $method, string $url) use ($returnValue): ResponseInterface {
-                if (self::PASSWORD_TRIGGERING_AN_ERROR_RANGE_URL === $url) {
-                    throw new class('Problem contacting the Have I been Pwned API.') extends \Exception implements ServerExceptionInterface {
-                        public function getResponse(): ResponseInterface
-                        {
-                            throw new \RuntimeException('Not implemented');
-                        }
-                    };
-                }
-
-                $responseStub = $this->createMock(ResponseInterface::class);
-                $responseStub
-                    ->method('getContent')
-                    ->willReturn($returnValue ?? implode("\r\n", self::RETURN));
-
-                return $responseStub;
+        return new MockHttpClient(function ($method, $url) use ($returnValue) {
+            if (self::PASSWORD_TRIGGERING_AN_ERROR_RANGE_URL !== $url) {
+                return new MockResponse($returnValue ?? implode("\r\n", self::RETURN));
             }
-        );
-
-        return $httpClientStub;
+        });
     }
 
     private function createHttpClientStubCustomEndpoint($expectedEndpoint): HttpClientInterface
     {
-        $httpClientStub = $this->createMock(HttpClientInterface::class);
-        $httpClientStub->method('request')->with('GET', $expectedEndpoint)->willReturnCallback(
-            function (string $method, string $url): ResponseInterface {
-                $responseStub = $this->createMock(ResponseInterface::class);
-                $responseStub
-                    ->method('getContent')
-                    ->willReturn(implode("\r\n", self::RETURN));
+        return new MockHttpClient(function ($method, $url) use ($expectedEndpoint) {
+            $this->assertSame('GET', $method);
+            $this->assertSame($expectedEndpoint, $url);
 
-                return $responseStub;
-            }
-        );
-
-        return $httpClientStub;
+            return new MockResponse(implode("\r\n", self::RETURN));
+        });
     }
 }

--- a/src/Symfony/Component/Validator/Tests/DataCollector/ValidatorDataCollectorTest.php
+++ b/src/Symfony/Component/Validator/Tests/DataCollector/ValidatorDataCollectorTest.php
@@ -22,14 +22,14 @@ class ValidatorDataCollectorTest extends TestCase
 {
     public function testCollectsValidatorCalls()
     {
-        $originalValidator = $this->createMock(ValidatorInterface::class);
+        $originalValidator = $this->createStub(ValidatorInterface::class);
         $validator = new TraceableValidator($originalValidator);
 
         $collector = new ValidatorDataCollector($validator);
 
         $violations = new ConstraintViolationList([
-            $this->createMock(ConstraintViolation::class),
-            $this->createMock(ConstraintViolation::class),
+            $this->createStub(ConstraintViolation::class),
+            $this->createStub(ConstraintViolation::class),
         ]);
         $originalValidator->method('validate')->willReturn($violations);
 
@@ -52,14 +52,14 @@ class ValidatorDataCollectorTest extends TestCase
 
     public function testReset()
     {
-        $originalValidator = $this->createMock(ValidatorInterface::class);
+        $originalValidator = $this->createStub(ValidatorInterface::class);
         $validator = new TraceableValidator($originalValidator);
 
         $collector = new ValidatorDataCollector($validator);
 
         $violations = new ConstraintViolationList([
-            $this->createMock(ConstraintViolation::class),
-            $this->createMock(ConstraintViolation::class),
+            $this->createStub(ConstraintViolation::class),
+            $this->createStub(ConstraintViolation::class),
         ]);
         $originalValidator->method('validate')->willReturn($violations);
 

--- a/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\Validator\Exception\NoSuchMetadataException;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Factory\LazyLoadingMetadataFactory;
 use Symfony\Component\Validator\Mapping\Loader\LoaderInterface;
+use Symfony\Component\Validator\Mapping\Loader\StaticMethodLoader;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintA;
 use Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\Entity;
 use Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\EntityParent;
@@ -111,9 +112,8 @@ class LazyLoadingMetadataFactoryTest extends TestCase
     {
         $this->expectException(NoSuchMetadataException::class);
         $testedValue = 'error@example.com';
-        $loader = $this->createMock(LoaderInterface::class);
         $cache = $this->createMock(CacheItemPoolInterface::class);
-        $factory = new LazyLoadingMetadataFactory($loader, $cache);
+        $factory = new LazyLoadingMetadataFactory(new StaticMethodLoader(), $cache);
         $cache
             ->expects($this->never())
             ->method('getItem');
@@ -137,7 +137,7 @@ class LazyLoadingMetadataFactoryTest extends TestCase
 
     public function testGroupsFromParent()
     {
-        $reader = new \Symfony\Component\Validator\Mapping\Loader\StaticMethodLoader();
+        $reader = new StaticMethodLoader();
         $factory = new LazyLoadingMetadataFactory($reader);
         $metadata = $factory->getMetadataFor('Symfony\Component\Validator\Tests\Fixtures\EntityStaticCarTurbo');
         $groups = [];

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/FilesLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/FilesLoaderTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Validator\Tests\Mapping\Loader;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Loader\LoaderInterface;
+use Symfony\Component\Validator\Mapping\Loader\StaticMethodLoader;
 use Symfony\Component\Validator\Tests\Fixtures\FilesLoader;
 use Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\Entity;
 
@@ -21,7 +22,7 @@ class FilesLoaderTest extends TestCase
 {
     public function testCallsGetFileLoaderInstanceForeachPath()
     {
-        $loader = $this->getFilesLoader($this->createMock(LoaderInterface::class));
+        $loader = $this->getFilesLoader(new StaticMethodLoader());
         $this->assertEquals(4, $loader->getTimesCalled());
     }
 

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/LoaderChainTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/LoaderChainTest.php
@@ -44,13 +44,13 @@ class LoaderChainTest extends TestCase
     {
         $metadata = new ClassMetadata('\stdClass');
 
-        $loader1 = $this->createMock(LoaderInterface::class);
-        $loader1->expects($this->any())
+        $loader1 = $this->createStub(LoaderInterface::class);
+        $loader1
             ->method('loadClassMetadata')
             ->willReturn(true);
 
-        $loader2 = $this->createMock(LoaderInterface::class);
-        $loader2->expects($this->any())
+        $loader2 = $this->createStub(LoaderInterface::class);
+        $loader2
             ->method('loadClassMetadata')
             ->willReturn(false);
 
@@ -66,13 +66,13 @@ class LoaderChainTest extends TestCase
     {
         $metadata = new ClassMetadata('\stdClass');
 
-        $loader1 = $this->createMock(LoaderInterface::class);
-        $loader1->expects($this->any())
+        $loader1 = $this->createStub(LoaderInterface::class);
+        $loader1
             ->method('loadClassMetadata')
             ->willReturn(false);
 
-        $loader2 = $this->createMock(LoaderInterface::class);
-        $loader2->expects($this->any())
+        $loader2 = $this->createStub(LoaderInterface::class);
+        $loader2
             ->method('loadClassMetadata')
             ->willReturn(false);
 

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/PropertyInfoLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/PropertyInfoLoaderTest.php
@@ -35,7 +35,7 @@ class PropertyInfoLoaderTest extends TestCase
 {
     public function testLoadClassMetadata()
     {
-        $propertyInfoStub = $this->createMock(PropertyInfoExtractorInterface::class);
+        $propertyInfoStub = $this->createStub(PropertyInfoExtractorInterface::class);
         $propertyInfoStub
             ->method('getProperties')
             ->willReturn([
@@ -190,7 +190,7 @@ class PropertyInfoLoaderTest extends TestCase
      */
     public function testClassValidator(bool $expected, ?string $classValidatorRegexp = null)
     {
-        $propertyInfoStub = $this->createMock(PropertyInfoExtractorInterface::class);
+        $propertyInfoStub = $this->createStub(PropertyInfoExtractorInterface::class);
         $propertyInfoStub
             ->method('getProperties')
             ->willReturn(['string'])
@@ -218,7 +218,7 @@ class PropertyInfoLoaderTest extends TestCase
 
     public function testClassNoAutoMapping()
     {
-        $propertyInfoStub = $this->createMock(PropertyInfoExtractorInterface::class);
+        $propertyInfoStub = $this->createStub(PropertyInfoExtractorInterface::class);
         $propertyInfoStub
             ->method('getProperties')
             ->willReturn(['string', 'autoMappingExplicitlyEnabled'])

--- a/src/Symfony/Component/Validator/Tests/Validator/TraceableValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/TraceableValidatorTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Validator\Tests\Validator;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
@@ -27,15 +27,15 @@ class TraceableValidatorTest extends TestCase
     {
         $originalValidator = $this->createMock(ValidatorInterface::class);
         $violations = new ConstraintViolationList([
-            $this->createMock(ConstraintViolation::class),
-            $this->createMock(ConstraintViolation::class),
+            $this->createStub(ConstraintViolation::class),
+            $this->createStub(ConstraintViolation::class),
         ]);
         $originalValidator->expects($this->exactly(2))->method('validate')->willReturn($violations);
 
         $validator = new TraceableValidator($originalValidator);
 
         $object = new \stdClass();
-        $constraints = [$this->createMock(Constraint::class)];
+        $constraints = [new NotNull()];
         $groups = ['Default', 'Create'];
 
         $validator->validate($object, $constraints, $groups);
@@ -74,16 +74,16 @@ class TraceableValidatorTest extends TestCase
 
         $expects = fn ($method) => $originalValidator->expects($this->once())->method($method);
 
-        $expects('getMetadataFor')->willReturn($expected = $this->createMock(MetadataInterface::class));
+        $expects('getMetadataFor')->willReturn($expected = $this->createStub(MetadataInterface::class));
         $this->assertSame($expected, $validator->getMetadataFor('value'), 'returns original validator getMetadataFor() result');
 
         $expects('hasMetadataFor')->willReturn($expected = false);
         $this->assertSame($expected, $validator->hasMetadataFor('value'), 'returns original validator hasMetadataFor() result');
 
-        $expects('inContext')->willReturn($expected = $this->createMock(ContextualValidatorInterface::class));
-        $this->assertSame($expected, $validator->inContext($this->createMock(ExecutionContextInterface::class)), 'returns original validator inContext() result');
+        $expects('inContext')->willReturn($expected = $this->createStub(ContextualValidatorInterface::class));
+        $this->assertSame($expected, $validator->inContext($this->createStub(ExecutionContextInterface::class)), 'returns original validator inContext() result');
 
-        $expects('startContext')->willReturn($expected = $this->createMock(ContextualValidatorInterface::class));
+        $expects('startContext')->willReturn($expected = $this->createStub(ContextualValidatorInterface::class));
         $this->assertSame($expected, $validator->startContext(), 'returns original validator startContext() result');
 
         $expects('validate')->willReturn($expected = new ConstraintViolationList());

--- a/src/Symfony/Component/Validator/Tests/ValidatorBuilderTest.php
+++ b/src/Symfony/Component/Validator/Tests/ValidatorBuilderTest.php
@@ -16,12 +16,12 @@ use Doctrine\Common\Annotations\Reader;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\Translation\IdentityTranslator;
 use Symfony\Component\Validator\ConstraintValidatorFactoryInterface;
 use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
 use Symfony\Component\Validator\ObjectInitializerInterface;
 use Symfony\Component\Validator\Validator\RecursiveValidator;
 use Symfony\Component\Validator\ValidatorBuilder;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ValidatorBuilderTest extends TestCase
 {
@@ -37,7 +37,7 @@ class ValidatorBuilderTest extends TestCase
     public function testAddObjectInitializer()
     {
         $this->assertSame($this->builder, $this->builder->addObjectInitializer(
-            $this->createMock(ObjectInitializerInterface::class)
+            $this->createStub(ObjectInitializerInterface::class)
         ));
     }
 
@@ -143,21 +143,19 @@ class ValidatorBuilderTest extends TestCase
 
     public function testSetMappingCache()
     {
-        $this->assertSame($this->builder, $this->builder->setMappingCache($this->createMock(CacheItemPoolInterface::class)));
+        $this->assertSame($this->builder, $this->builder->setMappingCache($this->createStub(CacheItemPoolInterface::class)));
     }
 
     public function testSetConstraintValidatorFactory()
     {
         $this->assertSame($this->builder, $this->builder->setConstraintValidatorFactory(
-            $this->createMock(ConstraintValidatorFactoryInterface::class))
+            $this->createStub(ConstraintValidatorFactoryInterface::class))
         );
     }
 
     public function testSetTranslator()
     {
-        $this->assertSame($this->builder, $this->builder->setTranslator(
-            $this->createMock(TranslatorInterface::class))
-        );
+        $this->assertSame($this->builder, $this->builder->setTranslator(new IdentityTranslator()));
     }
 
     public function testSetTranslationDomain()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | part of #62669
| License       | MIT
