### PR TITLE
[Translation] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/Translation/Bridge/Crowdin/Tests/CrowdinProviderFactoryTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/Tests/CrowdinProviderFactoryTest.php
@@ -11,7 +11,11 @@
 
 namespace Symfony\Component\Translation\Bridge\Crowdin\Tests;
 
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Translation\Bridge\Crowdin\CrowdinProviderFactory;
+use Symfony\Component\Translation\Dumper\XliffFileDumper;
+use Symfony\Component\Translation\Loader\ArrayLoader;
 use Symfony\Component\Translation\Provider\ProviderFactoryInterface;
 use Symfony\Component\Translation\Test\ProviderFactoryTestCase;
 
@@ -48,6 +52,6 @@ class CrowdinProviderFactoryTest extends ProviderFactoryTestCase
 
     public function createFactory(): ProviderFactoryInterface
     {
-        return new CrowdinProviderFactory($this->getClient(), $this->getLogger(), $this->getDefaultLocale(), $this->getLoader(), $this->getXliffFileDumper());
+        return new CrowdinProviderFactory(new MockHttpClient(), new NullLogger(), $this->getDefaultLocale(), new ArrayLoader(), new XliffFileDumper());
     }
 }

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/Tests/CrowdinProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/Tests/CrowdinProviderTest.php
@@ -749,8 +749,8 @@ XLIFF
             },
         ];
 
-        $loader = $this->getLoader();
-        $loader->expects($this->once())
+        $this->loader = $this->createMock(LoaderInterface::class);
+        $this->loader->expects($this->once())
             ->method('load')
             ->willReturn($expectedTranslatorBag->getCatalogue($locale));
 
@@ -876,8 +876,8 @@ XLIFF
             },
         ];
 
-        $loader = $this->getLoader();
-        $loader->expects($this->once())
+        $this->loader = $this->createMock(LoaderInterface::class);
+        $this->loader->expects($this->once())
             ->method('load')
             ->willReturn($expectedTranslatorBag->getCatalogue($locale));
 
@@ -1061,13 +1061,7 @@ XLIFF
                 $this->assertSame('GET', $method);
                 $this->assertSame('https://api.crowdin.com/api/v2/projects/1/strings?fileId=12&limit=500&offset=500', $url);
 
