### PR TITLE
 chore: PHP CS Fixer and protected_to_private

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -31,7 +31,7 @@ return (new PhpCsFixer\Config())
         '@Symfony' => true,
         '@Symfony:risky' => true,
         'phpdoc_var_annotation_correct_order' => true,
-        'protected_to_private' => false,
+        'protected_to_private' => true,
         'no_superfluous_phpdoc_tags' => [
             'remove_inheritdoc' => true,
             'allow_unused_params' => true, // for future-ready params, to be replaced with https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/7377

--- a/src/Symfony/Component/Cache/CacheItem.php
+++ b/src/Symfony/Component/Cache/CacheItem.php
@@ -197,3 +197,5 @@ final class CacheItem implements ItemInterface
         return true;
     }
 }
+
+// @php-cs-fixer-ignore protected_to_private Friend-level scope access relies on protected properties

--- a/src/Symfony/Component/Notifier/Bridge/Engagespot/EngagespotOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Engagespot/EngagespotOptions.php
@@ -20,7 +20,7 @@ use Symfony\Component\Notifier\Message\MessageOptionsInterface;
  */
 final class EngagespotOptions implements MessageOptionsInterface
 {
-    protected $options;
+    private $options;
 
     public function __construct(array $options = [])
     {

--- a/src/Symfony/Component/Notifier/Bridge/Redlink/RedlinkOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Redlink/RedlinkOptions.php
@@ -18,7 +18,7 @@ use Symfony\Component\Notifier\Message\MessageOptionsInterface;
  */
 final class RedlinkOptions implements MessageOptionsInterface
 {
-    public function __construct(protected array $options = [])
+    public function __construct(private array $options = [])
     {
     }
 

--- a/src/Symfony/Component/RateLimiter/RateLimiterFactory.php
+++ b/src/Symfony/Component/RateLimiter/RateLimiterFactory.php
@@ -55,7 +55,7 @@ final class RateLimiterFactory
         };
     }
 
-    protected static function configureOptions(OptionsResolver $options): void
+    private static function configureOptions(OptionsResolver $options): void
     {
         $intervalNormalizer = static function (Options $options, string $interval): \DateInterval {
             // Create DateTimeImmutable from unix timesatmp, so the default timezone is ignored and we don't need to


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix CS
| License       | MIT

Rule aims to reduce visibility from protected to private, when protected visibility makes no sense (ie in final class).

The rule is widely followed by codebase.
I recommend enabling it (and adding to the Symfony ruleset), as it's followed in almost each file.

There is one file - CacheItem - tha actually relies on "protected" even if class is final, due to having them exposed when serializing.

There are 3 other files where I believe protected was used accidentally, let the CI verify.
update: CI is green

-----

Alternative is to remove the rule to be mentioned at all in local repo config file.