### PR TITLE
[JsonPath] Add custom function support

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/JsonPathPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/JsonPathPass.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Collects metadata (arity, return type) for custom JsonPath functions
+ * and injects it into the json_path.crawler service.
+ */
+class JsonPathPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('json_path.crawler')) {
+            return;
+        }
+
+        $metadata = [];
+        foreach ($container->findTaggedServiceIds('json_path.function') as $tags) {
+            foreach ($tags as $attributes) {
+                if (!isset($attributes['name'])) {
+                    continue;
+                }
+
+                $metadata[$attributes['name']] = [
+                    'arity' => $attributes['arity'] ?? null,
+                    'return_type' => $attributes['return_type'] ?? null,
+                ];
+            }
+        }
+
+        $container->getDefinition('json_path.crawler')->setArgument(1, $metadata);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
@@ -54,6 +54,7 @@ class UnusedTagsPass implements CompilerPassInterface
         'form.type_guesser',
         'html_sanitizer',
         'http_client.client',
+        'json_path.function',
         'json_streamer.value_object_transformer',
         'json_streamer.property_value_transformer',
         'json_streamer.value_transformer',

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -111,6 +111,8 @@ use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
 use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
 use Symfony\Component\HttpKernel\EventListener\ControllerAttributesListener;
 use Symfony\Component\HttpKernel\Log\DebugLoggerConfigurator;
+use Symfony\Component\JsonPath\Attribute\AsJsonPathFunction;
+use Symfony\Component\JsonPath\JsonPathCrawler;
 use Symfony\Component\JsonStreamer\Attribute\JsonStreamable;
 use Symfony\Component\JsonStreamer\JsonStreamWriter;
 use Symfony\Component\JsonStreamer\Mapping\PropertyMetadata;
@@ -656,6 +658,21 @@ class FrameworkExtension extends Extension
             if (!class_exists(ReverseClassObjectMapperMetadataFactory::class)) {
                 $container->removeDefinition('object_mapper.metadata_factory.reverse_class');
             }
+        }
+
+        if (ContainerBuilder::willBeAvailable('symfony/json-path', JsonPathCrawler::class, ['symfony/framework-bundle'])) {
+            $loader->load('json_path.php');
+            $container->registerAttributeForAutoconfiguration(AsJsonPathFunction::class, static function (ChildDefinition $definition, AsJsonPathFunction $attribute, \ReflectionClass $reflector): void {
+                if (!$reflector->hasMethod('__invoke')) {
+                    throw new LogicException(\sprintf('The "%s" attribute can only be applied to invokable classes, "%s" is not invokable.', AsJsonPathFunction::class, $reflector->name));
+                }
+
+                $definition->addTag('json_path.function', [
+                    'name' => $attribute->name,
+                    'return_type' => $attribute->returnType,
+                    'arity' => $reflector->getMethod('__invoke')->getNumberOfRequiredParameters(),
+                ]);
+            });
         }
 
         $container->registerForAutoconfiguration(PackageInterface::class)

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -18,6 +18,7 @@ use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ConsoleArgumentV
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ContainerBuilderDebugDumpPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\DeprecateJsonStreamerValueTransformerTagPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ErrorLoggerCompilerPass;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\JsonPathPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\PhpConfigReferenceDumpPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ProfilerPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\RemoveUnusedSessionMarshallingHandlerPass;
@@ -217,6 +218,7 @@ class FrameworkBundle extends Bundle
         $this->addCompilerPassIfExists($container, StreamablePass::class);
         $this->addCompilerPassIfExists($container, TransformerPass::class);
         $this->addCompilerPassIfExists($container, ReverseMappingPass::class);
+        $this->addCompilerPassIfExists($container, JsonPathPass::class);
 
         if ($container->getParameter('kernel.debug')) {
             if ($container->hasParameter('.kernel.config_dir') && $container->hasParameter('.kernel.bundles_definition')) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/json_path.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/json_path.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Component\JsonPath\JsonPathCrawler;
+use Symfony\Component\JsonPath\JsonPathCrawlerInterface;
+
+return static function (ContainerConfigurator $container) {
+    $container->services()
+        ->set('json_path.crawler', JsonPathCrawler::class)
+            ->args([tagged_locator('json_path.function', 'name')])
+        ->alias(JsonPathCrawlerInterface::class, 'json_path.crawler')
+    ;
+};

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -14,12 +14,14 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\RequiresMethod;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LogLevel;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Fixtures\Workflow\Validator\DefinitionValidator;
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\JsonPath\UppercaseFunction;
 use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\DummyMessage;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 use Symfony\Bundle\FullStack;
@@ -68,6 +70,8 @@ use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 use Symfony\Component\HttpKernel\Fragment\FragmentUriGeneratorInterface;
+use Symfony\Component\JsonPath\FunctionReturnType;
+use Symfony\Component\JsonPath\JsonPathCrawlerInterface;
 use Symfony\Component\Lock\Store\FlockStore;
 use Symfony\Component\Lock\Store\SemaphoreStore;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsTransportFactory;
@@ -2972,6 +2976,40 @@ abstract class FrameworkExtensionTestCase extends TestCase
     {
         $container = $this->createContainerFromFile('json_streamer');
         $this->assertTrue($container->has('json_streamer.stream_writer'));
+    }
+
+    #[RequiresMethod(JsonPathCrawlerInterface::class, 'crawl')]
+    public function testJsonPathEnabled()
+    {
+        $container = $this->createContainerFromClosure(static function (ContainerBuilder $container) {
+            $container->loadFromExtension('framework', []);
+        });
+
+        $this->assertTrue($container->hasDefinition('json_path.crawler'));
+        $this->assertSame('json_path.crawler', (string) $container->getAlias(JsonPathCrawlerInterface::class));
+
+        $locatorArgument = $container->getDefinition('json_path.crawler')->getArgument(0);
+        $this->assertInstanceOf(ServiceLocatorArgument::class, $locatorArgument);
+        $this->assertInstanceOf(TaggedIteratorArgument::class, $locatorArgument->getTaggedIteratorArgument());
+        $this->assertSame('json_path.function', $locatorArgument->getTaggedIteratorArgument()->getTag());
+    }
+
+    #[RequiresMethod(JsonPathCrawlerInterface::class, 'crawl')]
+    public function testJsonPathFunctionAttributeAutoconfiguration()
+    {
+        $container = $this->createContainerFromClosure(static function (ContainerBuilder $container) {
+            $container->loadFromExtension('framework', []);
+            $container->register('json_path.function.upper', UppercaseFunction::class)
+                ->setAutoconfigured(true);
+        });
+
+        $this->assertEquals([['name' => 'upper', 'return_type' => FunctionReturnType::Value, 'arity' => 1]], $container->getDefinition('json_path.function.upper')->getTag('json_path.function'));
+
+        $locatorArgument = $container->getDefinition('json_path.crawler')->getArgument(0);
+        $this->assertInstanceOf(ServiceLocatorArgument::class, $locatorArgument);
+        $this->assertInstanceOf(TaggedIteratorArgument::class, $locatorArgument->getTaggedIteratorArgument());
+        $this->assertSame('json_path.function', $locatorArgument->getTaggedIteratorArgument()->getTag());
+        $this->assertSame('name', $locatorArgument->getTaggedIteratorArgument()->getIndexAttribute());
     }
 
     public function testObjectMapperEnabled()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/JsonPath/UppercaseFunction.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/JsonPath/UppercaseFunction.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures\JsonPath;
+
+use Symfony\Component\JsonPath\Attribute\AsJsonPathFunction;
+
+#[AsJsonPathFunction('upper')]
+final class UppercaseFunction
+{
+    public function __invoke(mixed $value): ?string
+    {
+        return \is_string($value) ? strtoupper($value) : null;
+    }
+}

--- a/src/Symfony/Component/JsonPath/Attribute/AsJsonPathFunction.php
+++ b/src/Symfony/Component/JsonPath/Attribute/AsJsonPathFunction.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonPath\Attribute;
+
+use Symfony\Component\JsonPath\FunctionReturnType;
+
+/**
+ * Service tag to autoconfigure JsonPath functions.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class AsJsonPathFunction
+{
+    public function __construct(
+        public string $name,
+        public FunctionReturnType $returnType = FunctionReturnType::Value,
+    ) {
+    }
+}

--- a/src/Symfony/Component/JsonPath/CHANGELOG.md
+++ b/src/Symfony/Component/JsonPath/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add `JsonPathCrawlerInterface`, an autowireable factory for creating `JsonCrawlerInterface` instances with custom functions
+ * Add `#[AsJsonPathFunction]` to declare invokable JsonPath functions for autoconfiguration
+
 7.4
 ---
 

--- a/src/Symfony/Component/JsonPath/Exception/InvalidJsonPathException.php
+++ b/src/Symfony/Component/JsonPath/Exception/InvalidJsonPathException.php
@@ -16,8 +16,8 @@ namespace Symfony\Component\JsonPath\Exception;
  */
 class InvalidJsonPathException extends \LogicException implements ExceptionInterface
 {
-    public function __construct(string $message, ?int $position = null)
+    public function __construct(string $message, ?int $position = null, ?\Throwable $previous = null)
     {
-        parent::__construct(\sprintf('JSONPath syntax error%s: %s', $position ? ' at position '.$position : '', $message));
+        parent::__construct(\sprintf('JSONPath syntax error%s: %s', $position ? ' at position '.$position : '', $message), previous: $previous);
     }
 }

--- a/src/Symfony/Component/JsonPath/FunctionReturnType.php
+++ b/src/Symfony/Component/JsonPath/FunctionReturnType.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonPath;
+
+/**
+ * Declares the return type of a custom JsonPath function as defined in RFC 9535.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc9535#name-type-system-for-function-ex
+ */
+enum FunctionReturnType: string
+{
+    /**
+     * A JSON value that can be used in comparisons.
+     */
+    case Value = 'value';
+
+    /**
+     * A boolean result usable as a filter expression (e.g. existence tests).
+     */
+    case Logical = 'logical';
+
+    /**
+     * A nodelist (array of matched nodes), not directly comparable.
+     */
+    case Nodes = 'nodes';
+}

--- a/src/Symfony/Component/JsonPath/JsonCrawler.php
+++ b/src/Symfony/Component/JsonPath/JsonCrawler.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\JsonPath;
 
+use Psr\Container\ContainerInterface;
 use Symfony\Component\JsonPath\Exception\InvalidArgumentException;
 use Symfony\Component\JsonPath\Exception\InvalidJsonPathException;
 use Symfony\Component\JsonPath\Exception\InvalidJsonStringInputException;
@@ -20,6 +21,7 @@ use Symfony\Component\JsonPath\Tokenizer\JsonPathTokenizer;
 use Symfony\Component\JsonPath\Tokenizer\TokenType;
 use Symfony\Component\JsonStreamer\Exception\UnexpectedValueException;
 use Symfony\Component\JsonStreamer\Read\Splitter;
+use Symfony\Contracts\Service\ServiceProviderInterface;
 
 /**
  * Crawls a JSON document using a JSON Path as described in the RFC 9535.
@@ -30,19 +32,6 @@ use Symfony\Component\JsonStreamer\Read\Splitter;
  */
 final class JsonCrawler implements JsonCrawlerInterface
 {
-    private const RFC9535_FUNCTIONS = [
-        'length' => true,
-        'count' => true,
-        'match' => true,
-        'search' => true,
-        'value' => true,
-    ];
-
-    private const SINGULAR_ARGUMENT_FUNCTIONS = ['length', 'match', 'search'];
-
-    /**
-     * Comparison operators and their corresponding lengths.
-     */
     private const COMPARISON_OPERATORS = [
         '!=' => 2,
         '==' => 2,
@@ -53,10 +42,14 @@ final class JsonCrawler implements JsonCrawlerInterface
     ];
 
     /**
-     * @param resource|string $raw
+     * @param resource|string                                                                        $raw
+     * @param ContainerInterface|ServiceProviderInterface<callable(mixed ...$arguments): mixed>|null $functionsProvider
+     * @param array<string, array{arity?: int|null, return_type?: FunctionReturnType|null}>          $functionsMetadata
      */
     public function __construct(
         private readonly mixed $raw,
+        private readonly ?ContainerInterface $functionsProvider = null,
+        private readonly array $functionsMetadata = [],
     ) {
         if (!\is_string($raw) && !\is_resource($raw)) {
             throw new InvalidArgumentException(\sprintf('Expected string or resource, got "%s".', get_debug_type($raw)));
@@ -391,25 +384,9 @@ final class JsonCrawler implements JsonCrawlerInterface
             }
 
             $needsParentheses = true;
-            if (str_starts_with($filterExpr, '(') && str_ends_with($filterExpr, ')')) {
-                $depth = 0;
-                $isWrapped = true;
-                $filterLen = \strlen($filterExpr);
-
-                for ($i = 0; $i < $filterLen; ++$i) {
-                    $char = $filterExpr[$i];
-                    if ('(' === $char) {
-                        ++$depth;
-                    } elseif (')' === $char && 0 === --$depth && $i < $filterLen - 1) {
-                        $isWrapped = false;
-                        break;
-                    }
-                }
-
-                if ($isWrapped) {
-                    $needsParentheses = false;
-                    $filterExpr = trim(substr($filterExpr, 1, -1));
-                }
+            if (null !== $unwrapped = self::unwrapParentheses($filterExpr)) {
+                $needsParentheses = false;
+                $filterExpr = $unwrapped;
             }
 
             if ($needsParentheses && !str_starts_with($filterExpr, '(')) {
@@ -543,22 +520,8 @@ final class JsonCrawler implements JsonCrawlerInterface
     {
         $expr = JsonPathUtils::normalizeWhitespace($expr);
 
-        // remove outer parentheses if they wrap the entire expression
-        if (str_starts_with($expr, '(') && str_ends_with($expr, ')')) {
-            $depth = 0;
-            $isWrapped = true;
-            $i = -1;
-            while (null !== $char = $expr[++$i] ?? null) {
-                if ('(' === $char) {
-                    ++$depth;
-                } elseif (')' === $char && 0 === --$depth && isset($expr[$i + 1])) {
-                    $isWrapped = false;
-                    break;
-                }
-            }
-            if ($isWrapped) {
-                $expr = trim(substr($expr, 1, -1));
-            }
+        if (null !== $unwrapped = self::unwrapParentheses($expr)) {
+            $expr = $unwrapped;
         }
 
         if (str_starts_with($expr, '!')) {
@@ -612,9 +575,11 @@ final class JsonCrawler implements JsonCrawlerInterface
         // function calls
         if (preg_match('/^(\w++)\s*+\((.*)\)$/', $expr, $matches)) {
             $functionName = trim($matches[1]);
-            if (!isset(self::RFC9535_FUNCTIONS[$functionName])) {
+            if (!isset(JsonPathTokenizer::RFC9535_FUNCTION_ARITY[$functionName]) && !$this->functionsProvider?->has($functionName)) {
                 throw new JsonCrawlerException($expr, \sprintf('invalid function "%s"', $functionName));
             }
+
+            $this->validateFunctionTestReturnType($expr);
 
             $functionResult = $this->evaluateFunction($functionName, $matches[2], $context);
 
@@ -730,7 +695,8 @@ final class JsonCrawler implements JsonCrawlerInterface
 
         // function calls
         if (preg_match('/^(\w++)\((.*)\)$/', $expr, $matches)) {
-            if (!isset(self::RFC9535_FUNCTIONS[$functionName = trim($matches[1])])) {
+            $functionName = trim($matches[1]);
+            if (!isset(JsonPathTokenizer::RFC9535_FUNCTION_ARITY[$functionName]) && !$this->functionsProvider?->has($functionName)) {
                 throw new JsonCrawlerException($expr, \sprintf('invalid function "%s"', $functionName));
             }
 
@@ -742,44 +708,57 @@ final class JsonCrawler implements JsonCrawlerInterface
 
     private function evaluateFunction(string $name, string $args, mixed $context): mixed
     {
+        $argStrings = ($args = trim($args)) ? JsonPathUtils::parseCommaSeparatedValues($args) : [];
+        $expectedArgCount = JsonPathTokenizer::RFC9535_FUNCTION_ARITY[$name] ?? $this->functionsMetadata[$name]['arity'] ?? null;
+
+        if (null !== $expectedArgCount && \count($argStrings) !== $expectedArgCount) {
+            throw new JsonCrawlerException($args, \sprintf('the JsonPath function "%s" requires exactly %d argument(s).', $name, $expectedArgCount));
+        }
+
+        // Parse and evaluate arguments
         $argList = [];
         $nodelistSizes = [];
-        if ($args = trim($args)) {
-            $args = JsonPathUtils::parseCommaSeparatedValues($args);
-            foreach ($args as $arg) {
-                $arg = trim($arg);
-                if (str_starts_with($arg, '$')) { // special handling for absolute paths
-                    $results = $this->evaluate(new JsonPath($arg));
-                    $argList[] = $results[0] ?? null;
-                    $nodelistSizes[] = \count($results);
-                } elseif (!str_starts_with($arg, '@')) { // special handling for @ to track nodelist size
-                    $argList[] = $this->evaluateScalar($arg, $context);
-                    $nodelistSizes[] = 1;
-                } elseif ('@' === $arg) {
-                    $argList[] = $context;
-                    $nodelistSizes[] = 1;
-                } elseif (!$this->isArrayOrObject($context)) {
-                    $argList[] = null;
-                    $nodelistSizes[] = 0;
-                } elseif (str_starts_with($pathPart = substr($arg, 1), '[')) {
-                    // handle bracket expressions like @['a','d']
-                    $results = $this->evaluateBracket(substr($pathPart, 1, -1), $context);
-                    $argList[] = $results;
-                    $nodelistSizes[] = \count($results);
-                } else {
-                    // handle dot notation like @.a
-                    $results = $this->evaluateTokensOnDecodedData(JsonPathTokenizer::tokenize(new JsonPath('$'.$pathPart)), $context);
-                    $argList[] = $results[0] ?? null;
-                    $nodelistSizes[] = \count($results);
-                }
+        foreach ($argStrings as $arg) {
+            $arg = trim($arg);
+            if (str_starts_with($arg, '$')) { // special handling for absolute paths
+                $results = $this->evaluate(new JsonPath($arg));
+                $argList[] = $results[0] ?? null;
+                $nodelistSizes[] = \count($results);
+            } elseif (!str_starts_with($arg, '@')) { // special handling for @ to track nodelist size
+                $argList[] = $this->evaluateScalar($arg, $context);
+                $nodelistSizes[] = 1;
+            } elseif ('@' === $arg) {
+                $argList[] = $context;
+                $nodelistSizes[] = 1;
+            } elseif (!$this->isArrayOrObject($context)) {
+                $argList[] = null;
+                $nodelistSizes[] = 0;
+            } elseif (str_starts_with($pathPart = substr($arg, 1), '[')) {
+                // handle bracket expressions like @['a','d']
+                $results = $this->evaluateBracket(substr($pathPart, 1, -1), $context);
+                $argList[] = $results;
+                $nodelistSizes[] = \count($results);
+            } else {
+                // handle dot notation like @.a
+                $results = $this->evaluateTokensOnDecodedData(JsonPathTokenizer::tokenize(new JsonPath('$'.$pathPart)), $context);
+                $argList[] = $results[0] ?? null;
+                $nodelistSizes[] = \count($results);
             }
         }
 
         $value = $argList[0] ?? null;
         $nodelistSize = $nodelistSizes[0] ?? 0;
 
-        if ($nodelistSize > 1 && \in_array($name, self::SINGULAR_ARGUMENT_FUNCTIONS, true)) {
+        if ($nodelistSize > 1 && \in_array($name, JsonPathTokenizer::SINGULAR_ARGUMENT_FUNCTIONS, true)) {
             throw new JsonCrawlerException($args, \sprintf('non-singular query is not allowed as argument to "%s" function', $name));
+        }
+
+        if ($this->functionsProvider?->has($name)) {
+            try {
+                return $this->functionsProvider->get($name)(...$argList);
+            } catch (\Exception $e) {
+                throw new InvalidJsonPathException(\sprintf('An error occurred while executing the custom JsonPath function "%s": ', $name).$e->getMessage(), null, $e);
+            }
         }
 
         return match ($name) {
@@ -972,11 +951,6 @@ final class JsonCrawler implements JsonCrawlerInterface
         }
     }
 
-    private function isNonSingularRelativeQuery(string $expr): bool
-    {
-        return preg_match('/@\[.*,.*]/', $expr) || '@.*' === $expr || preg_match('/@\[.*:.*]/', $expr);
-    }
-
     private function findOperatorPosition(string $expr, string $op): int|false
     {
         $bracketDepth = 0;
@@ -1005,6 +979,20 @@ final class JsonCrawler implements JsonCrawlerInterface
 
     private function validateFilterExpression(string $expr): void
     {
+        $expr = trim($expr);
+
+        if (null !== $unwrapped = self::unwrapParentheses($expr)) {
+            $this->validateFilterExpression($unwrapped);
+
+            return;
+        }
+
+        if (str_starts_with($expr, '!')) {
+            $this->validateFilterExpression(trim(substr($expr, 1)));
+
+            return;
+        }
+
         if ($logicalOp = $this->findRightmostLogicalOperator($expr)) {
             $this->validateFilterExpression(trim(substr($expr, 0, $logicalOp['position']))); // left
             $this->validateFilterExpression(trim(substr($expr, $logicalOp['position'] + \strlen($logicalOp['operator'])))); // right
@@ -1029,35 +1017,70 @@ final class JsonCrawler implements JsonCrawlerInterface
                 }
 
                 if (
-                    str_starts_with($left, '@') && $this->isNonSingularRelativeQuery($left)
-                    || str_starts_with($right, '@') && $this->isNonSingularRelativeQuery($right)
+                    str_starts_with($left, '@') && JsonPathTokenizer::isNonSingularRelativeQuery($left)
+                    || str_starts_with($right, '@') && JsonPathTokenizer::isNonSingularRelativeQuery($right)
                 ) {
                     throw new JsonCrawlerException($left, 'non-singular query is not comparable');
                 }
 
                 $this->validateFunctionArguments($left);
                 $this->validateFunctionArguments($right);
+                $this->validateFunctionReturnType($left);
+                $this->validateFunctionReturnType($right);
 
                 return;
             }
         }
+
+        $this->validateFunctionTestReturnType($expr);
     }
 
     private function validateFunctionArguments(string $expr): void
     {
-        // is there a function call?
         if (!preg_match('/^(\w+)\((.*)\)$/', trim($expr), $matches)) {
             return;
         }
 
-        if (!\in_array($functionName = $matches[1], self::SINGULAR_ARGUMENT_FUNCTIONS, true)) {
+        if (!\in_array($functionName = $matches[1], JsonPathTokenizer::SINGULAR_ARGUMENT_FUNCTIONS, true)) {
             return;
         }
 
         $arg = trim($matches[2]);
-        if (str_starts_with($arg, '@') && $this->isNonSingularRelativeQuery($arg)) {
+        if (str_starts_with($arg, '@') && JsonPathTokenizer::isNonSingularRelativeQuery($arg)) {
             throw new JsonCrawlerException($arg, \sprintf('non-singular query is not allowed as argument to "%s" function', $functionName));
         }
+    }
+
+    private function validateFunctionReturnType(string $expr): void
+    {
+        if (!preg_match('/^(\w+)\s*\(/', trim($expr), $matches)) {
+            return;
+        }
+
+        $functionName = $matches[1];
+        $returnType = $this->functionsMetadata[$functionName]['return_type'] ?? null;
+
+        if (null === $returnType || FunctionReturnType::Value === $returnType) {
+            return;
+        }
+
+        throw new JsonCrawlerException($expr, \sprintf('the result of the custom JsonPath function "%s" (%s) cannot be used in comparisons', $functionName, $returnType->name.'Type'));
+    }
+
+    private function validateFunctionTestReturnType(string $expr): void
+    {
+        if (!preg_match('/^(\w+)\s*\(/', trim($expr), $matches)) {
+            return;
+        }
+
+        $functionName = $matches[1];
+        $returnType = $this->functionsMetadata[$functionName]['return_type'] ?? null;
+
+        if (FunctionReturnType::Value !== $returnType) {
+            return;
+        }
+
+        throw new JsonCrawlerException($expr, \sprintf('the result of the custom JsonPath function "%s" (%s) cannot be used in test expressions', $functionName, $returnType->name.'Type'));
     }
 
     /**
@@ -1087,6 +1110,26 @@ final class JsonCrawler implements JsonCrawlerInterface
         }
 
         return $result;
+    }
+
+    private static function unwrapParentheses(string $expr): ?string
+    {
+        if (!str_starts_with($expr, '(') || !str_ends_with($expr, ')')) {
+            return null;
+        }
+
+        $depth = 0;
+        $i = -1;
+
+        while (null !== $char = $expr[++$i] ?? null) {
+            if ('(' === $char) {
+                ++$depth;
+            } elseif (')' === $char && 0 === --$depth && isset($expr[$i + 1])) {
+                return null;
+            }
+        }
+
+        return trim(substr($expr, 1, -1));
     }
 
     private function isArrayOrObject(mixed $value): bool

--- a/src/Symfony/Component/JsonPath/JsonPathCrawler.php
+++ b/src/Symfony/Component/JsonPath/JsonPathCrawler.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonPath;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Contracts\Service\ServiceProviderInterface;
+
+final class JsonPathCrawler implements JsonPathCrawlerInterface
+{
+    /**
+     * @param ContainerInterface|ServiceProviderInterface<callable(mixed ...$arguments): mixed>|null $functionsProvider
+     * @param array<string, array{arity?: int|null, return_type?: FunctionReturnType|null}>          $functionsMetadata
+     */
+    public function __construct(
+        private readonly ?ContainerInterface $functionsProvider = null,
+        private readonly array $functionsMetadata = [],
+    ) {
+    }
+
+    /**
+     * @param resource|string $raw
+     */
+    public function crawl(mixed $raw): JsonCrawlerInterface
+    {
+        return new JsonCrawler($raw, $this->functionsProvider, $this->functionsMetadata);
+    }
+}

--- a/src/Symfony/Component/JsonPath/JsonPathCrawlerInterface.php
+++ b/src/Symfony/Component/JsonPath/JsonPathCrawlerInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonPath;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ */
+interface JsonPathCrawlerInterface
+{
+    /**
+     * @param resource|string $raw
+     */
+    public function crawl(mixed $raw): JsonCrawlerInterface;
+}

--- a/src/Symfony/Component/JsonPath/Tests/Attribute/AsJsonPathFunctionTest.php
+++ b/src/Symfony/Component/JsonPath/Tests/Attribute/AsJsonPathFunctionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonPath\Tests\Attribute;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\JsonPath\Attribute\AsJsonPathFunction;
+
+class AsJsonPathFunctionTest extends TestCase
+{
+    public function testAttributeStoresFunctionName()
+    {
+        $attribute = new AsJsonPathFunction('upper');
+
+        $this->assertSame('upper', $attribute->name);
+    }
+
+    public function testAttributeTargetsClassesOnly()
+    {
+        $reflection = new \ReflectionClass(AsJsonPathFunction::class);
+        $attribute = $reflection->getAttributes(\Attribute::class)[0]->newInstance();
+
+        $this->assertSame(\Attribute::TARGET_CLASS, $attribute->flags);
+    }
+}

--- a/src/Symfony/Component/JsonPath/Tests/Functions/CustomFunctionTest.php
+++ b/src/Symfony/Component/JsonPath/Tests/Functions/CustomFunctionTest.php
@@ -1,0 +1,212 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonPath\Tests\Functions;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\JsonPath\Exception\JsonCrawlerException;
+use Symfony\Component\JsonPath\FunctionReturnType;
+use Symfony\Component\JsonPath\JsonCrawler;
+use Symfony\Component\JsonPath\Tests\FunctionsLocatorTrait;
+
+class CustomFunctionTest extends TestCase
+{
+    use FunctionsLocatorTrait;
+
+    public function testCustomFunctionWithSingleArgument()
+    {
+        $upperFunction = static fn (mixed $value): ?string => \is_string($value) ? strtoupper($value) : null;
+
+        $crawler = new JsonCrawler(<<<JSON
+                {"name": "test", "items": [{"title": "hello"}, {"title": "world"}]}
+            JSON, $this->createFunctionsLocator(['upper' => $upperFunction]));
+
+        $result = $crawler->find('$.items[?upper(@.title) == "HELLO"]');
+        $this->assertCount(1, $result);
+        $this->assertEquals('hello', $result[0]['title']);
+    }
+
+    public function testCustomFunctionWithMultipleArguments()
+    {
+        $concatFunction = static fn (mixed $first, mixed $second): string => \sprintf('%s%s', $first, $second);
+        $crawler = new JsonCrawler(<<<JSON
+                {"items": [{"first": "hello", "second": "world"}, {"first": "foo", "second": "bar"}]}
+            JSON, $this->createFunctionsLocator(['concat' => $concatFunction]));
+
+        $result = $crawler->find('$.items[?concat(@.first, @.second) == "helloworld"]');
+        $this->assertCount(1, $result);
+        $this->assertEquals('hello', $result[0]['first']);
+        $this->assertEquals('world', $result[0]['second']);
+    }
+
+    public function testBooleanFunction()
+    {
+        $isPositiveFunction = static fn (mixed $value): bool => is_numeric($value) && $value > 0;
+        $crawler = new JsonCrawler(<<<JSON
+                {"items": [{"value": 5}, {"value": -3}, {"value": 10}]}
+            JSON, $this->createFunctionsLocator(['is_positive' => $isPositiveFunction]));
+
+        $result = $crawler->find('$.items[?is_positive(@.value)]');
+
+        $this->assertCount(2, $result);
+        $this->assertEquals(5, $result[0]['value']);
+        $this->assertEquals(10, $result[1]['value']);
+    }
+
+    public function testNumericFunction()
+    {
+        $doubleFunction = static fn (mixed $value): int|float => is_numeric($value) ? $value * 2 : 0;
+        $crawler = new JsonCrawler(<<<JSON
+                {"items": [{"value": 5}, {"value": 10}]}
+            JSON, $this->createFunctionsLocator(['double' => $doubleFunction]));
+
+        $result = $crawler->find('$.items[?double(@.value) > 15]');
+        $this->assertCount(1, $result);
+        $this->assertEquals(10, $result[0]['value']);
+    }
+
+    public function testCustomFunctionReceivesEvaluatedArguments()
+    {
+        $surroundFunction = static fn (mixed $prefix, mixed $value, mixed $suffix): string => $prefix.$value.$suffix;
+
+        $crawler = new JsonCrawler(<<<JSON
+                {"items": [{"title": "hello"}, {"title": "world"}]}
+            JSON, $this->createFunctionsLocator(['surround' => $surroundFunction]));
+
+        $result = $crawler->find('$.items[?surround("<", @.title, ">") == "<hello>"]');
+
+        $this->assertCount(1, $result);
+        $this->assertSame('hello', $result[0]['title']);
+    }
+
+    public function testCustomFunctionThrowingExceptionIsWrapped()
+    {
+        $failingFunction = static function (mixed $value): string {
+            throw new \RuntimeException('Something went wrong inside the function');
+        };
+
+        $crawler = new JsonCrawler(<<<JSON
+                {"items": [{"title": "hello"}]}
+            JSON, $this->createFunctionsLocator(['failing' => $failingFunction]));
+
+        $this->expectException(JsonCrawlerException::class);
+        $this->expectExceptionMessage('An error occurred while executing the custom JsonPath function "failing"');
+
+        $crawler->find('$.items[?failing(@.title) == "x"]');
+    }
+
+    public function testCustomFunctionOverridesBuiltIn()
+    {
+        $customLength = static fn (mixed $value): int => 9999;
+
+        $crawler = new JsonCrawler(<<<JSON
+                {"items": [{"name": "hi"}, {"name": "hello world"}]}
+            JSON, $this->createFunctionsLocator(['length' => $customLength]));
+
+        // custom length returns 9999 for all values, so both items match > 5
+        $result = $crawler->find('$.items[?length(@.name) > 5]');
+        $this->assertCount(2, $result);
+    }
+
+    public function testCustomFunctionArityValidation()
+    {
+        $concatFunction = static fn (mixed $a, mixed $b): string => $a.$b;
+
+        $crawler = new JsonCrawler(
+            '{"items": [{"a": "x"}]}',
+            $this->createFunctionsLocator(['concat' => $concatFunction]),
+            ['concat' => ['arity' => 2, 'return_type' => FunctionReturnType::Value]],
+        );
+
+        $this->expectException(JsonCrawlerException::class);
+        $this->expectExceptionMessage('requires exactly 2 argument(s)');
+
+        $crawler->find('$.items[?concat(@.a) == "x"]');
+    }
+
+    public function testCustomFunctionLogicalReturnTypeCannotBeCompared()
+    {
+        $existsFunction = static fn (mixed $value): bool => null !== $value;
+
+        $crawler = new JsonCrawler(
+            '{"items": [{"a": 1}]}',
+            $this->createFunctionsLocator(['exists' => $existsFunction]),
+            ['exists' => ['arity' => 1, 'return_type' => FunctionReturnType::Logical]],
+        );
+
+        $this->expectException(JsonCrawlerException::class);
+        $this->expectExceptionMessage('LogicalType');
+
+        $crawler->find('$.items[?exists(@.a) == true]');
+    }
+
+    public function testCustomFunctionLogicalReturnTypeCanBeUsedAsFilter()
+    {
+        $existsFunction = static fn (mixed $value): bool => null !== $value;
+
+        $crawler = new JsonCrawler(
+            '{"items": [{"a": 1}, {"a": 2}]}',
+            $this->createFunctionsLocator(['exists' => $existsFunction]),
+            ['exists' => ['arity' => 1, 'return_type' => FunctionReturnType::Logical]],
+        );
+
+        $result = $crawler->find('$.items[?exists(@.a)]');
+        $this->assertCount(2, $result);
+    }
+
+    public function testCustomFunctionValueReturnTypeCannotBeUsedAsFilter()
+    {
+        $stringifyFunction = static fn (mixed $value): string => (string) $value;
+
+        $crawler = new JsonCrawler(
+            '{"items": [{"a": 1}]}',
+            $this->createFunctionsLocator(['stringify' => $stringifyFunction]),
+            ['stringify' => ['arity' => 1, 'return_type' => FunctionReturnType::Value]],
+        );
+
+        $this->expectException(JsonCrawlerException::class);
+        $this->expectExceptionMessage('ValueType');
+
+        $crawler->find('$.items[?stringify(@.a)]');
+    }
+
+    public function testCustomFunctionNodesReturnTypeCannotBeCompared()
+    {
+        $nodesFunction = static fn (mixed $value): array => [$value];
+
+        $crawler = new JsonCrawler(
+            '{"items": [{"a": 1}]}',
+            $this->createFunctionsLocator(['nodes' => $nodesFunction]),
+            ['nodes' => ['arity' => 1, 'return_type' => FunctionReturnType::Nodes]],
+        );
+
+        $this->expectException(JsonCrawlerException::class);
+        $this->expectExceptionMessage('NodesType');
+
+        $crawler->find('$.items[?nodes(@.a) == 1]');
+    }
+
+    public function testCustomFunctionNodesReturnTypeCanBeUsedAsFilter()
+    {
+        $nodesFunction = static fn (mixed $value): array => null === $value ? [] : [$value];
+
+        $crawler = new JsonCrawler(
+            '{"items": [{"a": 1}, {"b": 2}]}',
+            $this->createFunctionsLocator(['nodes' => $nodesFunction]),
+            ['nodes' => ['arity' => 1, 'return_type' => FunctionReturnType::Nodes]],
+        );
+
+        $result = $crawler->find('$.items[?nodes(@.a)]');
+
+        $this->assertCount(1, $result);
+        $this->assertSame(1, $result[0]['a']);
+    }
+}

--- a/src/Symfony/Component/JsonPath/Tests/FunctionsLocatorTrait.php
+++ b/src/Symfony/Component/JsonPath/Tests/FunctionsLocatorTrait.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonPath\Tests;
+
+use Psr\Container\ContainerInterface;
+
+trait FunctionsLocatorTrait
+{
+    private function createFunctionsLocator(array $functions): ContainerInterface
+    {
+        return new class($functions) implements ContainerInterface {
+            public function __construct(private array $functions)
+            {
+            }
+
+            public function get(string $id): mixed
+            {
+                if (!isset($this->functions[$id])) {
+                    throw new \RuntimeException(\sprintf('Unknown custom JSONPath function "%s".', $id));
+                }
+
+                return $this->functions[$id];
+            }
+
+            public function has(string $id): bool
+            {
+                return isset($this->functions[$id]);
+            }
+        };
+    }
+}

--- a/src/Symfony/Component/JsonPath/Tests/JsonCrawlerTest.php
+++ b/src/Symfony/Component/JsonPath/Tests/JsonCrawlerTest.php
@@ -17,10 +17,15 @@ use Symfony\Component\JsonPath\Exception\InvalidArgumentException;
 use Symfony\Component\JsonPath\Exception\InvalidJsonStringInputException;
 use Symfony\Component\JsonPath\Exception\JsonCrawlerException;
 use Symfony\Component\JsonPath\JsonCrawler;
+use Symfony\Component\JsonPath\JsonCrawlerInterface;
 use Symfony\Component\JsonPath\JsonPath;
+use Symfony\Component\JsonPath\JsonPathCrawler;
+use Symfony\Component\JsonPath\JsonPathCrawlerInterface;
 
 class JsonCrawlerTest extends TestCase
 {
+    use FunctionsLocatorTrait;
+
     public function testNotStringOrResourceThrows()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -35,6 +40,22 @@ class JsonCrawlerTest extends TestCase
         $this->expectExceptionMessage('Invalid JSON input: Syntax error');
 
         (new JsonCrawler('invalid'))->find('$..*');
+    }
+
+    public function testJsonPathCrawlerCreatesJsonCrawler()
+    {
+        $jsonPathCrawler = new JsonPathCrawler($this->createFunctionsLocator([
+            'upper' => static fn (mixed $value): ?string => \is_string($value) ? strtoupper($value) : null,
+        ]));
+
+        $this->assertInstanceOf(JsonPathCrawlerInterface::class, $jsonPathCrawler);
+
+        $crawler = $jsonPathCrawler->crawl('{"items": [{"title": "hello"}, {"title": "world"}]}');
+
+        $this->assertInstanceOf(JsonCrawlerInterface::class, $crawler);
+        $this->assertSame([
+            ['title' => 'hello'],
+        ], $crawler->find('$.items[?upper(@.title) == "HELLO"]'));
     }
 
     public function testAllAuthors()
@@ -537,6 +558,23 @@ class JsonCrawlerTest extends TestCase
 
         $this->assertCount(1, $result);
         $this->assertSame([42], $result[0]['extra']);
+    }
+
+    #[DataProvider('provideNonSingularRelativeQueryFunctionArguments')]
+    public function testNonSingularRelativeQueryFunctionArgument(string $path)
+    {
+        $this->expectException(JsonCrawlerException::class);
+        $this->expectExceptionMessage('the JsonPath function "length" argument must be a singular query');
+
+        self::getBookstoreCrawler()->find($path);
+    }
+
+    public static function provideNonSingularRelativeQueryFunctionArguments(): array
+    {
+        return [
+            ['$.store.book[?length(@.*) > 0]'],
+            ['$.store.book[?length(@..author) > 0]'],
+        ];
     }
 
     public function testUnknownFunction()

--- a/src/Symfony/Component/JsonPath/Tests/Tokenizer/JsonPathTokenizerTest.php
+++ b/src/Symfony/Component/JsonPath/Tests/Tokenizer/JsonPathTokenizerTest.php
@@ -303,6 +303,23 @@ class JsonPathTokenizerTest extends TestCase
         JsonPathTokenizer::tokenize(new JsonPath('$.store...name'));
     }
 
+    #[DataProvider('provideNonSingularRelativeQueryFunctionArguments')]
+    public function testTokenizeThrowsExceptionForNonSingularRelativeQueryFunctionArgument(string $path)
+    {
+        $this->expectException(InvalidJsonPathException::class);
+        $this->expectExceptionMessage('the JsonPath function "length" argument must be a singular query.');
+
+        JsonPathTokenizer::tokenize(new JsonPath($path));
+    }
+
+    public static function provideNonSingularRelativeQueryFunctionArguments(): array
+    {
+        return [
+            ['$.store.book[?length(@.*) > 0]'],
+            ['$.store.book[?length(@..author) > 0]'],
+        ];
+    }
+
     #[DataProvider('provideValidUtf8Chars')]
     public function testUtf8ValidChars(string $propertyName)
     {

--- a/src/Symfony/Component/JsonPath/Tokenizer/JsonPathTokenizer.php
+++ b/src/Symfony/Component/JsonPath/Tokenizer/JsonPathTokenizer.php
@@ -22,7 +22,15 @@ use Symfony\Component\JsonPath\JsonPathUtils;
  */
 final class JsonPathTokenizer
 {
-    private const RFC9535_WHITESPACE_CHARS = [' ', "\t", "\n", "\r"];
+    public const SINGULAR_ARGUMENT_FUNCTIONS = ['length', 'match', 'search'];
+    public const RFC9535_FUNCTION_ARITY = [
+        'length' => 1,
+        'count' => 1,
+        'value' => 1,
+        'match' => 2,
+        'search' => 2,
+    ];
+
     private const BARE_LITERAL_REGEX = '(true|false|null|\d+(\.\d+)?([eE][+-]?\d+)?|\'[^\']*\'|"[^"]*")';
 
     /**
@@ -269,7 +277,7 @@ final class JsonPathTokenizer
 
     private static function isWhitespace(string $char): bool
     {
-        return \in_array($char, self::RFC9535_WHITESPACE_CHARS, true);
+        return \in_array($char, [' ', "\t", "\n", "\r"], true);
     }
 
     private static function isEscaped(array $chars, int $position): bool
@@ -308,7 +316,7 @@ final class JsonPathTokenizer
                 [$left, $right] = array_map('trim', explode($op, $filterExpr, 2));
 
                 // check if either side contains non-singular queries
-                if (self::isNonSingularQuery($left) || self::isNonSingularQuery($right)) {
+                if (self::containsNonSingularRelativeComparisonQuery($left) || self::containsNonSingularRelativeComparisonQuery($right)) {
                     throw new InvalidJsonPathException('Non-singular query is not comparable.', $position);
                 }
 
@@ -363,39 +371,8 @@ final class JsonPathTokenizer
             throw new InvalidJsonPathException('Function result must be compared.', $position);
         }
 
-        if (preg_match('/\b(length|count|value)\s*\(([^)]*)\)/', $filterExpr, $matches)) {
-            $functionName = $matches[1];
-            $args = trim($matches[2]);
-            if (!$args) {
-                throw new InvalidJsonPathException('Function requires exactly one argument.', $position);
-            }
-
-            $argParts = JsonPathUtils::parseCommaSeparatedValues($args);
-            if (1 !== \count($argParts)) {
-                throw new InvalidJsonPathException('Function requires exactly one argument.', $position);
-            }
-
-            $arg = trim($argParts[0]);
-
-            if ('count' === $functionName && preg_match('/^'.self::BARE_LITERAL_REGEX.'$/', $arg)) {
-                throw new InvalidJsonPathException('count() function requires a query argument, not a literal.', $position);
-            }
-
-            if ('length' === $functionName && preg_match('/@\.\*/', $arg)) {
-                throw new InvalidJsonPathException('Function argument must be a singular query.', $position);
-            }
-        }
-
-        if (preg_match('/\b(match|search)\s*\(([^)]*)\)/', $filterExpr, $matches)) {
-            $args = trim($matches[2]);
-            if (!$args) {
-                throw new InvalidJsonPathException('Function requires exactly two arguments.', $position);
-            }
-
-            $argParts = JsonPathUtils::parseCommaSeparatedValues($args);
-            if (2 !== \count($argParts)) {
-                throw new InvalidJsonPathException('Function requires exactly two arguments.', $position);
-            }
+        foreach (self::parseFunctionCalls($filterExpr) as [$functionName, $args]) {
+            self::validateFunctionArguments($functionName, $args, $position);
         }
 
         if (preg_match('/^'.self::BARE_LITERAL_REGEX.'$/', $filterExpr)) {
@@ -406,8 +383,8 @@ final class JsonPathTokenizer
             throw new InvalidJsonPathException('Bare literals in logical expression - literals must be compared.', $position);
         }
 
-        if (preg_match('/\b(match|search|length|count|value)\s*\([^)]*\)\s*[=!]=\s*(true|false)\b/', $filterExpr)
-            || preg_match('/\b(true|false)\s*[=!]=\s*(match|search|length|count|value)\s*\([^)]*\)/', $filterExpr)) {
+        if (preg_match('/\b(length|count|value|match|search)\s*\([^)]*\)\s*[=!]=\s*(true|false)\b/', $filterExpr)
+            || preg_match('/\b(true|false)\s*[=!]=\s*(length|count|value|match|search)\s*\([^)]*\)/', $filterExpr)) {
             throw new InvalidJsonPathException('Function result cannot be compared to boolean literal.', $position);
         }
 
@@ -422,17 +399,169 @@ final class JsonPathTokenizer
         }
     }
 
-    private static function isNonSingularQuery(string $query): bool
+    public static function isNonSingularRelativeQuery(string $query): bool
     {
         if (!str_starts_with($query = trim($query), '@')) {
             return false;
         }
 
-        if (preg_match('/@(\.\.)|(.*\[\*])|(.*\.\*)|(.*\[.*:.*])|(.*\[.*,.*])/', $query)) {
+        if ('@.*' === $query || preg_match('/@(?:\.\.|.*\[.*:.*]|.*\[.*,.*])/', $query)) {
             return true;
         }
 
         return false;
+    }
+
+    private static function containsNonSingularRelativeComparisonQuery(string $query): bool
+    {
+        if (!str_starts_with($query = trim($query), '@')) {
+            return false;
+        }
+
+        return preg_match('/@(?:\.\.|.*\[\*]|.*\.\*|.*\[.*:.*]|.*\[.*,.*])/', $query);
+    }
+
+    private static function validateFunctionArguments(string $functionName, string $args, int $position): void
+    {
+        if (!isset(self::RFC9535_FUNCTION_ARITY[$functionName])) {
+            return;
+        }
+
+        $argStrings = ($args = trim($args)) ? JsonPathUtils::parseCommaSeparatedValues($args) : [];
+        $expectedArgCount = self::RFC9535_FUNCTION_ARITY[$functionName];
+
+        if (\count($argStrings) !== $expectedArgCount) {
+            throw new InvalidJsonPathException(\sprintf('the JsonPath function "%s" requires exactly %d argument(s).', $functionName, $expectedArgCount), $position);
+        }
+
+        if ('count' === $functionName && isset($argStrings[0])) {
+            $arg = trim($argStrings[0]);
+            if (preg_match('/^(true|false|null|\d+(\.\d+)?([eE][+-]?\d+)?|\'[^\']*\'|"[^"]*")$/', $arg)) {
+                throw new InvalidJsonPathException(\sprintf('the JsonPath function "%s" requires a query argument, not a literal.', $functionName), $position);
+            }
+        }
+
+        if (\in_array($functionName, self::SINGULAR_ARGUMENT_FUNCTIONS, true) && isset($argStrings[0])) {
+            $arg = trim($argStrings[0]);
+            if (self::isNonSingularRelativeQuery($arg)) {
+                throw new InvalidJsonPathException(\sprintf('the JsonPath function "%s" argument must be a singular query.', $functionName), $position);
+            }
+        }
+    }
+
+    /**
+     * @return list<array{0: string, 1: string}>
+     */
+    private static function parseFunctionCalls(string $expr): array
+    {
+        $calls = [];
+        $length = \strlen($expr);
+        $inQuote = false;
+        $quoteChar = '';
+
+        for ($i = 0; $i < $length; ++$i) {
+            $char = $expr[$i];
+
+            if ('\\' === $char && $inQuote && isset($expr[$i + 1])) {
+                ++$i;
+                continue;
+            }
+
+            if ('"' === $char || "'" === $char) {
+                if (!$inQuote) {
+                    $inQuote = true;
+                    $quoteChar = $char;
+                } elseif ($quoteChar === $char) {
+                    $inQuote = false;
+                    $quoteChar = '';
+                }
+
+                continue;
+            }
+
+            if ($inQuote || !(ctype_alnum($char) || '_' === $char)) {
+                continue;
+            }
+
+            $start = $i;
+            while (isset($expr[$i + 1]) && (ctype_alnum($expr[$i + 1]) || '_' === $expr[$i + 1])) {
+                ++$i;
+            }
+
+            $functionName = substr($expr, $start, $i - $start + 1);
+
+            if (\in_array($functionName, ['true', 'false', 'null'], true)) {
+                continue;
+            }
+
+            $openParenPos = $i + 1;
+            while (isset($expr[$openParenPos]) && ctype_space($expr[$openParenPos])) {
+                ++$openParenPos;
+            }
+
+            if (!isset($expr[$openParenPos]) || '(' !== $expr[$openParenPos]) {
+                continue;
+            }
+
+            $args = self::extractParenthesizedExpression($expr, $openParenPos);
+            if (null === $args) {
+                continue;
+            }
+
+            $calls[] = [$functionName, trim($args)];
+            array_push($calls, ...self::parseFunctionCalls($args));
+            $i = $openParenPos + \strlen($args) + 1;
+        }
+
+        return $calls;
+    }
+
+    private static function extractParenthesizedExpression(string $expr, int $openParenPos): ?string
+    {
+        if (!isset($expr[$openParenPos]) || '(' !== $expr[$openParenPos]) {
+            return null;
+        }
+
+        $depth = 0;
+        $length = \strlen($expr);
+        $inQuote = false;
+        $quoteChar = '';
+
+        for ($i = $openParenPos; $i < $length; ++$i) {
+            $char = $expr[$i];
+
+            if ('\\' === $char && $inQuote && isset($expr[$i + 1])) {
+                ++$i;
+                continue;
+            }
+
+            if ('"' === $char || "'" === $char) {
+                if (!$inQuote) {
+                    $inQuote = true;
+                    $quoteChar = $char;
+                } elseif ($quoteChar === $char) {
+                    $inQuote = false;
+                    $quoteChar = '';
+                }
+
+                continue;
+            }
+
+            if ($inQuote) {
+                continue;
+            }
+
+            if ('(' === $char) {
+                ++$depth;
+            } elseif (')' === $char) {
+                --$depth;
+                if (0 === $depth) {
+                    return substr($expr, $openParenPos + 1, $i - $openParenPos - 1);
+                }
+            }
+        }
+
+        return null;
     }
 
     private static function validateUnicodeEscape(array $chars, int $index, int $position): void

--- a/src/Symfony/Component/JsonPath/composer.json
+++ b/src/Symfony/Component/JsonPath/composer.json
@@ -35,6 +35,7 @@
         "symfony/polyfill-mbstring": "^1.0"
     },
     "require-dev": {
+        "symfony/service-contracts": "^2.5|^3",
         "symfony/json-streamer": "^7.4|^8.0",
         "jsonpath-standard/jsonpath-compliance-test-suite": "*"
     },


### PR DESCRIPTION
| Q             | A |
| ------------- | --- |
| Branch?       | 8.1 |
| Bug fix?      | no |
| New feature?  | yes |
| Deprecations? | no |
| Tickets       | - |
| License       | MIT |
| Doc PR        | - |

This PR adds support for custom JsonPath functions (as defined by [RFC 9535 §2.4](https://datatracker.ietf.org/doc/html/rfc9535#name-function-extensions)) and wires them into FrameworkBundle.

### Component

- `JsonCrawler` now accepts an optional `ContainerInterface` of custom function callables and a metadata array describing each function's arity and return type.
- Introduces `FunctionReturnType` enum (`Value`, `Logical`, `Nodes`) implementing the RFC 9535 type system for function extensions — `Value`-typed functions can be used in comparisons but not as bare test expressions; `Logical` and `Nodes` types can be used as filter tests but not in comparisons.
- Adds `JsonPathCrawlerInterface` / `JsonPathCrawler` as an autowireable factory that creates `JsonCrawlerInterface` instances for a given JSON string or resource, pre-configured with custom functions.
- Replaces fragile `[^)]*` regex-based function argument extraction with a proper balanced-parenthesis parser (`parseFunctionCalls` / `extractParenthesizedExpression`) to correctly handle nested function calls.
- Consolidates function argument validation (arity, singular query checks, count-literal rejection) into `validateFunctionArguments`.

### FrameworkBundle

- Introduces `#[AsJsonPathFunction('name')]` attribute for invokable service classes; arity is auto-derived from `__invoke`'s required parameter count, and return type defaults to `Value`.
- Registers a `json_path.crawler` service backed by a `tagged_locator('json_path.function', 'name')`.
- Adds `JsonPathPass` compiler pass to collect function metadata (arity, return type) from tags and inject it into the crawler service.

### Example

```php
use Symfony\Component\JsonPath\Attribute\AsJsonPathFunction;

#[AsJsonPathFunction('upper')]
final class UppercaseFunction
{
    public function __invoke(mixed $value): ?string
    {
        return \is_string($value) ? strtoupper($value) : null;
    }
}
```

```php
$result = $crawler->find('$.items[?upper(@.title) == "HELLO"]');
```