### PR TITLE
[ExpressionLanguage] Add support for null-safe syntax for array access

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/CHANGELOG.md
+++ b/src/Symfony/Component/ExpressionLanguage/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add support for null-safe array access syntax (`foo?.[0]`)
+
 8.0
 ---
 

--- a/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
@@ -27,17 +27,19 @@ class GetAttrNode extends Node
     /**
      * @param self::* $type
      */
-    public function __construct(Node $node, Node $attribute, ArrayNode $arguments, int $type)
+    public function __construct(Node $node, Node $attribute, ArrayNode $arguments, int $type, bool $isNullSafe = false)
     {
+        $isNullSafe = self::ARRAY_CALL === $type && $isNullSafe;
+
         parent::__construct(
             ['node' => $node, 'attribute' => $attribute, 'arguments' => $arguments],
-            ['type' => $type, 'is_null_coalesce' => false, 'is_short_circuited' => false],
+            ['type' => $type, 'is_null_coalesce' => false, 'is_short_circuited' => false, 'is_null_safe' => $isNullSafe],
         );
     }
 
     public function compile(Compiler $compiler): void
     {
-        $nullSafe = $this->nodes['attribute'] instanceof ConstantNode && $this->nodes['attribute']->isNullSafe;
+        $nullSafe = ($this->nodes['attribute'] instanceof ConstantNode && $this->nodes['attribute']->isNullSafe) || $this->attributes['is_null_safe'];
         switch ($this->attributes['type']) {
             case self::PROPERTY_CALL:
                 $compiler
@@ -59,17 +61,30 @@ class GetAttrNode extends Node
                 break;
 
             case self::ARRAY_CALL:
-                $compiler
-                    ->compile($this->nodes['node'])
-                    ->raw('[')
-                    ->compile($this->nodes['attribute'])->raw(']')
-                ;
+                if ($nullSafe) {
+                    $compiler
+                        ->raw('\\'.self::class.'::convertToArrayAccess(')
+                        ->compile($this->nodes['node'])
+                        ->raw(', ')
+                        ->string($this->nodes['node']->dump())
+                        ->raw(')?->offsetGet(')
+                        ->compile($this->nodes['attribute'])
+                        ->raw(')')
+                    ;
+                } else {
+                    $compiler
+                        ->compile($this->nodes['node'])
+                        ->raw('[')
+                        ->compile($this->nodes['attribute'])->raw(']')
+                    ;
+                }
                 break;
         }
     }
 
     public function evaluate(array $functions, array $values): mixed
     {
+        $nullSafe = $this->attributes['is_null_safe'];
         switch ($this->attributes['type']) {
             case self::PROPERTY_CALL:
                 $obj = $this->nodes['node']->evaluate($functions, $values);
@@ -118,7 +133,9 @@ class GetAttrNode extends Node
             case self::ARRAY_CALL:
                 $array = $this->nodes['node']->evaluate($functions, $values);
 
-                if (null === $array && $this->isShortCircuited()) {
+                if (null === $array && ($nullSafe || $this->isShortCircuited())) {
+                    $this->attributes['is_short_circuited'] = $nullSafe || $this->attributes['is_short_circuited'];
+
                     return null;
                 }
 
@@ -132,6 +149,26 @@ class GetAttrNode extends Node
 
                 return $array[$this->nodes['attribute']->evaluate($functions, $values)];
         }
+    }
+
+    /**
+     * @internal
+     */
+    public static function convertToArrayAccess(mixed $value, string $nodeDump): ?\ArrayAccess
+    {
+        if (null === $value) {
+            return null;
+        }
+
+        if (\is_array($value)) {
+            return new \ArrayObject($value);
+        }
+
+        if ($value instanceof \ArrayAccess) {
+            return $value;
+        }
+
+        throw new \RuntimeException(\sprintf('Unable to get an item of non-array "%s".', $nodeDump));
     }
 
     private function isShortCircuited(): bool
@@ -150,7 +187,7 @@ class GetAttrNode extends Node
                 return [$this->nodes['node'], $nullSafe ? '?.' : '.', $this->nodes['attribute'], '(', $this->nodes['arguments'], ')'];
 
             case self::ARRAY_CALL:
-                return [$this->nodes['node'], '[', $this->nodes['attribute'], ']'];
+                return [$this->nodes['node'], $this->attributes['is_null_safe'] ? '?.[' : '[', $this->nodes['attribute'], ']'];
         }
     }
 
