### PR TITLE
[Messenger] The component v8.0 is backed by Cadoles, thanks to them!

### DIFF
--- a/src/Symfony/Component/Messenger/README.md
+++ b/src/Symfony/Component/Messenger/README.md
@@ -7,7 +7,14 @@ other applications or via message queues.
 Sponsor
 -------
 
-Help Symfony by [sponsoring][1] its development!
+The Messenger component for Symfony 8.0 is [backed][1] by [Cadoles][2].
+
+Cadoles is a French Cooperative and Participative Company (SCOP) providing IT
+services based in Dijon. This company is a key player in free software and open
+formats, and uses Symfony in its development services for businesses and
+institutions.
+
+Help Symfony by [sponsoring][3] its development!
 
 Resources
 ---------
@@ -18,4 +25,6 @@ Resources
    [send Pull Requests](https://github.com/symfony/symfony/pulls)
    in the [main Symfony repository](https://github.com/symfony/symfony)
 
-[1]: https://symfony.com/sponsor
+[1]: https://symfony.com/backers
+[2]: https://www.cadoles.com
+[3]: https://symfony.com/sponsor


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Cadoles is a French Cooperative and Participative Company (SCOP) providing IT
services based in Dijon. This company is a key player in free software and open
formats, and uses Symfony in its development services for businesses and
institutions.

https://www.cadoles.com

Thanks to them!