### PR TITLE
[Console] Fix choice autocomplete issue when string has spaces

### DIFF
--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -316,7 +316,7 @@ class QuestionHelper extends Helper
                     if ($numMatches > 0 && -1 !== $ofs) {
                         $ret = (string) $matches[$ofs];
                         // Echo out remaining chars for current match
-                        $remainingCharacters = substr($ret, \strlen(trim($this->mostRecentlyEnteredValue($fullChoice))));
+                        $remainingCharacters = substr($ret, \strlen($this->mostRecentlyEnteredValue($fullChoice)));
                         $output->write($remainingCharacters);
                         $fullChoice .= $remainingCharacters;
                         $i = (false === $encoding = mb_detect_encoding($fullChoice, null, true)) ? \strlen($fullChoice) : mb_strlen($fullChoice, $encoding);
@@ -370,7 +370,7 @@ class QuestionHelper extends Helper
             if ($numMatches > 0 && -1 !== $ofs) {
                 $cursor->savePosition();
                 // Write highlighted text, complete the partially entered response
-                $charactersEntered = \strlen(trim($this->mostRecentlyEnteredValue($fullChoice)));
+                $charactersEntered = \strlen($this->mostRecentlyEnteredValue($fullChoice));
                 $output->write('<hl>'.OutputFormatter::escapeTrailingBackslash(substr($matches[$ofs], $charactersEntered)).'</hl>');
                 $cursor->restorePosition();
             }

--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -377,6 +377,24 @@ class QuestionHelperTest extends AbstractQuestionHelperTestCase
         $this->assertSame($character, $dialog->ask($this->createStreamableInputInterfaceMock($inputStream), $this->createOutputInterface(), $question));
     }
 
+    public function testAutocompleteWithSpaceAfterPartialMatch()
+    {
+        if (!Terminal::hasSttyAvailable()) {
+            $this->markTestSkipped('`stty` is required to test autocomplete functionality');
+        }
+
+        // a<SPACE><TAB><NEWLINE>
+        $inputStream = $this->getInputStream("a \t\n");
+
+        $dialog = new QuestionHelper();
+        $dialog->setHelperSet(new HelperSet([new FormatterHelper()]));
+
+        $question = new ChoiceQuestion('Please select a choice', ['a test', 'another choice']);
+        $question->setMaxAttempts(1);
+
+        $this->assertSame('a test', $dialog->ask($this->createStreamableInputInterfaceMock($inputStream), $this->createOutputInterface(), $question));
+    }
+
     public function testAutocompleteWithTrailingBackslash()
     {
         if (!Terminal::hasSttyAvailable()) {
@@ -942,7 +960,7 @@ EOD;
         }
 
         $p = new Process(
-            ['php', dirname(__DIR__).'/Fixtures/application_test_sigint.php', $mode],
+            ['php', \dirname(__DIR__).'/Fixtures/application_test_sigint.php', $mode],
             timeout: 2, // the process will auto shutdown if not killed by SIGINT, to prevent blocking
         );
         $p->setPty(true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62814
| License       | MIT

Choice = "a test"

Typing "a ", pressing SPACE suggests "a ` test`" (extra space), then TAB to autocomplete results in "`a  test`" (the extra space is included).
<img width="189" height="54" alt="image" src="https://github.com/user-attachments/assets/c505c5dc-1ea3-4ecb-b981-aad0cc3ebb01" />

The autocomplete logic was trimming the entered value before calculating what to append, ignoring the space the user already typed.

Fix: use the actual entered value length (including spaces). 

Also extracted variables for better readability.