-                $response = $this->createMock(ResponseInterface::class);
-                $response->expects($this->any())
-                    ->method('getContent')
-                    ->with(false)
-                    ->willReturn(json_encode(['data' => []]));
-
-                return $response;
+                return new JsonMockResponse(['data' => []]);
             },
             'deleteString1' => function (string $method, string $url): ResponseInterface {
                 $this->assertSame('DELETE', $method);
@@ -1172,13 +1166,7 @@ XLIFF
                 $this->assertSame('GET', $method);
                 $this->assertSame('https://api.crowdin.com/api/v2/projects/1/strings?fileId=12&limit=500&offset=500', $url);
 
-                $response = $this->createMock(ResponseInterface::class);
-                $response->expects($this->any())
-                    ->method('getContent')
-                    ->with(false)
-                    ->willReturn(json_encode(['data' => []]));
-
-                return $response;
+                return new JsonMockResponse(['data' => []]);
             },
             'deleteString1' => function (string $method, string $url): ResponseInterface {
                 $this->assertSame('DELETE', $method);

--- a/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderFactoryTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderFactoryTest.php
@@ -11,9 +11,13 @@
 
 namespace Symfony\Component\Translation\Bridge\Loco\Tests;
 
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Translation\Bridge\Loco\LocoProviderFactory;
+use Symfony\Component\Translation\Loader\ArrayLoader;
 use Symfony\Component\Translation\Provider\ProviderFactoryInterface;
 use Symfony\Component\Translation\Test\ProviderFactoryTestCase;
+use Symfony\Component\Translation\TranslatorBag;
 
 class LocoProviderFactoryTest extends ProviderFactoryTestCase
 {
@@ -43,6 +47,6 @@ class LocoProviderFactoryTest extends ProviderFactoryTestCase
 
     public function createFactory(): ProviderFactoryInterface
     {
-        return new LocoProviderFactory($this->getClient(), $this->getLogger(), $this->getDefaultLocale(), $this->getLoader(), $this->getTranslatorBag());
+        return new LocoProviderFactory(new MockHttpClient(), new NullLogger(), $this->getDefaultLocale(), new ArrayLoader(), new TranslatorBag());
     }
 }

--- a/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderFactoryWithoutTranslatorBagTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderFactoryWithoutTranslatorBagTest.php
@@ -11,13 +11,16 @@
 
 namespace Symfony\Component\Translation\Bridge\Loco\Tests;
 
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Translation\Bridge\Loco\LocoProviderFactory;
+use Symfony\Component\Translation\Loader\ArrayLoader;
 use Symfony\Component\Translation\Provider\ProviderFactoryInterface;
 
 class LocoProviderFactoryWithoutTranslatorBagTest extends LocoProviderFactoryTest
 {
     public function createFactory(): ProviderFactoryInterface
     {
-        return new LocoProviderFactory($this->getClient(), $this->getLogger(), $this->getDefaultLocale(), $this->getLoader(), null);
+        return new LocoProviderFactory(new MockHttpClient(), new NullLogger(), $this->getDefaultLocale(), new ArrayLoader(), null);
     }
 }

--- a/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderTest.php
@@ -703,21 +703,17 @@ class LocoProviderTest extends ProviderTestCase
      */
     public function testReadForOneLocaleAndOneDomain(string $locale, string $domain, string $responseContent, TranslatorBag $expectedTranslatorBag)
     {
-        $loader = $this->getLoader();
-        $loader->expects($this->once())
+        $this->loader = $this->createMock(LoaderInterface::class);
+        $this->loader->expects($this->once())
             ->method('load')
             ->willReturn((new XliffFileLoader())->load($responseContent, $locale, $domain));
-
-        $this->getTranslatorBag()->expects($this->any())
-            ->method('getCatalogue')
-            ->willReturn(new MessageCatalogue($locale));
 
         $provider = self::createProvider((new MockHttpClient(new MockResponse($responseContent)))->withOptions([
             'base_uri' => 'https://localise.biz/api/',
             'headers' => [
                 'Authorization' => 'Loco API_KEY',
             ],
-        ]), $loader, new NullLogger(), 'en', 'localise.biz/api/');
+        ]), $this->loader, new NullLogger(), 'en', 'localise.biz/api/');
         $translatorBag = $provider->read([$domain], [$locale]);
         // We don't want to assert equality of metadata here, due to the ArrayLoader usage.
         foreach ($translatorBag->getCatalogues() as $catalogue) {
@@ -744,8 +740,8 @@ class LocoProviderTest extends ProviderTestCase
             }
         }
 
-        $loader = $this->getLoader();
-        $loader->expects($this->exactly(\count($consecutiveLoadArguments)))
+        $this->loader = $this->createMock(LoaderInterface::class);
+        $this->loader->expects($this->exactly(\count($consecutiveLoadArguments)))
             ->method('load')
             ->willReturnCallback(function (...$args) use (&$consecutiveLoadArguments, &$consecutiveLoadReturns) {
                 $this->assertSame(array_shift($consecutiveLoadArguments), $args);
@@ -753,16 +749,12 @@ class LocoProviderTest extends ProviderTestCase
                 return array_shift($consecutiveLoadReturns);
             });
 
-        $this->getTranslatorBag()->expects($this->any())
-            ->method('getCatalogue')
-            ->willReturn(new MessageCatalogue($locale));
-
         $provider = self::createProvider((new MockHttpClient($responses))->withOptions([
             'base_uri' => 'https://localise.biz/api/',
             'headers' => [
                 'Authorization' => 'Loco API_KEY',
             ],
-        ]), $loader, $this->getLogger(), 'en', 'localise.biz/api/');
+        ]), $this->loader, $this->getLogger(), 'en', 'localise.biz/api/');
         $translatorBag = $provider->read($domains, $locales);
         // We don't want to assert equality of metadata here, due to the ArrayLoader usage.
         foreach ($translatorBag->getCatalogues() as $catalogue) {
@@ -800,8 +792,8 @@ class LocoProviderTest extends ProviderTestCase
             }
         }
 
