### PR TITLE
[VarDumper] Fix dumper selection for Accept: */* requests

### DIFF
--- a/src/Symfony/Component/VarDumper/Tests/Dumper/functions/dump_with_accept_header_wildcard.phpt
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/functions/dump_with_accept_header_wildcard.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Test dump() with "Accept: */*" uses HTML dumper
+--FILE--
+<?php
+putenv('NO_COLOR=1');
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = \dirname($vendor);
+}
+require $vendor.'/vendor/autoload.php';
+
+$_SERVER['HTTP_ACCEPT'] = '*/*';
+dump('Test with wildcard');
+--EXPECTF--
+%a>Test with wildcard</%a

--- a/src/Symfony/Component/VarDumper/VarDumper.php
+++ b/src/Symfony/Component/VarDumper/VarDumper.php
@@ -76,11 +76,13 @@ class VarDumper
             case 'server' === $format:
             case $format && 'tcp' === parse_url($format, \PHP_URL_SCHEME):
                 $host = 'server' === $format ? $_SERVER['VAR_DUMPER_SERVER'] ?? '127.0.0.1:9912' : $format;
-                $dumper = str_contains($_SERVER['HTTP_ACCEPT'] ?? (\in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true) ? 'txt' : 'html'), 'html') ? new HtmlDumper() : new CliDumper();
+                $accept = $_SERVER['HTTP_ACCEPT'] ?? (\in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true) ? 'txt' : 'html');
+                $dumper = str_contains($accept, 'html') || str_contains($accept, '*/*') ? new HtmlDumper() : new CliDumper();
                 $dumper = new ServerDumper($host, $dumper, self::getDefaultContextProviders());
                 break;
             default:
-                $dumper = str_contains($_SERVER['HTTP_ACCEPT'] ?? (\in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true) ? 'txt' : 'html'), 'html') ? new HtmlDumper() : new CliDumper();
+                $accept = $_SERVER['HTTP_ACCEPT'] ?? (\in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true) ? 'txt' : 'html');
+                $dumper = str_contains($accept, 'html') || str_contains($accept, '*/*') ? new HtmlDumper() : new CliDumper();
         }
 
         if (!$dumper instanceof ServerDumper) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62787
| License       | MIT

## What does this fix?

Fixes incorrect dumper selection when `Accept: */*` header is present in HTTP requests, causing `dd()` and `dump()` output to disappear in browsers.

## The Problem

Since version 7.4.0 (PR #58070), when an HTTP request includes `Accept: */*` header, the dumper selection logic incorrectly chooses `CliDumper` instead of `HtmlDumper`. This causes dumps to be sent to STDOUT instead of being rendered in the browser response.

**Affected scenario:**
```php
// Browser makes request with Accept: */*
// dd(['test' => 123]) produces blank page instead of showing dump
```

Common with:
- AJAX requests without explicit Accept header
- API clients (Postman, Insomnia) 
- cURL without `-H "Accept: text/html"`
- PHP-FPM environments

## Root Cause

Current code only checks if Accept contains literal string `'html'`:
```php
str_contains($_SERVER['HTTP_ACCEPT'], 'html') ? new HtmlDumper() : new CliDumper()
```

According to [RFC 9110 Section 12.5.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.1), `*/*` means "accept any media type", including `text/html`.

## Solution

Added explicit check for wildcard pattern:
```php
$accept = $_SERVER['HTTP_ACCEPT'] ?? (\in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true) ? 'txt' : 'html');
$dumper = (str_contains($accept, 'html') || str_contains($accept, '*/*')) ? new HtmlDumper() : new CliDumper();
```

**Before:** `Accept: */*` → ❌ CliDumper (blank page)  
**After:** `Accept: */*` → ✅ HtmlDumper (dump visible)

## Backward Compatibility

✅ Fully backward compatible - only fixes broken behavior introduced in 7.4.0

**Test coverage:**
- `Accept: text/html` → HtmlDumper (unchanged)
- `Accept: */*` → HtmlDumper (fixed)
- `Accept: application/json` → CliDumper (unchanged)
- CLI SAPI → CliDumper (unchanged)