### PR TITLE
 PHP CS Fixer: enable random_api_migration

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -46,6 +46,7 @@ return (new PhpCsFixer\Config())
             ]),
         ],
         'php_unit_attributes' => true,
+        'random_api_migration' => true,
         // 'static_lambda' => true, // @todo @keradus to fix last issues
     ])
     ->setRiskyAllowed(true)

--- a/src/Symfony/Component/Cache/Tests/Adapter/ProxyAdapterAndRedisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ProxyAdapterAndRedisAdapterTest.php
@@ -50,7 +50,7 @@ class ProxyAdapterAndRedisAdapterTest extends AbstractRedisAdapterTestCase
 
         $cache = $this->createCachePool(1);
         $cache->clear();
-        $value = rand();
+        $value = random_int(0, getrandmax());
         $item = $cache->getItem('foo');
         $setCacheItemExpiry($item, 0);
         $cache->save($item->set($value));

--- a/src/Symfony/Component/Config/Tests/Resource/DirectoryResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/DirectoryResourceTest.php
@@ -67,7 +67,7 @@ class DirectoryResourceTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessageMatches('/The directory ".*" does not exist./');
-        new DirectoryResource('/____foo/foobar'.mt_rand(1, 999999));
+        new DirectoryResource('/____foo/foobar'.random_int(1, 999999));
     }
 
     public function testIsFresh()

--- a/src/Symfony/Component/Config/Tests/Resource/FileResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/FileResourceTest.php
@@ -55,7 +55,7 @@ class FileResourceTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessageMatches('/The file ".*" does not exist./');
-        new FileResource('/____foo/foobar'.mt_rand(1, 999999));
+        new FileResource('/____foo/foobar'.random_int(1, 999999));
     }
 
     public function testIsFresh()

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -662,7 +662,7 @@ class FilesystemTest extends FilesystemTestCase
 
         $this->filesystem->symlink($file, $link);
 
-        $this->filesystem->chown($link, 'user'.time().mt_rand(1000, 9999));
+        $this->filesystem->chown($link, 'user'.time().random_int(1000, 9999));
     }
 
     public function testChownLinkFails()
@@ -677,7 +677,7 @@ class FilesystemTest extends FilesystemTestCase
 
         $this->filesystem->hardlink($file, $link);
 
-        $this->filesystem->chown($link, 'user'.time().mt_rand(1000, 9999));
+        $this->filesystem->chown($link, 'user'.time().random_int(1000, 9999));
     }
 
     public function testChownFail()
@@ -688,7 +688,7 @@ class FilesystemTest extends FilesystemTestCase
         $dir = $this->workspace.\DIRECTORY_SEPARATOR.'dir';
         mkdir($dir);
 
-        $this->filesystem->chown($dir, 'user'.time().mt_rand(1000, 9999));
+        $this->filesystem->chown($dir, 'user'.time().random_int(1000, 9999));
     }
 
     public function testChgrpByName()
@@ -795,7 +795,7 @@ class FilesystemTest extends FilesystemTestCase
 
         $this->filesystem->symlink($file, $link);
 
-        $this->filesystem->chgrp($link, 'user'.time().mt_rand(1000, 9999));
+        $this->filesystem->chgrp($link, 'user'.time().random_int(1000, 9999));
     }
 
     public function testChgrpLinkFails()
@@ -810,7 +810,7 @@ class FilesystemTest extends FilesystemTestCase
 
         $this->filesystem->hardlink($file, $link);
 
-        $this->filesystem->chgrp($link, 'user'.time().mt_rand(1000, 9999));
+        $this->filesystem->chgrp($link, 'user'.time().random_int(1000, 9999));
     }
 
     public function testChgrpFail()
@@ -821,7 +821,7 @@ class FilesystemTest extends FilesystemTestCase
         $dir = $this->workspace.\DIRECTORY_SEPARATOR.'dir';
         mkdir($dir);
 
-        $this->filesystem->chgrp($dir, 'user'.time().mt_rand(1000, 9999));
+        $this->filesystem->chgrp($dir, 'user'.time().random_int(1000, 9999));
     }
 
     public function testRename()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypePerformanceTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypePerformanceTest.php
@@ -30,7 +30,7 @@ class ChoiceTypePerformanceTest extends FormPerformanceTestCase
         $choices = range(1, 300);
 
         for ($i = 0; $i < 100; ++$i) {
-            $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', mt_rand(1, 400), [
+            $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', random_int(1, 400), [
                 'choices' => $choices,
             ]);
         }

