### PR TITLE
[Console] Add the ability to use enums for `ChoiceQuestion`

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+* Add support for enums in `ChoiceQuestion`
+
 8.0
 ---
 

--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -211,7 +211,11 @@ class QuestionHelper extends Helper
         foreach ($choices as $key => $value) {
             $padding = str_repeat(' ', $maxWidth - self::width($key));
 
-            $messages[] = \sprintf("  [<$tag>%s$padding</$tag>] %s", $key, $value);
+            $messages[] = \sprintf(
+                "  [<$tag>%s$padding</$tag>] %s",
+                $key,
+                $value instanceof \UnitEnum ? $this->formatEnumValue($value) : $value
+            );
         }
 
         return $messages;
@@ -234,8 +238,8 @@ class QuestionHelper extends Helper
     /**
      * Autocompletes a question.
      *
-     * @param resource                  $inputStream
-     * @param callable(string):string[] $autocomplete
+     * @param resource                                $inputStream
+     * @param callable(string):(string[]|\UnitEnum[]) $autocomplete
      */
     private function autocomplete(OutputInterface $output, Question $question, $inputStream, callable $autocomplete): string
     {
@@ -304,7 +308,7 @@ class QuestionHelper extends Helper
             } elseif ('' === $c || \ord($c) < 32) {
                 if ("\t" === $c || "\n" === $c) {
                     if ($numMatches > 0 && -1 !== $ofs) {
-                        $ret = (string) $matches[$ofs];
+                        $ret = (string) ($matches[$ofs] instanceof \UnitEnum ? $this->formatEnumValue($matches[$ofs]) : $matches[$ofs]);
                         // Echo out remaining chars for current match
                         $remainingCharacters = substr($ret, \strlen(trim($this->mostRecentlyEnteredValue($fullChoice))));
                         $output->write($remainingCharacters);
@@ -313,7 +317,17 @@ class QuestionHelper extends Helper
 
                         $matches = array_filter(
                             $autocomplete($ret),
-                            fn ($match) => '' === $ret || str_starts_with($match, $ret)
+                            function ($match) use ($ret) {
+                                if ('' === $ret) {
+                                    return true;
+                                }
+
+                                if ($match instanceof \UnitEnum) {
+                                    $match = $this->formatEnumValue($match);
+                                }
+
+                                return str_starts_with($match, $ret);
+                            }
                         );
                         $numMatches = \count($matches);
                         $ofs = -1;
@@ -348,6 +362,10 @@ class QuestionHelper extends Helper
                 $ofs = 0;
 
                 foreach ($autocomplete($ret) as $value) {
+                    if ($value instanceof \UnitEnum) {
+                        $value = $this->formatEnumValue($value);
+                    }
+
                     // If typed characters match the beginning chunk of value (e.g. [AcmeDe]moBundle)
                     if (str_starts_with($value, $tempRet)) {
                         $matches[$numMatches++] = $value;
@@ -361,7 +379,8 @@ class QuestionHelper extends Helper
                 $cursor->savePosition();
                 // Write highlighted text, complete the partially entered response
                 $charactersEntered = \strlen(trim($this->mostRecentlyEnteredValue($fullChoice)));
-                $output->write('<hl>'.OutputFormatter::escapeTrailingBackslash(substr($matches[$ofs], $charactersEntered)).'</hl>');
+                $stringValue = $matches[$ofs] instanceof \UnitEnum ? $this->formatEnumValue($matches[$ofs]) : $matches[$ofs];
+                $output->write('<hl>'.OutputFormatter::escapeTrailingBackslash(substr($stringValue, $charactersEntered)).'</hl>');
                 $cursor->restorePosition();
             }
         }
@@ -620,5 +639,13 @@ class QuestionHelper extends Helper
         }
 
         return $ret;
+    }
+
+    /**
+     * Converts an enum value to a human-readable string.
+     */
+    protected function formatEnumValue(\UnitEnum $value): string
+    {
+        return (string) s($value->name)->snake()->replace('_', ' ')->title();
     }
 }

--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -214,7 +214,7 @@ class QuestionHelper extends Helper
             $messages[] = \sprintf(
                 "  [<$tag>%s$padding</$tag>] %s",
                 $key,
-                $value instanceof \UnitEnum ? $this->formatEnumValue($value) : $value
+                $value instanceof \UnitEnum ? $this->formatEnumValue($question, $value) : $value
             );
         }
 
