### PR TITLE
[Messenger] Fix `DeduplicateStamp` serialization

### DIFF
--- a/src/Symfony/Component/Messenger/Stamp/DeduplicateStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/DeduplicateStamp.php
@@ -19,7 +19,7 @@ final class DeduplicateStamp implements StampInterface
     private Key $key;
 
     public function __construct(
-        string $key,
+        string|Key $key,
         private ?float $ttl = 300.0,
         private bool $onlyDeduplicateInQueue = false,
     ) {
@@ -27,7 +27,7 @@ final class DeduplicateStamp implements StampInterface
             throw new LogicException(\sprintf('You cannot use the "%s" as the Lock component is not installed. Try running "composer require symfony/lock".', self::class));
         }
 
-        $this->key = new Key($key);
+        $this->key = \is_string($key) ? new Key($key) : $key;
     }
 
     public function onlyDeduplicateInQueue(): bool

--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SerializerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SerializerTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
+use Symfony\Component\Messenger\Stamp\DeduplicateStamp;
 use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
 use Symfony\Component\Messenger\Stamp\SerializedMessageStamp;
 use Symfony\Component\Messenger\Stamp\SerializerStamp;
@@ -44,6 +45,7 @@ class SerializerTest extends TestCase
         $envelope = (new Envelope(new DummyMessage('Hello')))
             ->with(new SerializerStamp([ObjectNormalizer::GROUPS => ['foo']]))
             ->with(new ValidationStamp(['foo', 'bar']))
+            ->with(new DeduplicateStamp('someKey', 42, true))
             ->with(new SerializedMessageStamp('{"message":"Hello"}'))
         ;
 

--- a/src/Symfony/Component/Messenger/composer.json
+++ b/src/Symfony/Component/Messenger/composer.json
@@ -29,7 +29,7 @@
         "symfony/http-kernel": "^7.3|^8.0",
         "symfony/process": "^6.4|^7.0|^8.0",
         "symfony/property-access": "^6.4|^7.0|^8.0",
-        "symfony/lock": "^6.4|^7.0|^8.0",
+        "symfony/lock": "^7.4|^8.0",
         "symfony/rate-limiter": "^6.4|^7.0|^8.0",
         "symfony/routing": "^6.4|^7.0|^8.0",
         "symfony/serializer": "^6.4|^7.0|^8.0",
@@ -44,8 +44,8 @@
         "symfony/event-dispatcher-contracts": "<2.5",
         "symfony/framework-bundle": "<6.4",
         "symfony/http-kernel": "<7.3",
-        "symfony/lock": "<6.4",
-        "symfony/serializer": "<6.4"
+        "symfony/lock": "<7.4",
+        "symfony/serializer": "<6.4.32"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Messenger\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #60659
| License       | MIT

7.4 for bugfix since it requires the LockKeyNormalizer