### PR TITLE
[HttpKernel] Decouple controller attributes from source code and add `ResponseEvent::getControllerAttributes()`

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 
  * Add support for bundles as compiler pass
  * Add support for `SOURCE_DATE_EPOCH` environment variable
+ * Add `ResponseEvent::getControllerAttributes()`
+ * Add `Request` attribute `_controller_attributes` to decouple controller attributes from their source code
 
 8.0
 ---

--- a/src/Symfony/Component/HttpKernel/Event/ResponseEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/ResponseEvent.php
@@ -31,6 +31,7 @@ final class ResponseEvent extends KernelEvent
         Request $request,
         int $requestType,
         private Response $response,
+        private ?ControllerEvent $controllerEvent = null,
     ) {
         parent::__construct($kernel, $request, $requestType);
     }
@@ -43,5 +44,19 @@ final class ResponseEvent extends KernelEvent
     public function setResponse(Response $response): void
     {
         $this->response = $response;
+    }
+
+    /**
+     * @template T of class-string|null
+     *
+     * @param T $className
+     *
+     * @return array<class-string, list<object>>|list<object>
+     *
+     * @psalm-return (T is null ? array<class-string, list<object>> : list<object>)
+     */
+    public function getControllerAttributes(?string $className = null): array
+    {
+        return $this->controllerEvent?->getAttributes($className) ?? [];
     }
 }

--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -167,7 +167,7 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
             throw new NotFoundHttpException(\sprintf('Unable to find the controller for path "%s". The route is wrongly configured.', $request->getPathInfo()));
         }
 
-        $event = new ControllerEvent($this, $controller, $request, $type);
+        $controllerEvent = $event = new ControllerEvent($this, $controller, $request, $type);
         $this->dispatcher->dispatch($event, KernelEvents::CONTROLLER);
         $controller = $event->getController();
 
@@ -201,7 +201,7 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
             }
         }
 
-        return $this->filterResponse($response, $request, $type);
+        return $this->filterResponse($response, $request, $type, $controllerEvent);
     }
 
     /**
@@ -209,9 +209,9 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
      *
      * @throws \RuntimeException if the passed object is not a Response instance
      */
-    private function filterResponse(Response $response, Request $request, int $type): Response
+    private function filterResponse(Response $response, Request $request, int $type, ?ControllerEvent $controllerEvent = null): Response
     {
-        $event = new ResponseEvent($this, $request, $type, $response);
+        $event = new ResponseEvent($this, $request, $type, $response, $controllerEvent);
 
         $this->dispatcher->dispatch($event, KernelEvents::RESPONSE);
 

--- a/src/Symfony/Component/HttpKernel/Tests/Event/ResponseEventTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Event/ResponseEventTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Event;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\Tests\Fixtures\Attribute\Bar;
+use Symfony\Component\HttpKernel\Tests\Fixtures\Attribute\Baz;
+use Symfony\Component\HttpKernel\Tests\Fixtures\Controller\AttributeController;
+use Symfony\Component\HttpKernel\Tests\TestHttpKernel;
+
+class ResponseEventTest extends TestCase
+{
+    public function testGetControllerAttributesWithoutControllerEvent()
+    {
+        $kernel = new TestHttpKernel();
+        $request = new Request();
+        $response = new Response();
+
+        $event = new ResponseEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, $response);
+
+        $this->assertEquals([], $event->getControllerAttributes());
+        $this->assertEquals([], $event->getControllerAttributes(Bar::class));
+    }
+
+    public function testGetControllerAttributesWithControllerEvent()
+    {
+        $kernel = new TestHttpKernel();
+        $request = new Request();
+        $response = new Response();
+
+        $controller = [new AttributeController(), '__invoke'];
+        $controllerEvent = new ControllerEvent($kernel, $controller, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $event = new ResponseEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, $response, $controllerEvent);
+
+        $expected = [
+            Bar::class => [
+                new Bar('class'),
+                new Bar('method'),
+            ],
+            Baz::class => [
+                new Baz(),
+            ],
+        ];
+
+        $this->assertEquals($expected, $event->getControllerAttributes());
+    }
+
+    public function testGetControllerAttributesByClassName()
+    {
+        $kernel = new TestHttpKernel();
+        $request = new Request();
+        $response = new Response();
+
+        $controller = [new AttributeController(), '__invoke'];
+        $controllerEvent = new ControllerEvent($kernel, $controller, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $event = new ResponseEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, $response, $controllerEvent);
+
+        $expected = [
+            new Bar('class'),
+            new Bar('method'),
+        ];
+
+        $this->assertEquals($expected, $event->getControllerAttributes(Bar::class));
+    }
+
+    public function testGetControllerAttributesByInvalidClassName()
+    {
+        $kernel = new TestHttpKernel();
+        $request = new Request();
+        $response = new Response();
+
+        $controller = [new AttributeController(), '__invoke'];
+        $controllerEvent = new ControllerEvent($kernel, $controller, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $event = new ResponseEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, $response, $controllerEvent);
+
+        $this->assertEquals([], $event->getControllerAttributes(\stdClass::class));
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
@@ -31,6 +31,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\HttpKernel;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpKernel\Tests\Fixtures\Attribute\Bar;
 
 class HttpKernelTest extends TestCase
 {
@@ -492,6 +493,30 @@ class HttpKernelTest extends TestCase
         $kernel->handle($request, $kernel::MAIN_REQUEST, false);
 
         Request::setTrustedProxies([], -1);
+    }
+
+    public function testResponseEventCanAccessControllerAttributes()
+    {
+        $dispatcher = new EventDispatcher();
+        $capturedAttributes = null;
+
+        $dispatcher->addListener(KernelEvents::CONTROLLER, static function ($event) {
+            // Set some attributes on the controller event
+            $event->setController($event->getController(), [Bar::class => [new Bar('test')]]);
+        });
+
+        $dispatcher->addListener(KernelEvents::RESPONSE, static function ($event) use (&$capturedAttributes) {
+            $capturedAttributes = $event->getControllerAttributes();
+        });
+
+        $kernel = $this->getHttpKernel($dispatcher);
+
+        $kernel->handle(new Request(), HttpKernelInterface::MAIN_REQUEST, false);
+
+        // Should have the attributes we set
+        $this->assertIsArray($capturedAttributes);
+        $this->assertArrayHasKey(Bar::class, $capturedAttributes);
+        $this->assertEquals([new Bar('test')], $capturedAttributes[Bar::class]);
     }
 
     private function getHttpKernel(EventDispatcherInterface $eventDispatcher, $controller = null, ?RequestStack $requestStack = null, array $arguments = [], bool $handleAllThrowables = false)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR exposes controller attributes to `kernel.response` listeners. This should enable writing listeners that act as wrappers around controllers, with just a PHP attribute to enable their behavior.

The decoupling from PHP source code is design cleanup, restoring the declarative native of PHP attributes (allowing code to override them).