### PR TITLE
 Don't use `->getDeclaringClass()` when `->class` is enough

### DIFF
--- a/src/Symfony/Component/Console/Attribute/Interact.php
+++ b/src/Symfony/Component/Console/Attribute/Interact.php
@@ -29,11 +29,11 @@ class Interact implements InteractiveAttributeInterface
         }
 
         if (!$method->isPublic() || $method->isStatic()) {
-            throw new LogicException(\sprintf('The interactive method "%s::%s()" must be public and non-static.', $method->getDeclaringClass()->getName(), $method->getName()));
+            throw new LogicException(\sprintf('The interactive method "%s::%s()" must be public and non-static.', $method->class, $method->getName()));
         }
 
         if ('__invoke' === $method->getName()) {
-            throw new LogicException(\sprintf('The "%s::__invoke()" method cannot be used as an interactive method.', $method->getDeclaringClass()->getName()));
+            throw new LogicException(\sprintf('The "%s::__invoke()" method cannot be used as an interactive method.', $method->class));
         }
 
         $self->method = $method;

--- a/src/Symfony/Component/Console/Attribute/Reflection/ReflectionMember.php
+++ b/src/Symfony/Component/Console/Attribute/Reflection/ReflectionMember.php
@@ -36,7 +36,7 @@ class ReflectionMember
     public function getSourceName(): string
     {
         if ($this->member instanceof \ReflectionProperty) {
-            return $this->member->getDeclaringClass()->name;
+            return $this->member->class;
         }
 
         $function = $this->member->getDeclaringFunction();

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -109,7 +109,7 @@ class Command implements SignalableCommandInterface
             $this->addUsage($usage);
         }
 
