### PR TITLE
[DependencyInjection] Allow environment variables with `.` in them

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Deprecate setting the `framework.profiler.collect_serializer_data` config option
+ * Add support for `framework.secrets.decryption_env_var` to contain dots
 
 8.0
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1917,8 +1917,8 @@ class FrameworkExtension extends Extension
         }
 
         if ($config['decryption_env_var']) {
-            if (!preg_match('/^(?:[-.\w\\\\]*+:)*+\w++$/', $config['decryption_env_var'])) {
-                throw new InvalidArgumentException(\sprintf('Invalid value "%s" set as "decryption_env_var": only "word" characters are allowed.', $config['decryption_env_var']));
+            if (!preg_match('/^(?:[-.\w\\\\]*+:)*+[\w.]++$/', $config['decryption_env_var'])) {
+                throw new InvalidArgumentException(\sprintf('Invalid value "%s" set as "decryption_env_var": only "word" and dot characters are allowed.', $config['decryption_env_var']));
             }
 
             if (ContainerBuilder::willBeAvailable('symfony/string', LazyString::class, ['symfony/framework-bundle'])) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -2826,6 +2826,35 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->assertTrue($container->has('object_mapper'));
     }
 
+    public function testSecretsDecryptionEnvVarWithDot()
+    {
+        $container = $this->createContainerFromClosure(static function (ContainerBuilder $container) {
+            $container->loadFromExtension('framework', [
+                'secrets' => [
+                    'enabled' => true,
+                    'vault_directory' => '%kernel.project_dir%/config/secrets/%kernel.environment%',
+                    'decryption_env_var' => 'dynamic.var',
+                ],
+            ]);
+        });
+        $this->assertTrue($container->hasDefinition('secrets.vault'));
+    }
+
+    public function testSecretsDecryptionEnvVarWithInvalidCharacters()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid value "invalid@var" set as "decryption_env_var": only "word" and dot characters are allowed.');
+        $this->createContainerFromClosure(static function (ContainerBuilder $container) {
+            $container->loadFromExtension('framework', [
+                'secrets' => [
+                    'enabled' => true,
+                    'vault_directory' => '%kernel.project_dir%/config/secrets/%kernel.environment%',
+                    'decryption_env_var' => 'invalid@var',
+                ],
+            ]);
+        });
+    }
+
     protected function createContainer(array $data = [])
     {
         return new ContainerBuilder(new EnvPlaceholderParameterBag(array_merge([

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add support for `SOURCE_DATE_EPOCH` environment variable
  * Deprecate configuring options `alias`, `parent`, `synthetic`, `file`, `arguments`, `properties`, `configurator` or `calls` when using `from_callable`
  * Deprecate default index/priority methods when defining tagged locators/iterators; use the `#[AsTaggedItem]` attribute instead
+ * Allow environment variables with `.` in them
 
 8.0
 ---

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1604,7 +1604,7 @@ class PhpDumper extends Dumper
             $export = $this->exportParameters([$value], '', 12, $hasEnum);
             $export = explode('0 => ', substr(rtrim($export, " ]\n"), 2, -1), 2);
 
-            if ($hasEnum || preg_match("/\\\$container->(?:getEnv\('(?:[-.\w\\\\]*+:)*+\w*+'\)|targetDir\.'')/", $export[1])) {
+            if ($hasEnum || preg_match("/\\\$container->(?:getEnv\('(?:[-.\w\\\\]*+:)*+[\w.]*+'\)|targetDir\.'')/", $export[1])) {
                 $dynamicPhp[$key] = \sprintf('%s%s => %s,', $export[0], $this->export($key), $export[1]);
                 $this->dynamicParameters[$key] = true;
             } else {

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
@@ -41,8 +41,8 @@ class EnvPlaceholderParameterBag extends ParameterBag
                     return $placeholder; // return first result
                 }
             }
-            if (!preg_match('/^(?:[-.\w\\\\]*+:)*+\w*+$/', $env)) {
-                throw new InvalidArgumentException(\sprintf('The given env var name "%s" contains invalid characters (allowed characters: letters, digits, hyphens, backslashes and colons).', $name));
+            if (!preg_match('/^(?:[-.\w\\\\]*+:)*+[\w.]*+$/', $env)) {
+                throw new InvalidArgumentException(\sprintf('The given env var name "%s" contains invalid characters (allowed characters: letters, digits, hyphens, backslashes, dots and colons).', $name));
             }
             if ($this->has($name) && null !== ($defaultValue = parent::get($name)) && !\is_string($defaultValue)) {
                 throw new RuntimeException(\sprintf('The default value of an env() parameter must be a string or null, but "%s" given to "%s".', get_debug_type($defaultValue), $name));

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -597,6 +597,22 @@ class PhpDumperTest extends TestCase
         putenv('Baz');
     }
 
+    public function testEnvParameterWithDot()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('env(dynamic.var)', 'test_value');
+        $container->setParameter('test_with_dot', '%env(dynamic.var)%');
+        $container->compile();
+        $dumper = new PhpDumper($container);
+        $dumped = $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_EnvWithDot']);
+
+        $this->assertStringContainsString("'test_with_dot' => \$container->getEnv('dynamic.var')", $dumped, 'Parameter with dot should be in getDynamicParameter');
+
+        if (preg_match('/protected function getDefaultParameters\(\): array\s*\{\s*return \[(.*?)\];/s', $dumped, $matches)) {
+            $this->assertStringNotContainsString("'test_with_dot'", $matches[1], 'Parameter with dot should be dynamic in getDynamicParameter');
+        }
+    }
+
     public function testResolvedBase64EnvParameters()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/EnvPlaceholderParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/EnvPlaceholderParameterBagTest.php
@@ -31,7 +31,7 @@ class EnvPlaceholderParameterBagTest extends TestCase
     {
         $bag = new EnvPlaceholderParameterBag();
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The given env var name "env(%foo%)" contains invalid characters (allowed characters: letters, digits, hyphens, backslashes and colons).');
+        $this->expectExceptionMessage('The given env var name "env(%foo%)" contains invalid characters (allowed characters: letters, digits, hyphens, backslashes, dots and colons).');
         $bag->get('env(%foo%)');
     }
 
@@ -181,6 +181,16 @@ class EnvPlaceholderParameterBagTest extends TestCase
         $bag->resolve();
 
         $this->assertNull($bag->all()['env(NULL_VAR)']);
+    }
+
+    public function testGetEnvAllowsDot()
+    {
+        $bag = new EnvPlaceholderParameterBag();
+        $bag->set('env(dynamic.var)', 'foo');
+        $bag->get('env(dynamic.var)');
+        $bag->resolve();
+
+        $this->assertSame('foo', $bag->all()['env(dynamic.var)']);
     }
 
     public function testGetThrowsOnBadDefaultValue()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? |no
| Issues        | Fix https://github.com/symfony/symfony/issues/33806#issuecomment-539480798 -< old discussion that says `.` could be added
| License       | MIT

In our system, environment variables are generated dynamically (e.g. by a Go controller) and use dot-separated names to represent hierarchical keys.

These variables are valid at the OS level and can be accessed via getenv()/$_ENV, but Symfony currently rejects them due to strict validation.

This change allows consuming such existing environment variables.