### PR TITLE
[Messenger] Incorrect filtering of signed messages based on routing

### DIFF
--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -174,7 +174,6 @@ class MessengerPass implements CompilerPassInterface
             $signingSerializerDefinition = $container->getDefinition('messenger.signing_serializer');
             $messageToSerializersMapping = $signingSerializerDefinition->getArgument(2);
 
-            $signedMessageTypes = array_intersect_key($signedMessageTypes, $messageToSerializersMapping);
             $signingSerializerDefinition->replaceArgument(2, array_keys($signedMessageTypes));
 
             // because transports accept any message types - not only listed ones - we have to decorate all serializers regardless of message signing


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

During compilation, messages that must be signed are correctly discovered from handler configuration.
However, `MessengerPass` was additionally filtering those messages using `Messenger` routing configuration via `array_intersect_key`.

This behavior may rely on an intended coupling between routing and message signing (@nicolas-grekas ?), but routing configuration can contain wildcard patterns (e.g. `Some\Command\*`) that do not correspond to concrete message class names.
As a result, valid messages could be incorrectly excluded from the signing process.

This change removes the dependency on Messenger routing when determining which messages should be signed.
Message signing now relies solely on messages discovered at compile time, which is the only accurate source.
