### PR TITLE
[Serializer] Allow getting values from `ExtraAttributesException`

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Improve `NotNormalizableValueException` exception messages in `BackedEnumNormalizer` to contain more useful information
  * Trigger a deprecation when a date could not be parsed using the default format
+ * Add method `getValues` to `ExtraAttributesException`
 
 8.0
 ---

--- a/src/Symfony/Component/Serializer/Exception/ExtraAttributesException.php
+++ b/src/Symfony/Component/Serializer/Exception/ExtraAttributesException.php
@@ -12,8 +12,6 @@
 namespace Symfony\Component\Serializer\Exception;
 
 /**
- * ExtraAttributesException.
- *
  * @author Julien DIDIER <julien@didier.io>
  */
 class ExtraAttributesException extends RuntimeException
@@ -22,15 +20,20 @@ class ExtraAttributesException extends RuntimeException
         private readonly array $extraAttributes,
         ?\Throwable $previous = null,
     ) {
-        $msg = \sprintf('Extra attributes are not allowed ("%s" %s unknown).', implode('", "', $extraAttributes), \count($extraAttributes) > 1 ? 'are' : 'is');
+        $msg = \sprintf('Extra attributes are not allowed ("%s" %s unknown).', implode('", "', array_keys($extraAttributes)), \count($extraAttributes) > 1 ? 'are' : 'is');
 
         parent::__construct($msg, 0, $previous);
     }
 
     /**
-     * Get the extra attributes that are not allowed.
+     * Get the unallowed attributes top-level name.
      */
     public function getExtraAttributes(): array
+    {
+        return array_keys($this->extraAttributes);
+    }
+
+    public function getValues(): array
     {
         return $this->extraAttributes;
     }

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -356,7 +356,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                     && $this->nameConverter->normalize($attribute, $resolvedClass, $format, $context) !== $attribute
                 ) {
                     // Input was in wrong format (e.g., camelCase when snake_case expected)
-                    $extraAttributes[] = $notConverted;
+                    $extraAttributes[$notConverted] = $value;
                     continue;
                 }
             }
@@ -365,7 +365,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
 
             if ((false !== $allowedAttributes && !\in_array($attribute, $allowedAttributes, true)) || !$this->isAllowedAttribute($resolvedClass, $attribute, $format, $context)) {
                 if (!($context[self::ALLOW_EXTRA_ATTRIBUTES] ?? $this->defaultContext[self::ALLOW_EXTRA_ATTRIBUTES])) {
-                    $extraAttributes[] = $attribute;
+                    $extraAttributes[$attribute] = $value;
                 }
 
                 continue;

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -994,6 +994,35 @@ class AbstractObjectNormalizerTest extends TestCase
         $this->assertSame('nested-id', $test->id);
     }
 
+    public function testDenormalizeWithNestedExtraAttribute()
+    {
+        $normalizer = new AbstractObjectNormalizerWithMetadata();
+
+        $data = [
+            'data' => [
+                'foo' => 'bar',
+                'baz' => [
+                    'qux' => 'quux',
+                    'corge' => 'grault',
+                ],
+            ],
+        ];
+
+        $obj = new class {
+            #[SerializedPath('[data][baz][qux]')]
+            public $foo;
+        };
+
+        try {
+            $normalizer->denormalize($data, $obj::class, 'any', ['allow_extra_attributes' => false]);
+
+            $this->fail(\sprintf('Expected a "%s" to be thrown.', ExtraAttributesException::class));
+        } catch (ExtraAttributesException $e) {
+            $this->assertSame(['data'], $e->getExtraAttributes());
+            $this->assertSame(['data' => ['foo' => 'bar', 'baz' => ['corge' => 'grault']]], $e->getValues());
+        }
+    }
+
     public function testDenormalizeMissingAndNullNestedValues()
     {
         $normalizer = new AbstractObjectNormalizerWithMetadata();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | N/A
| License       | MIT

`ExtraAttributesException::getExtraAttributes` and `SerializedPath` aren’t quite a good match since you’d only get the top-level key.

This PR adds a `getValues` method, allowing to traverse the whole extra attributes path.