### PR TITLE
[Security] Fix persisting valid origin for both safe and non-safe requests

### DIFF
--- a/src/Symfony/Component/Security/Csrf/SameOriginCsrfTokenManager.php
+++ b/src/Symfony/Component/Security/Csrf/SameOriginCsrfTokenManager.php
@@ -182,7 +182,7 @@ final class SameOriginCsrfTokenManager implements CsrfTokenManagerInterface
 
         if (1 & $csrfProtection) {
             // Persist valid origin for both safe and non-safe requests
-            $previousCsrfProtection |= 1 & (1 << 8);
+            $previousCsrfProtection |= 1 | (1 << 8);
         }
 
         $request->attributes->set($this->cookieName, ($csrfProtection << $shift) | $previousCsrfProtection);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | just viewed Nicolas talk on AFUP YT channel
| License       | MIT

small typo fix
```php
1 & (1 << 8)
```
that is to say
```php
1 & 256
```

 is unfortunately always equal to 0
 
 
 Best regards,
 Laurent LEGAZ  (http://laurent.legaz.eu)
