### PR TITLE
[Serializer] Fix inconsistent field naming from accessors when using groups

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -107,7 +107,7 @@ class ObjectNormalizer extends AbstractObjectNormalizer
                 'i' => str_starts_with($name, 'is') && isset($name[$i = 2]),
                 default => false,
             } && !ctype_lower($name[$i])) {
-                if ($this->hasProperty($reflMethod, $name)) {
+                if ($this->hasProperty($reflMethod->getDeclaringClass(), $name)) {
                     $attributeName = $name;
                 } else {
                     $attributeName = substr($name, $i);
@@ -139,10 +139,8 @@ class ObjectNormalizer extends AbstractObjectNormalizer
         return array_keys($attributes);
     }
 
-    private function hasProperty(\ReflectionMethod $method, string $propName): bool
+    private function hasProperty(\ReflectionClass $class, string $propName): bool
     {
-        $class = $method->getDeclaringClass();
-
         do {
             if ($class->hasProperty($propName)) {
                 return true;

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/GroupDummyWithIsPrefixedProperty.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/GroupDummyWithIsPrefixedProperty.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures\Attributes;
+
+use Symfony\Component\Serializer\Attribute\Groups;
+
+class GroupDummyWithIsPrefixedProperty
+{
+    private bool $isSomething = false;
+
+    #[Groups(['test'])]
+    public function isSomething(): bool
+    {
+        return $this->isSomething;
+    }
+
+    public function setIsSomething(bool $isSomething): void
+    {
+        $this->isSomething = $isSomething;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -39,6 +39,7 @@ use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Component\Serializer\Tests\Fixtures\Attributes\GroupDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\GroupDummyWithIsPrefixedProperty;
 use Symfony\Component\Serializer\Tests\Fixtures\CircularReferenceDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyPrivatePropertyWithoutGetter;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyWithUnion;
@@ -1109,8 +1110,7 @@ class ObjectNormalizerTest extends TestCase
 
         $this->assertSame([
             'foo' => 'foo',
-        ],
-            $normalized);
+        ], $normalized);
     }
 
     /**
@@ -1165,6 +1165,22 @@ class ObjectNormalizerTest extends TestCase
         );
 
         $this->assertInstanceOf(DiscriminatorDummyTypeA::class, $obj);
+    }
+
+    public function testNormalizeObjectWithGroupsAndIsPrefixedProperty()
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
+        $normalizer = new ObjectNormalizer($classMetadataFactory);
+        $serializer = new Serializer([$normalizer]);
+        $normalizer->setSerializer($serializer);
+
+        $object = new GroupDummyWithIsPrefixedProperty();
+
+        $normalizedWithoutGroups = $normalizer->normalize($object);
+        $this->assertArrayHasKey('isSomething', $normalizedWithoutGroups);
+
+        $normalizedWithGroups = $normalizer->normalize($object, null, [AbstractNormalizer::GROUPS => ['test']]);
+        $this->assertArrayHasKey('isSomething', $normalizedWithGroups);
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62579
| License       | MIT

This adds the fix done on ObjectNormalizer in #61097 to AttributeLoader, fixing an inconsistency that leads to the linked issue.