### PR TITLE
[Finder] Fix `Finder::append()` breaking generic typing contract

### DIFF
--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -57,8 +57,10 @@ class Finder implements \IteratorAggregate, \Countable
     private bool $reverseSorting = false;
     private \Closure|int|false $sort = false;
     private int $ignore = 0;
+    /** @var list<string> */
     private array $dirs = [];
     private array $dates = [];
+    /** @var list<iterable<SplFileInfo|\SplFileInfo|string>> */
     private array $iterators = [];
     private array $contains = [];
     private array $notContains = [];
@@ -666,27 +668,33 @@ class Finder implements \IteratorAggregate, \Countable
      */
     public function getIterator(): \Iterator
     {
-        if (0 === \count($this->dirs) && 0 === \count($this->iterators)) {
+        if (!$this->dirs && !$this->iterators) {
             throw new \LogicException('You must call one of in() or append() methods before iterating over a Finder.');
         }
 
-        if (1 === \count($this->dirs) && 0 === \count($this->iterators)) {
+        if (1 === \count($this->dirs) && !$this->iterators) {
             $iterator = $this->searchInDirectory($this->dirs[0]);
-
-            if ($this->sort || $this->reverseSorting) {
-                $iterator = (new SortableIterator($iterator, $this->sort, $this->reverseSorting))->getIterator();
+        } else {
+            $iterator = new \AppendIterator();
+            foreach ($this->dirs as $dir) {
+                $iterator->append(new \IteratorIterator(new LazyIterator(fn () => $this->searchInDirectory($dir))));
             }
 
-            return $iterator;
-        }
+            foreach ($this->iterators as $it) {
+                $iterator->append((static function () use ($it) {
+                    foreach ($it as $file) {
+                        if (!$file instanceof \SplFileInfo) {
+                            $file = new \SplFileInfo($file);
+                        }
+                        $key = $file->getPathname();
+                        if (!$file instanceof SplFileInfo) {
+                            $file = new SplFileInfo($key, $file->getPath(), $key);
+                        }
 
-        $iterator = new \AppendIterator();
-        foreach ($this->dirs as $dir) {
-            $iterator->append(new \IteratorIterator(new LazyIterator(fn () => $this->searchInDirectory($dir))));
-        }
-
-        foreach ($this->iterators as $it) {
-            $iterator->append($it);
+                        yield $key => $file;
+                    }
+                })());
+            }
         }
 
         if ($this->sort || $this->reverseSorting) {
@@ -701,26 +709,13 @@ class Finder implements \IteratorAggregate, \Countable
      *
      * The set can be another Finder, an Iterator, an IteratorAggregate, or even a plain array.
      *
-     * @return $this
+     * @param iterable<SplFileInfo|\SplFileInfo|string> $iterator
      *
-     * @throws \InvalidArgumentException when the given argument is not iterable
+     * @return $this
      */
     public function append(iterable $iterator): static
     {
-        if ($iterator instanceof \IteratorAggregate) {
-            $this->iterators[] = $iterator->getIterator();
-        } elseif ($iterator instanceof \Iterator) {
-            $this->iterators[] = $iterator;
-        } elseif (is_iterable($iterator)) {
-            $it = new \ArrayIterator();
-            foreach ($iterator as $file) {
-                $file = $file instanceof \SplFileInfo ? $file : new \SplFileInfo($file);
-                $it[$file->getPathname()] = $file;
-            }
-            $this->iterators[] = $it;
-        } else {
-            throw new \InvalidArgumentException('Finder::append() method wrong argument type.');
-        }
+        $this->iterators[] = $iterator;
 
         return $this;
     }

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Finder\Tests;
 
 use Symfony\Component\Finder\Exception\DirectoryNotFoundException;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
 
 class FinderTest extends Iterator\RealIteratorTestCase
 {
@@ -1294,6 +1295,121 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $finder->append($this->toAbsolute(['foo', 'toto']));
 
         $this->assertIterator($this->toAbsolute(['foo', 'foo/bar.tmp', 'toto']), $finder->getIterator());
+    }
+
+    public function testAppendStandardizesItemsToBeSymfonySplFileInfo()
+    {
+        $finder1 = $this->buildFinder();
+        $finder1->files()->in(self::$tmpDir.\DIRECTORY_SEPARATOR.'foo');
+
+        $finder2 = $this->buildFinder();
+        $finder2->directories()->in(self::$tmpDir);
+
+        $finder1->append($finder2);
+        $finder1->append($this->toAbsolute(['foo']));
+        $finder1->append(array_map(static fn ($item) => new \SplFileInfo($item), $this->toAbsolute(['toto'])));
+
+        foreach ($finder1 as $item) {
+            $this->assertInstanceOf(SplFileInfo::class, $item);
+        }
+    }
+
+    public function testRelativePathOfAppendedItems()
+    {
+        $this->setupVfsProvider([
+            'a' => [
+                'a1' => '',
+                'a2' => '',
+                'b' => [
+                    'b1' => '',
+                    'b2' => '',
+                    'c' => [
+                        'c1' => '',
+                        'c2' => '',
+                    ],
+                ],
+            ],
+        ]);
+
+        $formatForAssert = static function (Finder $finder) {
+            $data = [];
+            foreach ($finder as $key => $value) {
+                $data[] = ['key' => $key, 'relativePathname' => $value->getRelativePathname()];
+            }
+
+            return $data;
+        };
+
+        $dir = $this->vfsScheme.'://';
+
+        // no append
+        $finder = Finder::create()->sortByName()->in($dir.'a/b');
+        $this->assertSame(
+            [
+                ['key' => $dir.'a/b/b1', 'relativePathname' => 'b1'],
+                ['key' => $dir.'a/b/b2', 'relativePathname' => 'b2'],
+                ['key' => $dir.'a/b/c', 'relativePathname' => 'c'],
+                ['key' => $dir.'a/b/c/c1', 'relativePathname' => 'c/c1'],
+                ['key' => $dir.'a/b/c/c2', 'relativePathname' => 'c/c2'],
+            ],
+            $formatForAssert($finder),
+        );
+
+        // appending another Finder with parent directory
+        $finder = Finder::create()->sortByName()->in($dir.'a/b');
+        $finder->append(Finder::create()->sortByName()->in($dir.'a'));
+        $this->assertSame(
+            [
+                ['key' => $dir.'a/a1', 'relativePathname' => 'a1'],
+                ['key' => $dir.'a/a2', 'relativePathname' => 'a2'],
+                ['key' => $dir.'a/b', 'relativePathname' => 'b'],
+                ['key' => $dir.'a/b/b1', 'relativePathname' => 'b/b1'],
+                ['key' => $dir.'a/b/b2', 'relativePathname' => 'b/b2'],
+                ['key' => $dir.'a/b/c', 'relativePathname' => 'b/c'],
+                ['key' => $dir.'a/b/c/c1', 'relativePathname' => 'b/c/c1'],
+                ['key' => $dir.'a/b/c/c2', 'relativePathname' => 'b/c/c2'],
+            ],
+            $formatForAssert($finder),
+        );
+
+        // appending another Finder with child directory
+        $finder = Finder::create()->sortByName()->in($dir.'a/b');
+        $finder->append(Finder::create()->sortByName()->in($dir.'a/b/c'));
+        $this->assertSame(
+            [
+                ['key' => $dir.'a/b/b1', 'relativePathname' => 'b1'],
+                ['key' => $dir.'a/b/b2', 'relativePathname' => 'b2'],
+                ['key' => $dir.'a/b/c', 'relativePathname' => 'c'],
+                ['key' => $dir.'a/b/c/c1', 'relativePathname' => 'c1'],
+                ['key' => $dir.'a/b/c/c2', 'relativePathname' => 'c2'],
+            ],
+            $formatForAssert($finder),
+        );
+
+        // appending file paths
+        $finder = Finder::create()->sortByName()->in($dir.'a/b');
+        $finder->append([$dir.'a/a1', $dir.'a/b/c/c1']);
+        $this->assertSame(
+            [
+                ['key' => $dir.'a/a1', 'relativePathname' => $dir.'a/a1'],
+                ['key' => $dir.'a/b/b1', 'relativePathname' => 'b1'],
+                ['key' => $dir.'a/b/b2', 'relativePathname' => 'b2'],
+                ['key' => $dir.'a/b/c', 'relativePathname' => 'c'],
+                ['key' => $dir.'a/b/c/c1', 'relativePathname' => $dir.'a/b/c/c1'],
+                ['key' => $dir.'a/b/c/c2', 'relativePathname' => 'c/c2'],
+            ],
+            $formatForAssert($finder),
+        );
+
+        // appending with to empty Finder
+        $finder = Finder::create()->sortByName();
+        $finder->append([$dir.'a/a1']);
+        $this->assertSame(
+            [
+                ['key' => $dir.'a/a1', 'relativePathname' => $dir.'a/a1'],
+            ],
+            $formatForAssert($finder),
+        );
     }
 
     public function testAppendReturnsAFinder()

--- a/src/Symfony/Component/Finder/Tests/Iterator/RealIteratorTestCase.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/RealIteratorTestCase.php
@@ -72,8 +72,9 @@ abstract class RealIteratorTestCase extends IteratorTestCase
         file_put_contents(self::toAbsolute('test.php'), str_repeat(' ', 800));
         file_put_contents(self::toAbsolute('test.py'), str_repeat(' ', 2000));
 
-        touch(self::toAbsolute('foo/bar.tmp'), strtotime('-19 years'));
-        touch(self::toAbsolute('test.php'), strtotime('-19 years'));
+        $oneYearAgo = strtotime('-1 year');
+        touch(self::toAbsolute('foo/bar.tmp'), $oneYearAgo);
+        touch(self::toAbsolute('test.php'), $oneYearAgo);
 
         if (FinderTest::class === static::class) {
             $fs = new Filesystem();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62734 
| License       | MIT

Updated Finder::append() to ensure the iterable items are SplFileInfo (symfony's version).