@@ -162,6 +199,7 @@ class GetAttrNode extends Node
         $this->nodes = $data['nodes'];
         $this->attributes = $data['attributes'];
         $this->attributes['is_null_coalesce'] ??= false;
+        $this->attributes['is_null_safe'] ??= false;
         $this->attributes['is_short_circuited'] ??= $data["\x00Symfony\Component\ExpressionLanguage\Node\GetAttrNode\x00isShortCircuited"] ?? false;
     }
 }

--- a/src/Symfony/Component/ExpressionLanguage/Parser.php
+++ b/src/Symfony/Component/ExpressionLanguage/Parser.php
@@ -359,39 +359,51 @@ class Parser
                 $isNullSafe = '?.' === $token->value;
                 $this->stream->next();
                 $token = $this->stream->current;
-                $this->stream->next();
-
-                if (
-                    Token::NAME_TYPE !== $token->type
-                    // Operators like "not" and "matches" are valid method or property names,
-                    //
-                    // In other words, besides NAME_TYPE, OPERATOR_TYPE could also be parsed as a property or method.
-                    // This is because operators are processed by the lexer prior to names. So "not" in "foo.not()" or "matches" in "foo.matches" will be recognized as an operator first.
-                    // But in fact, "not" and "matches" in such expressions shall be parsed as method or property names.
-                    //
-                    // And this ONLY works if the operator consists of valid characters for a property or method name.
-                    //
-                    // Other types, such as STRING_TYPE and NUMBER_TYPE, can't be parsed as property nor method names.
-                    //
-                    // As a result, if $token is NOT an operator OR $token->value is NOT a valid property or method name, an exception shall be thrown.
-                    && (Token::OPERATOR_TYPE !== $token->type || !preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/A', $token->value))
-                ) {
-                    throw new SyntaxError('Expected name.', $token->cursor, $this->stream->getExpression());
-                }
-
-                $arg = new Node\ConstantNode($token->value, true, $isNullSafe);
-
-                $arguments = new Node\ArgumentsNode();
-                if ($this->stream->current->test(Token::PUNCTUATION_TYPE, '(')) {
-                    $type = Node\GetAttrNode::METHOD_CALL;
-                    foreach ($this->parseArguments()->nodes as $n) {
-                        $arguments->addElement($n);
+                if ($token->test(Token::PUNCTUATION_TYPE, '[')) {
+                    if (!$isNullSafe) {
+                        throw new SyntaxError('Expected name.', $token->cursor, $this->stream->getExpression());
                     }
-                } else {
-                    $type = Node\GetAttrNode::PROPERTY_CALL;
-                }
 
-                $node = new Node\GetAttrNode($node, $arg, $arguments, $type);
+                    $this->stream->next();
+                    $arg = $this->parseExpression();
+                    $this->stream->expect(Token::PUNCTUATION_TYPE, ']');
+
+                    $node = new Node\GetAttrNode($node, $arg, new Node\ArgumentsNode(), Node\GetAttrNode::ARRAY_CALL, true);
+                } else {
+                    $this->stream->next();
+
+                    if (
+                        Token::NAME_TYPE !== $token->type
+                        // Operators like "not" and "matches" are valid method or property names,
+                        //
+                        // In other words, besides NAME_TYPE, OPERATOR_TYPE could also be parsed as a property or method.
+                        // This is because operators are processed by the lexer prior to names. So "not" in "foo.not()" or "matches" in "foo.matches" will be recognized as an operator first.
+                        // But in fact, "not" and "matches" in such expressions shall be parsed as method or property names.
+                        //
+                        // And this ONLY works if the operator consists of valid characters for a property or method name.
+                        //
+                        // Other types, such as STRING_TYPE and NUMBER_TYPE, can't be parsed as property nor method names.
+                        //
+                        // As a result, if $token is NOT an operator OR $token->value is NOT a valid property or method name, an exception shall be thrown.
+                        && (Token::OPERATOR_TYPE !== $token->type || !preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/A', $token->value))
+                    ) {
+                        throw new SyntaxError('Expected name.', $token->cursor, $this->stream->getExpression());
+                    }
+
+                    $arg = new Node\ConstantNode($token->value, true, $isNullSafe);
+
+                    $arguments = new Node\ArgumentsNode();
+                    if ($this->stream->current->test(Token::PUNCTUATION_TYPE, '(')) {
+                        $type = Node\GetAttrNode::METHOD_CALL;
+                        foreach ($this->parseArguments()->nodes as $n) {
+                            $arguments->addElement($n);
+                        }
+                    } else {
+                        $type = Node\GetAttrNode::PROPERTY_CALL;
+                    }
+
+                    $node = new Node\GetAttrNode($node, $arg, $arguments, $type, $isNullSafe);
+                }
             } elseif ('[' === $token->value) {
                 $this->stream->next();
                 $arg = $this->parseExpression();

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
@@ -346,6 +346,8 @@ class ExpressionLanguageTest extends TestCase
         yield ['foo["bar"]?.baz()', ['bar' => null]];
         yield ['foo.bar()?.baz', $foo];
         yield ['foo.bar()?.baz()', $foo];
+        yield ['foo?.[0]', null];
+        yield ['foo?.[0].bar', null];
 
         yield ['foo?.bar.baz', null];
         yield ['foo?.bar["baz"]', null];
@@ -396,6 +398,7 @@ class ExpressionLanguageTest extends TestCase
         yield ['foo?.bar.baz', (object) ['bar' => null], 'Unable to get property "baz" of non-object "foo?.bar".'];
         yield ['foo?.bar["baz"]', (object) ['bar' => null], 'Unable to get an item of non-array "foo?.bar".'];
         yield ['foo?.bar["baz"].qux.quux', (object) ['bar' => ['baz' => null]], 'Unable to get property "qux" of non-object "foo?.bar["baz"]".'];
+        yield ['foo?.[0].bar', [null], 'Unable to get property "bar" of non-object "foo?.[0]".'];
     }
 
     #[DataProvider('provideNullCoalescing')]

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/GetAttrNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/GetAttrNodeTest.php
@@ -29,6 +29,7 @@ class GetAttrNodeTest extends AbstractNodeTestCase
 
             ['baz', new GetAttrNode(new NameNode('foo'), new ConstantNode('foo'), self::getArrayNode(), GetAttrNode::METHOD_CALL), ['foo' => new Obj()]],
             ['a', new GetAttrNode(new NameNode('foo'), new NameNode('index'), self::getArrayNode(), GetAttrNode::ARRAY_CALL), ['foo' => ['b' => 'a', 'b'], 'index' => 'b']],
+            [null, new GetAttrNode(new NameNode('foo'), new ConstantNode(0), new ArgumentsNode(), GetAttrNode::ARRAY_CALL, true), ['foo' => null]],
         ];
     }
 
