### PR TITLE
[Uid] Concat $uid to InvalidArgumentException message

### DIFF
--- a/src/Symfony/Component/Uid/AbstractUid.php
+++ b/src/Symfony/Component/Uid/AbstractUid.php
@@ -53,7 +53,7 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable, HashableIn
     public static function fromBase58(string $uid): static
     {
         if (22 !== \strlen($uid)) {
-            throw new InvalidArgumentException('Invalid base-58 uid provided.');
+            throw new InvalidArgumentException(\sprintf('Invalid base-58 uid provided: "%s".', $uid));
         }
 
         return static::fromString($uid);
@@ -65,7 +65,7 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable, HashableIn
     public static function fromBase32(string $uid): static
     {
         if (26 !== \strlen($uid)) {
-            throw new InvalidArgumentException('Invalid base-32 uid provided.');
+            throw new InvalidArgumentException(\sprintf('Invalid base-32 uid provided: "%s".', $uid));
         }
 
         return static::fromString($uid);
@@ -79,7 +79,7 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable, HashableIn
     public static function fromRfc4122(string $uid): static
     {
         if (36 !== \strlen($uid)) {
-            throw new InvalidArgumentException('Invalid RFC4122 uid provided.');
+            throw new InvalidArgumentException(\sprintf('Invalid RFC4122 uid provided: "%s".', $uid));
         }
 
         return static::fromString($uid);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1 
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| License       | MIT

This PR introduces a small change to Uid component,
making sure that string-based uid factory methods will include invalid value in the exception message.