### PR TITLE
[DependencyInjection][SecurityBundle] Leverage `#[AsTaggedItem]` for voters

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add support for the `clientHints`, `prefetchCache`, and `prerenderCache` `ClearSite-Data` directives
+ * Add support for `#[AsTaggedItem]` attribute to configure voter priority
 
 8.0
 ---

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/AddSecurityVotersPass.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/AddSecurityVotersPass.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\PriorityTaggedServiceTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -35,7 +36,8 @@ class AddSecurityVotersPass implements CompilerPassInterface
             return;
         }
 
-        $voters = $this->findAndSortTaggedServices('security.voter', $container);
+        $voters = $this->findAndSortTaggedServices(new TaggedIteratorArgument('security.voter'), $container);
+
         if (!$voters) {
             throw new LogicException('No security voters found. You need to tag at least one with "security.voter".');
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix -
| License       | MIT

As suggested by @stof in https://github.com/symfony/symfony/pull/62341#issuecomment-3632056020

This PR allows `#[AsTaggedItem]` to set priority on voters

Unlike `#[AutoconfigureTag]` or YAML config, `#[AsTaggedItem]` doesn't create duplicate tags and doesn't require specifying a tag name.

```php
#[AsTaggedItem(priority: 10)]
final class PostVoter extends Voter
```