@@ -57,6 +58,7 @@ class GetAttrNodeTest extends AbstractNodeTestCase
             ['foo[index]', new GetAttrNode(new NameNode('foo'), new NameNode('index'), self::getArrayNode(), GetAttrNode::ARRAY_CALL)],
 
             ['foo?.foo()', new GetAttrNode(new NameNode('foo'), new ConstantNode('foo', true, true), new ArgumentsNode(), GetAttrNode::METHOD_CALL)],
+            ['foo?.[0]', new GetAttrNode(new NameNode('foo'), new ConstantNode(0), new ArgumentsNode(), GetAttrNode::ARRAY_CALL, true)],
         ];
     }
 

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
@@ -185,6 +185,11 @@ class ParserTest extends TestCase
                 ['foo'],
             ],
             [
+                new Node\GetAttrNode(new Node\NameNode('foo'), new Node\ConstantNode(0), new Node\ArgumentsNode(), Node\GetAttrNode::ARRAY_CALL, true),
+                'foo?.[0]',
+                ['foo'],
+            ],
+            [
                 new Node\NullCoalesceNode(new Node\GetAttrNode(new Node\NameNode('foo'), new Node\ConstantNode('bar', true), new Node\ArgumentsNode(), Node\GetAttrNode::PROPERTY_CALL), new Node\ConstantNode('default')),
                 'foo.bar ?? "default"',
                 ['foo'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1 
| Bug fix?      | no
| New feature?  | yes <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #59966
| License       | MIT

[Null Safe Access](https://symfony.com/doc/current/reference/formats/expression_language.html#null-safe-operator) was added in https://github.com/symfony/expression-language/pull/7 however that syntax does not work for array access.

[Javascript DOES support this syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining#syntax): `obj.val?.[expr]`

### Example

```js
myObject.getItems()?.[0]?.myFunction()
```
to avoid array access error.

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
