### PR TITLE
[Console] Fix EofShortcut instruction when using a modern terminal on Windows

### DIFF
--- a/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
@@ -34,7 +34,7 @@ class SymfonyQuestionHelper extends QuestionHelper
         $default = $question->getDefault();
 
         if ($question->isMultiline()) {
-            $text .= \sprintf(' (press %s to continue)', $this->getEofShortcut());
+            $text .= \sprintf(' (press %s to continue)', $this->getEofShortcut($output));
         }
 
         switch (true) {
@@ -98,9 +98,9 @@ class SymfonyQuestionHelper extends QuestionHelper
         parent::writeError($output, $error);
     }
 
-    private function getEofShortcut(): string
+    private function getEofShortcut(OutputInterface $output): string
     {
-        if ('Windows' === \PHP_OS_FAMILY) {
+        if ('\\' === \DIRECTORY_SEPARATOR && !$output->isDecorated()) {
             return '<comment>Ctrl+Z</comment> then <comment>Enter</comment>';
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62514
| License       | MIT

On `SymfonyQuestionHelper` use the `isDecoratedFlag` instead of the PHP_OS_FAMILY. @nicolas-grekas suggested to use `StreamOutput::hasColorSupport()`. As it is a protected method i thought we could use the `OutputInterface::isDecorated` flag which is constructed from `StreamOutput` like this: `$decorated ??= $this->hasColorSupport();`

Please review if it is a correct decision :)