### PR TITLE
[Form] Always normalize CRLF and CR to LF in `TextareaType`

### DIFF
--- a/.github/expected-missing-return-types.diff
+++ b/.github/expected-missing-return-types.diff
@@ -6247,7 +6247,14 @@ diff --git a/src/Symfony/Component/Form/Extension/Core/Type/TextType.php b/src/S
 diff --git a/src/Symfony/Component/Form/Extension/Core/Type/TextareaType.php b/src/Symfony/Component/Form/Extension/Core/Type/TextareaType.php
 --- a/src/Symfony/Component/Form/Extension/Core/Type/TextareaType.php
 +++ b/src/Symfony/Component/Form/Extension/Core/Type/TextareaType.php
-@@ -21,5 +21,5 @@ class TextareaType extends AbstractType
+@@ -23,5 +23,5 @@ class TextareaType extends AbstractType
+      * @return void
+      */
+-    public function buildForm(FormBuilderInterface $builder, array $options)
++    public function buildForm(FormBuilderInterface $builder, array $options): void
+     {
+         $builder->addEventSubscriber(new CrlfNormalizerListener());
+@@ -31,5 +31,5 @@ class TextareaType extends AbstractType
       * @return void
       */
 -    public function buildView(FormView $view, FormInterface $form, array $options)

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/CrlfNormalizerListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/CrlfNormalizerListener.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Extension\Core\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\Util\StringUtil;
+
+/**
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ */
+class CrlfNormalizerListener implements EventSubscriberInterface
+{
+    public function preSubmit(FormEvent $event): void
+    {
+        if (!\is_string($data = $event->getData())) {
+            return;
+        }
+
+        $event->setData(StringUtil::normalizeNewlines($data));
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [FormEvents::PRE_SUBMIT => 'preSubmit'];
+    }
+}

--- a/src/Symfony/Component/Form/Extension/Core/Type/TextareaType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TextareaType.php
@@ -12,11 +12,21 @@
 namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\EventListener\CrlfNormalizerListener;
+use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 
 class TextareaType extends AbstractType
 {
+    /**
+     * @return void
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->addEventSubscriber(new CrlfNormalizerListener());
+    }
+
     /**
      * @return void
      */

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/CrlfNormalizerListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/CrlfNormalizerListenerTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Core\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Form\Extension\Core\EventListener\CrlfNormalizerListener;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormConfigBuilder;
+use Symfony\Component\Form\FormEvent;
+
+class CrlfNormalizerListenerTest extends TestCase
+{
+    public function testNormalizeCrlf()
+    {
+        $form = new Form(new FormConfigBuilder('name', null, new EventDispatcher()));
+        $event = new FormEvent($form, "Line 1\r\nLine 2\r\nLine 3");
+
+        $listener = new CrlfNormalizerListener();
+        $listener->preSubmit($event);
+
+        $this->assertSame("Line 1\nLine 2\nLine 3", $event->getData());
+    }
+
+    public function testNormalizeCr()
+    {
+        $form = new Form(new FormConfigBuilder('name', null, new EventDispatcher()));
+        $event = new FormEvent($form, "Line 1\rLine 2\rLine 3");
+
+        $listener = new CrlfNormalizerListener();
+        $listener->preSubmit($event);
+
+        $this->assertSame("Line 1\nLine 2\nLine 3", $event->getData());
+    }
+
+    public function testNormalizeMixedNewlines()
+    {
+        $form = new Form(new FormConfigBuilder('name', null, new EventDispatcher()));
+        $event = new FormEvent($form, "Line 1\r\nLine 2\rLine 3\nLine 4");
+
+        $listener = new CrlfNormalizerListener();
+        $listener->preSubmit($event);
+
+        $this->assertSame("Line 1\nLine 2\nLine 3\nLine 4", $event->getData());
+    }
+
+    public function testPreserveLf()
+    {
+        $form = new Form(new FormConfigBuilder('name', null, new EventDispatcher()));
+        $event = new FormEvent($form, "Line 1\nLine 2\nLine 3");
+
+        $listener = new CrlfNormalizerListener();
+        $listener->preSubmit($event);
+
+        $this->assertSame("Line 1\nLine 2\nLine 3", $event->getData());
+    }
+
+    public function testSkipNonStrings()
+    {
+        $form = new Form(new FormConfigBuilder('name', null, new EventDispatcher()));
+        $event = new FormEvent($form, 1234);
+
+        $listener = new CrlfNormalizerListener();
+        $listener->preSubmit($event);
+
+        $this->assertSame(1234, $event->getData());
+    }
+
+    public function testEmptyString()
+    {
+        $form = new Form(new FormConfigBuilder('name', null, new EventDispatcher()));
+        $event = new FormEvent($form, '');
+
+        $listener = new CrlfNormalizerListener();
+        $listener->preSubmit($event);
+
+        $this->assertSame('', $event->getData());
+    }
+
+    public function testNoNewlines()
+    {
+        $data = 'Single line text';
+        $form = new Form(new FormConfigBuilder('name', null, new EventDispatcher()));
+        $event = new FormEvent($form, $data);
+
+        $listener = new CrlfNormalizerListener();
+        $listener->preSubmit($event);
+
+        $this->assertSame('Single line text', $event->getData());
+    }
+
+    public function testMultipleConsecutiveNewlines()
+    {
+        $data = "Line 1\r\n\r\n\r\nLine 2";
+        $form = new Form(new FormConfigBuilder('name', null, new EventDispatcher()));
+        $event = new FormEvent($form, $data);
+
+        $listener = new CrlfNormalizerListener();
+        $listener->preSubmit($event);
+
+        $this->assertSame("Line 1\n\n\nLine 2", $event->getData());
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TextareaTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TextareaTypeTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Core\Type;
+
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+
+class TextareaTypeTest extends BaseTypeTestCase
+{
+    public const TESTED_TYPE = TextareaType::class;
+
+    public function testSubmitNull($expected = null, $norm = null, $view = null)
+    {
+        parent::testSubmitNull($expected, $norm, '');
+    }
+
+    public function testSubmitNormalizeCrlf()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE);
+        $form->submit("Line 1\r\nLine 2\r\nLine 3");
+
+        $this->assertSame("Line 1\nLine 2\nLine 3", $form->getData());
+    }
+
+    public function testSubmitNormalizeCr()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE);
+        $form->submit("Line 1\rLine 2\rLine 3");
+
+        $this->assertSame("Line 1\nLine 2\nLine 3", $form->getData());
+    }
+
+    public function testSubmitNormalizeMixedNewlines()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE);
+        $form->submit("Line 1\r\nLine 2\rLine 3\nLine 4");
+
+        $this->assertSame("Line 1\nLine 2\nLine 3\nLine 4", $form->getData());
+    }
+
+    public function testSubmitPreserveLf()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE);
+        $form->submit("Line 1\nLine 2\nLine 3");
+
+        $this->assertSame("Line 1\nLine 2\nLine 3", $form->getData());
+    }
+
+    public function testSubmitSingleLine()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE);
+        $form->submit('Single line text');
+
+        $this->assertSame('Single line text', $form->getData());
+    }
+
+    public function testBuildViewDoesNotHavePattern()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE);
+        $view = $form->createView();
+
+        $this->assertNull($view->vars['pattern']);
+        $this->assertArrayNotHasKey('pattern', $view->vars['attr']);
+    }
+
+    public function testWithTrimDisabled()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, ['trim' => false]);
+        $form->submit("  Line 1\r\nLine 2  ");
+
+        $this->assertSame("  Line 1\nLine 2  ", $form->getData());
+    }
+
+    public function testWithTrimEnabled()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, ['trim' => true]);
+        $form->submit("  Line 1\r\nLine 2  ");
+
+        $this->assertSame("Line 1\nLine 2", $form->getData());
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Util/StringUtilTest.php
+++ b/src/Symfony/Component/Form/Tests/Util/StringUtilTest.php
@@ -87,6 +87,27 @@ class StringUtilTest extends TestCase
         ];
     }
 