-        if (!$code && \is_callable($this) && self::class === (new \ReflectionMethod($this, 'execute'))->getDeclaringClass()->name) {
+        if (!$code && \is_callable($this) && self::class === (new \ReflectionMethod($this, 'execute'))->class) {
             $this->code = new InvokableCommand($this, $this(...));
         }
 

--- a/src/Symfony/Component/Console/Command/TraceableCommand.php
+++ b/src/Symfony/Component/Console/Command/TraceableCommand.php
@@ -322,7 +322,7 @@ final class TraceableCommand extends Command
 
     protected function interact(InputInterface $input, OutputInterface $output): void
     {
-        if (!$this->isInteractive = Command::class !== (new \ReflectionMethod($this->command, 'interact'))->getDeclaringClass()->getName()) {
+        if (!$this->isInteractive = Command::class !== (new \ReflectionMethod($this->command, 'interact'))->class) {
             return;
         }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
@@ -203,7 +203,7 @@ final class CheckTypeDeclarationsPass extends AbstractRecursivePass
         }
 
         if ('self' === $type) {
-            $type = $parameter->getDeclaringClass()->getName();
+            $type = $parameter->getDeclaringClass()->name;
         }
 
         if ('static' === $type) {

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1285,7 +1285,7 @@ class PhpDumper extends Dumper
             if (null !== $r
                 && (null !== $constructor = $r->getConstructor())
                 && 0 === $constructor->getNumberOfRequiredParameters()
-                && Container::class !== $constructor->getDeclaringClass()->name
+                && Container::class !== $constructor->class
             ) {
                 $code .= "        parent::__construct();\n";
                 $code .= "        \$this->parameterBag = null;\n\n";

--- a/src/Symfony/Component/DependencyInjection/Exception/InvalidParameterTypeException.php
+++ b/src/Symfony/Component/DependencyInjection/Exception/InvalidParameterTypeException.php
@@ -27,7 +27,7 @@ class InvalidParameterTypeException extends InvalidArgumentException
 
         $function = $parameter->getDeclaringFunction();
         $functionName = $function instanceof \ReflectionMethod
-            ? \sprintf('%s::%s', $function->getDeclaringClass()->getName(), $function->getName())
+            ? \sprintf('%s::%s', $function->class, $function->getName())
             : $function->getName();
 
         parent::__construct(\sprintf('Invalid definition for service "%s": argument %d of "%s()" accepts "%s", "%s" passed.', $serviceId, 1 + $parameter->getPosition(), $functionName, $acceptedType, $type));

--- a/src/Symfony/Component/Runtime/SymfonyRuntime.php
+++ b/src/Symfony/Component/Runtime/SymfonyRuntime.php
@@ -187,7 +187,7 @@ class SymfonyRuntime extends GenericRuntime
             if (!$application->getName() || !$console->has($application->getName())) {
                 $application->setName($_SERVER['argv'][0]);
 
-                if (!method_exists($console, 'addCommand') || method_exists($console, 'add') && (new \ReflectionMethod($console, 'add'))->getDeclaringClass()->getName() !== (new \ReflectionMethod($console, 'addCommand'))->getDeclaringClass()->getName()) {
+                if (!method_exists($console, 'addCommand') || method_exists($console, 'add') && (new \ReflectionMethod($console, 'add'))->class !== (new \ReflectionMethod($console, 'addCommand'))->class) {
                     $console->add($application);
                 } else {
                     $console->addCommand($application);

--- a/src/Symfony/Component/Serializer/Mapping/Loader/AttributeLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AttributeLoader.php
@@ -100,7 +100,7 @@ class AttributeLoader implements LoaderInterface
             }
 
             $attributeMetadata = $attributesMetadata[$property->name];
-            if ($property->getDeclaringClass()->name === $className) {
+            if ($property->class === $className) {
                 if ($classContextAttribute) {
                     $this->setAttributeContextsForGroups($classContextAttribute, $attributeMetadata);
                 }
@@ -133,7 +133,7 @@ class AttributeLoader implements LoaderInterface
         }
 
         foreach ($reflectionClass->getMethods() as $method) {
-            if ($method->getDeclaringClass()->name !== $className) {
+            if ($method->class !== $className) {
                 continue;
             }
 
@@ -211,8 +211,8 @@ class AttributeLoader implements LoaderInterface
                     }
                     $on = match (true) {
                         $reflector instanceof \ReflectionClass => ' on class '.$reflector->name,
-                        $reflector instanceof \ReflectionMethod => \sprintf(' on "%s::%s()"', $reflector->getDeclaringClass()->name, $reflector->name),
-                        $reflector instanceof \ReflectionProperty => \sprintf(' on "%s::$%s"', $reflector->getDeclaringClass()->name, $reflector->name),
+                        $reflector instanceof \ReflectionMethod => \sprintf(' on "%s::%s()"', $reflector->class, $reflector->name),
+                        $reflector instanceof \ReflectionProperty => \sprintf(' on "%s::$%s"', $reflector->class, $reflector->name),
                         default => '',
                     };
 

--- a/src/Symfony/Component/TypeInfo/TypeResolver/ReflectionPropertyTypeResolver.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/ReflectionPropertyTypeResolver.php
@@ -41,7 +41,7 @@ final class ReflectionPropertyTypeResolver implements TypeResolverInterface
         try {
             return $this->reflectionTypeResolver->resolve($subject->getType(), $typeContext);
         } catch (UnsupportedException $e) {
-            $path = \sprintf('%s::$%s', $subject->getDeclaringClass()->getName(), $subject->getName());
+            $path = \sprintf('%s::$%s', $subject->class, $subject->getName());
 
             throw new UnsupportedException(\sprintf('Cannot resolve type for "%s".', $path), $subject, previous: $e);
         }

--- a/src/Symfony/Component/Validator/Mapping/Loader/AttributeLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/AttributeLoader.php
@@ -78,7 +78,7 @@ class AttributeLoader implements LoaderInterface
         }
 
         foreach ($reflClass->getProperties() as $property) {
-            if ($property->getDeclaringClass()->name === $className) {
+            if ($property->class === $className) {
                 foreach ($this->getAttributes($property) as $constraint) {
                     if ($constraint instanceof Constraint) {
                         $metadata->addPropertyConstraint($property->name, $constraint);
@@ -90,7 +90,7 @@ class AttributeLoader implements LoaderInterface
         }
 
         foreach ($reflClass->getMethods() as $method) {
-            if ($method->getDeclaringClass()->name === $className) {
+            if ($method->class === $className) {
                 foreach ($this->getAttributes($method) as $constraint) {
                     if ($constraint instanceof Callback) {
                         $constraint->callback = $method->getName();

--- a/src/Symfony/Component/Validator/Mapping/Loader/StaticMethodLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/StaticMethodLoader.php
@@ -47,7 +47,7 @@ class StaticMethodLoader implements LoaderInterface
                 throw new MappingException(\sprintf('The method "%s::%s()" should be static.', $reflClass->name, $this->methodName));
             }
 
-            if ($reflMethod->getDeclaringClass()->name != $reflClass->name) {
+            if ($reflMethod->class != $reflClass->name) {
                 return false;
             }
 

--- a/src/Symfony/Contracts/Service/ServiceMethodsSubscriberTrait.php
+++ b/src/Symfony/Contracts/Service/ServiceMethodsSubscriberTrait.php
@@ -33,7 +33,7 @@ trait ServiceMethodsSubscriberTrait
         $services = method_exists(get_parent_class(self::class) ?: '', __FUNCTION__) ? parent::getSubscribedServices() : [];
 
         foreach ((new \ReflectionClass(self::class))->getMethods() as $method) {
-            if (self::class !== $method->getDeclaringClass()->name) {
+            if (self::class !== $method->class) {
                 continue;
             }
 

--- a/src/Symfony/Contracts/Service/ServiceSubscriberTrait.php
+++ b/src/Symfony/Contracts/Service/ServiceSubscriberTrait.php
@@ -37,7 +37,7 @@ trait ServiceSubscriberTrait
         $services = method_exists(get_parent_class(self::class) ?: '', __FUNCTION__) ? parent::getSubscribedServices() : [];
 
         foreach ((new \ReflectionClass(self::class))->getMethods() as $method) {
-            if (self::class !== $method->getDeclaringClass()->name) {
+            if (self::class !== $method->class) {
                 continue;
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT
