### PR TITLE
[HttpKernel] Fix using HTTP Cache in worker mode

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -110,7 +110,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     public function boot()
     {
-        if (true === $this->booted) {
+        if ($this->booted) {
             if (!$this->requestStackSize && $this->resetServices) {
                 if ($this->container->has('services_resetter')) {
                     $this->container->get('services_resetter')->reset();
@@ -124,7 +124,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
             return;
         }
 
-        if (null === $this->container) {
+        if (!$this->container) {
             $this->preBoot();
         }
 
@@ -151,7 +151,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     public function terminate(Request $request, Response $response)
     {
-        if (false === $this->booted) {
+        if (!$this->booted) {
             return;
         }
 
@@ -165,7 +165,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     public function shutdown()
     {
-        if (false === $this->booted) {
+        if (!$this->booted) {
             return;
         }
 
@@ -183,18 +183,18 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
 
     public function handle(Request $request, int $type = HttpKernelInterface::MAIN_REQUEST, bool $catch = true): Response
     {
-        if (!$this->booted) {
-            $container = $this->container ?? $this->preBoot();
+        if (!$this->container) {
+            $this->preBoot();
+        }
 
-            if ($container->has('http_cache')) {
-                $this->handlingHttpCache = true;
+        if (HttpKernelInterface::MAIN_REQUEST === $type && !$this->handlingHttpCache && $this->container->has('http_cache')) {
+            $this->handlingHttpCache = true;
 
-                try {
-                    return $container->get('http_cache')->handle($request, $type, $catch);
-                } finally {
-                    $this->handlingHttpCache = false;
-                    $this->resetServices = true;
-                }
+            try {
+                return $this->container->get('http_cache')->handle($request, $type, $catch);
+            } finally {
+                $this->handlingHttpCache = false;
+                $this->resetServices = true;
             }
         }
 
@@ -614,7 +614,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
     {
         foreach (['cache' => $this->getCacheDir(), 'build' => $this->warmupDir ?: $this->getBuildDir(), 'logs' => $this->getLogDir()] as $name => $dir) {
             if (!is_dir($dir)) {
-                if (false === @mkdir($dir, 0777, true) && !is_dir($dir)) {
+                if (!@mkdir($dir, 0o777, true) && !is_dir($dir)) {
                     throw new \RuntimeException(\sprintf('Unable to create the "%s" directory (%s).', $name, $dir));
                 }
             } elseif (!is_writable($dir)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62832
| License       | MIT

Try to fix this issue #62832 by shutdown the kernel after the terminate call.