--- a/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
@@ -189,7 +189,7 @@ class FileProfilerStorage implements ProfilerStorageInterface
             ], ',', '"', '\\');
             fclose($file);
 
-            if (1 === mt_rand(1, 10)) {
+            if (1 === random_int(1, 10)) {
                 $this->removeExpiredProfiles();
             }
         }

--- a/src/Symfony/Component/Intl/Tests/Data/Bundle/Writer/JsonBundleWriterTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Bundle/Writer/JsonBundleWriterTest.php
@@ -28,7 +28,7 @@ class JsonBundleWriterTest extends TestCase
     protected function setUp(): void
     {
         $this->writer = new JsonBundleWriter();
-        $this->directory = sys_get_temp_dir().'/JsonBundleWriterTest/'.mt_rand(1000, 9999);
+        $this->directory = sys_get_temp_dir().'/JsonBundleWriterTest/'.random_int(1000, 9999);
         $this->filesystem = new Filesystem();
 
         $this->filesystem->mkdir($this->directory);

--- a/src/Symfony/Component/Intl/Tests/Data/Bundle/Writer/PhpBundleWriterTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Bundle/Writer/PhpBundleWriterTest.php
@@ -28,7 +28,7 @@ class PhpBundleWriterTest extends TestCase
     protected function setUp(): void
     {
         $this->writer = new PhpBundleWriter();
-        $this->directory = sys_get_temp_dir().'/PhpBundleWriterTest/'.mt_rand(1000, 9999);
+        $this->directory = sys_get_temp_dir().'/PhpBundleWriterTest/'.random_int(1000, 9999);
         $this->filesystem = new Filesystem();
 
         $this->filesystem->mkdir($this->directory);

--- a/src/Symfony/Component/Intl/Tests/Data/Bundle/Writer/TextBundleWriterTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Bundle/Writer/TextBundleWriterTest.php
@@ -29,7 +29,7 @@ class TextBundleWriterTest extends TestCase
     protected function setUp(): void
     {
         $this->writer = new TextBundleWriter();
-        $this->directory = sys_get_temp_dir().'/TextBundleWriterTest/'.mt_rand(1000, 9999);
+        $this->directory = sys_get_temp_dir().'/TextBundleWriterTest/'.random_int(1000, 9999);
         $this->filesystem = new Filesystem();
 
         $this->filesystem->mkdir($this->directory);

--- a/src/Symfony/Component/Intl/Tests/Data/Util/LocaleScannerTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Util/LocaleScannerTest.php
@@ -26,7 +26,7 @@ class LocaleScannerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->directory = sys_get_temp_dir().'/LocaleScannerTest/'.mt_rand(1000, 9999);
+        $this->directory = sys_get_temp_dir().'/LocaleScannerTest/'.random_int(1000, 9999);
         $this->filesystem = new Filesystem();
         $this->scanner = new LocaleScanner();
 

--- a/src/Symfony/Component/Mailer/Transport/RoundRobinTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/RoundRobinTransport.php
@@ -112,7 +112,7 @@ class RoundRobinTransport implements TransportInterface
     {
         // the cursor initial value is randomized so that
         // when are not in a daemon, we are still rotating the transports
-        return mt_rand(0, \count($this->transports) - 1);
+        return random_int(0, \count($this->transports) - 1);
     }
 
     protected function getNameSymbol(): string

--- a/src/Symfony/Component/Notifier/Transport/RoundRobinTransport.php
+++ b/src/Symfony/Component/Notifier/Transport/RoundRobinTransport.php
@@ -127,7 +127,7 @@ class RoundRobinTransport implements TransportInterface
     {
         // the cursor initial value is randomized so that
         // when are not in a daemon, we are still rotating the transports
-        return mt_rand(0, \count($this->transports) - 1);
+        return random_int(0, \count($this->transports) - 1);
     }
 
     protected function getNameSymbol(): string

--- a/src/Symfony/Component/Translation/PseudoLocalizationTranslator.php
+++ b/src/Symfony/Component/Translation/PseudoLocalizationTranslator.php
@@ -382,3 +382,5 @@ final class PseudoLocalizationTranslator implements TranslatorInterface, Transla
         return false === ($encoding = mb_detect_encoding($s, null, true)) ? \strlen($s) : mb_strlen($s, $encoding);
     }
 }
+
+// @php-cs-fixer-ignore random_api_migration As logic is coupled with mt_srand() in tests


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix CS
| License       | MIT

as required PHP is bumped to 8.1,
maybe we can use new random API ?