### PR TITLE
[Cache] Fix calling the callback wrapper for `ChainAdapter`

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/ChainAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ChainAdapter.php
@@ -106,7 +106,7 @@ class ChainAdapter implements AdapterInterface, CacheInterface, PruneableInterfa
                 $callback = $wrap;
                 $beta = \INF === $beta ? \INF : 0;
             }
-            if ($adapter instanceof CacheInterface) {
+            if ($adapter instanceof CacheInterface && $i !== $this->adapterCount) {
                 $value = $adapter->get($key, $callback, $beta, $metadata);
             } else {
                 $value = $this->doGet($adapter, $key, $callback, $beta, $metadata);

--- a/src/Symfony/Component/Cache/Tests/Adapter/ChainAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ChainAdapterTest.php
@@ -266,4 +266,28 @@ class ChainAdapterTest extends AdapterTestCase
     {
         return $this->createMock(AdapterInterface::class);
     }
+
+    public function testSetCallbackWrapperPropagation()
+    {
+        $adapter1 = new ArrayAdapter();
+        $adapter2 = new FilesystemAdapter();
+
+        $chain = new ChainAdapter([$adapter1, $adapter2]);
+
+        $callbackWrapperCalled = false;
+        $customWrapper = static function (callable $callback, CacheItem $item, bool &$save) use (&$callbackWrapperCalled) {
+            $callbackWrapperCalled = true;
+
+            return $callback($item, $save);
+        };
+
+        $chain->setCallbackWrapper($customWrapper);
+
+        $chain->delete('test-callback-wrapper');
+
+        $result = $chain->get('test-callback-wrapper', static fn () => 'computed-value');
+
+        $this->assertTrue($callbackWrapperCalled);
+        $this->assertSame('computed-value', $result);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62702
| License       | MIT

The `ChainAdapter::get()` method had a custom implementation that delegated to inner adapters' `get()` methods directly (for adapters implementing `CacheInterface`). This bypassed the `ChainAdapter`'s own `callbackWrapper` which is responsible for triggering early expiration messages.