### PR TITLE
[Console] Do not call non-static method via class-name

### DIFF
--- a/src/Symfony/Component/Console/Attribute/Argument.php
+++ b/src/Symfony/Component/Console/Attribute/Argument.php
@@ -84,6 +84,8 @@ class Argument
         }
 
         if (\is_array($self->suggestedValues) && !\is_callable($self->suggestedValues) && 2 === \count($self->suggestedValues) && ($instance = $parameter->getDeclaringFunction()->getClosureThis()) && $instance::class === $self->suggestedValues[0] && \is_callable([$instance, $self->suggestedValues[1]])) {
+            // In case that the callback is declared as a static method `[Foo::class, 'methodName']` - yet it is not callable,
+            // while non-static method `[Foo $instance, 'methodName']` would be callable, we transform the callback on the fly into a non-static version.
             $self->suggestedValues = [$instance, $self->suggestedValues[1]];
         }
 

--- a/src/Symfony/Component/Console/Tests/Command/InvokableCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/InvokableCommandTest.php
@@ -35,8 +35,15 @@ class InvokableCommandTest extends TestCase
             #[Argument] ?string $firstName,
             #[Argument] string $lastName = '',
             #[Argument(description: 'Short argument description')] string $bio = '',
+            // In this test case, we declare the callback in static context, even when the method is NOT static.
+            // PHP doesn't allow using `$this` here, and the callback is later modified on-the-fly
+            // to be called on the instance instead, and this test case validates if this mechanism works.
+            //
+            // @see \Symfony\Component\Console\Attribute\Argument
             #[Argument(suggestedValues: [self::class, 'getSuggestedRoles'])] array $roles = ['ROLE_USER'],
         ): int {
+            \assert(null !== $this); // so PHP CS Fixer knows this callback is actually coupled with `$this` and `static_lambda` rule shall not be applied
+
             return 0;
         });
 
@@ -81,6 +88,8 @@ class InvokableCommandTest extends TestCase
             #[Option(suggestedValues: [self::class, 'getSuggestedRoles'])] array $roles = ['ROLE_USER'],
             #[Option] string|bool $opt = false,
         ): int {
+            \assert(null !== $this); // so PHP CS Fixer knows this callback is actually coupled with `$this` and `static_lambda` rule shall not be applied
+
             return 0;
         });
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes-ish
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix compiler complaints
| License       | MIT

extracted from PR #62821 against 8.1, but targeting 7.3 (as the earliest supported branch with the issue)


Non-static lambda is working right now by "accident", but we still call non-static method `getSuggestedRoles` using class name and not instance - `suggestedValues: [self::class, 'getSuggestedRoles'])`. Yet, imagine `getSuggestedRoles` method would start using `$this`...

If lambda would be declared as static, calling non-static method from it would fail regardless of not using `$this` inside. This is similar issue as we faced in #62794

Let's not call non-static method statically -> solution to convert method into static one.
I'm changing lambdas to static in that case as well. [it's OK they are later re-bind, as those particular lambdas not using `$this` context anyway]