### PR TITLE
[DependencyInjection] Fix referencing build-time array parameters

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -97,7 +97,8 @@ class PassConfig
                 new AliasDeprecatedPublicServicesPass(),
             ],
             // Let build parameters be available as late as possible
-            -2048 => [new RemoveBuildParametersPass()],
+            // Don't remove array parameters since ResolveParameterPlaceHoldersPass doesn't resolve them
+            -2048 => [new RemoveBuildParametersPass(true)],
         ];
     }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/RemoveBuildParametersPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RemoveBuildParametersPass.php
@@ -20,6 +20,11 @@ class RemoveBuildParametersPass implements CompilerPassInterface
      */
     private array $removedParameters = [];
 
+    public function __construct(
+        private bool $preserveArrays = false,
+    ) {
+    }
+
     /**
      * @return void
      */
@@ -29,7 +34,7 @@ class RemoveBuildParametersPass implements CompilerPassInterface
         $this->removedParameters = [];
 
         foreach ($parameterBag->all() as $name => $value) {
-            if ('.' === ($name[0] ?? '')) {
+            if ('.' === ($name[0] ?? '') && (!$this->preserveArrays || !\is_array($value))) {
                 $this->removedParameters[$name] = $value;
 
                 $parameterBag->remove($name);

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1616,15 +1616,16 @@ EOF;
             trigger_deprecation(...self::DEPRECATED_PARAMETERS[$name]);
         }
 
-        if (isset($this->buildParameters[$name])) {
+        if (\array_key_exists($name, $this->buildParameters)) {
             return $this->buildParameters[$name];
         }
 
-        if (!(isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters))) {
-            throw new ParameterNotFoundException($name);
-        }
         if (isset($this->loadedDynamicParameters[$name])) {
             return $this->loadedDynamicParameters[$name] ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);
+        }
+
+        if (!\array_key_exists($name, $this->parameters) || '.' === ($name[0] ?? '')) {
+            throw new ParameterNotFoundException($name);
         }
 
         return $this->parameters[$name];
@@ -1632,11 +1633,11 @@ EOF;
 
     public function hasParameter(string $name): bool
     {
-        if (isset($this->buildParameters[$name])) {
+        if (\array_key_exists($name, $this->buildParameters)) {
             return true;
         }
 
-        return isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters);
+        return \array_key_exists($name, $this->parameters) || isset($this->loadedDynamicParameters[$name]);
     }
 
     public function setParameter(string $name, $value): void

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RemoveBuildParametersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RemoveBuildParametersPassTest.php
@@ -30,4 +30,35 @@ class RemoveBuildParametersPassTest extends TestCase
         $this->assertFalse($builder->hasParameter('.bar'), '".bar" parameter must be removed.');
         $this->assertSame(['.bar' => 'Bar'], $pass->getRemovedParameters(), '".bar" parameter must be returned with its value.');
     }
+
+    public function testArrayBuildParametersArePreservedWhenConfigured()
+    {
+        $builder = new ContainerBuilder();
+        $builder->setParameter('foo', 'Foo');
+        $builder->setParameter('.scalar', 'Bar');
+        $builder->setParameter('.array', ['baz' => 'qux']);
+
+        $pass = new RemoveBuildParametersPass(true);
+        $pass->process($builder);
+
+        $this->assertSame('Foo', $builder->getParameter('foo'), '"foo" parameter must be defined.');
+        $this->assertFalse($builder->hasParameter('.scalar'), '".scalar" parameter must be removed.');
+        $this->assertTrue($builder->hasParameter('.array'), '".array" parameter must be preserved.');
+        $this->assertSame(['baz' => 'qux'], $builder->getParameter('.array'), '".array" parameter must retain its value.');
+        $this->assertSame(['.scalar' => 'Bar'], $pass->getRemovedParameters(), 'Only ".scalar" parameter must be returned as removed.');
+    }
+
+    public function testNonArrayBuildParametersAreAlwaysRemoved()
+    {
+        $builder = new ContainerBuilder();
+        $builder->setParameter('.scalar', 'Bar');
+        $builder->setParameter('.array', ['baz' => 'qux']);
+
+        $pass = new RemoveBuildParametersPass();
+        $pass->process($builder);
+
+        $this->assertFalse($builder->hasParameter('.scalar'), '".scalar" parameter must be removed.');
+        $this->assertFalse($builder->hasParameter('.array'), '".array" parameter must be removed.');
+        $this->assertSame(['.scalar' => 'Bar', '.array' => ['baz' => 'qux']], $pass->getRemovedParameters(), 'Both parameters must be returned as removed.');
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -37,6 +37,7 @@ use Symfony\Component\DependencyInjection\Exception\EnvParameterException;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Exception\ParameterCircularReferenceException;
+use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException;
 use Symfony\Component\DependencyInjection\LazyProxy\PhpDumper\NullDumper;
@@ -1814,6 +1815,25 @@ PHP
 
         $dumper = new PhpDumper($container);
         $dumper->dump();
+    }
+
+    public function testDotPrefixedParametersAreNotAccessibleInDumpedContainer()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('.build_param', 'internal_value');
+        $container->setParameter('regular_param', 'public_value');
+        $container->compile();
+
+        $dumper = new PhpDumper($container);
+        eval('?>'.$dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_Dot_Prefixed']));
+
+        $dumped = new \Symfony_DI_PhpDumper_Test_Dot_Prefixed();
+
+        $this->assertTrue($dumped->hasParameter('regular_param'));
+        $this->assertSame('public_value', $dumped->getParameter('regular_param'));
+        $this->assertFalse($dumped->hasParameter('.build_param'));
+        $this->expectException(ParameterNotFoundException::class);
+        $dumped->getParameter('.build_param');
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10.php
@@ -50,11 +50,12 @@ class ProjectServiceContainer extends Container
 
     public function getParameter(string $name): array|bool|string|int|float|\UnitEnum|null
     {
-        if (!(isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters))) {
-            throw new ParameterNotFoundException($name);
-        }
         if (isset($this->loadedDynamicParameters[$name])) {
             return $this->loadedDynamicParameters[$name] ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);
+        }
+
+        if (!\array_key_exists($name, $this->parameters) || '.' === ($name[0] ?? '')) {
+            throw new ParameterNotFoundException($name);
         }
 
         return $this->parameters[$name];
@@ -62,7 +63,7 @@ class ProjectServiceContainer extends Container
 
     public function hasParameter(string $name): bool
     {
-        return isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters);
+        return \array_key_exists($name, $this->parameters) || isset($this->loadedDynamicParameters[$name]);
     }
 
     public function setParameter(string $name, $value): void

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services12.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services12.php
@@ -50,11 +50,12 @@ class ProjectServiceContainer extends Container
 
     public function getParameter(string $name): array|bool|string|int|float|\UnitEnum|null
     {
-        if (!(isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters))) {
-            throw new ParameterNotFoundException($name);
-        }
         if (isset($this->loadedDynamicParameters[$name])) {
             return $this->loadedDynamicParameters[$name] ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);
+        }
+
+        if (!\array_key_exists($name, $this->parameters) || '.' === ($name[0] ?? '')) {
+            throw new ParameterNotFoundException($name);
         }
 
         return $this->parameters[$name];
@@ -62,7 +63,7 @@ class ProjectServiceContainer extends Container
 
     public function hasParameter(string $name): bool
     {
-        return isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters);
+        return \array_key_exists($name, $this->parameters) || isset($this->loadedDynamicParameters[$name]);
     }
 
     public function setParameter(string $name, $value): void

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services19.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services19.php
@@ -65,11 +65,12 @@ class ProjectServiceContainer extends Container
 
     public function getParameter(string $name): array|bool|string|int|float|\UnitEnum|null
     {
-        if (!(isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters))) {
-            throw new ParameterNotFoundException($name);
-        }
         if (isset($this->loadedDynamicParameters[$name])) {
             return $this->loadedDynamicParameters[$name] ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);
+        }
+
+        if (!\array_key_exists($name, $this->parameters) || '.' === ($name[0] ?? '')) {
+            throw new ParameterNotFoundException($name);
         }
 
         return $this->parameters[$name];
