### PR TITLE
[Form] Add type hint for FormTypeInterface in FormBuilderInterface

### DIFF
--- a/src/Symfony/Component/Form/FormBuilderInterface.php
+++ b/src/Symfony/Component/Form/FormBuilderInterface.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Form;
 
+use Symfony\Component\Form\FormTypeInterface;
+
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
@@ -25,16 +27,17 @@ interface FormBuilderInterface extends \Traversable, \Countable, FormConfigBuild
      * If you add a nested group, this group should also be represented in the
      * object hierarchy.
      *
-     * @param array<string, mixed> $options
+     * @param class-string<FormTypeInterface>|null $type
+     * @param array<string, mixed>                 $options
      */
     public function add(string|self $child, ?string $type = null, array $options = []): static;
 
     /**
      * Creates a form builder.
      *
-     * @param string               $name    The name of the form or the name of the property
-     * @param string|null          $type    The type of the form or null if name is a property
-     * @param array<string, mixed> $options
+     * @param string                               $name    The name of the form or the name of the property
+     * @param class-string<FormTypeInterface>|null $type    The type of the form or null if name is a property
+     * @param array<string, mixed>                 $options
      */
     public function create(string $name, ?string $type = null, array $options = []): self;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Can we add this? Or does standalone Symfony Forms still support none class names?
