### PR TITLE
[HttpKernel] Add support for bundles as compiler passes

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add support for bundles as compiler pass
+
 8.0
 ---
 

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -616,6 +616,10 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
             if ($this->debug) {
                 $container->addObjectResource($bundle);
             }
+
+            if ($bundle instanceof CompilerPassInterface) {
+                $container->addCompilerPass($bundle, PassConfig::TYPE_BEFORE_OPTIMIZATION, -10000);
+            }
         }
 
         foreach ($this->bundles as $bundle) {

--- a/src/Symfony/Component/HttpKernel/Tests/Bundle/BundleTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Bundle/BundleTest.php
@@ -12,7 +12,10 @@
 namespace Symfony\Component\HttpKernel\Tests\Bundle;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\HttpKernel\Tests\Fixtures\BundleCompilerPass\BundleAsCompilerPassBundle;
 use Symfony\Component\HttpKernel\Tests\Fixtures\ExtensionPresentBundle\ExtensionPresentBundle;
 
 class BundleTest extends TestCase
@@ -42,6 +45,29 @@ class BundleTest extends TestCase
         $this->assertSame('ExplicitlyNamedBundle', $bundle->getName());
         $this->assertSame('Symfony\Component\HttpKernel\Tests\Bundle', $bundle->getNamespace());
         $this->assertSame('ExplicitlyNamedBundle', $bundle->getName());
+    }
+
+    public function testBundleAsCompilerPass()
+    {
+        $kernel = new class('test', true) extends Kernel {
+            public function registerBundles(): iterable
+            {
+                yield new BundleAsCompilerPassBundle();
+            }
+
+            public function registerContainerConfiguration(LoaderInterface $loader): void
+            {
+            }
+
+            public function getProjectDir(): string
+            {
+                return sys_get_temp_dir().'/bundle_as_compiler_pass';
+            }
+        };
+
+        $kernel->boot();
+
+        $this->assertTrue($kernel->getContainer()->has('foo'));
     }
 }
 

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/BundleCompilerPass/BundleAsCompilerPassBundle.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/BundleCompilerPass/BundleAsCompilerPassBundle.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures\BundleCompilerPass;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
+
+class BundleAsCompilerPassBundle extends AbstractBundle implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $container->register('foo', \stdClass::class)
+            ->setPublic(true);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #62470
| License       | MIT

Adds a bundle-level compiler pass to hook into the container compilation phase:
```php
class MyBundle extends AbstractBundle implements CompilerPassInterface
{
    public function process(ContainerBuilder $container): void
    {
        // ...
    }
}
```