@@ -77,7 +78,7 @@ class ProjectServiceContainer extends Container
 
     public function hasParameter(string $name): bool
     {
-        return isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters);
+        return \array_key_exists($name, $this->parameters) || isset($this->loadedDynamicParameters[$name]);
     }
 
     public function setParameter(string $name, $value): void

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services26.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services26.php
@@ -61,11 +61,12 @@ class Symfony_DI_PhpDumper_Test_EnvParameters extends Container
 
     public function getParameter(string $name): array|bool|string|int|float|\UnitEnum|null
     {
-        if (!(isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters))) {
-            throw new ParameterNotFoundException($name);
-        }
         if (isset($this->loadedDynamicParameters[$name])) {
             return $this->loadedDynamicParameters[$name] ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);
+        }
+
+        if (!\array_key_exists($name, $this->parameters) || '.' === ($name[0] ?? '')) {
+            throw new ParameterNotFoundException($name);
         }
 
         return $this->parameters[$name];
@@ -73,7 +74,7 @@ class Symfony_DI_PhpDumper_Test_EnvParameters extends Container
 
     public function hasParameter(string $name): bool
     {
-        return isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters);
+        return \array_key_exists($name, $this->parameters) || isset($this->loadedDynamicParameters[$name]);
     }
 
     public function setParameter(string $name, $value): void

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services8.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services8.php
@@ -37,11 +37,12 @@ class ProjectServiceContainer extends Container
 
     public function getParameter(string $name): array|bool|string|int|float|\UnitEnum|null
     {
-        if (!(isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters))) {
-            throw new ParameterNotFoundException($name);
-        }
         if (isset($this->loadedDynamicParameters[$name])) {
             return $this->loadedDynamicParameters[$name] ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);
+        }
+
+        if (!\array_key_exists($name, $this->parameters) || '.' === ($name[0] ?? '')) {
+            throw new ParameterNotFoundException($name);
         }
 
         return $this->parameters[$name];
@@ -49,7 +50,7 @@ class ProjectServiceContainer extends Container
 
     public function hasParameter(string $name): bool
     {
-        return isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters);
+        return \array_key_exists($name, $this->parameters) || isset($this->loadedDynamicParameters[$name]);
     }
 
     public function setParameter(string $name, $value): void

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_as_files.txt
@@ -661,15 +661,16 @@ class ProjectServiceContainer extends Container
 
     public function getParameter(string $name): array|bool|string|int|float|\UnitEnum|null
     {
-        if (isset($this->buildParameters[$name])) {
+        if (\array_key_exists($name, $this->buildParameters)) {
             return $this->buildParameters[$name];
         }
 
-        if (!(isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters))) {
-            throw new ParameterNotFoundException($name);
-        }
         if (isset($this->loadedDynamicParameters[$name])) {
             return $this->loadedDynamicParameters[$name] ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);
+        }
+
+        if (!\array_key_exists($name, $this->parameters) || '.' === ($name[0] ?? '')) {
+            throw new ParameterNotFoundException($name);
         }
 
         return $this->parameters[$name];
@@ -677,11 +678,11 @@ class ProjectServiceContainer extends Container
 
     public function hasParameter(string $name): bool
     {
-        if (isset($this->buildParameters[$name])) {
+        if (\array_key_exists($name, $this->buildParameters)) {
             return true;
         }
 
-        return isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters);
+        return \array_key_exists($name, $this->parameters) || isset($this->loadedDynamicParameters[$name]);
     }
 
     public function setParameter(string $name, $value): void

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -452,11 +452,12 @@ class ProjectServiceContainer extends Container
 
     public function getParameter(string $name): array|bool|string|int|float|\UnitEnum|null
     {
-        if (!(isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters))) {
-            throw new ParameterNotFoundException($name);
-        }
         if (isset($this->loadedDynamicParameters[$name])) {
             return $this->loadedDynamicParameters[$name] ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);
+        }
+
+        if (!\array_key_exists($name, $this->parameters) || '.' === ($name[0] ?? '')) {
+            throw new ParameterNotFoundException($name);
         }
 
         return $this->parameters[$name];
