### PR TITLE
[Mailer] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/Mailer/Test/TransportFactoryTestCase.php
+++ b/src/Symfony/Component/Mailer/Test/TransportFactoryTestCase.php
@@ -13,6 +13,9 @@ namespace Symfony\Component\Mailer\Test;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Mailer\Exception\IncompleteDsnException;
 use Symfony\Component\Mailer\Exception\UnsupportedSchemeException;
 use Symfony\Component\Mailer\Transport\Dsn;
@@ -102,16 +105,16 @@ abstract class TransportFactoryTestCase extends TestCase
 
     protected function getDispatcher(): EventDispatcherInterface
     {
-        return $this->dispatcher ??= $this->createMock(EventDispatcherInterface::class);
+        return $this->dispatcher ??= new EventDispatcher();
     }
 
     protected function getClient(): HttpClientInterface
     {
-        return $this->client ??= $this->createMock(HttpClientInterface::class);
+        return $this->client ??= new MockHttpClient();
     }
 
     protected function getLogger(): LoggerInterface
     {
-        return $this->logger ??= $this->createMock(LoggerInterface::class);
+        return $this->logger ??= new NullLogger();
     }
 }

--- a/src/Symfony/Component/Mailer/Tests/MailerTest.php
+++ b/src/Symfony/Component/Mailer/Tests/MailerTest.php
@@ -21,8 +21,8 @@ use Symfony\Component\Mailer\Mailer;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractTransport;
 use Symfony\Component\Mailer\Transport\NullTransport;
-use Symfony\Component\Mailer\Transport\TransportInterface;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBus;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Stamp\StampInterface;
 use Symfony\Component\Mime\Address;
@@ -35,7 +35,7 @@ class MailerTest extends TestCase
     {
         $this->expectException(LogicException::class);
 
-        $transport = new Mailer($this->createMock(TransportInterface::class), $this->createMock(MessageBusInterface::class), $this->createMock(EventDispatcherInterface::class));
+        $transport = new Mailer(new DummyTransport('localhost'), new MessageBus(), new EventDispatcher());
         $transport->send(new RawMessage('Some raw email message'));
     }
 
@@ -54,7 +54,7 @@ class MailerTest extends TestCase
             }
         };
 
-        $stamp = $this->createMock(StampInterface::class);
+        $stamp = new class implements StampInterface {};
 
         $dispatcher = $this->createMock(EventDispatcherInterface::class);
         $dispatcher->expects($this->once())

--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/SmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/SmtpTransportTest.php
@@ -143,8 +143,8 @@ class SmtpTransportTest extends TestCase
     public function testMessageIdFromServerIsEmbeddedInSentMessageEvent()
     {
         $calls = 0;
-        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
-        $eventDispatcher->expects($this->any())
+        $eventDispatcher = $this->createStub(EventDispatcherInterface::class);
+        $eventDispatcher
             ->method('dispatch')
             ->with($this->callback(static function ($event) use (&$calls): bool {
                 ++$calls;

--- a/src/Symfony/Component/Mailer/Tests/Transport/TransportsTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/TransportsTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Mailer\Tests\Transport;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mailer\Exception\InvalidArgumentException;
+use Symfony\Component\Mailer\Tests\DummyTransport;
 use Symfony\Component\Mailer\Transport\TransportInterface;
 use Symfony\Component\Mailer\Transport\Transports;
 use Symfony\Component\Mime\Header\Headers;
@@ -53,8 +54,8 @@ class TransportsTest extends TestCase
     public function testTransportDoesNotExist()
     {
         $transport = new Transports([
-            'foo' => $this->createMock(TransportInterface::class),
-            'bar' => $this->createMock(TransportInterface::class),
+            'foo' => new DummyTransport('localhost'),
+            'bar' => new DummyTransport('localhost'),
         ]);
 
         $headers = (new Headers())->addTextHeader('X-Transport', 'foobar');
@@ -69,7 +70,7 @@ class TransportsTest extends TestCase
     {
         $exception = new \Exception();
 
-        $fooTransport = $this->createMock(TransportInterface::class);
+        $fooTransport = $this->createStub(TransportInterface::class);
         $fooTransport->method('send')
             ->willThrowException($exception);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | part of #62669
| License       | MIT
