### PR TITLE
[PropertyInfo] Fix calling same-named method with required args instead of reading public property

### DIFF
--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -52,6 +52,21 @@ class PropertyAccessorTest extends TestCase
         $this->propertyAccessor = new PropertyAccessor();
     }
 
+    public function testPrefersPropertyOverMethodWithSameNameAndRequiredArgs()
+    {
+        $obj = new class {
+            public bool $loaded = true;
+
+            // Same name as property, but requires an argument: must NOT be called for reading
+            public function loaded(string $arg): bool
+            {
+                throw new \RuntimeException('Method should not be invoked during property read');
+            }
+        };
+
+        $this->assertTrue($this->propertyAccessor->getValue($obj, 'loaded'));
+    }
+
     public static function getPathsWithMissingProperty()
     {
         return [

--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -270,8 +270,10 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
 
         if ($allowGetterSetter && $reflClass->hasMethod($getsetter) && ($reflClass->getMethod($getsetter)->getModifiers() & $this->methodReflectionFlags)) {
             $method = $reflClass->getMethod($getsetter);
-
-            return new PropertyReadInfo(PropertyReadInfo::TYPE_METHOD, $getsetter, $this->getReadVisibilityForMethod($method), $method->isStatic(), false);
+            // Only consider jQuery-style accessors when they don't require parameters
+            if (!$method->getNumberOfRequiredParameters()) {
+                return new PropertyReadInfo(PropertyReadInfo::TYPE_METHOD, $getsetter, $this->getReadVisibilityForMethod($method), $method->isStatic(), false);
+            }
         }
 
         if ($allowMagicGet && $reflClass->hasMethod('__get') && (($r = $reflClass->getMethod('__get'))->getModifiers() & $this->methodReflectionFlags)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62733 
| License       | MIT

- Fixes PropertyAccess choosing a same‑named method over a public property when the method requires parameters.
- Ensures jQuery‑style accessors (methods named exactly like the property) are only considered if they have zero required parameters.
- Prevents `ArgumentCountError` during serialization and aligns behavior with standard getter rules (`getX()/isX()/hasX()/canX()`), which already require zero required parameters.
