### PR TITLE
[Console] Escape `%` in description of console commands

### DIFF
--- a/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
+++ b/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
@@ -135,10 +135,11 @@ class AddConsoleCommandPass implements CompilerPassInterface
             }
 
             if ($description) {
-                $definition->addMethodCall('setDescription', [str_replace('%', '%%', $description)]);
+                $escapedDescription = str_replace('%', '%%', $description);
+                $definition->addMethodCall('setDescription', [$escapedDescription]);
 
                 $container->register('.'.$id.'.lazy', LazyCommand::class)
-                    ->setArguments([$commandName, $aliases, $description, $isHidden, new ServiceClosureArgument($lazyCommandRefs[$id])]);
+                    ->setArguments([$commandName, $aliases, $escapedDescription, $isHidden, new ServiceClosureArgument($lazyCommandRefs[$id])]);
 
                 $lazyCommandRefs[$id] = new Reference('.'.$id.'.lazy');
             }

--- a/src/Symfony/Component/Console/Tests/DependencyInjection/AddConsoleCommandPassTest.php
+++ b/src/Symfony/Component/Console/Tests/DependencyInjection/AddConsoleCommandPassTest.php
@@ -327,6 +327,25 @@ class AddConsoleCommandPassTest extends TestCase
         self::assertSame('The %command.name% command help content.', $command->getHelp());
     }
 
+    public function testProcessCommandWithDescriptionWithpercentageSigns()
+    {
+        $container = new ContainerBuilder();
+        $container
+            ->register(
+                'description_with_percentage_signs_command',
+                DescriptionWithPercentageSignsCommand::class,
+            )
+            ->addTag('console.command')
+        ;
+        $pass = new AddConsoleCommandPass();
+        $pass->process($container);
+
+        $command = $container->get('console.command_loader')->get('description-percentage-signs');
+
+        self::assertTrue($container->has('description_with_percentage_signs_command.command'));
+        self::assertSame('Just testing %percentage-signs%', $command->getDescription());
+    }
+
     public function testProcessInvokableSignalableCommand()
     {
         $container = new ContainerBuilder();
@@ -378,6 +397,14 @@ class DescribedCommand extends Command
 
 #[AsCommand(name: 'invokable', description: 'Just testing', help: 'The %command.name% help content.')]
 class InvokableCommand
+{
+    public function __invoke(): void
+    {
+    }
+}
+
+#[AsCommand(name: 'description-percentage-signs', description: 'Just testing %percentage-signs%')]
+class DescriptionWithPercentageSignsCommand
 {
     public function __invoke(): void
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #62763 
| License       | MIT