-        $loader = $this->getLoader();
-        $loader->expects($this->exactly(\count($consecutiveLoadArguments)))
+        $this->loader = $this->createMock(LoaderInterface::class);
+        $this->loader->expects($this->exactly(\count($consecutiveLoadArguments)))
             ->method('load')
             ->willReturnCallback(function (...$args) use (&$consecutiveLoadArguments, &$consecutiveLoadReturns) {
                 $this->assertSame(array_shift($consecutiveLoadArguments), $args);
@@ -1165,12 +1157,10 @@ XLIFF,
 
     public function testReadForAllDomains()
     {
-        $loader = $this->getLoader();
-
-        $loader
-            ->expects($this->once())
+        $this->loader = $this->createMock(LoaderInterface::class);
+        $this->loader->expects($this->once())
             ->method('load')
-            ->willReturn($this->createMock(MessageCatalogue::class));
+            ->willReturn(new MessageCatalogue('fr'));
 
         $provider = self::createProvider(
             new MockHttpClient([

--- a/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderWithoutTranslatorBagTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderWithoutTranslatorBagTest.php
@@ -60,6 +60,7 @@ class LocoProviderWithoutTranslatorBagTest extends LocoProviderTest
             }
         }
 
+        $this->loader = $this->createMock(LoaderInterface::class);
         $loader = $this->getLoader();
         $consecutiveLoadArguments = array_merge($consecutiveLoadArguments, $consecutiveLoadArguments);
         $consecutiveLoadReturns = array_merge($consecutiveLoadReturns, $consecutiveLoadReturns);

--- a/src/Symfony/Component/Translation/Bridge/Lokalise/Tests/LokaliseProviderFactoryTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/Tests/LokaliseProviderFactoryTest.php
@@ -11,9 +11,11 @@
 
 namespace Symfony\Component\Translation\Bridge\Lokalise\Tests;
 
+use Psr\Log\NullLogger;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
 use Symfony\Component\Translation\Bridge\Lokalise\LokaliseProviderFactory;
+use Symfony\Component\Translation\Loader\ArrayLoader;
 use Symfony\Component\Translation\Provider\Dsn;
 use Symfony\Component\Translation\Provider\ProviderFactoryInterface;
 use Symfony\Component\Translation\Test\ProviderFactoryTestCase;
@@ -48,7 +50,7 @@ class LokaliseProviderFactoryTest extends ProviderFactoryTestCase
     {
         $response = new JsonMockResponse(['files' => []]);
         $httpClient = new MockHttpClient([$response]);
-        $factory = new LokaliseProviderFactory($httpClient, $this->getLogger(), $this->getDefaultLocale(), $this->getLoader());
+        $factory = new LokaliseProviderFactory($httpClient, new NullLogger(), $this->getDefaultLocale(), new ArrayLoader());
         $provider = $factory->create(new Dsn('lokalise://PROJECT_ID:API_KEY@default'));
 
         // Make a real HTTP request.
@@ -59,6 +61,6 @@ class LokaliseProviderFactoryTest extends ProviderFactoryTestCase
 
     public function createFactory(): ProviderFactoryInterface
     {
-        return new LokaliseProviderFactory($this->getClient(), $this->getLogger(), $this->getDefaultLocale(), $this->getLoader());
+        return new LokaliseProviderFactory(new MockHttpClient(), new NullLogger(), $this->getDefaultLocale(), new ArrayLoader());
     }
 }

--- a/src/Symfony/Component/Translation/Bridge/Lokalise/Tests/LokaliseProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/Tests/LokaliseProviderTest.php
@@ -670,7 +670,7 @@ class LokaliseProviderTest extends ProviderTestCase
             }, []),
         ]);
 
