### PR TITLE
[DoctrineBridge] Deprecate `RegisterMappingsPass::$aliasMap`

### DIFF
--- a/UPGRADE-8.1.md
+++ b/UPGRADE-8.1.md
@@ -6,6 +6,11 @@ DependencyInjection
 
  * Deprecate configuring options `alias`, `parent`, `synthetic`, `file`, `arguments`, `properties`, `configurator` or `calls` when using `from_callable`
 
+DoctrineBridge
+--------------
+
+ * Deprecate setting an `$aliasMap` in `RegisterMappingsPass`. Namespace aliases are no longer supported in Doctrine.
+
 FrameworkBundle
 ---------------
 

--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Deprecate setting an `$aliasMap` in `RegisterMappingsPass`. Namespace aliases are no longer supported in Doctrine.
+
 8.0
 ---
 

--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterMappingsPass.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterMappingsPass.php
@@ -65,8 +65,12 @@ abstract class RegisterMappingsPass implements CompilerPassInterface
         private readonly string $registerAliasMethodName = '',
         private readonly array $aliasMap = [],
     ) {
-        if ($aliasMap && (!$configurationPattern || !$registerAliasMethodName)) {
-            throw new \InvalidArgumentException('configurationPattern and registerAliasMethodName are required to register namespace alias.');
+        if ($aliasMap) {
+            trigger_deprecation('symfony/doctrine-bridge', '8.1', 'The property RegisterMappingsPass::$aliasMap is deprecated and will be removed in 9.0. Namespace alias are no longer supported.');
+
+            if (!$configurationPattern || !$registerAliasMethodName) {
+                throw new \InvalidArgumentException('configurationPattern and registerAliasMethodName are required to register namespace alias.');
+            }
         }
     }
 
@@ -103,7 +107,7 @@ abstract class RegisterMappingsPass implements CompilerPassInterface
      * Get the service name of the metadata chain driver that the mappings
      * should be registered with.
      *
-     * @throws InvalidArgumentException if non of the managerParameters has a
+     * @throws InvalidArgumentException if none of the managerParameters has a
      *                                  non-empty value
      */
     protected function getChainDriverServiceName(ContainerBuilder $container): string

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -19,6 +19,7 @@
         "php": ">=8.4",
         "doctrine/event-manager": "^2",
         "doctrine/persistence": "^3.1|^4",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/polyfill-ctype": "^1.8",
         "symfony/polyfill-mbstring": "^1.0",
         "symfony/service-contracts": "^2.5|^3"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | -
| License       | MIT

Namespace aliases have been deprecated from `doctrine/persistence` [2.3.0](https://github.com/doctrine/persistence/releases/tag/2.3.0) https://github.com/doctrine/persistence/issues/204, and removed from [3.0.0](https://github.com/doctrine/persistence/commit/7422aabf621f2d246e27cd7474a570c11f55da2e#diff-65217b628918b27724f64d13ef152e91e8d5223c594e564f8583fb2045cb779f).

- DoctrineBundle accepts this parameter, but the method `Configuration::addEntityNamespace` has been removed in `dotrine/orm` 3.0.0, which make it broken. Removing in https://github.com/doctrine/DoctrineMongoDBBundle/pull/971
- DoctrineMongoDBBundle accepts them but the namespace alias support is no longer supported. Removing in https://github.com/doctrine/DoctrineBundle/pull/2169
- DoctrinePHPCRBundle removed usage of this parameter in https://github.com/doctrine/DoctrinePHPCRBundle/commit/dc8219765a7883b9db249a9ffa9087c97fed8f3e

Projects using the child classes of `RegisterMappingPass` never set an `$aliasMap`.
- [`FOSUserBundle`](https://github.com/FriendsOfSymfony/FOSUserBundle/blob/607a7fb975bc0c39bc2aa7e4ab8c52aded74d63c/src/FOSUserBundle.php#L46-L52)

Removing this parameters is a breaking change but could be already done in 8.1 as it is unsupported or broken for all the Doctrine bundles.