### PR TITLE
[Messenger] fix test file/class name

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Handler/HandlerDescriptorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Handler/HandlerDescriptorTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Handler\HandlerDescriptor;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyCommandHandler;
 
-class HandleDescriptorTest extends TestCase
+class HandlerDescriptorTest extends TestCase
 {
     /**
      * @dataProvider provideHandlers
@@ -43,7 +43,7 @@ class HandleDescriptorTest extends TestCase
             public function __invoke()
             {
             }
-        }, 'class@anonymous%sHandleDescriptorTest.php%s::__invoke'];
+        }, 'class@anonymous%sHandlerDescriptorTest.php%s::__invoke'];
     }
 
     public function testGetOptions()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes-ish (SCA-issue)
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix SCA/DX
| License       | MIT

there is typo in test class name