-        $loader = $this->getLoader();
+        $loader = $this->createMock(LoaderInterface::class);
         $loader->expects($this->exactly(\count($consecutiveLoadArguments)))
             ->method('load')
             ->willReturnCallback(function (...$args) use (&$consecutiveLoadArguments, &$consecutiveLoadReturns) {

--- a/src/Symfony/Component/Translation/Bridge/Phrase/Tests/PhraseProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Phrase/Tests/PhraseProviderTest.php
@@ -11,11 +11,11 @@
 
 namespace Symfony\Component\Translation\Bridge\Phrase\Tests;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\HttpClient\HttpClientTrait;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
@@ -39,10 +39,10 @@ class PhraseProviderTest extends TestCase
     }
 
     private MockHttpClient $httpClient;
-    private MockObject&LoggerInterface $logger;
-    private MockObject&LoaderInterface $loader;
-    private MockObject&XliffFileDumper $xliffFileDumper;
-    private MockObject&CacheItemPoolInterface $cache;
+    private LoggerInterface $logger;
+    private LoaderInterface $loader;
+    private XliffFileDumper $xliffFileDumper;
+    private CacheItemPoolInterface $cache;
     private string $defaultLocale;
     private string $endpoint;
     private array $readConfig;
@@ -78,7 +78,6 @@ class PhraseProviderTest extends TestCase
             }));
 
         $this->getCache()
-            ->expects(self::once())
             ->method('getItem')
             ->with(self::callback(function ($v) use ($locale, $domain) {
                 $this->assertStringStartsWith($locale.'.'.$domain.'.', $v);
@@ -93,7 +92,6 @@ class PhraseProviderTest extends TestCase
         ];
 
         $this->getLoader()
-            ->expects($this->once())
             ->method('load')
             ->willReturn($expectedTranslatorBag->getCatalogue($locale));
 
@@ -132,6 +130,7 @@ class PhraseProviderTest extends TestCase
                 return true;
             }));
 
+        $this->cache = $this->createMock(CacheItemPoolInterface::class);
         $this->getCache()
             ->expects(self::once())
             ->method('getItem')
@@ -161,7 +160,6 @@ class PhraseProviderTest extends TestCase
         ];
 
         $this->getLoader()
-            ->expects($this->once())
             ->method('load')
             ->willReturn($expectedTranslatorBag->getCatalogue($locale));
 
@@ -210,6 +208,7 @@ class PhraseProviderTest extends TestCase
         $item->expects(self::once())->method('isHit')->willReturn(false);
         $item->expects(self::never())->method('set');
 
+        $this->cache = $this->createMock(CacheItemPoolInterface::class);
         $this->getCache()
             ->expects(self::once())
             ->method('getItem')
@@ -221,6 +220,7 @@ class PhraseProviderTest extends TestCase
             ->willReturn($item);
 
         $this->getCache()->expects(self::never())->method('save');
