### PR TITLE
[FrameworkBundle] Fix mocking decorated services in tests

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TestServiceContainerWeakRefPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TestServiceContainerWeakRefPass.php
@@ -34,7 +34,10 @@ class TestServiceContainerWeakRefPass implements CompilerPassInterface
         $definitions = $container->getDefinitions();
 
         foreach ($definitions as $id => $definition) {
-            if ($id && '.' !== $id[0] && (!$definition->isPublic() || $definition->isPrivate() || $definition->hasTag('container.private')) && !$definition->hasErrors() && !$definition->isAbstract()) {
+            if ($inner = $definition->getTag('container.decorator')[0]['inner'] ?? null) {
+                $privateServices[$inner] = new Reference($inner, ContainerBuilder::IGNORE_ON_UNINITIALIZED_REFERENCE);
+            }
+            if ($id && '.' !== $id[0] && ($definition->isPrivate() || $definition->hasTag('container.private')) && !$definition->hasErrors() && !$definition->isAbstract()) {
                 $privateServices[$id] = new Reference($id, ContainerBuilder::IGNORE_ON_UNINITIALIZED_REFERENCE);
             }
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Test/TestContainer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/TestContainer.php
@@ -71,15 +71,11 @@ class TestContainer extends Container
         $container = $this->getPublicContainer();
         $renamedId = $this->renamedIds[$id] ?? $id;
 
-        try {
+        if (!$this->getPrivateContainer()->has($renamedId)) {
             $container->set($renamedId, $service);
-        } catch (InvalidArgumentException $e) {
-            if (!str_starts_with($e->getMessage(), "The \"$renamedId\" service is private")) {
-                throw $e;
-            }
-            if (isset($container->privates[$renamedId])) {
-                throw new InvalidArgumentException(\sprintf('The "%s" service is already initialized, you cannot replace it.', $id));
-            }
+        } elseif (isset($container->privates[$renamedId])) {
+            throw new InvalidArgumentException(\sprintf('The "%s" service is already initialized, you cannot replace it.', $id));
+        } else {
             $container->privates[$renamedId] = $service;
         }
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/HttpClientMockingController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/HttpClientMockingController.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class HttpClientMockingController
+{
+    public function __invoke(HttpClientInterface $httpClient): Response
+    {
+        $response = $httpClient->request('GET', 'https://example.com/');
+
+        return new Response($response->getContent());
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Resources/config/routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Resources/config/routing.yml
@@ -65,6 +65,10 @@ http_client_call:
     path:     /http_client_call
     defaults: { _controller: Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\HttpClientController::index }
 
+http_client_mock:
+    path:     /http_client_mock
+    defaults: { _controller: Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\HttpClientMockingController }
+
 uid:
     resource: "../../Controller/UidController.php"
     type: "attribute"

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/HttpClientTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/HttpClientTest.php
@@ -11,6 +11,10 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
 class HttpClientTest extends AbstractWebTestCase
 {
     public function testHttpClientAssertions()
@@ -29,5 +33,16 @@ class HttpClientTest extends AbstractWebTestCase
         $this->assertNotHttpClientRequest('https://laravel.com', httpClientId: 'symfony.http_client');
 
         $this->assertHttpClientRequestCount(6, 'symfony.http_client');
+    }
+
+    public function testHttpClientCanBeOverriddenInWebTestCase()
+    {
+        $browser = $this->createClient(['test_case' => 'HttpClient', 'root_config' => 'config.yml', 'debug' => true]);
+        $mockedContent = 'Request Mocked successfully!';
+        static::getContainer()->set(HttpClientInterface::class, new MockHttpClient(new MockResponse($mockedContent)));
+
+        $browser->request('GET', '/http_client_mock');
+
+        self::assertSame($mockedContent, $browser->getResponse()->getContent());
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/HttpClient/services.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/HttpClient/services.yml
@@ -5,5 +5,8 @@ services:
     Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\HttpClientController:
         tags: ['controller.service_arguments']
 
+    Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\HttpClientMockingController:
+        tags: ['controller.service_arguments']
+
     Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Tests\MockClientCallback:
         class: Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Tests\MockClientCallback


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62693 and #62726
| License       | MIT

The root issue under #62693 was that the innermost decorated service (the original service wrapped by all decorators) was getting inlined into the first decorator during container compilation. When the service is inlined, it no longer exists as a separate service in the container, so `TestContainer::set()` can't replace it.