@@ -464,7 +465,7 @@ class ProjectServiceContainer extends Container
 
     public function hasParameter(string $name): bool
     {
-        return isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters);
+        return \array_key_exists($name, $this->parameters) || isset($this->loadedDynamicParameters[$name]);
     }
 
     public function setParameter(string $name, $value): void

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_inlined_factories.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_inlined_factories.txt
@@ -503,15 +503,16 @@ class ProjectServiceContainer extends Container
 
     public function getParameter(string $name): array|bool|string|int|float|\UnitEnum|null
     {
-        if (isset($this->buildParameters[$name])) {
+        if (\array_key_exists($name, $this->buildParameters)) {
             return $this->buildParameters[$name];
         }
 
-        if (!(isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters))) {
-            throw new ParameterNotFoundException($name);
-        }
         if (isset($this->loadedDynamicParameters[$name])) {
             return $this->loadedDynamicParameters[$name] ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);
+        }
+
+        if (!\array_key_exists($name, $this->parameters) || '.' === ($name[0] ?? '')) {
+            throw new ParameterNotFoundException($name);
         }
 
         return $this->parameters[$name];
@@ -519,11 +520,11 @@ class ProjectServiceContainer extends Container
 
     public function hasParameter(string $name): bool
     {
-        if (isset($this->buildParameters[$name])) {
+        if (\array_key_exists($name, $this->buildParameters)) {
             return true;
         }
 
-        return isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters);
+        return \array_key_exists($name, $this->parameters) || isset($this->loadedDynamicParameters[$name]);
     }
 
     public function setParameter(string $name, $value): void

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_lazy_inlined_factories.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_lazy_inlined_factories.txt
@@ -84,15 +84,16 @@ class ProjectServiceContainer extends Container
 
     public function getParameter(string $name): array|bool|string|int|float|\UnitEnum|null
     {
-        if (isset($this->buildParameters[$name])) {
+        if (\array_key_exists($name, $this->buildParameters)) {
             return $this->buildParameters[$name];
         }
 
-        if (!(isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters))) {
-            throw new ParameterNotFoundException($name);
-        }
         if (isset($this->loadedDynamicParameters[$name])) {
             return $this->loadedDynamicParameters[$name] ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);
+        }
+
+        if (!\array_key_exists($name, $this->parameters) || '.' === ($name[0] ?? '')) {
+            throw new ParameterNotFoundException($name);
         }
 
         return $this->parameters[$name];
@@ -100,11 +101,11 @@ class ProjectServiceContainer extends Container
 
     public function hasParameter(string $name): bool
     {
-        if (isset($this->buildParameters[$name])) {
+        if (\array_key_exists($name, $this->buildParameters)) {
             return true;
         }
 
-        return isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters);
+        return \array_key_exists($name, $this->parameters) || isset($this->loadedDynamicParameters[$name]);
     }
 
     public function setParameter(string $name, $value): void

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_array_params.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_array_params.php
@@ -54,11 +54,12 @@ class ProjectServiceContainer extends Container
 
     public function getParameter(string $name): array|bool|string|int|float|\UnitEnum|null
     {
-        if (!(isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters))) {
-            throw new ParameterNotFoundException($name);
-        }
         if (isset($this->loadedDynamicParameters[$name])) {
             return $this->loadedDynamicParameters[$name] ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);
+        }
+
+        if (!\array_key_exists($name, $this->parameters) || '.' === ($name[0] ?? '')) {
+            throw new ParameterNotFoundException($name);
         }
 
         return $this->parameters[$name];
@@ -66,7 +67,7 @@ class ProjectServiceContainer extends Container
 
     public function hasParameter(string $name): bool
     {
-        return isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters);
+        return \array_key_exists($name, $this->parameters) || isset($this->loadedDynamicParameters[$name]);
     }
 
     public function setParameter(string $name, $value): void

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_base64_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_base64_env.php
@@ -37,11 +37,12 @@ class Symfony_DI_PhpDumper_Test_Base64Parameters extends Container
 
     public function getParameter(string $name): array|bool|string|int|float|\UnitEnum|null
     {
-        if (!(isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters))) {
-            throw new ParameterNotFoundException($name);
-        }
         if (isset($this->loadedDynamicParameters[$name])) {
             return $this->loadedDynamicParameters[$name] ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);