+        $this->loader = $this->createMock(LoaderInterface::class);
         $this->getLoader()->expects($this->once())->method('load')->willReturn($bag->getCatalogue($locale));
 
         $responses = [
@@ -265,6 +265,7 @@ class PhraseProviderTest extends TestCase
      */
     public function testCacheKeyOptionsSort(array $options, string $expectedKey)
     {
+        $this->cache = $this->createMock(CacheItemPoolInterface::class);
         $this->getCache()->expects(self::once())->method('getItem')->with($expectedKey);
         $this->getLoader()->method('load')->willReturn(new MessageCatalogue('en'));
 
@@ -301,7 +302,6 @@ class PhraseProviderTest extends TestCase
         $item->method('get')->willReturn($cachedValue);
 
         $this->getCache()
-            ->expects(self::once())
             ->method('getItem')
             ->willReturn($item);
 
@@ -385,6 +385,7 @@ class PhraseProviderTest extends TestCase
         $this->expectExceptionCode(0);
         $this->expectExceptionMessage($expectedExceptionMessage);
 
+        $this->logger = $this->createMock(LoggerInterface::class);
         $this->getLogger()
             ->expects(self::once())
             ->method('error')
@@ -421,6 +422,7 @@ class PhraseProviderTest extends TestCase
         $this->expectExceptionCode(0);
         $this->expectExceptionMessage($expectedExceptionMessage);
 
+        $this->logger = $this->createMock(LoggerInterface::class);
         $this->getLogger()
             ->expects(self::once())
             ->method('error')
@@ -545,6 +547,7 @@ class PhraseProviderTest extends TestCase
         $this->expectExceptionCode(0);
         $this->expectExceptionMessage($expectedExceptionMessage);
 
+        $this->logger = $this->createMock(LoggerInterface::class);
         $this->getLogger()
             ->expects(self::once())
             ->method('error')
@@ -633,6 +636,7 @@ class PhraseProviderTest extends TestCase
         $this->expectExceptionCode(0);
         $this->expectExceptionMessage($expectedExceptionMessage);
 
+        $this->logger = $this->createMock(LoggerInterface::class);
         $this->getLogger()
             ->expects(self::once())
             ->method('error')
@@ -751,6 +755,7 @@ class PhraseProviderTest extends TestCase
         $this->expectExceptionCode(0);
         $this->expectExceptionMessage($expectedExceptionMessage);
 
+        $this->logger = $this->createMock(LoggerInterface::class);
         $this->getLogger()
             ->expects(self::once())
             ->method('error')
@@ -1124,24 +1129,24 @@ XLIFF,
         return $this->httpClient ??= new MockHttpClient();
     }
 
-    private function getLogger(): MockObject&LoggerInterface
+    private function getLogger(): LoggerInterface
     {
-        return $this->logger ??= $this->createMock(LoggerInterface::class);
+        return $this->logger ??= new NullLogger();
     }
 
-    private function getLoader(): MockObject&LoaderInterface
+    private function getLoader(): LoaderInterface
     {
-        return $this->loader ??= $this->createMock(LoaderInterface::class);
+        return $this->loader ??= $this->createStub(LoaderInterface::class);
     }
 
-    private function getXliffFileDumper(): XliffFileDumper&MockObject
+    private function getXliffFileDumper(): XliffFileDumper
     {
-        return $this->xliffFileDumper ??= $this->createMock(XliffFileDumper::class);
+        return $this->xliffFileDumper ??= $this->createStub(XliffFileDumper::class);
     }
 
-    private function getCache(): MockObject&CacheItemPoolInterface
+    private function getCache(): CacheItemPoolInterface
     {
-        return $this->cache ??= $this->createMock(CacheItemPoolInterface::class);
+        return $this->cache ??= $this->createStub(CacheItemPoolInterface::class);
     }
 
     private function getDefaultLocale(): string

--- a/src/Symfony/Component/Translation/Bridge/Phrase/composer.json
+++ b/src/Symfony/Component/Translation/Bridge/Phrase/composer.json
@@ -22,6 +22,9 @@
         "symfony/mime": "^5.4|^6.0|^7.0",
         "symfony/translation": "^5.4|^6.0|^7.0"
     },
