### PR TITLE
[Notifier][Prelude] Add bridge 

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -3207,6 +3207,7 @@ class FrameworkExtension extends Extension
             NotifierBridge\OvhCloud\OvhCloudTransportFactory::class => 'notifier.transport_factory.ovh-cloud',
             NotifierBridge\PagerDuty\PagerDutyTransportFactory::class => 'notifier.transport_factory.pager-duty',
             NotifierBridge\Plivo\PlivoTransportFactory::class => 'notifier.transport_factory.plivo',
+            NotifierBridge\Prelude\PreludeTransportFactory::class => 'notifier.transport_factory.prelude',
             NotifierBridge\Primotexto\PrimotextoTransportFactory::class => 'notifier.transport_factory.primotexto',
             NotifierBridge\Pushover\PushoverTransportFactory::class => 'notifier.transport_factory.pushover',
             NotifierBridge\Pushy\PushyTransportFactory::class => 'notifier.transport_factory.pushy',

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_transports.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_transports.php
@@ -89,6 +89,7 @@ return static function (ContainerConfigurator $container) {
         'orange-sms' => Bridge\OrangeSms\OrangeSmsTransportFactory::class,
         'ovh-cloud' => Bridge\OvhCloud\OvhCloudTransportFactory::class,
         'plivo' => Bridge\Plivo\PlivoTransportFactory::class,
+        'prelude' => Bridge\Prelude\PreludeTransportFactory::class,
         'primotexto' => Bridge\Primotexto\PrimotextoTransportFactory::class,
         'pushover' => Bridge\Pushover\PushoverTransportFactory::class,
         'pushy' => Bridge\Pushy\PushyTransportFactory::class,

--- a/src/Symfony/Component/Notifier/Bridge/Prelude/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Prelude/.gitattributes
@@ -1,0 +1,3 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Prelude/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Symfony/Component/Notifier/Bridge/Prelude/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/symfony
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Prelude/.github/workflows/close-pull-request.yml
+++ b/src/Symfony/Component/Notifier/Bridge/Prelude/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/symfony
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/Symfony/Component/Notifier/Bridge/Prelude/.gitignore
+++ b/src/Symfony/Component/Notifier/Bridge/Prelude/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+composer.lock
+phpunit.xml

--- a/src/Symfony/Component/Notifier/Bridge/Prelude/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Prelude/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+8.1
+---
+
+ * Add bridge

--- a/src/Symfony/Component/Notifier/Bridge/Prelude/LICENSE
+++ b/src/Symfony/Component/Notifier/Bridge/Prelude/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2026-present Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/Notifier/Bridge/Prelude/PreludeOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Prelude/PreludeOptions.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Prelude;
+
+use Symfony\Component\Notifier\Message\MessageOptionsInterface;
+
+/**
+ * @author Imad Zairig <imadzairig@gmail.com>
+ */
+final class PreludeOptions implements MessageOptionsInterface
+{
+    public function __construct(
+        private array $options = [],
+    ) {
+    }
+
+    public function toArray(): array
+    {
+        return $this->options;
+    }
+
+    public function getRecipientId(): ?string
+    {
+        return null;
+    }
+
+    /**
+     * @return $this
+     */
+    public function templateId(string $templateId): static
+    {
+        $this->options['template_id'] = $templateId;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function variables(array $variables): static
+    {
+        $this->options['variables'] = $variables;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function from(string $from): static
+    {
+        $this->options['from'] = $from;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function locale(string $locale): static
+    {
+        $this->options['locale'] = $locale;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function expiresAt(string $expiresAt): static
+    {
+        $this->options['expires_at'] = $expiresAt;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function scheduleAt(string $scheduleAt): static
+    {
+        $this->options['schedule_at'] = $scheduleAt;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function callbackUrl(string $callbackUrl): static
+    {
+        $this->options['callback_url'] = $callbackUrl;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function correlationId(string $correlationId): static
+    {
+        $this->options['correlation_id'] = $correlationId;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function preferredChannel(string $preferredChannel): static
+    {
+        $this->options['preferred_channel'] = $preferredChannel;
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Prelude/PreludeTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Prelude/PreludeTransport.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Prelude;
+
+use Symfony\Component\Notifier\Exception\LogicException;
+use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
+use Symfony\Component\Notifier\Exception\UnsupportedOptionsException;
+use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\SentMessage;
+use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Component\Notifier\Transport\AbstractTransport;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Imad Zairig <imadzairig@gmail.com>
+ */
+final class PreludeTransport extends AbstractTransport
+{
+    protected const HOST = 'api.prelude.dev';
+
+    public function __construct(
+        #[\SensitiveParameter] private readonly string $apiKey,
+        private readonly string $sender,
+        ?HttpClientInterface $client = null,
+        ?EventDispatcherInterface $dispatcher = null,
+    ) {
+        parent::__construct($client, $dispatcher);
+    }
+
+    public function __toString(): string
+    {
+        return \sprintf('prelude://%s?sender=%s', $this->getEndpoint(), $this->sender);
+    }
+
+    public function supports(MessageInterface $message): bool
+    {
+        return $message instanceof SmsMessage;
+    }
+
+    protected function doSend(MessageInterface $message): SentMessage
+    {
+        if (!$message instanceof SmsMessage) {
+            throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
+        }
+
+        if (($options = $message->getOptions()) && !$options instanceof PreludeOptions) {
+            throw new UnsupportedOptionsException(__CLASS__, PreludeOptions::class, $options);
+        }
+
+        $options = $options?->toArray() ?? [];
+
+        $body = [
+            'to' => $message->getPhone(),
+        ];
+
+        if ($this->sender) {
+            $body['from'] = $this->sender;
+        }
+
+        if (!isset($options['template_id'])) {
+            throw new LogicException(\sprintf('The "template_id" option is required for the "%s" transport.', __CLASS__));
+        }
+
+        $body = array_merge($body, $options);
+
+        $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/v2/notify', [
+            'json' => $body,
+            'headers' => [
+                'Authorization' => 'Bearer '.$this->apiKey,
+            ],
+        ]);
+
+        try {
+            $statusCode = $response->getStatusCode();
+        } catch (TransportExceptionInterface $error) {
+            throw new TransportException('Unable to send the SMS: '.($error->getMessage() ?: $response->getContent(false)), $response);
+        }
+
+        if (200 !== $statusCode && 201 !== $statusCode) {
+            $error = $response->toArray(false);
+
+            throw new TransportException('Unable to send the SMS: '.($error['message'] ?? $response->getContent(false)), $response);
+        }
+
+        $success = $response->toArray(false);
+
+        $sentMessage = new SentMessage($message, (string) $this);
+        if (isset($success['id'])) {
+            $sentMessage->setMessageId($success['id']);
+        }
+
+        return $sentMessage;
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Prelude/PreludeTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Prelude/PreludeTransportFactory.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Prelude;
+
+use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
+use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
+use Symfony\Component\Notifier\Transport\Dsn;
+
+/**
+ * @author Imad <imadzairig@gmail.com>
+ */
+final class PreludeTransportFactory extends AbstractTransportFactory
+{
+    public function create(Dsn $dsn): PreludeTransport
+    {
+        $scheme = $dsn->getScheme();
+
+        if ('prelude' !== $scheme) {
+            throw new UnsupportedSchemeException($dsn, 'prelude', $this->getSupportedSchemes());
+        }
+
+        $apiKey = $this->getUser($dsn);
+        $sender = $dsn->getOption('sender'); // Sender might be optional if configured in Prelude dashboard
+        $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
+        $port = $dsn->getPort();
+
+        return (new PreludeTransport($apiKey, $sender ?? '', $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+    }
+
+    protected function getSupportedSchemes(): array
+    {
+        return ['prelude'];
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Prelude/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Prelude/README.md
@@ -1,0 +1,59 @@
+# Prelude Notifier
+
+The `prelude-notifier` package provides a [Prelude](https://prelude.dev/) bridge for Symfony Notifier.
+
+## Installation
+
+```bash
+composer require symfony/prelude-notifier
+```
+
+## Configuration
+
+1.  Register the bundle in your application (if not using Symfony Flex).
+2.  Configure the DSN in your `.env` file:
+
+    ```dotenv
+    # API Key is required
+    # Sender ID is optional (can be set in options or DSN)
+    PRELUDE_DSN=prelude://YOUR_API_KEY@default?sender=YOUR_SENDER_ID
+    ```
+
+## Usage
+
+The Prelude Notify API **requires** a `template_id`. You must use `PreludeOptions` to provide it.
+
+```php
+use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Component\Notifier\Bridge\Prelude\PreludeOptions;
+
+$options = new PreludeOptions(
+    templateId: 'template_01k8xxxxxxxxxxxxx', // Required
+    variables: [
+        'order_id' => '12345',
+        'amount' => '$49.99',
+    ],
+    // Optional parameters
+    // from: 'MySenderID',
+    // locale: 'fr-FR',
+    // callbackUrl: 'https://example.com/webhook',
+    // preferredChannel: 'whatsapp'
+);
+
+$message = (new SmsMessage('+33612345678', 'Subject (ignored)'))
+    ->options($options);
+
+$notifier->send($message);
+```
+
+### Options
+
+* `templateId` (string, required): The template identifier.
+* `variables` (array): Key-value pairs for template variables.
+* `from` (string): The Sender ID.
+* `locale` (string): BCP-47 formatted locale string.
+* `expiresAt` (string): Message expiration date (RFC3339).
+* `scheduleAt` (string): Schedule delivery time (RFC3339).
+* `callbackUrl` (string): URL for delivery events.
+* `correlationId` (string): User-defined identifier.
+* `preferredChannel` (string): 'sms' or 'whatsapp'.

--- a/src/Symfony/Component/Notifier/Bridge/Prelude/Tests/PreludeTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Prelude/Tests/PreludeTransportFactoryTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Prelude\Tests;
+
+use Symfony\Component\Notifier\Bridge\Prelude\PreludeTransportFactory;
+use Symfony\Component\Notifier\Test\AbstractTransportFactoryTestCase;
+use Symfony\Component\Notifier\Test\IncompleteDsnTestTrait;
+
+final class PreludeTransportFactoryTest extends AbstractTransportFactoryTestCase
+{
+    use IncompleteDsnTestTrait;
+
+    public function createFactory(): PreludeTransportFactory
+    {
+        return new PreludeTransportFactory();
+    }
+
+    public static function createProvider(): iterable
+    {
+        yield [
+            'prelude://host.test?sender=0611223344',
+            'prelude://apiKey@host.test?sender=0611223344',
+        ];
+    }
+
+    public static function supportsProvider(): iterable
+    {
+        yield [true, 'prelude://apiKey@default?sender=0611223344'];
+        yield [false, 'somethingElse://apiKey@default?sender=0611223344'];
+    }
+
+    public static function incompleteDsnProvider(): iterable
+    {
+        yield 'missing api_key' => ['prelude://default?sender=0611223344'];
+    }
+
+    public static function unsupportedSchemeProvider(): iterable
+    {
+        yield ['somethingElse://apiKey@default?sender=0611223344'];
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Prelude/Tests/PreludeTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Prelude/Tests/PreludeTransportTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Prelude\Tests;
+
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\Notifier\Bridge\Prelude\PreludeOptions;
+use Symfony\Component\Notifier\Bridge\Prelude\PreludeTransport;
+use Symfony\Component\Notifier\Exception\LogicException;
+use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Message\ChatMessage;
+use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Transport\DummyMessage;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class PreludeTransportTest extends TransportTestCase
+{
+    public static function createTransport(?HttpClientInterface $client = null): PreludeTransport
+    {
+        return (new PreludeTransport('api-key', '0611223344', $client ?? new MockHttpClient()))->setHost('host.test');
+    }
+
+    public static function toStringProvider(): iterable
+    {
+        yield ['prelude://host.test?sender=0611223344', self::createTransport()];
+    }
+
+    public static function supportedMessagesProvider(): iterable
+    {
+        yield [new SmsMessage('0611223344', 'Hello!')];
+    }
+
+    public static function unsupportedMessagesProvider(): iterable
+    {
+        yield [new ChatMessage('Hello!')];
+        yield [new DummyMessage()];
+    }
+
+    public function testSendWithErrorResponseThrowsTransportException()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->expects($this->exactly(2))
+            ->method('getStatusCode')
+            ->willReturn(400);
+        $response->expects($this->once())
+            ->method('getContent')
+            ->willReturn(json_encode(['code' => 400, 'message' => 'bad request']));
+
+        $client = new MockHttpClient(static fn (): ResponseInterface => $response);
+
+        $transport = self::createTransport($client);
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('Unable to send the SMS: bad request');
+
+        $transport->send(new SmsMessage('phone', 'testMessage', '', (new PreludeOptions())->templateId('tpl_123')));
+    }
+
+    public function testSendWithoutTemplateIdThrowsLogicException()
+    {
+        $transport = self::createTransport();
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The "template_id" option is required');
+
+        $transport->send(new SmsMessage('phone', 'testMessage'));
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Prelude/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Prelude/composer.json
@@ -1,0 +1,39 @@
+{
+    "name": "symfony/prelude-notifier",
+    "type": "symfony-notifier-bridge",
+    "description": "Symfony Prelude Notifier Bridge",
+    "keywords": [
+        "prelude",
+        "sms",
+        "notifier",
+        "symfony"
+    ],
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Imad Zairig",
+            "email": "imadzairig@gmail.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=8.4",
+        "symfony/http-client": "^7.4|^8.0",
+        "symfony/notifier": "^7.4|^8.0"
+    },
+    "require-dev": {
+        "symfony/http-client": "^7.4|^8.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Symfony\\Component\\Notifier\\Bridge\\Prelude\\": ""
+        },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev"
+}

--- a/src/Symfony/Component/Notifier/Bridge/Prelude/phpunit.xml.dist
+++ b/src/Symfony/Component/Notifier/Bridge/Prelude/phpunit.xml.dist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.3/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnDeprecation="true"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony Prelude Notifier Bridge Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <source ignoreSuppressionOfDeprecations="true">
+        <include>
+            <directory>./</directory>
+        </include>
+        <exclude>
+            <directory>./Resources</directory>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </source>
+
+    <extensions>
+        <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension" />
+    </extensions>
+</phpunit>

--- a/src/Symfony/Component/Notifier/Transport.php
+++ b/src/Symfony/Component/Notifier/Transport.php
@@ -75,6 +75,7 @@ final class Transport
         Bridge\OvhCloud\OvhCloudTransportFactory::class,
         Bridge\PagerDuty\PagerDutyTransportFactory::class,
         Bridge\Plivo\PlivoTransportFactory::class,
+        Bridge\Prelude\PreludeTransportFactory::class,
         Bridge\Primotexto\PrimotextoTransportFactory::class,
         Bridge\Pushover\PushoverTransportFactory::class,
         Bridge\Pushy\PushyTransportFactory::class,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Recipe    | https://github.com/symfony/recipes/pull/1502
| Issues        | Fix #62802
| License       | MIT

This PR adds the support for Prelude Notification ( Prelude is a provider for OTP, Transactional SMS , and whatsapp messaging)

https://docs.prelude.so/introduction/welcome-to-prelude

