### PR TITLE
[BrowserKit] Allow Cookie expiration to be an int

### DIFF
--- a/src/Symfony/Component/BrowserKit/Cookie.php
+++ b/src/Symfony/Component/BrowserKit/Cookie.php
@@ -48,17 +48,17 @@ class Cookie
     /**
      * Sets a cookie.
      *
-     * @param string      $name         The cookie name
-     * @param string|null $value        The value of the cookie
-     * @param string|null $expires      The time the cookie expires
-     * @param string|null $path         The path on the server in which the cookie will be available on
-     * @param string      $domain       The domain that the cookie is available
-     * @param bool        $secure       Indicates that the cookie should only be transmitted over a secure HTTPS connection from the client
-     * @param bool        $httponly     The cookie httponly flag
-     * @param bool        $encodedValue Whether the value is encoded or not
-     * @param string|null $samesite     The cookie samesite attribute
+     * @param string          $name         The cookie name
+     * @param string|null     $value        The value of the cookie
+     * @param string|int|null $expires      The time the cookie expires
+     * @param string|null     $path         The path on the server in which the cookie will be available on
+     * @param string          $domain       The domain that the cookie is available
+     * @param bool            $secure       Indicates that the cookie should only be transmitted over a secure HTTPS connection from the client
+     * @param bool            $httponly     The cookie httponly flag
+     * @param bool            $encodedValue Whether the value is encoded or not
+     * @param string|null     $samesite     The cookie samesite attribute
      */
-    public function __construct(string $name, ?string $value, ?string $expires = null, ?string $path = null, string $domain = '', bool $secure = false, bool $httponly = true, bool $encodedValue = false, ?string $samesite = null)
+    public function __construct(string $name, ?string $value, string|int|null $expires = null, ?string $path = null, string $domain = '', bool $secure = false, bool $httponly = true, bool $encodedValue = false, ?string $samesite = null)
     {
         if ($encodedValue) {
             $this->rawValue = $value ?? '';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

The constructor parameter `$expires` of the `Cookie` class is typed as `string|null`. That is surprising because that parameter is expected to be provided as a Unix timestamp which is usually an integer. Also, looking at the tests and [the documentation](https://symfony.com/doc/current/components/browser_kit.html#setting-cookies), we commonly call that constructor with an integer ourselves, usually with a value returned by `strtotime()`.

https://github.com/symfony/symfony/blob/b96b6bb7ad6c546573a39a77cc349810391627bf/src/Symfony/Component/BrowserKit/Tests/CookieTest.php#L23

Creating a `Cookie` object as documented in a codebase that uses strict types will cause a `TypeError`.

In this PR, I'm widening the parameter type to `string|int|null`. This should not be a problem because while validating the value, we convert it back to a string anyway.

https://github.com/symfony/symfony/blob/b96b6bb7ad6c546573a39a77cc349810391627bf/src/Symfony/Component/BrowserKit/Cookie.php#L77-L84