+    "require-dev": {
+        "symfony/cache": "^6.4|^7.3"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Translation\\Bridge\\Phrase\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Translation/Test/ProviderTestCase.php
+++ b/src/Symfony/Component/Translation/Test/ProviderTestCase.php
@@ -14,10 +14,13 @@ namespace Symfony\Component\Translation\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Translation\Dumper\XliffFileDumper;
+use Symfony\Component\Translation\Loader\ArrayLoader;
 use Symfony\Component\Translation\Loader\LoaderInterface;
 use Symfony\Component\Translation\Provider\ProviderInterface;
+use Symfony\Component\Translation\TranslatorBag;
 use Symfony\Component\Translation\TranslatorBagInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -57,12 +60,12 @@ abstract class ProviderTestCase extends TestCase
 
     protected function getLoader(): LoaderInterface
     {
-        return $this->loader ??= $this->createMock(LoaderInterface::class);
+        return $this->loader ??= new ArrayLoader();
     }
 
     protected function getLogger(): LoggerInterface
     {
-        return $this->logger ??= $this->createMock(LoggerInterface::class);
+        return $this->logger ??= new NullLogger();
     }
 
     protected function getDefaultLocale(): string
@@ -72,11 +75,11 @@ abstract class ProviderTestCase extends TestCase
 
     protected function getXliffFileDumper(): XliffFileDumper
     {
-        return $this->xliffFileDumper ??= $this->createMock(XliffFileDumper::class);
+        return $this->xliffFileDumper ??= new XliffFileDumper();
     }
 
     protected function getTranslatorBag(): TranslatorBagInterface
     {
-        return $this->translatorBag ??= $this->createMock(TranslatorBagInterface::class);
+        return $this->translatorBag ??= new TranslatorBag();
     }
 }

