### PR TITLE
[Config][FrameworkBundle] Allow using ParamConfigurator with every configurable value

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/PhpConfigReferenceDumpPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/PhpConfigReferenceDumpPass.php
@@ -34,6 +34,8 @@ class PhpConfigReferenceDumpPass implements CompilerPassInterface
 
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+        use Symfony\Component\Config\Loader\ParamConfigurator as Param;
+
         {APP_TYPES}
         final class App
         {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/reference.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/reference.php
@@ -4,6 +4,8 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Symfony\Component\Config\Loader\ParamConfigurator as Param;
+
 /**
  * This class provides array-shapes for configuring the services and bundles of an application.
  *
@@ -124,14 +126,14 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
  * }
  * @psalm-type ExtensionType = array<string, mixed>
  * @psalm-type TestConfig = array{
- *     enabled?: scalar|null, // Default: false
+ *     enabled?: scalar|null|Param, // Default: false
  *     options?: array{
- *         name?: scalar|null,
- *         count?: int,
+ *         name?: scalar|null|Param,
+ *         count?: int|Param,
  *     },
- *     fromBundle?: bool, // Default: false
+ *     fromBundle?: bool|Param, // Default: false
  * }
- * @psalm-type AppConfig = bool
+ * @psalm-type AppConfig = bool|Param
  * @psalm-type ConfigType = array{
  *     imports?: ImportsConfig,
  *     parameters?: ParametersConfig,

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -20,7 +20,7 @@
         "composer-runtime-api": ">=2.1",
         "ext-xml": "*",
         "symfony/cache": "^6.4.12|^7.0|^8.0",
-        "symfony/config": "^7.4|^8.0",
+        "symfony/config": "^7.4.3|^8.0.3",
         "symfony/dependency-injection": "^7.4|^8.0",
         "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/error-handler": "^7.3|^8.0",

--- a/src/Symfony/Component/Config/Definition/ArrayShapeGenerator.php
+++ b/src/Symfony/Component/Config/Definition/ArrayShapeGenerator.php
@@ -24,7 +24,7 @@ final class ArrayShapeGenerator
     private static function doGeneratePhpDoc(NodeInterface $node, int $nestingLevel = 1): string
     {
         if (!$node instanceof ArrayNode) {
-            return match (true) {
+            $typeString = match (true) {
                 $node instanceof BooleanNode => $node->hasDefaultValue() && null === $node->getDefaultValue() ? 'bool|null' : 'bool',
                 $node instanceof StringNode => 'string',
                 $node instanceof NumericNode => self::handleNumericNode($node),
@@ -32,6 +32,11 @@ final class ArrayShapeGenerator
                 $node instanceof ScalarNode => 'scalar|null',
                 default => 'mixed',
             };
+            if ('mixed' !== $typeString) {
+                $typeString .= '|Param';
+            }
+
+            return $typeString;
         }
 
         if ($node instanceof PrototypedArrayNode) {

--- a/src/Symfony/Component/Config/Tests/Definition/ArrayShapeGeneratorTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/ArrayShapeGeneratorTest.php
@@ -78,7 +78,7 @@ class ArrayShapeGeneratorTest extends TestCase
         $root = new ArrayNode('root');
         $root->addChild($prototype);
 
-        $expected = "array{\n *     proto?: list<string>,\n * }";
+        $expected = "array{\n *     proto?: list<string|Param>,\n * }";
 
         $this->assertStringContainsString($expected, ArrayShapeGenerator::generate($root));
     }
@@ -92,7 +92,7 @@ class ArrayShapeGeneratorTest extends TestCase
         $root = new ArrayNode('root');
         $root->addChild($prototype);
 
-        $expected = "array{\n *     proto?: array<string, string>,\n * }";
+        $expected = "array{\n *     proto?: array<string, string|Param>,\n * }";
 
         $this->assertStringContainsString($expected, ArrayShapeGenerator::generate($root));
     }
@@ -120,7 +120,7 @@ class ArrayShapeGeneratorTest extends TestCase
         $root = new ArrayNode('root');
         $root->addChild($child);
 
-        $this->assertStringContainsString('node?: bool, // Deprecated: The "node" option is deprecated. // This is a boolean node. // Default: true', ArrayShapeGenerator::generate($root));
+        $this->assertStringContainsString('node?: bool|Param, // Deprecated: The "node" option is deprecated. // This is a boolean node. // Default: true', ArrayShapeGenerator::generate($root));
     }
 
     public function testPhpDocHandleMultilineDoc()
@@ -133,7 +133,7 @@ class ArrayShapeGeneratorTest extends TestCase
         $root = new ArrayNode('root');
         $root->addChild($child);
 
-        $this->assertStringContainsString('node?: bool, // Deprecated: The "node" option is deprecated. // This is a boolean node. Set to true to enable it. Set to false to disable it. // Default: true', ArrayShapeGenerator::generate($root));
+        $this->assertStringContainsString('node?: bool|Param, // Deprecated: The "node" option is deprecated. // This is a boolean node. Set to true to enable it. Set to false to disable it. // Default: true', ArrayShapeGenerator::generate($root));
     }
 
     public function testPhpDocShapeSingleLevel()
@@ -159,7 +159,7 @@ class ArrayShapeGeneratorTest extends TestCase
 
         $this->assertSame(<<<'CODE'
             bool|array{
-             *     enabled?: bool, // Default: false
+             *     enabled?: bool|Param, // Default: false
              * }
             CODE, ArrayShapeGenerator::generate($root->getNode()));
     }
@@ -171,7 +171,7 @@ class ArrayShapeGeneratorTest extends TestCase
 
         $this->assertSame(<<<'CODE'
             bool|array{
-             *     enabled?: bool, // Default: true
+             *     enabled?: bool|Param, // Default: true
              * }
             CODE, ArrayShapeGenerator::generate($root->getNode()));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62780
| License       | MIT

Updates generated typing to allow ParamConfigurator
