### PR TITLE
[Mailer] Use ini value for SendmailTransport command default

### DIFF
--- a/src/Symfony/Component/Mailer/Transport/SendmailTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/SendmailTransport.php
@@ -60,7 +60,7 @@ class SendmailTransport extends AbstractTransport
 
             $this->command = $command;
         } else {
-            $this->command = ini_get('sendmail_path') ?: '/usr/sbin/sendmail -bs';
+            $this->command = \ini_get('sendmail_path') ?: '/usr/sbin/sendmail -bs';
         }
 
         $this->stream = new ProcessStream();

--- a/src/Symfony/Component/Mailer/Transport/SendmailTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/SendmailTransport.php
@@ -33,7 +33,7 @@ use Symfony\Component\Mime\RawMessage;
  */
 class SendmailTransport extends AbstractTransport
 {
-    private string $command = '/usr/sbin/sendmail -bs';
+    private string $command;
     private ProcessStream $stream;
     private ?SmtpTransport $transport = null;
 
@@ -59,6 +59,8 @@ class SendmailTransport extends AbstractTransport
             }
 
             $this->command = $command;
+        } else {
+            $this->command = ini_get('sendmail_path') ?: '/usr/sbin/sendmail -bs';
         }
 
         $this->stream = new ProcessStream();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

PHP has a `sendmail_path` ini value that it uses by default: https://www.php.net/manual/en/mail.configuration.php.
When switching to Symfony, this value is no longer used. Instead a hardcoded default is used. Which is also a different one than the ini's default: `/usr/sbin/sendmail -t -i`.

Is it possible to use the same logic in Symfony's sendmail transport?