### PR TITLE
[PropertyInfo] bump required PropertyInfo component patch version

### DIFF
--- a/src/Symfony/Component/PropertyAccess/composer.json
+++ b/src/Symfony/Component/PropertyAccess/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/deprecation-contracts": "^2.5|^3",
-        "symfony/property-info": "^5.4|^6.0|^7.0"
+        "symfony/property-info": "^6.4.31|~7.3.9|^7.4.2"
     },
     "require-dev": {
         "symfony/cache": "^5.4|^6.0|^7.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

fixes low deps tests following the changes made in #62772