+        }
+
+        if (!\array_key_exists($name, $this->parameters) || '.' === ($name[0] ?? '')) {
+            throw new ParameterNotFoundException($name);
         }
 
         return $this->parameters[$name];
@@ -49,7 +50,7 @@ class Symfony_DI_PhpDumper_Test_Base64Parameters extends Container
 
     public function hasParameter(string $name): bool
     {
-        return isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters);
+        return \array_key_exists($name, $this->parameters) || isset($this->loadedDynamicParameters[$name]);
     }
 
     public function setParameter(string $name, $value): void

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_csv_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_csv_env.php
@@ -37,11 +37,12 @@ class Symfony_DI_PhpDumper_Test_CsvParameters extends Container
 
     public function getParameter(string $name): array|bool|string|int|float|\UnitEnum|null
     {
-        if (!(isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters))) {
-            throw new ParameterNotFoundException($name);
-        }
         if (isset($this->loadedDynamicParameters[$name])) {
             return $this->loadedDynamicParameters[$name] ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);
+        }
+
+        if (!\array_key_exists($name, $this->parameters) || '.' === ($name[0] ?? '')) {
+            throw new ParameterNotFoundException($name);
         }
 
         return $this->parameters[$name];
@@ -49,7 +50,7 @@ class Symfony_DI_PhpDumper_Test_CsvParameters extends Container
 
     public function hasParameter(string $name): bool
     {
-        return isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters);
+        return \array_key_exists($name, $this->parameters) || isset($this->loadedDynamicParameters[$name]);
     }
 
     public function setParameter(string $name, $value): void

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_default_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_default_env.php
@@ -37,11 +37,12 @@ class Symfony_DI_PhpDumper_Test_DefaultParameters extends Container
 
     public function getParameter(string $name): array|bool|string|int|float|\UnitEnum|null
     {
-        if (!(isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters))) {
-            throw new ParameterNotFoundException($name);
-        }
         if (isset($this->loadedDynamicParameters[$name])) {
             return $this->loadedDynamicParameters[$name] ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);
+        }
+
+        if (!\array_key_exists($name, $this->parameters) || '.' === ($name[0] ?? '')) {
+            throw new ParameterNotFoundException($name);
         }
 
         return $this->parameters[$name];
@@ -49,7 +50,7 @@ class Symfony_DI_PhpDumper_Test_DefaultParameters extends Container
 
     public function hasParameter(string $name): bool
     {
-        return isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters);
+        return \array_key_exists($name, $this->parameters) || isset($this->loadedDynamicParameters[$name]);
     }
 
     public function setParameter(string $name, $value): void

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_deprecated_parameters.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_deprecated_parameters.php
@@ -58,11 +58,12 @@ class ProjectServiceContainer extends Container
             trigger_deprecation(...self::DEPRECATED_PARAMETERS[$name]);
         }
 
-        if (!(isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters))) {
-            throw new ParameterNotFoundException($name);
-        }
         if (isset($this->loadedDynamicParameters[$name])) {
             return $this->loadedDynamicParameters[$name] ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);
+        }
+
+        if (!\array_key_exists($name, $this->parameters) || '.' === ($name[0] ?? '')) {
+            throw new ParameterNotFoundException($name);
         }
 
         return $this->parameters[$name];
@@ -70,7 +71,7 @@ class ProjectServiceContainer extends Container
 
     public function hasParameter(string $name): bool
     {
-        return isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters);
+        return \array_key_exists($name, $this->parameters) || isset($this->loadedDynamicParameters[$name]);
     }
 
     public function setParameter(string $name, $value): void

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_deprecated_parameters_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_deprecated_parameters_as_files.txt
@@ -95,15 +95,16 @@ class ProjectServiceContainer extends Container
             trigger_deprecation(...self::DEPRECATED_PARAMETERS[$name]);
         }
 
