### PR TITLE
[Uid] Remove $uid from InvalidArgumentException message

### DIFF
--- a/src/Symfony/Component/Uid/Tests/Command/InspectUlidCommandTest.php
+++ b/src/Symfony/Component/Uid/Tests/Command/InspectUlidCommandTest.php
@@ -22,7 +22,7 @@ final class InspectUlidCommandTest extends TestCase
         $commandTester = new CommandTester(new InspectUlidCommand());
 
         $this->assertSame(1, $commandTester->execute(['ulid' => 'foobar']));
-        $this->assertStringContainsString('Invalid ULID: "foobar"', $commandTester->getDisplay());
+        $this->assertStringContainsString('Invalid ULID.', $commandTester->getDisplay());
 
         foreach ([
             '01E439TP9XJZ9RPFH3T1PYBCR8',

--- a/src/Symfony/Component/Uid/Tests/Command/InspectUuidCommandTest.php
+++ b/src/Symfony/Component/Uid/Tests/Command/InspectUuidCommandTest.php
@@ -22,7 +22,7 @@ final class InspectUuidCommandTest extends TestCase
         $commandTester = new CommandTester(new InspectUuidCommand());
 
         $this->assertSame(1, $commandTester->execute(['uuid' => 'foobar']));
-        $this->assertStringContainsString('Invalid UUID: "foobar"', $commandTester->getDisplay());
+        $this->assertStringContainsString('Invalid UUID.', $commandTester->getDisplay());
     }
 
     public function testNil()

--- a/src/Symfony/Component/Uid/Tests/UlidTest.php
+++ b/src/Symfony/Component/Uid/Tests/UlidTest.php
@@ -42,7 +42,7 @@ class UlidTest extends TestCase
     public function testWithInvalidUlid()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid ULID: "this is not a ulid".');
+        $this->expectExceptionMessage('Invalid ULID.');
 
         new Ulid('this is not a ulid');
     }

--- a/src/Symfony/Component/Uid/Tests/UuidTest.php
+++ b/src/Symfony/Component/Uid/Tests/UuidTest.php
@@ -36,7 +36,7 @@ class UuidTest extends TestCase
     public function testConstructorWithInvalidUuid(string $uuid)
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid UUID: "'.$uuid.'".');
+        $this->expectExceptionMessage('Invalid UUID.');
 
         Uuid::fromString($uuid);
     }
@@ -59,7 +59,7 @@ class UuidTest extends TestCase
         $class = Uuid::class.'V'.$uuid[14];
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid UUIDv'.$uuid[14].': "'.$uuid.'".');
+        $this->expectExceptionMessage('Invalid UUIDv'.$uuid[14].'.');
 
         new $class($uuid);
     }

--- a/src/Symfony/Component/Uid/Ulid.php
+++ b/src/Symfony/Component/Uid/Ulid.php
@@ -36,7 +36,7 @@ class Ulid extends AbstractUid implements TimeBasedUidInterface
             $this->uid = $ulid;
         } else {
             if (!self::isValid($ulid)) {
-                throw new \InvalidArgumentException(\sprintf('Invalid ULID: "%s".', $ulid));
+                throw new \InvalidArgumentException('Invalid ULID.');
             }
 
             $this->uid = strtoupper($ulid);

--- a/src/Symfony/Component/Uid/Uuid.php
+++ b/src/Symfony/Component/Uid/Uuid.php
@@ -32,13 +32,13 @@ class Uuid extends AbstractUid
         $type = preg_match('{^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$}Di', $uuid) ? (int) $uuid[14] : false;
 
         if (false === $type || (static::TYPE ?: $type) !== $type) {
-            throw new \InvalidArgumentException(\sprintf('Invalid UUID%s: "%s".', static::TYPE ? 'v'.static::TYPE : '', $uuid));
+            throw new \InvalidArgumentException(\sprintf('Invalid UUID%s.', static::TYPE ? 'v'.static::TYPE : ''));
         }
 
         $this->uid = strtolower($uuid);
 
         if ($checkVariant && !\in_array($this->uid[19], ['8', '9', 'a', 'b'], true)) {
-            throw new \InvalidArgumentException(\sprintf('Invalid UUID%s: "%s".', static::TYPE ? 'v'.static::TYPE : '', $uuid));
+            throw new \InvalidArgumentException(\sprintf('Invalid UUID%s.', static::TYPE ? 'v'.static::TYPE : ''));
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | NO
| License       | MIT

This PR prevents user-submitted input from being concatenated to the exception message (possibly leading to an XSS in case the error happened is being displayed to end users).