--- a/src/Symfony/Component/Translation/Tests/Command/TranslationPullCommandTest.php
+++ b/src/Symfony/Component/Translation/Tests/Command/TranslationPullCommandTest.php
@@ -695,7 +695,7 @@ XLIFF
     public function testComplete(array $input, array $expectedSuggestions)
     {
         $application = new Application();
-        $application->add($this->createCommand($this->createMock(ProviderInterface::class), ['en', 'fr', 'it'], ['messages', 'validators'], 'en', ['loco', 'crowdin', 'lokalise']));
+        $application->add($this->createCommand($this->createStub(ProviderInterface::class), ['en', 'fr', 'it'], ['messages', 'validators'], 'en', ['loco', 'crowdin', 'lokalise']));
 
         $tester = new CommandCompletionTester($application->get('translation:pull'));
         $suggestions = $tester->complete($input);

--- a/src/Symfony/Component/Translation/Tests/Command/TranslationPushCommandTest.php
+++ b/src/Symfony/Component/Translation/Tests/Command/TranslationPushCommandTest.php
@@ -375,7 +375,7 @@ class TranslationPushCommandTest extends TranslationProviderTestCase
     public function testComplete(array $input, array $expectedSuggestions)
     {
         $application = new Application();
-        $application->add($this->createCommand($this->createMock(ProviderInterface::class), ['en', 'fr', 'it'], ['messages', 'validators'], ['loco', 'crowdin', 'lokalise']));
+        $application->add($this->createCommand($this->createStub(ProviderInterface::class), ['en', 'fr', 'it'], ['messages', 'validators'], ['loco', 'crowdin', 'lokalise']));
 
         $tester = new CommandCompletionTester($application->get('translation:push'));
         $suggestions = $tester->complete($input);

--- a/src/Symfony/Component/Translation/Tests/DataCollector/TranslationDataCollectorTest.php
+++ b/src/Symfony/Component/Translation/Tests/DataCollector/TranslationDataCollectorTest.php
@@ -16,15 +16,13 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Translation\DataCollector\TranslationDataCollector;
 use Symfony\Component\Translation\DataCollectorTranslator;
+use Symfony\Component\Translation\Translator;
 
 class TranslationDataCollectorTest extends TestCase
 {
     public function testCollectEmptyMessages()
     {
-        $translator = $this->getTranslator();
-        $translator->expects($this->any())->method('getCollectedMessages')->willReturn([]);
-
-        $dataCollector = new TranslationDataCollector($translator);
+        $dataCollector = new TranslationDataCollector(new DataCollectorTranslator(new Translator('en')));
         $dataCollector->lateCollect();
 
         $this->assertEquals(0, $dataCollector->getCountMissings());
@@ -139,7 +137,7 @@ class TranslationDataCollectorTest extends TestCase
         $translator->method('getFallbackLocales')->willReturn(['en']);
 
         $dataCollector = new TranslationDataCollector($translator);
-        $dataCollector->collect($this->createMock(Request::class), $this->createMock(Response::class));
+        $dataCollector->collect(new Request(), new Response());
 
         $this->assertSame('fr', $dataCollector->getLocale());
         $this->assertSame(['en'], $dataCollector->getFallbackLocales());

--- a/src/Symfony/Component/Translation/Tests/Exception/ProviderExceptionTest.php
+++ b/src/Symfony/Component/Translation/Tests/Exception/ProviderExceptionTest.php
@@ -19,7 +19,7 @@ class ProviderExceptionTest extends TestCase
 {
     public function testExceptionWithDebugMessage()
     {
-        $mock = $this->createMock(ResponseInterface::class);
+        $mock = $this->createStub(ResponseInterface::class);
         $mock->method('getInfo')->willReturn('debug');
 
         $exception = new ProviderException('Exception message', $mock, 503);
@@ -28,7 +28,7 @@ class ProviderExceptionTest extends TestCase
 
     public function testExceptionWithNullAsDebugMessage()
     {
-        $mock = $this->createMock(ResponseInterface::class);
+        $mock = $this->createStub(ResponseInterface::class);
         $mock->method('getInfo')->willReturn(null);
 
         $exception = new ProviderException('Exception message', $mock, 503);

--- a/src/Symfony/Component/Translation/Tests/MessageCatalogueTest.php
+++ b/src/Symfony/Component/Translation/Tests/MessageCatalogueTest.php
@@ -138,11 +138,11 @@ class MessageCatalogueTest extends TestCase
 
     public function testAddCatalogue()
     {
-        $r = $this->createMock(ResourceInterface::class);
-        $r->expects($this->any())->method('__toString')->willReturn('r');
+        $r = $this->createStub(ResourceInterface::class);
+        $r->method('__toString')->willReturn('r');
 
-        $r1 = $this->createMock(ResourceInterface::class);
-        $r1->expects($this->any())->method('__toString')->willReturn('r1');
+        $r1 = $this->createStub(ResourceInterface::class);
+        $r1->method('__toString')->willReturn('r1');
 
         $catalogue = new MessageCatalogue('en', ['domain1' => ['foo' => 'foo']]);
         $catalogue->addResource($r);
@@ -162,14 +162,14 @@ class MessageCatalogueTest extends TestCase
 
     public function testAddFallbackCatalogue()
     {
-        $r = $this->createMock(ResourceInterface::class);
-        $r->expects($this->any())->method('__toString')->willReturn('r');
+        $r = $this->createStub(ResourceInterface::class);
+        $r->method('__toString')->willReturn('r');
 
-        $r1 = $this->createMock(ResourceInterface::class);
-        $r1->expects($this->any())->method('__toString')->willReturn('r1');
+        $r1 = $this->createStub(ResourceInterface::class);
+        $r1->method('__toString')->willReturn('r1');
 
-        $r2 = $this->createMock(ResourceInterface::class);
-        $r2->expects($this->any())->method('__toString')->willReturn('r2');
+        $r2 = $this->createStub(ResourceInterface::class);
+        $r2->method('__toString')->willReturn('r2');
 
         $catalogue = new MessageCatalogue('fr_FR', ['domain1' => ['foo' => 'foo'], 'domain2' => ['bar' => 'bar']]);
         $catalogue->addResource($r);
@@ -221,12 +221,12 @@ class MessageCatalogueTest extends TestCase
     public function testGetAddResource()
     {
         $catalogue = new MessageCatalogue('en');
-        $r = $this->createMock(ResourceInterface::class);
-        $r->expects($this->any())->method('__toString')->willReturn('r');
+        $r = $this->createStub(ResourceInterface::class);
+        $r->method('__toString')->willReturn('r');
         $catalogue->addResource($r);
         $catalogue->addResource($r);
-        $r1 = $this->createMock(ResourceInterface::class);
-        $r1->expects($this->any())->method('__toString')->willReturn('r1');
+        $r1 = $this->createStub(ResourceInterface::class);
+        $r1->method('__toString')->willReturn('r1');
         $catalogue->addResource($r1);
 
         $this->assertEquals([$r, $r1], $catalogue->getResources());

--- a/src/Symfony/Component/Translation/Tests/Provider/TranslationProviderCollectionTest.php
+++ b/src/Symfony/Component/Translation/Tests/Provider/TranslationProviderCollectionTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Translation\Tests\Provider;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Translation\Provider\ProviderInterface;
+use Symfony\Component\Translation\Provider\NullProvider;
 use Symfony\Component\Translation\Provider\TranslationProviderCollection;
 
 class TranslationProviderCollectionTest extends TestCase
@@ -26,9 +26,9 @@ class TranslationProviderCollectionTest extends TestCase
     {
         $this->assertSame(['foo', 'baz'], (new TranslationProviderCollection(
             (function () {
-                yield 'foo' => $this->createMock(ProviderInterface::class);
+                yield 'foo' => new NullProvider();
 
-                yield 'baz' => $this->createMock(ProviderInterface::class);
+                yield 'baz' => new NullProvider();
             })()
         ))->keys());
     }
@@ -45,11 +45,11 @@ class TranslationProviderCollectionTest extends TestCase
 
     public function testGet()
     {
-        $provider = $this->createMock(ProviderInterface::class);
+        $provider = new NullProvider();
 
         $this->assertSame($provider, (new TranslationProviderCollection([
             'foo' => $provider,
-            'baz' => $this->createMock(ProviderInterface::class),
+            'baz' => new NullProvider(),
         ]))->get('foo'));
     }
 
@@ -64,8 +64,8 @@ class TranslationProviderCollectionTest extends TestCase
     private function createProviderCollection(): TranslationProviderCollection
     {
         return new TranslationProviderCollection([
-            'foo' => $this->createMock(ProviderInterface::class),
-            'baz' => $this->createMock(ProviderInterface::class),
+            'foo' => new NullProvider(),
+            'baz' => new NullProvider(),
         ]);
     }
 }

--- a/src/Symfony/Component/Translation/Tests/TranslatorCacheTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorCacheTest.php
@@ -252,7 +252,7 @@ class TranslatorCacheTest extends TestCase
 
     public function testRefreshCacheWhenResourcesAreNoLongerFresh()
     {
-        $resource = $this->createMock(SelfCheckingResourceInterface::class);
+        $resource = $this->createStub(SelfCheckingResourceInterface::class);
         $loader = $this->createMock(LoaderInterface::class);
         $resource->method('isFresh')->willReturn(false);
         $loader

--- a/src/Symfony/Component/Translation/Tests/Writer/TranslationWriterTest.php
+++ b/src/Symfony/Component/Translation/Tests/Writer/TranslationWriterTest.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\Translation\Tests\Writer;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Translation\Dumper\DumperInterface;
+use Symfony\Component\Translation\Dumper\XliffFileDumper;
+use Symfony\Component\Translation\Dumper\YamlFileDumper;
 use Symfony\Component\Translation\Exception\InvalidArgumentException;
 use Symfony\Component\Translation\Exception\RuntimeException;
 use Symfony\Component\Translation\MessageCatalogue;
@@ -35,8 +37,8 @@ class TranslationWriterTest extends TestCase
     public function testGetFormats()
     {
         $writer = new TranslationWriter();
-        $writer->addDumper('foo', $this->createMock(DumperInterface::class));
-        $writer->addDumper('bar', $this->createMock(DumperInterface::class));
+        $writer->addDumper('foo', new YamlFileDumper());
+        $writer->addDumper('bar', new XliffFileDumper());
 
         $this->assertEquals(['foo', 'bar'], $writer->getFormats());
     }
@@ -53,7 +55,7 @@ class TranslationWriterTest extends TestCase
     public function testUnwritableDirectory()
     {
         $writer = new TranslationWriter();
-        $writer->addDumper('foo', $this->createMock(DumperInterface::class));
+        $writer->addDumper('foo', new YamlFileDumper());
 
         $path = tempnam(sys_get_temp_dir(), '');
         file_put_contents($path, '');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | part of #62669
| License       | MIT