-        if (isset($this->buildParameters[$name])) {
+        if (\array_key_exists($name, $this->buildParameters)) {
             return $this->buildParameters[$name];
         }
 
-        if (!(isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters))) {
-            throw new ParameterNotFoundException($name);
-        }
         if (isset($this->loadedDynamicParameters[$name])) {
             return $this->loadedDynamicParameters[$name] ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);
+        }
+
+        if (!\array_key_exists($name, $this->parameters) || '.' === ($name[0] ?? '')) {
+            throw new ParameterNotFoundException($name);
         }
 
         return $this->parameters[$name];
@@ -111,11 +112,11 @@ class ProjectServiceContainer extends Container
 
     public function hasParameter(string $name): bool
     {
-        if (isset($this->buildParameters[$name])) {
+        if (\array_key_exists($name, $this->buildParameters)) {
             return true;
         }
 
-        return isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters);
+        return \array_key_exists($name, $this->parameters) || isset($this->loadedDynamicParameters[$name]);
     }
 
     public function setParameter(string $name, $value): void

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_env_in_id.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_env_in_id.php
@@ -69,11 +69,12 @@ class ProjectServiceContainer extends Container
 
     public function getParameter(string $name): array|bool|string|int|float|\UnitEnum|null
     {
-        if (!(isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters))) {
-            throw new ParameterNotFoundException($name);
-        }
         if (isset($this->loadedDynamicParameters[$name])) {
             return $this->loadedDynamicParameters[$name] ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);
+        }
+
+        if (!\array_key_exists($name, $this->parameters) || '.' === ($name[0] ?? '')) {
+            throw new ParameterNotFoundException($name);
         }
 
         return $this->parameters[$name];
@@ -81,7 +82,7 @@ class ProjectServiceContainer extends Container
 
     public function hasParameter(string $name): bool
     {
-        return isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters);
+        return \array_key_exists($name, $this->parameters) || isset($this->loadedDynamicParameters[$name]);
     }
 
     public function setParameter(string $name, $value): void

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_errored_definition.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_errored_definition.php
@@ -452,11 +452,12 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
 
     public function getParameter(string $name): array|bool|string|int|float|\UnitEnum|null
     {
-        if (!(isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters))) {
-            throw new ParameterNotFoundException($name);
-        }
         if (isset($this->loadedDynamicParameters[$name])) {
             return $this->loadedDynamicParameters[$name] ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);
+        }
+
+        if (!\array_key_exists($name, $this->parameters) || '.' === ($name[0] ?? '')) {
+            throw new ParameterNotFoundException($name);
         }
 
         return $this->parameters[$name];
@@ -464,7 +465,7 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
 
     public function hasParameter(string $name): bool
     {
-        return isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters);
+        return \array_key_exists($name, $this->parameters) || isset($this->loadedDynamicParameters[$name]);
     }
 
     public function setParameter(string $name, $value): void

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_json_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_json_env.php
@@ -37,11 +37,12 @@ class Symfony_DI_PhpDumper_Test_JsonParameters extends Container
 
     public function getParameter(string $name): array|bool|string|int|float|\UnitEnum|null
     {
-        if (!(isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters))) {
-            throw new ParameterNotFoundException($name);
-        }
         if (isset($this->loadedDynamicParameters[$name])) {
             return $this->loadedDynamicParameters[$name] ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);
+        }
+
+        if (!\array_key_exists($name, $this->parameters) || '.' === ($name[0] ?? '')) {
+            throw new ParameterNotFoundException($name);
         }
 
         return $this->parameters[$name];
@@ -49,7 +50,7 @@ class Symfony_DI_PhpDumper_Test_JsonParameters extends Container
 
     public function hasParameter(string $name): bool
     {
-        return isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters);
+        return \array_key_exists($name, $this->parameters) || isset($this->loadedDynamicParameters[$name]);
     }
 
     public function setParameter(string $name, $value): void

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_query_string_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_query_string_env.php
@@ -37,11 +37,12 @@ class Symfony_DI_PhpDumper_Test_QueryStringParameters extends Container
 
     public function getParameter(string $name): array|bool|string|int|float|\UnitEnum|null
     {
-        if (!(isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters))) {
-            throw new ParameterNotFoundException($name);
-        }
         if (isset($this->loadedDynamicParameters[$name])) {
             return $this->loadedDynamicParameters[$name] ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);