+    public static function normalizeNewlinesProvider(): array
+    {
+        return [
+            ["Line 1\r\nLine 2", "Line 1\nLine 2"],
+            ["Line 1\rLine 2", "Line 1\nLine 2"],
+            ["Line 1\r\nLine 2\rLine 3\nLine 4", "Line 1\nLine 2\nLine 3\nLine 4"],
+            ["Line 1\nLine 2", "Line 1\nLine 2"],
+            ['', ''],
+            ['Single line', 'Single line'],
+            ["Line 1\r\n\r\n\r\nLine 2", "Line 1\n\n\nLine 2"],
+        ];
+    }
+
+    /**
+     * @dataProvider normalizeNewlinesProvider
+     */
+    public function testNormalizeNewlines($data, $expectedData)
+    {
+        $this->assertSame($expectedData, StringUtil::normalizeNewlines($data));
+    }
+
     /**
      * @dataProvider fqcnToBlockPrefixProvider
      */

--- a/src/Symfony/Component/Form/Util/StringUtil.php
+++ b/src/Symfony/Component/Form/Util/StringUtil.php
@@ -37,6 +37,14 @@ class StringUtil
     }
 
     /**
+     * Converts both CRLF and CR to LF.
+     */
+    public static function normalizeNewlines(string $string): string
+    {
+        return str_replace(["\r\n", "\r"], "\n", $string);
+    }
+
+    /**
      * Converts a fully-qualified class name to a block prefix.
      *
      * @param string $fqcn The fully-qualified class name


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62611
| License       | MIT
