### PR TITLE
[Messenger] Fix integration with doctrine/migrations and dbal v4

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
@@ -21,11 +21,11 @@ use Doctrine\DBAL\Query\ForUpdate\ConflictResolutionMode;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Schema\AbstractAsset;
+use Doctrine\DBAL\Schema\ComparatorConfig;
 use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\NamedObject;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
-use Doctrine\DBAL\Schema\ComparatorConfig;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Types;
@@ -546,6 +546,11 @@ class Connection implements ResetInterface
 
                 $schema->createSequence($this->configuration['table_name'].self::ORACLE_SEQUENCES_SUFFIX);
             }
+        }
+
+        if (\defined(Table::class.'::OPTION_EXTRA_CREATE_SQL')) {
+            // DBAL v4.5
+            $table->addOption(Table::OPTION_EXTRA_CREATE_SQL, $this->getExtraSetupSqlForTable($table));
         }
     }
 

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/PostgreSqlConnection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/PostgreSqlConnection.php
@@ -104,6 +104,14 @@ final class PostgreSqlConnection extends Connection
             return [];
         }
 
+        if (\defined(Table::class.'::OPTION_EXTRA_DROP_SQL')) {
+            // DBAL v4.5
+            $createdTable->addOption(Table::OPTION_EXTRA_DROP_SQL, [
+                \sprintf('DROP TRIGGER IF EXISTS notify_trigger ON %s;', $this->configuration['table_name']),
+                \sprintf('DROP FUNCTION IF EXISTS %s();', $this->createTriggerFunctionName()),
+            ]);
+        }
+
         return $this->getTriggerSql();
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54039
| License       | MIT

Together with https://github.com/doctrine/dbal/pull/7261, this fixes generating migrations for the `messenger_messages` table.