### PR TITLE
[Form] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/Form/Test/TypeTestCase.php
+++ b/src/Symfony/Component/Form/Test/TypeTestCase.php
@@ -31,7 +31,9 @@ abstract class TypeTestCase extends FormIntegrationTestCase
     {
         parent::setUp();
 
-        $this->dispatcher = $this->createMock(EventDispatcherInterface::class);
+        if (!isset($this->dispatcher)) {
+            $this->dispatcher = $this->createMock(EventDispatcherInterface::class);
+        }
         $this->builder = new FormBuilder('', null, $this->dispatcher, $this->factory);
     }
 

--- a/src/Symfony/Component/Form/Tests/CompoundFormTest.php
+++ b/src/Symfony/Component/Form/Tests/CompoundFormTest.php
@@ -920,8 +920,8 @@ class CompoundFormTest extends TestCase
     public function testCreateViewWithChildren()
     {
         $type = $this->createMock(ResolvedFormTypeInterface::class);
-        $type1 = $this->createMock(ResolvedFormTypeInterface::class);
-        $type2 = $this->createMock(ResolvedFormTypeInterface::class);
+        $type1 = $this->createStub(ResolvedFormTypeInterface::class);
+        $type2 = $this->createStub(ResolvedFormTypeInterface::class);
         $options = ['a' => 'Foo', 'b' => 'Bar'];
         $field1 = $this->getBuilder('foo')
             ->setType($type1)

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTestCase.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTestCase.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\Test\TypeTestCase;
 
 /**
@@ -19,6 +20,13 @@ use Symfony\Component\Form\Test\TypeTestCase;
 abstract class BaseTypeTestCase extends TypeTestCase
 {
     public const TESTED_TYPE = '';
+
+    protected function setUp(): void
+    {
+        $this->dispatcher = new EventDispatcher();
+
+        parent::setUp();
+    }
 
     public function testPassDisabledAsOption()
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTranslationTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTranslationTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\Extension\Core\CoreExtension;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -27,10 +28,17 @@ class ChoiceTypeTranslationTest extends TypeTestCase
         'Roman' => 'e',
     ];
 
+    protected function setUp(): void
+    {
+        $this->dispatcher = new EventDispatcher();
+
+        parent::setUp();
+    }
+
     protected function getExtensions()
     {
-        $translator = $this->createMock(TranslatorInterface::class);
-        $translator->expects($this->any())->method('trans')
+        $translator = $this->createStub(TranslatorInterface::class);
+        $translator->method('trans')
             ->willReturnCallback(fn ($key, $params) => strtr(\sprintf('Translation of: %s', $key), $params)
             );
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/PercentTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/PercentTypeTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\Extension\Core\Type\PercentType;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\Intl\Util\IntlTestHelper;
@@ -23,6 +24,8 @@ class PercentTypeTest extends TypeTestCase
 
     protected function setUp(): void
     {
+        $this->dispatcher = new EventDispatcher();
+
         // we test against different locales, so we need the full
         // implementation
         IntlTestHelper::requireFullIntl($this);

--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Tests\Extension\Csrf\Type;
 
 use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Csrf\CsrfExtension;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -38,6 +39,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
     protected function setUp(): void
     {
         $this->tokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $this->dispatcher = new EventDispatcher();
 
         parent::setUp();
     }
@@ -51,6 +53,11 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
 
     public function testCsrfProtectionByDefaultIfRootAndCompound()
     {
+        $this->tokenManager->expects($this->once())
+            ->method('getToken')
+            ->with('form')
+            ->willReturn(new CsrfToken('TOKEN_ID', 'token'));
+
         $view = $this->factory
             ->create('Symfony\Component\Form\Extension\Core\Type\FormType', null, [
                 'csrf_field_name' => 'csrf',
@@ -59,15 +66,23 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
             ->createView();
 
         $this->assertArrayHasKey('csrf', $view);
+        $this->assertSame('token', $view['csrf']->vars['value']);
     }
 
     public function testNoCsrfProtectionByDefaultIfCompoundButNotRoot()
     {
+        $this->tokenManager->expects($this->once())
+            ->method('getToken')
+            ->with('root_token_id');
+
         $view = $this->factory
-            ->createNamedBuilder('root', 'Symfony\Component\Form\Extension\Core\Type\FormType')
+            ->createNamedBuilder('root', 'Symfony\Component\Form\Extension\Core\Type\FormType', null, [
+                'csrf_token_id' => 'root_token_id',
+            ])
             ->add($this->factory
                 ->createNamedBuilder('form', 'Symfony\Component\Form\Extension\Core\Type\FormType', null, [
                     'csrf_field_name' => 'csrf',
+                    'csrf_token_id' => 'child_token_id',
                     'compound' => true,
                 ])
             )
@@ -80,6 +95,10 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
 
     public function testNoCsrfProtectionByDefaultIfRootButNotCompound()
     {
+        $this->tokenManager
+            ->expects($this->never())
+            ->method('getToken');
+
         $view = $this->factory
             ->create('Symfony\Component\Form\Extension\Core\Type\FormType', null, [
                 'csrf_field_name' => 'csrf',
@@ -92,6 +111,10 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
 
     public function testCsrfProtectionCanBeDisabled()
     {
+        $this->tokenManager
+            ->expects($this->never())
+            ->method('getToken');
+
         $view = $this->factory
             ->create('Symfony\Component\Form\Extension\Core\Type\FormType', null, [
                 'csrf_field_name' => 'csrf',
@@ -331,6 +354,11 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
 
     public function testNoCsrfProtectionOnPrototype()
     {
+        $this->tokenManager
+            ->expects($this->once())
+            ->method('getToken')
+            ->with('collection');
+
         $prototypeView = $this->factory
             ->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', null, [
                 'entry_type' => __CLASS__.'_ChildType',

--- a/src/Symfony/Component/Form/Tests/Extension/HtmlSanitizer/Type/TextTypeHtmlSanitizerExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/HtmlSanitizer/Type/TextTypeHtmlSanitizerExtensionTest.php
@@ -9,9 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Form\Tests\Extension\Csrf\Type;
+namespace Symfony\Component\Form\Tests\Extension\HtmlSanitizer\Type;
 
 use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\HtmlSanitizer\HtmlSanitizerExtension;
@@ -20,6 +21,13 @@ use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
 
 class TextTypeHtmlSanitizerExtensionTest extends TypeTestCase
 {
+    protected function setUp(): void
+    {
+        $this->dispatcher = new EventDispatcher();
+
+        parent::setUp();
+    }
+
     protected function getExtensions()
     {
         $fooSanitizer = $this->createMock(HtmlSanitizerInterface::class);

--- a/src/Symfony/Component/Form/Tests/Extension/PasswordHasher/Type/PasswordTypePasswordHasherExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/PasswordHasher/Type/PasswordTypePasswordHasherExtensionTest.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Form\Tests\Extension\PasswordHasher\Type;
 
-use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\Exception\InvalidConfigurationException;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
@@ -21,13 +21,15 @@ use Symfony\Component\Form\Extension\PasswordHasher\PasswordHasherExtension;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\Form\Tests\Fixtures\RepeatedPasswordField;
 use Symfony\Component\Form\Tests\Fixtures\User;
+use Symfony\Component\PasswordHasher\Hasher\MessageDigestPasswordHasher;
+use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactory;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasher;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 
 class PasswordTypePasswordHasherExtensionTest extends TypeTestCase
 {
-    protected MockObject&UserPasswordHasherInterface $passwordHasher;
+    protected UserPasswordHasherInterface $passwordHasher;
 
     protected function setUp(): void
     {
@@ -35,7 +37,10 @@ class PasswordTypePasswordHasherExtensionTest extends TypeTestCase
             $this->markTestSkipped('PasswordAuthenticatedUserInterface not available.');
         }
 
-        $this->passwordHasher = $this->createMock(UserPasswordHasher::class);
+        $this->passwordHasher = new UserPasswordHasher(new PasswordHasherFactory([
+            User::class => new MessageDigestPasswordHasher('md5', false),
+        ]));
+        $this->dispatcher = new EventDispatcher();
 
         parent::setUp();
     }
@@ -52,14 +57,7 @@ class PasswordTypePasswordHasherExtensionTest extends TypeTestCase
         $user = new User();
 
         $plainPassword = 'PlainPassword';
-        $hashedPassword = 'HashedPassword';
-
-        $this->passwordHasher
-            ->expects($this->once())
-            ->method('hashPassword')
-            ->with($user, $plainPassword)
-            ->willReturn($hashedPassword)
-        ;
+        $hashedPassword = 'ec2d1846a8e988d344750b904739e19b';
 
         $this->assertNull($user->getPassword());
 
@@ -85,11 +83,6 @@ class PasswordTypePasswordHasherExtensionTest extends TypeTestCase
         $user = new User();
         $user->setPassword($oldHashedPassword);
 
-        $this->passwordHasher
-            ->expects($this->never())
-            ->method('hashPassword')
-        ;
-
         $this->assertEquals($user->getPassword(), $oldHashedPassword);
 
         $form = $this->factory
@@ -113,14 +106,7 @@ class PasswordTypePasswordHasherExtensionTest extends TypeTestCase
         $user = new User();
 
         $plainPassword = 'PlainPassword';
-        $hashedPassword = 'HashedPassword';
-
-        $this->passwordHasher
-            ->expects($this->once())
-            ->method('hashPassword')
-            ->with($user, $plainPassword)
-            ->willReturn($hashedPassword)
-        ;
+        $hashedPassword = 'ec2d1846a8e988d344750b904739e19b';
 
         $this->assertNull($user->getPassword());
 
@@ -152,14 +138,7 @@ class PasswordTypePasswordHasherExtensionTest extends TypeTestCase
         $user = new User();
 
         $plainPassword = 'PlainPassword';
-        $hashedPassword = 'HashedPassword';
-
-        $this->passwordHasher
-            ->expects($this->once())
-            ->method('hashPassword')
-            ->with($user, $plainPassword)
-            ->willReturn($hashedPassword)
-        ;
+        $hashedPassword = 'ec2d1846a8e988d344750b904739e19b';
 
         $this->assertNull($user->getPassword());
 
@@ -194,11 +173,6 @@ class PasswordTypePasswordHasherExtensionTest extends TypeTestCase
     public function testPasswordHashOnInvalidForm()
     {
         $user = new User();
-
-        $this->passwordHasher
-            ->expects($this->never())
-            ->method('hashPassword')
-        ;
 
         $this->assertNull($user->getPassword());
 

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/BaseValidatorExtensionTestCase.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/BaseValidatorExtensionTestCase.php
@@ -11,15 +11,25 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
 use Symfony\Component\Form\Test\FormInterface;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\Validator\Constraints\GroupSequence;
+use Symfony\Component\Validator\ValidatorBuilder;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 abstract class BaseValidatorExtensionTestCase extends TypeTestCase
 {
+    protected function setUp(): void
+    {
+        $this->dispatcher = new EventDispatcher();
+
+        parent::setUp();
+    }
+
     public function testValidationGroupNullByDefault()
     {
         $form = $this->createForm();
@@ -82,4 +92,11 @@ abstract class BaseValidatorExtensionTestCase extends TypeTestCase
     }
 
     abstract protected function createForm(array $options = []);
+
+    protected function getExtensions()
+    {
+        return [
+            new ValidatorExtension((new ValidatorBuilder())->getValidator()),
+        ];
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/BirthdayTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/BirthdayTypeValidatorExtensionTest.php
@@ -12,12 +12,9 @@
 namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
 use Symfony\Component\Form\Extension\Core\Type\BirthdayType;
-use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
 class BirthdayTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
-    use ValidatorExtensionTrait;
-
     protected function createForm(array $options = [])
     {
         return $this->factory->create(BirthdayType::class, null, $options + ['widget' => 'choice']);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/CheckboxTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/CheckboxTypeValidatorExtensionTest.php
@@ -12,12 +12,9 @@
 namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
-use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
 class CheckboxTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
-    use ValidatorExtensionTrait;
-
     protected function createForm(array $options = [])
     {
         return $this->factory->create(CheckboxType::class, null, $options);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/ChoiceTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/ChoiceTypeValidatorExtensionTest.php
@@ -12,12 +12,9 @@
 namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
 class ChoiceTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
-    use ValidatorExtensionTrait;
-
     protected function createForm(array $options = [])
     {
         return $this->factory->create(ChoiceType::class, null, $options);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/CollectionTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/CollectionTypeValidatorExtensionTest.php
@@ -12,12 +12,9 @@
 namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
-use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
 class CollectionTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
-    use ValidatorExtensionTrait;
-
     protected function createForm(array $options = [])
     {
         return $this->factory->create(CollectionType::class, null, $options);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/ColorTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/ColorTypeValidatorExtensionTest.php
@@ -12,12 +12,9 @@
 namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
 use Symfony\Component\Form\Extension\Core\Type\ColorType;
-use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
 class ColorTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
-    use ValidatorExtensionTrait;
-
     protected function createForm(array $options = [])
     {
         return $this->factory->create(ColorType::class, null, $options);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/CountryTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/CountryTypeValidatorExtensionTest.php
@@ -12,12 +12,9 @@
 namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
 use Symfony\Component\Form\Extension\Core\Type\CountryType;
-use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
 class CountryTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
-    use ValidatorExtensionTrait;
-
     protected function createForm(array $options = [])
     {
         return $this->factory->create(CountryType::class, null, $options);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/CurrencyTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/CurrencyTypeValidatorExtensionTest.php
@@ -12,12 +12,9 @@
 namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
 use Symfony\Component\Form\Extension\Core\Type\CurrencyType;
-use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
 class CurrencyTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
-    use ValidatorExtensionTrait;
-
     protected function createForm(array $options = [])
     {
         return $this->factory->create(CurrencyType::class, null, $options);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/DateIntervalTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/DateIntervalTypeValidatorExtensionTest.php
@@ -12,12 +12,9 @@
 namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
 use Symfony\Component\Form\Extension\Core\Type\DateIntervalType;
-use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
 class DateIntervalTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
-    use ValidatorExtensionTrait;
-
     protected function createForm(array $options = [])
     {
         return $this->factory->create(DateIntervalType::class, null, $options);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/DateTimeTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/DateTimeTypeValidatorExtensionTest.php
@@ -12,12 +12,9 @@
 namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
-use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
 class DateTimeTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
-    use ValidatorExtensionTrait;
-
     protected function createForm(array $options = [])
     {
         return $this->factory->create(DateTimeType::class, null, $options + ['widget' => 'choice']);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/DateTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/DateTypeValidatorExtensionTest.php
@@ -12,12 +12,9 @@
 namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
 use Symfony\Component\Form\Extension\Core\Type\DateType;
-use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
 class DateTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
-    use ValidatorExtensionTrait;
-
     protected function createForm(array $options = [])
     {
         return $this->factory->create(DateType::class, null, $options + ['widget' => 'choice']);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/EmailTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/EmailTypeValidatorExtensionTest.php
@@ -12,12 +12,9 @@
 namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
-use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
 class EmailTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
-    use ValidatorExtensionTrait;
-
     protected function createForm(array $options = [])
     {
         return $this->factory->create(EmailType::class, null, $options);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FileTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FileTypeValidatorExtensionTest.php
@@ -12,12 +12,9 @@
 namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
 use Symfony\Component\Form\Extension\Core\Type\FileType;
-use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
 class FileTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
-    use ValidatorExtensionTrait;
-
     protected function createForm(array $options = [])
     {
         return $this->factory->create(FileType::class, null, $options);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
@@ -11,10 +11,10 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\Forms;
-use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 use Symfony\Component\Form\Tests\Extension\Core\Type\FormTypeTest;
 use Symfony\Component\Form\Tests\Extension\Core\Type\TextTypeTest;
 use Symfony\Component\Form\Tests\Fixtures\Author;
@@ -22,16 +22,14 @@ use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\Validator\Constraints\GroupSequence;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\Valid;
-use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Factory\MetadataFactoryInterface;
 use Symfony\Component\Validator\Validation;
 
 class FormTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
-    use ValidatorExtensionTrait;
-
     public function testSubmitValidatesData()
     {
         $builder = $this->factory->createBuilder(
@@ -41,16 +39,17 @@ class FormTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
                 'validation_groups' => 'group',
             ]
         );
-        $builder->add('firstName', FormTypeTest::TESTED_TYPE);
+        $builder->add('firstName', TextType::class, [
+            'constraints' => new NotNull(groups: ['group']),
+        ]);
         $form = $builder->getForm();
-
-        $this->validator->expects($this->once())
-            ->method('validate')
-            ->with($this->equalTo($form))
-            ->willReturn(new ConstraintViolationList());
 
         // specific data is irrelevant
         $form->submit([]);
+
+        $this->assertTrue($form->isSubmitted());
+        $this->assertFalse($form->isValid());
+        $this->assertFalse($form->get('firstName')->isValid());
     }
 
     public function testValidConstraint()
@@ -101,8 +100,8 @@ class FormTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
         $authorMetadata = (new ClassMetadata(Author::class))
             ->addPropertyConstraint('firstName', new NotBlank(['groups' => 'Second']))
         ;
-        $metadataFactory = $this->createMock(MetadataFactoryInterface::class);
-        $metadataFactory->expects($this->any())
+        $metadataFactory = $this->createStub(MetadataFactoryInterface::class);
+        $metadataFactory
             ->method('getMetadataFor')
             ->willReturnCallback(static function ($classOrObject) use ($formMetadata, $authorMetadata) {
                 if (Author::class === $classOrObject || $classOrObject instanceof Author) {

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/HiddenTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/HiddenTypeValidatorExtensionTest.php
@@ -12,12 +12,9 @@
 namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
-use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
 class HiddenTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
-    use ValidatorExtensionTrait;
-
     protected function createForm(array $options = [])
     {
         return $this->factory->create(HiddenType::class, null, $options);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/IntegerTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/IntegerTypeValidatorExtensionTest.php
@@ -12,12 +12,9 @@
 namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
-use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
 class IntegerTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
-    use ValidatorExtensionTrait;
-
     protected function createForm(array $options = [])
     {
         return $this->factory->create(IntegerType::class, null, $options);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/LanguageTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/LanguageTypeValidatorExtensionTest.php
@@ -12,12 +12,9 @@
 namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
 use Symfony\Component\Form\Extension\Core\Type\LanguageType;
-use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
 class LanguageTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
-    use ValidatorExtensionTrait;
-
     protected function createForm(array $options = [])
     {
         return $this->factory->create(LanguageType::class, null, $options);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/LocaleTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/LocaleTypeValidatorExtensionTest.php
@@ -12,12 +12,9 @@
 namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
 use Symfony\Component\Form\Extension\Core\Type\LocaleType;
-use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
 class LocaleTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
-    use ValidatorExtensionTrait;
-
     protected function createForm(array $options = [])
     {
         return $this->factory->create(LocaleType::class, null, $options);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/MoneyTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/MoneyTypeValidatorExtensionTest.php
@@ -12,12 +12,9 @@
 namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
-use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
 class MoneyTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
-    use ValidatorExtensionTrait;
-
     protected function createForm(array $options = [])
     {
         return $this->factory->create(MoneyType::class, null, $options);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/NumberTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/NumberTypeValidatorExtensionTest.php
@@ -12,12 +12,9 @@
 namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
-use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
 class NumberTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
-    use ValidatorExtensionTrait;
-
     protected function createForm(array $options = [])
     {
         return $this->factory->create(NumberType::class, null, $options);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/PasswordTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/PasswordTypeValidatorExtensionTest.php
@@ -12,12 +12,9 @@
 namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
-use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
 class PasswordTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
-    use ValidatorExtensionTrait;
-
     protected function createForm(array $options = [])
     {
         return $this->factory->create(PasswordType::class, null, $options);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/PercentTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/PercentTypeValidatorExtensionTest.php
@@ -12,12 +12,9 @@
 namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
 use Symfony\Component\Form\Extension\Core\Type\PercentType;
-use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
 class PercentTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
-    use ValidatorExtensionTrait;
-
     protected function createForm(array $options = [])
     {
         return $this->factory->create(PercentType::class, null, $options + ['rounding_mode' => \NumberFormatter::ROUND_CEILING]);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/RadioTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/RadioTypeValidatorExtensionTest.php
@@ -12,12 +12,9 @@
 namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
 use Symfony\Component\Form\Extension\Core\Type\RadioType;
-use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
 class RadioTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
-    use ValidatorExtensionTrait;
-
     protected function createForm(array $options = [])
     {
         return $this->factory->create(RadioType::class, null, $options);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/RangeTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/RangeTypeValidatorExtensionTest.php
@@ -12,12 +12,9 @@
 namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
 use Symfony\Component\Form\Extension\Core\Type\RangeType;
-use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
 class RangeTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
-    use ValidatorExtensionTrait;
-
     protected function createForm(array $options = [])
     {
         return $this->factory->create(RangeType::class, null, $options);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/RepeatedTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/RepeatedTypeValidatorExtensionTest.php
@@ -12,12 +12,9 @@
 namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
-use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
 class RepeatedTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
-    use ValidatorExtensionTrait;
-
     protected function createForm(array $options = [])
     {
         return $this->factory->create(RepeatedType::class, null, $options);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/SearchTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/SearchTypeValidatorExtensionTest.php
@@ -12,12 +12,9 @@
 namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
 use Symfony\Component\Form\Extension\Core\Type\SearchType;
-use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
 class SearchTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
-    use ValidatorExtensionTrait;
-
     protected function createForm(array $options = [])
     {
         return $this->factory->create(SearchType::class, null, $options);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/SubmitTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/SubmitTypeValidatorExtensionTest.php
@@ -11,12 +11,8 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
-use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
-
 class SubmitTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
-    use ValidatorExtensionTrait;
-
     protected function createForm(array $options = [])
     {
         return $this->factory->create('Symfony\Component\Form\Extension\Core\Type\SubmitType', null, $options);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/TelTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/TelTypeValidatorExtensionTest.php
@@ -12,12 +12,9 @@
 namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
 use Symfony\Component\Form\Extension\Core\Type\TelType;
-use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
 class TelTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
-    use ValidatorExtensionTrait;
-
     protected function createForm(array $options = [])
     {
         return $this->factory->create(TelType::class, null, $options);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/TimeTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/TimeTypeValidatorExtensionTest.php
@@ -12,12 +12,9 @@
 namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
 use Symfony\Component\Form\Extension\Core\Type\TimeType;
-use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
 class TimeTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
-    use ValidatorExtensionTrait;
-
     protected function createForm(array $options = [])
     {
         return $this->factory->create(TimeType::class, null, $options + ['widget' => 'choice']);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/TimezoneTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/TimezoneTypeValidatorExtensionTest.php
@@ -12,12 +12,9 @@
 namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
 use Symfony\Component\Form\Extension\Core\Type\TimezoneType;
-use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
 class TimezoneTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
-    use ValidatorExtensionTrait;
-
     protected function createForm(array $options = [])
     {
         return $this->factory->create(TimezoneType::class, null, $options);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/UploadValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/UploadValidatorExtensionTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\Extension\Validator\Type\UploadValidatorExtension;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\Options;
@@ -20,6 +21,13 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class UploadValidatorExtensionTest extends TypeTestCase
 {
+    protected function setUp(): void
+    {
+        $this->dispatcher = new EventDispatcher();
+
+        parent::setUp();
+    }
+
     public function testPostMaxSizeTranslation()
     {
         $extension = new UploadValidatorExtension(new DummyTranslator());

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/UrlTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/UrlTypeValidatorExtensionTest.php
@@ -12,12 +12,9 @@
 namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
 use Symfony\Component\Form\Extension\Core\Type\UrlType;
-use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 
 class UrlTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
 {
-    use ValidatorExtensionTrait;
-
     protected function createForm(array $options = [])
     {
         return $this->factory->create(UrlType::class, null, $options);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationMapperTest.php
@@ -1722,13 +1722,9 @@ class ViolationMapperTest extends TestCase
 
     public function testLabelPlaceholderTranslatedWithTranslationDomainDefinedByParentType()
     {
-        $translator = $this->createMock(TranslatorInterface::class);
-        $translator->expects($this->any())
-            ->method('trans')
-            ->with('foo', [], 'domain')
-            ->willReturn('translated foo label')
-        ;
-        $this->mapper = new ViolationMapper(null, $translator);
+        $this->mapper = new ViolationMapper(null, new FixedTranslator([
+            'foo' => 'translated foo label',
+        ]));
 
         $form = $this->getForm('', null, null, [], false, true, [
             'translation_domain' => 'domain',
@@ -1749,17 +1745,9 @@ class ViolationMapperTest extends TestCase
 
     public function testLabelPlaceholderTranslatedWithTranslationParametersMergedFromParentForm()
     {
-        $translator = $this->createMock(TranslatorInterface::class);
-        $translator->expects($this->any())
-            ->method('trans')
-            ->with('foo', [
-                '{{ param_defined_in_parent }}' => 'param defined in parent value',
-                '{{ param_defined_in_child }}' => 'param defined in child value',
-                '{{ param_defined_in_parent_overridden_in_child }}' => 'param defined in parent overridden in child child value',
-            ])
-            ->willReturn('translated foo label')
-        ;
-        $this->mapper = new ViolationMapper(null, $translator);
+        $this->mapper = new ViolationMapper(null, new FixedTranslator([
+            'foo' => 'translated foo label',
+        ]));
 
         $form = $this->getForm('', null, null, [], false, true, [
             'label_translation_parameters' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | part of #62669
| License       | MIT