@@ -308,7 +308,7 @@ class QuestionHelper extends Helper
             } elseif ('' === $c || \ord($c) < 32) {
                 if ("\t" === $c || "\n" === $c) {
                     if ($numMatches > 0 && -1 !== $ofs) {
-                        $ret = (string) ($matches[$ofs] instanceof \UnitEnum ? $this->formatEnumValue($matches[$ofs]) : $matches[$ofs]);
+                        $ret = (string) ($matches[$ofs] instanceof \UnitEnum ? $this->formatEnumValue($question, $matches[$ofs]) : $matches[$ofs]);
                         // Echo out remaining chars for current match
                         $remainingCharacters = substr($ret, \strlen(trim($this->mostRecentlyEnteredValue($fullChoice))));
                         $output->write($remainingCharacters);
@@ -317,13 +317,13 @@ class QuestionHelper extends Helper
 
                         $matches = array_filter(
                             $autocomplete($ret),
-                            function ($match) use ($ret) {
+                            function ($match) use ($ret, $question) {
                                 if ('' === $ret) {
                                     return true;
                                 }
 
                                 if ($match instanceof \UnitEnum) {
-                                    $match = $this->formatEnumValue($match);
+                                    $match = $this->formatEnumValue($question, $match);
                                 }
 
                                 return str_starts_with($match, $ret);
@@ -363,7 +363,7 @@ class QuestionHelper extends Helper
 
                 foreach ($autocomplete($ret) as $value) {
                     if ($value instanceof \UnitEnum) {
-                        $value = $this->formatEnumValue($value);
+                        $value = $this->formatEnumValue($question, $value);
                     }
 
                     // If typed characters match the beginning chunk of value (e.g. [AcmeDe]moBundle)
@@ -379,7 +379,7 @@ class QuestionHelper extends Helper
                 $cursor->savePosition();
                 // Write highlighted text, complete the partially entered response
                 $charactersEntered = \strlen(trim($this->mostRecentlyEnteredValue($fullChoice)));
-                $stringValue = $matches[$ofs] instanceof \UnitEnum ? $this->formatEnumValue($matches[$ofs]) : $matches[$ofs];
+                $stringValue = $matches[$ofs] instanceof \UnitEnum ? $this->formatEnumValue($question, $matches[$ofs]) : $matches[$ofs];
                 $output->write('<hl>'.OutputFormatter::escapeTrailingBackslash(substr($stringValue, $charactersEntered)).'</hl>');
                 $cursor->restorePosition();
             }
@@ -644,8 +644,16 @@ class QuestionHelper extends Helper
     /**
      * Converts an enum value to a human-readable string.
      */
-    protected function formatEnumValue(\UnitEnum $value): string
+    protected function formatEnumValue(Question $question, \UnitEnum $value): string
     {
+        if (!($question instanceof ChoiceQuestion)) {
+            return '';
+        }
+
+        if (null !== $question->getCustomEnumRender()) {
+            return $question->getCustomEnumRender()($value);
+        }
+
         return (string) s($value->name)->snake()->replace('_', ' ')->title();
     }
 }

--- a/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
@@ -53,15 +53,20 @@ class SymfonyQuestionHelper extends QuestionHelper
                     $default[$key] = $choices[trim($value)];
                 }
 
+                /** @var array<string|bool|int|float|\Stringable> $default */
                 $text = \sprintf(' <info>%s</info> [<comment>%s</comment>]:', $text, OutputFormatter::escape(implode(', ', $default)));
 
                 break;
 
             case $question instanceof ChoiceQuestion:
                 $choices = $question->getChoices();
-                $defaultOutput = $default instanceof \UnitEnum
-                    ? $this->formatEnumValue($default)
-                    : ($choices[$default] ?? $default);
+
+                if ($default instanceof \UnitEnum) {
+                    $defaultOutput = $this->formatEnumValue($default);
+                } else {
+                    /** @var int|string $default */
+                    $defaultOutput = $choices[$default] ?? $default;
+                }
 
                 $text = \sprintf(' <info>%s</info> [<comment>%s</comment>]:', $text, OutputFormatter::escape($defaultOutput));
 

--- a/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
@@ -62,7 +62,7 @@ class SymfonyQuestionHelper extends QuestionHelper
                 $choices = $question->getChoices();
 
                 if ($default instanceof \UnitEnum) {
-                    $defaultOutput = $this->formatEnumValue($default);
+                    $defaultOutput = $this->formatEnumValue($question, $default);
                 } else {
                     /** @var int|string $default */
                     $defaultOutput = $choices[$default] ?? $default;

--- a/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
@@ -59,7 +59,11 @@ class SymfonyQuestionHelper extends QuestionHelper
 
             case $question instanceof ChoiceQuestion:
                 $choices = $question->getChoices();
-                $text = \sprintf(' <info>%s</info> [<comment>%s</comment>]:', $text, OutputFormatter::escape($choices[$default] ?? $default));
+                $defaultOutput = $default instanceof \UnitEnum
+                    ? $this->formatEnumValue($default)
+                    : ($choices[$default] ?? $default);
+
+                $text = \sprintf(' <info>%s</info> [<comment>%s</comment>]:', $text, OutputFormatter::escape($defaultOutput));
 
                 break;
 

--- a/src/Symfony/Component/Console/Question/ChoiceQuestion.php
+++ b/src/Symfony/Component/Console/Question/ChoiceQuestion.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\Console\Question;
 
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 
+use function Symfony\Component\String\s;
+
 /**
  * Represents a choice question.
  *
@@ -23,29 +25,43 @@ class ChoiceQuestion extends Question
     private bool $multiselect = false;
     private string $prompt = ' > ';
     private string $errorMessage = 'Value "%s" is invalid';
+    private bool $usesEnum = false;
 
     /**
-     * @param string                                   $question The question to ask to the user
-     * @param array<string|bool|int|float|\Stringable> $choices  The list of available choices
-     * @param string|bool|int|float|null               $default  The default answer to return
+     * @var array<string|bool|int|float|\Stringable|\UnitEnum>
+     */
+    private array $choices = [];
+
+    /**
+     * @param string                                                           $question      The question to ask to the user
+     * @param array<string|bool|int|float|\Stringable>|class-string<\UnitEnum> $choicesOrEnum The list of available choices or an Enum FQCN
+     * @param string|bool|int|float|\UnitEnum|null                             $default       The default answer to return
      */
     public function __construct(
         string $question,
-        private array $choices,
-        string|bool|int|float|null $default = null,
+        array|string $choicesOrEnum,
+        string|bool|int|float|\UnitEnum|null $default = null,
     ) {
-        if (!$choices) {
+        if (!$choicesOrEnum) {
             throw new \LogicException('Choice question must have at least 1 choice available.');
+        } elseif (\is_string($choicesOrEnum) && !enum_exists($choicesOrEnum)) {
+            throw new \LogicException(\sprintf('Enum "%s" does not exist.', $choicesOrEnum));
+        } elseif (\is_string($choicesOrEnum) && 0 === \count($choicesOrEnum::cases())) {
+            throw new \LogicException('Choice question must have at least 1 choice available.');
+        } elseif (\is_string($choicesOrEnum) && null !== $default && !($default instanceof $choicesOrEnum)) {
+            throw new \LogicException('Default value does not exist in the enum.');
         }
 
         parent::__construct($question, $default);
 
+        $this->usesEnum = \is_string($choicesOrEnum);
+        $this->choices = $this->usesEnum ? $choicesOrEnum::cases() : $choicesOrEnum;
         $this->setValidator($this->getDefaultValidator());
-        $this->setAutocompleterValues($choices);
+        $this->setAutocompleterValues($this->choices);
     }
 
     /**
-     * @return array<string|bool|int|float|\Stringable>
+     * @return array<string|bool|int|float|\Stringable|\UnitEnum>
      */
     public function getChoices(): array
     {
@@ -57,10 +73,18 @@ class ChoiceQuestion extends Question
      *
      * When multiselect is set to true, multiple choices can be answered.
      *
+     * This option cannot be enabled on enum questions.
+     *
      * @return $this
+     *
+     * @throws \LogicException When multiselect is set to true on an enum question
      */
     public function setMultiselect(bool $multiselect): static
     {
+        if ($this->usesEnum && $multiselect) {
+            throw new \LogicException('Enums cannot be set as multiselect.');
+        }
+
         $this->multiselect = $multiselect;
         $this->setValidator($this->getDefaultValidator());
 
@@ -110,6 +134,16 @@ class ChoiceQuestion extends Question
         return $this;
     }
 
+    #[\Override]
+    public function setMultiline(bool $multiline): static
+    {
+        if ($this->usesEnum && $multiline) {
+            throw new \LogicException('Enums cannot be set as multiline.');
+        }
+
+        return parent::setMultiline($multiline);
+    }
+
     private function getDefaultValidator(): callable
     {
         $choices = $this->choices;
@@ -118,6 +152,17 @@ class ChoiceQuestion extends Question
         $isAssoc = $this->isAssoc($choices);
 
         return function ($selected) use ($choices, $errorMessage, $multiselect, $isAssoc) {
+            if ($this->usesEnum) {
+                if (\in_array($selected, $choices, true)) {
+                    return $selected;
+                }
+
+                // Authorize a string representing the human-readable name of the enum (mainly for autocomplete)
+                if (null !== $selected && null !== ($enumValue = $this->convertStringToEnumValue($selected, $choices[0]::class))) {
+                    return $enumValue;
+                }
+            }
+
             if ($multiselect) {
                 // Check for a separated comma values
                 if (!preg_match('/^[^,]+(?:,[^,]+)*$/', (string) $selected, $matches)) {
@@ -174,5 +219,19 @@ class ChoiceQuestion extends Question
 
             return current($multiselectChoices);
         };
+    }
+
+    /**
+     * @param class-string<\UnitEnum> $enumClass
+     */
+    private function convertStringToEnumValue(string $value, string $enumClass): ?\UnitEnum
+    {
+        if (!enum_exists($enumClass)) {
+            return null;
+        }
+
+        $value = (string) s($value)->pascal();
+
+        return array_find($enumClass::cases(), fn ($case) => $case->name === $value);
     }
 }

--- a/src/Symfony/Component/Console/Question/ChoiceQuestion.php
+++ b/src/Symfony/Component/Console/Question/ChoiceQuestion.php
@@ -33,6 +33,11 @@ class ChoiceQuestion extends Question
     private array $choices = [];
 
     /**
+     * @var (\Closure(\UnitEnum):string)|null
+     */
+    private ?\Closure $customEnumRender = null;
+
+    /**
      * @param string                                                           $question      The question to ask to the user
      * @param array<string|bool|int|float|\Stringable>|class-string<\UnitEnum> $choicesOrEnum The list of available choices or an Enum FQCN
      * @param string|bool|int|float|\UnitEnum|null                             $default       The default answer to return
@@ -144,6 +149,30 @@ class ChoiceQuestion extends Question
         return parent::setMultiline($multiline);
     }
 
+    /**
+     * Sets a render function for the enum question.
+     *
+     * @param (callable(\UnitEnum):string)|null $customEnumRender
+     *
+     * @return $this
+     */
+    public function setCustomEnumRender(?callable $customEnumRender): static
+    {
+        $this->customEnumRender = null === $customEnumRender ? null : $customEnumRender(...);
+
+        return $this;
+    }
+
+    /**
+     * Gets the render function for the enum question.
+     *
+     * @return (callable(\UnitEnum):string)|null
+     */
+    public function getCustomEnumRender(): ?callable
+    {
+        return $this->customEnumRender;
+    }
+
     private function getDefaultValidator(): callable
     {
         $choices = $this->choices;
@@ -228,6 +257,16 @@ class ChoiceQuestion extends Question
     {
         if (!enum_exists($enumClass)) {
             return null;
+        }
+
+        if (null !== $this->customEnumRender) {
+            $enumCases = $enumClass::cases();
+            $renderFunction = $this->customEnumRender;
+
+            return array_find(
+                $enumCases,
+                fn ($case) => $renderFunction($case) === $value
+            );
         }
 
         $value = (string) s($value)->pascal();

--- a/src/Symfony/Component/Console/Question/Question.php
+++ b/src/Symfony/Component/Console/Question/Question.php
@@ -25,7 +25,7 @@ class Question
     private bool $hidden = false;
     private bool $hiddenFallback = true;
     /**
-     * @var (\Closure(string):string[])|null
+     * @var (\Closure(string):(string[]|\UnitEnum[]))|null
      */
     private ?\Closure $autocompleterCallback = null;
     /**
@@ -41,12 +41,12 @@ class Question
     private ?int $timeout = null;
 
     /**
-     * @param string                     $question The question to ask to the user
-     * @param string|bool|int|float|null $default  The default answer to return if the user enters nothing
+     * @param string                               $question The question to ask to the user
+     * @param string|bool|int|float|\UnitEnum|null $default  The default answer to return if the user enters nothing
      */
     public function __construct(
         private string $question,
-        private string|bool|int|float|null $default = null,
+        private string|bool|int|float|\UnitEnum|null $default = null,
     ) {
     }
 
@@ -61,7 +61,7 @@ class Question
     /**
      * Returns the default answer.
      */
-    public function getDefault(): string|bool|int|float|null
+    public function getDefault(): string|bool|int|float|\UnitEnum|null
     {
         return $this->default;
     }
@@ -204,7 +204,7 @@ class Question
      *
      * The callback is passed the user input as argument and should return an iterable of corresponding suggestions.
      *
-     * @param (callable(string):string[])|null $callback
+     * @param (callable(string):(string[]|\UnitEnum[]))|null $callback
      *
      * @return $this
      */

--- a/src/Symfony/Component/Console/Question/Question.php
+++ b/src/Symfony/Component/Console/Question/Question.php
@@ -192,7 +192,7 @@ class Question
     /**
      * Gets the callback function used for the autocompleter.
      *
-     * @return (callable(string):string[])|null
+     * @return (callable(string):(string[]|\UnitEnum[]))|null
      */
     public function getAutocompleterCallback(): ?callable
     {

--- a/src/Symfony/Component/Console/Style/StyleInterface.php
+++ b/src/Symfony/Component/Console/Style/StyleInterface.php
@@ -89,8 +89,10 @@ interface StyleInterface
 
     /**
      * Asks a choice question.
+     *
+     * @param array|class-string<\UnitEnum> $choicesOrEnum
      */
-    public function choice(string $question, array $choices, mixed $default = null): mixed;
+    public function choice(string $question, array|string $choicesOrEnum, mixed $default = null): mixed;
 
     /**
      * Add newline(s).

--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -234,7 +234,7 @@ class SymfonyStyle extends OutputStyle
         return $this->askQuestion(new ConfirmationQuestion($question, $default));
     }
 
-    public function choice(string $question, array|string $choicesOrEnum, mixed $default = null, bool $multiSelect = false): mixed
+    public function choice(string $question, array|string $choicesOrEnum, mixed $default = null, bool $multiSelect = false, ?callable $customEnumRender = null): mixed
     {
         if (null !== $default && \is_array($choicesOrEnum)) {
             $values = array_flip($choicesOrEnum);
@@ -243,6 +243,7 @@ class SymfonyStyle extends OutputStyle
 
         $questionChoice = new ChoiceQuestion($question, $choicesOrEnum, $default);
         $questionChoice->setMultiselect($multiSelect);
+        $questionChoice->setCustomEnumRender($customEnumRender);
 
         return $this->askQuestion($questionChoice);
     }

--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -234,14 +234,14 @@ class SymfonyStyle extends OutputStyle
         return $this->askQuestion(new ConfirmationQuestion($question, $default));
     }
 
-    public function choice(string $question, array $choices, mixed $default = null, bool $multiSelect = false): mixed
+    public function choice(string $question, array|string $choicesOrEnum, mixed $default = null, bool $multiSelect = false): mixed
     {
-        if (null !== $default) {
-            $values = array_flip($choices);
+        if (null !== $default && \is_array($choicesOrEnum)) {
+            $values = array_flip($choicesOrEnum);
             $default = $values[$default] ?? $default;
         }
 
-        $questionChoice = new ChoiceQuestion($question, $choices, $default);
+        $questionChoice = new ChoiceQuestion($question, $choicesOrEnum, $default);
         $questionChoice->setMultiselect($multiSelect);
 
         return $this->askQuestion($questionChoice);

--- a/src/Symfony/Component/Console/Tests/Fixtures/BasicEnumChoice.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/BasicEnumChoice.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Symfony\Component\Console\Tests\Fixtures;
+
+enum BasicEnumChoice
+{
+    case First;
+    case Second;
+    case ThirdName;
+    case AutocompleteValueFourth;
+    case AutocompleteValueFifth;
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/EmptyBasicEnumChoice.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/EmptyBasicEnumChoice.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Console\Tests\Fixtures;
+
+enum EmptyBasicEnumChoice
+{
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/OtherBasicEnumChoice.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/OtherBasicEnumChoice.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\Component\Console\Tests\Fixtures;
+
+enum OtherBasicEnumChoice
+{
+    case First;
+    case Second;
+}

--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -29,6 +29,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Terminal;
 use Symfony\Component\Console\Tester\ApplicationTester;
+use Symfony\Component\Console\Tests\Fixtures\BasicEnumChoice;
 use Symfony\Component\Process\Exception\ProcessSignaledException;
 use Symfony\Component\Process\Process;
 
@@ -979,6 +980,59 @@ class QuestionHelperTest extends AbstractQuestionHelperTestCase
         $this->expectException(ProcessSignaledException::class);
         $this->expectExceptionMessage('The process has been signaled with signal "2".');
         $p->wait();
+    }
+
+    public function testSelectDefaultEnumValue()
+    {
+        $dialog = new QuestionHelper();
+
+        $question = new ChoiceQuestion('What value?', BasicEnumChoice::class, BasicEnumChoice::First);
+        $inputStream = $this->getInputStream("\n");
+        $result = $dialog->ask($this->createStreamableInputInterfaceMock($inputStream), $this->createOutputInterface(), $question);
+        $this->assertEquals(BasicEnumChoice::First, $result);
+    }
+
+    public function testSelectEnumValueByIndex()
+    {
+        $dialog = new QuestionHelper();
+
+        $question = new ChoiceQuestion('What value?', BasicEnumChoice::class, BasicEnumChoice::First);
+        $inputStream = $this->getInputStream("1\n");
+        $result = $dialog->ask($this->createStreamableInputInterfaceMock($inputStream), $this->createOutputInterface(), $question);
+        $this->assertEquals(BasicEnumChoice::Second, $result);
+    }
+
+    public function testSelectEnumValueByName()
+    {
+        $dialog = new QuestionHelper();
+
+        $question = new ChoiceQuestion('What value?', BasicEnumChoice::class, BasicEnumChoice::First);
+        $inputStream = $this->getInputStream("Third name\n");
+        $result = $dialog->ask($this->createStreamableInputInterfaceMock($inputStream), $this->createOutputInterface(), $question);
+        $this->assertEquals(BasicEnumChoice::ThirdName, $result);
+    }
+
+    public function testAutocompleteWithEnum()
+    {
+        if (!Terminal::hasSttyAvailable()) {
+            $this->markTestSkipped('`stty` is required to test autocomplete functionality');
+        }
+
+        $dialog = new QuestionHelper();
+
+        $question = new ChoiceQuestion('What value?', BasicEnumChoice::class, BasicEnumChoice::Second);
+
+        // Auto<TAB><NEWLINE>
+        $inputStream = $this->getInputStream("Auto\t\n");
+        $this->assertSame(BasicEnumChoice::AutocompleteValueFourth, $dialog->ask($this->createStreamableInputInterfaceMock($inputStream), $this->createOutputInterface(), $question));
+
+        // Auto<KEYDOWN><TAB><NEWLINE>
+        $inputStream = $this->getInputStream("Auto\033[A\t\n");
+        $this->assertSame(BasicEnumChoice::AutocompleteValueFifth, $dialog->ask($this->createStreamableInputInterfaceMock($inputStream), $this->createOutputInterface(), $question));
+
+        // Auto<KEYDOWN><KEYDOWN><TAB><NEWLINE>
+        $inputStream = $this->getInputStream("Auto\033[A\033[A\t\n");
+        $this->assertSame(BasicEnumChoice::AutocompleteValueFourth, $dialog->ask($this->createStreamableInputInterfaceMock($inputStream), $this->createOutputInterface(), $question));
     }
 
     protected function getInputStream($input)

--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -1000,6 +1000,12 @@ class QuestionHelperTest extends AbstractQuestionHelperTestCase
         $inputStream = $this->getInputStream("1\n");
         $result = $dialog->ask($this->createStreamableInputInterfaceMock($inputStream), $this->createOutputInterface(), $question);
         $this->assertEquals(BasicEnumChoice::Second, $result);
+
+        $question = new ChoiceQuestion('What value?', BasicEnumChoice::class, BasicEnumChoice::First);
+        $question->setCustomEnumRender($this->createCustomEnumRender());
+        $inputStream = $this->getInputStream("1\n");
+        $result = $dialog->ask($this->createStreamableInputInterfaceMock($inputStream), $this->createOutputInterface(), $question);
+        $this->assertEquals(BasicEnumChoice::Second, $result);
     }
 
     public function testSelectEnumValueByName()
@@ -1008,6 +1014,12 @@ class QuestionHelperTest extends AbstractQuestionHelperTestCase
 
         $question = new ChoiceQuestion('What value?', BasicEnumChoice::class, BasicEnumChoice::First);
         $inputStream = $this->getInputStream("Third name\n");
+        $result = $dialog->ask($this->createStreamableInputInterfaceMock($inputStream), $this->createOutputInterface(), $question);
+        $this->assertEquals(BasicEnumChoice::ThirdName, $result);
+
+        $question = new ChoiceQuestion('What value?', BasicEnumChoice::class, BasicEnumChoice::First);
+        $question->setCustomEnumRender($this->createCustomEnumRender());
+        $inputStream = $this->getInputStream("third\n");
         $result = $dialog->ask($this->createStreamableInputInterfaceMock($inputStream), $this->createOutputInterface(), $question);
         $this->assertEquals(BasicEnumChoice::ThirdName, $result);
     }
@@ -1033,6 +1045,21 @@ class QuestionHelperTest extends AbstractQuestionHelperTestCase
         // Auto<KEYDOWN><KEYDOWN><TAB><NEWLINE>
         $inputStream = $this->getInputStream("Auto\033[A\033[A\t\n");
         $this->assertSame(BasicEnumChoice::AutocompleteValueFourth, $dialog->ask($this->createStreamableInputInterfaceMock($inputStream), $this->createOutputInterface(), $question));
+
+        $question = new ChoiceQuestion('What value?', BasicEnumChoice::class, BasicEnumChoice::Second);
+        $question->setCustomEnumRender($this->createCustomEnumRender());
+
+        // Auto<TAB><NEWLINE>
+        $inputStream = $this->getInputStream("auto\t\n");
+        $this->assertSame(BasicEnumChoice::AutocompleteValueFourth, $dialog->ask($this->createStreamableInputInterfaceMock($inputStream), $this->createOutputInterface(), $question));
+
+        // Auto<KEYDOWN><TAB><NEWLINE>
+        $inputStream = $this->getInputStream("auto\033[A\t\n");
+        $this->assertSame(BasicEnumChoice::AutocompleteValueFifth, $dialog->ask($this->createStreamableInputInterfaceMock($inputStream), $this->createOutputInterface(), $question));
+
+        // Auto<KEYDOWN><KEYDOWN><TAB><NEWLINE>
+        $inputStream = $this->getInputStream("auto\033[A\033[A\t\n");
+        $this->assertSame(BasicEnumChoice::AutocompleteValueFourth, $dialog->ask($this->createStreamableInputInterfaceMock($inputStream), $this->createOutputInterface(), $question));
     }
 
     protected function getInputStream($input)
@@ -1057,6 +1084,17 @@ class QuestionHelperTest extends AbstractQuestionHelperTestCase
             ->willReturn($interactive);
 
         return $mock;
+    }
+
+    protected function createCustomEnumRender()
+    {
+        return fn (BasicEnumChoice $choice) => match ($choice) {
+            BasicEnumChoice::First => 'first',
+            BasicEnumChoice::Second => 'second',
+            BasicEnumChoice::ThirdName => 'third',
+            BasicEnumChoice::AutocompleteValueFourth => 'auto fourth',
+            BasicEnumChoice::AutocompleteValueFifth => 'auto fifth',
+        };
     }
 }
 

--- a/src/Symfony/Component/Console/Tests/Helper/SymfonyQuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/SymfonyQuestionHelperTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Tests\Fixtures\BasicEnumChoice;
 
 #[Group('tty')]
 class SymfonyQuestionHelperTest extends AbstractQuestionHelperTestCase
@@ -180,6 +181,30 @@ class SymfonyQuestionHelperTest extends AbstractQuestionHelperTestCase
              qqq:
               [0] foo
              >ccc>
+            EOT,
+            $output,
+            true
+        );
+    }
+
+    public function testFormatEnumWithDefaultValue()
+    {
+        $choiceQuestion = new ChoiceQuestion('qqq', BasicEnumChoice::class, BasicEnumChoice::Second);
+
+        (new SymfonyQuestionHelper())->ask(
+            $this->createStreamableInputInterfaceMock($this->getInputStream('')),
+            $output = $this->createOutputInterface(),
+            $choiceQuestion
+        );
+
+        $this->assertOutputContains(<<<EOT
+             qqq [Second]:
+              [0] First
+              [1] Second
+              [2] Third name
+              [3] Autocomplete value fourth
+              [4] Autocomplete value fifth
+             >
             EOT,
             $output,
             true

--- a/src/Symfony/Component/Console/Tests/Question/ChoiceQuestionTest.php
+++ b/src/Symfony/Component/Console/Tests/Question/ChoiceQuestionTest.php
@@ -14,6 +14,9 @@ namespace Symfony\Component\Console\Tests\Question;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Console\Tests\Fixtures\BasicEnumChoice;
+use Symfony\Component\Console\Tests\Fixtures\EmptyBasicEnumChoice;
+use Symfony\Component\Console\Tests\Fixtures\OtherBasicEnumChoice;
 
 class ChoiceQuestionTest extends TestCase
 {
@@ -144,6 +147,46 @@ class ChoiceQuestionTest extends TestCase
         $question->setMultiselect(true);
 
         $this->assertSame([$result3, $result2], $question->getValidator()('baz, bar'));
+    }
+
+    public function testThrowExceptionWhenEnablingMultiselectOnEnumQuestion()
+    {
+        $question = new ChoiceQuestion('A question', [1, 2, 3]);
+        $question->setMultiselect(true);
+
+        $question = new ChoiceQuestion('A question', BasicEnumChoice::class);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Enums cannot be set as multiselect.');
+        $question->setMultiselect(true);
+    }
+
+    public function testThrowExceptionWhenEnablingMultilineOnEnumQuestion()
+    {
+        $question = new ChoiceQuestion('A question', [1, 2, 3]);
+        $question->setMultiline(true);
+
+        $question = new ChoiceQuestion('A question', BasicEnumChoice::class);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Enums cannot be set as multiline.');
+        $question->setMultiline(true);
+    }
+
+    public function testThrowExceptionWhenDefaultValueIsNotAnEnumValueOnEnumQuestion()
+    {
+        new ChoiceQuestion('A question', BasicEnumChoice::class, BasicEnumChoice::First);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Default value does not exist in the enum.');
+        new ChoiceQuestion('A question', BasicEnumChoice::class, OtherBasicEnumChoice::First);
+    }
+
+    public function testThrowExceptionWhenEnumValueOnEnumQuestion()
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Choice question must have at least 1 choice available.');
+        new ChoiceQuestion('A question', EmptyBasicEnumChoice::class);
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT


Add the ability to use enum in `ChoiceQuestion`.


# TECHNICAL DETAILS

- Works with all enum types (PR based on `UnitEnum`)
- Uses enum case names for display (for example, it converts "MyEnumValue" to "My enum value")
- Enum cases can be selected by their index or name (names can be autocompleted)
- The multiselect and multiline options are disabled when using enums and trying to enable them will trigger an exception
- The default value of an enum choice question needs to be a value from the enum otherwise it will trigger an exception

> [!WARNING]
> ~Right now, users need to follow the enum cases’ naming convention written in the Symfony documentation for the feature to work.~
> ~We can maybe allow the user inject a callable with a different naming strategy so users can choose another naming convention?~
> Updated with comment https://github.com/symfony/symfony/pull/62784#issuecomment-3662972218


# USAGE

```php
enum ColorEnum
{
    case ColorRed;
    case ColorGreen;
    case Blue;
}

#[AsCommand(name: 'app:run')]
class MyConsole
{
    public function __invoke(InputInterface $input, OutputInterface $output): int
    {
        $io = new SymfonyStyle($input, $output);
        $color = $io->choice(
            'Please choose a color: ',
            ColorEnum::class,
            ColorEnum::Blue
        );

        dump($color);

        return Command::SUCCESS;
    }
}
``` 

<img width="544" height="412" alt="ScreenSymfony" src="https://github.com/user-attachments/assets/714f09bf-1f92-4db4-8032-4696f616d804" />

In the screenshot above, the first run is using the enum case' index and the second one is using its name.