### PR TITLE
[JsonPath] fix calling non-static method statically

### DIFF
--- a/src/Symfony/Component/JsonPath/JsonCrawler.php
+++ b/src/Symfony/Component/JsonPath/JsonCrawler.php
@@ -1101,7 +1101,7 @@ final class JsonCrawler implements JsonCrawlerInterface
     private function normalizeStorage(\stdClass|array $data): array
     {
         return array_map(function ($value) {
-            return $value instanceof \stdClass || $value && \is_array($value) ? self::normalizeStorage($value) : $value;
+            return $value instanceof \stdClass || $value && \is_array($value) ? $this->normalizeStorage($value) : $value;
         }, (array) $data);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes-ish
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix compiler complaints
| License       | MIT

if [lambda would be declared as static](https://github.com/symfony/symfony/pull/62783/), calling non-static method from it would fail with the following error:
> Error: Non-static method Symfony\Component\JsonPath\JsonCrawler::normalizeStorage() cannot be called statically

let's not call non-static method statically.