### PR TITLE
[Messenger][AMQP] Fix negative delays with AMQP messenger transport

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -289,7 +289,7 @@ class Connection
         }
 
         $this->withConnectionExceptionRetry(function () use ($body, $headers, $delayInMs, $amqpStamp) {
-            if (0 !== $delayInMs) {
+            if (0 < $delayInMs) {
                 $this->publishWithDelay($body, $headers, $delayInMs, $amqpStamp);
 
                 return;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60658
| License       | MIT

This prevents the AMQP from creating delay queues in the past. When a delay is in the past, the message should be handled immediately, so we send it to the normal queue.
