### PR TITLE
[Security] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/Security/Core/Test/AccessDecisionStrategyTestCase.php
+++ b/src/Symfony/Component/Security/Core/Test/AccessDecisionStrategyTestCase.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Core\Test;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\NullToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManager;
 use Symfony\Component\Security\Core\Authorization\Strategy\AccessDecisionStrategyInterface;
@@ -31,10 +32,9 @@ abstract class AccessDecisionStrategyTestCase extends TestCase
      */
     final public function testDecide(AccessDecisionStrategyInterface $strategy, array $voters, bool $expected)
     {
-        $token = $this->createMock(TokenInterface::class);
         $manager = new AccessDecisionManager($voters, $strategy);
 
-        $this->assertSame($expected, $manager->decide($token, ['ROLE_FOO']));
+        $this->assertSame($expected, $manager->decide(new NullToken(), ['ROLE_FOO']));
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/RememberMeTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/RememberMeTokenTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Security\Core\Tests\Authentication\Token;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\RememberMeToken;
-use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\InMemoryUser;
 
 class RememberMeTokenTest extends TestCase
 {
@@ -40,13 +40,6 @@ class RememberMeTokenTest extends TestCase
 
     protected function getUser($roles = ['ROLE_FOO'])
     {
-        $user = $this->createMock(UserInterface::class);
-        $user
-            ->expects($this->any())
-            ->method('getRoles')
-            ->willReturn($roles)
-        ;
-
-        return $user;
+        return new InMemoryUser('John', 'password', $roles);
     }
 }

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/AccessDecisionManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/AccessDecisionManagerTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Core\Tests\Authorization;
 
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\NullToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManager;
 use Symfony\Component\Security\Core\Authorization\Strategy\AccessDecisionStrategyInterface;
@@ -31,8 +32,6 @@ class AccessDecisionManagerTest extends TestCase
 
     public function testVoterCalls()
     {
-        $token = $this->createMock(TokenInterface::class);
-
         $voters = [
             $this->getExpectedVoter(VoterInterface::ACCESS_DENIED),
             $this->getExpectedVoter(VoterInterface::ACCESS_GRANTED),
@@ -62,12 +61,12 @@ class AccessDecisionManagerTest extends TestCase
 
         $manager = new AccessDecisionManager($voters, $strategy);
 
-        $this->assertTrue($manager->decide($token, ['ROLE_FOO']));
+        $this->assertTrue($manager->decide(new NullToken(), ['ROLE_FOO']));
     }
 
     public function testCacheableVoters()
     {
-        $token = $this->createMock(TokenInterface::class);
+        $token = new NullToken();
         $voter = $this->createMock(CacheableVoterInterface::class);
 
         $voter
@@ -92,7 +91,7 @@ class AccessDecisionManagerTest extends TestCase
 
     public function testCacheableVotersIgnoresNonStringAttributes()
     {
-        $token = $this->createMock(TokenInterface::class);
+        $token = new NullToken();
         $voter = $this->createMock(CacheableVoterInterface::class);
         $voter
             ->expects($this->never())
@@ -114,7 +113,7 @@ class AccessDecisionManagerTest extends TestCase
 
     public function testCacheableVotersWithMultipleAttributes()
     {
-        $token = $this->createMock(TokenInterface::class);
+        $token = new NullToken();
         $voter = $this->createMock(CacheableVoterInterface::class);
         $voter
             ->expects($this->exactly(2))
@@ -147,7 +146,7 @@ class AccessDecisionManagerTest extends TestCase
 
     public function testCacheableVotersWithEmptyAttributes()
     {
-        $token = $this->createMock(TokenInterface::class);
+        $token = new NullToken();
         $voter = $this->createMock(CacheableVoterInterface::class);
         $voter
             ->expects($this->never())
@@ -169,7 +168,7 @@ class AccessDecisionManagerTest extends TestCase
 
     public function testCacheableVotersSupportsMethodsCalledOnce()
     {
-        $token = $this->createMock(TokenInterface::class);
+        $token = new NullToken();
         $voter = $this->createMock(CacheableVoterInterface::class);
         $voter
             ->expects($this->once())
@@ -194,7 +193,7 @@ class AccessDecisionManagerTest extends TestCase
 
     public function testCacheableVotersNotCalled()
     {
-        $token = $this->createMock(TokenInterface::class);
+        $token = new NullToken();
         $voter = $this->createMock(CacheableVoterInterface::class);
         $voter
             ->expects($this->once())
@@ -214,7 +213,7 @@ class AccessDecisionManagerTest extends TestCase
 
     public function testCacheableVotersWithMultipleAttributesAndNonString()
     {
-        $token = $this->createMock(TokenInterface::class);
+        $token = new NullToken();
         $voter = $this->createMock(CacheableVoterInterface::class);
         $voter
             ->expects($this->once())

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/TraceableAccessDecisionManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/TraceableAccessDecisionManagerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Core\Tests\Authorization;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\NullToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManager;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
@@ -26,7 +27,7 @@ class TraceableAccessDecisionManagerTest extends TestCase
      */
     public function testDecideLog(array $expectedLog, array $attributes, $object, array $voterVotes, bool $result)
     {
-        $token = $this->createMock(TokenInterface::class);
+        $token = new NullToken();
         $admMock = $this->createMock(AccessDecisionManagerInterface::class);
 
         $adm = new TraceableAccessDecisionManager($admMock);
@@ -176,25 +177,15 @@ class TraceableAccessDecisionManagerTest extends TestCase
      */
     public function testAccessDecisionManagerCalledByVoter()
     {
-        $voter1 = $this
-            ->getMockBuilder(VoterInterface::class)
-            ->onlyMethods(['vote'])
-            ->getMock();
+        $voter1 = $this->createStub(VoterInterface::class);
 
-        $voter2 = $this
-            ->getMockBuilder(VoterInterface::class)
-            ->onlyMethods(['vote'])
-            ->getMock();
+        $voter2 = $this->createStub(VoterInterface::class);
 
-        $voter3 = $this
-            ->getMockBuilder(VoterInterface::class)
-            ->onlyMethods(['vote'])
-            ->getMock();
+        $voter3 = $this->createStub(VoterInterface::class);
 
         $sut = new TraceableAccessDecisionManager(new AccessDecisionManager([$voter1, $voter2, $voter3]));
 
         $voter1
-            ->expects($this->any())
             ->method('vote')
             ->willReturnCallback(function (TokenInterface $token, $subject, array $attributes) use ($sut, $voter1) {
                 $vote = \in_array('attr1', $attributes) ? VoterInterface::ACCESS_GRANTED : VoterInterface::ACCESS_ABSTAIN;
@@ -204,7 +195,6 @@ class TraceableAccessDecisionManagerTest extends TestCase
             });
 
         $voter2
-            ->expects($this->any())
             ->method('vote')
             ->willReturnCallback(function (TokenInterface $token, $subject, array $attributes) use ($sut, $voter2) {
                 if (\in_array('attr2', $attributes)) {
@@ -219,7 +209,6 @@ class TraceableAccessDecisionManagerTest extends TestCase
             });
 
         $voter3
-            ->expects($this->any())
             ->method('vote')
             ->willReturnCallback(function (TokenInterface $token, $subject, array $attributes) use ($sut, $voter3) {
                 if (\in_array('attr2', $attributes) && $subject) {
@@ -233,7 +222,7 @@ class TraceableAccessDecisionManagerTest extends TestCase
                 return $vote;
             });
 
-        $token = $this->createMock(TokenInterface::class);
+        $token = new NullToken();
         $sut->decide($token, ['attr1'], null);
         $sut->decide($token, ['attr2'], $obj = new \stdClass());
 
@@ -270,7 +259,7 @@ class TraceableAccessDecisionManagerTest extends TestCase
 
     public function testCustomAccessDecisionManagerReturnsEmptyStrategy()
     {
-        $admMock = $this->createMock(AccessDecisionManagerInterface::class);
+        $admMock = $this->createStub(AccessDecisionManagerInterface::class);
 
         $adm = new TraceableAccessDecisionManager($admMock);
 

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/AuthenticatedVoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/AuthenticatedVoterTest.php
@@ -105,7 +105,7 @@ class AuthenticatedVoterTest extends TestCase
         }
 
         if ('impersonated' === $authenticated) {
-            return $this->getMockBuilder(SwitchUserToken::class)->disableOriginalConstructor()->getMock();
+            return new SwitchUserToken(new InMemoryUser('John', 'password'), 'main', ['ROLE_USER'], new NullToken());
         }
 
         return new NullToken();

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/ExpressionVoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/ExpressionVoterTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface;
 use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
+use Symfony\Component\Security\Core\Authentication\Token\NullToken;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Authorization\ExpressionLanguage;
 use Symfony\Component\Security\Core\Authorization\Voter\ExpressionVoter;
@@ -47,42 +48,44 @@ class ExpressionVoterTest extends TestCase
 
     protected function getTokenWithRoleNames(array $roles, $tokenExpectsGetRoles = true)
     {
-        $token = $this->createMock(AbstractToken::class);
-
         if ($tokenExpectsGetRoles) {
-            $token->expects($this->once())
+            $mock = $this->createMock(AbstractToken::class);
+            $mock->expects($this->once())
                 ->method('getRoleNames')
                 ->willReturn($roles);
+
+            return $mock;
         }
 
-        return $token;
+        return new NullToken();
     }
 
     protected function createExpressionLanguage($expressionLanguageExpectsEvaluate = true)
     {
-        $mock = $this->createMock(ExpressionLanguage::class);
-
         if ($expressionLanguageExpectsEvaluate) {
+            $mock = $this->createMock(ExpressionLanguage::class);
             $mock->expects($this->once())
                 ->method('evaluate')
                 ->willReturn(true);
+
+            return $mock;
         }
 
-        return $mock;
+        return new ExpressionLanguage();
     }
 
     protected function createTrustResolver()
     {
-        return $this->createMock(AuthenticationTrustResolverInterface::class);
+        return $this->createStub(AuthenticationTrustResolverInterface::class);
     }
 
     protected function createAuthorizationChecker()
     {
-        return $this->createMock(AuthorizationCheckerInterface::class);
+        return $this->createStub(AuthorizationCheckerInterface::class);
     }
 
     protected static function createExpression()
     {
-        return new Expression('');
+        return new Expression('is_granted("ROLE_ADMIN") or is_granted("ROLE_MANAGER")');
     }
 }

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/VoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/VoterTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Core\Tests\Authorization\Voter;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\NullToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
@@ -22,7 +23,7 @@ class VoterTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->token = $this->createMock(TokenInterface::class);
+        $this->token = new NullToken();
     }
 
     public static function getTests(): array

--- a/src/Symfony/Component/Security/Core/Tests/User/ChainUserCheckerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/ChainUserCheckerTest.php
@@ -13,14 +13,14 @@ namespace Symfony\Component\Security\Core\Tests\User;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\User\ChainUserChecker;
+use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
-use Symfony\Component\Security\Core\User\UserInterface;
 
 final class ChainUserCheckerTest extends TestCase
 {
     public function testForwardsPreAuthToAllUserCheckers()
     {
-        $user = $this->createMock(UserInterface::class);
+        $user = new InMemoryUser('John', 'password');
 
         $checker1 = $this->createMock(UserCheckerInterface::class);
         $checker1->expects($this->once())
@@ -42,7 +42,7 @@ final class ChainUserCheckerTest extends TestCase
 
     public function testForwardsPostAuthToAllUserCheckers()
     {
-        $user = $this->createMock(UserInterface::class);
+        $user = new InMemoryUser('John', 'password');
 
         $checker1 = $this->createMock(UserCheckerInterface::class);
         $checker1->expects($this->once())

--- a/src/Symfony/Component/Security/Core/Tests/User/ChainUserProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/ChainUserProviderTest.php
@@ -20,7 +20,6 @@ use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\InMemoryUserProvider;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
-use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 class ChainUserProviderTest extends TestCase
@@ -40,7 +39,7 @@ class ChainUserProviderTest extends TestCase
             ->expects($this->once())
             ->method('loadUserByIdentifier')
             ->with($this->equalTo('foo'))
-            ->willReturn($account = $this->createMock(UserInterface::class))
+            ->willReturn($account = new InMemoryUser('John', 'password'))
         ;
 
         $provider = new ChainUserProvider([$provider1, $provider2]);
@@ -70,7 +69,7 @@ class ChainUserProviderTest extends TestCase
             ->expects($this->once())
             ->method('loadUserByIdentifier')
             ->with($this->equalTo('foo'), $this->equalTo(['attr' => 5]))
-            ->willReturn($account = $this->createMock(UserInterface::class))
+            ->willReturn($account = new InMemoryUser('John', 'password'))
         ;
 
         $provider = new ChainUserProvider([$provider0, $provider1, $provider2]);
@@ -132,11 +131,11 @@ class ChainUserProviderTest extends TestCase
         $provider3
             ->expects($this->once())
             ->method('refreshUser')
-            ->willReturn($account = $this->createMock(UserInterface::class))
+            ->willReturn($account = new InMemoryUser('John', 'password'))
         ;
 
         $provider = new ChainUserProvider([$provider1, $provider2, $provider3]);
-        $this->assertSame($account, $provider->refreshUser($this->createMock(UserInterface::class)));
+        $this->assertSame($account, $provider->refreshUser(new InMemoryUser('John', 'password')));
     }
 
     public function testRefreshUserAgain()
@@ -164,11 +163,11 @@ class ChainUserProviderTest extends TestCase
         $provider2
             ->expects($this->once())
             ->method('refreshUser')
-            ->willReturn($account = $this->createMock(UserInterface::class))
+            ->willReturn($account = new InMemoryUser('John', 'password'))
         ;
 
         $provider = new ChainUserProvider([$provider1, $provider2]);
-        $this->assertSame($account, $provider->refreshUser($this->createMock(UserInterface::class)));
+        $this->assertSame($account, $provider->refreshUser(new InMemoryUser('John', 'password')));
     }
 
     public function testRefreshUserThrowsUnsupportedUserException()
@@ -201,7 +200,7 @@ class ChainUserProviderTest extends TestCase
         ;
 
         $provider = new ChainUserProvider([$provider1, $provider2]);
-        $provider->refreshUser($this->createMock(UserInterface::class));
+        $provider->refreshUser(new InMemoryUser('John', 'password'));
     }
 
     public function testSupportsClass()
@@ -273,11 +272,11 @@ class ChainUserProviderTest extends TestCase
         $provider2
             ->expects($this->once())
             ->method('refreshUser')
-            ->willReturn($account = $this->createMock(UserInterface::class))
+            ->willReturn($account = new InMemoryUser('John', 'password'))
         ;
 
         $provider = new ChainUserProvider(new \ArrayObject([$provider1, $provider2]));
-        $this->assertSame($account, $provider->refreshUser($this->createMock(UserInterface::class)));
+        $this->assertSame($account, $provider->refreshUser(new InMemoryUser('John', 'password')));
     }
 
     public function testPasswordUpgrades()

--- a/src/Symfony/Component/Security/Core/Tests/User/InMemoryUserCheckerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/InMemoryUserCheckerTest.php
@@ -15,7 +15,6 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Exception\DisabledException;
 use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\InMemoryUserChecker;
-use Symfony\Component\Security\Core\User\UserInterface;
 
 class InMemoryUserCheckerTest extends TestCase
 {
@@ -23,7 +22,7 @@ class InMemoryUserCheckerTest extends TestCase
     {
         $checker = new InMemoryUserChecker();
 
-        $this->assertNull($checker->checkPostAuth($this->createMock(UserInterface::class)));
+        $this->assertNull($checker->checkPostAuth(new InMemoryUser('John', 'password')));
     }
 
     public function testCheckPostAuthPass()

--- a/src/Symfony/Component/Security/Core/Tests/User/InMemoryUserTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/InMemoryUserTest.php
@@ -93,6 +93,6 @@ class InMemoryUserTest extends TestCase
     public function testIsEqualToWithDifferentUser()
     {
         $user = new InMemoryUser('username', 'password');
-        $this->assertFalse($user->isEqualTo($this->createMock(UserInterface::class)));
+        $this->assertFalse($user->isEqualTo($this->createStub(UserInterface::class)));
     }
 }

--- a/src/Symfony/Component/Security/Csrf/Tests/CsrfTokenManagerTest.php
+++ b/src/Symfony/Component/Security/Csrf/Tests/CsrfTokenManagerTest.php
@@ -27,32 +27,50 @@ class CsrfTokenManagerTest extends TestCase
 {
     public function testGetNonExistingTokenEmptyNamespace()
     {
-        $this->assertGetNonExistingToken(...$this->getEmptyNamespaceMocks());
+        $generator = $this->createMock(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertGetNonExistingToken('', $this->getEmptyNamespaceMocks($generator, $storage), $storage, $generator);
     }
 
     public function testGetNonExistingTokenHttpsNamespace()
     {
-        $this->assertGetNonExistingToken(...$this->getHttpsNamespaceMocks());
+        $generator = $this->createMock(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertGetNonExistingToken('https-', $this->getHttpsNamespaceMocks($generator, $storage), $storage, $generator);
     }
 
     public function testGetNonExistingTokenCustomNamespace()
     {
-        $this->assertGetNonExistingToken(...$this->getCustomNamespaceMocks());
+        $generator = $this->createMock(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertGetNonExistingToken('aNamespace-', $this->getCustomNamespaceMocks($generator, $storage), $storage, $generator);
     }
 
     public function testGetNonExistingTokenRequestStack()
     {
-        $this->assertGetNonExistingToken(...$this->getRequestStackMocks());
+        $generator = $this->createMock(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertGetNonExistingToken('https-', $this->getRequestStackMocks($generator, $storage), $storage, $generator);
     }
 
     public function testGetNonExistingTokenClosure()
     {
-        $this->assertGetNonExistingToken(...$this->getClosureMocks());
+        $generator = $this->createMock(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertGetNonExistingToken('generated-', $this->getClosureMocks($generator, $storage), $storage, $generator);
     }
 
     public function testGetNonExistingTokenRequestStackEmptyNamespace()
     {
-        $this->assertGetNonExistingToken(...$this->getRequestStackWithEmptyNamespaceMocks());
+        $generator = $this->createMock(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertGetNonExistingToken('', $this->getRequestStackWithEmptyNamespaceMocks($generator, $storage), $storage, $generator);
     }
 
     private function assertGetNonExistingToken($namespace, $manager, $storage, $generator): void
@@ -79,32 +97,50 @@ class CsrfTokenManagerTest extends TestCase
 
     public function testUseExistingTokenIfAvailableEmptyNamespace()
     {
-        $this->assertUseExistingTokenIfAvailable(...$this->getEmptyNamespaceMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertUseExistingTokenIfAvailable('', $this->getEmptyNamespaceMocks($generator, $storage), $storage);
     }
 
     public function testUseExistingTokenIfAvailableHttpsNamespace()
     {
-        $this->assertUseExistingTokenIfAvailable(...$this->getHttpsNamespaceMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertUseExistingTokenIfAvailable('https-', $this->getHttpsNamespaceMocks($generator, $storage), $storage);
     }
 
     public function testUseExistingTokenIfAvailableCustomNamespace()
     {
-        $this->assertUseExistingTokenIfAvailable(...$this->getCustomNamespaceMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertUseExistingTokenIfAvailable('aNamespace-', $this->getCustomNamespaceMocks($generator, $storage), $storage);
     }
 
     public function testUseExistingTokenIfAvailableRequestStack()
     {
-        $this->assertUseExistingTokenIfAvailable(...$this->getRequestStackMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertUseExistingTokenIfAvailable('https-', $this->getRequestStackMocks($generator, $storage), $storage);
     }
 
     public function testUseExistingTokenIfAvailableClosure()
     {
-        $this->assertUseExistingTokenIfAvailable(...$this->getClosureMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertUseExistingTokenIfAvailable('generated-', $this->getClosureMocks($generator, $storage), $storage);
     }
 
     public function testUseExistingTokenIfAvailableRequestStackEmptyNamespace()
     {
-        $this->assertUseExistingTokenIfAvailable(...$this->getRequestStackWithEmptyNamespaceMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertUseExistingTokenIfAvailable('', $this->getRequestStackWithEmptyNamespaceMocks($generator, $storage), $storage);
     }
 
     private function assertUseExistingTokenIfAvailable($namespace, $manager, $storage): void
@@ -128,42 +164,60 @@ class CsrfTokenManagerTest extends TestCase
 
     public function testRandomizeTheTokenEmptyNamespace()
     {
-        $this->assertRandomizeTheToken(...$this->getEmptyNamespaceMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createStub(TokenStorageInterface::class);
+
+        $this->assertRandomizeTheToken('', $this->getEmptyNamespaceMocks($generator, $storage), $storage);
     }
 
     public function testRandomizeTheTokenHttpsNamespace()
     {
-        $this->assertRandomizeTheToken(...$this->getHttpsNamespaceMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createStub(TokenStorageInterface::class);
+
+        $this->assertRandomizeTheToken('https-', $this->getHttpsNamespaceMocks($generator, $storage), $storage);
     }
 
     public function testRandomizeTheTokenCustomNamespace()
     {
-        $this->assertRandomizeTheToken(...$this->getCustomNamespaceMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createStub(TokenStorageInterface::class);
+
+        $this->assertRandomizeTheToken('aNamespace-', $this->getCustomNamespaceMocks($generator, $storage), $storage);
     }
 
     public function testRandomizeTheTokenRequestStack()
     {
-        $this->assertRandomizeTheToken(...$this->getRequestStackMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createStub(TokenStorageInterface::class);
+
+        $this->assertRandomizeTheToken('https-', $this->getRequestStackMocks($generator, $storage), $storage);
     }
 
     public function testRandomizeTheTokenClosure()
     {
-        $this->assertRandomizeTheToken(...$this->getClosureMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createStub(TokenStorageInterface::class);
+
+        $this->assertRandomizeTheToken('generated-', $this->getClosureMocks($generator, $storage), $storage);
     }
 
     public function testRandomizeTheTokenRequestStackEmptyNamespace()
     {
-        $this->assertRandomizeTheToken(...$this->getRequestStackWithEmptyNamespaceMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createStub(TokenStorageInterface::class);
+
+        $this->assertRandomizeTheToken('', $this->getRequestStackWithEmptyNamespaceMocks($generator, $storage), $storage);
     }
 
     private function assertRandomizeTheToken($namespace, $manager, $storage): void
     {
-        $storage->expects($this->any())
+        $storage
             ->method('hasToken')
             ->with($namespace.'token_id')
             ->willReturn(true);
 
-        $storage->expects($this->any())
+        $storage
             ->method('getToken')
             ->with($namespace.'token_id')
             ->willReturn('TOKEN');
@@ -182,32 +236,50 @@ class CsrfTokenManagerTest extends TestCase
 
     public function testRefreshTokenAlwaysReturnsNewTokenEmptyNamespace()
     {
-        $this->assertRefreshTokenAlwaysReturnsNewToken(...$this->getEmptyNamespaceMocks());
+        $generator = $this->createMock(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertRefreshTokenAlwaysReturnsNewToken('', $this->getEmptyNamespaceMocks($generator, $storage), $storage, $generator);
     }
 
     public function testRefreshTokenAlwaysReturnsNewTokenHttpsNamespace()
     {
-        $this->assertRefreshTokenAlwaysReturnsNewToken(...$this->getHttpsNamespaceMocks());
+        $generator = $this->createMock(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertRefreshTokenAlwaysReturnsNewToken('https-', $this->getHttpsNamespaceMocks($generator, $storage), $storage, $generator);
     }
 
     public function testRefreshTokenAlwaysReturnsNewTokenCustomNamespace()
     {
-        $this->assertRefreshTokenAlwaysReturnsNewToken(...$this->getCustomNamespaceMocks());
+        $generator = $this->createMock(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertRefreshTokenAlwaysReturnsNewToken('aNamespace-', $this->getCustomNamespaceMocks($generator, $storage), $storage, $generator);
     }
 
     public function testRefreshTokenAlwaysReturnsNewTokenRequestStack()
     {
-        $this->assertRefreshTokenAlwaysReturnsNewToken(...$this->getRequestStackMocks());
+        $generator = $this->createMock(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertRefreshTokenAlwaysReturnsNewToken('https-', $this->getRequestStackMocks($generator, $storage), $storage, $generator);
     }
 
     public function testRefreshTokenAlwaysReturnsNewTokenClosure()
     {
-        $this->assertRefreshTokenAlwaysReturnsNewToken(...$this->getClosureMocks());
+        $generator = $this->createMock(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertRefreshTokenAlwaysReturnsNewToken('generated-', $this->getClosureMocks($generator, $storage), $storage, $generator);
     }
 
     public function testRefreshTokenAlwaysReturnsNewTokenRequestStackEmptyNamespace()
     {
-        $this->assertRefreshTokenAlwaysReturnsNewToken(...$this->getRequestStackWithEmptyNamespaceMocks());
+        $generator = $this->createMock(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertRefreshTokenAlwaysReturnsNewToken('', $this->getRequestStackWithEmptyNamespaceMocks($generator, $storage), $storage, $generator);
     }
 
     private function assertRefreshTokenAlwaysReturnsNewToken($namespace, $manager, $storage, $generator): void
@@ -232,32 +304,50 @@ class CsrfTokenManagerTest extends TestCase
 
     public function testMatchingTokenIsValidEmptyNamespace()
     {
-        $this->assertMatchingTokenIsValid(...$this->getEmptyNamespaceMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertMatchingTokenIsValid('', $this->getEmptyNamespaceMocks($generator, $storage), $storage);
     }
 
     public function testMatchingTokenIsValidHttpsNamespace()
     {
-        $this->assertMatchingTokenIsValid(...$this->getHttpsNamespaceMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertMatchingTokenIsValid('https-', $this->getHttpsNamespaceMocks($generator, $storage), $storage);
     }
 
     public function testMatchingTokenIsValidCustomNamespace()
     {
-        $this->assertMatchingTokenIsValid(...$this->getCustomNamespaceMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertMatchingTokenIsValid('aNamespace-', $this->getCustomNamespaceMocks($generator, $storage), $storage);
     }
 
     public function testMatchingTokenIsValidRequestStack()
     {
-        $this->assertMatchingTokenIsValid(...$this->getRequestStackMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertMatchingTokenIsValid('https-', $this->getRequestStackMocks($generator, $storage), $storage);
     }
 
     public function testMatchingTokenIsValidClosure()
     {
-        $this->assertMatchingTokenIsValid(...$this->getClosureMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertMatchingTokenIsValid('generated-', $this->getClosureMocks($generator, $storage), $storage);
     }
 
     public function testMatchingTokenIsValidRequestStackEmptyNamespace()
     {
-        $this->assertMatchingTokenIsValid(...$this->getRequestStackWithEmptyNamespaceMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertMatchingTokenIsValid('', $this->getRequestStackWithEmptyNamespaceMocks($generator, $storage), $storage);
     }
 
     private function assertMatchingTokenIsValid($namespace, $manager, $storage)
@@ -279,32 +369,50 @@ class CsrfTokenManagerTest extends TestCase
 
     public function testMatchingTokenIsValidWithLegacyTokenEmptyNamespace()
     {
-        $this->assertMatchingTokenIsValidWithLegacyToken(...$this->getEmptyNamespaceMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertMatchingTokenIsValidWithLegacyToken('', $this->getEmptyNamespaceMocks($generator, $storage), $storage);
     }
 
     public function testMatchingTokenIsValidWithLegacyTokenHttpsNamespace()
     {
-        $this->assertMatchingTokenIsValidWithLegacyToken(...$this->getHttpsNamespaceMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertMatchingTokenIsValidWithLegacyToken('https-', $this->getHttpsNamespaceMocks($generator, $storage), $storage);
     }
 
     public function testMatchingTokenIsValidWithLegacyTokenCustomNamespace()
     {
-        $this->assertMatchingTokenIsValidWithLegacyToken(...$this->getCustomNamespaceMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertMatchingTokenIsValidWithLegacyToken('aNamespace-', $this->getCustomNamespaceMocks($generator, $storage), $storage);
     }
 
     public function testMatchingTokenIsValidWithLegacyTokenRequestStack()
     {
-        $this->assertMatchingTokenIsValidWithLegacyToken(...$this->getRequestStackMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertMatchingTokenIsValidWithLegacyToken('https-', $this->getRequestStackMocks($generator, $storage), $storage);
     }
 
     public function testMatchingTokenIsValidWithLegacyTokenClosure()
     {
-        $this->assertMatchingTokenIsValidWithLegacyToken(...$this->getClosureMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertMatchingTokenIsValidWithLegacyToken('generated-', $this->getClosureMocks($generator, $storage), $storage);
     }
 
     public function testMatchingTokenIsValidWithLegacyTokenRequestStackEmptyNamespace()
     {
-        $this->assertMatchingTokenIsValidWithLegacyToken(...$this->getRequestStackWithEmptyNamespaceMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertMatchingTokenIsValidWithLegacyToken('', $this->getRequestStackWithEmptyNamespaceMocks($generator, $storage), $storage);
     }
 
     private function assertMatchingTokenIsValidWithLegacyToken($namespace, $manager, $storage): void
@@ -324,32 +432,50 @@ class CsrfTokenManagerTest extends TestCase
 
     public function testNonMatchingTokenIsNotValidEmptyNamespace()
     {
-        $this->assertNonMatchingTokenIsNotValid(...$this->getEmptyNamespaceMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertNonMatchingTokenIsNotValid('', $this->getEmptyNamespaceMocks($generator, $storage), $storage);
     }
 
     public function testNonMatchingTokenIsNotValidHttpsNamespace()
     {
-        $this->assertNonMatchingTokenIsNotValid(...$this->getHttpsNamespaceMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertNonMatchingTokenIsNotValid('https-', $this->getHttpsNamespaceMocks($generator, $storage), $storage);
     }
 
     public function testNonMatchingTokenIsNotValidCustomNamespace()
     {
-        $this->assertNonMatchingTokenIsNotValid(...$this->getCustomNamespaceMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertNonMatchingTokenIsNotValid('aNamespace-', $this->getCustomNamespaceMocks($generator, $storage), $storage);
     }
 
     public function testNonMatchingTokenIsNotValidRequestStack()
     {
-        $this->assertNonMatchingTokenIsNotValid(...$this->getRequestStackMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertNonMatchingTokenIsNotValid('https-', $this->getRequestStackMocks($generator, $storage), $storage);
     }
 
     public function testNonMatchingTokenIsNotValidClosure()
     {
-        $this->assertNonMatchingTokenIsNotValid(...$this->getClosureMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertNonMatchingTokenIsNotValid('generated-', $this->getClosureMocks($generator, $storage), $storage);
     }
 
     public function testNonMatchingTokenIsNotValidRequestStackEmptyNamespace()
     {
-        $this->assertNonMatchingTokenIsNotValid(...$this->getRequestStackWithEmptyNamespaceMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertNonMatchingTokenIsNotValid('', $this->getRequestStackWithEmptyNamespaceMocks($generator, $storage), $storage);
     }
 
     private function assertNonMatchingTokenIsNotValid($namespace, $manager, $storage): void
@@ -369,32 +495,50 @@ class CsrfTokenManagerTest extends TestCase
 
     public function testNonExistingTokenIsNotValidEmptyNamespace()
     {
-        $this->assertNonExistingTokenIsNotValid(...$this->getEmptyNamespaceMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertNonExistingTokenIsNotValid('', $this->getEmptyNamespaceMocks($generator, $storage), $storage);
     }
 
     public function testNonExistingTokenIsNotValidHttpsNamespace()
     {
-        $this->assertNonExistingTokenIsNotValid(...$this->getHttpsNamespaceMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertNonExistingTokenIsNotValid('https-', $this->getHttpsNamespaceMocks($generator, $storage), $storage);
     }
 
     public function testNonExistingTokenIsNotValidCustomNamespace()
     {
-        $this->assertNonExistingTokenIsNotValid(...$this->getCustomNamespaceMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertNonExistingTokenIsNotValid('aNamespace-', $this->getCustomNamespaceMocks($generator, $storage), $storage);
     }
 
     public function testNonExistingTokenIsNotValidRequestStack()
     {
-        $this->assertNonExistingTokenIsNotValid(...$this->getRequestStackMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertNonExistingTokenIsNotValid('https-', $this->getRequestStackMocks($generator, $storage), $storage);
     }
 
     public function testNonExistingTokenIsNotValidClosure()
     {
-        $this->assertNonExistingTokenIsNotValid(...$this->getClosureMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertNonExistingTokenIsNotValid('generated-', $this->getClosureMocks($generator, $storage), $storage);
     }
 
     public function testNonExistingTokenIsNotValidRequestStackEmptyNamespace()
     {
-        $this->assertNonExistingTokenIsNotValid(...$this->getRequestStackWithEmptyNamespaceMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertNonExistingTokenIsNotValid('', $this->getRequestStackWithEmptyNamespaceMocks($generator, $storage), $storage);
     }
 
     private function assertNonExistingTokenIsNotValid($namespace, $manager, $storage): void
@@ -412,8 +556,8 @@ class CsrfTokenManagerTest extends TestCase
 
     public function testTokenShouldNotTriggerDivisionByZero()
     {
-        [$generator, $storage] = $this->getGeneratorAndStorage();
-        $manager = new CsrfTokenManager($generator, $storage);
+        $storage = $this->createMock(TokenStorageInterface::class);
+        $manager = new CsrfTokenManager($this->createStub(TokenGeneratorInterface::class), $storage);
 
         // Scenario: the token that was returned is abc.def.ghi, and gets modified in the browser to abc..ghi
 
@@ -432,32 +576,50 @@ class CsrfTokenManagerTest extends TestCase
 
     public function testRemoveTokenEmptyNamespace()
     {
-        $this->assertRemoveToken(...$this->getEmptyNamespaceMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertRemoveToken('', $this->getEmptyNamespaceMocks($generator, $storage), $storage);
     }
 
     public function testRemoveTokenHttpsNamespace()
     {
-        $this->assertRemoveToken(...$this->getHttpsNamespaceMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertRemoveToken('https-', $this->getHttpsNamespaceMocks($generator, $storage), $storage);
     }
 
     public function testRemoveTokenCustomNamespace()
     {
-        $this->assertRemoveToken(...$this->getCustomNamespaceMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertRemoveToken('aNamespace-', $this->getCustomNamespaceMocks($generator, $storage), $storage);
     }
 
     public function testRemoveTokenRequestStack()
     {
-        $this->assertRemoveToken(...$this->getRequestStackMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertRemoveToken('https-', $this->getRequestStackMocks($generator, $storage), $storage);
     }
 
     public function testRemoveTokenClosure()
     {
-        $this->assertRemoveToken(...$this->getClosureMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertRemoveToken('generated-', $this->getClosureMocks($generator, $storage), $storage);
     }
 
     public function testRemoveTokenRequestStackEmptyNamespace()
     {
-        $this->assertRemoveToken(...$this->getRequestStackWithEmptyNamespaceMocks());
+        $generator = $this->createStub(TokenGeneratorInterface::class);
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $this->assertRemoveToken('', $this->getRequestStackWithEmptyNamespaceMocks($generator, $storage), $storage);
     }
 
     private function assertRemoveToken($namespace, $manager, $storage): void
@@ -474,69 +636,50 @@ class CsrfTokenManagerTest extends TestCase
     {
         $generator = $this->createMock(TokenGeneratorInterface::class);
         $generator->expects($this->once())->method('generateToken')->willReturn('random');
-        $storage = $this->createMock(TokenStorageInterface::class);
 
         $requestStack = new RequestStack();
         $requestStack->push(new Request([], [], [], [], [], ['HTTPS' => 'on']));
 
-        $manager = new CsrfTokenManager($generator, $storage);
+        $manager = new CsrfTokenManager($generator, $this->createStub(TokenStorageInterface::class));
 
         $token = $manager->getToken('foo');
         $this->assertSame('foo', $token->getId());
     }
 
-    private function getEmptyNamespaceMocks(): array
+    private function getEmptyNamespaceMocks(TokenGeneratorInterface $generator, TokenStorageInterface $storage): CsrfTokenManager
     {
-        [$generator, $storage] = $this->getGeneratorAndStorage();
-
-        return ['', new CsrfTokenManager($generator, $storage, ''), $storage, $generator];
+        return new CsrfTokenManager($generator, $storage, '');
     }
 
-    private function getHttpsNamespaceMocks(): array
+    private function getHttpsNamespaceMocks(TokenGeneratorInterface $generator, TokenStorageInterface $storage): CsrfTokenManager
     {
-        [$generator, $storage] = $this->getGeneratorAndStorage();
-
-        return ['https-', new CsrfTokenManager($generator, $storage), $storage, $generator];
+        return new CsrfTokenManager($generator, $storage);
     }
 
-    private function getCustomNamespaceMocks(): array
+    private function getCustomNamespaceMocks(TokenGeneratorInterface $generator, TokenStorageInterface $storage): CsrfTokenManager
     {
-        [$generator, $storage] = $this->getGeneratorAndStorage();
-
-        return ['aNamespace-', new CsrfTokenManager($generator, $storage, 'aNamespace-'), $storage, $generator];
+        return new CsrfTokenManager($generator, $storage, 'aNamespace-');
     }
 
-    private function getRequestStackMocks(): array
+    private function getRequestStackMocks(TokenGeneratorInterface $generator, TokenStorageInterface $storage): CsrfTokenManager
     {
         $requestStack = new RequestStack();
         $requestStack->push(new Request([], [], [], [], [], ['HTTPS' => 'on']));
-        [$generator, $storage] = $this->getGeneratorAndStorage();
 
-        return ['https-', new CsrfTokenManager($generator, $storage, $requestStack), $storage, $generator];
+        return new CsrfTokenManager($generator, $storage, $requestStack);
     }
 
-    private function getClosureMocks(): array
+    private function getClosureMocks(TokenGeneratorInterface $generator, TokenStorageInterface $storage): CsrfTokenManager
     {
-        [$generator, $storage] = $this->getGeneratorAndStorage();
-
-        return ['generated-', new CsrfTokenManager($generator, $storage, fn () => 'generated-'), $storage, $generator];
+        return new CsrfTokenManager($generator, $storage, fn () => 'generated-');
     }
 
-    private function getRequestStackWithEmptyNamespaceMocks(): array
+    private function getRequestStackWithEmptyNamespaceMocks(TokenGeneratorInterface $generator, TokenStorageInterface $storage): CsrfTokenManager
     {
         $requestStack = new RequestStack();
         $requestStack->push(new Request());
-        [$generator, $storage] = $this->getGeneratorAndStorage();
 
-        return ['', new CsrfTokenManager($generator, $storage, $requestStack), $storage, $generator];
-    }
-
-    private function getGeneratorAndStorage(): array
-    {
-        return [
-            $this->createMock(TokenGeneratorInterface::class),
-            $this->createMock(TokenStorageInterface::class),
-        ];
+        return new CsrfTokenManager($generator, $storage, $requestStack);
     }
 
     protected function setUp(): void

--- a/src/Symfony/Component/Security/Http/Tests/AccessMapTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessMapTest.php
@@ -20,7 +20,7 @@ class AccessMapTest extends TestCase
 {
     public function testReturnsFirstMatchedPattern()
     {
-        $request = $this->createMock(Request::class);
+        $request = new Request();
         $requestMatcher1 = $this->getRequestMatcher($request, false);
         $requestMatcher2 = $this->getRequestMatcher($request, true);
 
@@ -33,7 +33,7 @@ class AccessMapTest extends TestCase
 
     public function testReturnsEmptyPatternIfNoneMatched()
     {
-        $request = $this->createMock(Request::class);
+        $request = new Request();
         $requestMatcher = $this->getRequestMatcher($request, false);
 
         $map = new AccessMap();

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/AuthenticatorManagerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/AuthenticatorManagerTest.php
@@ -11,13 +11,13 @@
 
 namespace Symfony\Component\Security\Http\Tests\Authentication;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\AbstractLogger;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
@@ -38,22 +38,21 @@ use Symfony\Component\Security\Http\Tests\Fixtures\DummySupportsAuthenticator;
 
 class AuthenticatorManagerTest extends TestCase
 {
-    private MockObject&TokenStorageInterface $tokenStorage;
+    private TokenStorageInterface $tokenStorage;
     private EventDispatcher $eventDispatcher;
     private Request $request;
     private InMemoryUser $user;
-    private MockObject&TokenInterface $token;
+    private TokenInterface $token;
     private Response $response;
 
     protected function setUp(): void
     {
-        $this->tokenStorage = $this->createMock(TokenStorageInterface::class);
+        $this->tokenStorage = new TokenStorage();
         $this->eventDispatcher = new EventDispatcher();
         $this->request = new Request();
         $this->user = new InMemoryUser('wouter', null);
-        $this->token = $this->createMock(TokenInterface::class);
-        $this->token->expects($this->any())->method('getUser')->willReturn($this->user);
-        $this->response = $this->createMock(Response::class);
+        $this->token = new UsernamePasswordToken($this->user, 'main');
+        $this->response = new Response();
     }
 
     /**
@@ -94,7 +93,8 @@ class AuthenticatorManagerTest extends TestCase
         // the attribute stores the supported authenticators, returning false now
         // means support changed between calling supports() and authenticateRequest()
         // (which is the case with lazy firewalls)
-        $authenticator = $this->createAuthenticator(false);
+        $authenticator = $this->createMock(TestInteractiveAuthenticator::class);
+        $authenticator->method('supports')->willReturn(false);
         $this->request->attributes->set('_security_authenticators', [$authenticator]);
 
         $authenticator->expects($this->never())->method('authenticate');
@@ -108,13 +108,26 @@ class AuthenticatorManagerTest extends TestCase
      */
     public function testAuthenticateRequest($matchingAuthenticatorIndex)
     {
-        $authenticators = [$this->createAuthenticator(0 === $matchingAuthenticatorIndex), $this->createAuthenticator(1 === $matchingAuthenticatorIndex)];
+        $matchingAuthenticator = $this->createStub(TestInteractiveAuthenticator::class);
+        $matchingAuthenticator->method('supports')->willReturn(true);
+        $notMatchingAuthenticator = $this->createMock(TestInteractiveAuthenticator::class);
+        $notMatchingAuthenticator->method('supports')->willReturn(false);
+        $notMatchingAuthenticator->expects($this->never())->method('authenticate');
+
+        if (0 === $matchingAuthenticatorIndex) {
+            $authenticators = [
+                $matchingAuthenticator,
+                $notMatchingAuthenticator,
+            ];
+        } else {
+            $authenticators = [
+                $notMatchingAuthenticator,
+                $matchingAuthenticator,
+            ];
+        }
         $this->request->attributes->set('_security_authenticators', $authenticators);
-        $matchingAuthenticator = $authenticators[$matchingAuthenticatorIndex];
 
-        $authenticators[($matchingAuthenticatorIndex + 1) % 2]->expects($this->never())->method('authenticate');
-
-        $matchingAuthenticator->expects($this->any())->method('authenticate')->willReturn(new SelfValidatingPassport(new UserBadge('wouter', fn () => $this->user)));
+        $matchingAuthenticator->method('authenticate')->willReturn(new SelfValidatingPassport(new UserBadge('wouter', fn () => $this->user)));
 
         $listenerCalled = false;
         $this->eventDispatcher->addListener(CheckPassportEvent::class, function (CheckPassportEvent $event) use (&$listenerCalled, $matchingAuthenticator) {
@@ -122,13 +135,12 @@ class AuthenticatorManagerTest extends TestCase
                 $listenerCalled = true;
             }
         });
-        $matchingAuthenticator->expects($this->any())->method('createToken')->willReturn($this->token);
-
-        $this->tokenStorage->expects($this->once())->method('setToken')->with($this->token);
+        $matchingAuthenticator->method('createToken')->willReturn($this->token);
 
         $manager = $this->createManager($authenticators);
         $this->assertNull($manager->authenticateRequest($this->request));
         $this->assertTrue($listenerCalled, 'The CheckPassportEvent listener is not called');
+        $this->assertSame($this->token, $this->tokenStorage->getToken());
     }
 
     public static function provideMatchingAuthenticatorIndex()
@@ -139,10 +151,10 @@ class AuthenticatorManagerTest extends TestCase
 
     public function testNoCredentialsValidated()
     {
-        $authenticator = $this->createAuthenticator();
+        $authenticator = $this->createMock(TestInteractiveAuthenticator::class);
         $this->request->attributes->set('_security_authenticators', [$authenticator]);
 
-        $authenticator->expects($this->any())->method('authenticate')->willReturn(new Passport(new UserBadge('wouter', fn () => $this->user), new PasswordCredentials('pass')));
+        $authenticator->method('authenticate')->willReturn(new Passport(new UserBadge('wouter', fn () => $this->user), new PasswordCredentials('pass')));
 
         $authenticator->expects($this->once())
             ->method('onAuthenticationFailure')
@@ -154,7 +166,7 @@ class AuthenticatorManagerTest extends TestCase
 
     public function testRequiredBadgeMissing()
     {
-        $authenticator = $this->createAuthenticator();
+        $authenticator = $this->createMock(TestInteractiveAuthenticator::class);
         $this->request->attributes->set('_security_authenticators', [$authenticator]);
 
         $authenticator->expects($this->any())->method('authenticate')->willReturn(new SelfValidatingPassport(new UserBadge('wouter')));
@@ -167,7 +179,7 @@ class AuthenticatorManagerTest extends TestCase
 
     public function testAllRequiredBadgesPresent()
     {
-        $authenticator = $this->createAuthenticator();
+        $authenticator = $this->createMock(TestInteractiveAuthenticator::class);
         $this->request->attributes->set('_security_authenticators', [$authenticator]);
 
         $csrfBadge = new CsrfTokenBadge('csrfid', 'csrftoken');
@@ -186,14 +198,15 @@ class AuthenticatorManagerTest extends TestCase
      */
     public function testEraseCredentials($eraseCredentials)
     {
-        $authenticator = $this->createAuthenticator();
+        $authenticator = $this->createStub(TestInteractiveAuthenticator::class);
         $this->request->attributes->set('_security_authenticators', [$authenticator]);
 
-        $authenticator->expects($this->any())->method('authenticate')->willReturn(new SelfValidatingPassport(new UserBadge('wouter', fn () => $this->user)));
+        $authenticator->method('authenticate')->willReturn(new SelfValidatingPassport(new UserBadge('wouter', fn () => $this->user)));
 
-        $authenticator->expects($this->any())->method('createToken')->willReturn($this->token);
+        $token = $this->createMock(TokenInterface::class);
+        $authenticator->method('createToken')->willReturn($token);
 
-        $this->token->expects($eraseCredentials ? $this->once() : $this->never())->method('eraseCredentials');
+        $token->expects($eraseCredentials ? $this->once() : $this->never())->method('eraseCredentials');
 
         $manager = $this->createManager([$authenticator], 'main', $eraseCredentials);
         $manager->authenticateRequest($this->request);
@@ -207,26 +220,24 @@ class AuthenticatorManagerTest extends TestCase
 
     public function testAuthenticateRequestCanModifyTokenFromEvent()
     {
-        $authenticator = $this->createAuthenticator();
+        $authenticator = $this->createStub(TestInteractiveAuthenticator::class);
         $this->request->attributes->set('_security_authenticators', [$authenticator]);
 
-        $authenticator->expects($this->any())->method('authenticate')->willReturn(new SelfValidatingPassport(new UserBadge('wouter', fn () => $this->user)));
+        $authenticator->method('authenticate')->willReturn(new SelfValidatingPassport(new UserBadge('wouter', fn () => $this->user)));
 
-        $authenticator->expects($this->any())->method('createToken')->willReturn($this->token);
+        $authenticator->method('createToken')->willReturn($this->token);
 
-        $modifiedToken = $this->createMock(TokenInterface::class);
-        $modifiedToken->expects($this->any())->method('getUser')->willReturn($this->user);
+        $modifiedToken = new UsernamePasswordToken($this->user, 'main');
         $listenerCalled = false;
         $this->eventDispatcher->addListener(AuthenticationTokenCreatedEvent::class, function (AuthenticationTokenCreatedEvent $event) use (&$listenerCalled, $modifiedToken) {
             $event->setAuthenticatedToken($modifiedToken);
             $listenerCalled = true;
         });
 
-        $this->tokenStorage->expects($this->once())->method('setToken')->with($this->identicalTo($modifiedToken));
-
         $manager = $this->createManager([$authenticator]);
         $this->assertNull($manager->authenticateRequest($this->request));
         $this->assertTrue($listenerCalled, 'The AuthenticationTokenCreatedEvent listener is not called');
+        $this->assertSame($modifiedToken, $this->tokenStorage->getToken());
     }
 
     public function testAuthenticateUser()
@@ -235,45 +246,41 @@ class AuthenticatorManagerTest extends TestCase
         $authenticator->expects($this->any())->method('createToken')->willReturn($this->token);
         $authenticator->expects($this->any())->method('onAuthenticationSuccess')->willReturn($this->response);
 
-        $this->tokenStorage->expects($this->once())->method('setToken')->with($this->token);
-
         $manager = $this->createManager([$authenticator]);
         $manager->authenticateUser($this->user, $authenticator, $this->request);
+
+        $this->assertSame($this->token, $this->tokenStorage->getToken());
     }
 
     public function testAuthenticateUserCanModifyTokenFromEvent()
     {
-        $authenticator = $this->createAuthenticator();
-        $authenticator->expects($this->any())->method('createToken')->willReturn($this->token);
-        $authenticator->expects($this->any())->method('onAuthenticationSuccess')->willReturn($this->response);
+        $authenticator = $this->createStub(TestInteractiveAuthenticator::class);
+        $authenticator->method('createToken')->willReturn($this->token);
+        $authenticator->method('onAuthenticationSuccess')->willReturn($this->response);
 
-        $modifiedToken = $this->createMock(TokenInterface::class);
-        $modifiedToken->expects($this->any())->method('getUser')->willReturn($this->user);
+        $modifiedToken = new UsernamePasswordToken($this->user, 'main');
         $listenerCalled = false;
         $this->eventDispatcher->addListener(AuthenticationTokenCreatedEvent::class, function (AuthenticationTokenCreatedEvent $event) use (&$listenerCalled, $modifiedToken) {
             $event->setAuthenticatedToken($modifiedToken);
             $listenerCalled = true;
         });
 
-        $this->tokenStorage->expects($this->once())->method('setToken')->with($this->identicalTo($modifiedToken));
-
         $manager = $this->createManager([$authenticator]);
         $manager->authenticateUser($this->user, $authenticator, $this->request);
         $this->assertTrue($listenerCalled, 'The AuthenticationTokenCreatedEvent listener is not called');
+        $this->assertSame($modifiedToken, $this->tokenStorage->getToken());
     }
 
     public function testInteractiveAuthenticator()
     {
-        $authenticator = $this->createMock(TestInteractiveAuthenticator::class);
-        $authenticator->expects($this->any())->method('isInteractive')->willReturn(true);
+        $authenticator = $this->createStub(TestInteractiveAuthenticator::class);
+        $authenticator->method('isInteractive')->willReturn(true);
         $this->request->attributes->set('_security_authenticators', [$authenticator]);
 
-        $authenticator->expects($this->any())->method('authenticate')->willReturn(new SelfValidatingPassport(new UserBadge('wouter', fn () => $this->user)));
-        $authenticator->expects($this->any())->method('createToken')->willReturn($this->token);
+        $authenticator->method('authenticate')->willReturn(new SelfValidatingPassport(new UserBadge('wouter', fn () => $this->user)));
+        $authenticator->method('createToken')->willReturn($this->token);
 
-        $this->tokenStorage->expects($this->once())->method('setToken')->with($this->token);
-
-        $authenticator->expects($this->any())
+        $authenticator
             ->method('onAuthenticationSuccess')
             ->with($this->anything(), $this->token, 'main')
             ->willReturn($this->response);
@@ -281,20 +288,19 @@ class AuthenticatorManagerTest extends TestCase
         $manager = $this->createManager([$authenticator]);
         $response = $manager->authenticateRequest($this->request);
         $this->assertSame($this->response, $response);
+        $this->assertSame($this->token, $this->tokenStorage->getToken());
     }
 
     public function testLegacyInteractiveAuthenticator()
     {
-        $authenticator = $this->createMock(InteractiveAuthenticatorInterface::class);
-        $authenticator->expects($this->any())->method('isInteractive')->willReturn(true);
+        $authenticator = $this->createStub(InteractiveAuthenticatorInterface::class);
+        $authenticator->method('isInteractive')->willReturn(true);
         $this->request->attributes->set('_security_authenticators', [$authenticator]);
 
-        $authenticator->expects($this->any())->method('authenticate')->willReturn(new SelfValidatingPassport(new UserBadge('wouter', fn () => $this->user)));
-        $authenticator->expects($this->any())->method('createToken')->willReturn($this->token);
+        $authenticator->method('authenticate')->willReturn(new SelfValidatingPassport(new UserBadge('wouter', fn () => $this->user)));
+        $authenticator->method('createToken')->willReturn($this->token);
 
-        $this->tokenStorage->expects($this->once())->method('setToken')->with($this->token);
-
-        $authenticator->expects($this->any())
+        $authenticator
             ->method('onAuthenticationSuccess')
             ->with($this->anything(), $this->token, 'main')
             ->willReturn($this->response);
@@ -302,17 +308,18 @@ class AuthenticatorManagerTest extends TestCase
         $manager = $this->createManager([$authenticator]);
         $response = $manager->authenticateRequest($this->request);
         $this->assertSame($this->response, $response);
+        $this->assertSame($this->token, $this->tokenStorage->getToken());
     }
 
     public function testAuthenticateRequestHidesInvalidUserExceptions()
     {
         $invalidUserException = new UserNotFoundException();
-        $authenticator = $this->createMock(TestInteractiveAuthenticator::class);
+        $authenticator = $this->createStub(TestInteractiveAuthenticator::class);
         $this->request->attributes->set('_security_authenticators', [$authenticator]);
 
-        $authenticator->expects($this->any())->method('authenticate')->willThrowException($invalidUserException);
+        $authenticator->method('authenticate')->willThrowException($invalidUserException);
 
-        $authenticator->expects($this->any())
+        $authenticator
             ->method('onAuthenticationFailure')
             ->with($this->equalTo($this->request), $this->callback(fn ($e) => $e instanceof BadCredentialsException && $invalidUserException === $e->getPrevious()))
             ->willReturn($this->response);
@@ -324,21 +331,19 @@ class AuthenticatorManagerTest extends TestCase
 
     public function testLogsUseTheDecoratedAuthenticatorWhenItIsTraceable()
     {
-        $authenticator = $this->createMock(TestInteractiveAuthenticator::class);
-        $authenticator->expects($this->any())->method('isInteractive')->willReturn(true);
+        $authenticator = $this->createStub(TestInteractiveAuthenticator::class);
+        $authenticator->method('isInteractive')->willReturn(true);
         $this->request->attributes->set('_security_authenticators', [new TraceableAuthenticator($authenticator)]);
 
-        $authenticator->expects($this->any())->method('authenticate')->willReturn(new SelfValidatingPassport(new UserBadge('wouter', fn () => $this->user)));
-        $authenticator->expects($this->any())->method('createToken')->willReturn($this->token);
+        $authenticator->method('authenticate')->willReturn(new SelfValidatingPassport(new UserBadge('wouter', fn () => $this->user)));
+        $authenticator->method('createToken')->willReturn($this->token);
 
-        $this->tokenStorage->expects($this->once())->method('setToken')->with($this->token);
-
-        $authenticator->expects($this->any())
+        $authenticator
             ->method('onAuthenticationSuccess')
             ->with($this->anything(), $this->token, 'main')
             ->willReturn($this->response);
 
-        $authenticator->expects($this->any())
+        $authenticator
             ->method('onAuthenticationSuccess')
             ->with($this->anything(), $this->token, 'main')
             ->willReturn($this->response);
@@ -358,6 +363,7 @@ class AuthenticatorManagerTest extends TestCase
         $response = $manager->authenticateRequest($this->request);
         $this->assertSame($this->response, $response);
         $this->assertStringContainsString('Mock_TestInteractiveAuthenticator', $logger->logContexts[0]['authenticator']);
+        $this->assertSame($this->token, $this->tokenStorage->getToken());
     }
 
     private function createAuthenticator(?bool $supports = true)

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationFailureHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationFailureHandlerTest.php
@@ -11,14 +11,16 @@
 
 namespace Symfony\Component\Security\Http\Tests\Authentication;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Authentication\DefaultAuthenticationFailureHandler;
@@ -27,28 +29,16 @@ use Symfony\Component\Security\Http\SecurityRequestAttributes;
 
 class DefaultAuthenticationFailureHandlerTest extends TestCase
 {
-    private MockObject&HttpKernelInterface $httpKernel;
-    private MockObject&HttpUtils $httpUtils;
-    private MockObject&LoggerInterface $logger;
     private Request $request;
-    private Response $response;
-    private MockObject&SessionInterface $session;
+    private SessionInterface $session;
     private AuthenticationException $exception;
 
     protected function setUp(): void
     {
-        $this->response = new Response();
-        $this->httpKernel = $this->createMock(HttpKernelInterface::class);
-        $this->httpKernel->expects($this->any())
-            ->method('handle')->willReturn($this->response);
-
-        $this->httpUtils = $this->createMock(HttpUtils::class);
-        $this->logger = $this->createMock(LoggerInterface::class);
-
-        $this->session = $this->createMock(SessionInterface::class);
-        $this->request = $this->createMock(Request::class);
+        $this->session = new Session(new MockArraySessionStorage());
+        $this->request = Request::create('https://localhost/');
         $this->request->attributes = new ParameterBag(['_stateless' => false]);
-        $this->request->expects($this->any())->method('getSession')->willReturn($this->session);
+        $this->request->setSession($this->session);
         $this->exception = $this->getMockBuilder(AuthenticationException::class)->onlyMethods(['getMessage'])->getMock();
     }
 
@@ -56,78 +46,80 @@ class DefaultAuthenticationFailureHandlerTest extends TestCase
     {
         $options = ['failure_forward' => true];
 
-        $subRequest = $this->getRequest();
+        $subRequest = new Request();
+        $subRequest->attributes = $this->createMock(ParameterBag::class);
         $subRequest->attributes->expects($this->once())
             ->method('set')->with(SecurityRequestAttributes::AUTHENTICATION_ERROR, $this->exception);
-        $this->httpUtils->expects($this->once())
+        $httpUtils = $this->createMock(HttpUtils::class);
+        $httpUtils->expects($this->once())
             ->method('createRequest')->with($this->request, '/login')
             ->willReturn($subRequest);
 
-        $handler = new DefaultAuthenticationFailureHandler($this->httpKernel, $this->httpUtils, $options, $this->logger);
-        $result = $handler->onAuthenticationFailure($this->request, $this->exception);
-
-        $this->assertSame($this->response, $result);
-    }
-
-    public function testRedirect()
-    {
-        $response = new RedirectResponse('/login');
-        $this->httpUtils->expects($this->once())
-            ->method('createRedirectResponse')->with($this->request, '/login')
-            ->willReturn($response);
-
-        $handler = new DefaultAuthenticationFailureHandler($this->httpKernel, $this->httpUtils, [], $this->logger);
+        $response = new Response();
+        $httpKernel = $this->createStub(HttpKernelInterface::class);
+        $httpKernel->method('handle')->willReturn($response);
+        $handler = new DefaultAuthenticationFailureHandler($httpKernel, $httpUtils, $options, new NullLogger());
         $result = $handler->onAuthenticationFailure($this->request, $this->exception);
 
         $this->assertSame($response, $result);
     }
 
+    public function testRedirect()
+    {
+        $handler = new DefaultAuthenticationFailureHandler($this->createStub(HttpKernelInterface::class), new HttpUtils(), [], new NullLogger());
+        $result = $handler->onAuthenticationFailure($this->request, $this->exception);
+
+        $this->assertEquals(new RedirectResponse('https://localhost/login'), $result);
+    }
+
     public function testExceptionIsPersistedInSession()
     {
-        $this->session->expects($this->once())
-            ->method('set')->with(SecurityRequestAttributes::AUTHENTICATION_ERROR, $this->exception);
-
-        $handler = new DefaultAuthenticationFailureHandler($this->httpKernel, $this->httpUtils, [], $this->logger);
+        $handler = new DefaultAuthenticationFailureHandler($this->createStub(HttpKernelInterface::class), new HttpUtils(), [], new NullLogger());
         $handler->onAuthenticationFailure($this->request, $this->exception);
+
+        $this->assertTrue($this->session->has(SecurityRequestAttributes::AUTHENTICATION_ERROR));
+        $this->assertSame($this->exception, $this->session->get(SecurityRequestAttributes::AUTHENTICATION_ERROR));
     }
 
     public function testExceptionIsNotPersistedInSessionOnStatelessRequest()
     {
         $this->request->attributes = new ParameterBag(['_stateless' => true]);
 
-        $this->session->expects($this->never())
-            ->method('set')->with(SecurityRequestAttributes::AUTHENTICATION_ERROR, $this->exception);
-
-        $handler = new DefaultAuthenticationFailureHandler($this->httpKernel, $this->httpUtils, [], $this->logger);
+        $handler = new DefaultAuthenticationFailureHandler($this->createStub(HttpKernelInterface::class), new HttpUtils(), [], new NullLogger());
         $handler->onAuthenticationFailure($this->request, $this->exception);
+
+        $this->assertFalse($this->session->has(SecurityRequestAttributes::AUTHENTICATION_ERROR));
     }
 
     public function testExceptionIsPassedInRequestOnForward()
     {
         $options = ['failure_forward' => true];
 
-        $subRequest = $this->getRequest();
+        $subRequest = new Request();
+        $subRequest->attributes = $this->createMock(ParameterBag::class);
         $subRequest->attributes->expects($this->once())
             ->method('set')->with(SecurityRequestAttributes::AUTHENTICATION_ERROR, $this->exception);
 
-        $this->httpUtils->expects($this->once())
+        $httpUtils = $this->createMock(HttpUtils::class);
+        $httpUtils->expects($this->once())
             ->method('createRequest')->with($this->request, '/login')
             ->willReturn($subRequest);
 
-        $this->session->expects($this->never())->method('set');
+        $handler = new DefaultAuthenticationFailureHandler($this->createStub(HttpKernelInterface::class), $httpUtils, $options, new NullLogger());
+        $result = $handler->onAuthenticationFailure($this->request, $this->exception);
 
-        $handler = new DefaultAuthenticationFailureHandler($this->httpKernel, $this->httpUtils, $options, $this->logger);
-        $handler->onAuthenticationFailure($this->request, $this->exception);
+        $this->assertSame([], $this->session->all());
     }
 
     public function testRedirectIsLogged()
     {
-        $this->logger
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger
             ->expects($this->once())
             ->method('debug')
             ->with('Authentication failure, redirect triggered.', ['failure_path' => '/login']);
 
-        $handler = new DefaultAuthenticationFailureHandler($this->httpKernel, $this->httpUtils, [], $this->logger);
+        $handler = new DefaultAuthenticationFailureHandler($this->createStub(HttpKernelInterface::class), new HttpUtils(), [], $logger);
         $handler->onAuthenticationFailure($this->request, $this->exception);
     }
 
@@ -135,16 +127,13 @@ class DefaultAuthenticationFailureHandlerTest extends TestCase
     {
         $options = ['failure_forward' => true];
 
-        $this->httpUtils->expects($this->once())
-            ->method('createRequest')->with($this->request, '/login')
-            ->willReturn($this->getRequest());
-
-        $this->logger
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger
             ->expects($this->once())
             ->method('debug')
             ->with('Authentication failure, forward triggered.', ['failure_path' => '/login']);
 
-        $handler = new DefaultAuthenticationFailureHandler($this->httpKernel, $this->httpUtils, $options, $this->logger);
+        $handler = new DefaultAuthenticationFailureHandler($this->createStub(HttpKernelInterface::class), new HttpUtils(), $options, $logger);
         $handler->onAuthenticationFailure($this->request, $this->exception);
     }
 
@@ -152,63 +141,52 @@ class DefaultAuthenticationFailureHandlerTest extends TestCase
     {
         $options = ['failure_path' => '/auth/login'];
 
-        $this->httpUtils->expects($this->once())
-            ->method('createRedirectResponse')->with($this->request, '/auth/login');
+        $handler = new DefaultAuthenticationFailureHandler($this->createStub(HttpKernelInterface::class), new HttpUtils(), $options, new NullLogger());
+        $result = $handler->onAuthenticationFailure($this->request, $this->exception);
 
-        $handler = new DefaultAuthenticationFailureHandler($this->httpKernel, $this->httpUtils, $options, $this->logger);
-        $handler->onAuthenticationFailure($this->request, $this->exception);
+        $this->assertEquals(new RedirectResponse('https://localhost/auth/login'), $result);
     }
 
     public function testFailurePathCanBeOverwrittenWithRequest()
     {
-        $this->request->expects($this->once())
-            ->method('get')->with('_failure_path')
-            ->willReturn('/auth/login');
+        $this->request->attributes->set('_failure_path', '/auth/login');
 
-        $this->httpUtils->expects($this->once())
-            ->method('createRedirectResponse')->with($this->request, '/auth/login');
+        $handler = new DefaultAuthenticationFailureHandler($this->createStub(HttpKernelInterface::class), new HttpUtils(), [], new NullLogger());
+        $result = $handler->onAuthenticationFailure($this->request, $this->exception);
 
-        $handler = new DefaultAuthenticationFailureHandler($this->httpKernel, $this->httpUtils, [], $this->logger);
-        $handler->onAuthenticationFailure($this->request, $this->exception);
+        $this->assertEquals(new RedirectResponse('https://localhost/auth/login'), $result);
     }
 
     public function testFailurePathCanBeOverwrittenWithNestedAttributeInRequest()
     {
-        $this->request->expects($this->once())
-            ->method('get')->with('_failure_path')
-            ->willReturn(['value' => '/auth/login']);
+        $this->request->attributes->set('_failure_path', ['value' => '/auth/login']);
 
-        $this->httpUtils->expects($this->once())
-            ->method('createRedirectResponse')->with($this->request, '/auth/login');
+        $handler = new DefaultAuthenticationFailureHandler($this->createStub(HttpKernelInterface::class), new HttpUtils(), ['failure_path_parameter' => '_failure_path[value]'], new NullLogger());
+        $result = $handler->onAuthenticationFailure($this->request, $this->exception);
 
-        $handler = new DefaultAuthenticationFailureHandler($this->httpKernel, $this->httpUtils, ['failure_path_parameter' => '_failure_path[value]'], $this->logger);
-        $handler->onAuthenticationFailure($this->request, $this->exception);
+        $this->assertEquals(new RedirectResponse('https://localhost/auth/login'), $result);
     }
 
     public function testFailurePathParameterCanBeOverwritten()
     {
         $options = ['failure_path_parameter' => '_my_failure_path'];
 
-        $this->request->expects($this->once())
-            ->method('get')->with('_my_failure_path')
-            ->willReturn('/auth/login');
+        $this->request->attributes->set('_my_failure_path', '/auth/login');
 
-        $this->httpUtils->expects($this->once())
-            ->method('createRedirectResponse')->with($this->request, '/auth/login');
+        $handler = new DefaultAuthenticationFailureHandler($this->createStub(HttpKernelInterface::class), new HttpUtils(), $options, new NullLogger());
+        $result = $handler->onAuthenticationFailure($this->request, $this->exception);
 
-        $handler = new DefaultAuthenticationFailureHandler($this->httpKernel, $this->httpUtils, $options, $this->logger);
-        $handler->onAuthenticationFailure($this->request, $this->exception);
+        $this->assertEquals(new RedirectResponse('https://localhost/auth/login'), $result);
     }
 
     public function testFailurePathFromRequestWithInvalidUrl()
     {
         $options = ['failure_path_parameter' => '_my_failure_path'];
 
-        $this->request->expects($this->once())
-            ->method('get')->with('_my_failure_path')
-            ->willReturn('some_route_name');
+        $this->request->attributes->set('_my_failure_path', 'some_route_name');
 
-        $this->logger->expects($this->exactly(2))
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->exactly(2))
             ->method('debug')
             ->willReturnCallback(function (...$args) {
                 static $series = [
@@ -220,7 +198,7 @@ class DefaultAuthenticationFailureHandlerTest extends TestCase
                 $this->assertSame($expectedArgs, $args);
             });
 
-        $handler = new DefaultAuthenticationFailureHandler($this->httpKernel, $this->httpUtils, $options, $this->logger);
+        $handler = new DefaultAuthenticationFailureHandler($this->createStub(HttpKernelInterface::class), new HttpUtils(), $options, $logger);
 
         $handler->onAuthenticationFailure($this->request, $this->exception);
     }
@@ -229,22 +207,11 @@ class DefaultAuthenticationFailureHandlerTest extends TestCase
     {
         $options = ['failure_path_parameter' => '_my_failure_path'];
 
-        $this->request->expects($this->once())
-            ->method('get')->with('_my_failure_path')
-            ->willReturn('https://localhost/some-path');
+        $this->request->attributes->set('_my_failure_path', 'https://localhost/some-path');
 
-        $this->httpUtils->expects($this->once())
-            ->method('createRedirectResponse')->with($this->request, 'https://localhost/some-path');
+        $handler = new DefaultAuthenticationFailureHandler($this->createStub(HttpKernelInterface::class), new HttpUtils(), $options, new NullLogger());
+        $result = $handler->onAuthenticationFailure($this->request, $this->exception);
 
-        $handler = new DefaultAuthenticationFailureHandler($this->httpKernel, $this->httpUtils, $options, $this->logger);
-        $handler->onAuthenticationFailure($this->request, $this->exception);
-    }
-
-    private function getRequest()
-    {
-        $request = $this->createMock(Request::class);
-        $request->attributes = $this->createMock(ParameterBag::class);
-
-        return $request;
+        $this->assertEquals(new RedirectResponse('https://localhost/some-path'), $result);
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationSuccessHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationSuccessHandlerTest.php
@@ -13,10 +13,13 @@ namespace Symfony\Component\Security\Http\Tests\Authentication;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authentication\Token\NullToken;
 use Symfony\Component\Security\Http\Authentication\DefaultAuthenticationSuccessHandler;
 use Symfony\Component\Security\Http\HttpUtils;
 
@@ -27,33 +30,31 @@ class DefaultAuthenticationSuccessHandlerTest extends TestCase
      */
     public function testRequestRedirections(Request $request, $options, $redirectedUrl)
     {
-        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
-        $urlGenerator->expects($this->any())->method('generate')->willReturn('http://localhost/login');
+        $urlGenerator = $this->createStub(UrlGeneratorInterface::class);
+        $urlGenerator->method('generate')->willReturn('http://localhost/login');
         $httpUtils = new HttpUtils($urlGenerator);
-        $token = $this->createMock(TokenInterface::class);
         $handler = new DefaultAuthenticationSuccessHandler($httpUtils, $options);
         if ($request->hasSession()) {
             $handler->setFirewallName('admin');
         }
-        $this->assertSame('http://localhost'.$redirectedUrl, $handler->onAuthenticationSuccess($request, $token)->getTargetUrl());
+        $this->assertSame('http://localhost'.$redirectedUrl, $handler->onAuthenticationSuccess($request, new NullToken())->getTargetUrl());
     }
 
     public function testRequestRedirectionsWithTargetPathInSessions()
     {
-        $session = $this->createMock(SessionInterface::class);
-        $session->expects($this->once())->method('get')->with('_security.admin.target_path')->willReturn('/admin/dashboard');
-        $session->expects($this->once())->method('remove')->with('_security.admin.target_path');
+        $session = new Session(new MockArraySessionStorage());
+        $session->set('_security.admin.target_path', '/admin/dashboard');
         $requestWithSession = Request::create('/');
         $requestWithSession->setSession($session);
 
-        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
-        $urlGenerator->expects($this->any())->method('generate')->willReturn('http://localhost/login');
+        $urlGenerator = $this->createStub(UrlGeneratorInterface::class);
+        $urlGenerator->method('generate')->willReturn('http://localhost/login');
         $httpUtils = new HttpUtils($urlGenerator);
-        $token = $this->createMock(TokenInterface::class);
         $handler = new DefaultAuthenticationSuccessHandler($httpUtils);
         $handler->setFirewallName('admin');
 
-        $this->assertSame('http://localhost/admin/dashboard', $handler->onAuthenticationSuccess($requestWithSession, $token)->getTargetUrl());
+        $this->assertSame('http://localhost/admin/dashboard', $handler->onAuthenticationSuccess($requestWithSession, new NullToken())->getTargetUrl());
+        $this->assertFalse($session->has('_security.admin.target_path'));
     }
 
     public function testStatelessRequestRedirections()
@@ -65,14 +66,13 @@ class DefaultAuthenticationSuccessHandlerTest extends TestCase
         $statelessRequest->setSession($session);
         $statelessRequest->attributes->set('_stateless', true);
 
-        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
-        $urlGenerator->expects($this->any())->method('generate')->willReturn('http://localhost/login');
+        $urlGenerator = $this->createStub(UrlGeneratorInterface::class);
+        $urlGenerator->method('generate')->willReturn('http://localhost/login');
         $httpUtils = new HttpUtils($urlGenerator);
-        $token = $this->createMock(TokenInterface::class);
         $handler = new DefaultAuthenticationSuccessHandler($httpUtils);
         $handler->setFirewallName('admin');
 
-        $this->assertSame('http://localhost/', $handler->onAuthenticationSuccess($statelessRequest, $token)->getTargetUrl());
+        $this->assertSame('http://localhost/', $handler->onAuthenticationSuccess($statelessRequest, new NullToken())->getTargetUrl());
     }
 
     public static function getRequestRedirections()
@@ -143,23 +143,19 @@ class DefaultAuthenticationSuccessHandlerTest extends TestCase
 
     public function testTargetPathFromRequestWithInvalidUrl()
     {
-        $httpUtils = $this->createMock(HttpUtils::class);
         $options = ['target_path_parameter' => '_my_target_path'];
-        $token = $this->createMock(TokenInterface::class);
 
-        $request = $this->createMock(Request::class);
-        $request->expects($this->once())
-            ->method('get')->with('_my_target_path')
-            ->willReturn('some_route_name');
+        $request = Request::create('/');
+        $request->attributes->set('_my_target_path', 'some_route_name');
 
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects($this->once())
             ->method('debug')
             ->with('Ignoring query parameter "_my_target_path": not a valid URL.');
 
-        $handler = new DefaultAuthenticationSuccessHandler($httpUtils, $options, $logger);
+        $handler = new DefaultAuthenticationSuccessHandler(new HttpUtils($this->createStub(UrlGeneratorInterface::class)), $options, $logger);
 
-        $handler->onAuthenticationSuccess($request, $token);
+        $handler->onAuthenticationSuccess($request, new NullToken());
     }
 
     public function testTargetPathWithAbsoluteUrlFromRequest()
@@ -171,11 +167,9 @@ class DefaultAuthenticationSuccessHandlerTest extends TestCase
             ->method('get')->with('_my_target_path')
             ->willReturn('https://localhost/some-path');
 
-        $httpUtils = $this->createMock(HttpUtils::class);
-        $httpUtils->expects($this->once())
-            ->method('createRedirectResponse')->with($request, 'https://localhost/some-path');
+        $handler = new DefaultAuthenticationSuccessHandler(new HttpUtils($this->createStub(UrlGeneratorInterface::class)), $options);
+        $response = $handler->onAuthenticationSuccess($request, new NullToken());
 
-        $handler = new DefaultAuthenticationSuccessHandler($httpUtils, $options);
-        $handler->onAuthenticationSuccess($request, $this->createMock(TokenInterface::class));
+        $this->assertEquals(new RedirectResponse('https://localhost/some-path'), $response);
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/AccessTokenAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/AccessTokenAuthenticatorTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Authenticator;
+namespace Symfony\Component\Security\Http\Tests\Authenticator;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
@@ -25,14 +25,10 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 
 class AccessTokenAuthenticatorTest extends TestCase
 {
-    private AccessTokenHandlerInterface $accessTokenHandler;
-    private AccessTokenExtractorInterface $accessTokenExtractor;
     private InMemoryUserProvider $userProvider;
 
     protected function setUp(): void
     {
-        $this->accessTokenHandler = $this->createMock(AccessTokenHandlerInterface::class);
-        $this->accessTokenExtractor = $this->createMock(AccessTokenExtractorInterface::class);
         $this->userProvider = new InMemoryUserProvider(['test' => ['password' => 's$cr$t']]);
     }
 
@@ -43,15 +39,16 @@ class AccessTokenAuthenticatorTest extends TestCase
 
         $request = Request::create('/test');
 
-        $this->accessTokenExtractor
+        $accessTokenExtractor = $this->createMock(AccessTokenExtractorInterface::class);
+        $accessTokenExtractor
             ->expects($this->once())
             ->method('extractAccessToken')
             ->with($request)
             ->willReturn(null);
 
         $authenticator = new AccessTokenAuthenticator(
-            $this->accessTokenHandler,
-            $this->accessTokenExtractor,
+            $this->createStub(AccessTokenHandlerInterface::class),
+            $accessTokenExtractor,
         );
 
         $authenticator->authenticate($request);
@@ -61,20 +58,22 @@ class AccessTokenAuthenticatorTest extends TestCase
     {
         $request = Request::create('/test');
 
-        $this->accessTokenExtractor
+        $accessTokenHandler = $this->createMock(AccessTokenHandlerInterface::class);
+        $accessTokenExtractor = $this->createMock(AccessTokenExtractorInterface::class);
+        $accessTokenExtractor
             ->expects($this->once())
             ->method('extractAccessToken')
             ->with($request)
             ->willReturn('test');
-        $this->accessTokenHandler
+        $accessTokenHandler
             ->expects($this->once())
             ->method('getUserBadgeFrom')
             ->with('test')
             ->willReturn(new UserBadge('john', fn () => new InMemoryUser('john', null)));
 
         $authenticator = new AccessTokenAuthenticator(
-            $this->accessTokenHandler,
-            $this->accessTokenExtractor,
+            $accessTokenHandler,
+            $accessTokenExtractor,
             $this->userProvider,
         );
 
@@ -87,20 +86,22 @@ class AccessTokenAuthenticatorTest extends TestCase
     {
         $request = Request::create('/test');
 
-        $this->accessTokenExtractor
+        $accessTokenHandler = $this->createMock(AccessTokenHandlerInterface::class);
+        $accessTokenExtractor = $this->createMock(AccessTokenExtractorInterface::class);
+        $accessTokenExtractor
             ->expects($this->once())
             ->method('extractAccessToken')
             ->with($request)
             ->willReturn('test');
-        $this->accessTokenHandler
+        $accessTokenHandler
             ->expects($this->once())
             ->method('getUserBadgeFrom')
             ->with('test')
             ->willReturn(new UserBadge('test'));
 
         $authenticator = new AccessTokenAuthenticator(
-            $this->accessTokenHandler,
-            $this->accessTokenExtractor,
+            $accessTokenHandler,
+            $accessTokenExtractor,
             $this->userProvider,
         );
 
@@ -113,20 +114,22 @@ class AccessTokenAuthenticatorTest extends TestCase
     {
         $request = Request::create('/test');
 
-        $this->accessTokenExtractor
+        $accessTokenHandler = $this->createMock(AccessTokenHandlerInterface::class);
+        $accessTokenExtractor = $this->createMock(AccessTokenExtractorInterface::class);
+        $accessTokenExtractor
             ->expects($this->once())
             ->method('extractAccessToken')
             ->with($request)
             ->willReturn('test');
-        $this->accessTokenHandler
+        $accessTokenHandler
             ->expects($this->once())
             ->method('getUserBadgeFrom')
             ->with('test')
             ->willReturn(new UserBadge('john', fn () => new InMemoryUser('john', null)));
 
         $authenticator = new AccessTokenAuthenticator(
-            $this->accessTokenHandler,
-            $this->accessTokenExtractor,
+            $accessTokenHandler,
+            $accessTokenExtractor,
             $this->userProvider,
         );
 
@@ -139,20 +142,22 @@ class AccessTokenAuthenticatorTest extends TestCase
     {
         $request = Request::create('/test');
 
-        $this->accessTokenExtractor
+        $accessTokenHandler = $this->createMock(AccessTokenHandlerInterface::class);
+        $accessTokenExtractor = $this->createMock(AccessTokenExtractorInterface::class);
+        $accessTokenExtractor
             ->expects($this->once())
             ->method('extractAccessToken')
             ->with($request)
             ->willReturn('test');
-        $this->accessTokenHandler
+        $accessTokenHandler
             ->expects($this->once())
             ->method('getUserBadgeFrom')
             ->with('test')
             ->willReturn(new UserBadge('test', new FallbackUserLoader(fn () => new InMemoryUser('john', null))));
 
         $authenticator = new AccessTokenAuthenticator(
-            $this->accessTokenHandler,
-            $this->accessTokenExtractor,
+            $accessTokenHandler,
+            $accessTokenExtractor,
             $this->userProvider,
         );
 

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/HttpBasicAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/HttpBasicAuthenticatorTest.php
@@ -13,8 +13,6 @@ namespace Symfony\Component\Security\Http\Tests\Authenticator;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
-use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\InMemoryUserProvider;
 use Symfony\Component\Security\Http\Authenticator\HttpBasicAuthenticator;
@@ -30,14 +28,6 @@ class HttpBasicAuthenticatorTest extends TestCase
     protected function setUp(): void
     {
         $this->userProvider = new InMemoryUserProvider();
-
-        $hasherFactory = $this->createMock(PasswordHasherFactoryInterface::class);
-        $hasher = $this->createMock(PasswordHasherInterface::class);
-        $hasherFactory
-            ->expects($this->any())
-            ->method('getPasswordHasher')
-            ->willReturn($hasher);
-
         $this->authenticator = new HttpBasicAuthenticator('test', $this->userProvider);
     }
 

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/LoginLinkAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/LoginLinkAuthenticatorTest.php
@@ -11,10 +11,9 @@
 
 namespace Symfony\Component\Security\Http\Tests\Authenticator;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
 use Symfony\Component\Security\Http\Authenticator\LoginLinkAuthenticator;
@@ -28,16 +27,16 @@ use Symfony\Component\Security\Http\LoginLink\LoginLinkHandlerInterface;
 
 class LoginLinkAuthenticatorTest extends TestCase
 {
-    private MockObject&LoginLinkHandlerInterface $loginLinkHandler;
-    private MockObject&AuthenticationSuccessHandlerInterface $successHandler;
-    private MockObject&AuthenticationFailureHandlerInterface $failureHandler;
+    private LoginLinkHandlerInterface $loginLinkHandler;
+    private AuthenticationSuccessHandlerInterface $successHandler;
+    private AuthenticationFailureHandlerInterface $failureHandler;
     private LoginLinkAuthenticator $authenticator;
 
     protected function setUp(): void
     {
-        $this->loginLinkHandler = $this->createMock(LoginLinkHandlerInterface::class);
-        $this->successHandler = $this->createMock(AuthenticationSuccessHandlerInterface::class);
-        $this->failureHandler = $this->createMock(AuthenticationFailureHandlerInterface::class);
+        $this->loginLinkHandler = $this->createStub(LoginLinkHandlerInterface::class);
+        $this->successHandler = $this->createStub(AuthenticationSuccessHandlerInterface::class);
+        $this->failureHandler = $this->createStub(AuthenticationFailureHandlerInterface::class);
     }
 
     /**
@@ -60,16 +59,15 @@ class LoginLinkAuthenticatorTest extends TestCase
 
     public function testSuccessfulAuthenticate()
     {
-        $this->setUpAuthenticator();
-
         $request = Request::create('/login/link/check?stuff=1&user=weaverryan');
-        $user = $this->createMock(UserInterface::class);
-        $this->loginLinkHandler->expects($this->once())
+        $user = new InMemoryUser('John', 'password');
+        $loginLinkHandler = $this->createMock(LoginLinkHandlerInterface::class);
+        $loginLinkHandler->expects($this->once())
             ->method('consumeLoginLink')
             ->with($request)
             ->willReturn($user);
 
-        $passport = $this->authenticator->authenticate($request);
+        $passport = (new LoginLinkAuthenticator($loginLinkHandler, new HttpUtils(), $this->successHandler, $this->failureHandler, []))->authenticate($request);
         $this->assertInstanceOf(SelfValidatingPassport::class, $passport);
         /** @var UserBadge $userBadge */
         $userBadge = $passport->getBadge(UserBadge::class);
@@ -83,12 +81,14 @@ class LoginLinkAuthenticatorTest extends TestCase
         $this->setUpAuthenticator();
 
         $request = Request::create('/login/link/check?stuff=1&user=weaverryan');
-        $this->loginLinkHandler->expects($this->once())
+        $loginLinkHandler = $this->createMock(LoginLinkHandlerInterface::class);
+        $loginLinkHandler->expects($this->once())
             ->method('consumeLoginLink')
             ->with($request)
             ->willThrowException(new ExpiredLoginLinkException());
 
-        $passport = $this->authenticator->authenticate($request);
+        $passport = (new LoginLinkAuthenticator($loginLinkHandler, new HttpUtils(), $this->successHandler, $this->failureHandler, []))->authenticate($request);
+
         // trigger the user loader to try to load the user
         $passport->getBadge(UserBadge::class)->getUser();
     }
@@ -99,11 +99,11 @@ class LoginLinkAuthenticatorTest extends TestCase
         $this->setUpAuthenticator();
 
         $request = Request::create('/login/link/check?stuff=1');
-        $this->createMock(UserInterface::class);
-        $this->loginLinkHandler->expects($this->never())
+        $loginLinkHandler = $this->createMock(LoginLinkHandlerInterface::class);
+        $loginLinkHandler->expects($this->never())
             ->method('consumeLoginLink');
 
-        $this->authenticator->authenticate($request);
+        (new LoginLinkAuthenticator($loginLinkHandler, new HttpUtils(), $this->successHandler, $this->failureHandler, []))->authenticate($request);
     }
 
     public function testPassportBadges()

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/RememberMeAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/RememberMeAuthenticatorTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Security\Http\Tests\Authenticator;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
@@ -26,13 +25,13 @@ use Symfony\Component\Security\Http\RememberMe\ResponseListener;
 
 class RememberMeAuthenticatorTest extends TestCase
 {
-    private MockObject&RememberMeHandlerInterface $rememberMeHandler;
+    private RememberMeHandlerInterface $rememberMeHandler;
     private TokenStorage $tokenStorage;
     private RememberMeAuthenticator $authenticator;
 
     protected function setUp(): void
     {
-        $this->rememberMeHandler = $this->createMock(RememberMeHandlerInterface::class);
+        $this->rememberMeHandler = $this->createStub(RememberMeHandlerInterface::class);
         $this->tokenStorage = new TokenStorage();
         $this->authenticator = new RememberMeAuthenticator($this->rememberMeHandler, 's3cr3t', $this->tokenStorage, '_remember_me_cookie');
     }
@@ -69,11 +68,12 @@ class RememberMeAuthenticatorTest extends TestCase
 
     public function testAuthenticate()
     {
+        $rememberMeHandler = $this->createMock(RememberMeHandlerInterface::class);
         $rememberMeDetails = new RememberMeDetails(InMemoryUser::class, 'wouter', 1, 'secret');
         $request = Request::create('/', 'GET', [], ['_remember_me_cookie' => $rememberMeDetails->toString()]);
-        $passport = $this->authenticator->authenticate($request);
+        $passport = (new RememberMeAuthenticator($rememberMeHandler, 's3cr3t', $this->tokenStorage, '_remember_me_cookie'))->authenticate($request);
 
-        $this->rememberMeHandler->expects($this->once())->method('consumeRememberMeCookie')->with($this->callback(fn ($arg) => $rememberMeDetails == $arg));
+        $rememberMeHandler->expects($this->once())->method('consumeRememberMeCookie')->with($this->callback(fn ($arg) => $rememberMeDetails == $arg));
         $passport->getUser(); // trigger the user loader
     }
 

--- a/src/Symfony/Component/Security/Http/Tests/Controller/UserValueResolverTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Controller/UserValueResolverTest.php
@@ -24,6 +24,7 @@ use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
 use Symfony\Component\Security\Http\Controller\UserValueResolver;
+use Symfony\Component\Security\Http\Tests\Fixtures\CustomUser;
 
 class UserValueResolverTest extends TestCase
 {
@@ -125,7 +126,7 @@ class UserValueResolverTest extends TestCase
 
     public function testResolveThrowsAccessDeniedWithWrongUserClass()
     {
-        $user = $this->createMock(UserInterface::class);
+        $user = new CustomUser('John', ['ROLE_USER'], 'password', 'hash');
         $token = new UsernamePasswordToken($user, 'provider');
         $tokenStorage = new TokenStorage();
         $tokenStorage->setToken($token);
@@ -134,7 +135,7 @@ class UserValueResolverTest extends TestCase
         $metadata = new ArgumentMetadata('foo', InMemoryUser::class, false, false, null, false, [new CurrentUser()]);
 
         $this->expectException(AccessDeniedException::class);
-        $this->expectExceptionMessageMatches('/^The logged-in user is an instance of "Mock_UserInterface[^"]+" but a user of type "Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\InMemoryUser" is expected.$/');
+        $this->expectExceptionMessage(\sprintf('The logged-in user is an instance of "%s" but a user of type "Symfony\Component\Security\Core\User\InMemoryUser" is expected.', $user::class));
         $resolver->resolve(Request::create('/'), $metadata);
     }
 

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/CheckCredentialsListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/CheckCredentialsListenerTest.php
@@ -11,13 +11,11 @@
 
 namespace Symfony\Component\Security\Http\Tests\EventListener;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
+use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactory;
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\User\InMemoryUser;
-use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\PasswordUpgradeBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\CustomCredentials;
@@ -26,17 +24,14 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\Event\CheckPassportEvent;
 use Symfony\Component\Security\Http\EventListener\CheckCredentialsListener;
+use Symfony\Component\Security\Http\Tests\Fixtures\DummyAuthenticator;
 
 class CheckCredentialsListenerTest extends TestCase
 {
-    private MockObject&PasswordHasherFactoryInterface $hasherFactory;
-    private CheckCredentialsListener $listener;
     private InMemoryUser $user;
 
     protected function setUp(): void
     {
-        $this->hasherFactory = $this->createMock(PasswordHasherFactoryInterface::class);
-        $this->listener = new CheckCredentialsListener($this->hasherFactory);
         $this->user = new InMemoryUser('wouter', 'password-hash');
     }
 
@@ -45,10 +40,12 @@ class CheckCredentialsListenerTest extends TestCase
      */
     public function testPasswordAuthenticated($password, $passwordValid, $result)
     {
-        $hasher = $this->createMock(PasswordHasherInterface::class);
-        $hasher->expects($this->any())->method('verify')->with('password-hash', $password)->willReturn($passwordValid);
+        $hasher = $this->createStub(PasswordHasherInterface::class);
+        $hasher->method('verify')->with('password-hash', $password)->willReturn($passwordValid);
 
-        $this->hasherFactory->expects($this->any())->method('getPasswordHasher')->with($this->identicalTo($this->user))->willReturn($hasher);
+        $hasherFactory = new PasswordHasherFactory([
+            InMemoryUser::class => $hasher,
+        ]);
 
         if (false === $result) {
             $this->expectException(BadCredentialsException::class);
@@ -56,7 +53,7 @@ class CheckCredentialsListenerTest extends TestCase
         }
 
         $credentials = new PasswordCredentials($password);
-        $this->listener->checkPassport($this->createEvent(new Passport(new UserBadge('wouter', fn () => $this->user), $credentials)));
+        (new CheckCredentialsListener($hasherFactory))->checkPassport($this->createEvent(new Passport(new UserBadge('wouter', fn () => $this->user), $credentials)));
 
         if (true === $result) {
             $this->assertTrue($credentials->isResolved());
@@ -74,10 +71,11 @@ class CheckCredentialsListenerTest extends TestCase
         $this->expectException(BadCredentialsException::class);
         $this->expectExceptionMessage('The presented password cannot be empty.');
 
-        $this->hasherFactory->expects($this->never())->method('getPasswordHasher');
+        $hasherFactory = $this->createMock(PasswordHasherFactory::class);
+        $hasherFactory->expects($this->never())->method('getPasswordHasher');
 
         $event = $this->createEvent(new Passport(new UserBadge('wouter', fn () => $this->user), new PasswordCredentials('')));
-        $this->listener->checkPassport($event);
+        (new CheckCredentialsListener($hasherFactory))->checkPassport($event);
     }
 
     /**
@@ -85,14 +83,15 @@ class CheckCredentialsListenerTest extends TestCase
      */
     public function testCustomAuthenticated($result)
     {
-        $this->hasherFactory->expects($this->never())->method('getPasswordHasher');
+        $hasherFactory = $this->createMock(PasswordHasherFactory::class);
+        $hasherFactory->expects($this->never())->method('getPasswordHasher');
 
         if (false === $result) {
             $this->expectException(BadCredentialsException::class);
         }
 
         $credentials = new CustomCredentials(fn () => $result, ['password' => 'foo']);
-        $this->listener->checkPassport($this->createEvent(new Passport(new UserBadge('wouter', fn () => $this->user), $credentials)));
+        (new CheckCredentialsListener($hasherFactory))->checkPassport($this->createEvent(new Passport(new UserBadge('wouter', fn () => $this->user), $credentials)));
 
         if (true === $result) {
             $this->assertTrue($credentials->isResolved());
@@ -107,21 +106,24 @@ class CheckCredentialsListenerTest extends TestCase
 
     public function testNoCredentialsBadgeProvided()
     {
-        $this->hasherFactory->expects($this->never())->method('getPasswordHasher');
+        $hasherFactory = $this->createMock(PasswordHasherFactory::class);
+        $hasherFactory->expects($this->never())->method('getPasswordHasher');
 
         $event = $this->createEvent(new SelfValidatingPassport(new UserBadge('wouter', fn () => $this->user)));
-        $this->listener->checkPassport($event);
+        (new CheckCredentialsListener($hasherFactory))->checkPassport($event);
     }
 
     public function testAddsPasswordUpgradeBadge()
     {
-        $hasher = $this->createMock(PasswordHasherInterface::class);
-        $hasher->expects($this->any())->method('verify')->with('password-hash', 'ThePa$$word')->willReturn(true);
+        $hasher = $this->createStub(PasswordHasherInterface::class);
+        $hasher->method('verify')->with('password-hash', 'ThePa$$word')->willReturn(true);
 
-        $this->hasherFactory->expects($this->any())->method('getPasswordHasher')->with($this->identicalTo($this->user))->willReturn($hasher);
+        $hasherFactory = new PasswordHasherFactory([
+            InMemoryUser::class => $hasher,
+        ]);
 
         $passport = new Passport(new UserBadge('wouter', fn () => $this->user), new PasswordCredentials('ThePa$$word'));
-        $this->listener->checkPassport($this->createEvent($passport));
+        (new CheckCredentialsListener($hasherFactory))->checkPassport($this->createEvent($passport));
 
         $this->assertTrue($passport->hasBadge(PasswordUpgradeBadge::class));
         $this->assertEquals('ThePa$$word', $passport->getBadge(PasswordUpgradeBadge::class)->getAndErasePlaintextPassword());
@@ -129,10 +131,12 @@ class CheckCredentialsListenerTest extends TestCase
 
     public function testAddsNoPasswordUpgradeBadgeIfItAlreadyExists()
     {
-        $hasher = $this->createMock(PasswordHasherInterface::class);
-        $hasher->expects($this->any())->method('verify')->with('password-hash', 'ThePa$$word')->willReturn(true);
+        $hasher = $this->createStub(PasswordHasherInterface::class);
+        $hasher->method('verify')->with('password-hash', 'ThePa$$word')->willReturn(true);
 
-        $this->hasherFactory->expects($this->any())->method('getPasswordHasher')->with($this->identicalTo($this->user))->willReturn($hasher);
+        $hasherFactory = new PasswordHasherFactory([
+            InMemoryUser::class => $hasher,
+        ]);
 
         $passport = $this->getMockBuilder(Passport::class)
             ->onlyMethods(['addBadge'])
@@ -141,15 +145,17 @@ class CheckCredentialsListenerTest extends TestCase
 
         $passport->expects($this->never())->method('addBadge')->with($this->isInstanceOf(PasswordUpgradeBadge::class));
 
-        $this->listener->checkPassport($this->createEvent($passport));
+        (new CheckCredentialsListener($hasherFactory))->checkPassport($this->createEvent($passport));
     }
 
     public function testAddsNoPasswordUpgradeBadgeIfPasswordIsInvalid()
     {
-        $hasher = $this->createMock(PasswordHasherInterface::class);
-        $hasher->expects($this->any())->method('verify')->with('password-hash', 'ThePa$$word')->willReturn(false);
+        $hasher = $this->createStub(PasswordHasherInterface::class);
+        $hasher->method('verify')->with('password-hash', 'ThePa$$word')->willReturn(false);
 
-        $this->hasherFactory->expects($this->any())->method('getPasswordHasher')->with($this->identicalTo($this->user))->willReturn($hasher);
+        $hasherFactory = new PasswordHasherFactory([
+            InMemoryUser::class => $hasher,
+        ]);
 
         $passport = $this->getMockBuilder(Passport::class)
             ->onlyMethods(['addBadge'])
@@ -158,11 +164,11 @@ class CheckCredentialsListenerTest extends TestCase
 
         $passport->expects($this->never())->method('addBadge')->with($this->isInstanceOf(PasswordUpgradeBadge::class));
 
-        $this->listener->checkPassport($this->createEvent($passport));
+        (new CheckCredentialsListener($hasherFactory))->checkPassport($this->createEvent($passport));
     }
 
     private function createEvent($passport)
     {
-        return new CheckPassportEvent($this->createMock(AuthenticatorInterface::class), $passport);
+        return new CheckPassportEvent(new DummyAuthenticator(), $passport);
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/CheckRememberMeConditionsListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/CheckRememberMeConditionsListenerTest.php
@@ -14,15 +14,15 @@ namespace Symfony\Component\Security\Http\Tests\EventListener;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authentication\Token\NullToken;
 use Symfony\Component\Security\Core\User\InMemoryUser;
-use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\RememberMeBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\Event\LoginSuccessEvent;
 use Symfony\Component\Security\Http\EventListener\CheckRememberMeConditionsListener;
+use Symfony\Component\Security\Http\Tests\Fixtures\DummyAuthenticator;
 
 class CheckRememberMeConditionsListenerTest extends TestCase
 {
@@ -143,7 +143,7 @@ class CheckRememberMeConditionsListenerTest extends TestCase
 
     private function createLoginSuccessfulEvent(Passport $passport)
     {
-        return new LoginSuccessEvent($this->createMock(AuthenticatorInterface::class), $passport, $this->createMock(TokenInterface::class), $this->request, $this->response, 'main_firewall');
+        return new LoginSuccessEvent(new DummyAuthenticator(), $passport, new NullToken(), $this->request, $this->response, 'main_firewall');
     }
 
     private function createPassport(?array $badges = null)

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/IsGrantedAttributeListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/IsGrantedAttributeListenerTest.php
@@ -34,7 +34,7 @@ class IsGrantedAttributeListenerTest extends TestCase
             ->willReturn(true);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsGrantedAttributeController(), 'foo'],
             [],
             new Request(),
@@ -50,7 +50,7 @@ class IsGrantedAttributeListenerTest extends TestCase
             ->willReturn(true);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsGrantedAttributeController(), 'bar'],
             [],
             new Request(),
@@ -68,7 +68,7 @@ class IsGrantedAttributeListenerTest extends TestCase
             ->method('isGranted');
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsGrantedAttributeMethodsController(), 'noAttribute'],
             [],
             new Request(),
@@ -88,7 +88,7 @@ class IsGrantedAttributeListenerTest extends TestCase
             ->willReturn(true);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsGrantedAttributeMethodsController(), 'admin'],
             [],
             new Request(),
@@ -109,7 +109,7 @@ class IsGrantedAttributeListenerTest extends TestCase
             ->willReturn(true);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsGrantedAttributeMethodsController(), 'withSubject'],
             ['arg1Value', 'arg2Value'],
             new Request(),
@@ -134,7 +134,7 @@ class IsGrantedAttributeListenerTest extends TestCase
             ->willReturn(true);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsGrantedAttributeMethodsController(), 'withSubjectArray'],
             ['arg1Value', 'arg2Value'],
             new Request(),
@@ -155,7 +155,7 @@ class IsGrantedAttributeListenerTest extends TestCase
             ->willReturn(true);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsGrantedAttributeMethodsController(), 'withSubject'],
             ['arg1Value', null],
             new Request(),
@@ -178,7 +178,7 @@ class IsGrantedAttributeListenerTest extends TestCase
             ->willReturn(true);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsGrantedAttributeMethodsController(), 'withSubjectArray'],
             ['arg1Value', null],
             new Request(),
@@ -193,10 +193,10 @@ class IsGrantedAttributeListenerTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        $authChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authChecker = $this->createStub(AuthorizationCheckerInterface::class);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsGrantedAttributeMethodsController(), 'withMissingSubject'],
             [],
             new Request(),
@@ -217,8 +217,8 @@ class IsGrantedAttributeListenerTest extends TestCase
             ->method('isGranted')
             ->willReturn(false);
 
-        $expressionLanguage = $this->createMock(ExpressionLanguage::class);
-        $expressionLanguage->expects($this->any())
+        $expressionLanguage = $this->createStub(ExpressionLanguage::class);
+        $expressionLanguage
             ->method('evaluate')
             ->willReturn('bar');
 
@@ -228,7 +228,7 @@ class IsGrantedAttributeListenerTest extends TestCase
         $listener = new IsGrantedAttributeListener($authChecker, $expressionLanguage);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsGrantedAttributeMethodsController(), $method],
             $arguments,
             new Request(),
@@ -264,13 +264,13 @@ class IsGrantedAttributeListenerTest extends TestCase
         $this->expectException(HttpException::class);
         $this->expectExceptionMessage('Not found');
 
-        $authChecker = $this->createMock(AuthorizationCheckerInterface::class);
-        $authChecker->expects($this->any())
+        $authChecker = $this->createStub(AuthorizationCheckerInterface::class);
+        $authChecker
             ->method('isGranted')
             ->willReturn(false);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsGrantedAttributeMethodsController(), 'notFound'],
             [],
             new Request(),
@@ -290,7 +290,7 @@ class IsGrantedAttributeListenerTest extends TestCase
             ->willReturn(true);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsGrantedAttributeMethodsController(), 'withExpressionInAttribute'],
             ['postVal'],
             new Request(),
@@ -321,7 +321,7 @@ class IsGrantedAttributeListenerTest extends TestCase
             ->willReturn('author');
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsGrantedAttributeMethodsController(), 'withExpressionInSubject'],
             ['postVal'],
             $request,
@@ -352,7 +352,7 @@ class IsGrantedAttributeListenerTest extends TestCase
             ->willReturn('author');
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsGrantedAttributeMethodsController(), 'withNestedExpressionInSubject'],
             ['postVal', 'arg2Val'],
             $request,
@@ -374,7 +374,7 @@ class IsGrantedAttributeListenerTest extends TestCase
             ->willReturn(true);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsGrantedAttributeMethodsController(), 'withRequestAsSubject'],
             [],
             $request,
@@ -391,13 +391,13 @@ class IsGrantedAttributeListenerTest extends TestCase
         $this->expectExceptionMessage('Exception Code');
         $this->expectExceptionCode(10010);
 
-        $authChecker = $this->createMock(AuthorizationCheckerInterface::class);
-        $authChecker->expects($this->any())
+        $authChecker = $this->createStub(AuthorizationCheckerInterface::class);
+        $authChecker
             ->method('isGranted')
             ->willReturn(false);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsGrantedAttributeMethodsController(), 'exceptionCodeInHttpException'],
             [],
             new Request(),
@@ -414,13 +414,13 @@ class IsGrantedAttributeListenerTest extends TestCase
         $this->expectExceptionMessage('Exception Code');
         $this->expectExceptionCode(10010);
 
-        $authChecker = $this->createMock(AuthorizationCheckerInterface::class);
-        $authChecker->expects($this->any())
+        $authChecker = $this->createStub(AuthorizationCheckerInterface::class);
+        $authChecker
             ->method('isGranted')
             ->willReturn(false);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsGrantedAttributeMethodsController(), 'exceptionCodeInAccessDeniedException'],
             [],
             new Request(),

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/LoginThrottlingListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/LoginThrottlingListenerTest.php
@@ -18,13 +18,13 @@ use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\TooManyLoginAttemptsAuthenticationException;
-use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\Event\CheckPassportEvent;
 use Symfony\Component\Security\Http\Event\LoginFailureEvent;
 use Symfony\Component\Security\Http\EventListener\LoginThrottlingListener;
 use Symfony\Component\Security\Http\RateLimiter\DefaultLoginRateLimiter;
+use Symfony\Component\Security\Http\Tests\Fixtures\DummyAuthenticator;
 
 class LoginThrottlingListenerTest extends TestCase
 {
@@ -107,12 +107,12 @@ class LoginThrottlingListenerTest extends TestCase
 
     private function createLoginFailedEvent($passport)
     {
-        return new LoginFailureEvent($this->createMock(AuthenticationException::class), $this->createMock(AuthenticatorInterface::class), $this->requestStack->getCurrentRequest(), null, 'main', $passport);
+        return new LoginFailureEvent(new AuthenticationException(), new DummyAuthenticator(), $this->requestStack->getCurrentRequest(), null, 'main', $passport);
     }
 
     private function createCheckPassportEvent($passport)
     {
-        return new CheckPassportEvent($this->createMock(AuthenticatorInterface::class), $passport);
+        return new CheckPassportEvent(new DummyAuthenticator(), $passport);
     }
 
     private function createRequest($ip = '192.168.1.0')

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/RememberMeListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/RememberMeListenerTest.php
@@ -15,9 +15,8 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authentication\Token\NullToken;
 use Symfony\Component\Security\Core\User\InMemoryUser;
-use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\RememberMeBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
@@ -25,6 +24,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPasspor
 use Symfony\Component\Security\Http\Event\LoginSuccessEvent;
 use Symfony\Component\Security\Http\EventListener\RememberMeListener;
 use Symfony\Component\Security\Http\RememberMe\RememberMeHandlerInterface;
+use Symfony\Component\Security\Http\Tests\Fixtures\DummyAuthenticator;
 
 class RememberMeListenerTest extends TestCase
 {
@@ -69,7 +69,7 @@ class RememberMeListenerTest extends TestCase
     {
         $passport ??= $this->createPassport();
 
-        return new LoginSuccessEvent($this->createMock(AuthenticatorInterface::class), $passport, $this->createMock(TokenInterface::class), $this->request, $this->response, 'main_firewall');
+        return new LoginSuccessEvent(new DummyAuthenticator(), $passport, new NullToken(), $this->request, $this->response, 'main_firewall');
     }
 
     private function createPassport(?array $badges = null)

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/SessionLogoutListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/SessionLogoutListenerTest.php
@@ -34,9 +34,8 @@ class SessionLogoutListenerTest extends TestCase
         $session = $this->createMock(Session::class);
         $session->expects($this->once())->method('invalidate');
 
-        $request = $this->createMock(Request::class);
-        $request->method('getSession')->willReturn($session);
-        $request->method('hasSession')->willReturn(true);
+        $request = new Request();
+        $request->setSession($session);
 
         $sessionLogoutListener = new SessionLogoutListener();
         $sessionLogoutListener->onLogout(new LogoutEvent($request, null));

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/SessionStrategyListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/SessionStrategyListenerTest.php
@@ -11,23 +11,24 @@
 
 namespace Symfony\Component\Security\Http\Tests\EventListener;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\Security\Core\Authentication\Token\NullToken;
+use Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\User\InMemoryUser;
-use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\Event\LoginSuccessEvent;
 use Symfony\Component\Security\Http\EventListener\SessionStrategyListener;
 use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterface;
+use Symfony\Component\Security\Http\Tests\Fixtures\DummyAuthenticator;
 
 class SessionStrategyListenerTest extends TestCase
 {
-    private MockObject&SessionAuthenticationStrategyInterface $sessionAuthenticationStrategy;
+    private SessionAuthenticationStrategyInterface $sessionAuthenticationStrategy;
     private SessionStrategyListener $listener;
     private Request $request;
     private NullToken $token;
@@ -37,7 +38,7 @@ class SessionStrategyListenerTest extends TestCase
         $this->sessionAuthenticationStrategy = $this->createMock(SessionAuthenticationStrategyInterface::class);
         $this->listener = new SessionStrategyListener($this->sessionAuthenticationStrategy);
         $this->request = new Request();
-        $this->token = $this->createMock(NullToken::class);
+        $this->token = new NullToken();
     }
 
     public function testRequestWithSession()
@@ -69,16 +70,10 @@ class SessionStrategyListenerTest extends TestCase
         $this->configurePreviousSession();
         $this->sessionAuthenticationStrategy->expects($this->never())->method('onAuthentication');
 
-        $token = $this->createMock(NullToken::class);
-        $token->expects($this->once())
-            ->method('getUserIdentifier')
-            ->willReturn('test');
-        $previousToken = $this->createMock(NullToken::class);
-        $previousToken->expects($this->once())
-            ->method('getUserIdentifier')
-            ->willReturn('test');
+        $token = new UsernamePasswordToken(new InMemoryUser('test', 'password'), 'main');
+        $previousToken = new UsernamePasswordToken(new InMemoryUser('test', 'password'), 'main');
 
-        $event = new LoginSuccessEvent($this->createMock(AuthenticatorInterface::class), new SelfValidatingPassport(new UserBadge('test', function () {})), $token, $this->request, null, 'main_firewall', $previousToken);
+        $event = new LoginSuccessEvent(new DummyAuthenticator(), new SelfValidatingPassport(new UserBadge('test', function () {})), $token, $this->request, null, 'main_firewall', $previousToken);
 
         $this->listener->onSuccessfulLogin($event);
     }
@@ -87,33 +82,25 @@ class SessionStrategyListenerTest extends TestCase
     {
         $this->configurePreviousSession();
 
-        $token = $this->createMock(NullToken::class);
-        $token->expects($this->once())
-            ->method('getUserIdentifier')
-            ->willReturn('test');
-        $previousToken = $this->createMock(UsernamePasswordToken::class);
-        $previousToken->expects($this->once())
-            ->method('getUserIdentifier')
-            ->willReturn('test');
+        $token = new PreAuthenticatedToken(new InMemoryUser('test', 'password'), 'main');
+        $previousToken = new UsernamePasswordToken(new InMemoryUser('test', 'password'), 'main');
 
         $this->sessionAuthenticationStrategy->expects($this->once())->method('onAuthentication')->with($this->request, $token);
 
-        $event = new LoginSuccessEvent($this->createMock(AuthenticatorInterface::class), new SelfValidatingPassport(new UserBadge('test', function () {})), $token, $this->request, null, 'main_firewall', $previousToken);
+        $event = new LoginSuccessEvent(new DummyAuthenticator(), new SelfValidatingPassport(new UserBadge('test', function () {})), $token, $this->request, null, 'main_firewall', $previousToken);
 
         $this->listener->onSuccessfulLogin($event);
     }
 
     private function createEvent($firewallName)
     {
-        return new LoginSuccessEvent($this->createMock(AuthenticatorInterface::class), new SelfValidatingPassport(new UserBadge('test', fn ($username) => new InMemoryUser($username, null))), $this->token, $this->request, null, $firewallName);
+        return new LoginSuccessEvent(new DummyAuthenticator(), new SelfValidatingPassport(new UserBadge('test', fn ($username) => new InMemoryUser($username, null))), $this->token, $this->request, null, $firewallName);
     }
 
     private function configurePreviousSession()
     {
-        $session = $this->createMock(SessionInterface::class);
-        $session->expects($this->any())
-            ->method('getName')
-            ->willReturn('test_session_name');
+        $sessionStorage = new MockArraySessionStorage('test_session_name');
+        $session = new Session($sessionStorage);
         $this->request->setSession($session);
         $this->request->cookies->set('test_session_name', 'session_cookie_val');
     }

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/UserCheckerListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/UserCheckerListenerTest.php
@@ -16,13 +16,13 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Event\AuthenticationSuccessEvent;
 use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
-use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\PreAuthenticatedUserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\Authenticator\Token\PostAuthenticationToken;
 use Symfony\Component\Security\Http\Event\CheckPassportEvent;
 use Symfony\Component\Security\Http\EventListener\UserCheckerListener;
+use Symfony\Component\Security\Http\Tests\Fixtures\DummyAuthenticator;
 
 class UserCheckerListenerTest extends TestCase
 {
@@ -62,7 +62,7 @@ class UserCheckerListenerTest extends TestCase
     {
         $passport ??= new SelfValidatingPassport(new UserBadge('test', fn () => $this->user));
 
-        return new CheckPassportEvent($this->createMock(AuthenticatorInterface::class), $passport);
+        return new CheckPassportEvent(new DummyAuthenticator(), $passport);
     }
 
     private function createAuthenticationSuccessEvent()

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/UserProviderListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/UserProviderListenerTest.php
@@ -14,11 +14,11 @@ namespace Symfony\Component\Security\Http\Tests\EventListener;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\InMemoryUserProvider;
-use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\Event\CheckPassportEvent;
 use Symfony\Component\Security\Http\EventListener\UserProviderListener;
+use Symfony\Component\Security\Http\Tests\Fixtures\DummyAuthenticator;
 
 class UserProviderListenerTest extends TestCase
 {
@@ -35,7 +35,7 @@ class UserProviderListenerTest extends TestCase
     {
         $passport = new SelfValidatingPassport(new UserBadge('wouter'));
 
-        $this->listener->checkPassport(new CheckPassportEvent($this->createMock(AuthenticatorInterface::class), $passport));
+        $this->listener->checkPassport(new CheckPassportEvent(new DummyAuthenticator(), $passport));
 
         $user = new InMemoryUser('wouter', null);
         $this->userProvider->createUser($user);
@@ -48,7 +48,7 @@ class UserProviderListenerTest extends TestCase
     public function testNotOverrideUserLoader($passport)
     {
         $badgeBefore = $passport->hasBadge(UserBadge::class) ? $passport->getBadge(UserBadge::class) : null;
-        $this->listener->checkPassport(new CheckPassportEvent($this->createMock(AuthenticatorInterface::class), $passport));
+        $this->listener->checkPassport(new CheckPassportEvent(new DummyAuthenticator(), $passport));
 
         $this->assertEquals($passport->hasBadge(UserBadge::class) ? $passport->getBadge(UserBadge::class) : null, $badgeBefore);
     }

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/AccessListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/AccessListenerTest.php
@@ -24,6 +24,7 @@ use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\User\InMemoryUser;
+use Symfony\Component\Security\Http\AccessMap;
 use Symfony\Component\Security\Http\AccessMapInterface;
 use Symfony\Component\Security\Http\Event\LazyResponseEvent;
 use Symfony\Component\Security\Http\Firewall\AccessListener;
@@ -49,12 +50,8 @@ class AccessListenerTest extends TestCase
             }
         };
 
-        $tokenStorage = $this->createMock(TokenStorageInterface::class);
-        $tokenStorage
-            ->expects($this->any())
-            ->method('getToken')
-            ->willReturn($token)
-        ;
+        $tokenStorage = new TokenStorage();
+        $tokenStorage->setToken($token);
 
         $accessDecisionManager = $this->createMock(AccessDecisionManagerInterface::class);
         $accessDecisionManager
@@ -70,7 +67,7 @@ class AccessListenerTest extends TestCase
             $accessMap
         );
 
-        $listener(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
+        $listener(new RequestEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
     }
 
     public function testHandleWhenThereIsNoAccessMapEntryMatchingTheRequest()
@@ -93,11 +90,11 @@ class AccessListenerTest extends TestCase
 
         $listener = new AccessListener(
             $tokenStorage,
-            $this->createMock(AccessDecisionManagerInterface::class),
+            $this->createStub(AccessDecisionManagerInterface::class),
             $accessMap
         );
 
-        $listener(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
+        $listener(new RequestEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
     }
 
     public function testHandleWhenAccessMapReturnsEmptyAttributes()
@@ -120,11 +117,11 @@ class AccessListenerTest extends TestCase
 
         $listener = new AccessListener(
             $tokenStorage,
-            $this->createMock(AccessDecisionManagerInterface::class),
+            $this->createStub(AccessDecisionManagerInterface::class),
             $accessMap
         );
 
-        $event = new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
+        $event = new RequestEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
 
         $listener(new LazyResponseEvent($event));
     }
@@ -155,7 +152,7 @@ class AccessListenerTest extends TestCase
             false
         );
 
-        $listener(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
+        $listener(new RequestEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
     }
 
     public function testHandleWhenPublicAccessIsAllowed()
@@ -183,7 +180,7 @@ class AccessListenerTest extends TestCase
             false
         );
 
-        $listener(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
+        $listener(new RequestEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
     }
 
     public function testHandleWhenPublicAccessWhileAuthenticated()
@@ -213,10 +210,10 @@ class AccessListenerTest extends TestCase
             false
         );
 
-        $listener(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
+        $listener(new RequestEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
     }
 
-    public function testHandleMWithultipleAttributesShouldBeHandledAsAnd()
+    public function testHandleWithMultipleAttributesShouldBeHandledAsAnd()
     {
         $request = new Request();
 
@@ -263,8 +260,8 @@ class AccessListenerTest extends TestCase
             ->willReturn([[AuthenticatedVoter::PUBLIC_ACCESS], null])
         ;
 
-        $listener = new AccessListener($tokenStorage, $this->createMock(AccessDecisionManagerInterface::class), $accessMap, false);
-        $listener(new LazyResponseEvent(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST)));
+        $listener = new AccessListener($tokenStorage, $this->createStub(AccessDecisionManagerInterface::class), $accessMap, false);
+        $listener(new LazyResponseEvent(new RequestEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST)));
     }
 
     public function testConstructWithTrueExceptionOnNoToken()
@@ -272,12 +269,10 @@ class AccessListenerTest extends TestCase
         $tokenStorage = $this->createMock(TokenStorageInterface::class);
         $tokenStorage->expects($this->never())->method(self::anything());
 
-        $accessMap = $this->createMock(AccessMapInterface::class);
-
         $this->expectExceptionObject(
             new \LogicException('Argument $exceptionOnNoToken of "Symfony\Component\Security\Http\Firewall\AccessListener::__construct()" must be set to "false".')
         );
 
-        new AccessListener($tokenStorage, $this->createMock(AccessDecisionManagerInterface::class), $accessMap, true);
+        new AccessListener($tokenStorage, $this->createStub(AccessDecisionManagerInterface::class), new AccessMap(), true);
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ChannelListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ChannelListenerTest.php
@@ -15,29 +15,20 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\HeaderBag;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcher\SchemeRequestMatcher;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Symfony\Component\Security\Http\AccessMapInterface;
+use Symfony\Component\Security\Http\AccessMap;
 use Symfony\Component\Security\Http\Firewall\ChannelListener;
 
 class ChannelListenerTest extends TestCase
 {
     public function testHandleWithNotSecuredRequestAndHttpChannel()
     {
-        $request = $this->createMock(Request::class);
-        $request
-            ->expects($this->any())
-            ->method('isSecure')
-            ->willReturn(false)
-        ;
+        $request = Request::create('http://symfony.com');
 
-        $accessMap = $this->createMock(AccessMapInterface::class);
-        $accessMap
-            ->expects($this->any())
-            ->method('getPatterns')
-            ->with($this->equalTo($request))
-            ->willReturn([[], 'http'])
-        ;
+        $accessMap = new AccessMap();
+        $accessMap->add(new SchemeRequestMatcher('https'), [], 'http');
 
         $event = new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
 
@@ -49,20 +40,10 @@ class ChannelListenerTest extends TestCase
 
     public function testHandleWithSecuredRequestAndHttpsChannel()
     {
-        $request = $this->createMock(Request::class);
-        $request
-            ->expects($this->any())
-            ->method('isSecure')
-            ->willReturn(true)
-        ;
+        $request = Request::create('https://symfony.com');
 
-        $accessMap = $this->createMock(AccessMapInterface::class);
-        $accessMap
-            ->expects($this->any())
-            ->method('getPatterns')
-            ->with($this->equalTo($request))
-            ->willReturn([[], 'https'])
-        ;
+        $accessMap = new AccessMap();
+        $accessMap->add(new SchemeRequestMatcher('http'), [], 'https');
 
         $event = new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
 
@@ -74,75 +55,45 @@ class ChannelListenerTest extends TestCase
 
     public function testHandleWithNotSecuredRequestAndHttpsChannel()
     {
-        $request = $this->createMock(Request::class);
-        $request
-            ->expects($this->any())
-            ->method('isSecure')
-            ->willReturn(false)
-        ;
+        $request = Request::create('http://symfony.com');
 
-        $accessMap = $this->createMock(AccessMapInterface::class);
-        $accessMap
-            ->expects($this->any())
-            ->method('getPatterns')
-            ->with($this->equalTo($request))
-            ->willReturn([[], 'https'])
-        ;
+        $accessMap = new AccessMap();
+        $accessMap->add(new SchemeRequestMatcher('http'), [], 'https');
 
-        $event = new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
+        $event = new RequestEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
 
         $listener = new ChannelListener($accessMap);
         $listener($event);
 
         $response = $event->getResponse();
         $this->assertInstanceOf(RedirectResponse::class, $response);
-        $this->assertEquals('https://', $response->getTargetUrl());
+        $this->assertEquals('https://symfony.com/', $response->getTargetUrl());
     }
 
     public function testHandleWithSecuredRequestAndHttpChannel()
     {
-        $request = $this->createMock(Request::class);
-        $request
-            ->expects($this->any())
-            ->method('isSecure')
-            ->willReturn(true)
-        ;
+        $request = Request::create('https://symfony.com');
 
-        $accessMap = $this->createMock(AccessMapInterface::class);
-        $accessMap
-            ->expects($this->any())
-            ->method('getPatterns')
-            ->with($this->equalTo($request))
-            ->willReturn([[], 'http'])
-        ;
+        $accessMap = new AccessMap();
+        $accessMap->add(new SchemeRequestMatcher('https'), [], 'http');
 
-        $event = new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
+        $event = new RequestEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
 
         $listener = new ChannelListener($accessMap);
         $listener($event);
 
         $response = $event->getResponse();
         $this->assertInstanceOf(RedirectResponse::class, $response);
-        $this->assertEquals('http://', $response->getTargetUrl());
+        $this->assertEquals('http://symfony.com/', $response->getTargetUrl());
     }
 
     public function testSupportsWithoutHeaders()
     {
-        $request = $this->createMock(Request::class);
-        $request
-            ->expects($this->any())
-            ->method('isSecure')
-            ->willReturn(false)
-        ;
+        $request = Request::create('http://symfony.com');
         $request->headers = new HeaderBag();
 
-        $accessMap = $this->createMock(AccessMapInterface::class);
-        $accessMap
-            ->expects($this->any())
-            ->method('getPatterns')
-            ->with($this->equalTo($request))
-            ->willReturn([[], 'https'])
-        ;
+        $accessMap = new AccessMap();
+        $accessMap->add(new SchemeRequestMatcher('http'), [], 'https');
 
         $listener = new ChannelListener($accessMap);
 

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/SwitchUserListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/SwitchUserListenerTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Security\Http\Tests\Firewall;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -26,6 +25,7 @@ use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 use Symfony\Component\Security\Core\User\InMemoryUser;
+use Symfony\Component\Security\Core\User\InMemoryUserChecker;
 use Symfony\Component\Security\Core\User\InMemoryUserProvider;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use Symfony\Component\Security\Http\Event\SwitchUserEvent;
@@ -37,8 +37,8 @@ class SwitchUserListenerTest extends TestCase
 {
     private TokenStorage $tokenStorage;
     private InMemoryUserProvider $userProvider;
-    private MockObject&UserCheckerInterface $userChecker;
-    private MockObject&AccessDecisionManagerInterface $accessDecisionManager;
+    private UserCheckerInterface $userChecker;
+    private AccessDecisionManagerInterface $accessDecisionManager;
     private Request $request;
     private RequestEvent $event;
 
@@ -46,10 +46,10 @@ class SwitchUserListenerTest extends TestCase
     {
         $this->tokenStorage = new TokenStorage();
         $this->userProvider = new InMemoryUserProvider(['kuba' => []]);
-        $this->userChecker = $this->createMock(UserCheckerInterface::class);
-        $this->accessDecisionManager = $this->createMock(AccessDecisionManagerInterface::class);
+        $this->userChecker = new InMemoryUserChecker();
+        $this->accessDecisionManager = $this->createStub(AccessDecisionManagerInterface::class);
         $this->request = new Request();
-        $this->event = new RequestEvent($this->createMock(HttpKernelInterface::class), $this->request, HttpKernelInterface::MAIN_REQUEST);
+        $this->event = new RequestEvent($this->createStub(HttpKernelInterface::class), $this->request, HttpKernelInterface::MAIN_REQUEST);
     }
 
     public function testFirewallNameIsRequired()
@@ -113,7 +113,7 @@ class SwitchUserListenerTest extends TestCase
 
         $this->request->query->set('_switch_user', SwitchUserListener::EXIT_VALUE);
 
-        $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager, urlGenerator: $this->createMock(UrlGeneratorInterface::class), targetRoute: 'whatever');
+        $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager, urlGenerator: $this->createStub(UrlGeneratorInterface::class), targetRoute: 'whatever');
         $listener($this->event);
 
         $this->assertInstanceOf(RedirectResponse::class, $this->event->getResponse());
@@ -124,9 +124,8 @@ class SwitchUserListenerTest extends TestCase
     {
         $originalUser = new InMemoryUser('username', null);
         $refreshedUser = new InMemoryUser('username', null);
-        $userProvider = $this->createMock(InMemoryUserProvider::class);
+        $userProvider = $this->createStub(InMemoryUserProvider::class);
         $userProvider
-            ->expects($this->any())
             ->method('refreshUser')
             ->with($this->identicalTo($originalUser))
             ->willReturn($refreshedUser);
@@ -157,11 +156,12 @@ class SwitchUserListenerTest extends TestCase
         $this->tokenStorage->setToken($token);
         $this->request->query->set('_switch_user', 'kuba');
 
-        $this->accessDecisionManager->expects($this->once())
+        $accessDecisionManager = $this->createMock(AccessDecisionManagerInterface::class);
+        $accessDecisionManager->expects($this->once())
             ->method('decide')->with($token, ['ROLE_ALLOWED_TO_SWITCH'])
             ->willReturn(false);
 
-        $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager);
+        $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $accessDecisionManager);
         $listener($this->event);
     }
 
@@ -173,10 +173,11 @@ class SwitchUserListenerTest extends TestCase
         $this->tokenStorage->setToken($token);
         $this->request->query->set('_switch_user', 'not-existing');
 
-        $this->accessDecisionManager->expects($this->never())
+        $accessDecisionManager = $this->createMock(AccessDecisionManagerInterface::class);
+        $accessDecisionManager->expects($this->never())
             ->method('decide');
 
-        $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager);
+        $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $accessDecisionManager);
         $listener($this->event);
     }
 
@@ -187,14 +188,16 @@ class SwitchUserListenerTest extends TestCase
         $this->tokenStorage->setToken($token);
         $this->request->query->set('_switch_user', 'kuba');
 
-        $this->accessDecisionManager->expects($this->once())
+        $accessDecisionManager = $this->createMock(AccessDecisionManagerInterface::class);
+        $accessDecisionManager->expects($this->once())
             ->method('decide')->with($token, ['ROLE_ALLOWED_TO_SWITCH'], $this->callback(fn ($user) => 'kuba' === $user->getUserIdentifier()))
             ->willReturn(true);
 
-        $this->userChecker->expects($this->once())
+        $userChecker = $this->createMock(UserCheckerInterface::class);
+        $userChecker->expects($this->once())
             ->method('checkPostAuth')->with($this->callback(fn ($user) => 'kuba' === $user->getUserIdentifier()));
 
-        $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager);
+        $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $userChecker, 'provider123', $accessDecisionManager);
         $listener($this->event);
 
         $this->assertSame([], $this->request->query->all());
@@ -213,17 +216,19 @@ class SwitchUserListenerTest extends TestCase
         $this->request->query->set('_switch_user', 'kuba');
 
         $targetsUser = $this->callback(fn ($user) => 'kuba' === $user->getUserIdentifier());
-        $this->accessDecisionManager->expects($this->once())
+        $accessDecisionManager = $this->createMock(AccessDecisionManagerInterface::class);
+        $accessDecisionManager->expects($this->once())
             ->method('decide')->with(self::callback(function (TokenInterface $token) use ($originalToken, $tokenStorage) {
                 // the token storage should also contain the original token for voters depending on it
                 return $token === $originalToken && $tokenStorage->getToken() === $originalToken;
             }), ['ROLE_ALLOWED_TO_SWITCH'], $targetsUser)
             ->willReturn(true);
 
-        $this->userChecker->expects($this->once())
+        $userChecker = $this->createMock(UserCheckerInterface::class);
+        $userChecker->expects($this->once())
             ->method('checkPostAuth')->with($targetsUser);
 
-        $listener = new SwitchUserListener($tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager, null, '_switch_user', 'ROLE_ALLOWED_TO_SWITCH', null, false);
+        $listener = new SwitchUserListener($tokenStorage, $this->userProvider, $userChecker, 'provider123', $accessDecisionManager, null, '_switch_user', 'ROLE_ALLOWED_TO_SWITCH', null, false);
         $listener($this->event);
 
         $this->assertSame([], $this->request->query->all());
@@ -242,14 +247,16 @@ class SwitchUserListenerTest extends TestCase
 
         $this->userProvider->createUser($user = new InMemoryUser('0', null));
 
-        $this->accessDecisionManager->expects($this->once())
+        $accessDecisionManager = $this->createMock(AccessDecisionManagerInterface::class);
+        $accessDecisionManager->expects($this->once())
             ->method('decide')->with($token, ['ROLE_ALLOWED_TO_SWITCH'])
             ->willReturn(true);
 
-        $this->userChecker->expects($this->once())
+        $userChecker = $this->createMock(UserCheckerInterface::class);
+        $userChecker->expects($this->once())
             ->method('checkPostAuth')->with($this->callback(fn ($argUser) => $user->isEqualTo($argUser)));
 
-        $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager);
+        $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $userChecker, 'provider123', $accessDecisionManager);
         $listener($this->event);
 
         $this->assertSame([], $this->request->query->all());
@@ -269,14 +276,16 @@ class SwitchUserListenerTest extends TestCase
         ]);
 
         $targetsUser = $this->callback(fn ($user) => 'kuba' === $user->getUserIdentifier());
-        $this->accessDecisionManager->expects($this->once())
+        $accessDecisionManager = $this->createMock(AccessDecisionManagerInterface::class);
+        $accessDecisionManager->expects($this->once())
             ->method('decide')->with($token, ['ROLE_ALLOWED_TO_SWITCH'], $targetsUser)
             ->willReturn(true);
 
-        $this->userChecker->expects($this->once())
+        $userChecker = $this->createMock(UserCheckerInterface::class);
+        $userChecker->expects($this->once())
             ->method('checkPostAuth')->with($targetsUser);
 
-        $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager);
+        $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $userChecker, 'provider123', $accessDecisionManager);
         $listener($this->event);
 
         $this->assertSame('page=3&section=2', $this->request->server->get('QUERY_STRING'));
@@ -294,7 +303,8 @@ class SwitchUserListenerTest extends TestCase
         $this->tokenStorage->setToken($token);
         $this->request->query->set('_switch_user', 'kuba');
 
-        $this->accessDecisionManager->expects($this->any())
+        $accessDecisionManager = $this->createMock(AccessDecisionManagerInterface::class);
+        $accessDecisionManager->expects($this->once())
             ->method('decide')->with($token, ['ROLE_ALLOWED_TO_SWITCH'], $this->callback(fn ($user) => 'kuba' === $user->getUserIdentifier()))
             ->willReturn(true);
 
@@ -314,7 +324,7 @@ class SwitchUserListenerTest extends TestCase
                 SecurityEvents::SWITCH_USER
             );
 
-        $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager, null, '_switch_user', 'ROLE_ALLOWED_TO_SWITCH', $dispatcher);
+        $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $accessDecisionManager, null, '_switch_user', 'ROLE_ALLOWED_TO_SWITCH', $dispatcher);
         $listener($this->event);
 
         $this->assertSame($replacedToken, $this->tokenStorage->getToken());
@@ -337,14 +347,16 @@ class SwitchUserListenerTest extends TestCase
         $this->request->query->set('_switch_user', 'kuba');
 
         $targetsUser = $this->callback(fn ($user) => 'kuba' === $user->getUserIdentifier());
-        $this->accessDecisionManager->expects($this->once())
+        $accessDecisionManager = $this->createMock(AccessDecisionManagerInterface::class);
+        $accessDecisionManager->expects($this->once())
             ->method('decide')->with($token, ['ROLE_ALLOWED_TO_SWITCH'], $targetsUser)
             ->willReturn(true);
 
-        $this->userChecker->expects($this->once())
+        $userChecker = $this->createMock(UserCheckerInterface::class);
+        $userChecker->expects($this->once())
             ->method('checkPostAuth')->with($targetsUser);
 
-        $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager, null, '_switch_user', 'ROLE_ALLOWED_TO_SWITCH', null, true);
+        $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $userChecker, 'provider123', $accessDecisionManager, null, '_switch_user', 'ROLE_ALLOWED_TO_SWITCH', null, true);
         $listener($this->event);
 
         $this->assertInstanceOf(UsernamePasswordToken::class, $this->tokenStorage->getToken());
@@ -355,9 +367,8 @@ class SwitchUserListenerTest extends TestCase
     {
         $originalUser = new InMemoryUser('username', null);
         $refreshedOriginalUser = new InMemoryUser('username', null);
-        $userProvider = $this->createMock(InMemoryUserProvider::class);
+        $userProvider = $this->createStub(InMemoryUserProvider::class);
         $userProvider
-            ->expects($this->any())
             ->method('refreshUser')
             ->with($this->identicalTo($originalUser))
             ->willReturn($refreshedOriginalUser);

--- a/src/Symfony/Component/Security/Http/Tests/FirewallMapTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/FirewallMapTest.php
@@ -43,7 +43,7 @@ class FirewallMapTest extends TestCase
             ->willReturn(true)
         ;
         $theListener = function () {};
-        $theException = $this->createMock(ExceptionListener::class);
+        $theException = $this->createStub(ExceptionListener::class);
 
         $map->add($matchingMatcher, [$theListener], $theException);
 
@@ -78,7 +78,7 @@ class FirewallMapTest extends TestCase
         $map->add($notMatchingMatcher, [function () {}]);
 
         $theListener = function () {};
-        $theException = $this->createMock(ExceptionListener::class);
+        $theException = $this->createStub(ExceptionListener::class);
 
         $map->add(null, [$theListener], $theException);
 

--- a/src/Symfony/Component/Security/Http/Tests/FirewallTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/FirewallTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Security\Http\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
@@ -27,7 +27,7 @@ class FirewallTest extends TestCase
 {
     public function testOnKernelRequestRegistersExceptionListener()
     {
-        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher = new EventDispatcher();
 
         $listener = $this->createMock(ExceptionListener::class);
         $listener
@@ -36,7 +36,7 @@ class FirewallTest extends TestCase
             ->with($this->equalTo($dispatcher))
         ;
 
-        $request = $this->createMock(Request::class);
+        $request = new Request();
 
         $map = $this->createMock(FirewallMapInterface::class);
         $map
@@ -46,7 +46,7 @@ class FirewallTest extends TestCase
             ->willReturn([[], $listener, null])
         ;
 
-        $event = new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
+        $event = new RequestEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
 
         $firewall = new Firewall($map, $dispatcher);
         $firewall->onKernelRequest($event);
@@ -71,10 +71,10 @@ class FirewallTest extends TestCase
             ->willReturn([[$first, $second], null, null])
         ;
 
-        $event = new RequestEvent($this->createMock(HttpKernelInterface::class), new Request(), HttpKernelInterface::MAIN_REQUEST);
+        $event = new RequestEvent($this->createStub(HttpKernelInterface::class), new Request(), HttpKernelInterface::MAIN_REQUEST);
         $event->setResponse(new Response());
 
-        $firewall = new Firewall($map, $this->createMock(EventDispatcherInterface::class));
+        $firewall = new Firewall($map, new EventDispatcher());
         $firewall->onKernelRequest($event);
 
         $this->assertSame([1], $called);
@@ -89,12 +89,12 @@ class FirewallTest extends TestCase
         ;
 
         $event = new RequestEvent(
-            $this->createMock(HttpKernelInterface::class),
-            $this->createMock(Request::class),
+            $this->createStub(HttpKernelInterface::class),
+            new Request(),
             HttpKernelInterface::SUB_REQUEST
         );
 
-        $firewall = new Firewall($map, $this->createMock(EventDispatcherInterface::class));
+        $firewall = new Firewall($map, new EventDispatcher());
         $firewall->onKernelRequest($event);
 
         $this->assertFalse($event->hasResponse());
@@ -141,7 +141,7 @@ class FirewallTest extends TestCase
             }
         };
 
-        $request = $this->createMock(Request::class);
+        $request = new Request();
 
         $map = $this->createMock(FirewallMapInterface::class);
         $map
@@ -151,9 +151,9 @@ class FirewallTest extends TestCase
             ->willReturn([[$callableListener, $firewallListener, $callableFirewallListener], null, null])
         ;
 
-        $event = new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
+        $event = new RequestEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
 
-        $firewall = new Firewall($map, $this->createMock(EventDispatcherInterface::class));
+        $firewall = new Firewall($map, new EventDispatcher());
         $firewall->onKernelRequest($event);
 
         $this->assertSame(['callableListener', 'firewallListener', 'callableFirewallListener'], $calledListeners);

--- a/src/Symfony/Component/Security/Http/Tests/Fixtures/CustomUser.php
+++ b/src/Symfony/Component/Security/Http/Tests/Fixtures/CustomUser.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\Fixtures;
+
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+final class CustomUser implements UserInterface, PasswordAuthenticatedUserInterface
+{
+    public function __construct(
+        private string $username,
+        private array $roles,
+        private ?string $password,
+        private ?bool $hashPassword,
+    ) {
+    }
+
+    public function getUserIdentifier(): string
+    {
+        return $this->username;
+    }
+
+    public function getRoles(): array
+    {
+        return $this->roles;
+    }
+
+    public function getPassword(): ?string
+    {
+        return $this->password ?? null;
+    }
+
+    public function eraseCredentials(): void
+    {
+    }
+
+    public function __serialize(): array
+    {
+        $data = (array) $this;
+        $passwordKey = \sprintf("\0%s\0password", self::class);
+
+        if ($this->hashPassword) {
+            $data[$passwordKey] = hash('crc32c', $this->password);
+        } elseif (null !== $this->hashPassword) {
+            unset($data[$passwordKey]);
+        }
+
+        return $data;
+    }
+}

--- a/src/Symfony/Component/Security/Http/Tests/HttpUtilsTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/HttpUtilsTest.php
@@ -13,7 +13,8 @@ namespace Symfony\Component\Security\Http\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\Generator\UrlGenerator;
@@ -142,18 +143,16 @@ class HttpUtilsTest extends TestCase
 
     public function testCreateRedirectResponseWithRouteName()
     {
-        $utils = new HttpUtils($urlGenerator = $this->createMock(UrlGeneratorInterface::class));
+        $utils = new HttpUtils($urlGenerator = $this->createStub(UrlGeneratorInterface::class));
 
         $urlGenerator
-            ->expects($this->any())
             ->method('generate')
             ->with('foobar', [], UrlGeneratorInterface::ABSOLUTE_URL)
             ->willReturn('http://localhost/foo/bar')
         ;
         $urlGenerator
-            ->expects($this->any())
             ->method('getContext')
-            ->willReturn($this->createMock(RequestContext::class))
+            ->willReturn(new RequestContext())
         ;
 
         $response = $utils->createRedirectResponse($this->getRequest(), 'foobar');
@@ -186,7 +185,7 @@ class HttpUtilsTest extends TestCase
         $urlGenerator
             ->expects($this->any())
             ->method('getContext')
-            ->willReturn($this->createMock(RequestContext::class))
+            ->willReturn(new RequestContext())
         ;
 
         $subRequest = $utils->createRequest($this->getRequest(), 'foobar');
@@ -196,7 +195,7 @@ class HttpUtilsTest extends TestCase
 
     public function testCreateRequestWithAbsoluteUrl()
     {
-        $utils = new HttpUtils($this->createMock(UrlGeneratorInterface::class));
+        $utils = new HttpUtils($this->createStub(UrlGeneratorInterface::class));
         $subRequest = $utils->createRequest($this->getRequest(), 'http://symfony.com/');
 
         $this->assertEquals('/', $subRequest->getPathInfo());
@@ -205,7 +204,7 @@ class HttpUtilsTest extends TestCase
     public function testCreateRequestPassesSessionToTheNewRequest()
     {
         $request = $this->getRequest();
-        $request->setSession($session = $this->createMock(SessionInterface::class));
+        $request->setSession($session = new Session(new MockArraySessionStorage()));
 
         $utils = new HttpUtils($this->getUrlGenerator());
         $subRequest = $utils->createRequest($request, '/foobar');
@@ -279,9 +278,8 @@ class HttpUtilsTest extends TestCase
 
     public function testCheckRequestPathWithUrlMatcherAndResourceNotFound()
     {
-        $urlMatcher = $this->createMock(UrlMatcherInterface::class);
+        $urlMatcher = $this->createStub(UrlMatcherInterface::class);
         $urlMatcher
-            ->expects($this->any())
             ->method('match')
             ->with('/')
             ->willThrowException(new ResourceNotFoundException())
@@ -294,9 +292,8 @@ class HttpUtilsTest extends TestCase
     public function testCheckRequestPathWithUrlMatcherAndMethodNotAllowed()
     {
         $request = $this->getRequest();
-        $urlMatcher = $this->createMock(RequestMatcherInterface::class);
+        $urlMatcher = $this->createStub(RequestMatcherInterface::class);
         $urlMatcher
-            ->expects($this->any())
             ->method('matchRequest')
             ->with($request)
             ->willThrowException(new MethodNotAllowedException([]))
@@ -308,9 +305,8 @@ class HttpUtilsTest extends TestCase
 
     public function testCheckRequestPathWithUrlMatcherAndResourceFoundByUrl()
     {
-        $urlMatcher = $this->createMock(UrlMatcherInterface::class);
+        $urlMatcher = $this->createStub(UrlMatcherInterface::class);
         $urlMatcher
-            ->expects($this->any())
             ->method('match')
             ->with('/foo/bar')
             ->willReturn(['_route' => 'foobar'])
@@ -323,9 +319,8 @@ class HttpUtilsTest extends TestCase
     public function testCheckRequestPathWithUrlMatcherAndResourceFoundByRequest()
     {
         $request = $this->getRequest();
-        $urlMatcher = $this->createMock(RequestMatcherInterface::class);
+        $urlMatcher = $this->createStub(RequestMatcherInterface::class);
         $urlMatcher
-            ->expects($this->any())
             ->method('matchRequest')
             ->with($request)
             ->willReturn(['_route' => 'foobar'])
@@ -338,9 +333,8 @@ class HttpUtilsTest extends TestCase
     public function testCheckRequestPathWithUrlMatcherLoadingException()
     {
         $this->expectException(\RuntimeException::class);
-        $urlMatcher = $this->createMock(UrlMatcherInterface::class);
+        $urlMatcher = $this->createStub(UrlMatcherInterface::class);
         $urlMatcher
-            ->expects($this->any())
             ->method('match')
             ->willThrowException(new \RuntimeException())
         ;
@@ -367,9 +361,8 @@ class HttpUtilsTest extends TestCase
 
     public function testCheckPathWithoutRouteParam()
     {
-        $urlMatcher = $this->createMock(UrlMatcherInterface::class);
+        $urlMatcher = $this->createStub(UrlMatcherInterface::class);
         $urlMatcher
-            ->expects($this->any())
             ->method('match')
             ->willReturn(['_controller' => 'PathController'])
         ;
@@ -406,9 +399,8 @@ class HttpUtilsTest extends TestCase
 
     private function getUrlGenerator($generatedUrl = '/foo/bar')
     {
-        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator = $this->createStub(UrlGeneratorInterface::class);
         $urlGenerator
-            ->expects($this->any())
             ->method('generate')
             ->willReturn($generatedUrl)
         ;

--- a/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Security\Http\Tests\LoginLink;
 
 use PHPUnit\Framework\Constraint\Constraint;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
@@ -32,7 +31,7 @@ use Symfony\Component\Security\Http\LoginLink\LoginLinkHandler;
 
 class LoginLinkHandlerTest extends TestCase
 {
-    private MockObject&UrlGeneratorInterface $router;
+    private UrlGeneratorInterface $router;
     private TestLoginLinkHandlerUserProvider $userProvider;
     private PropertyAccessorInterface $propertyAccessor;
     private ExpiredSignatureStorage $expiredLinkStorage;
@@ -40,7 +39,6 @@ class LoginLinkHandlerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->router = $this->createMock(UrlGeneratorInterface::class);
         $this->userProvider = new TestLoginLinkHandlerUserProvider();
         $this->propertyAccessor = PropertyAccess::createPropertyAccessor();
         $this->expiredLinkCache = new ArrayAdapter();
@@ -54,6 +52,7 @@ class LoginLinkHandlerTest extends TestCase
      */
     public function testCreateLoginLink($user, array $extraProperties, ?Request $request = null)
     {
+        $this->router = $this->createMock(UrlGeneratorInterface::class);
         $this->router->expects($this->once())
             ->method('generate')
             ->with(
@@ -125,6 +124,7 @@ class LoginLinkHandlerTest extends TestCase
     {
         $extraProperties = ['emailProperty' => 'ryan@symfonycasts.com', 'passwordProperty' => 'pwhash'];
 
+        $this->router = $this->createMock(UrlGeneratorInterface::class);
         $this->router->expects($this->once())
             ->method('generate')
             ->with(
@@ -279,7 +279,7 @@ class LoginLinkHandlerTest extends TestCase
             'route_name' => 'app_check_login_link_route',
         ], $options);
 
-        return new LoginLinkHandler($this->router, $this->userProvider, new SignatureHasher($this->propertyAccessor, $extraProperties, 's3cret', $this->expiredLinkStorage, $options['max_uses'] ?? null), $options);
+        return new LoginLinkHandler($this->router ?? $this->createStub(UrlGeneratorInterface::class), $this->userProvider, new SignatureHasher($this->propertyAccessor, $extraProperties, 's3cret', $this->expiredLinkStorage, $options['max_uses'] ?? null), $options);
     }
 }
 

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/ResponseListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/ResponseListenerTest.php
@@ -90,6 +90,6 @@ class ResponseListenerTest extends TestCase
 
     private function getEvent(Request $request, Response $response, int $type = HttpKernelInterface::MAIN_REQUEST): ResponseEvent
     {
-        return new ResponseEvent($this->createMock(HttpKernelInterface::class), $request, $type, $response);
+        return new ResponseEvent($this->createStub(HttpKernelInterface::class), $request, $type, $response);
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Session/SessionAuthenticationStrategyTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Session/SessionAuthenticationStrategyTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Security\Http\Tests\Session;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authentication\Token\NullToken;
 use Symfony\Component\Security\Csrf\TokenStorage\ClearableTokenStorageInterface;
 use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategy;
 
@@ -22,22 +22,22 @@ class SessionAuthenticationStrategyTest extends TestCase
 {
     public function testSessionIsNotChanged()
     {
-        $request = $this->getRequest();
+        $request = $this->createMock(Request::class);
         $request->expects($this->never())->method('getSession');
 
         $strategy = new SessionAuthenticationStrategy(SessionAuthenticationStrategy::NONE);
-        $strategy->onAuthentication($request, $this->createMock(TokenInterface::class));
+        $strategy->onAuthentication($request, new NullToken());
     }
 
     public function testUnsupportedStrategy()
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Invalid session authentication strategy "foo"');
-        $request = $this->getRequest();
+        $request = $this->createMock(Request::class);
         $request->expects($this->never())->method('getSession');
 
         $strategy = new SessionAuthenticationStrategy('foo');
-        $strategy->onAuthentication($request, $this->createMock(TokenInterface::class));
+        $strategy->onAuthentication($request, new NullToken());
     }
 
     public function testSessionIsMigrated()
@@ -46,7 +46,7 @@ class SessionAuthenticationStrategyTest extends TestCase
         $session->expects($this->once())->method('migrate')->with($this->equalTo(true));
 
         $strategy = new SessionAuthenticationStrategy(SessionAuthenticationStrategy::MIGRATE);
-        $strategy->onAuthentication($this->getRequest($session), $this->createMock(TokenInterface::class));
+        $strategy->onAuthentication($this->getRequest($session), new NullToken());
     }
 
     public function testSessionIsInvalidated()
@@ -55,7 +55,7 @@ class SessionAuthenticationStrategyTest extends TestCase
         $session->expects($this->once())->method('invalidate');
 
         $strategy = new SessionAuthenticationStrategy(SessionAuthenticationStrategy::INVALIDATE);
-        $strategy->onAuthentication($this->getRequest($session), $this->createMock(TokenInterface::class));
+        $strategy->onAuthentication($this->getRequest($session), new NullToken());
     }
 
     public function testCsrfTokensAreCleared()
@@ -67,15 +67,15 @@ class SessionAuthenticationStrategyTest extends TestCase
         $csrfStorage->expects($this->once())->method('clear');
 
         $strategy = new SessionAuthenticationStrategy(SessionAuthenticationStrategy::MIGRATE, $csrfStorage);
-        $strategy->onAuthentication($this->getRequest($session), $this->createMock(TokenInterface::class));
+        $strategy->onAuthentication($this->getRequest($session), new NullToken());
     }
 
     private function getRequest($session = null)
     {
-        $request = $this->createMock(Request::class);
+        $request = new Request();
 
         if (null !== $session) {
-            $request->expects($this->any())->method('getSession')->willReturn($session);
+            $request->setSession($session);
         }
 
         return $request;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | part of #62669
| License       | MIT
