### PR TITLE
[Form] Reset cache when `AbstractTypeExtension::getExtendedTypes` change

### DIFF
--- a/src/Symfony/Component/Config/Resource/StaticMethodResource.php
+++ b/src/Symfony/Component/Config/Resource/StaticMethodResource.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Resource;
+
+class StaticMethodResource implements SelfCheckingResourceInterface
+{
+    private string $hash;
+
+    /**
+     * @param array $staticMethod A callable represented as [className, methodName]
+     */
+    public function __construct(
+        private $staticMethod,
+    ) {
+    }
+
+    public function isFresh(int $timestamp): bool
+    {
+        $hash = $this->computeHash();
+        $this->hash ??= $hash;
+
+        return $this->hash === $hash;
+    }
+
+    public function __serialize(): array
+    {
+        $this->hash ??= $this->computeHash();
+
+        return [
+            'hash' => $this->hash,
+            'staticMethod' => $this->staticMethod,
+        ];
+    }
+
+    public function __unserialize(array $data): void
+    {
+        $this->hash = array_shift($data);
+        $this->staticMethod = array_shift($data);
+    }
+
+    public function __toString(): string
+    {
+        return 'static_method_resource'.$this->staticMethod[0].'::'.$this->staticMethod[1];
+    }
+
+    private function computeHash(): string
+    {
+        $hash = hash_init('xxh128');
+
+        $ret = ($this->staticMethod)();
+
+        if (is_iterable($ret)) {
+            foreach ($ret as $value) {
+                hash_update($hash, serialize($value));
+            }
+        } else {
+            hash_update($hash, serialize($ret));
+        }
+
+        return hash_final($hash);
+    }
+}

--- a/src/Symfony/Component/Form/DependencyInjection/FormPass.php
+++ b/src/Symfony/Component/Form/DependencyInjection/FormPass.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form\DependencyInjection;
 
+use Symfony\Component\Config\Resource\StaticMethodResource;
 use Symfony\Component\DependencyInjection\Argument\ArgumentInterface;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -90,6 +91,7 @@ class FormPass implements CompilerPassInterface
                     $typeExtensions[$extendedType][] = new Reference($serviceId);
                     $extendsTypes = true;
                 }
+                $container->addResource(new StaticMethodResource([$typeExtensionClass, 'getExtendedTypes']));
 
                 if (!$extendsTypes) {
                     throw new InvalidArgumentException(\sprintf('The getExtendedTypes() method for service "%s" does not return any extended types.', $serviceId));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62694
| License       | MIT

Not finished, obviously. But is this the way to go?
