### PR TITLE
[TwigBundle] Align TemplateIterator handling of @! original bundle templates with TwigExtension

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/TemplateIterator.php
+++ b/src/Symfony/Bundle/TwigBundle/TemplateIterator.php
@@ -64,6 +64,12 @@ class TemplateIterator implements \IteratorAggregate
             if (null !== $this->defaultPath) {
                 $templates[] = $this->findTemplatesInDirectory($this->defaultPath.'/bundles/'.$bundle->getName(), $name);
             }
+
+            /*
+             * The bundle's own templates are also registered with the "!" prefix namespace - this matches
+             * @see \Symfony\Bundle\TwigBundle\DependencyInjection\TwigExtension::load()
+             */
+            $templates[] = $this->findTemplatesInDirectory($bundleTemplatesDir, '!'.$name);
         }
 
         foreach ($this->paths as $dir => $namespace) {

--- a/src/Symfony/Bundle/TwigBundle/Tests/TemplateIteratorTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/TemplateIteratorTest.php
@@ -25,6 +25,7 @@ class TemplateIteratorTest extends TestCase
         sort($sorted);
         $this->assertEquals(
             [
+                '@!Bar/index.html.twig',
                 '@Bar/index.html.twig',
                 '@Bar/layout.html.twig',
                 '@Foo/index.html.twig',
@@ -43,6 +44,7 @@ class TemplateIteratorTest extends TestCase
         sort($sorted);
         $this->assertEquals(
             [
+                '@!Bar/index.html.twig',
                 '@Bar/index.html.twig',
                 '@Bar/layout.html.twig',
                 '@Foo/index.html.twig',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62730
| License       | MIT

## Bug Fix: TemplateIterator not discovering templates with @! namespace prefix

The `TemplateIterator` (used by the cache warmer) was not discovering templates registered with the `@!` namespace prefix, even though `TwigExtension` registers them with the Twig loader. This caused incomplete cache warming for templates referenced as `@!BundleName/template.twig` during `cache:warmup`, requiring additional compilation at runtime.

**Example:**

```php
// Both are valid in Twig:
$this->render('@Foo/index.html.twig');   // Uses override if exists, otherwise bundle template
$this->render('@!Foo/index.html.twig');  // Always uses original bundle template
```

**Before:** Only `@Foo/index.html.twig` was compiled during `cache:warmup`
**After:** Both `@Foo/index.html.twig` and `@!Foo/index.html.twig` are compiled during `cache:warmup`

The fix adds one line to match the behavior of `TwigExtension::load()`:

```php
$templates[] = $this->findTemplatesInDirectory($bundleTemplatesDir, '!'.$name);
```

**Tests:** Updated `TemplateIteratorTest` to verify templates with the `@!` prefix are included.
**Verified:** Fix was also tested on the original bug reproducer: https://github.com/mbessolov/twig-override-cache-reproducer
