### PR TITLE
[Serializer] Fix serialization of method with same name than property

### DIFF
--- a/src/Symfony/Component/Serializer/Mapping/Loader/AttributeLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AttributeLoader.php
@@ -138,8 +138,9 @@ class AttributeLoader implements LoaderInterface
                 default => false,
             } && ('s' === $name[0] || !$method->getNumberOfRequiredParameters() && !\in_array((string) $method->getReturnType(), ['void', 'never'], true));
 
-            if ($accessorOrMutator && !ctype_lower($name[$i])) {
-                if ($this->hasProperty($method->getDeclaringClass(), $name)) {
+            $hasProperty = $this->hasProperty($method->getDeclaringClass(), $name);
+            if ($hasProperty || $accessorOrMutator && !ctype_lower($name[$i])) {
+                if ($hasProperty) {
                     $attributeName = $name;
                 } else {
                     $attributeName = substr($name, $i);
@@ -159,7 +160,7 @@ class AttributeLoader implements LoaderInterface
 
             foreach ($this->loadAttributes($method) as $annotation) {
                 if ($annotation instanceof Groups) {
-                    if (!$accessorOrMutator) {
+                    if (!$accessorOrMutator && !$hasProperty) {
                         throw new MappingException(\sprintf('Groups on "%s::%s()" cannot be added. Groups can only be added on methods beginning with "get", "is", "has", "can" or "set".', $className, $method->name));
                     }
 
@@ -167,29 +168,29 @@ class AttributeLoader implements LoaderInterface
                         $attributeMetadata->addGroup($group);
                     }
                 } elseif ($annotation instanceof MaxDepth) {
-                    if (!$accessorOrMutator) {
+                    if (!$accessorOrMutator && !$hasProperty) {
                         throw new MappingException(\sprintf('MaxDepth on "%s::%s()" cannot be added. MaxDepth can only be added on methods beginning with "get", "is", "has", "can" or "set".', $className, $method->name));
                     }
 
                     $attributeMetadata->setMaxDepth($annotation->getMaxDepth());
                 } elseif ($annotation instanceof SerializedName) {
-                    if (!$accessorOrMutator) {
+                    if (!$accessorOrMutator && !$hasProperty) {
                         throw new MappingException(\sprintf('SerializedName on "%s::%s()" cannot be added. SerializedName can only be added on methods beginning with "get", "is", "has", "can" or "set".', $className, $method->name));
                     }
 
                     $attributeMetadata->setSerializedName($annotation->getSerializedName());
                 } elseif ($annotation instanceof SerializedPath) {
-                    if (!$accessorOrMutator) {
+                    if (!$accessorOrMutator && !$hasProperty) {
                         throw new MappingException(\sprintf('SerializedPath on "%s::%s()" cannot be added. SerializedPath can only be added on methods beginning with "get", "is", "has", "can" or "set".', $className, $method->name));
                     }
 
                     $attributeMetadata->setSerializedPath($annotation->getSerializedPath());
                 } elseif ($annotation instanceof Ignore) {
-                    if ($accessorOrMutator) {
+                    if ($accessorOrMutator && !$hasProperty) {
                         $attributeMetadata->setIgnore(true);
                     }
                 } elseif ($annotation instanceof Context) {
-                    if (!$accessorOrMutator) {
+                    if (!$accessorOrMutator && !$hasProperty) {
                         throw new MappingException(\sprintf('Context on "%s::%s()" cannot be added. Context can only be added on methods beginning with "get", "is", "has", "can" or "set".', $className, $method->name));
                     }
 

--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -117,6 +117,8 @@ class ObjectNormalizer extends AbstractObjectNormalizer
                         $attributeName = lcfirst($attributeName);
                     }
                 }
+            } elseif ($this->hasProperty($reflMethod->getDeclaringClass(), $name)) {
+                $attributeName = $name;
             }
 
             if (null !== $attributeName && $this->isAllowedAttribute($object, $attributeName, $format, $context)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes (maybe ?)
| New feature?  | no (not sure ?)
| Deprecations? | no 
| Issues        | Fix #... 
| License       | MIT

Currently the DeduplicateStamp has two issues with Symfony Serializer (cf https://github.com/symfony/symfony/issues/60659)
- The Key field is not correctly serialized
- The property `onlyDeduplicateInQueue ` is not serialized at all

While the first issue is easily solved, the second one does not seems that easy.
Related to discussion https://github.com/symfony/symfony/pull/62779#discussion_r2640144845

The property `onlyDeduplicateInQueue` is private and the related "getter" is called `onlyDeduplicateInQueue()` too, which means it's not serialized by the ObjectNormalizer since it only support `get/is/can/has` methods.
This PR allows
- to serialized method which has the same name than an object property
- to add attributes to these methods

I don't know if 
- this should be on 6.4 as a bugfix like https://github.com/symfony/symfony/pull/61097
- this should be on 8.1 as a new feature like https://github.com/symfony/symfony/pull/61023

If merged in 6.4 this could be used for the fix https://github.com/symfony/symfony/pull/62779 (or we use a workaround of having two methods in DeduplicateStamp until 8.1)

cc @nicolas-grekas 