### PR TITLE
[Cache][HttpFoundation] Fix VARBINARY columns on sqlsrv

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/PdoAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/PdoAdapter.php
@@ -314,7 +314,17 @@ class PdoAdapter extends AbstractAdapter implements PruneableInterface
             $insertStmt->bindValue(':time', $now, \PDO::PARAM_INT);
         }
 
+        if ('sqlsrv' === $driver) {
+            $dataStream = fopen('php://memory', 'r+');
+        }
         foreach ($values as $id => $data) {
+            if ('sqlsrv' === $driver) {
+                rewind($dataStream);
+                fwrite($dataStream, $data);
+                ftruncate($dataStream, \strlen($data));
+                rewind($dataStream);
+                $data = $dataStream;
+            }
             try {
                 $stmt->execute();
             } catch (\PDOException $e) {

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
@@ -390,6 +390,46 @@ class PdoSessionHandlerTest extends TestCase
         }
     }
 
+    public function testSqlsrvDataBindingUsesStream()
+    {
+        $pdo = new MockPdo('sqlsrv', null, '10');
+        $boundData = [];
+
+        $mergeStmt = $this->createMock(\PDOStatement::class);
+        $selectStmt = $this->createMock(\PDOStatement::class);
+        $selectStmt->method('fetchAll')->willReturn([]);
+
+        $mergeStmt->method('bindParam')
+            ->willReturnCallback(function ($param, $data, $type = null) use (&$boundData) {
+                $boundData[$param] = ['data' => $data, 'type' => $type];
+
+                return true;
+            });
+
+        $mergeStmt->method('bindValue')->willReturn(true);
+        $mergeStmt->method('execute')->willReturn(true);
+
+        $pdo->prepareResult = fn ($statement) => str_starts_with($statement, 'MERGE') ? $mergeStmt : $selectStmt;
+
+        $storage = new PdoSessionHandler($pdo, ['lock_mode' => PdoSessionHandler::LOCK_NONE]);
+        $storage->open('', 'sid');
+        $storage->read('id');
+        $storage->write('id', 'test_data');
+        $storage->close();
+
+        $this->assertArrayHasKey(3, $boundData);
+        $this->assertIsResource($boundData[3]['data']);
+        $this->assertSame(\PDO::PARAM_LOB, $boundData[3]['type']);
+        rewind($boundData[3]['data']);
+        $this->assertSame('test_data', stream_get_contents($boundData[3]['data']));
+
+        $this->assertArrayHasKey(6, $boundData);
+        $this->assertIsResource($boundData[6]['data']);
+        $this->assertSame(\PDO::PARAM_LOB, $boundData[6]['type']);
+        rewind($boundData[6]['data']);
+        $this->assertSame('test_data', stream_get_contents($boundData[6]['data']));
+    }
+
     /**
      * @return resource
      */
@@ -408,11 +448,13 @@ class MockPdo extends \PDO
     public \Closure|\PDOStatement|false $prepareResult;
     private ?string $driverName;
     private bool|int $errorMode;
+    private ?string $serverVersion;
 
-    public function __construct(?string $driverName = null, ?int $errorMode = null)
+    public function __construct(?string $driverName = null, ?int $errorMode = null, ?string $serverVersion = null)
     {
         $this->driverName = $driverName;
         $this->errorMode = null !== $errorMode ?: \PDO::ERRMODE_EXCEPTION;
+        $this->serverVersion = $serverVersion;
     }
 
     public function getAttribute($attribute): mixed
@@ -423,6 +465,10 @@ class MockPdo extends \PDO
 
         if (\PDO::ATTR_DRIVER_NAME === $attribute) {
             return $this->driverName;
+        }
+
+        if (\PDO::ATTR_SERVER_VERSION === $attribute) {
+            return $this->serverVersion;
         }
 
         return parent::getAttribute($attribute);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62241
| License       | MIT

PdoSessionHandler was failing against SQL Azure when writing session data to a VARBINARY(MAX) column because the pdo_sqlsrv driver sent the data as nvarchar, which SQL Server cannot implicitly convert to varbinary(max).

This patch makes the sqlsrv driver use a stream resource for session data (like the existing oci handling), both for INSERT/UPDATE statements and the MERGE upsert path. This ensures the data is treated as binary and avoids the implicit conversion error, while keeping the existing schema (VARBINARY(MAX)) unchanged.

A new test (testSqlsrvDataBindingUsesStream) verifies that, for sqlsrv, the session data is bound as a PDO::PARAM_LOB resource when using the MERGE path.