+        }
+
+        if (!\array_key_exists($name, $this->parameters) || '.' === ($name[0] ?? '')) {
+            throw new ParameterNotFoundException($name);
         }
 
         return $this->parameters[$name];
@@ -49,7 +50,7 @@ class Symfony_DI_PhpDumper_Test_QueryStringParameters extends Container
 
     public function hasParameter(string $name): bool
     {
-        return isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters);
+        return \array_key_exists($name, $this->parameters) || isset($this->loadedDynamicParameters[$name]);
     }
 
     public function setParameter(string $name, $value): void

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_rot13_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_rot13_env.php
@@ -73,11 +73,12 @@ class Symfony_DI_PhpDumper_Test_Rot13Parameters extends Container
 
     public function getParameter(string $name): array|bool|string|int|float|\UnitEnum|null
     {
-        if (!(isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters))) {
-            throw new ParameterNotFoundException($name);
-        }
         if (isset($this->loadedDynamicParameters[$name])) {
             return $this->loadedDynamicParameters[$name] ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);
+        }
+
+        if (!\array_key_exists($name, $this->parameters) || '.' === ($name[0] ?? '')) {
+            throw new ParameterNotFoundException($name);
         }
 
         return $this->parameters[$name];
@@ -85,7 +86,7 @@ class Symfony_DI_PhpDumper_Test_Rot13Parameters extends Container
 
     public function hasParameter(string $name): bool
     {
-        return isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters);
+        return \array_key_exists($name, $this->parameters) || isset($this->loadedDynamicParameters[$name]);
     }
 
     public function setParameter(string $name, $value): void

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_unsupported_characters.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_unsupported_characters.php
@@ -72,11 +72,12 @@ class Symfony_DI_PhpDumper_Test_Unsupported_Characters extends Container
 
     public function getParameter(string $name): array|bool|string|int|float|\UnitEnum|null
     {
-        if (!(isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters))) {
-            throw new ParameterNotFoundException($name);
-        }
         if (isset($this->loadedDynamicParameters[$name])) {
             return $this->loadedDynamicParameters[$name] ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);
+        }
+
+        if (!\array_key_exists($name, $this->parameters) || '.' === ($name[0] ?? '')) {
+            throw new ParameterNotFoundException($name);
         }
 
         return $this->parameters[$name];
@@ -84,7 +85,7 @@ class Symfony_DI_PhpDumper_Test_Unsupported_Characters extends Container
 
     public function hasParameter(string $name): bool
     {
-        return isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters);
+        return \array_key_exists($name, $this->parameters) || isset($this->loadedDynamicParameters[$name]);
     }
 
     public function setParameter(string $name, $value): void

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_url_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_url_env.php
@@ -37,11 +37,12 @@ class Symfony_DI_PhpDumper_Test_UrlParameters extends Container
 
     public function getParameter(string $name): array|bool|string|int|float|\UnitEnum|null
     {
-        if (!(isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters))) {
-            throw new ParameterNotFoundException($name);
-        }
         if (isset($this->loadedDynamicParameters[$name])) {
             return $this->loadedDynamicParameters[$name] ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);
+        }
+
+        if (!\array_key_exists($name, $this->parameters) || '.' === ($name[0] ?? '')) {
+            throw new ParameterNotFoundException($name);
         }
 
         return $this->parameters[$name];
@@ -49,7 +50,7 @@ class Symfony_DI_PhpDumper_Test_UrlParameters extends Container
 
     public function hasParameter(string $name): bool
     {
-        return isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || \array_key_exists($name, $this->parameters);
+        return \array_key_exists($name, $this->parameters) || isset($this->loadedDynamicParameters[$name]);
     }
 
     public function setParameter(string $name, $value): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

As spotted in https://github.com/symfony/symfony/pull/62599#discussion_r2642736974, build-time array parameters are removed but still referenced since #23143.

This fixes it by telling `RemoveBuildParametersPass` to not remove them, and also by telling PhpDumper to throw when a build-time parameter is accessed. Internally, the code bypasses the method by using `$this->parameters` directly.