### PR TITLE
[ObjectMapper] Tag `MapCollection` as service

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Deprecate setting the `framework.profiler.collect_serializer_data` config option
  * Add support for `framework.secrets.decryption_env_var` to contain dots
+ * Add `object_mapper.transform.map_collection` service
 
 8.0
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/object_mapper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/object_mapper.php
@@ -16,11 +16,18 @@ use Symfony\Component\ObjectMapper\Metadata\ReflectionObjectMapperMetadataFactor
 use Symfony\Component\ObjectMapper\Metadata\ReverseClassObjectMapperMetadataFactory;
 use Symfony\Component\ObjectMapper\ObjectMapper;
 use Symfony\Component\ObjectMapper\ObjectMapperInterface;
+use Symfony\Component\ObjectMapper\Transform\MapCollection;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
         ->set('object_mapper.metadata_factory', ReflectionObjectMapperMetadataFactory::class)
         ->alias(ObjectMapperMetadataFactoryInterface::class, 'object_mapper.metadata_factory')
+
+        ->set('object_mapper.transform.map_collection', MapCollection::class)
+            ->tag('object_mapper.transform_callable')
+            ->args([
+                service('object_mapper'),
+            ])
 
         ->set('object_mapper.metadata_factory.reverse_class', ReverseClassObjectMapperMetadataFactory::class)
             ->decorate('object_mapper.metadata_factory')

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/object_mapper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/object_mapper.php
@@ -23,17 +23,24 @@ return static function (ContainerConfigurator $container) {
         ->set('object_mapper.metadata_factory', ReflectionObjectMapperMetadataFactory::class)
         ->alias(ObjectMapperMetadataFactoryInterface::class, 'object_mapper.metadata_factory')
 
+        ->set('object_mapper.metadata_factory.reverse_class', ReverseClassObjectMapperMetadataFactory::class)
+            ->decorate('object_mapper.metadata_factory')
+            ->args([
+                service('.inner'),
+                abstract_arg('class_map'),
+            ])
+
         ->set('object_mapper.transform.map_collection', MapCollection::class)
             ->tag('object_mapper.transform_callable')
             ->args([
                 service('object_mapper'),
             ])
 
-        ->set('object_mapper.metadata_factory.reverse_class', ReverseClassObjectMapperMetadataFactory::class)
-            ->decorate('object_mapper.metadata_factory')
+        ->set(MapCollection::class)
+            ->tag('object_mapper.transform_callable')
+            ->class(MapCollection::class)
             ->args([
-                service('.inner'),
-                abstract_arg('class_map'),
+                service('object_mapper'),
             ])
 
         ->set('object_mapper', ObjectMapper::class)

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -2845,6 +2845,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
             $container->loadFromExtension('framework', []);
         });
         $this->assertTrue($container->has('object_mapper'));
+        $this->assertTrue($container->has('object_mapper.transform.map_collection'));
     }
 
     public function testSecretsDecryptionEnvVarWithDot()

--- a/src/Symfony/Component/ObjectMapper/Metadata/ReverseClassObjectMapperMetadataFactory.php
+++ b/src/Symfony/Component/ObjectMapper/Metadata/ReverseClassObjectMapperMetadataFactory.php
@@ -50,7 +50,10 @@ final class ReverseClassObjectMapperMetadataFactory implements ObjectMapperMetad
         }
 
         if (!$property) {
-            $mappings[] = new Mapping($targetClass);
+            // if the mappings don't already contain a mapping to the target class, add one
+            if (!array_any($mappings, static fn ($mapping) => $mapping->target === $targetClass)) {
+                $mappings[] = new Mapping($targetClass);
+            }
 
             return $this->attributesCache[$key] = $mappings;
         }

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/TransformCollection/TransformCollectionA.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/TransformCollection/TransformCollectionA.php
@@ -7,7 +7,7 @@ use Symfony\Component\ObjectMapper\Transform\MapCollection;
 
 class TransformCollectionA
 {
-    #[Map(transform: new MapCollection())]
+    #[Map(transform: MapCollection::class)]
     /** @var TransformCollectionC[] */
     public array $foo;
 }

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -103,6 +103,7 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformC
 use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformCollectionB;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformCollectionC;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformCollectionD;
+use Symfony\Component\ObjectMapper\Transform\MapCollection;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
 final class ObjectMapperTest extends TestCase
@@ -589,7 +590,11 @@ final class ObjectMapperTest extends TestCase
     {
         $u = new TransformCollectionA();
         $u->foo = [new TransformCollectionC('a'), new TransformCollectionC('b')];
-        $mapper = new ObjectMapper();
+        $mapper = new ObjectMapper(
+            transformCallableLocator: $this->getServiceLocator([
+                MapCollection::class => new MapCollection(),
+            ])
+        );
 
         $transformed = $mapper->map($u, TransformCollectionB::class);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| License       | MIT

From the docs, if you want to map an array, you need to use the `MapCollection` class :
```php
use Symfony\Component\ObjectMapper\Attribute\Map;
use Symfony\Component\ObjectMapper\Transform\MapCollection;

class ProductListInput
{
    #[Map(transform: new MapCollection())]
    /** @var ProductInput[] */
    public array $products;
}
```

But when doing so, the MapCollection class doesn't use the ObjectMapper registered in the container and instantiate a new one.

With this PR, you will map iterable like this :
```php
use Symfony\Component\ObjectMapper\Attribute\Map;
use Symfony\Component\ObjectMapper\Transform\MapCollection;

class ProductListInput
{
    #[Map(transform: 'object_mapper.transform.map_collection')]
    /** @var ProductInput[] */
    public array $products;
}
```

A current workaround is to register the service in your own `services.yaml` : 

```yaml
    object_mapper.transform.map_collection:
        class: Symfony\Component\ObjectMapper\Transform\MapCollection
        arguments:
            - '@object_mapper'
```

I didn't know how to add tests for this, so any suggestion is welcome :)

All credit goes to @soyuka who gave the idea in the Symfony Slack ! 